### PR TITLE
fix(app): correct various displayed text inconsistencies

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -164,7 +164,7 @@
   "name_love_it": "{{name}}, love it!",
   "name_rule_description": "Enter up to 17 characters (letters and numbers only)",
   "name_rule_error_exist": "Oops! Name is already in use. Choose a different name.",
-  "name_rule_error_name_length": "Oops! Robot name must follow the character count and limitations",
+  "name_rule_error_name_length": "Oops! Robot name must follow the character count and limitations.",
   "name_rule_error_too_short": "Oops! Too short. Robot name must be at least 1 character.",
   "name_your_robot_description": "Don’t worry, you can always change this in your settings.",
   "name_your_robot": "Name your robot",

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -2,7 +2,7 @@
   "adapter_in_mod_in_slot": "{{adapter}} in {{module}} in {{slot}}",
   "adapter_in_slot": "{{adapter}} in {{slot}}",
   "adapter_in_tc": "{{adapter}} in {{module}}",
-  "all_modules_and_labware_from_protocol": "All modules and labware used in the protocol",
+  "all_modules_and_labware_from_protocol": "All modules and labware used in the protocol {{protocol_name}}",
   "applied_offset_data": "Applied Labware Offset data",
   "apply_offset_data": "Apply labware offset data",
   "apply_offsets": "apply offsets",

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -63,11 +63,22 @@ interface PipetteCardProps {
   updatePipette: () => void
   pipetteId?: AttachedPipette['id'] | null
 }
