### PR TITLE
docs(api): specify link text for most `:ref:` links and fix broken links

### DIFF
--- a/api/docs/v2/adapting_ot2_flex.rst
+++ b/api/docs/v2/adapting_ot2_flex.rst
@@ -18,7 +18,7 @@ Metadata and Requirements
 Flex requires you to specify an ``apiLevel`` of 2.15 or higher. If your OT-2 protocol specified ``apiLevel`` in the ``metadata`` dictionary, it's best to move it to the ``requirements`` dictionary. You can't specify it in both places, or the API will raise an error.
 
 .. note::
-    Consult the list of :ref:`version-notes` to see what effect raising the ``apiLevel`` will have. If you increased it by multiple minor versions to get your protocol running on Flex, make sure that your protocol isn't using removed commands or commands whose behavior has changed in a way that may affect your scientific results.
+    Consult the :ref:`list of changes in API versions <version-notes>` to see what effect raising the ``apiLevel`` will have. If you increased it by multiple minor versions to get your protocol running on Flex, make sure that your protocol isn't using removed commands or commands whose behavior has changed in a way that may affect your scientific results.
 
 You also need to specify ``'robotType': 'Flex'``. If you omit ``robotType`` in the ``requirements`` dictionary, the API will assume the protocol is designed for the OT-2.
 
@@ -87,7 +87,7 @@ This example converts OT-2 code that uses a P300 Single-Channel GEN2 pipette and
 Deck Slot Labels
 ================
 
-It's good practice to update numeric labels for :ref:`deck-slots` (which match the labels on an OT-2) to coordinate ones (which match the labels on Flex). This is an optional step, since the two formats are interchangeable.
+It's good practice to update numeric labels for :ref:`deck slots <deck-slots>` (which match the labels on an OT-2) to coordinate ones (which match the labels on Flex). This is an optional step, since the two formats are interchangeable.
 
 For example, the code in the previous section changed the location of the tip rack from ``1`` to ``"D1"``.
 
@@ -102,7 +102,7 @@ If your OT-2 protocol uses older generations of the Temperature Module or Thermo
     
 The Heater-Shaker Module only has one generation, ``heaterShakerModuleV1``, which is compatible with Flex and OT-2.
 
-The Magnetic Module is not compatible with Flex. For protocols that load ``magnetic module``, ``magdeck``, or ``magnetic module gen2``, you will need to make further modifications to use the :ref:`magnetic-block` and Flex Gripper instead. This will require reworking some of your protocol steps, and you should verify that your new protocol design achieves similar results.
+The Magnetic Module is not compatible with Flex. For protocols that load ``magnetic module``, ``magdeck``, or ``magnetic module gen2``, you will need to make further modifications to use the :ref:`Magnetic Block <magnetic-block>` and Flex Gripper instead. This will require reworking some of your protocol steps, and you should verify that your new protocol design achieves similar results.
 
 This simplified example, taken from a DNA extraction protocol, shows how using the Flex Gripper and the Magnetic Block can save time. Instead of pipetting an entire plate's worth of liquid from the Heater-Shaker to the Magnetic Module and then engaging the module, the gripper moves the plate to the Magnetic Block in one step.
 

--- a/api/docs/v2/complex_commands/order_operations.rst
+++ b/api/docs/v2/complex_commands/order_operations.rst
@@ -6,14 +6,14 @@
 Order of Operations
 *******************
 
-Complex commands perform a series of :ref:`v2-atomic-commands` in order. In fact, the run preview for your protocol in the Opentrons App lists all of these commands as separate steps. This lets you examine what effect your complex commands will have before running them. 
+Complex commands perform a series of :ref:`building block commands <v2-atomic-commands>` in order. In fact, the run preview for your protocol in the Opentrons App lists all of these commands as separate steps. This lets you examine what effect your complex commands will have before running them. 
 
 This page describes what steps you should expect the robot to perform when using different complex commands with different required and :ref:`optional <complex_params>` parameters.
 
 Step Sequence
 =============
 
