### PR TITLE
fix(app): fix protocolsetup next step button issue

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -79,6 +79,9 @@ export function ProtocolRunSetup({
     LPC_KEY,
     LABWARE_SETUP_KEY,
   ])
+  const [targetStepKeyInOrder, setTargetStepKeyInOrder] = React.useState<
+    StepKey[]
+  >(stepsKeysInOrder)
 
   React.useEffect(() => {
     let nextStepKeysInOrder = stepsKeysInOrder
@@ -95,6 +98,33 @@ export function ProtocolRunSetup({
     setStepKeysInOrder(nextStepKeysInOrder)
   }, [Boolean(protocolData), protocolData?.commands])
 
+  React.useEffect(() => {
+    const filteredStepKeysInOrder = stepsKeysInOrder.filter(
+      (stepKey: StepKey) => {
+        if (protocolData == null) {
+          return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
+        }
+
+        if (
+          protocolData.modules.length === 0 &&
+          protocolData.liquids.length === 0
+        ) {
+          return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
+        }
+
+        if (protocolData.modules.length === 0) {
+          return stepKey !== MODULE_SETUP_KEY
+        }
+
+        if (protocolData.liquids.length === 0) {
+          return stepKey !== LIQUID_SETUP_KEY
+        }
+        return true
+      }
+    )
+    setTargetStepKeyInOrder(filteredStepKeysInOrder)
+  }, [stepsKeysInOrder, protocolData])
+
   if (robot == null) return null
   const hasLiquids = protocolData != null && protocolData.liquids?.length > 0
   const hasModules = protocolData != null && modules.length > 0
@@ -109,8 +139,8 @@ export function ProtocolRunSetup({
           robotName={robotName}
           runId={runId}
           nextStep={
-            stepsKeysInOrder[
-              stepsKeysInOrder.findIndex(
+            targetStepKeyInOrder[
+              targetStepKeyInOrder.findIndex(
                 v => v === ROBOT_CALIBRATION_STEP_KEY
               ) + 1
             ]
@@ -154,8 +184,8 @@ export function ProtocolRunSetup({
           robotName={robotName}
           runId={runId}
           nextStep={
-            stepsKeysInOrder.findIndex(v => v === LABWARE_SETUP_KEY) ===
-            stepsKeysInOrder.length - 1
+            targetStepKeyInOrder.findIndex(v => v === LABWARE_SETUP_KEY) ===
+            targetStepKeyInOrder.length - 1
               ? null
               : LIQUID_SETUP_KEY
           }

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -74,56 +74,39 @@ export function ProtocolRunSetup({
   const [expandedStepKey, setExpandedStepKey] = React.useState<StepKey | null>(
     null
   )
-  const [stepsKeysInOrder, setStepKeysInOrder] = React.useState<StepKey[]>([
-    ROBOT_CALIBRATION_STEP_KEY,
-    LPC_KEY,
-    LABWARE_SETUP_KEY,
-  ])
-  const [targetStepKeyInOrder, setTargetStepKeyInOrder] = React.useState<
-    StepKey[]
-  >(stepsKeysInOrder)
 
-  React.useEffect(() => {
-    let nextStepKeysInOrder = stepsKeysInOrder
+  const stepsKeysInOrder =
+    protocolData != null
+      ? [
+          ROBOT_CALIBRATION_STEP_KEY,
+          MODULE_SETUP_KEY,
+          LPC_KEY,
+          LABWARE_SETUP_KEY,
+          LIQUID_SETUP_KEY,
+        ]
+      : [ROBOT_CALIBRATION_STEP_KEY, LPC_KEY, LABWARE_SETUP_KEY]
 
-    if (protocolData != null) {
-      nextStepKeysInOrder = [
-        ROBOT_CALIBRATION_STEP_KEY,
-        MODULE_SETUP_KEY,
-        LPC_KEY,
-        LABWARE_SETUP_KEY,
-        LIQUID_SETUP_KEY,
-      ]
+  const targetStepKeyInOrder = stepsKeysInOrder.filter((stepKey: StepKey) => {
+    if (protocolData == null) {
+      return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
     }
-    setStepKeysInOrder(nextStepKeysInOrder)
-  }, [Boolean(protocolData), protocolData?.commands])
 
-  React.useEffect(() => {
-    const filteredStepKeysInOrder = stepsKeysInOrder.filter(
-      (stepKey: StepKey) => {
-        if (protocolData == null) {
-          return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
-        }
+    if (
+      protocolData.modules.length === 0 &&
+      protocolData.liquids.length === 0
+    ) {
+      return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
+    }
 
-        if (
-          protocolData.modules.length === 0 &&
-          protocolData.liquids.length === 0
-        ) {
-          return stepKey !== MODULE_SETUP_KEY && stepKey !== LIQUID_SETUP_KEY
-        }
+    if (protocolData.modules.length === 0) {
+      return stepKey !== MODULE_SETUP_KEY
+    }
 
-        if (protocolData.modules.length === 0) {
-          return stepKey !== MODULE_SETUP_KEY
-        }
-
-        if (protocolData.liquids.length === 0) {
-          return stepKey !== LIQUID_SETUP_KEY
-        }
-        return true
-      }
-    )
-    setTargetStepKeyInOrder(filteredStepKeysInOrder)
-  }, [stepsKeysInOrder, protocolData])
+    if (protocolData.liquids.length === 0) {
+      return stepKey !== LIQUID_SETUP_KEY
+    }
+    return true
+  })
 
   if (robot == null) return null
   const hasLiquids = protocolData != null && protocolData.liquids?.length > 0


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue is that nextStep doesn't track the actual required steps that a protocol file has. This pr check protocol data  and create an array to track the required steps

close RQA-1620
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update ProtocolSetup component to add filteredStepKeysInOrder array to track the actual required steps for the protocol setup
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
For `filteredStepKeysInOrder`, if there is a better way, please let me know.

if (protocolData?.modules.length !== 0) {
      nextStepKeysInOrder = [...nextStepKeysInOrder, MODULE_SETUP_KEY]
    } else if (protocolData.labware.length !== 0) {
      nextStepKeysInOrder = [...nextStepKeysInOrder, LABWARE_SETUP_KEY]
    } else if (protocolData.liquids.length !== 0) {
      nextStepKeysInOrder = [...nextStepKeysInOrder, LIQUID_SETUP_KEY]
    }
    setStepKeysInOrder(
      nextStepKeysInOrder.sort(
        (a, b) => targetStepsOrder.indexOf(a) - targetStepsOrder.indexOf(b)
      )
    )
```

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
