### PR TITLE
test(robot-server): Fix race condition in integration test

### DIFF
--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -1,4 +1,3 @@
-import asyncio
 from dataclasses import dataclass, field
 from pathlib import Path
 from shutil import copytree
@@ -9,14 +8,13 @@ import anyio
 import pytest
 
 from tests.integration.dev_server import DevServer
-from tests.integration.robot_client import RobotClient
+from tests.integration.robot_client import RobotClient, poll_until_run_completes
 
 from .persistence_snapshots_dir import PERSISTENCE_SNAPSHOTS_DIR
 
 # Allow plenty of time for database migrations, which can take a while in our CI runners.
 _STARTUP_TIMEOUT = 60
 
-_POLL_INTERVAL = 0.1
 _RUN_TIMEOUT = 5
 
 # Our Tavern tests have servers that stay up for the duration of the test session.
@@ -193,15 +191,9 @@ async def test_rerun_flex_dev_compat() -> None:
             )
 
             with anyio.fail_after(_RUN_TIMEOUT):
-                final_status = await _poll_until_not_running(client, new_run["id"])
+                final_status = (
+                    await poll_until_run_completes(
+                        robot_client=client, run_id=new_run["id"]
+                    )
+                )["data"]["status"]
             assert final_status == "succeeded"
-
-
-async def _poll_until_not_running(robot_client: RobotClient, run_id: str) -> str:
-    while True:
-        latest_status = (await robot_client.get_run(run_id)).json()["data"]["status"]
-        if latest_status not in {"running", "finishing"}:
-            return latest_status  # type: ignore[no-any-return]
-        else:
-            # Sleep, then poll again.
-            await asyncio.sleep(_POLL_INTERVAL)

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -200,7 +200,7 @@ async def test_rerun_flex_dev_compat() -> None:
 async def _poll_until_not_running(robot_client: RobotClient, run_id: str) -> str:
     while True:
         latest_status = (await robot_client.get_run(run_id)).json()["data"]["status"]
-        if latest_status != "running":
+        if latest_status not in {"running", "finishing"}:
             return latest_status  # type: ignore[no-any-return]
         else:
             # Sleep, then poll again.

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -10,8 +10,8 @@ import httpx
 from httpx import Response
 
 
-STARTUP_WAIT = 20
-SHUTDOWN_WAIT = 20
+_STARTUP_WAIT = 20
+_SHUTDOWN_WAIT = 20
 
 _RUN_POLL_INTERVAL = 0.1
 
@@ -87,14 +87,14 @@ class RobotClient:
             # returns some kind of "not ready."
             await asyncio.sleep(0.1)
 
-    async def wait_until_alive(self, timeout_sec: float = STARTUP_WAIT) -> bool:
+    async def wait_until_alive(self, timeout_sec: float = _STARTUP_WAIT) -> bool:
         try:
             await asyncio.wait_for(self._poll_for_alive(), timeout=timeout_sec)
             return True
         except asyncio.TimeoutError:
             return False
 
-    async def wait_until_dead(self, timeout_sec: float = SHUTDOWN_WAIT) -> bool:
+    async def wait_until_dead(self, timeout_sec: float = _SHUTDOWN_WAIT) -> bool:
         """Retry GET /health and until unreachable."""
         try:
             await asyncio.wait_for(self._poll_for_dead(), timeout=timeout_sec)

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -134,7 +134,9 @@ class RobotClient:
         multipart_upload_name = "files"
 
         with contextlib.ExitStack() as file_exit_stack:
-            opened_files: List[Union[BinaryIO, Tuple[str, bytes]],] = []
+            opened_files: List[
+                Union[BinaryIO, Tuple[str, bytes]],
+            ] = []
 
             for file in files:
                 if isinstance(file, Path):


### PR DESCRIPTION
# Overview

This fixes a test that was flaky because of a race condition.

We were waiting for a run to succeed by:

1. Polling until its status indicated "done."
2. Checking that the final status was `succeeded`.

But we would erroneously proceed from step 1 to step 2 when the run transitioned from `running` to `finishing`, and `finishing` is of course not `succeeded`, so the test would sometimes fail depending on timing.

# Test Plan

Just make sure CI keeps passing.

# Risk assessment

No risk.
