### PR TITLE
docs(api): updating docstrings for the Well class 

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -249,6 +249,9 @@ Equivalently, using ``rows_by_name``::
 
 .. versionadded:: 2.0
 
+
+.. _labeling-liquids:
+
 *************************
 Labeling Liquids in Wells
 *************************

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -166,6 +166,8 @@ Small, direct movements can be useful for working inside of a well, without havi
 .. versionadded:: 2.0
 
 
+.. _points-locations:
+
 Points and Locations
 --------------------
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -229,8 +229,8 @@ class Well:
             position in absolute deck coordinates.
 
         .. note:: Even if the absolute values of ``x``, ``y``, and ``z`` are all less
-            than 1, applying the result of ``from_center_cartesian`` to the well's
-            center may produce a location outside the physical well. For example,
+            than 1, a location constructed from the well and the result of
+            ``from_center_cartesian`` may be outside of the physical well. For example,
             ``from_center_cartesian(0.9, 0.9, 0)`` would be outside of a cylindrical
             well, but inside a square well.
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -182,8 +182,8 @@ class Well:
     def bottom(self, z: float = 0.0) -> Location:
         """
         :param z: An offset on the z-axis, in mm. Positive offsets are higher and
-            negative offsets are lower. 
-        
+            negative offsets are lower.
+
         :return: A :py:class:`~opentrons.types.Location` corresponding to the
             absolute position of the bottom-center of the well, plus the ``z`` offset
             (if specified).
@@ -211,10 +211,10 @@ class Well:
 
         :param x: The fraction of the distance from the well's center to its edge
             along the x-axis. Negative values are to the left, and positive values
-            are to the right. 
+            are to the right.
         :param y: The fraction of the distance from the well's center to its edge
             along the y-axis. Negative values are to the front, and positive values
-            are to the back. 
+            are to the back.
         :param z: The fraction of the distance from the well's center to its edge
             along the x-axis. Negative values are down, and positive values are up.
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -68,10 +68,13 @@ class OutOfTipsError(Exception):
 
 class Well:
     """
-    The Well class represents a  single well in a :py:class:`Labware`
+    The Well class represents a single well in a :py:class:`Labware`. It provides parameters and functions for three major uses:
 
-    It provides functions to return positions used in operations on the well
-    such as :py:meth:`top`, :py:meth:`bottom`
+        - Calculating positions relative to the well. See :ref:`position-relative-labware` for details.
+
+        - Returning well measurements. see :ref:`new-labware-well-properties` for details.
+
+        - Specifying what liquid should be in the well at the beginning of a protocol. See :ref:`labeling-liquids` for details.
     """
 
     def __init__(self, parent: Labware, core: WellCore, api_version: APIVersion):
@@ -95,7 +98,7 @@ class Well:
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def has_tip(self) -> bool:
-        """If parent labware is a tip rack, whether this well contains a tip."""
+        """Whether this well contains a tip. Always ``False`` if the parent labware isn't a tip rack."""
         return self._core.has_tip()
 
     @has_tip.setter
@@ -126,8 +129,8 @@ class Well:
     @requires_version(2, 9)
     def length(self) -> Optional[float]:
         """
-        The length of a well, if the labware has
-        square wells.
+        The length, in mm, of a rectangular well along the x-axis (left to right). Returns ``None``
+        if the well is not rectangular.
         """
         return self._core.length
 
@@ -135,8 +138,8 @@ class Well:
     @requires_version(2, 9)
     def width(self) -> Optional[float]:
         """
-        The width of a well, if the labware has
-        square wells.
+        The width, in mm, of a rectangular well along the y-axis (front to back). Returns ``None``
+        if the well is not rectangular.
         """
         return self._core.width
 
@@ -144,7 +147,7 @@ class Well:
     @requires_version(2, 9)
     def depth(self) -> float:
         """
-        The depth of a well in a labware.
+        The depth, in mm, of a well along the z-axis, from the very top of the well to the very bottom.
         """
         return self._core.depth
 
