### PR TITLE
fix(app): fix calibration health check result summary condition issue

### DIFF
--- a/app/src/organisms/CheckCalibration/ResultsSummary/CalibrationHealthCheckResults.tsx
+++ b/app/src/organisms/CheckCalibration/ResultsSummary/CalibrationHealthCheckResults.tsx
@@ -13,11 +13,11 @@ import { StyledText } from '../../../atoms/text'
 import { StatusLabel } from '../../../atoms/StatusLabel'
 
 interface CalibrationHealthCheckResultsProps {
-  isCalibrationCompleted: boolean
+  isCalibrationRecommended: boolean
 }
 
 export const CalibrationHealthCheckResults = ({
-  isCalibrationCompleted,
+  isCalibrationRecommended,
 }: CalibrationHealthCheckResultsProps): JSX.Element => {
   const { t } = useTranslation('robot_calibration')
   return (
@@ -25,17 +25,19 @@ export const CalibrationHealthCheckResults = ({
       <StyledText as="h1">{t('calibration_health_check_results')}</StyledText>
       <StatusLabel
         status={
-          isCalibrationCompleted
-            ? t('calibration_complete')
-            : t('calibration_recommended')
+          isCalibrationRecommended
+            ? t('calibration_recommended')
+            : t('calibration_complete')
         }
         backgroundColor={
-          isCalibrationCompleted
-            ? COLORS.successBackgroundLight
-            : COLORS.warningBackgroundLight
+          isCalibrationRecommended
+            ? COLORS.warningBackgroundLight
+            : COLORS.successBackgroundLight
         }
         iconColor={
-          isCalibrationCompleted ? COLORS.successEnabled : COLORS.warningEnabled
+          isCalibrationRecommended
+            ? COLORS.warningEnabled
+            : COLORS.successEnabled
         }
         textColor={COLORS.darkBlackEnabled}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}

--- a/app/src/organisms/CheckCalibration/ResultsSummary/__tests__/CalibrationHealthCheckResults.test.tsx
+++ b/app/src/organisms/CheckCalibration/ResultsSummary/__tests__/CalibrationHealthCheckResults.test.tsx
@@ -15,7 +15,7 @@ describe('CalibrationHealthCheckResults', () => {
   let props: React.ComponentProps<typeof CalibrationHealthCheckResults>
   beforeEach(() => {
     props = {
-      isCalibrationCompleted: true,
+      isCalibrationRecommended: false,
     }
   })
 
@@ -35,7 +35,7 @@ describe('CalibrationHealthCheckResults', () => {
   })
 
   it('should render title and warning StatusLabel when calibration results includes bad', () => {
-    props.isCalibrationCompleted = false
+    props.isCalibrationRecommended = true
     const { getByText, getByTestId } = render(props)
     getByText('Calibration recommended')
     expect(getByTestId('status_circle')).toHaveStyle(

--- a/app/src/organisms/CheckCalibration/ResultsSummary/index.tsx
+++ b/app/src/organisms/CheckCalibration/ResultsSummary/index.tsx
@@ -111,7 +111,7 @@ export function ResultsSummary(
 
   // check all calibration status
   // if all of them are good, this returns true. otherwise return false
-  const isCalibrationCompleted = (): boolean => {
+  const isCalibrationRecommended = (): boolean => {
     const isOffsetsBad =
       pipetteResultsBad(calibrationsByMount.left.calibration).offsetBad &&
       pipetteResultsBad(calibrationsByMount.right.calibration).offsetBad
@@ -130,7 +130,7 @@ export function ResultsSummary(
     >
       <Box marginBottom="1.5rem">
         <CalibrationHealthCheckResults
-          isCalibrationCompleted={isCalibrationCompleted()}
+          isCalibrationRecommended={isCalibrationRecommended()}
         />
       </Box>
       <Box marginBottom={SPACING.spacing16}>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue was the condition was the opposite. Fix that issue and rename the variable name since the previous one didn't describe itself well.

close RQA-1736
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- calibrate deck, pipette offset, and tip length
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update ResultSummary component and rename the variable
- update ResultSummary tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