-const BANNER_LINK_CSS = css`
+const BANNER_LINK_STYLE = css`
   text-decoration: underline;
   cursor: pointer;
   margin-left: ${SPACING.spacing8};
 `
+
+const INSTRUMENT_CARD_STYLE = css`
+  p {
+    text-transform: lowercase;
+  }
+
+  p::first-letter {
+    text-transform: uppercase;
+  }
+`
+
 const SUBSYSTEM_UPDATE_POLL_MS = 5000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
@@ -294,6 +305,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       {(pipetteIsBad || subsystemUpdateData != null) && (
         <InstrumentCard
           label={i18n.format(t('mount', { side: mount }), 'capitalize')}
+          css={INSTRUMENT_CARD_STYLE}
           description={t('instrument_attached')}
           banner={
             <Banner
@@ -311,7 +323,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
                   updateLink: (
                     <StyledText
                       as="p"
-                      css={BANNER_LINK_CSS}
+                      css={BANNER_LINK_STYLE}
                       onClick={updatePipette}
                     />
                   ),

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/SetupLabwarePositionCheck.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/SetupLabwarePositionCheck.test.tsx
@@ -5,6 +5,11 @@ import { fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../../i18n'
+import {
+  useRunQuery,
+  useProtocolQuery,
+  useProtocolAnalysisAsDocumentQuery,
+} from '@opentrons/react-api-client'
 import { useLPCSuccessToast } from '../../../hooks/useLPCSuccessToast'
 import { getModuleTypesThatRequireExtraAttention } from '../../utils/getModuleTypesThatRequireExtraAttention'
 import { useLaunchLPC } from '../../../../LabwarePositionCheck/useLaunchLPC'
@@ -24,6 +29,7 @@ jest.mock('../../../../RunTimeControl/hooks')
 jest.mock('../../../../../redux/config')
 jest.mock('../../../hooks')
 jest.mock('../../../hooks/useLPCSuccessToast')
+jest.mock('@opentrons/react-api-client')
 
 const mockGetModuleTypesThatRequireExtraAttention = getModuleTypesThatRequireExtraAttention as jest.MockedFunction<
   typeof getModuleTypesThatRequireExtraAttention
@@ -51,6 +57,13 @@ const mockUseLPCDisabledReason = useLPCDisabledReason as jest.MockedFunction<
 >
 const mockUseLaunchLPC = useLaunchLPC as jest.MockedFunction<
   typeof useLaunchLPC
+>
+const mockUseRunQuery = useRunQuery as jest.MockedFunction<typeof useRunQuery>
+const mockUseProtocolQuery = useProtocolQuery as jest.MockedFunction<
+  typeof useProtocolQuery
+>
+const mockUseProtocolAnalysisAsDocumentQuery = useProtocolAnalysisAsDocumentQuery as jest.MockedFunction<
+  typeof useProtocolAnalysisAsDocumentQuery
 >
 const DISABLED_REASON = 'MOCK_DISABLED_REASON'
 const ROBOT_NAME = 'otie'
@@ -150,11 +163,22 @@ describe('SetupLabware', () => {
     when(mockGetIsLabwareOffsetCodeSnippetsOn).mockReturnValue(false)
     when(mockUseLPCDisabledReason).mockReturnValue(null)
     when(mockUseLaunchLPC)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, 'test protocol')
       .mockReturnValue({
         launchLPC: mockLaunchLPC,
         LPCWizard: <div>mock LPC Wizard</div>,
       })
+    when(mockUseRunQuery).mockReturnValue({
+      data: {
+        data: { protocolId: 'fakeProtocolId' },
+      },
+    } as any)
+    when(mockUseProtocolQuery).mockReturnValue({
+      data: { data: { metadata: { protocolName: 'test protocol' } } },
+    } as any)
+    when(mockUseProtocolAnalysisAsDocumentQuery).mockReturnValue({
+      data: null,
+    } as any)
   })
 
   afterEach(() => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -13,7 +13,7 @@ import {
   PrimaryButton,
   COLORS,
 } from '@opentrons/components'
-import { useRunQuery } from '@opentrons/react-api-client'
+import { useRunQuery, useProtocolQuery } from '@opentrons/react-api-client'
 import { useMostRecentCompletedAnalysis } from '../../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useLPCSuccessToast } from '../../hooks/useLPCSuccessToast'
 import { Tooltip } from '../../../../atoms/Tooltip'
@@ -36,6 +36,16 @@ export function SetupLabwarePositionCheck(
   const { t, i18n } = useTranslation('protocol_setup')
 
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
+  const { data: protocolRecord } = useProtocolQuery(
+    runRecord?.data.protocolId ?? null,
+    {
+      staleTime: Infinity,
+    }
+  )
+  const protocolName =
+    protocolRecord?.data.metadata.protocolName ??
+    protocolRecord?.data.files[0].name ??
+    ''
   const currentOffsets = runRecord?.data?.labwareOffsets ?? []
   const sortedOffsets: LabwareOffset[] =
     currentOffsets.length > 0
@@ -62,7 +72,7 @@ export function SetupLabwarePositionCheck(
 
   const { setIsShowingLPCSuccessToast } = useLPCSuccessToast()
 
-  const { launchLPC, LPCWizard } = useLaunchLPC(runId)
+  const { launchLPC, LPCWizard } = useLaunchLPC(runId, protocolName)
 
   return (
     <Flex

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/RenameRobotSlideout.test.tsx
@@ -127,7 +127,7 @@ describe('RobotSettings RenameRobotSlideout', () => {
     expect(input).toHaveValue('mockInput@@@')
     const renameButton = getByRole('button', { name: 'Rename robot' })
     const error = await findByText(
-      'Oops! Robot name must follow the character count and limitations'
+      'Oops! Robot name must follow the character count and limitations.'
     )
     await waitFor(() => {
       expect(renameButton).toBeDisabled()
@@ -144,7 +144,7 @@ describe('RobotSettings RenameRobotSlideout', () => {
     expect(input).toHaveValue('aaaaaaaaaaaaaaaaaa')
     const renameButton = getByRole('button', { name: 'Rename robot' })
     const error = await findByText(
-      'Oops! Robot name must follow the character count and limitations'
+      'Oops! Robot name must follow the character count and limitations.'
     )
     await waitFor(() => {
       expect(renameButton).toBeDisabled()
@@ -161,7 +161,7 @@ describe('RobotSettings RenameRobotSlideout', () => {
     expect(input).toHaveValue('Hello world123')
     const renameButton = getByRole('button', { name: 'Rename robot' })
     const error = await findByText(
-      'Oops! Robot name must follow the character count and limitations'
+      'Oops! Robot name must follow the character count and limitations.'
     )
     await waitFor(() => {
       expect(renameButton).toBeDisabled()
@@ -178,7 +178,7 @@ describe('RobotSettings RenameRobotSlideout', () => {
     expect(input).toHaveValue(' ')
     const renameButton = getByRole('button', { name: 'Rename robot' })
     const error = await findByText(
-      'Oops! Robot name must follow the character count and limitations'
+      'Oops! Robot name must follow the character count and limitations.'
     )
     await waitFor(() => {
       expect(renameButton).toBeDisabled()

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -23,6 +23,17 @@ const BANNER_LINK_CSS = css`
   cursor: pointer;
   margin-left: ${SPACING.spacing8};
 `
+
+const INSTRUMENT_CARD_STYLE = css`
+  p {
+    text-transform: lowercase;
+  }
+
+  p::first-letter {
+    text-transform: uppercase;
+  }
+`
+
 const SUBSYSTEM_UPDATE_POLL_MS = 5000
 
 export function GripperCard({
@@ -125,6 +136,7 @@ export function GripperCard({
       {attachedGripper?.ok === false || subsystemUpdateData != null ? (
         <InstrumentCard
           label={i18n.format(t('mount', { side: 'extension' }), 'capitalize')}
+          css={INSTRUMENT_CARD_STYLE}
           description={t('instrument_attached')}
           banner={
             <Banner

--- a/app/src/organisms/GripperWizardFlows/Success.tsx
+++ b/app/src/organisms/GripperWizardFlows/Success.tsx
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux'
 import * as React from 'react'
+import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import {
   COLORS,
@@ -20,6 +21,15 @@ import {
 } from './constants'
 import type { GripperWizardStepProps, SuccessStep } from './types'
 
+const HEADER_STYLE = css`
+  p {
+    text-transform: lowercase;
+  }
+
+  p::first-letter {
+    text-transform: uppercase;
+  }
+`
 export const Success = (
   props: Pick<GripperWizardStepProps, 'proceed'> &
     Pick<GripperWizardStepProps, 'isRobotMoving'> &
@@ -66,6 +76,7 @@ export const Success = (
       iconColor={COLORS.successEnabled}
       header={header}
       isSuccess
+      css={HEADER_STYLE}
     >
       {isOnDevice ? (
         <Flex justifyContent={JUSTIFY_FLEX_END} width="100%">

--- a/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/IntroScreen/index.tsx
@@ -51,6 +51,7 @@ export const IntroScreen = (props: {
   setFatalError: (errorMessage: string) => void
   isRobotMoving: boolean
   existingOffsets: LabwareOffset[]
+  protocolName: string
 }): JSX.Element | null => {
   const {
     proceed,
@@ -59,6 +60,7 @@ export const IntroScreen = (props: {
     isRobotMoving,
     setFatalError,
     existingOffsets,
+    protocolName,
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
   const { t, i18n } = useTranslation(['labware_position_check', 'shared'])
@@ -92,8 +94,12 @@ export const IntroScreen = (props: {
         <WizardRequiredEquipmentList
           equipmentList={[
             {
-              loadName: t('all_modules_and_labware_from_protocol'),
-              displayName: t('all_modules_and_labware_from_protocol'),
+              loadName: t('all_modules_and_labware_from_protocol', {
+                protocol_name: protocolName,
+              }),
+              displayName: t('all_modules_and_labware_from_protocol', {
+                protocol_name: protocolName,
+              }),
             },
           ]}
         />

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -46,6 +46,7 @@ interface LabwarePositionCheckModalProps {
   maintenanceRunId: string
   mostRecentAnalysis: CompletedProtocolAnalysis | null
   existingOffsets: LabwareOffset[]
+  protocolName: string
   caughtError?: Error
   setMaintenanceRunId: (id: string | null) => void
 }
@@ -60,6 +61,7 @@ export const LabwarePositionCheckComponent = (
     runId,
     maintenanceRunId,
     setMaintenanceRunId,
+    protocolName,
   } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
   const isOnDevice = useSelector(getIsOnDevice)
@@ -323,7 +325,11 @@ export const LabwarePositionCheckComponent = (
     )
   } else if (currentStep.section === 'BEFORE_BEGINNING') {
     modalContent = (
-      <IntroScreen {...movementStepProps} {...{ existingOffsets }} />
+      <IntroScreen
+        {...movementStepProps}
+        {...{ existingOffsets }}
+        protocolName={protocolName}
+      />
     )
   } else if (
     currentStep.section === 'CHECK_POSITIONS' ||

--- a/app/src/organisms/LabwarePositionCheck/RobotMotionLoader.tsx
+++ b/app/src/organisms/LabwarePositionCheck/RobotMotionLoader.tsx
@@ -44,6 +44,14 @@ export function RobotMotionLoader(props: RobotMotionLoaderProps): JSX.Element {
 const LoadingText = styled.h1`
   ${TYPOGRAPHY.h1Default}
 
