### PR TITLE
refactor(api): only restore changed currents

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -932,7 +932,7 @@ class OT3Controller:
             self._current_settings[axis].hold_current = current
 
     @asynccontextmanager
-    async def restore_current(
+    async def motor_current(
         self,
         run_currents: OT3AxisMap[float] = {},
         hold_currents: OT3AxisMap[float] = {},

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -932,14 +932,32 @@ class OT3Controller:
             self._current_settings[axis].hold_current = current
 
     @asynccontextmanager
-    async def restore_current(self) -> AsyncIterator[None]:
-        """Save the current."""
-        old_current_settings = deepcopy(self._current_settings)
+    async def restore_current(
+        self,
+        run_currents: OT3AxisMap[float] = {},
+        hold_currents: OT3AxisMap[float] = {},
+    ) -> AsyncIterator[None]:
+        """Update and restore current."""
+        assert self._current_settings
+        old_settings = deepcopy(self._current_settings)
+        if run_currents:
+            await self.set_active_current(run_currents)
+        if hold_currents:
+            await self.set_hold_current(hold_currents)
         try:
             yield
         finally:
-            self._current_settings = old_current_settings
-            await self.set_default_currents()
+            if run_currents:
+                await self.set_active_current(
+                    {ax: old_settings[ax].run_current for ax in run_currents.keys()}
+                )
+            if hold_currents:
+                await self.set_hold_current(
+                    {ax: old_settings[ax].hold_current for ax in hold_currents.keys()}
+                )
+            if not run_currents and not hold_currents:
+                self._current_settings = old_settings
+                await self.set_default_currents()
 
     @asynccontextmanager
     async def restore_z_r_run_current(self) -> AsyncIterator[None]:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -540,7 +540,7 @@ class OT3Simulator:
         return None
 
     @asynccontextmanager
-    async def restore_current(
+    async def motor_current(
         self,
         run_currents: OT3AxisMap[float] = {},
         hold_currents: OT3AxisMap[float] = {},

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -540,7 +540,11 @@ class OT3Simulator:
         return None
 
     @asynccontextmanager
-    async def restore_current(self) -> AsyncIterator[None]:
+    async def restore_current(
+        self,
+        run_currents: OT3AxisMap[float] = {},
+        hold_currents: OT3AxisMap[float] = {},
+    ) -> AsyncIterator[None]:
         """Save the current."""
         yield
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1329,7 +1329,7 @@ class OT3API(
                 moves = self._build_moves(
                     origin, target_pos, instr.config.plunger_homing_configurations.speed
                 )
-                async with self._backend.restore_current(
+                async with self._backend.motor_current(
                     run_currents={
                         axis: instr.config.plunger_homing_configurations.current
                     }
@@ -1341,7 +1341,7 @@ class OT3API(
                     )
                     await self._backend.home([axis], self.gantry_load)
         else:
-            async with self._backend.restore_current(
+            async with self._backend.motor_current(
                 run_currents={axis: instr.config.plunger_homing_configurations.current}
             ):
                 await self._backend.home([axis], self.gantry_load)
@@ -1695,7 +1695,7 @@ class OT3API(
         # NOTE: plunger position (mm) decreases up towards homing switch
         # NOTE: if already at BOTTOM, we still need to run backlash-compensation movement,
         #       because we do not know if we arrived at BOTTOM from above or below.
-        async with self._backend.restore_current(
+        async with self._backend.motor_current(
             run_currents={
                 pip_ax: instrument.config.plunger_homing_configurations.current
             }
@@ -1881,7 +1881,7 @@ class OT3API(
         self, mount: OT3Mount, pipette_spec: PickUpTipSpec
     ) -> None:
         for press in pipette_spec.presses:
-            async with self._backend.restore_current(
+            async with self._backend.motor_current(
                 run_currents={axis: current for axis, current in press.current.items()}
             ):
                 target_down = target_position_from_relative(
@@ -1899,7 +1899,7 @@ class OT3API(
     async def _motor_pick_up_tip(
         self, mount: OT3Mount, pipette_spec: TipMotorPickUpTipSpec
     ) -> None:
-        async with self._backend.restore_current(
+        async with self._backend.motor_current(
             run_currents={
                 axis: current for axis, current in pipette_spec.currents.items()
             }

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1329,10 +1329,11 @@ class OT3API(
                 moves = self._build_moves(
                     origin, target_pos, instr.config.plunger_homing_configurations.speed
                 )
-                async with self._backend.restore_current():
-                    await self._backend.set_active_current(
-                        {axis: instr.config.plunger_homing_configurations.current}
-                    )
+                async with self._backend.restore_current(
+                    run_currents={
+                        axis: instr.config.plunger_homing_configurations.current
+                    }
+                ):
                     await self._backend.move(
                         origin,
                         moves[0],
@@ -1340,10 +1341,9 @@ class OT3API(
                     )
                     await self._backend.home([axis], self.gantry_load)
         else:
-            async with self._backend.restore_current():
-                await self._backend.set_active_current(
-                    {axis: instr.config.plunger_homing_configurations.current}
-                )
+            async with self._backend.restore_current(
+                run_currents={axis: instr.config.plunger_homing_configurations.current}
+            ):
                 await self._backend.home([axis], self.gantry_load)
 
     async def _retrieve_home_position(
@@ -1695,10 +1695,11 @@ class OT3API(
         # NOTE: plunger position (mm) decreases up towards homing switch
         # NOTE: if already at BOTTOM, we still need to run backlash-compensation movement,
         #       because we do not know if we arrived at BOTTOM from above or below.
-        async with self._backend.restore_current():
-            await self._backend.set_active_current(
-                {pip_ax: instrument.config.plunger_homing_configurations.current}
-            )
+        async with self._backend.restore_current(
+            run_currents={
+                pip_ax: instrument.config.plunger_homing_configurations.current
+            }
+        ):
             if self._current_position[pip_ax] < backlash_pos[pip_ax]:
                 await self._move(
                     backlash_pos,
@@ -1880,10 +1881,9 @@ class OT3API(
         self, mount: OT3Mount, pipette_spec: PickUpTipSpec
     ) -> None:
         for press in pipette_spec.presses:
-            async with self._backend.restore_current():
-                await self._backend.set_active_current(
-                    {axis: current for axis, current in press.current.items()}
-                )
+            async with self._backend.restore_current(
+                run_currents={axis: current for axis, current in press.current.items()}
+            ):
                 target_down = target_position_from_relative(
                     mount, press.relative_down, self._current_position
                 )
@@ -1899,10 +1899,11 @@ class OT3API(
     async def _motor_pick_up_tip(
         self, mount: OT3Mount, pipette_spec: TipMotorPickUpTipSpec
     ) -> None:
-        async with self._backend.restore_current():
-            await self._backend.set_active_current(
-                {axis: current for axis, current in pipette_spec.currents.items()}
-            )
+        async with self._backend.restore_current(
+            run_currents={
+                axis: current for axis, current in pipette_spec.currents.items()
+            }
+        ):
             # Move to pick up position
             target_down = target_position_from_relative(
                 mount,

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -1122,7 +1122,7 @@ async def test_requires_estop(
         [{}, {}],
     ],
 )
-async def test_restore_current(
+async def test_motor_current(
     controller: OT3Controller,
     run_currents: OT3AxisMap[float],
     hold_currents: OT3AxisMap[float],
@@ -1134,7 +1134,7 @@ async def test_restore_current(
         with mock.patch.object(controller, "set_hold_current") as mock_hold_currents:
             with mock.patch.object(controller, "set_default_currents") as mock_default:
 
-                async with controller.restore_current(run_currents, hold_currents):
+                async with controller.motor_current(run_currents, hold_currents):
                     await controller.update_position()
 
                 if not run_currents and not hold_currents:

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -581,7 +581,7 @@ async def move_plunger_absolute_ot3(
     if motor_current is None:
         await _move_coro
     else:
-        async with api._backend.restore_current():
+        async with api._backend.motor_current():
             await api._backend.set_active_current(
                 {Axis.of_main_tool_actuator(mount): motor_current}  # type: ignore[dict-item]
             )
@@ -613,7 +613,7 @@ async def move_tip_motor_relative_ot3(
     if motor_current is None:
         await _move_coro
     else:
-        async with api._backend.restore_current():
+        async with api._backend.motor_current():
             await api._backend.set_active_current(
                 {Axis.Q: motor_current}  # type: ignore[dict-item]
             )

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -581,10 +581,9 @@ async def move_plunger_absolute_ot3(
     if motor_current is None:
         await _move_coro
     else:
-        async with api._backend.motor_current():
-            await api._backend.set_active_current(
-                {Axis.of_main_tool_actuator(mount): motor_current}  # type: ignore[dict-item]
-            )
+        async with api._backend.motor_current(
+            run_currents={Axis.of_main_tool_actuator(mount): motor_current}
+        ):
             await _move_coro
 
 
@@ -613,10 +612,7 @@ async def move_tip_motor_relative_ot3(
     if motor_current is None:
         await _move_coro
     else:
-        async with api._backend.motor_current():
-            await api._backend.set_active_current(
-                {Axis.Q: motor_current}  # type: ignore[dict-item]
-            )
+        async with api._backend.motor_current(run_currents={Axis.Q: motor_current}):
             await _move_coro
 
 

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
@@ -152,8 +152,7 @@ async def _drop_tip(api: OT3API, trash: Point) -> None:
 async def _partial_pick_up_z_motion(
     api: OT3API, current: float, distance: float, speed: float
 ) -> None:
-    async with api._backend.motor_current():
-        await api._backend.set_active_current({Axis.Z_L: current})
+    async with api._backend.motor_current(run_currents={Axis.Z_L: current}):
         target_down = target_position_from_relative(
             OT3Mount.LEFT, Point(z=-distance), api._current_position
         )

--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_droplets.py
@@ -152,7 +152,7 @@ async def _drop_tip(api: OT3API, trash: Point) -> None:
 async def _partial_pick_up_z_motion(
     api: OT3API, current: float, distance: float, speed: float
 ) -> None:
-    async with api._backend.restore_current():
+    async with api._backend.motor_current():
         await api._backend.set_active_current({Axis.Z_L: current})
         target_down = target_position_from_relative(
             OT3Mount.LEFT, Point(z=-distance), api._current_position

--- a/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
@@ -252,8 +252,9 @@ async def _force_gauge(
             force_output = []
             TH.start()
             try:
-                async with api._backend.motor_current():
-                    await api._backend.set_active_current({z_ax: test_current})
+                async with api._backend.motor_current(
+                    run_currents={z_ax: test_current}
+                ):
                     await api.move_to(
                         mount=mount,
                         abs_position=press_pos,

--- a/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
@@ -252,7 +252,7 @@ async def _force_gauge(
             force_output = []
             TH.start()
             try:
-                async with api._backend.restore_current():
+                async with api._backend.motor_current():
                     await api._backend.set_active_current({z_ax: test_current})
                     await api.move_to(
                         mount=mount,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR updates the `ot3controller.restore_current` function so it can optionally take in run currents and hold currents. Instead of unconditionally restoring _all_ current settings for every present axis, now this function can intelligently restore only the ones that were changed.

