### PR TITLE
fix(api): Support simulating PAPIv≥2.14

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -21,7 +21,7 @@ Flex touchscreen
 - Manage instruments: View information about connected pipettes and the gripper. Attach, detach, or recalibrate instruments.
 - Robot settings: Customize the behavior of your Flex, including the LED and touchscreen displays.
 
-Flex features 
+Flex features
 
 - Analyze and run protocols that use the Flex robot, Flex pipettes, and Flex tip racks.
 - Move labware around the deck automatically with the Flex Gripper.
@@ -48,7 +48,6 @@ Python API features
 Some protocols can't be simulated with the `opentrons_simulate` command-line tool:
 
 - JSON protocols created or modified with Protocol Designer v6.0.0 or higher.
-- Python protocols specifying an `apiLevel` of 2.14 or higher.
 
 ---
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -410,9 +410,7 @@ def execute(  # noqa: C901
             )
         protocol_file.seek(0)
         _run_file_pe(
-            protocol_file=protocol_file,
-            protocol_name=protocol_name,
-            extra_labware=extra_labware,
+            protocol=protocol,
             hardware_api=_get_global_hardware_controller(_get_robot_type()),
             emit_runlog=emit_runlog,
         )
@@ -594,9 +592,7 @@ def _run_file_non_pe(
 
 
 def _run_file_pe(
-    protocol_file: Union[BinaryIO, TextIO],
-    protocol_name: str,
-    extra_labware: Dict[str, entrypoint_util.FoundLabware],
+    protocol: Protocol,
     hardware_api: ThreadManagedHardware,
     emit_runlog: Optional[_EmitRunlogCallable],
 ) -> None:
@@ -629,11 +625,7 @@ def _run_file_pe(
                 result.state_summary.errors
             )
 
-    with entrypoint_util.adapt_protocol_source(
-        protocol_file=protocol_file,
-        protocol_name=protocol_name,
-        extra_labware=extra_labware,
-    ) as protocol_source:
+    with entrypoint_util.adapt_protocol_source(protocol) as protocol_source:
         asyncio.run(run(protocol_source))
 
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -180,6 +180,8 @@ def get_protocol_api(
         )
     else:
         if bundled_labware is not None:
+            # Protocol Engine has a deep assumption that standard labware definitions are always
+            # implicitly loadable.
             raise NotImplementedError(
                 f"The bundled_labware argument is not currently supported for Python protocols"
                 f" with apiLevel {ENGINE_CORE_API_VERSION} or newer."

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -353,8 +353,6 @@ def execute(  # noqa: C901
     stack_logger.propagate = propagate_logs
     stack_logger.setLevel(getattr(logging, log_level.upper(), logging.WARNING))
 
-    contents = protocol_file.read()
-
     # TODO(mm, 2023-10-02): Switch this truthy check to `is not None`
     # to match documented behavior.
     # See notes in https://github.com/Opentrons/opentrons/pull/13107
@@ -368,6 +366,7 @@ def execute(  # noqa: C901
     else:
         extra_data = {}
 
+    contents = protocol_file.read()
     try:
         protocol = parse.parse(
             contents,

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -32,7 +32,6 @@ from opentrons.commands import types as command_types
 
 from opentrons.hardware_control import (
     API as OT2API,
-    HardwareControlAPI,
     ThreadManagedHardware,
     ThreadManager,
 )
@@ -414,7 +413,7 @@ def execute(  # noqa: C901
             protocol_file=protocol_file,
             protocol_name=protocol_name,
             extra_labware=extra_labware,
-            hardware_api=_get_global_hardware_controller(_get_robot_type()).wrapped(),
+            hardware_api=_get_global_hardware_controller(_get_robot_type()),
             emit_runlog=emit_runlog,
         )
 
@@ -598,21 +597,21 @@ def _run_file_pe(
     protocol_file: Union[BinaryIO, TextIO],
     protocol_name: str,
     extra_labware: Dict[str, entrypoint_util.FoundLabware],
-    hardware_api: HardwareControlAPI,
+    hardware_api: ThreadManagedHardware,
     emit_runlog: Optional[_EmitRunlogCallable],
 ) -> None:
     """Run a protocol file with Protocol Engine."""
 
     async def run(protocol_source: ProtocolSource) -> None:
         protocol_engine = await create_protocol_engine(
-            hardware_api=hardware_api,
+            hardware_api=hardware_api.wrapped(),
             config=_get_protocol_engine_config(),
         )
 
         protocol_runner = create_protocol_runner(
             protocol_config=protocol_source.config,
             protocol_engine=protocol_engine,
-            hardware_api=hardware_api,
+            hardware_api=hardware_api.wrapped(),
         )
 
         unsubscribe = protocol_runner.broker.subscribe(

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -47,10 +47,19 @@ def run_python(proto: PythonProtocol, context: ProtocolContext):
     # If the protocol is written correctly, it will have defined a function
     # like run(context: ProtocolContext). If so, that function is now in the
     # current scope.
+
+    # TODO(mm, 2023-10-11): This coupling to opentrons.protocols.parse is fragile.
+    # Can we get the correct filename directly from proto.contents?
     if proto.filename and proto.filename.endswith("zip"):
+        # The ".zip" extension needs to match what opentrons.protocols.parse recognizes as a bundle,
+        # and the "protocol.ot2.py" fallback needs to match what opentrons.protocol.py sets as the
+        # AST filename.
         filename = "protocol.ot2.py"
     else:
+        # "<protocol>" needs to match what opentrons.protocols.parse sets as the fallback
+        # AST filename.
         filename = proto.filename or "<protocol>"
+
     try:
         _runfunc_ok(new_globs.get("run"))
     except SyntaxError as se:

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -32,11 +32,22 @@ class StaticPythonInfo:
 @dataclass(frozen=True)
 class _ProtocolCommon:
     text: str
+
     filename: Optional[str]
+    """The original name of the main protocol file, if it had a name.
+
+    For JSON protocols, this will be the name of the .json file.
+    For Python protocols, this will be the name of the .py file.
+    For bundled protocols, this will be the name of the .zip file.
+
+    This can be `None` if, for example, we've parsed the protocol from an in-memory text stream.
+    """
+
     # TODO(mm, 2023-06-22): Move api_level out of _ProtocolCommon and into PythonProtocol.
     # JSON protocols do not have an intrinsic api_level, especially since JSONv6,
     # where they are no longer executed via the Python Protocol API.
     api_level: "APIVersion"
+
     robot_type: RobotType
 
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -80,6 +80,12 @@ This should match what `opentrons.protocols.parse()` accepts in a protocol's `re
 """
 
 
+# TODO(mm, 2023-10-05): Type _SimulateResultRunLog more precisely by using TypedDicts from
+# opentrons.commands.
+_SimulateResultRunLog = List[Mapping[str, Any]]
+_SimulateResult = Tuple[_SimulateResultRunLog, Optional[BundleContents]]
+
+
 class _AccumulatingHandler(logging.Handler):
     def __init__(
         self,
@@ -113,10 +119,10 @@ class _CommandScraper:
         self._logger = logger
         self._level = level
         self._broker = broker
-        self._commands: List[Mapping[str, Any]] = []
+        self._commands: _SimulateResultRunLog = []
 
     @property
-    def commands(self) -> List[Mapping[str, Mapping[str, Any]]]:
+    def commands(self) -> _SimulateResultRunLog:
         """The list of commands scraped while `.scrape()` was open, integrated with log messages.
 
         See :py:obj:`simulate` for the return type.
@@ -361,7 +367,7 @@ def simulate(  # noqa: C901
     hardware_simulator_file_path: Optional[str] = None,
     duration_estimator: Optional[DurationEstimator] = None,
     log_level: str = "warning",
-) -> Tuple[List[Mapping[str, Any]], Optional[BundleContents]]:
+) -> _SimulateResult:
     """
     Simulate the protocol itself.
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -301,6 +301,8 @@ def get_protocol_api(
         )
     else:
         if bundled_labware is not None:
+            # Protocol Engine has a deep assumption that standard labware definitions are always
+            # implicitly loadable.
             raise NotImplementedError(
                 f"The bundled_labware argument is not currently supported for Python protocols"
                 f" with apiLevel {ENGINE_CORE_API_VERSION} or newer."

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -403,7 +403,7 @@ def bundle_from_sim(
     )
 
 
-def simulate(  # noqa: C901
+def simulate(
     protocol_file: Union[BinaryIO, TextIO],
     file_name: Optional[str] = None,
     custom_labware_paths: Optional[List[str]] = None,

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -541,14 +541,8 @@ def simulate(  # noqa: C901
                 )
             protocol_file.seek(0)
             return _run_file_pe(
-                protocol_file=protocol_file,
-                protocol_name=(
-                    file_name
-                    if file_name is not None
-                    else "<protocol>"  # FIX BEFORE MERGE
-                ),
+                protocol=protocol,
                 robot_type=protocol.robot_type,
-                extra_labware=extra_labware,
                 hardware_api=hardware_simulator,
                 stack_logger=stack_logger,
                 log_level=log_level,
@@ -854,12 +848,8 @@ def _run_file_non_pe(
 
 
 def _run_file_pe(
-    # TODO(mm, 2023-10-02): Can we combine protocol_file, protocol_name, and robot_type
-    # into a single `Protocol` argument?
-    protocol_file: Union[BinaryIO, TextIO],
-    protocol_name: str,
+    protocol: Protocol,
     robot_type: RobotType,
-    extra_labware: Dict[str, entrypoint_util.FoundLabware],
     hardware_api: ThreadManagedHardware,
     stack_logger: logging.Logger,
     log_level: str,
@@ -889,11 +879,7 @@ def _run_file_pe(
 
         return scraper.commands, None  # FIX BEFORE MERGE
 
-    with entrypoint_util.adapt_protocol_source(
-        protocol_file=protocol_file,
-        protocol_name=protocol_name,
-        extra_labware=extra_labware,
-    ) as protocol_source:
+    with entrypoint_util.adapt_protocol_source(protocol) as protocol_source:
         return asyncio.run(run(protocol_source))
 
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -437,8 +437,6 @@ def simulate(  # noqa: C901
     stack_logger.propagate = propagate_logs
     # _CommandScraper will set the level of this logger.
 
-    contents = protocol_file.read()
-
     # TODO(mm, 2023-10-02): Switch this truthy check to `is not None`
     # to match documented behavior.
     # See notes in https://github.com/Opentrons/opentrons/pull/13107
@@ -460,6 +458,7 @@ def simulate(  # noqa: C901
             pathlib.Path(hardware_simulator_file_path),
         )
 
+    contents = protocol_file.read()
     try:
         protocol = parse.parse(
             contents,

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -50,11 +50,7 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.robot.dev_types import RobotType
 
-from .util.entrypoint_util import (
-    find_jupyter_labware,
-    labware_from_paths,
-    datafiles_from_paths,
-)
+from .util import entrypoint_util
 
 
 # See Jira RCORE-535.
@@ -250,7 +246,7 @@ def get_protocol_api(
     if extra_labware is None:
         extra_labware = {
             uri: details.definition
-            for uri, details in (find_jupyter_labware() or {}).items()
+            for uri, details in (entrypoint_util.find_jupyter_labware() or {}).items()
         }
 
     checked_hardware = _check_hardware_simulator(hardware_simulator, parsed_robot_type)
@@ -441,12 +437,12 @@ def simulate(  # noqa: C901
     # to match documented behavior.
     # See notes in https://github.com/Opentrons/opentrons/pull/13107
     if custom_labware_paths:
-        extra_labware = labware_from_paths(custom_labware_paths)
+        extra_labware = entrypoint_util.labware_from_paths(custom_labware_paths)
     else:
-        extra_labware = find_jupyter_labware() or {}
+        extra_labware = entrypoint_util.find_jupyter_labware() or {}
 
     if custom_data_paths:
-        extra_data = datafiles_from_paths(custom_data_paths)
+        extra_data = entrypoint_util.datafiles_from_paths(custom_data_paths)
     else:
         extra_data = {}
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -935,15 +935,21 @@ def main() -> int:
     # TODO(mm, 2022-12-01): Configure the DurationEstimator with the correct deck type.
     duration_estimator = DurationEstimator() if args.estimate_duration else None  # type: ignore[no-untyped-call]
 
-    runlog, maybe_bundle = simulate(
-        protocol_file=args.protocol,
-        file_name=args.protocol.name,
-        custom_labware_paths=args.custom_labware_path,
-        custom_data_paths=(args.custom_data_path + args.custom_data_file),
-        duration_estimator=duration_estimator,
-        hardware_simulator_file_path=getattr(args, "custom_hardware_simulator_file"),
-        log_level=args.log_level,
-    )
+    try:
+        runlog, maybe_bundle = simulate(
+            protocol_file=args.protocol,
+            file_name=args.protocol.name,
+            custom_labware_paths=args.custom_labware_path,
+            custom_data_paths=(args.custom_data_path + args.custom_data_file),
+            duration_estimator=duration_estimator,
+            hardware_simulator_file_path=getattr(
+                args, "custom_hardware_simulator_file"
+            ),
+            log_level=args.log_level,
+        )
+    except entrypoint_util.ProtocolEngineExecuteError as error:
+        print(error.to_stderr_string(), file=sys.stderr)
+        return 1
 
     if maybe_bundle:
         bundle_name = getattr(args, "bundle", None)

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -129,16 +129,11 @@ def protocol_file() -> str:
 
 @pytest.fixture()
 def protocol(protocol_file: str) -> Generator[Protocol, None, None]:
-    root = protocol_file
-    filename = os.path.join(os.path.dirname(__file__), "data", root)
-
-    file = open(filename)
-    text = "".join(list(file))
-    file.seek(0)
-
-    yield Protocol(text=text, filename=filename, filelike=file)
-
-    file.close()
+    filename = os.path.join(os.path.dirname(__file__), "data", protocol_file)
+    with open(filename, encoding="utf-8") as file:
+        text = file.read()
+        file.seek(0)
+        yield Protocol(text=text, filename=filename, filelike=file)
 
 
 @pytest.fixture()

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -426,14 +426,19 @@ def test_parse_python_details(
     assert parsed.text == protocol_source
     assert isinstance(parsed.text, str)
 
-    fname = filename if filename is not None else "<protocol>"
-
-    assert parsed.filename == fname
+    assert parsed.filename == filename
+    assert parsed.contents.co_filename == (
+        filename if filename is not None else "<protocol>"
+    )
 
     assert parsed.api_level == expected_api_level
     assert expected_robot_type == expected_robot_type
     assert parsed.metadata == expected_metadata
-    assert parsed.contents == compile(protocol_source, filename=fname, mode="exec")
+    assert parsed.contents == compile(
+        protocol_source,
+        filename="<Python ignores this filename in this comparison>",
+        mode="exec",
+    )
 
 
 @pytest.mark.parametrize(
@@ -481,7 +486,7 @@ def test_parse_bundle_details(get_bundle_fixture: Callable[..., Any]) -> None:
     parsed = parse(fixture["binary_zipfile"], filename)
 
     assert isinstance(parsed, PythonProtocol)
-    assert parsed.filename == "protocol.ot2.py"
+    assert parsed.filename == filename
     assert parsed.bundled_labware == fixture["bundled_labware"]
     assert parsed.bundled_python == fixture["bundled_python"]
     assert parsed.bundled_data == fixture["bundled_data"]

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -62,6 +62,12 @@ def test_simulate_function_apiv2_bundle(
     assert isinstance(bundle_contents, protocols.types.BundleContents)
 
 
+@pytest.mark.parametrize("protocol_file", ["testosaur_v2.py", "testosaur_v2_14.py"])
+def test_simulate_without_filename(protocol: Protocol, protocol_file: str) -> None:
+    """`simulate()` should accept a protocol without a filename."""
+    simulate.simulate(protocol.filelike)  # Should not raise.
+
+
 @pytest.mark.parametrize(
     ("protocol_file", "expected_entries"),
     [

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -5,13 +5,14 @@ import io
 import json
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Generator, TextIO, cast
+from typing import TYPE_CHECKING, Callable, Generator, List, TextIO, cast
 
 import pytest
 
 from opentrons_shared_data import get_shared_data_root, load_shared_data
 
 from opentrons import simulate, protocols
+from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
 from opentrons.protocols.types import ApiDeprecationError
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.execution.errors import ExceptionInProtocolError
@@ -24,13 +25,7 @@ if TYPE_CHECKING:
 HERE = Path(__file__).parent
 
 
-@pytest.fixture(
-    params=[
-        APIVersion(2, 0),
-        # TODO(mm, 2023-07-14): Enable this for https://opentrons.atlassian.net/browse/RSS-268.
-        # ENGINE_CORE_API_VERSION,
-    ]
-)
+@pytest.fixture(params=[APIVersion(2, 0), ENGINE_CORE_API_VERSION])
 def api_version(request: pytest.FixtureRequest) -> APIVersion:
     """Return an API version to test with.
 
@@ -44,28 +39,62 @@ def api_version(request: pytest.FixtureRequest) -> APIVersion:
     "protocol_file",
     [
         "testosaur_v2.py",
-        # TODO(mm, 2023-07-14): Resolve this xfail. https://opentrons.atlassian.net/browse/RSS-268
         pytest.param(
             "testosaur_v2_14.py",
-            marks=pytest.mark.xfail(strict=True, raises=NotImplementedError),
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "We can't currently get bundle contents"
+                    " from protocols run through Protocol Engine."
+                ),
+            ),
         ),
     ],
 )
-def test_simulate_function_apiv2(
+def test_simulate_function_apiv2_bundle(
     protocol: Protocol,
     protocol_file: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test `simulate()` with a Python file."""
+    """Test that `simulate()` returns the expected bundle contents from a Python file."""
     monkeypatch.setenv("OT_API_FF_allowBundleCreation", "1")
-    runlog, bundle = simulate.simulate(protocol.filelike, protocol.filename)
-    assert isinstance(bundle, protocols.types.BundleContents)
-    assert [item["payload"]["text"] for item in runlog] == [
-        "Picking up tip from A1 of Opentrons 96 Tip Rack 1000 µL on 1",
-        "Aspirating 100.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 500.0 uL/sec",
-        "Dispensing 100.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1000.0 uL/sec",
-        "Dropping tip into H12 of Opentrons 96 Tip Rack 1000 µL on 1",
-    ]
+    _, bundle_contents = simulate.simulate(protocol.filelike, protocol.filename)
+    assert isinstance(bundle_contents, protocols.types.BundleContents)
+
+
+@pytest.mark.parametrize(
+    ("protocol_file", "expected_entries"),
+    [
+        (
+            "testosaur_v2.py",
+            [
+                "Picking up tip from A1 of Opentrons 96 Tip Rack 1000 µL on 1",
+                "Aspirating 100.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 500.0 uL/sec",
+                "Dispensing 100.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1000.0 uL/sec",
+                "Dropping tip into H12 of Opentrons 96 Tip Rack 1000 µL on 1",
+            ],
+        ),
+        (
+            "testosaur_v2_14.py",
+            # FIXME(2023-10-04): This run log is wrong. It should match the one above.
+            # https://opentrons.atlassian.net/browse/RSS-368
+            [
+                "Picking up tip from A1 of None",
+                "Aspirating 100.0 uL from A1 of None at 500.0 uL/sec",
+                "Dispensing 100.0 uL into B1 of None at 1000.0 uL/sec",
+                "Dropping tip into H12 of None",
+            ],
+        ),
+    ],
+)
+def test_simulate_function_apiv2_run_log(
+    protocol: Protocol,
+    protocol_file: str,
+    expected_entries: List[str],
+) -> None:
+    """Test that `simulate()` returns the expected run log from a Python file."""
+    run_log, _ = simulate.simulate(protocol.filelike, protocol.filename)
+    assert [item["payload"]["text"] for item in run_log] == expected_entries
 
 
 def test_simulate_function_json(

--- a/api/tests/opentrons/util/test_entrypoint_util.py
+++ b/api/tests/opentrons/util/test_entrypoint_util.py
@@ -1,17 +1,13 @@
-import io
 import json
 import os
 from pathlib import Path
 from typing import Callable
-
-import pytest
 
 from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
 from opentrons.util.entrypoint_util import (
     FoundLabware,
     labware_from_paths,
     datafiles_from_paths,
-    copy_file_like,
 )
 
 
@@ -79,70 +75,3 @@ def test_datafiles_from_paths(tmp_path: Path) -> None:
         "test1": "wait theres a second file???".encode(),
         "test-file": "this isnt even in a directory".encode(),
     }
-
-
-class TestCopyFileLike:
-    """Tests for `copy_file_like()`."""
-
-    @pytest.fixture(params=["abc", "µ"])
-    def source_text(self, request: pytest.FixtureRequest) -> str:
-        return request.param  # type: ignore[attr-defined,no-any-return]
-
-    @pytest.fixture
-    def source_bytes(self, source_text: str) -> bytes:
-        return b"\x00\x01\x02\x03\x04"
-
-    @pytest.fixture
-    def source_path(self, tmp_path: Path) -> Path:
-        return tmp_path / "source"
-
-    @pytest.fixture
-    def destination_path(self, tmp_path: Path) -> Path:
-        return tmp_path / "destination"
-
-    def test_from_text_file(
-        self,
-        source_text: str,
-        source_path: Path,
-        destination_path: Path,
-    ) -> None:
-        """Test that it correctly copies from a text-mode `open()`."""
-        source_path.write_text(source_text)
-
-        with open(
-            source_path,
-            mode="rt",
-        ) as source_file:
-            copy_file_like(source=source_file, destination=destination_path)
-
-        assert destination_path.read_text() == source_text
-
-    def test_from_binary_file(
-        self,
-        source_bytes: bytes,
-        source_path: Path,
-        destination_path: Path,
-    ) -> None:
-        """Test that it correctly copies from a binary-mode `open()`."""
-        source_path.write_bytes(source_bytes)
-
-        with open(source_path, mode="rb") as source_file:
-            copy_file_like(source=source_file, destination=destination_path)
-
-        assert destination_path.read_bytes() == source_bytes
-
-    def test_from_stringio(self, source_text: str, destination_path: Path) -> None:
-        """Test that it correctly copies from an `io.StringIO`."""
-        stringio = io.StringIO(source_text)
-
-        copy_file_like(source=stringio, destination=destination_path)
-
-        assert destination_path.read_text() == source_text
-
-    def test_from_bytesio(self, source_bytes: bytes, destination_path: Path) -> None:
-        """Test that it correctly copies from an `io.BytesIO`."""
-        bytesio = io.BytesIO(source_bytes)
-
-        copy_file_like(source=bytesio, destination=destination_path)
-
-        assert destination_path.read_bytes() == source_bytes


### PR DESCRIPTION
# Overview

Closes RSS-322. Lets you run new Python protocols through `opentrons_simulate`, `opentrons.simulate.simulate()`, and `opentrons.simulate.get_protocol_api()`.

Also fixes a straggling instance of RSS-156, incorrectly using the machine's current deck type in simulation, instead of the correct deck type to match the protocol.

# Test Plan

See [this document](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3836739643/Manual+test+plan+for+opentrons+simulate+and+friends+in+v7.0.1).

# Changelog

Notable changes:

* Rework `simulate.py` to support PAPIv≥2.14 protocols, via Protocol Engine. This rework mirrors what we did to `execute.py` in #12970.
* Rework the `adapt_protocol_source()` helper to cope with protocols for which we don't know the filename. This is necessary to support `opentrons.simulate.simulate()`, whose `filename` argument is optional.

  Unfortunately, this requires modifications to `opentrons.protocols.parse` to make the filename more pass-through, so `adapt_protocol_source()` can tell when it wasn't provided.

Plus various smaller refactors for type safety, deduplication, and consistency.

# Code review requests

I suggest code-reviewing this in two ways:

1. Read the latest `simulate.py` file side-by-side with the latest `execute.py` file. They should mirror each other almost exactly.
    * Known discrepancy: They have minor differences because of differences in their interfaces. For example, the stuff in `simulate.py` *returns* the run log, whereas the stuff in `execute.py` sends run log events to a callback.
    * Known discrepancy: `execute.py` has a global hardware controller and global `ProtocolEngine`s, whereas `simulate.py` only has the global `ProtocolEngine`s.
2. To get a more semantic sense of what changed, go commit-by-commit. Many of the commits are trivial refactors and can be glossed over. The commit messages should mark when this is the case.

Some special things to watch out for:

* When rewriting `simulate.py` to make it look like `execute.py`, make sure I didn't accidentally drop anything unique to the old `simulate.py` that was important.
* Double-check my work on `adapt_protocol_source()` and `opentrons.protocols.parse`. 

# Risk assessment

Medium.

This touches some subtle parts of `opentrons.protocols.parse` and `opentrons.protocols.execute`. The touches are light, but those areas are critical to protocol execution.

It also touches the simulation of PAPIv≤2.13 and JSONv≤5 protocols, so we need regression testing on those. See the test plan.