### PR TITLE
fix(app): filter LPC offsets for duplicates on ODD

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -11,6 +11,7 @@ import { useChainRunCommands } from '../../../resources/runs/hooks'
 import type { RegisterPositionAction } from '../types'
 import type { Jog } from '../../../molecules/JogControls'
 import { WizardRequiredEquipmentList } from '../../../molecules/WizardRequiredEquipmentList'
+import { getLatestCurrentOffsets } from '../../Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
 import { getIsOnDevice } from '../../../redux/config'
 import { NeedHelpLink } from '../../CalibrationPanels'
 import { useSelector } from 'react-redux'
@@ -144,6 +145,7 @@ function ViewOffsets(props: ViewOffsetsProps): JSX.Element {
   const { existingOffsets, labwareDefinitions } = props
   const { t, i18n } = useTranslation('labware_position_check')
   const [showOffsetsTable, setShowOffsetsModal] = React.useState(false)
+  const latestCurrentOffsets = getLatestCurrentOffsets(existingOffsets)
   return existingOffsets.length > 0 ? (
     <>
       <Btn
@@ -184,7 +186,7 @@ function ViewOffsets(props: ViewOffsetsProps): JSX.Element {
           >
             <Box overflowY="scroll" marginBottom={SPACING.spacing16}>
               <TerseOffsetTable
-                offsets={existingOffsets}
+                offsets={latestCurrentOffsets}
                 labwareDefinitions={labwareDefinitions}
               />
             </Box>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The "View Current Offsets" modal on the LPC step of protocol setup should be filtered on ODD the same way it is filtered on desktop
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Clone a run that has LPC offsets
2. Rerun LPC and change some of the offsets
3. Look at the applied offsets on protocol setup on the desktop app and on the ODD and see that there are the same number on each and no duplicates printed for the same labware/location combination

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Filter offsets for ODD modal the same way we do on the desktop app
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Run through test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