@@ -160,54 +163,47 @@ class Well:
     @requires_version(2, 0)
     def top(self, z: float = 0.0) -> Location:
         """
-        :param z: the z distance in mm
-        :return: a Point corresponding to the absolute position of the
-                 top-center of the well relative to the deck (with the
-                 front-left corner of slot 1 as (0,0,0)). If z is specified,
-                 returns a point offset by z mm from top-center
+        :param z: An offset on the z-axis, in mm. Positive offsets are higher and negative offsets are lower.
+        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute position of the
+                 top-center of the well, plus the ``z`` offset (if specified).
         """
         return Location(self._core.get_top(z_offset=z), self)
 
     @requires_version(2, 0)
     def bottom(self, z: float = 0.0) -> Location:
         """
-        :param z: the z distance in mm
-        :return: a Point corresponding to the absolute position of the
-                 bottom-center of the well (with the front-left corner of
-                 slot 1 as (0,0,0)). If z is specified, returns a point
-                 offset by z mm from bottom-center
+        :param z: An offset on the z-axis, in mm. Positive offsets are higher and negative offsets are lower.
+        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute position of the
+                 bottom-center of the well, plus the ``z`` offset (if specified).
         """
         return Location(self._core.get_bottom(z_offset=z), self)
 
     @requires_version(2, 0)
     def center(self) -> Location:
         """
-        :return: a Point corresponding to the absolute position of the center
-                 of the well relative to the deck (with the front-left corner
-                 of slot 1 as (0,0,0))
+        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute position of the
+                 center of the well (in all three dimensions).
         """
         return Location(self._core.get_center(), self)
 
     @requires_version(2, 8)
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """
-        Specifies an arbitrary point in deck coordinates based
-        on percentages of the radius in each axis. For example, to specify the
-        back-right corner of a well at 1/4 of the well depth from the bottom,
-        the call would be ``from_center_cartesian(1, 1, -0.5)``.
+        Specifies a :py:class:`~opentrons.types.Point` based
+        on fractions of the distance from the center of the well to the edge along each axis. 
+        
+        For example, ``from_center_cartesian(0, 0, 0.5)`` specifies a point with no change in the x- or y-axis, and half of the distance from the center of the well to its top along the z-axis. Use :py:meth:`.move` to construct a :py:class:`~opentrons.types.Location` that a pipette can move to.
 
-        No checks are performed to ensure that the resulting position will be
-        inside of the well.
+        :param x: The fraction of the distance from the well's center to its edge along the x-axis. Negative values are to the left, and positive values are to the right.
+        :param y: The fraction of the distance from the well's center to its edge along the y-axis. Negative values are to the front, and positive values are to the back.
+        :param z: The fraction of the distance from the well's center to its edge along the x-axis. Negative values are down, and positive values are up.
 
-        :param x: a float in the range [-1.0, 1.0] for a percentage of half of
-            the radius/length in the X axis
-        :param y: a float in the range [-1.0, 1.0] for a percentage of half of
-            the radius/width in the Y axis
-        :param z: a float in the range [-1.0, 1.0] for a percentage of half of
-            the height above/below the center
+        :return: A :py:class:`~opentrons.types.Point` representing the specified
+                 distances in mm.
+                 
+        .. note::
+            Even if the absolute values of ``x``, ``y``, and ``z`` are all less than 1, applying the result of ``from_center_cartesian`` to the well's center may produce a location outside the physical well. For example, ``from_center_cartesian(0.9, 0.9, 0)`` would be outside of a cylindrical well, but inside a square well.
 
-        :return: a :py:class:`opentrons.types.Point` representing the specified
-                 location in absolute deck coordinates
         """
         return self._core.from_center_cartesian(x, y, z)
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -98,7 +98,8 @@ class Well:
     @property  # type: ignore[misc]
     @requires_version(2, 0)
     def has_tip(self) -> bool:
-        """Whether this well contains a tip. Always ``False`` if the parent labware isn't a tip rack."""
+        """Whether this well contains a tip. Always ``False`` if the parent labware
+        isn't a tip rack."""
         return self._core.has_tip()
 
     @has_tip.setter
