### PR TITLE
fix(app): remove LED status bar disabling feature flag

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsFeatureFlags.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsFeatureFlags.tsx
@@ -35,6 +35,7 @@ const NON_FEATURE_FLAG_SETTINGS = [
   'useOldAspirationFunctions',
   'disableLogAggregation',
   'disableFastProtocolUpload',
+  'disableStatusBar',
 ]
 
 export function RobotSettingsFeatureFlags({


### PR DESCRIPTION
closes [RQA-1731](https://opentrons.atlassian.net/browse/RQA-1731)

# Overview

remove `disableStatusBar` Flex setting from feature flags to avoid redundancy with advanced setting

# Test Plan

- verify that 'disable LED status bar' does not show on the Flex feature flag tab in robot settings

# Risk assessment

low

[RQA-1731]: https://opentrons.atlassian.net/browse/RQA-1731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