### PR TITLE
docs(api): expand `Well.bottom()` warning

### DIFF
--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -58,7 +58,11 @@ This is a good position for :ref:`aspirating liquid <new-aspirate>` or an activi
 
 .. warning::
 
-    Negative ``z`` arguments to ``Well.bottom()`` can cause a pipette tip to collide with the bottom of the well. While Flex can detect collisions, the OT-2 has no sensors to detect an impact with a well bottom. For both robot types, a collision with a well bottom may bend the pipette's tip (affecting liquid handling) and the pipette may be higher on the z-axis than expected until it picks up another tip.
+    Negative ``z`` arguments to ``Well.bottom()`` will cause the pipette tip to collide with the bottom of the well. Collisions may bend the tip (affecting liquid handling) and the pipette may be higher than expected on the z-axis until it picks up another tip.
+    
+    Flex can detect collisions, and even gentle contact may trigger an overpressure error and cause the protocol to fail. Avoid ``z`` values less than 1, if possible.
+    
+    The OT-2 has no sensors to detect contact with a well bottom. The protocol will continue even after a collision.
 
 .. versionadded:: 2.0
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Elaborate upon the existing warning for `Well.bottom()` on the Labware and Deck Positions page. We previously only warned against negative values. Testing has shown that values below 1 may cause problems on Flex, and the warning now (gently) cautions against them. 

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Check the [sandbox](http://sandbox.docs.opentrons.com/docs-overpressure-warning/v2/robot_position.html#bottom).

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Updated warning text in `robot_position.rst`

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Is this guidance good? Do we need to add this warning in other places (e.g., docstring)?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

none, docs