### PR TITLE
fix(app): remove pipette settings from overflow menu if no pipette settings found

### DIFF
--- a/app/src/organisms/ConfigurePipette/__tests__/ConfigurePipette.test.tsx
+++ b/app/src/organisms/ConfigurePipette/__tests__/ConfigurePipette.test.tsx
@@ -4,7 +4,6 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import * as RobotApi from '../../../redux/robot-api'
 import { ConfigurePipette } from '../../ConfigurePipette'
-import { getAttachedPipetteSettingsFieldsById } from '../../../redux/pipettes'
 import { mockPipetteSettingsFieldsMap } from '../../../redux/pipettes/__fixtures__'
 import { getConfig } from '../../../redux/config'
 
@@ -13,7 +12,6 @@ import type { State } from '../../../redux/types'
 
 jest.mock('../../../redux/robot-api')
 jest.mock('../../../redux/config')
-jest.mock('../../../redux/pipettes')
 
 const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
 const mockUseDispatchApiRequest = RobotApi.useDispatchApiRequest as jest.MockedFunction<
@@ -21,9 +19,6 @@ const mockUseDispatchApiRequest = RobotApi.useDispatchApiRequest as jest.MockedF
 >
 const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
   typeof RobotApi.getRequestById
->
-const mockGetAttachedPipetteSettingsFieldsById = getAttachedPipetteSettingsFieldsById as jest.MockedFunction<
-  typeof getAttachedPipetteSettingsFieldsById
 >
 
 const render = (props: React.ComponentProps<typeof ConfigurePipette>) => {
@@ -40,7 +35,7 @@ describe('ConfigurePipette', () => {
 
   beforeEach(() => {
     props = {
-      pipetteId: 'id',
+      settings: mockPipetteSettingsFieldsMap,
       robotName: mockRobotName,
       updateRequest: { status: 'pending' },
       updateSettings: jest.fn(),
@@ -59,9 +54,6 @@ describe('ConfigurePipette', () => {
         },
       })
     mockGetConfig.mockReturnValue({} as any)
-    when(mockGetAttachedPipetteSettingsFieldsById)
-      .calledWith({} as State, mockRobotName, 'id')
-      .mockReturnValue(mockPipetteSettingsFieldsMap)
     dispatchApiRequest = jest.fn()
     when(mockUseDispatchApiRequest)
       .calledWith()

--- a/app/src/organisms/ConfigurePipette/index.tsx
+++ b/app/src/organisms/ConfigurePipette/index.tsx
@@ -1,41 +1,30 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@opentrons/components'
+
 import { SUCCESS, FAILURE, PENDING } from '../../redux/robot-api'
 import { ConfigForm } from './ConfigForm'
 import { ConfigErrorBanner } from './ConfigErrorBanner'
+
 import type {
-  AttachedPipette,
   PipetteSettingsFieldsUpdate,
+  PipetteSettingsFieldsMap,
 } from '../../redux/pipettes/types'
-import { getAttachedPipetteSettingsFieldsById } from '../../redux/pipettes'
 import type { RequestState } from '../../redux/robot-api/types'
-import type { State } from '../../redux/types'
 
 interface Props {
   closeModal: () => void
-  pipetteId: AttachedPipette['id']
   updateRequest: RequestState | null
   updateSettings: (fields: PipetteSettingsFieldsUpdate) => void
   robotName: string
   formId: string
+  settings: PipetteSettingsFieldsMap
 }
 
 export function ConfigurePipette(props: Props): JSX.Element {
-  const {
-    closeModal,
-    pipetteId,
-    updateRequest,
-    updateSettings,
-    robotName,
-    formId,
-  } = props
+  const { closeModal, updateRequest, updateSettings, formId, settings } = props
   const { t } = useTranslation('device_details')
 
-  const settings = useSelector((state: State) =>
-    getAttachedPipetteSettingsFieldsById(state, robotName, pipetteId)
-  )
   const groupLabels = [
     t('plunger_positions'),
     t('tip_pickup_drop'),
@@ -58,15 +47,13 @@ export function ConfigurePipette(props: Props): JSX.Element {
   return (
     <Box zIndex={1}>
       {updateError && <ConfigErrorBanner message={updateError} />}
-      {settings != null && pipetteId != null && (
-        <ConfigForm
-          settings={settings}
-          updateInProgress={updateRequest?.status === PENDING}
-          updateSettings={updateSettings}
-          groupLabels={groupLabels}
-          formId={formId}
-        />
-      )}
+      <ConfigForm
+        settings={settings}
+        updateInProgress={updateRequest?.status === PENDING}
+        updateSettings={updateSettings}
+        groupLabels={groupLabels}
+        formId={formId}
+      />
     </Box>
   )
 }

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+
 import {
   Flex,
   POSITION_RELATIVE,
@@ -8,18 +9,23 @@ import {
   SPACING,
   DIRECTION_COLUMN,
 } from '@opentrons/components'
-import { MenuItem } from '../../../atoms/MenuList/MenuItem'
-import { Divider } from '../../../atoms/structure'
-
 import {
   isOT3Pipette,
   PipetteModelSpecs,
   PipetteName,
 } from '@opentrons/shared-data'
-import type { Mount } from '../../../redux/pipettes/types'
+
+import { MenuItem } from '../../../atoms/MenuList/MenuItem'
+import { Divider } from '../../../atoms/structure'
+
+import type {
+  Mount,
+  PipetteSettingsFieldsMap,
+} from '../../../redux/pipettes/types'
 
 interface PipetteOverflowMenuProps {
   pipetteSpecs: PipetteModelSpecs | null
+  pipetteSettings: PipetteSettingsFieldsMap | null
   mount: Mount
   handleChangePipette: () => void
   handleCalibrate: () => void
@@ -35,6 +41,7 @@ export const PipetteOverflowMenu = (
   const {
     mount,
     pipetteSpecs,
+    pipetteSettings,
     handleChangePipette,
     handleCalibrate,
     handleAboutSlideout,
@@ -103,7 +110,7 @@ export const PipetteOverflowMenu = (
               {t('about_pipette')}
             </MenuItem>
             <Divider marginY="0" />
-            {!isOT3PipetteAttached ? (
+            {!isOT3PipetteAttached && pipetteSettings != null ? (
               <MenuItem
                 key={`${String(pipetteDisplayName)}_${mount}_view_settings`}
                 onClick={() => handleSettingsSlideout()}

--- a/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
@@ -20,6 +20,7 @@ import { ConfigurePipette } from '../../ConfigurePipette'
 import type {
   AttachedPipette,
   PipetteSettingsFieldsUpdate,
+  PipetteSettingsFieldsMap,
 } from '../../../redux/pipettes/types'
 import type { Dispatch, State } from '../../../redux/types'
 
@@ -31,12 +32,20 @@ interface PipetteSettingsSlideoutProps {
   onCloseClick: () => void
   isExpanded: boolean
   pipetteId: AttachedPipette['id']
+  settings: PipetteSettingsFieldsMap
 }
 
 export const PipetteSettingsSlideout = (
   props: PipetteSettingsSlideoutProps
 ): JSX.Element | null => {
-  const { pipetteName, robotName, isExpanded, pipetteId, onCloseClick } = props
+  const {
+    pipetteName,
+    robotName,
+    isExpanded,
+    pipetteId,
+    onCloseClick,
+    settings,
+  } = props
   const { t } = useTranslation('device_details')
   const dispatch = useDispatch<Dispatch>()
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
@@ -73,11 +82,11 @@ export const PipetteSettingsSlideout = (
       <Flex data-testid={`PipetteSettingsSlideout_${robotName}_${pipetteId}`}>
         <ConfigurePipette
           closeModal={onCloseClick}
-          pipetteId={pipetteId}
           updateRequest={updateRequest}
           updateSettings={updateSettings}
           robotName={robotName}
           formId={FORM_ID}
+          settings={settings}
         />
       </Flex>
     </Slideout>

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -7,6 +7,7 @@ import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
 import { getHasCalibrationBlock } from '../../../../redux/config'
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
+import { getAttachedPipetteSettingsFieldsById } from '../../../../redux/pipettes'
 import { AskForCalibrationBlockModal } from '../../../CalibrateTipLength'
 import { useCalibratePipetteOffset } from '../../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import { useDeckCalibrationData, useIsOT3 } from '../../hooks'
@@ -17,9 +18,11 @@ import { PipetteCard } from '..'
 import {
   mockLeftSpecs,
   mockRightSpecs,
+  mockPipetteSettingsFieldsMap,
 } from '../../../../redux/pipettes/__fixtures__'
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
 
+import type { State } from '../../../../redux/types'
 import type { DispatchApiRequestType } from '../../../../redux/robot-api'
 
 jest.mock('../PipetteOverflowMenu')
@@ -30,6 +33,7 @@ jest.mock('../../hooks')
 jest.mock('../AboutPipetteSlideout')
 jest.mock('../../../../redux/robot-api')
 jest.mock('@opentrons/react-api-client')
+jest.mock('../../../../redux/pipettes')
 
 const mockPipetteOverflowMenu = PipetteOverflowMenu as jest.MockedFunction<
   typeof PipetteOverflowMenu
@@ -55,6 +59,9 @@ const mockUseDispatchApiRequest = useDispatchApiRequest as jest.MockedFunction<
 const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUseCurrentSubsystemUpdateQuery = useCurrentSubsystemUpdateQuery as jest.MockedFunction<
   typeof useCurrentSubsystemUpdateQuery
+>
+const mockGetAttachedPipetteSettingsFieldsById = getAttachedPipetteSettingsFieldsById as jest.MockedFunction<
+  typeof getAttachedPipetteSettingsFieldsById
 >
 
 const render = (props: React.ComponentProps<typeof PipetteCard>) => {
@@ -105,6 +112,9 @@ describe('PipetteCard', () => {
     mockUseCurrentSubsystemUpdateQuery.mockReturnValue({
       data: undefined,
     } as any)
+    when(mockGetAttachedPipetteSettingsFieldsById)
+      .calledWith({} as State, mockRobotName, 'id')
+      .mockReturnValue(mockPipetteSettingsFieldsMap)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -273,5 +283,16 @@ describe('PipetteCard', () => {
     getByText('Right mount')
     getByText('Instrument attached')
     getByText('Firmware update in progress...')
+  })
+  it('does not render a pipette settings slideout card if the pipette has no settings', () => {
+    when(mockGetAttachedPipetteSettingsFieldsById)
+      .calledWith({} as State, mockRobotName, 'id')
+      .mockReturnValue(null)
+    const { queryByTestId } = render(props)
+    expect(
+      queryByTestId(
+        `PipetteSettingsSlideout_${mockRobotName}_${props.pipetteId}`
+      )
+    ).not.toBeInTheDocument()
   })
 })

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -4,7 +4,10 @@ import { resetAllWhenMocks } from 'jest-when'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import { PipetteOverflowMenu } from '../PipetteOverflowMenu'
-import { mockLeftProtoPipette } from '../../../../redux/pipettes/__fixtures__'
+import {
+  mockLeftProtoPipette,
+  mockPipetteSettingsFieldsMap,
+} from '../../../../redux/pipettes/__fixtures__'
 import { isOT3Pipette } from '@opentrons/shared-data'
 
 import type { Mount } from '../../../../redux/pipettes/types'
@@ -35,6 +38,7 @@ describe('PipetteOverflowMenu', () => {
   beforeEach(() => {
     props = {
       pipetteSpecs: mockLeftProtoPipette.modelSpecs,
+      pipetteSettings: mockPipetteSettingsFieldsMap,
       mount: LEFT,
       handleChangePipette: jest.fn(),
       handleCalibrate: jest.fn(),
@@ -62,13 +66,8 @@ describe('PipetteOverflowMenu', () => {
   })
   it('renders information with no pipette attached', () => {
     props = {
+      ...props,
       pipetteSpecs: null,
-      mount: LEFT,
-      handleChangePipette: jest.fn(),
-      handleCalibrate: jest.fn(),
-      handleAboutSlideout: jest.fn(),
-      handleSettingsSlideout: jest.fn(),
-      isPipetteCalibrated: false,
     }
     const { getByRole } = render(props)
     const btn = getByRole('button', { name: 'Attach pipette' })
@@ -78,14 +77,8 @@ describe('PipetteOverflowMenu', () => {
 
   it('renders recalibrate pipette text for OT-3 pipette', () => {
     mockIsOT3Pipette.mockReturnValue(true)
-
     props = {
-      pipetteSpecs: mockLeftProtoPipette.modelSpecs,
-      mount: LEFT,
-      handleChangePipette: jest.fn(),
-      handleCalibrate: jest.fn(),
-      handleAboutSlideout: jest.fn(),
-      handleSettingsSlideout: jest.fn(),
+      ...props,
       isPipetteCalibrated: true,
     }
     const { getByRole } = render(props)
@@ -129,5 +122,17 @@ describe('PipetteOverflowMenu', () => {
     expect(settings).toBeNull()
     fireEvent.click(about)
     expect(props.handleAboutSlideout).toHaveBeenCalled()
+  })
+
+  it('does not render the pipette settings button if the pipette has no settings', () => {
+    mockIsOT3Pipette.mockReturnValue(false)
+    props = {
+      ...props,
+      pipetteSettings: null,
+    }
+    const { queryByRole } = render(props)
+    const settings = queryByRole('button', { name: 'Pipette Settings' })
+
+    expect(settings).not.toBeInTheDocument()
   })
 })

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteSettingsSlideout.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteSettingsSlideout.test.tsx
@@ -5,10 +5,7 @@ import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../i18n'
 import * as RobotApi from '../../../../redux/robot-api'
-import {
-  getAttachedPipetteSettingsFieldsById,
-  updatePipetteSettings,
-} from '../../../../redux/pipettes'
+import { updatePipetteSettings } from '../../../../redux/pipettes'
 import { getConfig } from '../../../../redux/config'
 import { PipetteSettingsSlideout } from '../PipetteSettingsSlideout'
 
@@ -30,9 +27,6 @@ const mockUseDispatchApiRequest = RobotApi.useDispatchApiRequest as jest.MockedF
 >
 const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
   typeof RobotApi.getRequestById
->
-const mockGetAttachedPipetteSettingsFieldsById = getAttachedPipetteSettingsFieldsById as jest.MockedFunction<
-  typeof getAttachedPipetteSettingsFieldsById
 >
 const mockUpdatePipetteSettings = updatePipetteSettings as jest.MockedFunction<
   typeof updatePipetteSettings
@@ -56,6 +50,7 @@ describe('PipetteSettingsSlideout', () => {
   beforeEach(() => {
     props = {
       pipetteId: 'id',
+      settings: mockPipetteSettingsFieldsMap,
       robotName: mockRobotName,
       pipetteName: mockLeftSpecs.displayName,
       isExpanded: true,
@@ -71,9 +66,6 @@ describe('PipetteSettingsSlideout', () => {
       },
     })
     mockGetConfig.mockReturnValue({} as any)
-    mockGetAttachedPipetteSettingsFieldsById.mockReturnValue(
-      mockPipetteSettingsFieldsMap
-    )
     dispatchApiRequest = jest.fn()
     when(mockUseDispatchApiRequest)
       .calledWith()

--- a/app/src/redux/robot-update/__tests__/epic.test.ts
+++ b/app/src/redux/robot-update/__tests__/epic.test.ts
@@ -207,7 +207,7 @@ describe('robot update epics', () => {
 
         expectObservable(output$).toBe('-a', {
           a: actions.unexpectedRobotUpdateError(
-            'This robot must be updated by the system before a custom update can occur.'
+            'This robot must be updated by the system before a custom update can occur'
           ),
         })
       })

--- a/app/src/redux/robot-update/epic.ts
+++ b/app/src/redux/robot-update/epic.ts
@@ -97,10 +97,10 @@ const ROBOT_DID_NOT_RECONNECT = 'Robot did not successfully reconnect'
 const BUT_WE_EXPECTED = 'but we expected'
 const UNKNOWN = 'unknown'
 const CHECK_TO_VERIFY_UPDATE =
-  "Check your robot's settings page to verify whether or not the update was successful."
-const UNABLE_TO_FIND_SYSTEM_FILE = 'Unable to find system file for update.'
+  "Check your robot's settings page to verify whether or not the update was successful"
+const UNABLE_TO_FIND_SYSTEM_FILE = 'Unable to find system file for update'
 const ROBOT_REQUIRES_PREMIGRATION =
-  'This robot must be updated by the system before a custom update can occur.'
+  'This robot must be updated by the system before a custom update can occur'
 
 // listen for the kickoff action and:
 //   if not ready for buildroot, kickoff premigration


### PR DESCRIPTION
Closes RQA-1231, RQA-1228

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR addresses an OT-2 issue in which advanced pipette settings would display an empty modal for certain pipettes. HW indicates we don't actually have more pipette function updates on the backend, so the plan is not to show "pipette settings as an option within the overflow menu (and in general) if the pipette does not have settings stored on the server.

### Before 

<img width="1440" alt="Screenshot 2023-08-04 at 1 13 49 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/1497bb94-de15-4027-a8d6-a412ece64ec2">

### After

<img width="1013" alt="Screenshot 2023-09-26 at 10 58 55 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/0f743981-fbf5-4799-8744-d8745869e68e">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verify that existing pipettes on the /pipettes/settings endpoint still show an overflow menu option with an appropriate modal.
- Verify that a pipette that is not able to store settings on the /pipettes/settings endpoint does not show the overflow menu (P3HSV202019072249 on ParityBot, example).

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Fixed text errors displaying extra periods.
- Moved the selector logic up a few component layers to PipetteCard to conditionally render the overflow button.
- Improved the conditional check within PipetteSettingsSlideout, as there are instances where this is rendered without the overflow menu (mainly after attaching a different pipette).
- Added relevant testing.
- 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
