### PR TITLE
fix(app): fix command sequencing for 96-Channel flows

### DIFF
--- a/app/src/assets/localization/en/devices_landing.json
+++ b/app/src/assets/localization/en/devices_landing.json
@@ -24,6 +24,7 @@
   "lights_on": "lights on",
   "loading": "loading",
   "looking_for_robots": "Looking for robots",
+  "ninety_six_mount": "Left + Right Mount",
   "make_sure_robot_is_connected": "Make sure the robot is connected to this computer",
   "modules": "Modules",
   "no_robots_found": "No robots found",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -31,6 +31,7 @@
   "detach_and_retry": "detach and retry",
   "detach_mount_attach_96": "Detach {{mount}} Pipette and Attach 96-Channel Pipette",
   "detach_mounting_plate_instructions": "Hold onto the plate so it does not fall. Then remove the pins on the plate from the slots on the gantry carriage.",
+  "detach_next_pipette": "Detach next pipette",
   "detach_pipette_to_attach_96": "Detach {{pipetteName}} and attach 96-Channel pipette",
   "detach_pipette": "detach {{mount}} pipette",
   "detach_pipettes_attach_96": "Detach Pipettes and Attach 96-Channel Pipette",

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -111,7 +111,8 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
   return !confirmPipetteLevel &&
     (wrongWantedPipette != null || (props.wantedPipette != null && success)) &&
     actualPipette != null &&
