### PR TITLE
 feat(protocol-designer, step-generation): add drop tip field to mix & transfer forms

### DIFF
--- a/protocol-designer/cypress/integration/mixSettings.spec.js
+++ b/protocol-designer/cypress/integration/mixSettings.spec.js
@@ -314,20 +314,22 @@ describe('Advanced Settings for Mix Form', () => {
     cy.get('[data-test="StepItem_2"]').click()
     cy.get('button[id="AspDispSection_settings_button_aspirate"]').click()
 
-    // Verify that fixedTrash is selected
-    cy.get('[id=BlowoutLocationField_dropdown]').should(
-      'have.value',
-      'fixedTrash'
-    )
+    // Verify trash is selected
+    cy.get('[id=BlowoutLocationField_dropdown]').should($input => {
+      const value = $input.val()
+      const expectedSubstring = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+      expect(value).to.include(expectedSubstring)
+    })
     // Click on step 3 to verify the batch editing
     cy.get('[data-test="StepItem_3"]').click()
     cy.get('button[id="AspDispSection_settings_button_aspirate"]').click()
 
     // Verify that trash is selected for the blowout option
-    cy.get('[id=BlowoutLocationField_dropdown]').should(
-      'have.value',
-      'fixedTrash'
-    )
+    cy.get('[id=BlowoutLocationField_dropdown]').should($input => {
+      const value = $input.val()
+      const expectedSubstring = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+      expect(value).to.include(expectedSubstring)
+    })
   })
 
   it('verify well-order indeterminate state', () => {

--- a/protocol-designer/cypress/integration/transferSettings.spec.js
+++ b/protocol-designer/cypress/integration/transferSettings.spec.js
@@ -384,19 +384,21 @@ describe('Advanced Settings for Transfer Form', () => {
     cy.get('[data-test="StepItem_2"]').click()
     cy.get('button[id="AspDispSection_settings_button_aspirate"]').click()
 
-    // Verify that fixedTrash is selected
-    cy.get('[id=BlowoutLocationField_dropdown]').should(
-      'have.value',
-      'fixedTrash'
-    )
+    // Verify that trash is selected
+    cy.get('[id=BlowoutLocationField_dropdown]').should($input => {
+      const value = $input.val()
+      const expectedSubstring = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+      expect(value).to.include(expectedSubstring)
+    })
     // Click on step 3 to verify the batch editing
     cy.get('[data-test="StepItem_3"]').click()
     cy.get('button[id="AspDispSection_settings_button_aspirate"]').click()
 
     // Verify that trash is selected for the blowout option
-    cy.get('[id=BlowoutLocationField_dropdown]').should(
-      'have.value',
-      'fixedTrash'
-    )
+    cy.get('[id=BlowoutLocationField_dropdown]').should($input => {
+      const value = $input.val()
+      const expectedSubstring = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+      expect(value).to.include(expectedSubstring)
+    })
   })
 })

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -189,7 +189,8 @@
           "id": "f9a294f1-f42b-4cae-893a-592405349d56",
           "stepType": "moveLiquid",
           "stepName": "transfer",
-          "stepDetails": ""
+          "stepDetails": "",
+          "dropTip_location": "89d0e1b6-4d51-447b-b01b-3726a1f54137:opentrons/opentrons_1_trash_3200ml_fixed/1"
         },
         "5fdb9a12-fab4-42fd-886f-40af107b15d6": {
           "times": "2",
@@ -214,7 +215,8 @@
           "id": "5fdb9a12-fab4-42fd-886f-40af107b15d6",
           "stepType": "mix",
           "stepName": "mix",
-          "stepDetails": ""
+          "stepDetails": "",
+          "dropTip_location": "89d0e1b6-4d51-447b-b01b-3726a1f54137:opentrons/opentrons_1_trash_3200ml_fixed/1"
         },
         "3901f6f9-cecd-4d2a-8d85-40d85f9f8b4f": {
           "labware": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",

--- a/protocol-designer/src/components/StepEditForm/StepEditForm.css
+++ b/protocol-designer/src/components/StepEditForm/StepEditForm.css
@@ -151,6 +151,16 @@
   text-transform: uppercase;
 }
 
