### PR TITLE
chore: release notes for 7.0.1

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -12,10 +12,6 @@ Welcome to the v7.0.1 release of the Opentrons robot software! This release buil
 
 This update may take longer than usual if you are updating from v6.x. Allow **approximately 15 minutes** for your robot to restart. This delay will only happen once.
 
-### Bug Fixes
-
-- Fixed a problem with empty files being stored in the robot's database if the robot is power cycled at the wrong time.
-
 ### Known Issues
 
 Some protocols can't be simulated with the `opentrons_simulate` command-line tool:
@@ -60,6 +56,7 @@ Python API features
 
 ### Bug Fixes
 
+- Fixed a problem with empty files being stored in the robot's database if the robot is power cycled at the wrong time.
 - The API no longer raises an error when dropping tips into labware other than the fixed trash.
 - All API versions now properly track tips, including starting at a well other than A1.
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,25 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons Robot Software Changes in 7.0.1
+
+Welcome to the v7.0.1 release of the Opentrons robot software! This release builds on the major release that added support for Opentrons Flex.
+
+This update may take longer than usual if you are updating from v6.x. Allow **approximately 15 minutes** for your robot to restart. This delay will only happen once.
+
+### New Features
+
+### Bug Fixes
+
+### Known Issues
+
+Some protocols can't be simulated with the `opentrons_simulate` command-line tool:
+
+- JSON protocols created or modified with Protocol Designer v6.0.0 or higher.
+- Python protocols specifying an `apiLevel` of 2.14 or higher.
+
+---
+
 ## Opentrons Robot Software Changes in 7.0.0
 
 Welcome to the v7.0.0 release of the Opentrons robot software! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -32,6 +32,7 @@ Python API features
 - Manually move labware around, off of, or onto the deck without ending your protocol.
 - Load adapters separately from labware (to allow moving labware onto or off of the adapter).
 - Use coordinate or numeric deck slot names interchangeably.
+- Set 50 µL pipettes to a low-volume mode for handling very small quantities of liquid.
 
 ### Improved Features
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -12,9 +12,9 @@ Welcome to the v7.0.1 release of the Opentrons robot software! This release buil
 
 This update may take longer than usual if you are updating from v6.x. Allow **approximately 15 minutes** for your robot to restart. This delay will only happen once.
 
-### New Features
-
 ### Bug Fixes
+
+- Fixed a problem with empty files being stored in the robot's database if the robot is power cycled at the wrong time.
 
 ### Known Issues
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,9 +10,14 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.0.0 release of the Opentrons App! This release builds on the major release that added support for Opentrons Flex.
 
-### New Features
+### Improved Features
+
+- Pipettes move higher during Labware Position Check to avoid crashes in all deck slots, not just those with labware loaded in the protocol.
 
 ### Bug Fixes
+
+- The app no longer blocks running valid protocols due to "not valid JSON" or "apiLevel not declared" errors.
+- Robot commands, like turning the lights on or off, no longer take a long time to execute.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,16 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons App Changes in 7.0.1
+
+Welcome to the v7.0.0 release of the Opentrons App! This release builds on the major release that added support for Opentrons Flex.
+
+### New Features
+
+### Bug Fixes
+
+---
+
 ## Opentrons App Changes in 7.0.0
 
 Welcome to the v7.0.0 release of the Opentrons App! This release adds support for the Opentrons Flex robot, instruments, modules, and labware.


### PR DESCRIPTION
# Overview

7.0.1 release notes. These focus on bugs present in 6.3.x for OT-2 that are fixed in 7.0.1.

Will close RTC-352, RQA-1744.

# Test Plan

Read the words. Make sure nothing's missing. See that these render in the next alpha tag.

# Changelog

- Lists app and robot stack bug fixes. One (empty files in database) is listed in both places for extra visibility.
- Add one new feature missed in 7.0.0.

# Risk assessment

basically none