### PR TITLE
docs(api): Fix code sample errors

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -111,9 +111,9 @@ Loading Together
 Use the ``adapter`` argument of ``load_labware()`` to load an adapter at the same time as labware. For example, to load the same 96-well plate and adapter from the previous section at once::
     
     hs_plate = hs_mod.load_labware(
-        load_name='nest_96_wellplate_200ul_flat',
-        location='D1',
-        adapter='opentrons_96_flat_bottom_adapter')
+        name='nest_96_wellplate_200ul_flat',
+        adapter='opentrons_96_flat_bottom_adapter'
+    )
 
 .. versionadded:: 2.15
     The ``adapter`` parameter.


### PR DESCRIPTION
# Overview

With the recent, and very large overhaul of the API docs, we've had a report of mistakes in a code sample. This is to correct the code snippet in the [Loading Together section](https://docs.opentrons.com/v2/new_labware.html#loading-together) of the [Labware doc](https://docs.opentrons.com/v2/new_labware.html) (`new_labware.rst`).

**Sandbox**:  http://sandbox.docs.opentrons.com/code-sample-fix/v2/index.html

# Test Plan

Verify that this code snippet is accurate:

```
hs_plate = hs_mod.load_labware(
        name='nest_96_wellplate_200ul_flat',
        adapter='opentrons_96_flat_bottom_adapter'
    )
```

# Changelog

Replacing an erroneous code sample with an accurate code sample.

# Review requests

Please check the code in the [Loading Together section](https://docs.opentrons.com/v2/new_labware.html#loading-together).

# Risk assessment

Low. This is a change to a code snippet/example only. 