-    actualPipette.channels === 8 ? (
+    actualPipette.channels === 8 &&
+    actualPipette.displayCategory === 'GEN2' ? (
     <LevelPipette
       mount={mount}
       pipetteModelName={actualPipette.name}

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -40,13 +40,8 @@ import { useIsOT3 } from '../hooks'
 import { PipetteOverflowMenu } from './PipetteOverflowMenu'
 import { PipetteSettingsSlideout } from './PipetteSettingsSlideout'
 import { AboutPipetteSlideout } from './AboutPipetteSlideout'
-
 import type { State } from '../../../redux/types'
-import type {
-  PipetteModelSpecs,
-  PipetteMount,
-  PipetteName,
-} from '@opentrons/shared-data'
+import type { PipetteModelSpecs, PipetteName } from '@opentrons/shared-data'
 import type { AttachedPipette, Mount } from '../../../redux/pipettes/types'
 import type {
   PipetteWizardFlow,

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -175,12 +175,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       {pipetteWizardFlow != null ? (
         <PipetteWizardFlows
           flowType={pipetteWizardFlow}
-          mount={
-            //  hardcoding in LEFT mount for whenever a 96 channel is selected
-            selectedPipette === NINETY_SIX_CHANNEL
-              ? LEFT
-              : (mount as PipetteMount)
-          }
+          mount={mount}
           closeFlow={() => {
             setSelectedPipette(SINGLE_MOUNT_PIPETTES)
             setPipetteWizardFlow(null)

--- a/app/src/organisms/Devices/ProtocolRun/SetupFlexPipetteCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupFlexPipetteCalibrationItem.tsx
@@ -122,7 +122,11 @@ export function SetupFlexPipetteCalibrationItem({
         button={button}
         calibratedDate={pipetteCalDate}
         subText={subText}
-        label={t(`devices_landing:${mount}_mount`)}
+        label={
+          requestedPipetteSpecs?.channels === 96
+            ? t('devices_landing:ninety_six_mount')
+            : t(`devices_landing:${mount}_mount`)
+        }
         title={requestedPipetteSpecs?.displayName}
         id={`PipetteCalibration_${mount}MountTitle`}
         runId={runId}

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -28,7 +28,7 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
   } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
 
-  const handleReattachCarraigeProceed = (): void => {
+  const handleReattachCarriageProceed = (): void => {
     chainRunCommands?.(
       [
         {
@@ -97,7 +97,7 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
             onClick={
               flowType === FLOWS.ATTACH
                 ? proceed
-                : handleReattachCarraigeProceed
+                : handleReattachCarriageProceed
             }
             buttonText={capitalize(t('shared:continue'))}
           />
@@ -106,7 +106,7 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
             onClick={
               flowType === FLOWS.ATTACH
                 ? proceed
-                : handleReattachCarraigeProceed
+                : handleReattachCarriageProceed
             }
           >
             {capitalize(t('shared:continue'))}

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -1,20 +1,73 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import capitalize from 'lodash/capitalize'
-import { SPACING, PrimaryButton } from '@opentrons/components'
+import {
+  TYPOGRAPHY,
+  COLORS,
+  SPACING,
+  PrimaryButton,
+} from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { getPipetteAnimations96 } from './utils'
 import { BODY_STYLE, FLOWS, SECTIONS } from './constants'
 
 import type { PipetteWizardStepProps } from './types'
 
 export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
-  const { goBack, flowType, isOnDevice, proceed } = props
+  const {
+    goBack,
+    flowType,
+    isOnDevice,
+    proceed,
+    chainRunCommands,
+    errorMessage,
+    setShowErrorMessage,
+  } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
 
-  return (
+  const handleReattachCarraigeProceed = (): void => {
+    chainRunCommands?.(
+      [
+        {
+          commandType: 'home' as const,
+          params: {
+            axes: ['rightZ'],
+          },
+        },
+      ],
+      false
+    )
+      .then(() => {
+        proceed()
+      })
+      .catch(error => {
+        setShowErrorMessage(error.message)
+      })
+  }
+
+  return errorMessage != null ? (
+    <SimpleWizardBody
+      isSuccess={false}
+      iconColor={COLORS.errorEnabled}
+      header={t('shared:error_encountered')}
+      subHeader={
+        <Trans
+          t={t}
+          i18nKey={'detach_pipette_error'}
+          values={{ error: errorMessage }}
+          components={{
+            block: <StyledText as="p" />,
+            bold: (
+              <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold} />
+            ),
+          }}
+        />
+      }
+    />
+  ) : (
     <GenericWizardTile
       header={i18n.format(
         t(flowType === FLOWS.ATTACH ? 'unscrew_carriage' : 'reattach_carriage'),
@@ -41,11 +94,21 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
       proceedButton={
         isOnDevice ? (
           <SmallButton
-            onClick={proceed}
+            onClick={
+              flowType === FLOWS.ATTACH
+                ? proceed
+                : handleReattachCarraigeProceed
+            }
             buttonText={capitalize(t('shared:continue'))}
           />
         ) : (
-          <PrimaryButton onClick={proceed}>
+          <PrimaryButton
+            onClick={
+              flowType === FLOWS.ATTACH
+                ? proceed
+                : handleReattachCarraigeProceed
+            }
+          >
             {capitalize(t('shared:continue'))}
           </PrimaryButton>
         )

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -123,10 +123,15 @@ export const Results = (props: ResultsProps): JSX.Element => {
             header = t('ninety_six_detached_success', {
               pipetteName: NINETY_SIX_CHANNEL,
             })
-          } else {
+          } else if (
+            attachedPipettes[LEFT] == null &&
+            attachedPipettes[RIGHT] == null
+          ) {
             header = t('all_pipette_detached')
             subHeader = t('gantry_empty_for_96_channel_success')
             buttonText = t('attach_pip')
+          } else {
+            buttonText = t('detach_next_pip')
           }
         }
       }

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -35,7 +35,7 @@ interface ResultsProps extends PipetteWizardStepProps {
   setFetching: React.Dispatch<React.SetStateAction<boolean>>
   hasCalData: boolean
   requiredPipette?: LoadedPipette
-  nextMount?: 'left' | 'right' | 'both'
+  nextMount?: string
 }
 
 export const Results = (props: ResultsProps): JSX.Element => {

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -137,7 +137,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
   const handleProceed = (): void => {
     if (currentStepIndex === totalStepCount || !isSuccess) {
       handleCleanUpAndClose()
-    } else if (isSuccess && nextMount !== null) {
+    } else if (isSuccess && nextMount != null) {
       // move the gantry into the correct position for the next step of strung together flows
       chainRunCommands?.(
         [

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -51,7 +51,6 @@ describe('Results', () => {
       isFetching: false,
       setFetching: jest.fn(),
       hasCalData: false,
-      nextMount: undefined,
     }
     pipettePromise = Promise.resolve()
     mockRefetchInstruments = jest.fn(() => pipettePromise)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -51,6 +51,7 @@ describe('Results', () => {
       isFetching: false,
       setFetching: jest.fn(),
       hasCalData: false,
+      nextMount: undefined,
     }
     pipettePromise = Promise.resolve()
     mockRefetchInstruments = jest.fn(() => pipettePromise)
@@ -61,6 +62,8 @@ describe('Results', () => {
   it('renders the correct information when pipette cal is a success for calibrate flow', () => {
     props = {
       ...props,
+      currentStepIndex: 6,
+      totalStepCount: 6,
       hasCalData: true,
     }
     const { getByText, getByRole } = render(props)
@@ -71,7 +74,7 @@ describe('Results', () => {
     getByText('Exit')
     const exit = getByRole('button', { name: 'Results_exit' })
     fireEvent.click(exit)
-    expect(props.proceed).toHaveBeenCalled()
+    expect(props.handleCleanUpAndClose).toHaveBeenCalled()
   })
 
   it('renders the correct information when pipette wizard is a success for attach flow', async () => {
@@ -84,9 +87,8 @@ describe('Results', () => {
     const image = getByRole('img', { name: 'Success Icon' })
     expect(image.getAttribute('src')).toEqual('icon_success.png')
     getByRole('img', { name: 'Success Icon' })
-    getByText('Calibrate pipette')
-    const exit = getByRole('button', { name: 'Results_exit' })
-    fireEvent.click(exit)
+    getByRole('button', { name: 'Results_exit' })
+    fireEvent.click(getByText('Calibrate pipette'))
     expect(props.chainRunCommands).toHaveBeenCalledWith(
       [
         {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -201,7 +201,12 @@ describe('getPipetteWizardStepsForProtocol', () => {
         mount: LEFT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+        nextMount: LEFT,
+      },
       {
         section: SECTIONS.MOUNT_PIPETTE,
         mount: LEFT,
@@ -250,7 +255,12 @@ describe('getPipetteWizardStepsForProtocol', () => {
         mount: LEFT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -309,7 +319,12 @@ describe('getPipetteWizardStepsForProtocol', () => {
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: RIGHT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -368,13 +383,23 @@ describe('getPipetteWizardStepsForProtocol', () => {
         mount: LEFT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+        nextMount: RIGHT,
+      },
       {
         section: SECTIONS.DETACH_PIPETTE,
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: RIGHT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,

--- a/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/hooks.test.tsx
@@ -344,7 +344,7 @@ describe('usePipetteFlowWizardHeaderText', () => {
       }
     )
     expect(result.current).toEqual(
-      'Detach Right Pipette and Attach 96-Channel Pipette'
+      'Detach Left Pipette and Attach 96-Channel Pipette'
     )
   })
   it('should return correct title for detaching pipette and attaching 96 channel from pipette info from right mount', () => {
@@ -371,7 +371,7 @@ describe('usePipetteFlowWizardHeaderText', () => {
       }
     )
     expect(result.current).toEqual(
-      'Detach Left Pipette and Attach 96-Channel Pipette'
+      'Detach Right Pipette and Attach 96-Channel Pipette'
     )
   })
   it('should return correct title for detaching 2 pipettes and attaching 96 channel from pipette info', () => {

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -97,23 +97,23 @@ export const getPipetteWizardSteps = (
             },
             {
               section: SECTIONS.FIRMWARE_UPDATE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
             {
               section: SECTIONS.ATTACH_PROBE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.DETACH_PROBE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.RESULTS,
-              mount: mount,
+              mount: LEFT,
               flowType: FLOWS.CALIBRATE,
             },
           ]
@@ -127,43 +127,43 @@ export const getPipetteWizardSteps = (
           const ALL_STEPS = [
             {
               section: SECTIONS.BEFORE_BEGINNING,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.CARRIAGE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.MOUNTING_PLATE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.MOUNT_PIPETTE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.FIRMWARE_UPDATE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
-            { section: SECTIONS.RESULTS, mount: mount, flowType: FLOWS.ATTACH },
+            { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
             {
               section: SECTIONS.ATTACH_PROBE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.DETACH_PROBE,
-              mount: mount,
+              mount: LEFT,
               flowType: flowType,
             },
             {
               section: SECTIONS.RESULTS,
-              mount: mount,
+              mount: LEFT,
               flowType: FLOWS.CALIBRATE,
             },
           ]

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -72,7 +72,12 @@ export const getPipetteWizardStepsForProtocol = (
           mount: LEFT,
           flowType: FLOWS.DETACH,
         },
-        { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+        {
+          section: SECTIONS.RESULTS,
+          mount: LEFT,
+          flowType: FLOWS.DETACH,
+          nextMount: mount,
+        },
         {
           section: SECTIONS.MOUNT_PIPETTE,
           mount: mount,
@@ -165,13 +170,23 @@ export const getPipetteWizardStepsForProtocol = (
         mount: LEFT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+        nextMount: RIGHT,
+      },
       {
         section: SECTIONS.DETACH_PIPETTE,
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: RIGHT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -229,7 +244,12 @@ export const getPipetteWizardStepsForProtocol = (
         mount: LEFT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: LEFT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,
@@ -287,7 +307,12 @@ export const getPipetteWizardStepsForProtocol = (
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: RIGHT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,

--- a/app/src/organisms/PipetteWizardFlows/hooks.tsx
+++ b/app/src/organisms/PipetteWizardFlows/hooks.tsx
@@ -105,12 +105,12 @@ export function usePipetteFlowWizardHeaderText(
         attachedPipettes[LEFT] != null &&
         attachedPipettes[RIGHT] == null
       ) {
-        return t('detach_mount_attach_96', { mount: capitalize(RIGHT) })
+        return t('detach_mount_attach_96', { mount: capitalize(LEFT) })
       } else if (
         attachedPipettes[LEFT] == null &&
         attachedPipettes[RIGHT] != null
       ) {
-        return t('detach_mount_attach_96', { mount: capitalize(LEFT) })
+        return t('detach_mount_attach_96', { mount: capitalize(RIGHT) })
       } else {
         return t('detach_pipettes_attach_96')
       }

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -38,7 +38,7 @@ export interface AttachProbeStep extends BaseStep {
 
 export interface ResultsStep extends BaseStep {
   section: typeof SECTIONS.RESULTS
-  nextMount?: 'right' | 'left' | 'both'
+  nextMount?: string
 }
 export interface MountPipetteStep extends BaseStep {
   section: typeof SECTIONS.MOUNT_PIPETTE

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -38,7 +38,7 @@ export interface AttachProbeStep extends BaseStep {
 
 export interface ResultsStep extends BaseStep {
   section: typeof SECTIONS.RESULTS
-  recalibrate?: boolean
+  nextMount?: 'right' | 'left' | 'both'
 }
 export interface MountPipetteStep extends BaseStep {
   section: typeof SECTIONS.MOUNT_PIPETTE


### PR DESCRIPTION
fix RQA-1106, RQA-1243, RQA-1367, RQA-1269, RAUT-734, RAUT-735

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The 96 channel requires attach and detach flows to be strung together in various orders. This PR makes sure we are issuing the correct commands to allow for proper attachment/detachment in all scenarios.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
I tested the following flows and all work as expected:
1. 96 attach on empty gantry (from devices page and run setup page)
2. 96 attach when one pipette is on gantry (from devices page and run setup page)
3. 96 attach when two pipettes are on gantry (only possible from run setup)
4. 96 channel detach (from devices)
5. 96 channel detach to attach a single mount pipette (from run setup)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Add `nextMount` field to `Results` screen type that indicates whether the modal will be proceeding to an attach/detach of a left mount pipette, right mount pipette, or 96-channel. We use this to issue the correct `moveToMaintenancePosition` command when proceeding from `Results`
2. Add in a few homing commands as necessary when we're getting server errors
3. Add error screens wherever commands are issued
4. Update some mounts where needed

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over code
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
