### PR TITLE
fix(app): apply identity vector labware offsets

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/CurrentOffsetsTable.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/CurrentOffsetsTable.tsx
@@ -22,7 +22,6 @@ import { StyledText } from '../../../../atoms/text'
 import { LabwareOffsetTabs } from '../../../LabwareOffsetTabs'
 import { OffsetVector } from '../../../../molecules/OffsetVector'
 import { PythonLabwareOffsetSnippet } from '../../../../molecules/PythonLabwareOffsetSnippet'
-import { getLatestCurrentOffsets } from './utils'
 import type { LabwareOffset } from '@opentrons/api-client'
 import type {
   RunTimeCommand,
@@ -71,7 +70,6 @@ export function CurrentOffsetsTable(
   const isLabwareOffsetCodeSnippetsOn = useSelector(
     getIsLabwareOffsetCodeSnippetsOn
   )
-  const latestCurrentOffsets = getLatestCurrentOffsets(currentOffsets)
 
   const TableComponent = (
     <OffsetTable>
@@ -83,7 +81,7 @@ export function CurrentOffsetsTable(
         </tr>
       </thead>
       <tbody>
-        {latestCurrentOffsets.map(offset => {
+        {currentOffsets.map(offset => {
           const labwareDisplayName =
             offset.definitionUri in defsByURI
               ? getLabwareDisplayName(defsByURI[offset.definitionUri])
@@ -112,7 +110,7 @@ export function CurrentOffsetsTable(
   const JupyterSnippet = (
     <PythonLabwareOffsetSnippet
       mode="jupyter"
-      labwareOffsets={latestCurrentOffsets.map(o =>
+      labwareOffsets={currentOffsets.map(o =>
         pick(o, ['definitionUri', 'location', 'vector'])
       )}
       commands={commands ?? []}
@@ -123,7 +121,7 @@ export function CurrentOffsetsTable(
   const CommandLineSnippet = (
     <PythonLabwareOffsetSnippet
       mode="cli"
-      labwareOffsets={latestCurrentOffsets.map(o =>
+      labwareOffsets={currentOffsets.map(o =>
         pick(o, ['definitionUri', 'location', 'vector'])
       )}
       commands={commands ?? []}
@@ -137,7 +135,9 @@ export function CurrentOffsetsTable(
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       padding={SPACING.spacing16}
     >
-      <StyledText as="label">{t('applied_offset_data')}</StyledText>
+      <StyledText as="label">
+        {i18n.format(t('applied_offset_data'), 'upperCase')}
+      </StyledText>
       {isLabwareOffsetCodeSnippetsOn ? (
         <LabwareOffsetTabs
           TableComponent={TableComponent}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/CurrentOffsetsTable.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/CurrentOffsetsTable.test.tsx
@@ -61,13 +61,6 @@ const mockCurrentOffsets: LabwareOffset[] = [
     vector: { x: 0, y: 0, z: 0 },
   },
   {
-    createdAt: '2022-12-20T14:09:08.688756+00:00',
-    definitionUri: 'opentrons/opentrons_96_tiprack_10ul/1',
-    id: '494ec3d1-224f-4f9a-a83b-3dd3060ea332',
-    location: { slotName: '2' },
-    vector: { x: 0, y: -0.09999999999999432, z: -0.09999999999999432 },
-  },
-  {
     createdAt: '2022-12-20T14:09:08.689813+00:00',
     definitionUri:
       'opentrons/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1',
@@ -141,7 +134,7 @@ describe('CurrentOffsetsTable', () => {
   })
   it('renders the correct text', () => {
     const { getByText } = render(props)
-    getByText('Applied Labware Offset data')
+    getByText('APPLIED LABWARE OFFSET DATA')
     getByText('location')
     getByText('labware')
     getByText('labware offset data')

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/index.tsx
@@ -22,6 +22,7 @@ import { CurrentOffsetsTable } from './CurrentOffsetsTable'
 import { useLaunchLPC } from '../../../LabwarePositionCheck/useLaunchLPC'
 import { StyledText } from '../../../../atoms/text'
 import type { LabwareOffset } from '@opentrons/api-client'
+import { getLatestCurrentOffsets } from './utils'
 
 interface SetupLabwarePositionCheckProps {
   expandLabwareStep: () => void
@@ -74,15 +75,17 @@ export function SetupLabwarePositionCheck(
 
   const { launchLPC, LPCWizard } = useLaunchLPC(runId, protocolName)
 
+  const nonIdentityOffsets = getLatestCurrentOffsets(sortedOffsets)
+
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
       marginTop={SPACING.spacing16}
       gridGap={SPACING.spacing16}
     >
-      {sortedOffsets.length > 0 ? (
+      {nonIdentityOffsets.length > 0 ? (
         <CurrentOffsetsTable
-          currentOffsets={sortedOffsets}
+          currentOffsets={nonIdentityOffsets}
           commands={protocolData?.commands ?? []}
           labware={protocolData?.labware ?? []}
           modules={protocolData?.modules ?? []}


### PR DESCRIPTION
closes [RQA-1626](https://opentrons.atlassian.net/browse/RQA-1626)
closes [RQA-1627](https://opentrons.atlassian.net/browse/RQA-1627)

# Overview

Currently, identity vector labware offset data are filtered in the CurrentOffsetsTable component. This unintentionally renders and empty offsets table when there are some offsets saved and they are all equal to the identity vector, rather than the intended "No labware offset data yet" text.  

This PR also takes care of a minor styling bug in the table header when there are some offsets.

# Test Plan

- Verify that if no offset data is saved, "No labware offset data available" renders on the choose protocol/robot slideout.
- Verify that if no offset data is saved, SetupLabwarePositionCheck component renders "No labware offset data yet" rather than an empty table.
- Verify that if only identity offset data is saved, "No labware offset data available" renders on the choose protocol/robot slideout.
- Verify that if only identity offset data is saved, SetupLabwarePositionCheck component renders "No labware offset data yet" rather than an empty table.
- Verify that if some identity offset data and some non-identity offset data is saved, "Apply offset data" renders on the choose protocol/robot slideout. Selecting "View data" should show a table of only non-identity offsets.
- Verify that if some identity offset data and some non-identity offset data is saved, SetupLabwarePositionCheck component renders a CurrentOffsetsTable component showing only non-identity offsets.


[RQA-1626]: https://opentrons.atlassian.net/browse/RQA-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-1627]: https://opentrons.atlassian.net/browse/RQA-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