### PR TITLE
fix(app): Fix physical odd stylistic issues

### DIFF
--- a/app/src/atoms/Snackbar/index.tsx
+++ b/app/src/atoms/Snackbar/index.tsx
@@ -22,10 +22,17 @@ export interface SnackbarProps extends StyleProps {
 
 const SNACKBAR_ANIMATION_DURATION = 500
 
+const ODD_ANIMATION_OPTIMIZATIONS = `
+  backface-visibility: hidden;
+  perspective: 1000;
+  will-change: opacity;
+  `
+
 const OPEN_STYLE = css`
   animation-duration: ${SNACKBAR_ANIMATION_DURATION}ms;
   animation-name: fadein;
   overflow: hidden;
+  ${ODD_ANIMATION_OPTIMIZATIONS}
 
   @keyframes fadein {
     0% {
@@ -41,6 +48,7 @@ const CLOSE_STYLE = css`
   animation-duration: ${SNACKBAR_ANIMATION_DURATION}ms;
   animation-name: fadeout;
   overflow: hidden;
+  ${ODD_ANIMATION_OPTIMIZATIONS}
 
   @keyframes fadeout {
     0% {

--- a/app/src/atoms/Toast/index.tsx
+++ b/app/src/atoms/Toast/index.tsx
@@ -103,7 +103,7 @@ export function Toast(props: ToastProps): JSX.Element {
   const ODD_ANIMATION_OPTIMIZATIONS = `
   backface-visibility: hidden;
   perspective: 1000;
-  will-change: opacity, transform3d;
+  will-change: opacity, transform;
   `
   const DESKTOP_ANIMATION_SLIDE_UP_AND_IN = css`
     animation-duration: ${TOAST_ANIMATION_DURATION}ms;

--- a/app/src/organisms/GripperWizardFlows/getGripperWizardSteps.ts
+++ b/app/src/organisms/GripperWizardFlows/getGripperWizardSteps.ts
@@ -12,7 +12,8 @@ import {
 import type { GripperWizardStep, GripperWizardFlowType } from './types'
 
 export const getGripperWizardSteps = (
-  flowType: GripperWizardFlowType
+  flowType: GripperWizardFlowType,
+  requiresFirmwareUpdate: boolean
 ): GripperWizardStep[] => {
   switch (flowType) {
     case GRIPPER_FLOW_TYPES.RECALIBRATE: {
@@ -31,7 +32,7 @@ export const getGripperWizardSteps = (
       ]
     }
     case GRIPPER_FLOW_TYPES.ATTACH: {
-      return [
+      const ALL_STEPS = [
         { section: SECTIONS.BEFORE_BEGINNING },
         { section: SECTIONS.MOUNT_GRIPPER },
         { section: SECTIONS.FIRMWARE_UPDATE },
@@ -47,6 +48,10 @@ export const getGripperWizardSteps = (
           successfulAction: SUCCESSFULLY_ATTACHED_AND_CALIBRATED,
         },
       ]
+
+      return requiresFirmwareUpdate
+        ? ALL_STEPS
+        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     }
     case GRIPPER_FLOW_TYPES.DETACH: {
       return [
@@ -56,5 +61,4 @@ export const getGripperWizardSteps = (
       ]
     }
   }
-  return []
 }

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -209,7 +209,11 @@ export const GripperWizard = (
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('gripper_wizard_flows')
-  const gripperWizardSteps = getGripperWizardSteps(flowType)
+  const requiresFirmwareUpdate = !attachedGripper?.ok
+  const gripperWizardSteps = getGripperWizardSteps(
+    flowType,
+    requiresFirmwareUpdate
+  )
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
   const [
     frontJawOffset,

--- a/app/src/organisms/ModuleWizardFlows/getModuleCalibrationSteps.ts
+++ b/app/src/organisms/ModuleWizardFlows/getModuleCalibrationSteps.ts
@@ -1,8 +1,10 @@
 import { SECTIONS } from './constants'
 import type { ModuleCalibrationWizardStep } from './types'
 
-export const getModuleCalibrationSteps = (): ModuleCalibrationWizardStep[] => {
-  return [
+export const getModuleCalibrationSteps = (
+  requiresFirmwareUpdate: boolean
+): ModuleCalibrationWizardStep[] => {
+  const ALL_STEPS = [
     { section: SECTIONS.BEFORE_BEGINNING },
     { section: SECTIONS.FIRMWARE_UPDATE },
     { section: SECTIONS.SELECT_LOCATION },
@@ -11,4 +13,8 @@ export const getModuleCalibrationSteps = (): ModuleCalibrationWizardStep[] => {
     { section: SECTIONS.DETACH_PROBE },
     { section: SECTIONS.SUCCESS },
   ]
+
+  return requiresFirmwareUpdate
+    ? ALL_STEPS
+    : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
 }

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -61,7 +61,13 @@ export const ModuleWizardFlows = (
   const { t } = useTranslation('module_wizard_flows')
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
   const attachedPipette = attachedPipettes.left ?? attachedPipettes.right
-  const moduleCalibrationSteps = getModuleCalibrationSteps()
+  const requiresFirmwareUpdate = !attachedPipette?.ok
+  const attachedPipetteMount =
+    attachedPipette?.mount === LEFT ? 'pipette_left' : 'pipette_right'
+
+  const moduleCalibrationSteps = getModuleCalibrationSteps(
+    requiresFirmwareUpdate
+  )
 
   const availableSlotNames =
     FLEX_SLOT_NAMES_BY_MOD_TYPE[getModuleType(attachedModule.moduleModel)] ?? []
@@ -263,9 +269,7 @@ export const ModuleWizardFlows = (
     modalContent = (
       <FirmwareUpdateModal
         proceed={proceed}
-        subsystem={
-          attachedPipette.mount === LEFT ? 'pipette_left' : 'pipette_right'
-        }
+        subsystem={attachedPipetteMount}
         description={t('firmware_update')}
       />
     )

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -36,14 +36,20 @@ import type { RunStatus } from '@opentrons/api-client'
 import type { TrackProtocolRunEvent } from '../../Devices/hooks'
 import type { RobotAnalyticsData } from '../../../redux/analytics/types'
 
+const ODD_ANIMATION_OPTIMIZATIONS = `
+  backface-visibility: hidden;
+  perspective: 1000;
+  will-change: opacity, transform;
+  `
+
 const fadeIn = keyframes`
 from {
   opacity: 0;
-  transform: translateY(100%);
+  transform: translate3d(0,15%,0);
 }
 to {
   opacity: 1;
-  transform: translateY(0%);
+  transform: translate3d(0,0,0);
 }
 `
 
@@ -79,6 +85,7 @@ const COMMAND_ROW_STYLE_ANIMATED = css`
   -webkit-line-clamp: 2;
   overflow: hidden;
   animation: ${fadeIn} 1.5s ease-in-out;
+  ${ODD_ANIMATION_OPTIMIZATIONS}
 `
 
 const COMMAND_ROW_STYLE = css`

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -34,9 +34,16 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, SINGLE_MOUNT_PIPETTES, false)
+      getPipetteWizardSteps(
+        FLOWS.CALIBRATE,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        true
+      )
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
+
   it('returns the correct array of info for attach pipette flow single channel', () => {
     const mockAttachPipetteFlowSteps = [
       {
@@ -77,7 +84,58 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
+      getPipetteWizardSteps(
+        FLOWS.ATTACH,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        true
+      )
+    ).toStrictEqual(mockAttachPipetteFlowSteps)
+  })
+
+  it('returns the correct array of info when a firmware update is not required', () => {
+    const mockAttachPipetteFlowSteps = [
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
+    ] as PipetteWizardStep[]
+
+    expect(
+      getPipetteWizardSteps(
+        FLOWS.ATTACH,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        false
+      )
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -101,7 +159,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
+      getPipetteWizardSteps(
+        FLOWS.DETACH,
+        LEFT,
+        SINGLE_MOUNT_PIPETTES,
+        false,
+        true
+      )
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 
@@ -155,7 +219,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true)
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true, true)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -189,7 +253,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true)
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true, true)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
   it('returns the correct array when 96-channel is going to be attached and there is a pipette already on the mount', () => {
@@ -248,7 +312,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false)
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false, true)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
   it('returns the corect array of info for calibrate pipette 96 channel', () => {
@@ -276,7 +340,13 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, NINETY_SIX_CHANNEL, false)
+      getPipetteWizardSteps(
+        FLOWS.CALIBRATE,
+        LEFT,
+        NINETY_SIX_CHANNEL,
+        false,
+        true
+      )
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -36,14 +36,20 @@ describe('getPipetteWizardStepsForProtocol', () => {
             mount: 'left',
           },
         ],
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
   it('returns an empty array when there is no pipette attached and no pipette is needed', () => {
     const mockFlowSteps = [] as PipetteWizardStep[]
     expect(
-      getPipetteWizardStepsForProtocol({ left: null, right: null }, [], LEFT)
+      getPipetteWizardStepsForProtocol(
+        { left: null, right: null },
+        [],
+        LEFT,
+        true
+      )
     ).toStrictEqual(mockFlowSteps)
   })
   it('returns the calibration flow only when correct pipette is attached but there is no pip cal data', () => {
@@ -75,7 +81,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
           } as any,
         },
         [{ id: '123', pipetteName: 'p1000_single_flex', mount: 'right' }],
-        RIGHT
+        RIGHT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -123,7 +130,52 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         mockSingleMountPipetteAttached,
         mockPipettesInProtocolMulti as any,
-        LEFT
+        LEFT,
+        true
+      )
+    ).toStrictEqual(mockFlowSteps)
+  })
+  it('returns the correct array of info when the attached pipette does not require a firmware update', () => {
+    const mockFlowSteps = [
+      {
+        section: SECTIONS.BEFORE_BEGINNING,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      {
+        section: SECTIONS.DETACH_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+      },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.MOUNT_PIPETTE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+      {
+        section: SECTIONS.ATTACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.DETACH_PROBE,
+        mount: LEFT,
+        flowType: FLOWS.ATTACH,
+      },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.CALIBRATE,
+      },
+    ] as PipetteWizardStep[]
+    expect(
+      getPipetteWizardStepsForProtocol(
+        mockSingleMountPipetteAttached,
+        mockPipettesInProtocolMulti as any,
+        LEFT,
+        false
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -181,7 +233,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: mock96ChannelAttachedPipetteInformation, right: null },
         mockPipettesInProtocolNotEmpty as any,
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -239,7 +292,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: mockAttachedPipetteInformation, right: null },
         mockPipetteInfo as any,
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -297,7 +351,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: null, right: mockAttachedPipetteInformation },
         mockPipetteInfo as any,
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -364,7 +419,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
           right: mockAttachedPipetteInformation,
         },
         mockPipetteInfo as any,
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -406,7 +462,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: null, right: null },
         mockPipettesInProtocolNotEmpty as any,
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -458,7 +515,8 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: null, right: null },
         mockPipetteInfo as any,
-        LEFT
+        LEFT,
+        true
       )
     ).toStrictEqual(mockFlowSteps)
   })

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -11,7 +11,8 @@ export const getPipetteWizardSteps = (
   flowType: PipetteWizardFlow,
   mount: PipetteMount,
   selectedPipette: SelectablePipettes,
-  isGantryEmpty: boolean
+  isGantryEmpty: boolean,
+  requiresFirmwareUpdate: boolean
 ): PipetteWizardStep[] => {
   switch (flowType) {
     case FLOWS.CALIBRATE: {
@@ -32,7 +33,7 @@ export const getPipetteWizardSteps = (
     }
     case FLOWS.ATTACH: {
       if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        return [
+        const ALL_STEPS = [
           {
             section: SECTIONS.BEFORE_BEGINNING,
             mount: mount,
@@ -53,6 +54,9 @@ export const getPipetteWizardSteps = (
             flowType: FLOWS.CALIBRATE,
           },
         ]
+        return requiresFirmwareUpdate
+          ? ALL_STEPS
+          : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
       } else {
         //  pipette needs to be detached before attached 96 channel
         if (!isGantryEmpty) {
@@ -60,7 +64,7 @@ export const getPipetteWizardSteps = (
           if (mount === LEFT) {
             detachMount = RIGHT
           }
-          return [
+          const ALL_STEPS = [
             {
               section: SECTIONS.BEFORE_BEGINNING,
               mount: detachMount,
@@ -113,9 +117,14 @@ export const getPipetteWizardSteps = (
               flowType: FLOWS.CALIBRATE,
             },
           ]
+          return requiresFirmwareUpdate
+            ? ALL_STEPS
+            : ALL_STEPS.filter(
+                step => step.section !== SECTIONS.FIRMWARE_UPDATE
+              )
           //  gantry empty to attach 96 channel
         } else {
-          return [
+          const ALL_STEPS = [
             {
               section: SECTIONS.BEFORE_BEGINNING,
               mount: mount,
@@ -158,6 +167,11 @@ export const getPipetteWizardSteps = (
               flowType: FLOWS.CALIBRATE,
             },
           ]
+          return requiresFirmwareUpdate
+            ? ALL_STEPS
+            : ALL_STEPS.filter(
+                step => step.section !== SECTIONS.FIRMWARE_UPDATE
+              )
         }
       }
     }

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -7,7 +7,8 @@ import type { PipetteWizardStep } from './types'
 export const getPipetteWizardStepsForProtocol = (
   attachedPipettes: AttachedPipettesFromInstrumentsQuery,
   pipetteInfo: LoadedPipette[],
-  mount: Mount
+  mount: Mount,
+  requiresFirmwareUpdate: boolean
 ): PipetteWizardStep[] => {
   const requiredPipette = pipetteInfo.find(pipette => pipette.mount === mount)
   const nintySixChannelAttached =
@@ -50,7 +51,7 @@ export const getPipetteWizardStepsForProtocol = (
   ) {
     //    96-channel pipette attached and need to attach single mount pipette
     if (nintySixChannelAttached) {
-      return [
+      const ALL_STEPS = [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: LEFT,
@@ -99,9 +100,12 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
+      return requiresFirmwareUpdate
+        ? ALL_STEPS
+        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
       //    Single mount pipette attached and need to attach new single mount pipette
     } else {
-      return [
+      const ALL_STEPS = [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: mount,
@@ -140,6 +144,9 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
+      return requiresFirmwareUpdate
+        ? ALL_STEPS
+        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     }
     //  Single mount pipette attached to both mounts and need to attach 96-channel pipette
   } else if (
@@ -147,7 +154,7 @@ export const getPipetteWizardStepsForProtocol = (
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] != null
   ) {
-    return [
+    const ALL_STEPS = [
       {
         section: SECTIONS.BEFORE_BEGINNING,
         mount: LEFT,
@@ -202,13 +209,16 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.CALIBRATE,
       },
     ]
+    return requiresFirmwareUpdate
+      ? ALL_STEPS
+      : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     //  Single mount pipette attached to left mount and need to attach 96-channel pipette
   } else if (
     requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] == null
   ) {
-    return [
+    const ALL_STEPS = [
       {
         section: SECTIONS.BEFORE_BEGINNING,
         mount: LEFT,
@@ -257,13 +267,16 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.CALIBRATE,
       },
     ]
+    return requiresFirmwareUpdate
+      ? ALL_STEPS
+      : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     //  Single mount pipette attached to right mount and need to attach 96-channel pipette
   } else if (
     requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] == null &&
     attachedPipettes[RIGHT] != null
   ) {
-    return [
+    const ALL_STEPS = [
       {
         section: SECTIONS.BEFORE_BEGINNING,
         mount: RIGHT,
@@ -312,11 +325,14 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.CALIBRATE,
       },
     ]
+    return requiresFirmwareUpdate
+      ? ALL_STEPS
+      : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     //  if no pipette is attached to gantry
   } else {
     //  Gantry empty and need to attach 96-channel pipette
     if (requiredPipette.pipetteName === 'p1000_96') {
-      return [
+      const ALL_STEPS = [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: LEFT,
@@ -359,9 +375,12 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
+      return requiresFirmwareUpdate
+        ? ALL_STEPS
+        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
       //    Gantry empty and need to attach single mount pipette
     } else {
-      return [
+      const ALL_STEPS = [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: mount,
@@ -394,6 +413,9 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
+      return requiresFirmwareUpdate
+        ? ALL_STEPS
+        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     }
   }
 }

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -64,17 +64,26 @@ export const PipetteWizardFlows = (
   const { t } = useTranslation('pipette_wizard_flows')
 
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
+  const attachedPipette = attachedPipettes.left ?? attachedPipettes.right
+  const requiresFirmwareUpdate = !attachedPipette?.ok
   const memoizedPipetteInfo = React.useMemo(() => props.pipetteInfo ?? null, [])
   const isGantryEmpty =
     attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null
   const pipetteWizardSteps = React.useMemo(
     () =>
       memoizedPipetteInfo == null
-        ? getPipetteWizardSteps(flowType, mount, selectedPipette, isGantryEmpty)
+        ? getPipetteWizardSteps(
+            flowType,
+            mount,
+            selectedPipette,
+            isGantryEmpty,
+            requiresFirmwareUpdate
+          )
         : getPipetteWizardStepsForProtocol(
             attachedPipettes,
             memoizedPipetteInfo,
-            mount
+            mount,
+            requiresFirmwareUpdate
           ),
     []
   )

--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -6,6 +6,7 @@ import {
   useProtocolQuery,
 } from '@opentrons/react-api-client'
 import { getLabwareSetupItemGroups } from '../utils'
+import { getProtocolUsesGripper } from '../../../organisms/ProtocolSetupInstruments/utils'
 
 import type {
   CompletedProtocolAnalysis,
@@ -13,7 +14,7 @@ import type {
   PipetteName,
 } from '@opentrons/shared-data'
 import type { LabwareSetupItem } from '../utils'
-import { getProtocolUsesGripper } from '../../../organisms/ProtocolSetupInstruments/utils'
+import type { AttachedModule } from '@opentrons/api-client'
 
 interface ProtocolPipette {
   hardwareType: 'pipette'
@@ -85,14 +86,24 @@ export const useRequiredProtocolHardware = (
       ]
     : []
 
+  const handleModuleConnectionCheckFor = (
+    attachedModules: AttachedModule[],
+    model: ModuleModel
+  ): boolean => {
+    const ASSUME_ALWAYS_CONNECTED_MODULES = ['magneticBlockV1']
+
+    return !ASSUME_ALWAYS_CONNECTED_MODULES.includes(model)
+      ? attachedModules.some(m => m.moduleModel === model)
+      : true
+  }
+
   const requiredModules: ProtocolModule[] = analysis.modules.map(
     ({ location, model }) => {
       return {
         hardwareType: 'module',
         moduleModel: model,
         slot: location.slotName as Slot,
-        // TODO: check module compatability using brent's changes when they're in edge
-        connected: attachedModules.some(m => m.moduleModel === model),
+        connected: handleModuleConnectionCheckFor(attachedModules, model),
       }
     }
   )


### PR DESCRIPTION
**This PR was already reviewed under #13636. Just need a code review (testing already completed) for the firmware step filtering after Brian/Koji feedback.**

Closes RQA-1513, RAUT-750, RQA-1686

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a number of stylistic bugs that occur only on the physical ODD. 

### Firmware Update Step

The firmware update step no longer shows in any flow if a firmware update isn't required. There were two main issues here: first, the total step counter was off - total steps would be +1 what actually occurred if a firmware update was not a part of the flow. Second, on the physical ODD, a brief flash of the firmware update screen occurs. 

This PR creates a new utility hook for conditionally filtering out steps that are unneeded. Currently, that is only firmware updates, but it will be easy to add/modify functionality in the future. 

Note that the hook hits the GET /instruments endpoint only once, since polling doesn't seem to make sense during a launched flow. 

**BEFORE**

https://github.com/Opentrons/opentrons/assets/64858653/2b692c66-62d7-4c1e-95a9-1df453a16174

**AFTER** 

https://github.com/Opentrons/opentrons/assets/64858653/66ff4b8c-c613-4083-a9a5-9bef21261fb1

### Magblock is Not Connected

The attached modules endpoint is compared against required protocol modules to determine if a module needs attachment. The problem is there is no way to detect if a magblock is attached. The easy and likely correct solution is just to assume it's attached when compared against a protocol - users are informed that it needs to be on the deck, anyway.

**BEFORE**
![block not attached](https://github.com/Opentrons/opentrons/assets/64858653/757fa9ca-ad59-46ed-8a38-a4bd78b78fc8)

**AFTER**
![magblock attached](https://github.com/Opentrons/opentrons/assets/64858653/478b3fad-f659-493e-b2ea-169d27ac04b9)

### Protocol Command Tearing & Snackbar Optimizations

Yep, you guessed it - other animations also tear on the ODD. This PR includes the ODD animation optimizations. Design helped modify the animations to be non-tearing.

I added the ODD optimizations to Snackbars as well...it can't hurt!

**BEFORE**

https://github.com/Opentrons/opentrons/assets/64858653/b0f6c8d9-1ca3-4449-81e0-7731d164c1cc

**AFTER** 

https://github.com/Opentrons/opentrons/assets/64858653/bcbac5c7-388b-4c0c-b1d1-ff837c23d329

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

### Protocol Command Tearing
- Run any protocol and see that animations do not tear. Here's an easy one that just needs a gripper attached. [GripperMoveTesting.py.zip](https://github.com/Opentrons/opentrons/files/12704376/GripperMoveTesting.py.zip)

### Magblock is Not Connected
- Navigate to the ProtocolDetails screen for any protocol that includes a mag block. NOTE: A dev environment may not work here - the test-flex.json file needs updating (it's on my TODO). If behavior isn't correct, remove the magdeck from the test-flex.json.
- Here's an easy protocol to test: 
[MagneticBlockTest.py.zip](https://github.com/Opentrons/opentrons/files/12704436/MagneticBlockTest.py.zip)


### Firmware Update Step
- Test on the physical ODD (it's the only way to see the screen blip) and go through any attachment/module cal flow. There shouldn't be a firmware update step included in the total or a screen blip if the pipette/gripper doesn't need a firmware update.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- Changed command protocol animations and added ODD optimizations.
- Tweaked a Toast optimzation.
- Create a new hook for filtering wizard steps.
- Added supportive hook tests.
- Added a special case filter for the magblock connected property.
- Pre-emptive snackbar animation optimization for ODD.

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Firmware updates and animations need testing on the physical ODD. See notes on magdeck testing if on the dev environment.

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
