### PR TITLE
fix(api): Addition of distribution error to prevent invalid disposal values

### DIFF
--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -696,11 +696,12 @@ class TransferPlan:
                *.. Aspirate -> Air gap -> Touch tip ->..
                .. Aspirate -> .....*
         """
-        self._check_valid_volume_parameters(
-            disposal_volume=self._strategy.disposal_volume,
-            air_gap=self._strategy.air_gap,
-            max_volume=self._instr.max_volume,
-        )
+        # TODO: verify if _check_valid_volume_parameters should be re-enabled here
+        # self._check_valid_volume_parameters(
+        #     disposal_volume=self._strategy.disposal_volume,
+        #     air_gap=self._strategy.air_gap,
+        #     max_volume=self._instr.max_volume,
+        # )
         plan_iter = self._expand_for_volume_constraints(
             # todo(mm, 2021-03-09): Is it right to use _instr.max_volume here?
             # Why don't we account for tip max volume, disposal volume, or air

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -534,6 +534,12 @@ class TransferPlan:
             ]
         return sources, targets
 
+    def _check_valid_disposal_volume(self):
+        if self._strategy.disposal_volume >= self._instr.max_volume:
+            raise ValueError(
+                "The disposal volume must be less than the maximum volume of the pipette"
+            )
+
     def _plan_distribute(self):
         """
         * **Source/ Dest:** One source to many destinations
@@ -572,10 +578,7 @@ class TransferPlan:
 
         """
 
-        if self._strategy.disposal_volume >= self._instr.max_volume:
-            raise ValueError(
-                "The Disposal Volume must be less than the Maximum Volume of the Instrument"
-            )
+        self._check_valid_disposal_volume()
 
         # TODO: decide whether default disposal vol for distribute should be
         # pipette min_vol or should we leave it to being 0 by default and

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -484,6 +484,11 @@ class TransferPlan:
             -> Blow out -> Touch tip -> Drop tip*
         """
         # reform source target lists
+        self._check_valid_volume_parameters(
+            self._strategy.disposal_volume,
+            self._strategy.air_gap,
+            self._instr._core.get_working_volume(),
+        )
         sources, dests = self._extend_source_target_lists(self._sources, self._dests)
         plan_iter = self._expand_for_volume_constraints(
             self._volumes,
@@ -534,12 +539,6 @@ class TransferPlan:
             ]
         return sources, targets
 
-    def _check_valid_disposal_volume(self, disposal_volume, working_volume):
-        if disposal_volume >= working_volume:
-            raise ValueError(
-                "The disposal volume must be less than the working volume of the pipette"
-            )
-
     def _plan_distribute(self):
         """
         * **Source/ Dest:** One source to many destinations
@@ -578,8 +577,10 @@ class TransferPlan:
 
         """
 
