### PR TITLE
fix(app,app-shell): undelete old robot update urls

### DIFF
--- a/app-shell-odd/src/config/__fixtures__/index.ts
+++ b/app-shell-odd/src/config/__fixtures__/index.ts
@@ -7,7 +7,7 @@ import type {
   ConfigV17,
   ConfigV18,
   ConfigV19,
-  ConfigV20
+  ConfigV20,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V12: ConfigV12 = {
@@ -125,7 +125,7 @@ export const MOCK_CONFIG_V20: ConfigV20 = {
   version: 20,
   robotSystemUpdate: {
     manifestUrls: {
-      OT2: 'not-used-on-ODD'
-    }
-  }
+      OT2: 'not-used-on-ODD',
+    },
+  },
 }

--- a/app-shell-odd/src/config/__fixtures__/index.ts
+++ b/app-shell-odd/src/config/__fixtures__/index.ts
@@ -7,6 +7,7 @@ import type {
   ConfigV17,
   ConfigV18,
   ConfigV19,
+  ConfigV20
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V12: ConfigV12 = {
@@ -117,4 +118,14 @@ export const MOCK_CONFIG_V19: ConfigV19 = {
     ...MOCK_CONFIG_V18.update,
     hasJustUpdated: false,
   },
+}
+
+export const MOCK_CONFIG_V20: ConfigV20 = {
+  ...MOCK_CONFIG_V19,
+  version: 20,
+  robotSystemUpdate: {
+    manifestUrls: {
+      OT2: 'not-used-on-ODD'
+    }
+  }
 }

--- a/app-shell-odd/src/config/__tests__/migrate.test.ts
+++ b/app-shell-odd/src/config/__tests__/migrate.test.ts
@@ -8,10 +8,11 @@ import {
   MOCK_CONFIG_V17,
   MOCK_CONFIG_V18,
   MOCK_CONFIG_V19,
+  MOCK_CONFIG_V20,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
-const NEWEST_VERSION = 19
+const NEWEST_VERSION = 20
 
 describe('config migration', () => {
   it('should migrate version 12 to latest', () => {
@@ -19,7 +20,7 @@ describe('config migration', () => {
     const result = migrate(v12Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 13 to latest', () => {
@@ -27,7 +28,7 @@ describe('config migration', () => {
     const result = migrate(v13Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 14 to latest', () => {
@@ -35,7 +36,7 @@ describe('config migration', () => {
     const result = migrate(v14Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 15 to latest', () => {
@@ -43,7 +44,7 @@ describe('config migration', () => {
     const result = migrate(v15Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 16 to latest', () => {
@@ -51,7 +52,7 @@ describe('config migration', () => {
     const result = migrate(v16Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 17 to latest', () => {
@@ -59,22 +60,30 @@ describe('config migration', () => {
     const result = migrate(v17Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
-  it('should keep version 18', () => {
+  it('should migration version 18 to latest', () => {
     const v18Config = MOCK_CONFIG_V18
     const result = migrate(v18Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
-  it('should keep version 19', () => {
+  it('should migration version 19 to latest', () => {
     const v19Config = MOCK_CONFIG_V19
     const result = migrate(v19Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(v19Config)
+    expect(result).toEqual(MOCK_CONFIG_V20)
+  })
+
+  it('should keep version 20', () => {
+    const v20Config = MOCK_CONFIG_V20
+    const result = migrate(v20Config)
+
+    expect(result.version).toBe(NEWEST_VERSION)
+    expect(result).toEqual(v20Config)
   })
 })

--- a/app-shell-odd/src/config/migrate.ts
+++ b/app-shell-odd/src/config/migrate.ts
@@ -13,6 +13,7 @@ import type {
   ConfigV17,
   ConfigV18,
   ConfigV19,
+  ConfigV20,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v12 defaults
@@ -156,6 +157,18 @@ const toVersion19 = (prevConfig: ConfigV18): ConfigV19 => {
   return nextConfig
 }
 
+const toVersion20 = (prevConfig: ConfigV19): ConfigV20 => {
+  return {
+    ...prevConfig,
+    version: 20 as const,
+    robotSystemUpdate: {
+      manifestUrls: {
+        OT2: 'not-used-on-ODD',
+      },
+    },
+  }
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV12) => ConfigV13,
   (prevConfig: ConfigV13) => ConfigV14,
@@ -163,7 +176,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV15) => ConfigV16,
   (prevConfig: ConfigV16) => ConfigV17,
   (prevConfig: ConfigV17) => ConfigV18,
-  (prevConfig: ConfigV18) => ConfigV19
+  (prevConfig: ConfigV18) => ConfigV19,
+  (prevConfig: ConfigV19) => ConfigV20
 ] = [
   toVersion13,
   toVersion14,
@@ -172,6 +186,7 @@ const MIGRATIONS: [
   toVersion17,
   toVersion18,
   toVersion19,
+  toVersion20,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V12)
@@ -186,6 +201,7 @@ export function migrate(
     | ConfigV17
     | ConfigV18
     | ConfigV19
+    | ConfigV20
 ): Config {
   let result = prevConfig
   // loop through the migrations, skipping any migrations that are unnecessary

--- a/app-shell/src/config/__fixtures__/index.ts
+++ b/app-shell/src/config/__fixtures__/index.ts
@@ -19,6 +19,7 @@ import type {
   ConfigV17,
   ConfigV18,
   ConfigV19,
+  ConfigV20,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V0: ConfigV0 = {
@@ -248,5 +249,16 @@ export const MOCK_CONFIG_V19: ConfigV19 = {
   update: {
     ...MOCK_CONFIG_V18.update,
     hasJustUpdated: false,
+  },
+}
+
+export const MOCK_CONFIG_V20: ConfigV20 = {
+  ...MOCK_CONFIG_V19,
+  version: 20,
+  robotSystemUpdate: {
+    manifestUrls: {
+      OT2:
+        'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json',
+    },
   },
 }

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -20,10 +20,11 @@ import {
   MOCK_CONFIG_V17,
   MOCK_CONFIG_V18,
   MOCK_CONFIG_V19,
+  MOCK_CONFIG_V20,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
-const NEWEST_VERSION = 19
+const NEWEST_VERSION = 20
 
 describe('config migration', () => {
   it('should migrate version 0 to latest', () => {
@@ -176,11 +177,17 @@ describe('config migration', () => {
     expect(result.version).toBe(NEWEST_VERSION)
     expect(result).toEqual(MOCK_CONFIG_V19)
   })
-  it('should keep version 19', () => {
+  it('should keep migrate version 19 to latest', () => {
     const v19Config = MOCK_CONFIG_V19
     const result = migrate(v19Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(v19Config)
+    expect(result).toEqual(MOCK_CONFIG_V20)
+  })
+  it('should keep version 20', () => {
+    const v20Config = MOCK_CONFIG_V20
+    const result = migrate(v20Config)
+    expect(result.version).toBe(NEWEST_VERSION)
+    expect(result).toEqual(v20Config)
   })
 })

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -32,7 +32,7 @@ describe('config migration', () => {
     const result = migrate(v0Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 1 to latest', () => {
@@ -40,7 +40,7 @@ describe('config migration', () => {
     const result = migrate(v1Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 2 to latest', () => {
@@ -48,7 +48,7 @@ describe('config migration', () => {
     const result = migrate(v2Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 3 to latest', () => {
@@ -56,7 +56,7 @@ describe('config migration', () => {
     const result = migrate(v3Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 4 to latest', () => {
@@ -64,7 +64,7 @@ describe('config migration', () => {
     const result = migrate(v4Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 5 to latest', () => {
@@ -72,7 +72,7 @@ describe('config migration', () => {
     const result = migrate(v5Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 6 to latest', () => {
@@ -80,7 +80,7 @@ describe('config migration', () => {
     const result = migrate(v6Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 7 to latest', () => {
@@ -88,7 +88,7 @@ describe('config migration', () => {
     const result = migrate(v7Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 8 to latest', () => {
@@ -96,7 +96,7 @@ describe('config migration', () => {
     const result = migrate(v8Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 9 to latest', () => {
@@ -104,7 +104,7 @@ describe('config migration', () => {
     const result = migrate(v9Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 10 to latest', () => {
@@ -112,7 +112,7 @@ describe('config migration', () => {
     const result = migrate(v10Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 11 to latest', () => {
@@ -120,7 +120,7 @@ describe('config migration', () => {
     const result = migrate(v11Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 12 to latest', () => {
@@ -128,7 +128,7 @@ describe('config migration', () => {
     const result = migrate(v12Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 13 to latest', () => {
@@ -136,7 +136,7 @@ describe('config migration', () => {
     const result = migrate(v13Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 14 to latest', () => {
@@ -144,7 +144,7 @@ describe('config migration', () => {
     const result = migrate(v14Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 15 to latest', () => {
@@ -152,7 +152,7 @@ describe('config migration', () => {
     const result = migrate(v15Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 16 to latest', () => {
@@ -160,7 +160,7 @@ describe('config migration', () => {
     const result = migrate(v16Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
 
   it('should migrate version 17 to latest', () => {
@@ -168,14 +168,14 @@ describe('config migration', () => {
     const result = migrate(v17Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
   it('should migrate version 18 to latest', () => {
     const v18Config = MOCK_CONFIG_V18
     const result = migrate(v18Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V19)
+    expect(result).toEqual(MOCK_CONFIG_V20)
   })
   it('should keep migrate version 19 to latest', () => {
     const v19Config = MOCK_CONFIG_V19

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -25,6 +25,7 @@ import type {
   ConfigV17,
   ConfigV18,
   ConfigV19,
+  ConfigV20,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v0 defaults
@@ -42,7 +43,9 @@ export const DEFAULTS_V0: ConfigV0 = {
   },
 
   buildroot: {
-    manifestUrl: 'not-used',
+    // do not rely on this value; it is present only for back compatibility
+    manifestUrl:
+      'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json',
   },
 
   // logging config
@@ -258,7 +261,9 @@ const toVersion12 = (prevConfig: ConfigV11): ConfigV12 => {
     version: 12 as const,
     robotSystemUpdate: {
       manifestUrls: {
-        OT2: 'not-used',
+        // do not rely on this value; it is present only for back compatibility
+        OT2:
+          'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json',
         OT3: 'not-used',
       },
     },
@@ -354,6 +359,21 @@ const toVersion19 = (prevConfig: ConfigV18): ConfigV19 => {
   return nextConfig
 }
 
+const toVersion20 = (prevConfig: ConfigV20) => {
+  const nextConfig = {
+    ...prevConfig,
+    version: 20 as const,
+    robotSystemUpdate: {
+      manifestUrls: {
+        // do not rely on this value; it is present only for back compatibility
+        OT2:
+          'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json',
+      },
+    },
+  }
+  return nextConfig
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV0) => ConfigV1,
   (prevConfig: ConfigV1) => ConfigV2,
@@ -373,7 +393,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV15) => ConfigV16,
   (prevConfig: ConfigV16) => ConfigV17,
   (prevConfig: ConfigV17) => ConfigV18,
-  (prevConfig: ConfigV18) => ConfigV19
+  (prevConfig: ConfigV18) => ConfigV19,
+  (prevConfig: ConfigV20) => ConfigV20
 ] = [
   toVersion1,
   toVersion2,
@@ -394,6 +415,7 @@ const MIGRATIONS: [
   toVersion17,
   toVersion18,
   toVersion19,
+  toVersion20,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V0)
@@ -420,6 +442,7 @@ export function migrate(
     | ConfigV17
     | ConfigV18
     | ConfigV19
+    | ConfigV20
 ): Config {
   const prevVersion = prevConfig.version
   let result = prevConfig

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -359,7 +359,7 @@ const toVersion19 = (prevConfig: ConfigV18): ConfigV19 => {
   return nextConfig
 }
 
-const toVersion20 = (prevConfig: ConfigV20) => {
+const toVersion20 = (prevConfig: ConfigV19): ConfigV20 => {
   const nextConfig = {
     ...prevConfig,
     version: 20 as const,
@@ -394,7 +394,7 @@ const MIGRATIONS: [
   (prevConfig: ConfigV16) => ConfigV17,
   (prevConfig: ConfigV17) => ConfigV18,
   (prevConfig: ConfigV18) => ConfigV19,
-  (prevConfig: ConfigV20) => ConfigV20
+  (prevConfig: ConfigV19) => ConfigV20
 ] = [
   toVersion1,
   toVersion2,

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -226,7 +226,7 @@ export type ConfigV19 = Omit<ConfigV18, 'version' | 'update'> & {
   }
 }
 
-export type ConfigV20 = ConfigV19 & {
+export type ConfigV20 = Omit<ConfigV19, 'version'> & {
   version: 20
   robotSystemUpdate: {
     manifestUrls: {

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -226,4 +226,13 @@ export type ConfigV19 = Omit<ConfigV18, 'version' | 'update'> & {
   }
 }
 
-export type Config = ConfigV19
+export type ConfigV20 = ConfigV19 & {
+  version: 20
+  robotSystemUpdate: {
+    manifestUrls: {
+      OT2: string
+    }
+  }
+}
+
+export type Config = ConfigV20


### PR DESCRIPTION
We removed the urls for the old OT-2 infrastructure, because we don't want them anymore. But because we removed them from the app config, and the app doesn't downgrade configs, then if you
- ran 7.0, the config gets deleted
- run 6.3.1 or previous, the config never gets restored and the app just doesn't know where to get robot system updates and therefore acts as if there are none. That in turn means you can't downgrade your robot through the app, you have to manually update from zip.

The gross but only solution is to change the config back to get those values to be present again when you downgrade. This leaves a historical hole - someone who ran 7.0.0 and downgraded to 6.3.1 would still have that behavior - but it's fixed going forward, and those affected can just remove their app config.

## Testing
- Run this branch through `make -C app dev` (just has to migrate the config, don't have to do anything with it)
- Run 6.3.1 and check that you still get downgrade banners on robots. You could make dev it, but also the installers are on opentrons.com/ot-app