### PR TITLE
fix(api): specify gripper probe

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -778,7 +778,7 @@ async def calibrate_gripper_jaw(
         hcapi.add_gripper_probe(probe)
         await hcapi.grip(GRIPPER_GRIP_FORCE)
         offset = await _calibrate_mount(
-            hcapi, OT3Mount.GRIPPER, slot, method, raise_verify_error
+            hcapi, OT3Mount.GRIPPER, slot, method, raise_verify_error, probe=probe.to_type(probe)
         )
         LOG.info(f"Gripper {probe.name} probe offset: {offset}")
         return offset

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -778,7 +778,12 @@ async def calibrate_gripper_jaw(
         hcapi.add_gripper_probe(probe)
         await hcapi.grip(GRIPPER_GRIP_FORCE)
         offset = await _calibrate_mount(
-            hcapi, OT3Mount.GRIPPER, slot, method, raise_verify_error, probe=probe.to_type(probe)
+            hcapi,
+            OT3Mount.GRIPPER,
+            slot,
+            method,
+            raise_verify_error,
+            probe=probe.to_type(probe),
         )
         LOG.info(f"Gripper {probe.name} probe offset: {offset}")
         return offset


### PR DESCRIPTION
462049edbc added the ability to calibrate the 8 channel pipette, but broke calibration for gripper and possibly 96 channel while doing so since those devices need to calibrate with the secondary probe by default.

This fixes that problem by explicitly forwarding the requested probe to the internals.