+  p {
+    text-transform: lowercase;
+  }
+
+  p::first-letter {
+    text-transform: uppercase;
+  }
+
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     ${TYPOGRAPHY.level4HeaderSemiBold}
   }

--- a/app/src/organisms/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/index.tsx
@@ -12,6 +12,7 @@ interface LabwarePositionCheckModalProps {
   maintenanceRunId: string
   existingOffsets: LabwareOffset[]
   mostRecentAnalysis: CompletedProtocolAnalysis | null
+  protocolName: string
   caughtError?: Error
   setMaintenanceRunId: (id: string | null) => void
 }
@@ -24,7 +25,6 @@ export const LabwarePositionCheck = (
   props: LabwarePositionCheckModalProps
 ): JSX.Element => {
   const logger = useLogger(__filename)
-
   return (
     <ErrorBoundary
       logger={logger}

--- a/app/src/organisms/LabwarePositionCheck/useLaunchLPC.tsx
+++ b/app/src/organisms/LabwarePositionCheck/useLaunchLPC.tsx
@@ -10,9 +10,11 @@ import { useMostRecentCompletedAnalysis } from './useMostRecentCompletedAnalysis
 import { getLabwareDefinitionsFromCommands } from './utils/labware'
 
 export function useLaunchLPC(
-  runId: string
+  runId: string,
+  protocolName?: string
 ): { launchLPC: () => void; LPCWizard: JSX.Element | null } {
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
+
   const {
     createTargetedMaintenanceRun,
   } = useCreateTargetedMaintenanceRunMutation()
@@ -71,6 +73,7 @@ export function useLaunchLPC(
           existingOffsets={runRecord?.data?.labwareOffsets ?? []}
           maintenanceRunId={maintenanceRunId}
           setMaintenanceRunId={setMaintenanceRunId}
+          protocolName={protocolName ?? ''}
         />
       ) : null,
   }

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -269,7 +269,7 @@ describe('ProtocolSetup', () => {
       .calledWith()
       .mockReturnValue({ data: { data: [] } } as any)
     when(mockUseLaunchLPC)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, PROTOCOL_NAME)
       .mockReturnValue({
         launchLPC: mockLaunchLPC,
         LPCWizard: <div>mock LPC Wizard</div>,

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -359,7 +359,7 @@ function PrepareToRun({
     protocolRecord?.data.files[0].name ??
     ''
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
-  const { launchLPC, LPCWizard } = useLaunchLPC(runId)
+  const { launchLPC, LPCWizard } = useLaunchLPC(runId, protocolName)
 
   const onConfirmCancelClose = (): void => {
     setShowConfirmCancelModal(false)

--- a/app/src/pages/OnDeviceDisplay/__tests__/NameRobot.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/__tests__/NameRobot.test.tsx
@@ -90,7 +90,7 @@ describe('NameRobot', () => {
     const [{ findByText, getByLabelText }] = render()
     getByLabelText('SmallButton_primary').click()
     const error = await findByText(
-      'Oops! Robot name must follow the character count and limitations'
+      'Oops! Robot name must follow the character count and limitations.'
     )
     await waitFor(() => {
       expect(error).toBeInTheDocument()


### PR DESCRIPTION
**NOTE: No need to review. Just needs approval. This was already approved as #13672 - just changing the branch from edge to chore_release-7.0.1**

Closes RQA-1648, RQA-1649, RQA-1646, RQA-1652, RQA-1645

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes various punctuation, casing, and missing errors on the desktop app/ODD that were found in Design's recent audit. See tickets listed above for further details.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- See tickets for specific issues. None of these require more involvement other than navigating to the proper page.
- For the LPC missing protocol name, here is a simple protocol for launching LPC [LPCTest.py.zip](https://github.com/Opentrons/opentrons/files/12742230/LPCTest.py.zip)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Various punctuation, casing, and missing errors on the desktop app/ODD.
- For the LPC protocol name, prop drilling is the most efficient way and avoids a superfluous network request.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
