### PR TITLE
fix(app): fix text and buttons for gripper wizard flows

### DIFF
--- a/app/src/assets/localization/en/gripper_wizard_flows.json
+++ b/app/src/assets/localization/en/gripper_wizard_flows.json
@@ -20,7 +20,7 @@
   "gripper_successfully_attached": "Gripper successfully attached",
   "gripper_successfully_calibrated": "Flex Gripper successfully calibrated",
   "gripper_successfully_detached": "Flex Gripper successfully detached",
-  "gripper": "Gripper",
+  "gripper": "Flex Gripper",
   "hex_screwdriver": "2.5 mm Hex Screwdriver",
   "hold_gripper_and_loosen_screws": "Hold the gripper in place and loosen the top gripper screw first. After that move onto the bottom screw. (The screws are captive and will not come apart from the gripper.) Then carefully remove the gripper.",
   "insert_pin_into_front_jaw": "Insert calibration pin in front jaw",

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/CurrentOffsetsTable.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/CurrentOffsetsTable.tsx
@@ -137,7 +137,7 @@ export function CurrentOffsetsTable(
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       padding={SPACING.spacing16}
     >
-      <StyledText as="h6">{t('applied_offset_data')}</StyledText>
+      <StyledText as="label">{t('applied_offset_data')}</StyledText>
       {isLabwareOffsetCodeSnippetsOn ? (
         <LabwareOffsetTabs
           TableComponent={TableComponent}

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -140,7 +140,6 @@ export const MountGripper = (
       proceedButtonText={t('continue')}
       proceedIsDisabled={isPending}
       proceed={handleOnClick}
-      getHelp={'https://support.opentrons.com/s/opentrons-flex'}
     />
   )
 }

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -57,7 +57,7 @@ const ALIGN_BUTTONS = css`
 export const MountGripper = (
   props: GripperWizardStepProps
 ): JSX.Element | null => {
-  const { proceed, isRobotMoving, goBack } = props
+  const { proceed, isRobotMoving } = props
   const { t } = useTranslation(['gripper_wizard_flows', 'shared'])
   const isOnDevice = useSelector(getIsOnDevice)
   const [showUnableToDetect, setShowUnableToDetect] = React.useState(false)
@@ -140,7 +140,7 @@ export const MountGripper = (
       proceedButtonText={t('continue')}
       proceedIsDisabled={isPending}
       proceed={handleOnClick}
-      back={goBack}
+      getHelp={'https://support.opentrons.com/s/opentrons-flex'}
     />
   )
 }

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -243,6 +243,13 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
         }
       />
     )
+
+  // render help link but not back button for mounting to front jaw step
+  let back
+  if (movement !== MOVE_PIN_TO_FRONT_JAW) {
+    back = goBack
+  }
+
   return errorMessage != null ? (
     <SimpleWizardBody
       isSuccess={false}
@@ -270,7 +277,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       proceedButtonText={buttonText}
       proceed={handleOnClick}
       proceedIsDisabled={maintenanceRunId == null}
-      back={goBack}
+      back={back}
     />
   )
 }

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -244,12 +244,6 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       />
     )
 
-  // render help link but not back button for mounting to front jaw step
-  let back
-  if (movement !== MOVE_PIN_TO_FRONT_JAW) {
-    back = goBack
-  }
-
   return errorMessage != null ? (
     <SimpleWizardBody
       isSuccess={false}
@@ -277,7 +271,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
       proceedButtonText={buttonText}
       proceed={handleOnClick}
       proceedIsDisabled={maintenanceRunId == null}
-      back={back}
+      back={movement !== MOVE_PIN_TO_FRONT_JAW ? goBack : undefined}
     />
   )
 }

--- a/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -60,7 +60,7 @@ describe('BeforeBeginning', () => {
     getByText(
       'Provided with robot. Using another size can strip the instrument’s screws.'
     )
-    getByText('Gripper')
+    getByText('Flex Gripper')
 
     getByRole('button', { name: 'Move gantry to front' }).click()
     expect(props.chainRunCommands).toHaveBeenCalledWith(
@@ -121,7 +121,7 @@ describe('BeforeBeginning', () => {
     )
     getByText('You will need:')
     getByText('Calibration Pin')
-    getByText('Gripper')
+    getByText('Flex Gripper')
     // getByText('mock need help link')
 
     getByRole('button', { name: 'Move gantry to front' }).click()

--- a/app/src/organisms/GripperWizardFlows/__tests__/MountGripper.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MountGripper.test.tsx
@@ -20,13 +20,11 @@ describe('MountGripper', () => {
     props?: Partial<React.ComponentProps<typeof MountGripper>>
   ) => ReturnType<typeof renderWithProviders>
   let mockRefetch: jest.Mock
-  let mockGoBack: jest.Mock
   let mockProceed: jest.Mock
   let mockChainRunCommands: jest.Mock
   let mockSetErrorMessage: jest.Mock
 
   beforeEach(() => {
-    mockGoBack = jest.fn()
     mockProceed = jest.fn()
     mockChainRunCommands = jest.fn()
     mockRefetch = jest.fn(() => Promise.resolve())
@@ -39,7 +37,7 @@ describe('MountGripper', () => {
           attachedGripper={props?.attachedGripper ?? null}
           chainRunCommands={mockChainRunCommands}
           isRobotMoving={false}
-          goBack={mockGoBack}
+          goBack={() => null}
           errorMessage={null}
           setErrorMessage={mockSetErrorMessage}
           {...props}
@@ -83,16 +81,6 @@ describe('MountGripper', () => {
     expect(mockProceed).not.toHaveBeenCalled()
   })
 
-  it('clicking go back calls back', () => {
-    mockUseInstrumentsQuery.mockReturnValue({
-      refetch: mockRefetch,
-      data: null,
-    } as any)
-    const { getByLabelText } = render()[0]
-    getByLabelText('back').click()
-    expect(mockGoBack).toHaveBeenCalled()
-  })
-
   it('renders correct text', () => {
     mockUseInstrumentsQuery.mockReturnValue({
       refetch: mockRefetch,
@@ -103,5 +91,6 @@ describe('MountGripper', () => {
     getByText(
       'Attach the gripper to the robot by aligning the connector and pressing to ensure a secure connection. Hold the gripper in place. Tighten the top gripper screw first, and the bottom screw second. Then test that the gripper is securely attached by gently pulling it side to side.'
     )
+    getByText('Need help?')
   })
 })

--- a/app/src/organisms/GripperWizardFlows/__tests__/MountGripper.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MountGripper.test.tsx
@@ -91,6 +91,5 @@ describe('MountGripper', () => {
     getByText(
       'Attach the gripper to the robot by aligning the connector and pressing to ensure a secure connection. Hold the gripper in place. Tighten the top gripper screw first, and the bottom screw second. Then test that the gripper is securely attached by gently pulling it side to side.'
     )
-    getByText('Need help?')
   })
 })

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -97,9 +97,17 @@ describe('MovePin', () => {
     await expect(mockProceed).toHaveBeenCalled()
   })
 
-  it('clicking go back calls back', () => {
+  it('clicking go back calls back on moving pin from front to rear jaw', () => {
     const { getByLabelText } = render({
       movement: MOVE_PIN_FROM_FRONT_JAW_TO_REAR_JAW,
+    })[0]
+    getByLabelText('back').click()
+    expect(mockGoBack).toHaveBeenCalled()
+  })
+
+  it('clicking go back calls back on removing pin from rear jaw', () => {
+    const { getByLabelText } = render({
+      movement: REMOVE_PIN_FROM_REAR_JAW,
     })[0]
     getByLabelText('back').click()
     expect(mockGoBack).toHaveBeenCalled()

--- a/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/MovePin.test.tsx
@@ -98,7 +98,9 @@ describe('MovePin', () => {
   })
 
   it('clicking go back calls back', () => {
-    const { getByLabelText } = render()[0]
+    const { getByLabelText } = render({
+      movement: MOVE_PIN_FROM_FRONT_JAW_TO_REAR_JAW,
+    })[0]
     getByLabelText('back').click()
     expect(mockGoBack).toHaveBeenCalled()
   })


### PR DESCRIPTION
closes [RQA-1640](https://opentrons.atlassian.net/browse/RQA-1640)
closes [RQA-1641](https://opentrons.atlassian.net/browse/RQA-1641)
closes [RQA-1654](https://opentrons.atlassian.net/browse/RQA-1654)

# Overview

There are currently some deviations from our designs on gripper wizard flows. This PR addresses 3 outstanding bugs for misplaced back buttons, help links, and equipment list copy.

# Test Plan

- Verify that the equipment list in Before Beginning step renders "Flex Gripper" rather than just "Gripper"
- Verify that the Mount Gripper step does not render a back button
- Verify that there is no back button present during the first calibration pin handling step (moving the pin from storage to front jaw)

# Changelog

- remove go back button from attach gripper step
- remove go back button from attach pin to front jaw step
- update tests, including creating unique tests for each pin movement step (the first movement should not render a back button, but the proceeding 2 steps should)

# Risk assessment

low

[RQA-1640]: https://opentrons.atlassian.net/browse/RQA-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-1641]: https://opentrons.atlassian.net/browse/RQA-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-1654]: https://opentrons.atlassian.net/browse/RQA-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