+.section_header_text_column {
+  flex: 1;
+  max-width: 20rem;
+  color: #666;
+  letter-spacing: 1px;
+  font-size: var(--fs-body-2);
+  font-weight: var(--fw-semibold);
+  text-transform: uppercase;
+}
+
 .path_option {
   width: 2.275rem;
   height: 1.55rem;

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { DropdownField, DropdownOption, FormGroup } from '@opentrons/components'
-import { FLEX_TRASH_DEF_URI } from '../../../../constants'
+import { FLEX_TRASH_DEF_URI, OT_2_TRASH_DEF_URI } from '../../../../constants'
 import { i18n } from '../../../../localization'
 import {
   getAdditionalEquipmentEntities,
@@ -20,13 +20,18 @@ export function DropTipField(
     aE => aE.name === 'wasteChute'
   )
   const trash = Object.values(labware).find(
-    lw => lw.labwareDefURI === FLEX_TRASH_DEF_URI
+    lw =>
+      lw.labwareDefURI === FLEX_TRASH_DEF_URI ||
+      lw.labwareDefURI === OT_2_TRASH_DEF_URI
   )
-  const wasteChuteOption = {
+  const wasteChuteOption: DropdownOption = {
     name: 'Waste Chute',
-    value: wasteChute?.id,
-  } as DropdownOption
-  const trashOption = { name: 'Trash Bin', value: trash?.id } as DropdownOption
+    value: wasteChute?.id ?? '',
+  }
+  const trashOption: DropdownOption = {
+    name: 'Trash Bin',
+    value: trash?.id ?? '',
+  }
 
   const options = []
   if (wasteChute) options.push(wasteChuteOption)

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { DropdownField, DropdownOption, FormGroup } from '@opentrons/components'
+import { FLEX_TRASH_DEF_URI } from '../../../../constants'
+import { i18n } from '../../../../localization'
+import {
+  getAdditionalEquipmentEntities,
+  getLabwareEntities,
+} from '../../../../step-forms/selectors'
+import { StepFormDropdown } from '../StepFormDropdownField'
+import styles from '../../StepEditForm.css'
+
+export function DropTipField(
+  props: Omit<React.ComponentProps<typeof StepFormDropdown>, 'options'>
+): JSX.Element {
+  const { value } = props
+  const labware = useSelector(getLabwareEntities)
+  const additionalEquipment = useSelector(getAdditionalEquipmentEntities)
+  const wasteChute = Object.values(additionalEquipment).find(
+    aE => aE.name === 'wasteChute'
+  )
+  const trash = Object.values(labware).find(
+    lw => lw.labwareDefURI === FLEX_TRASH_DEF_URI
+  )
+  const wasteChuteOption = {
+    name: 'Waste Chute',
+    value: wasteChute?.id,
+  } as DropdownOption
+  const trashOption = { name: 'Trash Bin', value: trash?.id } as DropdownOption
+
+  const options = []
+  if (wasteChute) options.push(wasteChuteOption)
+  if (trash) options.push(trashOption)
+
+  const [selectedValue, setSelectedValue] = React.useState(
+    value || (options[0] && options[0].value)
+  )
+  React.useEffect(() => {
+    props.updateValue(selectedValue)
+  }, [selectedValue])
+
+  return (
+    <FormGroup
+      label={i18n.t('form.step_edit_form.field.location.label')}
+      className={styles.large_field}
+    >
+      <DropdownField
+        options={options}
+        name={props.name}
+        value={value ? String(value) : options[0].value}
+        onBlur={props.onFieldBlur}
+        onFocus={props.onFieldFocus}
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+          const newValue = e.currentTarget.value
+          setSelectedValue(newValue)
+          props.updateValue(newValue)
+        }}
+      />
+    </FormGroup>
+  )
+}

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -13,7 +13,13 @@ import styles from '../../StepEditForm.css'
 export function DropTipField(
   props: Omit<React.ComponentProps<typeof StepFormDropdown>, 'options'>
 ): JSX.Element {
-  const { value } = props
+  const {
+    value: dropdownItem,
+    name,
+    onFieldBlur,
+    onFieldFocus,
+    updateValue,
+  } = props
   const labware = useSelector(getLabwareEntities)
   const additionalEquipment = useSelector(getAdditionalEquipmentEntities)
   const wasteChute = Object.values(additionalEquipment).find(
@@ -33,12 +39,12 @@ export function DropTipField(
     value: trash?.id ?? '',
   }
 
-  const options = []
-  if (wasteChute) options.push(wasteChuteOption)
-  if (trash) options.push(trashOption)
+  const options: DropdownOption[] = []
+  if (wasteChute != null) options.push(wasteChuteOption)
+  if (trash != null) options.push(trashOption)
 
   const [selectedValue, setSelectedValue] = React.useState(
-    value || (options[0] && options[0].value)
+    dropdownItem || (options[0] && options[0].value)
   )
   React.useEffect(() => {
     props.updateValue(selectedValue)
@@ -51,14 +57,14 @@ export function DropTipField(
     >
       <DropdownField
         options={options}
-        name={props.name}
-        value={value ? String(value) : options[0].value}
-        onBlur={props.onFieldBlur}
-        onFocus={props.onFieldFocus}
+        name={name}
+        value={dropdownItem ? String(dropdownItem) : options[0].value}
+        onBlur={onFieldBlur}
+        onFocus={onFieldFocus}
         onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
           const newValue = e.currentTarget.value
           setSelectedValue(newValue)
-          props.updateValue(newValue)
+          updateValue(newValue)
         }}
       />
     </FormGroup>

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -47,7 +47,7 @@ export function DropTipField(
     dropdownItem || (options[0] && options[0].value)
   )
   React.useEffect(() => {
-    props.updateValue(selectedValue)
+    updateValue(selectedValue)
   }, [selectedValue])
 
   return (

--- a/protocol-designer/src/components/StepEditForm/forms/MixForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MixForm.tsx
@@ -21,6 +21,7 @@ import {
   getLabwareFieldForPositioningField,
 } from '../utils'
 import { AspDispSection } from './AspDispSection'
+import { DropTipField } from '../fields/DropTipField'
 
 import { StepFormProps } from '../types'
 
@@ -194,8 +195,11 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
       )}
 
       <div className={styles.section_header}>
-        <span className={styles.section_header_text}>
+        <span className={styles.section_header_text_column}>
           {i18n.t('form.step_edit_form.section.sterility')}
+        </span>
+        <span className={styles.section_header_text_column}>
+          {i18n.t('form.step_edit_form.section.dropTip')}
         </span>
       </div>
       <div className={styles.section_wrapper}>
@@ -207,6 +211,9 @@ export const MixForm = (props: StepFormProps): JSX.Element => {
             path={formData.path}
             stepType={formData.stepType}
           />
+        </div>
+        <div className={cx(styles.form_row, styles.section_column)}>
+          <DropTipField {...propsForFields.dropTip_location} />
         </div>
       </div>
     </div>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
@@ -28,7 +28,6 @@ export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
   const { propsForFields, formData } = props
   const { stepType, path } = formData
 
-  console.log(propsForFields.dropTip_location)
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/index.tsx
@@ -10,10 +10,11 @@ import {
   DisposalVolumeField,
   PathField,
 } from '../../fields'
+import { DropTipField } from '../../fields/DropTipField'
 import styles from '../../StepEditForm.css'
-import { StepFormProps } from '../../types'
 import { SourceDestFields } from './SourceDestFields'
 import { SourceDestHeaders } from './SourceDestHeaders'
+import type { StepFormProps } from '../../types'
 
 // TODO: BC 2019-01-25 instead of passing path from here, put it in connect fields where needed
 // or question if it even needs path
@@ -27,6 +28,7 @@ export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
   const { propsForFields, formData } = props
   const { stepType, path } = formData
 
+  console.log(propsForFields.dropTip_location)
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -122,6 +124,14 @@ export const MoveLiquidForm = (props: StepFormProps): JSX.Element => {
             />
           )}
         </div>
+      </div>
+      <div className={styles.section_header}>
+        <span className={styles.section_header_text}>
+          {i18n.t('form.step_edit_form.section.dropTip')}
+        </span>
+      </div>
+      <div className={cx(styles.form_row, styles.section_column)}>
+        <DropTipField {...propsForFields.dropTip_location} />
       </div>
     </div>
   )

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.tsx
@@ -5,16 +5,19 @@ import { MixForm } from '../MixForm'
 import { AspDispSection } from '../AspDispSection'
 import * as stepFormSelectors from '../../../../step-forms/selectors'
 import { FormData } from '../../../../form-types'
+import { DropTipField } from '../../fields/DropTipField/index'
 import { WellOrderField } from '../../fields'
 
 const { DelayFields } = jest.requireActual('../../fields')
 
 jest.mock('../../../../step-forms/selectors')
-
+jest.mock('../../fields/DropTipField/index')
 const getUnsavedFormMock = stepFormSelectors.getUnsavedForm as jest.MockedFunction<
   typeof stepFormSelectors.getUnsavedForm
 >
-
+const mockDropTipField = DropTipField as jest.MockedFunction<
+  typeof DropTipField
+>
 jest.mock('../../fields/', () => {
   const actualFields = jest.requireActual('../../fields')
 
@@ -56,6 +59,7 @@ describe('MixForm', () => {
     getUnsavedFormMock.mockReturnValue({
       stepType: 'mix',
     } as FormData)
+    mockDropTipField.mockReturnValue(<div>mock drop tip field</div>)
 
     props = {
       formData: {
@@ -94,6 +98,15 @@ describe('MixForm', () => {
           errorToShow: null,
           disabled: false,
           name: 'mix_wellOrder_second',
+          updateValue: jest.fn() as any,
+          value: null,
+        },
+        dropTip_location: {
+          onFieldFocus: jest.fn() as any,
+          onFieldBlur: jest.fn() as any,
+          errorToShow: null,
+          disabled: false,
+          name: 'dropTip_location',
           updateValue: jest.fn() as any,
           value: null,
         },

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/MixForm.test.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import { mount, ReactWrapper } from 'enzyme'
 import { Provider } from 'react-redux'
-import { MixForm } from '../MixForm'
-import { AspDispSection } from '../AspDispSection'
 import * as stepFormSelectors from '../../../../step-forms/selectors'
-import { FormData } from '../../../../form-types'
 import { DropTipField } from '../../fields/DropTipField/index'
 import { WellOrderField } from '../../fields'
+import { MixForm } from '../MixForm'
+import { AspDispSection } from '../AspDispSection'
+import type { FormData } from '../../../../form-types'
 
 const { DelayFields } = jest.requireActual('../../fields')
 

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -215,6 +215,7 @@ export interface HydratedMoveLiquidFormData {
     disposalVolume_volume: number | null | undefined
     blowout_checkbox: boolean
     blowout_location: string | null | undefined // labwareId or 'SOURCE_WELL' or 'DEST_WELL'
+    dropTip_location: string
   }
 }
 
@@ -253,6 +254,7 @@ export interface HydratedMixFormDataLegacy {
   aspirate_delay_seconds: number | null | undefined
   dispense_delay_checkbox: boolean
   dispense_delay_seconds: number | null | undefined
+  dropTip_location: string
 }
 export type MagnetAction = 'engage' | 'disengage'
 export type HydratedMagnetFormData = AnnotationFields & {

--- a/protocol-designer/src/load-file/migration/7_1_0.ts
+++ b/protocol-designer/src/load-file/migration/7_1_0.ts
@@ -14,6 +14,7 @@ import type {
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 
 // NOTE: this migration updates fixed trash by treating it as an entity
+// additionally, drop tip location is now selectable
 const PD_VERSION = '7.1.0'
 
 interface LabwareLocationUpdate {
@@ -74,6 +75,7 @@ export const migrateFile = (
             stepForm.blowout_location === 'fixedTrash'
               ? trashId
               : stepForm.blowout_location,
+          dropTip_location: trashId,
         }
       } else if (stepForm.stepType === 'mix') {
         return {
@@ -82,6 +84,7 @@ export const migrateFile = (
             stepForm.blowout_location === 'fixedTrash'
               ? trashId
               : stepForm.blowout_location,
+          dropTip_location: trashId,
         }
       }
 

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -151,6 +151,10 @@
       "HEATER_SHAKER_LATCH_CLOSED": {
         "title": "Heater-Shaker labware latch is closed",
         "body": "The Heater-Shaker’s labware latch must be open when moving labware to or from the module. Add a Heater-Shaker step that opens the latch before this step."
+      },
+      "DROP_TIP_LOCATION_DOES_NOT_EXIST": {
+        "title": "Attempting to drop tip in an unknown location",
+        "body": "The Waste Chute or Trash Bin to drop tip in does not exist."
       }
     },
     "warning": {

--- a/protocol-designer/src/localization/en/form.json
+++ b/protocol-designer/src/localization/en/form.json
@@ -29,7 +29,8 @@
   "step_edit_form": {
     "section": {
       "sterility": "sterility",
-      "sterility&motion": "sterility & motion"
+      "sterility&motion": "sterility & motion",
+      "dropTip": "drop tip"
     },
     "labwareLabel": {
       "aspirate": "source",
@@ -50,6 +51,9 @@
     "field": {
       "airGap": { "label": "air gap" },
       "blowout": { "label": "blowout" },
+      "location": {
+        "label": "location"
+      },
       "change_tip": {
         "label": "change tip",
         "option": {

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -129,6 +129,7 @@ describe('createPresavedStepForm', () => {
       pipette: 'leftPipetteId',
       stepType: 'moveLiquid',
       // default fields
+      dropTip_location: null,
       aspirate_airGap_checkbox: false,
       aspirate_airGap_volume: '1',
       aspirate_delay_checkbox: false,
@@ -183,6 +184,7 @@ describe('createPresavedStepForm', () => {
         stepType: 'mix',
         // default fields
         labware: null,
+        dropTip_location: null,
         wells: [],
         aspirate_delay_checkbox: false,
         aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -34,6 +34,7 @@ export function getDefaultsForStepType(
         dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         mix_touchTip_checkbox: false,
         mix_touchTip_mmFromBottom: null,
+        dropTip_location: null,
       }
 
     case 'moveLiquid':
@@ -80,6 +81,7 @@ export function getDefaultsForStepType(
         dispense_delay_checkbox: false,
         dispense_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         dispense_delay_mmFromBottom: null,
+        dropTip_location: null,
       }
 
     case 'moveLabware':

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -15,7 +15,7 @@ type MixStepArgs = MixArgs
 export const mixFormToArgs = (
   hydratedFormData: HydratedMixFormDataLegacy
 ): MixStepArgs => {
-  const { labware, pipette } = hydratedFormData
+  const { labware, pipette, dropTip_location } = hydratedFormData
   const unorderedWells = hydratedFormData.wells || []
   const orderFirst = hydratedFormData.mix_wellOrder_first
   const orderSecond = hydratedFormData.mix_wellOrder_second
@@ -93,5 +93,6 @@ export const mixFormToArgs = (
     blowoutOffsetFromTopMm,
     aspirateDelaySeconds,
     dispenseDelaySeconds,
+    dropTipLocation: dropTip_location,
   }
 }

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -74,6 +74,7 @@ export const moveLiquidFormToArgs = (
     dispense_labware: destLabware,
     aspirate_wells: sourceWellsUnordered,
     dispense_wells: destWellsUnordered,
+    dropTip_location: dropTipLocation,
     path,
   } = fields
   let sourceWells = getOrderedWells(
@@ -176,6 +177,7 @@ export const moveLiquidFormToArgs = (
     touchTipAfterDispenseOffsetMmFromBottom,
     description: hydratedFormData.description,
     name: hydratedFormData.stepName,
+    dropTipLocation,
   }
   assert(
     sourceWellsUnordered.length > 0,

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -18,6 +18,7 @@ describe('getDefaultsForStepType', () => {
         volume: null,
         changeTip: DEFAULT_CHANGE_TIP_OPTION,
         path: 'single',
+        dropTip_location: null,
         aspirate_wells_grouped: false,
 
         aspirate_flowRate: null,
@@ -70,6 +71,7 @@ describe('getDefaultsForStepType', () => {
       expect(getDefaultsForStepType('mix')).toEqual({
         changeTip: DEFAULT_CHANGE_TIP_OPTION,
         labware: null,
+        dropTip_location: null,
         aspirate_delay_checkbox: false,
         aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,
         dispense_delay_checkbox: false,

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -12,11 +12,10 @@ import {
   DeactivateTemperatureArgs,
 } from '../../../../step-generation/lib/types.d'
 import { THERMOCYCLER_STATE } from '../../constants'
-import { StepArgsAndErrors } from '../types'
 import { generateSubstepItem } from '../generateSubstepItem'
 
 import type { ThermocyclerStateStepArgs } from '../../../../step-generation/src/types'
-import type { LabwareNamesByModuleId } from '../types'
+import type { StepArgsAndErrors, LabwareNamesByModuleId } from '../types'
 
 describe('generateSubstepItem', () => {
   const stepId = 'step123'

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -1,4 +1,3 @@
-import { generateSubstepItem } from '../generateSubstepItem'
 import {
   makeInitialRobotState,
   makeContext,
@@ -8,13 +7,16 @@ import {
   DisengageMagnetArgs,
   FIXED_TRASH_ID,
 } from '@opentrons/step-generation'
-import { THERMOCYCLER_STATE } from '../../constants'
-import { LabwareNamesByModuleId, StepArgsAndErrors } from '../types'
 import {
   SetTemperatureArgs,
   DeactivateTemperatureArgs,
 } from '../../../../step-generation/lib/types.d'
-import { ThermocyclerStateStepArgs } from '../../../../step-generation/src/types'
+import { THERMOCYCLER_STATE } from '../../constants'
+import { StepArgsAndErrors } from '../types'
+import { generateSubstepItem } from '../generateSubstepItem'
+
+import type { ThermocyclerStateStepArgs } from '../../../../step-generation/src/types'
+import type { LabwareNamesByModuleId } from '../types'
 
 describe('generateSubstepItem', () => {
   const stepId = 'step123'

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -6,6 +6,7 @@ import {
   RobotState,
   EngageMagnetArgs,
   DisengageMagnetArgs,
+  FIXED_TRASH_ID,
 } from '@opentrons/step-generation'
 import { THERMOCYCLER_STATE } from '../../constants'
 import { LabwareNamesByModuleId, StepArgsAndErrors } from '../types'
@@ -157,6 +158,7 @@ describe('generateSubstepItem', () => {
       touchTipAfterDispenseOffsetMmFromBottom: number
       dispenseFlowRateUlSec: number
       dispenseOffsetFromBottomMm: number
+      dropTipLocation: string
     }
     beforeEach(() => {
       sharedArgs = {
@@ -175,6 +177,7 @@ describe('generateSubstepItem', () => {
         touchTipAfterDispenseOffsetMmFromBottom: 10,
         dispenseFlowRateUlSec: 5,
         dispenseOffsetFromBottomMm: 10,
+        dropTipLocation: FIXED_TRASH_ID,
       }
     })
     ;[
@@ -189,6 +192,7 @@ describe('generateSubstepItem', () => {
           blowoutOffsetFromTopMm: 5,
           mixFirstAspirate: null,
           mixInDestination: null,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         expected: {
           substepType: 'sourceDest',
@@ -239,6 +243,7 @@ describe('generateSubstepItem', () => {
           blowoutFlowRateUlSec: 10,
           blowoutOffsetFromTopMm: 5,
           mixBeforeAspirate: null,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         expected: {
           commandCreatorFnName: 'distribute',
@@ -300,6 +305,7 @@ describe('generateSubstepItem', () => {
           blowoutOffsetFromTopMm: 5,
           mixBeforeAspirate: null,
           mixInDestination: null,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         expected: {
           substepType: 'sourceDest',
@@ -389,6 +395,7 @@ describe('generateSubstepItem', () => {
         dispenseOffsetFromBottomMm: 10,
         aspirateFlowRateUlSec: 5,
         dispenseFlowRateUlSec: 5,
+        dropTipLocation: FIXED_TRASH_ID,
       },
       // @ts-expect-error(sa, 2021-6-15): errors should be boolean typed
       errors: {},

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -5,6 +5,7 @@ import {
   MULTI_PIPETTE,
   SOURCE_LABWARE,
   DEST_LABWARE,
+  FIXED_TRASH_ID,
 } from '@opentrons/step-generation'
 import { StepArgsAndErrorsById } from '../../steplist'
 import { generateRobotStateTimeline } from '../generateRobotStateTimeline'
@@ -15,6 +16,7 @@ describe('generateRobotStateTimeline', () => {
       a: {
         errors: false,
         stepArgs: {
+          dropTipLocation: FIXED_TRASH_ID,
           pipette: DEFAULT_PIPETTE,
           volume: 5,
           sourceLabware: SOURCE_LABWARE,
@@ -48,6 +50,7 @@ describe('generateRobotStateTimeline', () => {
       b: {
         errors: false,
         stepArgs: {
+          dropTipLocation: FIXED_TRASH_ID,
           pipette: MULTI_PIPETTE,
           volume: 5,
           sourceLabware: SOURCE_LABWARE,
@@ -81,6 +84,7 @@ describe('generateRobotStateTimeline', () => {
       c: {
         errors: false,
         stepArgs: {
+          dropTipLocation: FIXED_TRASH_ID,
           commandCreatorFnName: 'mix',
           name: 'Mix',
           description: 'description would be here 2018-03-01',

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -50,8 +50,11 @@ export const generateRobotStateTimeline = (
       // we know the current tip(s) aren't going to be reused, so we can drop them
       // immediately after the current step is done.
       const pipetteId = StepGeneration.getPipetteIdFromCCArgs(args)
+      const dropTipLocation =
+        'dropTipLocation' in args ? args.dropTipLocation : null
 
-      if (pipetteId) {
+      //  assume that whenever we have a pipetteId we also have a dropTipLocation
+      if (pipetteId && dropTipLocation) {
         const nextStepArgsForPipette = continuousStepArgs
           .slice(stepIndex + 1)
           // @ts-expect-error(sa, 2021-6-20): not a valid type narrow, use in operator
@@ -71,6 +74,7 @@ export const generateRobotStateTimeline = (
                   curriedCommandCreator,
                   StepGeneration.curryCommandCreator(StepGeneration.dropTip, {
                     pipette: pipetteId,
+                    dropTipLocation,
                   }),
                 ],
                 _invariantContext,

--- a/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
+++ b/protocol-designer/src/timelineMiddleware/generateRobotStateTimeline.ts
@@ -54,7 +54,7 @@ export const generateRobotStateTimeline = (
         'dropTipLocation' in args ? args.dropTipLocation : null
 
       //  assume that whenever we have a pipetteId we also have a dropTipLocation
-      if (pipetteId && dropTipLocation) {
+      if (pipetteId != null && dropTipLocation != null) {
         const nextStepArgsForPipette = continuousStepArgs
           .slice(stepIndex + 1)
           // @ts-expect-error(sa, 2021-6-20): not a valid type narrow, use in operator

--- a/protocol-designer/src/ui/steps/__fixtures__/index.ts
+++ b/protocol-designer/src/ui/steps/__fixtures__/index.ts
@@ -47,6 +47,7 @@ export const getMockMoveLiquidStep = (): SavedStepFormState => ({
     stepType: 'moveLiquid',
     stepName: 'transfer',
     stepDetails: '',
+    dropTip_location: 'fixedTrash',
   },
 })
 export const getMockMixStep = (): SavedStepFormState => ({
@@ -74,5 +75,6 @@ export const getMockMixStep = (): SavedStepFormState => ({
     dispense_delay_seconds: '1',
     mix_touchTip_checkbox: false,
     mix_touchTip_mmFromBottom: null,
+    dropTip_location: 'fixedTrash',
   },
 })

--- a/protocol-designer/src/ui/steps/test/selectors.test.ts
+++ b/protocol-designer/src/ui/steps/test/selectors.test.ts
@@ -583,6 +583,10 @@ describe('_getSavedMultiSelectFieldValues', () => {
           isIndeterminate: false,
           value: 'single',
         },
+        dropTip_location: {
+          value: 'fixedTrash',
+          isIndeterminate: false,
+        },
       })
     })
   })
@@ -782,6 +786,10 @@ describe('_getSavedMultiSelectFieldValues', () => {
           isIndeterminate: false,
           value: '30',
         },
+        dropTip_location: {
+          value: 'fixedTrash',
+          isIndeterminate: false,
+        },
       })
     })
   })
@@ -826,6 +834,10 @@ describe('_getSavedMultiSelectFieldValues', () => {
         dispense_delay_seconds: { value: '1', isIndeterminate: false },
         mix_touchTip_checkbox: { value: false, isIndeterminate: false },
         mix_touchTip_mmFromBottom: { value: null, isIndeterminate: false },
+        dropTip_location: {
+          value: 'fixedTrash',
+          isIndeterminate: false,
+        },
       })
     })
   })
@@ -889,6 +901,10 @@ describe('_getSavedMultiSelectFieldValues', () => {
         dispense_delay_seconds: { isIndeterminate: true },
         mix_touchTip_checkbox: { isIndeterminate: true },
         mix_touchTip_mmFromBottom: { isIndeterminate: true },
+        dropTip_location: {
+          value: 'fixedTrash',
+          isIndeterminate: false,
+        },
       })
     })
   })

--- a/step-generation/src/__tests__/__snapshots__/fixtureGeneration.test.ts.snap
+++ b/step-generation/src/__tests__/__snapshots__/fixtureGeneration.test.ts.snap
@@ -1748,7 +1748,7 @@ Object {
         },
       },
       "id": "fixedTrash",
-      "labwareDefURI": "fixture/fixture_trash/1",
+      "labwareDefURI": "opentrons/opentrons_1_trash_1100ml_fixed/1",
     },
     "sourcePlateId": Object {
       "def": Object {

--- a/step-generation/src/__tests__/consolidate.test.ts
+++ b/step-generation/src/__tests__/consolidate.test.ts
@@ -97,6 +97,7 @@ beforeEach(() => {
     touchTipAfterDispense: false,
     mixInDestination: null,
     blowoutLocation: null,
+    dropTipLocation: FIXED_TRASH_ID,
   }
 })
 
@@ -3092,7 +3093,7 @@ describe('consolidate multi-channel', () => {
     destWell: 'A12',
     sourceLabware: SOURCE_LABWARE,
     destLabware: DEST_LABWARE,
-
+    dropTipLocation: FIXED_TRASH_ID,
     // volume and changeTip should be explicit in tests
 
     preWetTip: false,

--- a/step-generation/src/__tests__/distribute.test.ts
+++ b/step-generation/src/__tests__/distribute.test.ts
@@ -81,6 +81,7 @@ beforeEach(() => {
     dispenseDelay: null,
     aspirateAirGapVolume: null,
     touchTipAfterDispense: false,
+    dropTipLocation: FIXED_TRASH_ID,
   }
 
   blowoutSingleToTrash = blowoutHelper(FIXED_TRASH_ID, {

--- a/step-generation/src/__tests__/dropTip.test.ts
+++ b/step-generation/src/__tests__/dropTip.test.ts
@@ -5,9 +5,10 @@ import {
   getSuccessResult,
   DEFAULT_PIPETTE,
 } from '../fixtures'
-import { FIXED_TRASH_ID } from '../constants'
 import { dropTip } from '../commandCreators/atomic/dropTip'
 import type { InvariantContext, RobotState } from '../types'
+
+const mockDropTipLocation = 'mockLocation'
 describe('dropTip', () => {
   let invariantContext: InvariantContext
   beforeEach(() => {
@@ -37,6 +38,7 @@ describe('dropTip', () => {
       const result = dropTip(
         {
           pipette: DEFAULT_PIPETTE,
+          dropTipLocation: mockDropTipLocation,
         },
         invariantContext,
         makeRobotState({
@@ -51,7 +53,7 @@ describe('dropTip', () => {
           key: expect.any(String),
           params: {
             pipetteId: DEFAULT_PIPETTE,
-            labwareId: FIXED_TRASH_ID,
+            labwareId: 'mockLocation',
             wellName: 'A1',
           },
         },
@@ -65,6 +67,7 @@ describe('dropTip', () => {
       const result = dropTip(
         {
           pipette: DEFAULT_PIPETTE,
+          dropTipLocation: mockDropTipLocation,
         },
         invariantContext,
         initialRobotState
@@ -78,6 +81,7 @@ describe('dropTip', () => {
       const result = dropTip(
         {
           pipette: 'p300MultiId',
+          dropTipLocation: mockDropTipLocation,
         },
         invariantContext,
         makeRobotState({
@@ -92,7 +96,7 @@ describe('dropTip', () => {
           key: expect.any(String),
           params: {
             pipetteId: 'p300MultiId',
-            labwareId: FIXED_TRASH_ID,
+            labwareId: 'mockLocation',
             wellName: 'A1',
           },
         },
@@ -106,6 +110,7 @@ describe('dropTip', () => {
       const result = dropTip(
         {
           pipette: 'p300MultiId',
+          dropTipLocation: mockDropTipLocation,
         },
         invariantContext,
         initialRobotState

--- a/step-generation/src/__tests__/mix.test.ts
+++ b/step-generation/src/__tests__/mix.test.ts
@@ -1,4 +1,5 @@
 import flatMap from 'lodash/flatMap'
+import { FIXED_TRASH_ID } from '@opentrons/shared-data'
 import { mix } from '../commandCreators/compound/mix'
 import {
   getRobotStateWithTipStandard,
@@ -48,6 +49,7 @@ beforeEach(() => {
 
     aspirateDelaySeconds: null,
     dispenseDelaySeconds: null,
+    dropTipLocation: FIXED_TRASH_ID,
   }
 
   invariantContext = makeContext()

--- a/step-generation/src/__tests__/replaceTip.test.ts
+++ b/step-generation/src/__tests__/replaceTip.test.ts
@@ -9,6 +9,7 @@ import {
   dropTipHelper,
   DEFAULT_PIPETTE,
 } from '../fixtures'
+import { FIXED_TRASH_ID } from '..'
 import { replaceTip } from '../commandCreators/atomic/replaceTip'
 import type { InvariantContext, RobotState } from '../types'
 
@@ -28,6 +29,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         initialRobotState
@@ -39,6 +41,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         merge({}, initialRobotState, {
@@ -71,6 +74,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         initialTestRobotState
@@ -94,6 +98,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         initialTestRobotState
@@ -115,6 +120,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300SingleId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         initialTestRobotState
@@ -132,6 +138,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300MultiId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         initialRobotState
@@ -157,6 +164,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300MultiId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         robotStateWithTipA1Missing
@@ -181,6 +189,7 @@ describe('replaceTip', () => {
       const result = replaceTip(
         {
           pipette: p300MultiId,
+          dropTipLocation: FIXED_TRASH_ID,
         },
         invariantContext,
         robotStateWithTipsOnMulti

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -20,6 +20,7 @@ import {
   makeDispenseAirGapHelper,
   AIR_GAP_META,
 } from '../fixtures'
+import { FIXED_TRASH_ID } from '..'
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
   SOURCE_WELL_BLOWOUT_DESTINATION,
@@ -71,6 +72,7 @@ beforeEach(() => {
     touchTipAfterDispense: false,
     mixInDestination: null,
     blowoutLocation: null,
+    dropTipLocation: FIXED_TRASH_ID,
   }
 
   invariantContext = makeContext()

--- a/step-generation/src/commandCreators/atomic/dropAllTips.ts
+++ b/step-generation/src/commandCreators/atomic/dropAllTips.ts
@@ -1,3 +1,9 @@
+import {
+  CommandCreatorError,
+  FLEX_TRASH_DEF_URI,
+  OT_2_TRASH_DEF_URI,
+} from '../..'
+import * as errorCreators from '../../errorCreators'
 import type { CommandCreator } from '../../types'
 import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 import { dropTip } from './dropTip'
@@ -10,10 +16,34 @@ export const dropAllTips: CommandCreator<null> = (
   invariantContext,
   prevRobotState
 ) => {
+  const errors: CommandCreatorError[] = []
   const pipetteIds: string[] = Object.keys(prevRobotState.pipettes)
+  const trashId = Object.values(invariantContext.labwareEntities).find(
+    lw =>
+      lw.labwareDefURI === FLEX_TRASH_DEF_URI ||
+      lw.labwareDefURI === OT_2_TRASH_DEF_URI
+  )?.id
+  const wasteChuteId = Object.values(
+    invariantContext.additionalEquipmentEntities
+  ).find(aE => aE.name === 'wasteChute')?.id
+
+  let dropTipLocation: string | null = null
+  if (trashId != null && wasteChuteId != null) {
+    dropTipLocation = wasteChuteId
+  } else if (trashId == null && wasteChuteId != null) {
+    dropTipLocation = wasteChuteId
+  } else if (trashId != null && wasteChuteId == null) {
+    dropTipLocation = trashId
+  }
+
+  if (dropTipLocation == null) {
+    errors.push(errorCreators.dropTipLocationDoesNotExist())
+  }
+
   const commandCreators = pipetteIds.map(pipette =>
     curryCommandCreator(dropTip, {
       pipette,
+      dropTipLocation: dropTipLocation ?? '',
     })
   )
   return reduceCommandCreators(

--- a/step-generation/src/commandCreators/atomic/dropAllTips.ts
+++ b/step-generation/src/commandCreators/atomic/dropAllTips.ts
@@ -1,12 +1,9 @@
-import {
-  CommandCreatorError,
-  FLEX_TRASH_DEF_URI,
-  OT_2_TRASH_DEF_URI,
-} from '../..'
+import { FLEX_TRASH_DEF_URI, OT_2_TRASH_DEF_URI } from '../../constants'
 import * as errorCreators from '../../errorCreators'
-import type { CommandCreator } from '../../types'
 import { curryCommandCreator, reduceCommandCreators } from '../../utils'
 import { dropTip } from './dropTip'
+
+import type { CommandCreatorError, CommandCreator } from '../../types'
 
 /** Drop all tips from equipped pipettes.
  * If no tips are attached to a pipette, do nothing.
@@ -19,13 +16,13 @@ export const dropAllTips: CommandCreator<null> = (
   const errors: CommandCreatorError[] = []
   const pipetteIds: string[] = Object.keys(prevRobotState.pipettes)
   const trashId = Object.values(invariantContext.labwareEntities).find(
-    lw =>
-      lw.labwareDefURI === FLEX_TRASH_DEF_URI ||
-      lw.labwareDefURI === OT_2_TRASH_DEF_URI
+    labwareEntity =>
+      labwareEntity.labwareDefURI === FLEX_TRASH_DEF_URI ||
+      labwareEntity.labwareDefURI === OT_2_TRASH_DEF_URI
   )?.id
   const wasteChuteId = Object.values(
     invariantContext.additionalEquipmentEntities
-  ).find(aE => aE.name === 'wasteChute')?.id
+  ).find(additionalEquipment => additionalEquipment.name === 'wasteChute')?.id
 
   let dropTipLocation: string | null = null
   if (trashId != null && wasteChuteId != null) {

--- a/step-generation/src/commandCreators/atomic/dropTip.ts
+++ b/step-generation/src/commandCreators/atomic/dropTip.ts
@@ -2,6 +2,7 @@ import { uuid } from '../../utils'
 import type { CommandCreator } from '../../types'
 interface DropTipArgs {
   pipette: string
+  dropTipLocation: string
 }
 
 /** Drop tip if given pipette has a tip. If it has no tip, do nothing. */
@@ -10,11 +11,7 @@ export const dropTip: CommandCreator<DropTipArgs> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipette } = args
-  const { labwareEntities } = invariantContext
-  const trashId = Object.values(labwareEntities).find(lw =>
-    lw.def.parameters.quirks?.includes('fixedTrash')
-  )?.id
+  const { pipette, dropTipLocation } = args
   // No-op if there is no tip
   if (!prevRobotState.tipState.pipettes[pipette]) {
     return {
@@ -28,8 +25,9 @@ export const dropTip: CommandCreator<DropTipArgs> = (
       key: uuid(),
       params: {
         pipetteId: pipette,
-        //  TODO(jr, 9/26/23): support no trash, return tip and waste chute
-        labwareId: trashId != null ? trashId : '',
+        //  TODO(jr, 10/02/23): this param will probably be slightly changed in order to drop tip to waste chute
+        //  since there is no labwareId or wellName for it
+        labwareId: dropTipLocation,
         wellName: 'A1',
       },
       //  TODO(jr, 7/17/23): add WellLocation params!

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -12,12 +12,12 @@ import {
   getHasWasteChute,
   getTiprackHasTips,
   getLabwareHasLiquid,
-  CommandCreatorWarning,
-} from '../..'
+} from '../../utils'
 import type {
   CommandCreator,
   CommandCreatorError,
   MoveLabwareArgs,
+  CommandCreatorWarning,
 } from '../../types'
 
 /** Move labware from one location to another, manually or via a gripper. */
@@ -28,9 +28,14 @@ export const moveLabware: CommandCreator<MoveLabwareArgs> = (
 ) => {
   const { labware, useGripper, newLocation } = args
   const { additionalEquipmentEntities } = invariantContext
-  const { tipState, liquidState } = prevRobotState
-  const tiprackHasTip = getTiprackHasTips(tipState, labware)
-  const labwareHasLiquid = getLabwareHasLiquid(liquidState, labware)
+  const tiprackHasTip =
+    prevRobotState.tipState != null
+      ? getTiprackHasTips(prevRobotState.tipState, labware)
+      : false
+  const labwareHasLiquid =
+    prevRobotState.liquidState != null
+      ? getLabwareHasLiquid(prevRobotState.liquidState, labware)
+      : false
 
   const actionName = 'moveToLabware'
   const errors: CommandCreatorError[] = []

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -7,11 +7,11 @@ import {
 } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import * as warningCreators from '../../warningCreators'
-import { uuid } from '../../utils'
 import {
   getHasWasteChute,
   getTiprackHasTips,
   getLabwareHasLiquid,
+  uuid,
 } from '../../utils'
 import type {
   CommandCreator,

--- a/step-generation/src/commandCreators/atomic/replaceTip.ts
+++ b/step-generation/src/commandCreators/atomic/replaceTip.ts
@@ -40,6 +40,7 @@ const _pickUpTip: CommandCreator<PickUpTipArgs> = (
 
 interface ReplaceTipArgs {
   pipette: string
+  dropTipLocation: string
 }
 
 /**
@@ -52,7 +53,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   invariantContext,
   prevRobotState
 ) => {
-  const { pipette } = args
+  const { pipette, dropTipLocation } = args
   const nextTiprack = getNextTiprack(pipette, invariantContext, prevRobotState)
   if (nextTiprack == null) {
     // no valid next tip / tiprack, bail out
@@ -86,6 +87,12 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         }),
       ],
     }
+  }
+  if (
+    !invariantContext.labwareEntities[args.dropTipLocation] &&
+    !invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  ) {
+    return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
   }
   if (
     modulePipetteCollision({
@@ -134,6 +141,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   const commandCreators: CurriedCommandCreator[] = [
     curryCommandCreator(dropTip, {
       pipette,
+      dropTipLocation,
     }),
     curryCommandCreator(_pickUpTip, {
       pipette,

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -57,6 +57,13 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     }
   }
 
+  if (
+    !invariantContext.labwareEntities[args.dropTipLocation] &&
+    !invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  ) {
+    return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
+  }
+
   // TODO: BC 2019-07-08 these argument names are a bit misleading, instead of being values bound
   // to the action of aspiration of dispensing in a given command, they are actually values bound
   // to a given labware associated with a command (e.g. Source, Destination). For this reason we
@@ -74,6 +81,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     dispenseOffsetFromBottomMm,
     mixFirstAspirate,
     mixInDestination,
+    dropTipLocation,
   } = args
   const aspirateAirGapVolume = args.aspirateAirGapVolume || 0
   const maxWellsPerChunk = Math.floor(
@@ -182,6 +190,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         tipCommands = [
           curryCommandCreator(replaceTip, {
             pipette: args.pipette,
+            dropTipLocation,
           }),
         ]
       }
@@ -297,6 +306,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           ? [
               curryCommandCreator(dropTip, {
                 pipette: args.pipette,
+                dropTipLocation: dropTipLocation,
               }),
             ]
           : []

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -70,6 +70,13 @@ export const distribute: CommandCreator<DistributeArgs> = (
     )
   }
 
+  if (
+    !invariantContext.labwareEntities[args.dropTipLocation] &&
+    !invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  ) {
+    errors.push(errorCreators.dropTipLocationDoesNotExist())
+  }
+
   if (errors.length > 0)
     return {
       errors,
@@ -233,6 +240,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
         tipCommands = [
           curryCommandCreator(replaceTip, {
             pipette: args.pipette,
+            dropTipLocation: args.dropTipLocation,
           }),
         ]
       }
@@ -281,6 +289,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ? [
               curryCommandCreator(dropTip, {
                 pipette: args.pipette,
+                dropTipLocation: args.dropTipLocation,
               }),
             ]
           : []

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -108,6 +108,7 @@ export const mix: CommandCreator<MixArgs> = (
     dispenseFlowRateUlSec,
     blowoutFlowRateUlSec,
     blowoutOffsetFromTopMm,
+    dropTipLocation,
   } = data
 
   // Errors
@@ -137,6 +138,13 @@ export const mix: CommandCreator<MixArgs> = (
     }
   }
 
+  if (
+    !invariantContext.labwareEntities[dropTipLocation] &&
+    !invariantContext.additionalEquipmentEntities[dropTipLocation]
+  ) {
+    return { errors: [errorCreators.dropTipLocationDoesNotExist()] }
+  }
+
   const configureForVolumeCommand: CurriedCommandCreator[] =
     invariantContext.pipetteEntities[pipette].name === 'p50_single_flex' ||
     invariantContext.pipetteEntities[pipette].name === 'p50_multi_flex'
@@ -158,6 +166,7 @@ export const mix: CommandCreator<MixArgs> = (
         tipCommands = [
           curryCommandCreator(replaceTip, {
             pipette,
+            dropTipLocation,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -79,6 +79,13 @@ export const transfer: CommandCreator<TransferArgs> = (
     )
   }
 
+  if (
+    !invariantContext.labwareEntities[args.dropTipLocation] &&
+    !invariantContext.additionalEquipmentEntities[args.dropTipLocation]
+  ) {
+    errors.push(errorCreators.dropTipLocationDoesNotExist())
+  }
+
   if (errors.length > 0)
     return {
       errors,
@@ -181,6 +188,7 @@ export const transfer: CommandCreator<TransferArgs> = (
             ? [
                 curryCommandCreator(replaceTip, {
                   pipette: args.pipette,
+                  dropTipLocation: args.dropTipLocation,
                 }),
               ]
             : []
@@ -402,6 +410,7 @@ export const transfer: CommandCreator<TransferArgs> = (
               ? [
                   curryCommandCreator(dropTip, {
                     pipette: args.pipette,
+                    dropTipLocation: args.dropTipLocation,
                   }),
                 ]
               : []

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -15,3 +15,6 @@ export const MODULES_WITH_COLLISION_ISSUES = [
   TEMPERATURE_MODULE_V1,
 ]
 export const FIXED_TRASH_ID: 'fixedTrash' = 'fixedTrash'
+
+export const OT_2_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_1100ml_fixed/1'
+export const FLEX_TRASH_DEF_URI = 'opentrons/opentrons_1_trash_3200ml_fixed/1'

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -188,3 +188,10 @@ export const labwareOffDeck = (): CommandCreatorError => {
     message: 'Attempted to interact with labware off deck',
   }
 }
+
+export const dropTipLocationDoesNotExist = (): CommandCreatorError => {
+  return {
+    type: 'DROP_TIP_LOCATION_DOES_NOT_EXIST',
+    message: 'The destination for dropping tip does not exist',
+  }
+}

--- a/step-generation/src/fixtures/robotStateFixtures.ts
+++ b/step-generation/src/fixtures/robotStateFixtures.ts
@@ -21,6 +21,7 @@ import {
   TEMPERATURE_AT_TARGET,
   TEMPERATURE_DEACTIVATED,
   FIXED_TRASH_ID,
+  OT_2_TRASH_DEF_URI,
 } from '../constants'
 import {
   DEFAULT_PIPETTE,
@@ -80,7 +81,7 @@ export function makeContext(): InvariantContext {
     [FIXED_TRASH_ID]: {
       id: FIXED_TRASH_ID,
 
-      labwareDefURI: getLabwareDefURI(fixtureTrash),
+      labwareDefURI: OT_2_TRASH_DEF_URI,
       def: fixtureTrash,
     },
     [SOURCE_LABWARE]: {

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -38,6 +38,11 @@ export function dispenseUpdateLiquidState(
     volume,
     wellName,
   } = args
+  console.log(
+    'invariantContext.labwareEntities',
+    invariantContext.labwareEntities
+  )
+  console.log('labwareId for dispense', labwareId)
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
   assert(

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -38,11 +38,7 @@ export function dispenseUpdateLiquidState(
     volume,
     wellName,
   } = args
-  console.log(
-    'invariantContext.labwareEntities',
-    invariantContext.labwareEntities
-  )
-  console.log('labwareId for dispense', labwareId)
+
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
   assert(

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -38,7 +38,6 @@ export function dispenseUpdateLiquidState(
     volume,
     wellName,
   } = args
-
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
   assert(

--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -1,18 +1,35 @@
+import { FLEX_TRASH_DEF_URI, OT_2_TRASH_DEF_URI } from '..'
 import { dispenseUpdateLiquidState } from './dispenseUpdateLiquidState'
 import type { DropTipParams } from '@opentrons/shared-data/protocol/types/schemaV6/command/pipetting'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
+
 export function forDropTip(
   params: DropTipParams,
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings
 ): void {
-  const { pipetteId, labwareId, wellName } = params
+  const { pipetteId, wellName } = params
+  const trashId = Object.values(invariantContext.labwareEntities).find(
+    lw =>
+      lw.labwareDefURI === FLEX_TRASH_DEF_URI ||
+      lw.labwareDefURI === OT_2_TRASH_DEF_URI
+  )?.id
+
+  if (trashId == null) {
+    console.error(
+      `expected to find trash id ${trashId} in labware entities but could not`
+    )
+  }
   const { robotState } = robotStateAndWarnings
+  //  TODO(jr, 10/02/23): wire this up properly when we support dispensing into waste chute
+  //  i honestly am not sure why we even need to update the liquid state for dropping tip? I guess
+  //  it is to account for if a user diliberately drops tip with liquid still in it which I didn't realize
+  //  is supported into PD???? Maybe it is error handling?
   dispenseUpdateLiquidState({
     invariantContext,
     prevLiquidState: robotState.liquidState,
     pipetteId,
-    labwareId,
+    labwareId: trashId ?? '',
     useFullVolume: true,
     wellName,
   })

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -170,7 +170,8 @@ export type SharedTransferLikeArgs = CommonArgs & {
   destLabware: string
   /** volume is interpreted differently by different Step types */
   volume: number
-
+  /** drop tip location entity id */
+  dropTipLocation: string
   // ===== ASPIRATE SETTINGS =====
   /** Pre-wet tip with ??? uL liquid from the first source well. */
   preWetTip: boolean
@@ -270,7 +271,8 @@ export type MixArgs = CommonArgs & {
   touchTipMmFromBottom: number
   /** change tip: see comments in step-generation/mix.js */
   changeTip: ChangeTipOptions
-
+  /** drop tip location entity id */
+  dropTipLocation: string
   /** If given, blow out in the specified destination after mixing each well */
   blowoutLocation: string | null | undefined
   blowoutFlowRateUlSec: number
@@ -509,6 +511,7 @@ export type ErrorType =
   | 'HEATER_SHAKER_NORTH_SOUTH__OF_NON_TIPRACK_WITH_MULTI_CHANNEL'
   | 'HEATER_SHAKER_LATCH_CLOSED'
   | 'LABWARE_OFF_DECK'
+  | 'DROP_TIP_LOCATION_DOES_NOT_EXIST'
 
 export interface CommandCreatorError {
   message: string


### PR DESCRIPTION
closes RAUT-718

# Overview

This PR adds a drop tip field to Transfer and Mix forms and then wires it up in the pipette related compound commands in step-generation. It sorta wires stuff up in `dropTip.ts` but not fully since we don't yet know what a drop tip into waste chute will look like. This PR lays out the ground work for wiring up the `dropTip.ts` options though.

# Test Plan

- Create a Flex protocol with the deck configuration FF turned on. 
- Add a waste chute and a trash bin. 
- Go to the deck map and add a labware to the deck. Add a transfer step, see that there is a drop tip section with a location dropdown with 2 options to drop tip. See that the default is the waste chute. Add the step to drop tip in the waste chute.
- Now, create a mix step and see the drop tip section with the location dropdown again. This time, drop tip in the trash bin.
- Download the protocol and see in the json file that the 1st drop tip's labwareId is the waste chute and the 2nd drop tip's labwareId is the trash bin. NOTE: this is incorrect for the waste chute since it is not a labware but what I stubbed in for now. It will be fixed in a follow up when we know more about dropping tips in waste chute.
- Now, go back to the protocol you just created and delete either the waste chute or trash bin, go to the deck map view and see that there is a timeline error saying that the drop tip location is unknown.
- Finally, create a protocol for the OT-2, add a mix and transfer step and see that the drop tip location drop down only has the trash bin option and is automatically selected.

# Changelog

- add `dropTip_location` and `dropTipLocation` types to Transfer and Mix.
- create `DropTipField` and default the drop down location to always select something so the user won't have to select an option each time if there is only 1 option available.
- extend the args in `Transfer`, `Consolidate`, `Distribute`, and `Mix` compound commands
- create an error creator for if a drop tip is missing for some reason (which shouldn't happen unless you delete the trash bin)
- add test coverage
- add to the 7.1.0 migration to add the drop tip location fields
- fix up the cypress tests (I think some were previously failing but we can't tell since the checks are broken)

# Review requests

see test plan

# Risk assessment

low
