### PR TITLE
fix(app): robot status header styling

### DIFF
--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -25,6 +25,7 @@ i18n.use(initReactI18next).init(
       escapeValue: false, // not needed for react as it escapes by default
       format: function (value, format, lng) {
         if (format === 'upperCase') return value.toUpperCase()
+        if (format === 'lowerCase') return value.toLowerCase()
         if (format === 'capitalize') return capitalize(value)
         if (format === 'sentenceCase') return startCase(value)
         if (format === 'titleCase') return titleCase(value)

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -46,7 +46,7 @@ const STATUS_REFRESH_MS = 5000
 
 export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   const { name, local, robotModel, ...styleProps } = props
-  const { t } = useTranslation([
+  const { t, i18n } = useTranslation([
     'devices_landing',
     'device_settings',
     'run_details',
@@ -75,8 +75,9 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
           paddingRight={SPACING.spacing8}
           overflowWrap="anywhere"
         >
-          {`${truncateString(displayName, 80, 65)}; ${t(
-            `run_details:status_${currentRunStatus}`
+          {`${truncateString(displayName, 80, 65)}; ${i18n.format(
+            t(`run_details:status_${currentRunStatus}`),
+            'lowerCase'
           )}`}
         </StyledText>
         <Link

--- a/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotStatusHeader.test.tsx
@@ -172,7 +172,7 @@ describe('RobotStatusHeader', () => {
 
     const [{ getByRole, getByText }] = render(props)
 
-    getByText('fake protocol name; Running')
+    getByText('fake protocol name; running')
 
     const runLink = getByRole('link', { name: 'Go to Run' })
     expect(runLink.getAttribute('href')).toEqual(


### PR DESCRIPTION
closes [RQA-1644](https://opentrons.atlassian.net/browse/RQA-1644)

# Overview

The robot status header (displaying protocol name and run status) is rendering the run status capitalized. Here, I change to lowercase to reflect designs. In doing this, I add a new formatting option to i18n interpolation for `lowerCase`.

# Test Plan

- verify that robot cards on devices landing page render lowercase run status
<img width="1040" alt="Screen Shot 2023-09-27 at 11 27 36 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/90f05a30-a166-4066-981c-79e0adbb19ac">

- verify that robot overview in device details page renders lowercase run status
<img width="1046" alt="Screen Shot 2023-09-27 at 11 27 47 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/77f5e33a-c815-4a3d-819a-1800289db0b3">

# Changelog

- add 'lowerCase` format option to i18n interpolation
- format current robot status on robot status header to lower case
- update tests
 
# Risk assessment

low

[RQA-1644]: https://opentrons.atlassian.net/browse/RQA-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