### PR TITLE
fix(app): add support link for manual intervention steps

### DIFF
--- a/app/src/organisms/InterventionModal/InterventionModal.stories.tsx
+++ b/app/src/organisms/InterventionModal/InterventionModal.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Provider } from 'react-redux'
 import { createStore } from 'redux'
+import fixture_96_plate from '@opentrons/shared-data/labware/fixtures/2/fixture_96_plate.json'
 import { configReducer } from '../../redux/config/reducer'
 import { mockRunData } from './__fixtures__'
 import { InterventionModal as InterventionModalComponent } from './'
@@ -45,4 +46,49 @@ PauseIntervention.args = {
   robotName: 'Otie',
   command: pauseCommand,
   run: mockRunData,
+}
+
+export const MoveLabwareIntervention = Template.bind({})
+MoveLabwareIntervention.args = {
+  robotName: 'Otie',
+  command: {
+    commandType: 'moveLabware',
+    params: {
+      labwareId: 'fake_labware_id',
+      newLocation: {
+        slotName: '1',
+      },
+    },
+  },
+  run: {
+    ...mockRunData,
+    labware: [
+      {
+        id: 'fake_labware_id',
+        loadName: fixture_96_plate.parameters.loadName,
+        definitionUri: 'fixture/fixture_96_plate/1',
+        location: {
+          slotName: '9',
+        },
+      },
+    ],
+  },
+  analysis: {
+    commands: [
+      {
+        commandType: 'loadLabware',
+        params: {
+          displayName: 'fake display name',
+          labwareId: 'fake_labware_id',
+          loadName: fixture_96_plate.parameters.loadName,
+          namespace: 'fixture',
+          version: 1,
+          location: { slotName: '9' },
+        },
+        result: {
+          definition: fixture_96_plate,
+        },
+      },
+    ],
+  },
 }

--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -144,7 +144,6 @@ export function MoveLabwareInterventionContent({
     movedLabwareDefUri != null
       ? labwareDefsByUri?.[movedLabwareDefUri] ?? null
       : null
-
   if (oldLabwareLocation == null || movedLabwareDef == null) return null
   return (
     <Flex

--- a/app/src/organisms/InterventionModal/index.tsx
+++ b/app/src/organisms/InterventionModal/index.tsx
@@ -20,7 +20,9 @@ import {
   ALIGN_FLEX_START,
   Icon,
   PrimaryButton,
-  JUSTIFY_FLEX_END,
+  JUSTIFY_SPACE_BETWEEN,
+  TYPOGRAPHY,
+  Link,
 } from '@opentrons/components'
 
 import { SmallButton } from '../../atoms/buttons'
@@ -33,6 +35,9 @@ import { MoveLabwareInterventionContent } from './MoveLabwareInterventionContent
 import type { RunCommandSummary, RunData } from '@opentrons/api-client'
 import type { IconName } from '@opentrons/components'
 import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+
+const LEARN_ABOUT_MANUAL_STEPS_URL =
+  'https://support.opentrons.com/s/article/Manual-protocol-steps'
 
 const BASE_STYLE = {
   position: POSITION_ABSOLUTE,
@@ -82,7 +87,7 @@ const FOOTER_STYLE = {
   display: DISPLAY_FLEX,
   width: '100%',
   alignItems: ALIGN_CENTER,
-  justifyContent: JUSTIFY_FLEX_END,
+  justifyContent: JUSTIFY_SPACE_BETWEEN,
 } as const
 
 export interface InterventionModalProps {
@@ -202,9 +207,11 @@ export function InterventionModal({
           <Box {...CONTENT_STYLE}>
             {childContent}
             <Box {...FOOTER_STYLE}>
-              {/* 
-              TODO(BC, 08/31/23): reintroduce this link and justify space between when support article is written 
-              <Link css={TYPOGRAPHY.darkLinkH4SemiBold} href="" external>
+              <Link
+                css={TYPOGRAPHY.darkLinkH4SemiBold}
+                href={LEARN_ABOUT_MANUAL_STEPS_URL}
+                external
+              >
                 {t('protocol_info:manual_steps_learn_more')}
                 <Icon
                   name="open-in-new"
@@ -212,7 +219,6 @@ export function InterventionModal({
                   size="0.5rem"
                 />
               </Link>
-              */}
               <PrimaryButton onClick={onResume}>
                 {t('confirm_and_resume')}
               </PrimaryButton>


### PR DESCRIPTION
# Overview

Reintroduce the link to the desktop manual intervention modal that leads to a page explaining manual intervention steps.

https://github.com/Opentrons/opentrons/assets/4731953/4ab49e1d-5b05-48f0-8ce8-e69fa20d190a

# Review requests

- Link should appear on Desktop `moveLabware` manual intervention modals
- Link should NOT appear on ODD `moveLabware` manual intervention modals

# Risk assessment
low

