### PR TITLE
fix(app): nicknames on modules in protocol setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/SetupLabwareMap.tsx
@@ -88,8 +88,8 @@ export function SetupLabwareMap({
                       labwareInAdapterInMod?.result?.labwareId ??
                       nestedLabwareId
                     const topLabwareDisplayName =
-                      labwareInAdapterInMod?.result?.definition.metadata
-                        .displayName ?? nestedLabwareDisplayName
+                      labwareInAdapterInMod?.params.displayName ??
+                      nestedLabwareDisplayName
 
                     return (
                       <Module
@@ -134,8 +134,7 @@ export function SetupLabwareMap({
                     const topLabwareId =
                       labwareInAdapter?.result?.labwareId ?? labwareId
                     const topLabwareDisplayName =
-                      labwareInAdapter?.result?.definition.metadata
-                        .displayName ?? displayName
+                      labwareInAdapter?.params.displayName ?? displayName
 
                     return (
                       <React.Fragment

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
@@ -118,8 +118,8 @@ export function SetupLiquidsMap(props: SetupLiquidsMapProps): JSX.Element {
                 const topLabwareId =
                   labwareInAdapterInMod?.result?.labwareId ?? nestedLabwareId
                 const topLabwareDisplayName =
-                  labwareInAdapterInMod?.result?.definition.metadata
-                    .displayName ?? nestedLabwareDisplayName
+                  labwareInAdapterInMod?.params.displayName ??
+                  nestedLabwareDisplayName
 
                 const wellFill = getWellFillFromLabwareId(
                   topLabwareId ?? '',
@@ -196,8 +196,7 @@ export function SetupLiquidsMap(props: SetupLiquidsMapProps): JSX.Element {
                 const topLabwareId =
                   labwareInAdapter?.result?.labwareId ?? labwareId
                 const topLabwareDisplayName =
-                  labwareInAdapter?.result?.definition.metadata.displayName ??
-                  displayName
+                  labwareInAdapter?.params.displayName ?? displayName
                 const wellFill = getWellFillFromLabwareId(
                   topLabwareId ?? '',
                   liquids,

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -1,22 +1,12 @@
 {
-  "machine": "OT-3 Standard",
-  "strict_attached_instruments": false,
   "attached_instruments": {
     "right": {
-      "model": "p1000_single_v3.4",
-      "id": "321",
-      "max_volume": 1000,
-      "name": "p1000_single",
-      "tip_length": 0,
-      "channels": 1
+      "model": "p300_single_v1",
+      "id": "321"
     },
     "left": {
-      "model": "p50_single_v3.4",
-      "id": "123",
-      "max_volume": 50,
-      "name": "p50_single",
-      "tip_length": 0,
-      "channels": 1
+      "model": "p10_single_v1",
+      "id": "123"
     }
   },
   "attached_modules": {

--- a/robot-server/simulators/test.json
+++ b/robot-server/simulators/test.json
@@ -1,12 +1,22 @@
 {
+  "machine": "OT-3 Standard",
+  "strict_attached_instruments": false,
   "attached_instruments": {
     "right": {
-      "model": "p300_single_v1",
-      "id": "321"
+      "model": "p1000_single_v3.4",
+      "id": "321",
+      "max_volume": 1000,
+      "name": "p1000_single",
+      "tip_length": 0,
+      "channels": 1
     },
     "left": {
-      "model": "p10_single_v1",
-      "id": "123"
+      "model": "p50_single_v3.4",
+      "id": "123",
+      "max_volume": 50,
+      "name": "p50_single",
+      "tip_length": 0,
+      "channels": 1
     }
   },
   "attached_modules": {


### PR DESCRIPTION
closes RAUT-768

# Overview

Previously, we were grabbing the display name instead of the nick name. it is very confusing since they are both key "displayName" and lots of utils refer to both as "displayName"

# Test Plan

upload a protocol with a nickname on a labware on deck, on adapter on deck, on module, and on adapter on module on deck. See that they render properly in labware and liquid setup. Also upload a protocol without any nicknames and make sure it works as expected showing the displayname.

see nicknames (one -> four):
<img width="669" alt="Screen Shot 2023-10-02 at 2 00 24 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/b56b929f-4524-4630-a3db-fc0bf0442af2">

# Changelog

- change to get display name from params instead of the definition metadata

# Review requests

see test plan

# Risk assessment

low