-The order of steps is fixed within complex commands. Aspiration and dispensing are the only required actions. You can enable or disable all of the other actions with :ref:`complex_params`. A complex command designed to perform every possible action will proceed in this order:
+The order of steps is fixed within complex commands. Aspiration and dispensing are the only required actions. You can enable or disable all of the other actions with :ref:`complex liquid handling parameters <complex_params>`. A complex command designed to perform every possible action will proceed in this order:
 
     1. Pick up tip
     2. Mix at source

--- a/api/docs/v2/complex_commands/sources_destinations.rst
+++ b/api/docs/v2/complex_commands/sources_destinations.rst
@@ -175,7 +175,7 @@ When the source and destination both contain the same number of wells, the mappi
       - B11
       - B12
 
-There's no requirement that the source and destination lists be mutually exclusive. In fact, this command adapted from the :ref:`tutorial` deliberately uses slices of the same list, saved to the variable ``row``, with the effect that each aspiration happens in the same location as the previous dispense::
+There's no requirement that the source and destination lists be mutually exclusive. In fact, this command adapted from the :ref:`tutorial <tutorial>` deliberately uses slices of the same list, saved to the variable ``row``, with the effect that each aspiration happens in the same location as the previous dispense::
 
     row = plate.rows()[0]
     pipette.transfer(

--- a/api/docs/v2/modules/magnetic_block.rst
+++ b/api/docs/v2/modules/magnetic_block.rst
@@ -7,7 +7,7 @@ Magnetic Block
 **************
 
 .. note::
-   The Magnetic Block is compatible with Opentrons Flex only. If you have an OT-2, use the :ref:`magnetic-module`.
+   The Magnetic Block is compatible with Opentrons Flex only. If you have an OT-2, use the :ref:`Magnetic Module <magnetic-module>`.
 
 The Magnetic Block is an unpowered, 96-well plate that holds labware close to its high-strength neodymium magnets. This module is suitable for many magnetic bead-based protocols, but does not move beads up or down in solution.
 

--- a/api/docs/v2/modules/magnetic_module.rst
+++ b/api/docs/v2/modules/magnetic_module.rst
@@ -7,7 +7,7 @@ Magnetic Module
 ***************
 
 .. note::
-   The Magnetic Module is compatible with the OT-2 only. If you have a Flex, use the :ref:`magnetic-block`.
+   The Magnetic Module is compatible with the OT-2 only. If you have a Flex, use the :ref:`Magnetic Block <magnetic-block>`.
 
 The Magnetic Module controls a set of permanent magnets which can move vertically to induce a magnetic field in the labware loaded on the module. 
 

--- a/api/docs/v2/modules/setup.rst
+++ b/api/docs/v2/modules/setup.rst
@@ -96,7 +96,7 @@ The first parameter of :py:meth:`.ProtocolContext.load_module` is the module's  
    | GEN1               |                               |                           |
    +--------------------+-------------------------------+---------------------------+
 
-Some modules were added to our Python API later than others, and others span multiple hardware generations. When writing a protocol that requires a module, make sure your ``requirements`` or ``metadata`` code block specifies a :ref:`Protocol API version <v2-versioning>` high enough to support all the module generations you want to use.
+Some modules were added to our Python API later than others, and others span multiple hardware generations. When writing a protocol that requires a module, make sure your ``requirements`` or ``metadata`` code block specifies an :ref:`API version <v2-versioning>` high enough to support all the module generations you want to use.
 
 .. _load-labware-module:
 
@@ -117,7 +117,7 @@ Use the ``load_labware()`` method on the module context to load labware on a mod
 
 When you load labware on a module, you don’t need to specify the deck slot. In the above example, the ``load_module()`` method already specifies where the module is on the deck: ``location= "D1"``.
 
-Any :ref:`v2-custom-labware` added to your Opentrons App is also accessible when loading labware onto a module. You can find and copy its load name by going to its card on the Labware page.
+Any :ref:`custom labware <v2-custom-labware>` added to your Opentrons App is also accessible when loading labware onto a module. You can find and copy its load name by going to its card on the Labware page.
 
 .. versionadded:: 2.1
 

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -133,7 +133,7 @@ If you have custom labware definitions you want to use with Jupyter, make a new 
 Using Modules
 -------------
 
-If your protocol uses :ref:`new_modules`, you need to take additional steps to make sure that Jupyter Notebook doesn't send commands that conflict with the robot server. Sending commands to modules while the robot server is running will likely cause errors, and the module commands may not execute as expected.
+If your protocol uses :ref:`modules <new_modules>`, you need to take additional steps to make sure that Jupyter Notebook doesn't send commands that conflict with the robot server. Sending commands to modules while the robot server is running will likely cause errors, and the module commands may not execute as expected.
 
 To disable the robot server, open a Jupyter terminal session by going to **New > Terminal** and run ``systemctl stop opentrons-robot-server``. Then you can run code from cells in your notebook as usual. When you are done using Jupyter Notebook, you should restart the robot server with ``systemctl start opentrons-robot-server``.
 

--- a/api/docs/v2/new_complex_commands.rst
+++ b/api/docs/v2/new_complex_commands.rst
@@ -11,7 +11,7 @@ Complex Commands
     complex_commands/order_operations
     complex_commands/parameters
 
-Complex liquid handling commands combine multiple :ref:`v2-atomic-commands` into a single method call. These commands make it easier to handle larger groups of wells and repeat actions without having to write your own control flow code. They integrate tip-handling behavior and can pick up, use, and drop multiple tips depending on how you want to handle your liquids. They can optionally perform other actions, like adding air gaps, knocking droplets off the tip, mixing, and blowing out excess liquid from the tip.
+Complex liquid handling commands combine multiple :ref:`building block commands <v2-atomic-commands>` into a single method call. These commands make it easier to handle larger groups of wells and repeat actions without having to write your own control flow code. They integrate tip-handling behavior and can pick up, use, and drop multiple tips depending on how you want to handle your liquids. They can optionally perform other actions, like adding air gaps, knocking droplets off the tip, mixing, and blowing out excess liquid from the tip.
 
 There are three complex liquid handling commands, each optimized for a different liquid handling scenario: 
 
@@ -25,4 +25,4 @@ Pages in this section of the documentation cover:
     - :ref:`complex-command-order`: The order of basic commands that are part of a complex commmand.
     - :ref:`complex_params`: Additional keyword arguments that affect complex command behavior.
     
-Code samples throughout these pages assume that you've loaded the pipettes and labware from the basic :ref:`protocol-template`.
+Code samples throughout these pages assume that you've loaded the pipettes and labware from the :ref:`basic protocol template <protocol-template>`.

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -6,7 +6,7 @@
 Protocol Examples
 *****************
 
-This page provides simple, ready-made protocols for Flex and OT-2. Feel free to copy and modify these examples to create unique protocols that help automate your laboratory workflows. Also, experimenting with these protocols is another way to build upon the skills you've learned from working through the :ref:`tutorial`. Try adding different hardware, labware, and commands to a sample protocol and test its validity after importing it into the Opentrons App.
+This page provides simple, ready-made protocols for Flex and OT-2. Feel free to copy and modify these examples to create unique protocols that help automate your laboratory workflows. Also, experimenting with these protocols is another way to build upon the skills you've learned from working through the :ref:`tutorial <tutorial>`. Try adding different hardware, labware, and commands to a sample protocol and test its validity after importing it into the Opentrons App.
 
 Using These Protocols
 =====================
@@ -131,7 +131,7 @@ These protocols demonstrate how to move 100 µL of liquid from one well to anoth
 Basic Method
 ------------
 
-This protocol uses some :ref:`basic commands <v2-atomic-commands>` to tell the robot, explicitly, where to go to aspirate and dispense liquid. These commands include the :py:meth:`~.InstrumentContext.pick_up_tip`, :py:meth:`~.InstrumentContext.aspirate`, and :py:meth:`~.InstrumentContext.dispense` methods.
+This protocol uses some :ref:`building block commands <v2-atomic-commands>` to tell the robot, explicitly, where to go to aspirate and dispense liquid. These commands include the :py:meth:`~.InstrumentContext.pick_up_tip`, :py:meth:`~.InstrumentContext.aspirate`, and :py:meth:`~.InstrumentContext.dispense` methods.
 
 .. tabs::
 

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -21,6 +21,8 @@ Default Labware
 
 Default labware is everything listed in the `Opentrons Labware Library <https://labware.opentrons.com/>`_. When used in a protocol, your Flex or OT-2 knows how to work with default labware. However, you must first inform the API about the labware you will place on the robot’s deck. Search the library when you’re looking for the API load names of the labware you want to use. You can copy the load names from the library and pass them to the :py:meth:`~.ProtocolContext.load_labware` method in your protocol.
 
+.. _v2-custom-labware:
+
 Custom Labware
 ==============
 
@@ -316,7 +318,7 @@ The ``load_liquid`` arguments include a volume amount (``volume=n`` in µL). Thi
 Well Dimensions
 ***************
 
-The functions in the :ref:`new-well-access` section above return a single :py:class:`.Well` object or a larger object representing many wells. :py:class:`.Well` objects have attributes that provide information about their physical shape, such as the depth or diameter, as specified in their corresponding labware definition. These properties can be used for different applications, such as calculating the volume of a well or a :ref:`position-relative-labware`.
+The functions in the :ref:`new-well-access` section above return a single :py:class:`.Well` object or a larger object representing many wells. :py:class:`.Well` objects have attributes that provide information about their physical shape, such as the depth or diameter, as specified in their corresponding labware definition. These properties can be used for different applications, such as calculating the volume of a well or a :ref:`position relative to the well <position-relative-labware>`.
 
 Depth
 =====

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -408,6 +408,8 @@ The following table provides data on the default aspirate, dispense, and blow-ou
 
 Additionally, all Flex pipettes have a well bottom clearance of 1 mm for aspirate and dispense actions.
 
+.. _ot2-flow-rates:
+
 OT-2 Pipette Flow Rates
 -----------------------
 

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -78,7 +78,7 @@ For this tutorial, you’ll write very little Python outside of the ``run()`` fu
 Metadata
 ^^^^^^^^
 
-Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version <version-table>` of the API the protocol requires. The `scripts <https://github.com/Opentrons/opentrons/blob/edge/api/docs/v2/example_protocols/>`_ for this tutorial were validated against API version 2.15, so specify:
+Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version of the API <version-table>` the protocol requires. The `scripts <https://github.com/Opentrons/opentrons/blob/edge/api/docs/v2/example_protocols/>`_ for this tutorial were validated against API version 2.15, so specify:
 
 .. code-block:: python
 
@@ -364,4 +364,4 @@ When it’s all done, check the results of your serial dilution procedure — yo
 Next Steps
 **********
 
-This tutorial has relied heavily on the ``transfer()`` method, but there's much more that the Python Protocol API can do. Many advanced applications use :ref:`building block commands <v2-atomic-commands>` for finer control over the robot. These commands let you aspirate and dispense separately, add air gaps, blow out excess liquid, move the pipette to any location, and more. For protocols that use Opentrons :ref:`new_modules`, there are methods to control their behavior. And all of the API's classes and methods are catalogued in the :ref:`protocol-api-reference`.
+This tutorial has relied heavily on the ``transfer()`` method, but there's much more that the Python Protocol API can do. Many advanced applications use :ref:`building block commands <v2-atomic-commands>` for finer control over the robot. These commands let you aspirate and dispense separately, add air gaps, blow out excess liquid, move the pipette to any location, and more. For protocols that use :ref:`Opentrons hardware modules <new_modules>`, there are methods to control their behavior. And all of the API's classes and methods are catalogued in the :ref:`API Reference <protocol-api-reference>`.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -140,7 +140,7 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - The new :py:meth:`.move_labware` method can move labware automatically using the Flex Gripper. You can also move labware manually on Flex.
   
-  - :py:meth:`.load_module` supports loading the :ref:`magnetic-block`. 
+  - :py:meth:`.load_module` supports loading the :ref:`Magnetic Block <magnetic-block>`. 
   
   - The API does not enforce placement restrictions for the Heater-Shaker module on Flex, because it is installed below-deck in a module caddy. Pipetting restrictions are still in place when the Heater-Shaker is shaking or its labware latch is open.
   
@@ -150,7 +150,7 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - Optionally specify ``"robotType": "OT-2"`` in ``requirements``.
 
-  - Use coordinates or numbers to specify :ref:`deck-slots`. These formats match physical labels on Flex and OT-2, but you can use either system, regardless of ``robotType``.
+  - Use coordinates or numbers to specify :ref:`deck slots <deck-slots>`. These formats match physical labels on Flex and OT-2, but you can use either system, regardless of ``robotType``.
   
   - The new :py:meth:`.load_adapter` method lets you load adapters and labware separately on modules, and lets you load adapters directly in deck slots. See :ref:`labware-on-adapters`.
   
@@ -292,7 +292,7 @@ Version 2.8
 
 - You can now pass in a list of volumes to distribute and consolidate. See :ref:`distribute-consolidate-volume-list` for more information.
 
-  - Passing in a zero volume to any :ref:`v2-complex-commands` will result in no actions taken for aspirate or dispense
+  - Passing in a zero volume to any :ref:`complex command <v2-complex-commands>` will result in no actions taken for aspirate or dispense
 
 - :py:meth:`.Well.from_center_cartesian` can be used to find a point within a well using normalized distance from the center in each axis.
 
@@ -323,13 +323,13 @@ Version 2.6
 
   - Protocols that manually configure pipette flow rates will be unaffected
 
-  - For a comparison between API Versions, see :ref:`defaults`
+  - For a comparison between API Versions, see :ref:`ot2-flow-rates`
 
 
 Version 2.5
 -----------
 
-- New :ref:`new-utility-commands` were added:
+- New :ref:`utility commands <new-utility-commands>` were added:
 
   - :py:meth:`.ProtocolContext.set_rail_lights`: turns robot rail lights on or off
   - :py:obj:`.ProtocolContext.rail_lights_on`: describes whether or not the rail lights are on
@@ -353,7 +353,7 @@ Version 2.3
   module gen2"`` and ``"temperature module gen2"``, respectively.
 - All pipettes will return tips to tip racks from a higher position to avoid
   possible collisions.
-- During a :ref:`mix`, the pipette will no longer move up to clear the liquid in
+- During a :py:meth:`.mix`, the pipette will no longer move up to clear the liquid in
   between every dispense and following aspirate.
 - You can now access the Temperature Module's status via :py:obj:`.TemperatureModuleContext.status`.
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

We've decided that nearly all `:ref:` links in the API docs should specify custom link text. Doing so provides more graceful fallbacks in case we change something at the target and don't realize that there's an inbound link.

For example, look at this inline link and target:

**Link**

```
Any :ref:`v2-custom-labware` added to your Opentrons App...
```

**Target**

```
.. _v2-custom-labware:

Custom Labware
==============
```

We accidentally broke the anchor at the target, and this text was rendering as "Any v2-custom-labware added to your Opentrons App". If we changed the header to `Custom Labware is Cool` then the text would render as "Any Custom Labware is Cool added to your Opentrons App". This didn't happen, but it would be even worse, because it's a _valid_ link that wouldn't raise a warning when compiling the docs.

Updating the link to…
```
:ref:`custom labware <v2-custom-labware>`
```
…fixes both scenarios. If we break the anchor, Sphinx renders "Any custom labware added…" with no link. If we change the header, the link text is still `custom labware`.

### What isn't changing

We're deliberately leaving plain `:ref:` links for _cross-references_ that identify a page or section, i.e., they aren't hyperlinks of an ordinary phrase in running prose.

In other words, if we want to say "See the _How to Foo_ section" and we have an anchor `.. _foo:`, we'll still use:
```
:ref:`foo`
```

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Searched for all uses of `:ref:` and checked they're valid links in local `make -C api docs` build.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- A light touch across many pages. I tried to only change link text. Sometimes this meant shifting a word or two into or out of the hyperlink.
- Changed one `:ref:` link to a `:py:meth:` reference because I thought it made more sense.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Check the [sandbox](http://sandbox.docs.opentrons.com/docs-improve-refs/v2/).

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

v low