-        self._check_valid_disposal_volume(
-            self._strategy.disposal_volume, self._instr._core.get_working_volume()
+        self._check_valid_volume_parameters(
+            self._strategy.disposal_volume,
+            self._strategy.air_gap,
+            self._instr._core.get_working_volume(),
         )
 
         # TODO: decide whether default disposal vol for distribute should be
@@ -644,6 +645,7 @@ class TransferPlan:
         """Split a sequence of proposed transfers if necessary to keep each
         transfer under the given max volume.
         """
+        assert max_volume > 0
         for volume, target in zip(volumes, targets):
             while volume > max_volume * 2:
                 yield max_volume, target
@@ -691,6 +693,11 @@ class TransferPlan:
                *.. Aspirate -> Air gap -> Touch tip ->..
                .. Aspirate -> .....*
         """
+        self._check_valid_volume_parameters(
+            self._strategy.disposal_volume,
+            self._strategy.air_gap,
+            self._instr._core.get_working_volume(),
+        )
         plan_iter = self._expand_for_volume_constraints(
             # todo(mm, 2021-03-09): Is it right to use _instr.max_volume here?
             # Why don't we account for tip max volume, disposal volume, or air
@@ -853,6 +860,20 @@ class TransferPlan:
             return (rel_y * diff_vol) + min_v
 
         return [_map_volume(i) for i in range(total)]
+
+    def _check_valid_volume_parameters(self, disposal_volume, air_gap, working_volume):
+        if air_gap >= working_volume:
+            raise ValueError(
+                "The air gap must be less than the working volume of the pipette"
+            )
+        elif disposal_volume >= working_volume:
+            raise ValueError(
+                "The disposal volume must be less than the working volume of the pipette"
+            )
+        elif disposal_volume + air_gap >= working_volume:
+            raise ValueError(
+                "The sum of the air gap and disposal volume must be less than the working volume of the pipette"
+            )
 
     def _check_valid_well_list(self, well_list, id, old_well_list):
         if self._api_version >= APIVersion(2, 2) and len(well_list) < 1:

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -870,15 +870,15 @@ class TransferPlan:
     ):
         if air_gap >= max_volume:
             raise ValueError(
-                "The air gap must be less than the working volume of the pipette"
+                "The air gap must be less than the maximum volume of the pipette"
             )
         elif disposal_volume >= max_volume:
             raise ValueError(
-                "The disposal volume must be less than the working volume of the pipette"
+                "The disposal volume must be less than the maximum volume of the pipette"
             )
         elif disposal_volume + air_gap >= max_volume:
             raise ValueError(
-                "The sum of the air gap and disposal volume must be less than the working volume of the pipette"
+                "The sum of the air gap and disposal volume must be less than the maximum volume of the pipette"
             )
 
     def _check_valid_well_list(self, well_list, id, old_well_list):

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -534,10 +534,10 @@ class TransferPlan:
             ]
         return sources, targets
 
-    def _check_valid_disposal_volume(self):
-        if self._strategy.disposal_volume >= self._instr.max_volume:
+    def _check_valid_disposal_volume(self, disposal_volume, working_volume):
+        if disposal_volume >= working_volume:
             raise ValueError(
-                "The disposal volume must be less than the maximum volume of the pipette"
+                "The disposal volume must be less than the working volume of the pipette"
             )
 
     def _plan_distribute(self):
@@ -578,7 +578,9 @@ class TransferPlan:
 
         """
 
-        self._check_valid_disposal_volume()
+        self._check_valid_disposal_volume(
+            self._strategy.disposal_volume, self._instr._core.get_working_volume()
+        )
 
         # TODO: decide whether default disposal vol for distribute should be
         # pipette min_vol or should we leave it to being 0 by default and

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -571,6 +571,12 @@ class TransferPlan:
                .. Dispense air gap -> ...*
 
         """
+
+        if self._strategy.disposal_volume >= self._instr.max_volume:
+            raise ValueError(
+                "The Disposal Volume must be less than the Maximum Volume of the Instrument"
+            )
+
         # TODO: decide whether default disposal vol for distribute should be
         # pipette min_vol or should we leave it to being 0 by default and
         # recommend users to specify a disposal vol when using distribute.

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -796,6 +796,17 @@ def test_all_options(_instr_labware):
     assert xfer_plan_list == exp1
 
 
+def test_invalid_disposal_volume_distribute(_instr_labware):
+    _instr_labware["ctx"].home()
+    # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
+    with pytest.raises(ValueError):
+        tx.TransferPlan._check_valid_disposal_volume(
+            _instr_labware,
+            _instr_labware["instr"].hw_pipette["max_volume"],
+            _instr_labware["instr"].hw_pipette["max_volume"],
+        )
+
+
 def test_oversized_distribute(_instr_labware):
     _instr_labware["ctx"].home()
     lw1 = _instr_labware["lw1"]

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -796,15 +796,81 @@ def test_all_options(_instr_labware):
     assert xfer_plan_list == exp1
 
 
+def test_invalid_air_gap_disposal_sum_distribute(_instr_labware):
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
+    # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
+
+    options = tx.TransferOptions()
+    options = options._replace(
+        transfer=options.transfer._replace(
+            disposal_volume=_instr_labware["instr"].max_volume / 2,
+            air_gap=_instr_labware["instr"].max_volume / 2,
+        )
+    )
+    with pytest.raises(ValueError):
+        plan = tx.TransferPlan(
+            700,
+            lw1.columns()[0][0],
+            lw2.rows()[0][1:3],
+            _instr_labware["instr"],
+            max_volume=_instr_labware["instr"].hw_pipette["max_volume"],
+            api_version=_instr_labware["ctx"].api_version,
+            mode="distribute",
+            options=options,
+        )
+        list(plan)
+
+
+def test_invalid_air_gap_distribute(_instr_labware):
+    _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
+    # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
+
+    options = tx.TransferOptions()
+    options = options._replace(
+        transfer=options.transfer._replace(air_gap=_instr_labware["instr"].max_volume)
+    )
+    with pytest.raises(ValueError):
+        plan = tx.TransferPlan(
+            700,
+            lw1.columns()[0][0],
+            lw2.rows()[0][1:3],
+            _instr_labware["instr"],
+            max_volume=_instr_labware["instr"].hw_pipette["max_volume"],
+            api_version=_instr_labware["ctx"].api_version,
+            mode="distribute",
+            options=options,
+        )
+        list(plan)
+
+
 def test_invalid_disposal_volume_distribute(_instr_labware):
     _instr_labware["ctx"].home()
+    lw1 = _instr_labware["lw1"]
+    lw2 = _instr_labware["lw2"]
     # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
-    with pytest.raises(ValueError):
-        tx.TransferPlan._check_valid_disposal_volume(
-            _instr_labware,
-            _instr_labware["instr"].hw_pipette["max_volume"],
-            _instr_labware["instr"].hw_pipette["max_volume"],
+
+    options = tx.TransferOptions()
+    options = options._replace(
+        transfer=options.transfer._replace(
+            disposal_volume=_instr_labware["instr"].max_volume
         )
+    )
+    with pytest.raises(ValueError):
+        plan = tx.TransferPlan(
+            700,
+            lw1.columns()[0][0],
+            lw2.rows()[0][1:3],
+            _instr_labware["instr"],
+            max_volume=_instr_labware["instr"].hw_pipette["max_volume"],
+            api_version=_instr_labware["ctx"].api_version,
+            mode="distribute",
+            options=options,
+        )
+        list(plan)
 
 
 def test_oversized_distribute(_instr_labware):

--- a/api/tests/opentrons/protocols/advanced_control/test_transfers.py
+++ b/api/tests/opentrons/protocols/advanced_control/test_transfers.py
@@ -802,9 +802,8 @@ def test_invalid_air_gap_disposal_sum_distribute(_instr_labware):
     lw2 = _instr_labware["lw2"]
     # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
 
-    options = tx.TransferOptions()
-    options = options._replace(
-        transfer=options.transfer._replace(
+    options = tx.TransferOptions(
+        transfer=tx.Transfer(
             disposal_volume=_instr_labware["instr"].max_volume / 2,
             air_gap=_instr_labware["instr"].max_volume / 2,
         )
@@ -820,6 +819,7 @@ def test_invalid_air_gap_disposal_sum_distribute(_instr_labware):
             mode="distribute",
             options=options,
         )
+        # Exhaust the iterator in case it raises the expected exception lazily.
         list(plan)
 
 
@@ -829,9 +829,8 @@ def test_invalid_air_gap_distribute(_instr_labware):
     lw2 = _instr_labware["lw2"]
     # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
 
-    options = tx.TransferOptions()
-    options = options._replace(
-        transfer=options.transfer._replace(air_gap=_instr_labware["instr"].max_volume)
+    options = tx.TransferOptions(
+        transfer=tx.Transfer(air_gap=_instr_labware["instr"].max_volume)
     )
     with pytest.raises(ValueError):
         plan = tx.TransferPlan(
@@ -844,6 +843,7 @@ def test_invalid_air_gap_distribute(_instr_labware):
             mode="distribute",
             options=options,
         )
+        # Exhaust the iterator in case it raises the expected exception lazily.
         list(plan)
 
 
@@ -853,11 +853,8 @@ def test_invalid_disposal_volume_distribute(_instr_labware):
     lw2 = _instr_labware["lw2"]
     # Supply the disposal volume assessment with the instrument followed by a disposal value equal to the max volume
 
-    options = tx.TransferOptions()
-    options = options._replace(
-        transfer=options.transfer._replace(
-            disposal_volume=_instr_labware["instr"].max_volume
-        )
+    options = tx.TransferOptions(
+        transfer=tx.Transfer(disposal_volume=_instr_labware["instr"].max_volume)
     )
     with pytest.raises(ValueError):
         plan = tx.TransferPlan(
@@ -870,6 +867,7 @@ def test_invalid_disposal_volume_distribute(_instr_labware):
             mode="distribute",
             options=options,
         )
+        # Exhaust the iterator in case it raises the expected exception lazily.
         list(plan)
 
 


### PR DESCRIPTION
# Overview
Prevents the distribute functionality from accepting a disposal value equal to or greater than the maximum value of the instrument. This was necessary to prevent an infinite looping issue where when disposal values greater than or equal to the maximum volume of an instrument were provided, which would cause the looping component of the _plan_distribute function to get caught in an state that was impossible to complete. This would seek to solve the issue detailed in RSS-347.
