### PR TITLE
fix(robot-server): mutable configs for attached

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -263,6 +263,14 @@ class PipetteHandlerProvider(Generic[MountType]):
         return self.get_attached_instruments()
 
     @property
+    def attached_pipettes(self) -> Dict[MountType, PipetteDict]:
+        return self.get_attached_instruments()
+
+    @property
+    def get_attached_pipettes(self) -> Dict[MountType, PipetteDict]:
+        return self.get_attached_instruments()
+
+    @property
     def hardware_instruments(self) -> InstrumentsByMount[MountType]:
         """Do not write new code that uses this."""
         return self._attached_instruments

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -77,6 +77,18 @@ class InstrumentConfigurer(Protocol):
     def attached_instruments(self) -> Dict[Mount, PipetteDict]:
         return self.get_attached_instruments()
 
+    def get_attached_pipettes(self) -> Dict[Mount, PipetteDict]:
+        """Get the status dicts of cached attached pipettes.
+
+        Works like get_attached_instruments but for pipettes only - on the Flex,
+        there will be no gripper information here.
+        """
+        ...
+
+    @property
+    def attached_pipettes(self) -> Dict[Mount, PipetteDict]:
+        return self.get_attached_pipettes()
+
     def calibrate_plunger(
         self,
         mount: Mount,

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -6,9 +6,16 @@ from starlette import status
 from fastapi import APIRouter, Depends
 
 from opentrons_shared_data.errors import ErrorCodes
-from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control import (
+    HardwareControlAPI,
+    dev_types as hardware_dev_types,
+)
 from opentrons.system import log_control
-from opentrons_shared_data.pipette import mutable_configurations, types as pip_types
+from opentrons_shared_data.pipette import (
+    mutable_configurations,
+    types as pip_types,
+    pipette_load_name_conversions as pip_names,
+)
 from opentrons.config import (
     reset as reset_util,
     robot_configs,
@@ -276,15 +283,22 @@ async def get_robot_settings(
     response_model_by_alias=True,
     response_model_exclude_unset=True,
 )
-async def get_pipette_settings() -> MultiPipetteSettings:
+async def get_pipette_settings(
+    hardware: HardwareControlAPI = Depends(get_hardware),
+) -> MultiPipetteSettings:
     res = {}
+    attached_pipettes = hardware.attached_pipettes
     for pipette_id in mutable_configurations.known_pipettes(
         get_opentrons_path("pipette_config_overrides_dir")
     ):
         # Have to convert to dict using by_alias due to bug in fastapi
-        res[pipette_id] = _pipette_settings_from_config(
+        res[pipette_id] = _pipette_settings_from_id(
             pipette_id,
         )
+    for dct in attached_pipettes.values():
+        if "pipette_id" not in dct:
+            continue
+        res[dct["pipette_id"]] = _pipette_settings_from_pipette_dict(dct)
     return res
 
 
@@ -298,16 +312,22 @@ async def get_pipette_settings() -> MultiPipetteSettings:
         status.HTTP_404_NOT_FOUND: {"model": LegacyErrorResponse},
     },
 )
-async def get_pipette_setting(pipette_id: str) -> PipetteSettings:
-    if pipette_id not in mutable_configurations.known_pipettes(
+async def get_pipette_setting(
+    pipette_id: str, hardware: HardwareControlAPI = Depends(get_hardware)
+) -> PipetteSettings:
+    attached_pipettes = hardware.attached_pipettes
+    known_ids = mutable_configurations.known_pipettes(
         get_opentrons_path("pipette_config_overrides_dir")
-    ):
-        raise LegacyErrorResponse(
-            message=f"{pipette_id} is not a valid pipette id",
-            errorCode=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
-        ).as_error(status.HTTP_404_NOT_FOUND)
-    r = _pipette_settings_from_config(pipette_id)
-    return r
+    )
+    if pipette_id in known_ids:
+        return _pipette_settings_from_id(pipette_id)
+    for dct in attached_pipettes.values():
+        if dct.get("pipette_id") == pipette_id:
+            return _pipette_settings_from_pipette_dict(dct)
+    raise LegacyErrorResponse(
+        message=f"{pipette_id} is not a valid pipette id",
+        errorCode=ErrorCodes.PIPETTE_NOT_PRESENT.value.code,
+    ).as_error(status.HTTP_404_NOT_FOUND)
 
 
 @router.patch(
@@ -339,22 +359,13 @@ async def patch_pipette_setting(
             raise LegacyErrorResponse(
                 message=str(e), errorCode=ErrorCodes.GENERAL_ERROR.value.code
             ).as_error(status.HTTP_412_PRECONDITION_FAILED)
-    r = _pipette_settings_from_config(pipette_id)
+    r = _pipette_settings_from_id(pipette_id)
     return r
 
 
-def _pipette_settings_from_config(pipette_id: str) -> PipetteSettings:
-    """
-    Create a PipetteSettings object from pipette config for single pipette
-
-    :param pc: pipette config module
-    :param pipette_id: pipette id
-    :return: PipetteSettings object
-    """
-    mutable_configs = mutable_configurations.list_mutable_configs(
-        pipette_serial_number=pipette_id,
-        pipette_override_path=get_opentrons_path("pipette_config_overrides_dir"),
-    )
+def _pipette_settings_from_mutable_configs(
+    mutable_configs: pip_types.OverrideType,
+) -> PipetteSettings:
     converted_dict: Dict[str, Union[str, Dict[str, Any]]] = {}
     # TODO rather than doing this gross thing, we should
     # mess around with pydantic dataclasses.
@@ -376,3 +387,35 @@ def _pipette_settings_from_config(pipette_id: str) -> PipetteSettings:
         ),
         fields=fields,
     )
+
+
+def _pipette_settings_from_id(pipette_id: str) -> PipetteSettings:
+    """
+    Create a PipetteSettings object from pipette config for single pipette
+
+    :param pc: pipette config module
+    :param pipette_id: pipette id
+    :return: PipetteSettings object
+    """
+    mutable_configs = mutable_configurations.list_mutable_configs(
+        pipette_serial_number=pipette_id,
+        pipette_override_path=get_opentrons_path("pipette_config_overrides_dir"),
+    )
+    return _pipette_settings_from_mutable_configs(mutable_configs)
+
+
+def _pipette_settings_from_pipette_dict(
+    pipette_dict: hardware_dev_types.PipetteDict,
+) -> PipetteSettings:
+    """
+    Create a PipetteSettings object from a pipette dict from hardware
+    """
+    pipette_id = pipette_dict["pipette_id"]
+    pipette_model = pipette_dict["model"]
+    pipette_modelversion = pip_names.convert_pipette_model(pipette_model)
+    mutable_configs = mutable_configurations.list_mutable_configs_with_defaults(
+        pipette_model=pipette_modelversion,
+        pipette_serial_number=pipette_id,
+        pipette_override_path=get_opentrons_path("pipette_config_overrides_dir"),
+    )
+    return _pipette_settings_from_mutable_configs(mutable_configs)

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -1,5 +1,5 @@
 import logging
-from mock import patch, call
+from mock import patch, call, MagicMock
 from dataclasses import make_dataclass
 from typing import Generator
 from pathlib import Path
@@ -10,7 +10,11 @@ from decoy import Decoy
 
 from opentrons.config.reset import ResetOptionId
 from opentrons.config import advanced_settings
-from opentrons_shared_data.pipette import types as pip_types
+from opentrons_shared_data.pipette import (
+    types as pip_types,
+    pipette_definition as pip_def,
+)
+from opentrons.types import Mount
 
 
 from robot_server import app
@@ -125,6 +129,15 @@ def mock_list_mutable_configs(decoy: Decoy) -> Decoy:
 
 
 @pytest.fixture
+def mock_list_mutable_configs_with_defaults(decoy: Decoy) -> Decoy:
+    with patch(
+        "opentrons_shared_data.pipette.mutable_configurations.list_mutable_configs_with_defaults",
+        new=decoy.mock(),
+    ) as m:
+        yield m
+
+
+@pytest.fixture
 def mock_save_overrides(decoy: Decoy) -> Decoy:
     with patch(
         "opentrons_shared_data.pipette.mutable_configurations.save_overrides",
@@ -140,6 +153,70 @@ def mock_get_opentrons_dir(decoy: Decoy) -> Decoy:
         new=decoy.mock(),
     ) as m:
         yield m
+
+
+def test_receive_attached_pipette_settings(
+    decoy: Decoy,
+    api_client,
+    mock_known_pipettes: Decoy,
+    mock_get_opentrons_dir: Decoy,
+    mock_list_mutable_configs_with_defaults: Decoy,
+    hardware: MagicMock,
+) -> None:
+    decoy.when(mock_get_opentrons_dir("pipette_config_overrides_dir")).then_return(
+        "nope"
+    )
+    decoy.when(mock_known_pipettes("nope")).then_return([])
+    hardware.attached_pipettes = {
+        Mount.LEFT: {"pipette_id": "P12345", "model": "p20_multi_v3.5"}
+    }
+    decoy.when(
+        mock_list_mutable_configs_with_defaults(
+            pipette_model=pip_def.PipetteModelVersionType(
+                pip_types.PipetteModelType.p20,
+                pip_types.PipetteChannelType.EIGHT_CHANNEL,
+                pip_types.PipetteVersionType(3, 5),
+            ),
+            pipette_serial_number="P12345",
+            pipette_override_path="nope",
+        )
+    ).then_return(
+        {
+            "pickUpCurrent": pip_types.MutableConfig.build(
+                **{
+                    "units": "mm",
+                    "type": "float",
+                    "min": 1.0,
+                    "max": 3.0,
+                    "default": 1.5,
+                    "value": 1.2,
+                },
+                name="pickUpCurrent",
+            ),
+            "quirks": {
+                "dropTipShake": pip_types.QuirkConfig(name="dropTipShake", value=True)
+            },
+            "model": "p20_multi_v3.5",
+        }
+    )
+    resp = api_client.get("/settings/pipettes")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "P12345": {
+            "info": {"model": "p20_multi_v3.5", "name": ""},
+            "fields": {
+                "pickUpCurrent": {
+                    "units": "mm",
+                    "type": "float",
+                    "min": 1.0,
+                    "max": 3.0,
+                    "default": 1.5,
+                    "value": 1.2,
+                },
+                "quirks": {"dropTipShake": True},
+            },
+        },
+    }
 
 
 def test_receive_pipette_settings(


### PR DESCRIPTION
When something hits /settings/pipettes, we load known mutable configuration overrides. So if you don't have any for the attached pipettes, we don't return anything.

The thing is, what we actually want is to return all of the mutable configurations, with overrides applied. So now we do.

Closes RET-1376

## Testing
On an OT-2, attach a pipette that doesn't have overrides and `GET /settings/pipettes` (or view the pipette settings in the opentrons app).