### PR TITLE
fix(hardware): wrong val for dummy moves

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
+++ b/hardware/opentrons_hardware/hardware_control/motion_planning/types.py
@@ -163,18 +163,18 @@ class Move(Generic[AxisKey]):
             max_speed=np.float64(0),
             blocks=(
                 Block(
-                    distance=np.float64(20),
-                    initial_speed=np.float64(3),
+                    distance=np.float64(0),
+                    initial_speed=np.float64(0),
                     acceleration=np.float64(0),
                 ),
                 Block(
-                    distance=np.float64(20),
-                    initial_speed=np.float64(3),
+                    distance=np.float64(0),
+                    initial_speed=np.float64(0),
                     acceleration=np.float64(0),
                 ),
                 Block(
-                    distance=np.float64(20),
-                    initial_speed=np.float64(3),
+                    distance=np.float64(0),
+                    initial_speed=np.float64(0),
                     acceleration=np.float64(0),
                 ),
             ),


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We've been using the wrong values in the dummy moves that probably got added from a gnarly rebase, but this is not going to affect actual move behaviors. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
