### PR TITLE
fix(app): render labware on module correctly in moveLabware modal

### DIFF
--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -202,9 +202,17 @@ export function MoveLabwareInterventionContent({
               backgroundItems={
                 <>
                   {moduleRenderInfo.map(
-                    ({ x, y, moduleId, moduleDef, nestedLabwareDef }) => (
+                    ({
+                      x,
+                      y,
+                      moduleId,
+                      moduleDef,
+                      nestedLabwareDef,
+                      nestedLabwareId,
+                    }) => (
                       <Module key={moduleId} def={moduleDef} x={x} y={y}>
-                        {nestedLabwareDef != null ? (
+                        {nestedLabwareDef != null &&
+                        nestedLabwareId !== command.params.labwareId ? (
                           <LabwareRender definition={nestedLabwareDef} />
                         ) : null}
                       </Module>


### PR DESCRIPTION
closes RAUT-772

# Overview

Fix labware moving away from on top of the module in move labware intervention modal

# Test Plan

Run a protocol with a move labware manually step from on top of a module to another location. See that the deck map in the intervention modal shows that there is no labware on top of the module.

# Changelog

- fix logic to not render the nested labware if it matches the `labwareId` in the move labware command

# Review requests

see test plan

# Risk assessment

low