### PR TITLE
fix(app): 96-channel detach probe video

### DIFF
--- a/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/DetachProbe.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { css } from 'styled-components'
 import detachProbe1 from '../../assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_1.webm'
 import detachProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_8.webm'
-import detachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Detach_96.webm'
+import detachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Detach_Probe_96.webm'
 import { useTranslation } from 'react-i18next'
 import {
   Flex,


### PR DESCRIPTION
closes [https://opentrons.atlassian.net/browse/RQA-1511](RQA-1511)

# Overview

The detach probe module wizard step video is currently rendering the wrong animation. Here, I update to the correct animation.

# Test Plan

- Verify that during module calibration with a 96-channel pipette, the detach probe step shows the proper animation

# Risk assessment

Low