@@ -123,14 +124,18 @@ class Well:
     @property  # type: ignore
     @requires_version(2, 0)
     def diameter(self) -> Optional[float]:
+        """
+        The diameter, in mm, of a circular well. Returns ``None``
+        if the well is not circular.
+        """
         return self._core.diameter
 
     @property  # type: ignore
     @requires_version(2, 9)
     def length(self) -> Optional[float]:
         """
-        The length, in mm, of a rectangular well along the x-axis (left to right). Returns ``None``
-        if the well is not rectangular.
+        The length, in mm, of a rectangular well along the x-axis (left to right).
+        Returns ``None`` if the well is not rectangular.
         """
         return self._core.length
 
@@ -138,8 +143,8 @@ class Well:
     @requires_version(2, 9)
     def width(self) -> Optional[float]:
         """
-        The width, in mm, of a rectangular well along the y-axis (front to back). Returns ``None``
-        if the well is not rectangular.
+        The width, in mm, of a rectangular well along the y-axis (front to back).
+        Returns ``None`` if the well is not rectangular.
         """
         return self._core.width
 
@@ -147,7 +152,8 @@ class Well:
     @requires_version(2, 9)
     def depth(self) -> float:
         """
-        The depth, in mm, of a well along the z-axis, from the very top of the well to the very bottom.
+        The depth, in mm, of a well along the z-axis, from the very top of the well to
+        the very bottom.
         """
         return self._core.depth
 
@@ -163,46 +169,56 @@ class Well:
     @requires_version(2, 0)
     def top(self, z: float = 0.0) -> Location:
         """
-        :param z: An offset on the z-axis, in mm. Positive offsets are higher and negative offsets are lower.
-        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute position of the
-                 top-center of the well, plus the ``z`` offset (if specified).
+        :param z: An offset on the z-axis, in mm. Positive offsets are higher and
+        negative offsets are lower. :return: A :py:class:`~opentrons.types.Point`
+        corresponding to the absolute position of the top-center of the well, plus the
+        ``z`` offset (if specified).
         """
         return Location(self._core.get_top(z_offset=z), self)
 
     @requires_version(2, 0)
     def bottom(self, z: float = 0.0) -> Location:
         """
-        :param z: An offset on the z-axis, in mm. Positive offsets are higher and negative offsets are lower.
-        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute position of the
-                 bottom-center of the well, plus the ``z`` offset (if specified).
-        """
+        :param z: An offset on the z-axis, in mm. Positive offsets are higher and
+        negative offsets are lower. :return: A :py:class:`~opentrons.types.Point`
+        corresponding to the absolute position of the bottom-center of the well, plus
+        the ``z`` offset (if specified)."""
         return Location(self._core.get_bottom(z_offset=z), self)
 
     @requires_version(2, 0)
     def center(self) -> Location:
         """
-        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute position of the
-                 center of the well (in all three dimensions).
+        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute
+        position of the center of the well (in all three dimensions).
         """
         return Location(self._core.get_center(), self)
 
     @requires_version(2, 8)
     def from_center_cartesian(self, x: float, y: float, z: float) -> Point:
         """
-        Specifies a :py:class:`~opentrons.types.Point` based
-        on fractions of the distance from the center of the well to the edge along each axis. 
-        
-        For example, ``from_center_cartesian(0, 0, 0.5)`` specifies a point with no change in the x- or y-axis, and half of the distance from the center of the well to its top along the z-axis. Use :py:meth:`.move` to construct a :py:class:`~opentrons.types.Location` that a pipette can move to.
+        Specifies a :py:class:`~opentrons.types.Point` based on fractions of the
+        distance from the center of the well to the edge along each axis.
 
-        :param x: The fraction of the distance from the well's center to its edge along the x-axis. Negative values are to the left, and positive values are to the right.
-        :param y: The fraction of the distance from the well's center to its edge along the y-axis. Negative values are to the front, and positive values are to the back.
-        :param z: The fraction of the distance from the well's center to its edge along the x-axis. Negative values are down, and positive values are up.
+        For example, ``from_center_cartesian(0, 0, 0.5)`` specifies a point with no
+        change in the x- or y-axis, and half of the distance from the center of the well
+        to its top along the z-axis. Use :py:meth:`.move` to construct a
+        :py:class:`~opentrons.types.Location` that a pipette can move to.
+
+        :param x: The fraction of the distance from the well's center to its edge along
+        the x-axis. Negative values are to the left, and positive values are to the
+        right. :param y: The fraction of the distance from the well's center to its edge
+        along the y-axis. Negative values are to the front, and positive values are to
+        the back. :param z: The fraction of the distance from the well's center to its
+        edge along the x-axis. Negative values are down, and positive values are up.
 
         :return: A :py:class:`~opentrons.types.Point` representing the specified
-                 distances in mm.
-                 
-        .. note::
-            Even if the absolute values of ``x``, ``y``, and ``z`` are all less than 1, applying the result of ``from_center_cartesian`` to the well's center may produce a location outside the physical well. For example, ``from_center_cartesian(0.9, 0.9, 0)`` would be outside of a cylindrical well, but inside a square well.
+        distances in mm.
+
+        .. note:: Even if the absolute values of ``x``, ``y``, and ``z`` are all less
+        than 1, applying the result of ``from_center_cartesian`` to the well's center
+        may produce a location outside the physical well. For example,
+        ``from_center_cartesian(0.9, 0.9, 0)`` would be outside of a cylindrical well,
+        but inside a square well.
 
         """
         return self._core.from_center_cartesian(x, y, z)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -170,9 +170,11 @@ class Well:
     def top(self, z: float = 0.0) -> Location:
         """
         :param z: An offset on the z-axis, in mm. Positive offsets are higher and
-        negative offsets are lower. :return: A :py:class:`~opentrons.types.Point`
-        corresponding to the absolute position of the top-center of the well, plus the
-        ``z`` offset (if specified).
+            negative offsets are lower.
+
+        :return: A :py:class:`~opentrons.types.Location` corresponding to the
+            absolute position of the top-center of the well, plus the ``z`` offset
+            (if specified).
         """
         return Location(self._core.get_top(z_offset=z), self)
 
@@ -180,16 +182,19 @@ class Well:
     def bottom(self, z: float = 0.0) -> Location:
         """
         :param z: An offset on the z-axis, in mm. Positive offsets are higher and
-        negative offsets are lower. :return: A :py:class:`~opentrons.types.Point`
-        corresponding to the absolute position of the bottom-center of the well, plus
-        the ``z`` offset (if specified)."""
+            negative offsets are lower. 
+        
+        :return: A :py:class:`~opentrons.types.Location` corresponding to the
+            absolute position of the bottom-center of the well, plus the ``z`` offset
+            (if specified).
+        """
         return Location(self._core.get_bottom(z_offset=z), self)
 
     @requires_version(2, 0)
     def center(self) -> Location:
         """
-        :return: A :py:class:`~opentrons.types.Point` corresponding to the absolute
-        position of the center of the well (in all three dimensions).
+        :return: A :py:class:`~opentrons.types.Location` corresponding to the
+            absolute position of the center of the well (in all three dimensions).
         """
         return Location(self._core.get_center(), self)
 
@@ -200,25 +205,27 @@ class Well:
         distance from the center of the well to the edge along each axis.
 
         For example, ``from_center_cartesian(0, 0, 0.5)`` specifies a point with no
-        change in the x- or y-axis, and half of the distance from the center of the well
-        to its top along the z-axis. Use :py:meth:`.move` to construct a
+        change in the x- or y-axis, and half of the distance from the center of
+        the well to its top along the z-axis. Use :py:meth:`.move` to construct a
         :py:class:`~opentrons.types.Location` that a pipette can move to.
 
-        :param x: The fraction of the distance from the well's center to its edge along
-        the x-axis. Negative values are to the left, and positive values are to the
-        right. :param y: The fraction of the distance from the well's center to its edge
-        along the y-axis. Negative values are to the front, and positive values are to
-        the back. :param z: The fraction of the distance from the well's center to its
-        edge along the x-axis. Negative values are down, and positive values are up.
+        :param x: The fraction of the distance from the well's center to its edge
+            along the x-axis. Negative values are to the left, and positive values
+            are to the right. 
+        :param y: The fraction of the distance from the well's center to its edge
+            along the y-axis. Negative values are to the front, and positive values
+            are to the back. 
+        :param z: The fraction of the distance from the well's center to its edge
+            along the x-axis. Negative values are down, and positive values are up.
 
         :return: A :py:class:`~opentrons.types.Point` representing the specified
-        distances in mm.
+            distances in mm.
 
         .. note:: Even if the absolute values of ``x``, ``y``, and ``z`` are all less
-        than 1, applying the result of ``from_center_cartesian`` to the well's center
-        may produce a location outside the physical well. For example,
-        ``from_center_cartesian(0.9, 0.9, 0)`` would be outside of a cylindrical well,
-        but inside a square well.
+            than 1, applying the result of ``from_center_cartesian`` to the well's
+            center may produce a location outside the physical well. For example,
+            ``from_center_cartesian(0.9, 0.9, 0)`` would be outside of a cylindrical
+            well, but inside a square well.
 
         """
         return self._core.from_center_cartesian(x, y, z)

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -209,8 +209,8 @@ class Well:
         the well to its top along the z-axis. To move the pipette to that location,
         construct a :py:class:`~opentrons.types.Location` relative to the same well::
 
-            location = Location(
-                plate["A1"], plate["A1"].from_center_cartesian(0, 0, 0.5)
+            location = types.Location(
+                plate["A1"].from_center_cartesian(0, 0, 0.5), plate["A1"]
             )
             pipette.move_to(location)
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -204,10 +204,17 @@ class Well:
         Specifies a :py:class:`~opentrons.types.Point` based on fractions of the
         distance from the center of the well to the edge along each axis.
 
-        For example, ``from_center_cartesian(0, 0, 0.5)`` specifies a point with no
-        change in the x- or y-axis, and half of the distance from the center of
-        the well to its top along the z-axis. Use :py:meth:`.move` to construct a
-        :py:class:`~opentrons.types.Location` that a pipette can move to.
+        For example, ``from_center_cartesian(0, 0, 0.5)`` specifies a point at the
+        well's center on the x- and y-axis, and half of the distance from the center of
+        the well to its top along the z-axis. To move the pipette to that location,
+        construct a :py:class:`~opentrons.types.Location` relative to the same well::
+
+            location = Location(
+                plate["A1"], plate["A1"].from_center_cartesian(0, 0, 0.5)
+            )
+            pipette.move_to(location)
+
+        See :ref:`points-locations` for more information.
 
         :param x: The fraction of the distance from the well's center to its edge
             along the x-axis. Negative values are to the left, and positive values
@@ -219,7 +226,7 @@ class Well:
             along the x-axis. Negative values are down, and positive values are up.
 
         :return: A :py:class:`~opentrons.types.Point` representing the specified
-            distances in mm.
+            position in absolute deck coordinates.
 
         .. note:: Even if the absolute values of ``x``, ``y``, and ``z`` are all less
             than 1, applying the result of ``from_center_cartesian`` to the well's


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Updating docstrings for the Well class. Not trying to be revolutionary, just trying to improve things for readers of the API Reference.

Closes RTC-206.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

- Checked formatting of [API Reference in sandbox](http://sandbox.docs.opentrons.com/docstrings-well/v2/new_protocol_api.html#opentrons.protocol_api.Well).
- Verified any new claims about how code works with `opentrons_simulate` for API version 2.13.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

- Updated basically every docstring in the Well class.
- Added a missing docstring for `Well.diameter`.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

Looks good? Sounds right?

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

low, inline docstrings