### PR TITLE
feat(protocol-designer): wire up loadFixture for waste chute in fileCreator

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -83,7 +83,10 @@ describe('createFile selector', () => {
       v7Fixture.moduleEntities,
       pipetteEntities,
       labwareNicknamesById,
-      labwareDefsByURI
+      labwareDefsByURI,
+      //  TODO(jr, 10/3/23): add additionalEquipmentEntities when the schemaV7 supports
+      //  loadFixture
+      {}
     )
     expectResultToMatchSchema(result)
 

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -22,6 +22,7 @@ import {
   LoadFixtureCreateCommand,
   STAGING_AREA_LOAD_NAME,
   STANDARD_SLOT_LOAD_NAME,
+  TRASH_BIN_LOAD_NAME,
 } from '@opentrons/shared-data'
 import type { RootState as LabwareDefsRootState } from '../../labware-defs'
 import { rootReducer as labwareDefsRootReducer } from '../../labware-defs'
@@ -1332,7 +1333,8 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           //  until it is supported
           if (
             loadName === STAGING_AREA_LOAD_NAME ||
-            loadName === STANDARD_SLOT_LOAD_NAME
+            loadName === STANDARD_SLOT_LOAD_NAME ||
+            loadName === TRASH_BIN_LOAD_NAME
           ) {
             return acc
           }

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1350,7 +1350,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
         {}
       )
       const hasGripper = gripperCommands.length > 0
-      const isOt3 = file.robot.model === FLEX_ROBOT_TYPE
+      const isFlex = file.robot.model === FLEX_ROBOT_TYPE
       const gripperId = `${uuid()}:gripper`
       const gripper = {
         [gripperId]: {
@@ -1358,7 +1358,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           id: gripperId,
         },
       }
-      if (isOt3) {
+      if (isFlex) {
         if (hasGripper) {
           return { ...state, ...gripper, ...fixtures }
         } else {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -19,6 +19,9 @@ import {
   MAGNETIC_MODULE_V1,
   PipetteName,
   THERMOCYCLER_MODULE_TYPE,
+  LoadFixtureCreateCommand,
+  STAGING_AREA_LOAD_NAME,
+  STANDARD_SLOT_LOAD_NAME,
 } from '@opentrons/shared-data'
 import type { RootState as LabwareDefsRootState } from '../../labware-defs'
 import { rootReducer as labwareDefsRootReducer } from '../../labware-defs'
@@ -1309,23 +1312,56 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       action: LoadFileAction
     ): NormalizedAdditionalEquipmentById => {
       const { file } = action.payload
-      const gripper = Object.values(file.commands).filter(
+      const gripperCommands = Object.values(file.commands).filter(
         (command): command is MoveLabwareCreateCommand =>
           command.commandType === 'moveLabware' &&
           command.params.strategy === 'usingGripper'
       )
-      //  TODO(jr, 9/18/23): add wasteChute when loadFixture commands exist
-      const hasGripper = gripper.length > 0
+      const fixtureCommands = Object.values(file.commands).filter(
+        (command): command is LoadFixtureCreateCommand =>
+          command.commandType === 'loadFixture'
+      )
+      const fixtures = fixtureCommands.reduce(
+        (
+          acc: NormalizedAdditionalEquipmentById,
+          command: LoadFixtureCreateCommand
+        ) => {
+          const { fixtureId, loadName, location } = command.params
+          const id = fixtureId ?? ''
+          //  TODO(jr, 10/03/23): filtering out staging area for now
+          //  until it is supported
+          if (
+            loadName === STAGING_AREA_LOAD_NAME ||
+            loadName === STANDARD_SLOT_LOAD_NAME
+          ) {
+            return acc
+          }
+          return {
+            ...acc,
+            [id]: {
+              id: id,
+              name: loadName,
+              location: location.cutout,
+            },
+          }
+        },
+        {}
+      )
+      const hasGripper = gripperCommands.length > 0
       const isOt3 = file.robot.model === FLEX_ROBOT_TYPE
-      const additionalEquipmentId = `${uuid()}:gripper`
-      const updatedEquipment = {
-        [additionalEquipmentId]: {
+      const gripperId = `${uuid()}:gripper`
+      const gripper = {
+        [gripperId]: {
           name: 'gripper' as const,
-          id: additionalEquipmentId,
+          id: gripperId,
         },
       }
-      if (hasGripper && isOt3) {
-        return { ...state, ...updatedEquipment }
+      if (isOt3) {
+        if (hasGripper) {
+          return { ...state, ...gripper, ...fixtures }
+        } else {
+          return { ...state, ...fixtures }
+        }
       } else {
         return { ...state }
       }

--- a/protocol-designer/typings/reselect.d.ts
+++ b/protocol-designer/typings/reselect.d.ts
@@ -1,6 +1,6 @@
 import { OutputSelector, Selector } from 'reselect'
 declare module 'reselect' {
-  // declaring type for createSelector with 14 selectors because the reselect types only support up to 12 selectors
+  // declaring type for createSelector with 15 selectors because the reselect types only support up to 12 selectors
   export function createSelector<
     S,
     R1,
@@ -17,6 +17,7 @@ declare module 'reselect' {
     R12,
     R13,
     R14,
+    R15,
     T
   >(
     selector1: Selector<S, R1>,
@@ -33,6 +34,7 @@ declare module 'reselect' {
     selector12: Selector<S, R12>,
     selector13: Selector<S, R13>,
     selector14: Selector<S, R14>,
+    selector15: Selector<S, R15>,
     combiner: (
       res1: R1,
       res2: R2,
@@ -47,7 +49,8 @@ declare module 'reselect' {
       res11: R11,
       res12: R12,
       res13: R13,
-      res14: R14
+      res14: R14,
+      res15: R15
     ) => T
   ): OutputSelector<
     S,
@@ -66,7 +69,8 @@ declare module 'reselect' {
       res11: R11,
       res12: R12,
       res13: R13,
-      res14: R14
+      res14: R14,
+      res15: R15
     ) => T
   >
 }


### PR DESCRIPTION
closes RAUT-687 RAUT-723

# Overview

Now that `loadFixtureCreateCommand` type exists in v7 command types, I wired up creating the command in file creator and importing as well.

# Test Plan

- make sure the deck configuration FF is turned on and create a protocol for the Flex. Go through the form and add a waste chute. Export the protocol. Look at the json file and see that there is a `loadFixture` command with the proper params.
- Change the version from `7.0.0` to `7.1.0` in the json file (this is so the protocol doesn't go through a migration)
- import the protocol back into PD. See that the waste chute entity exists in the Additional Items section

# Changelog

- extend createSelector to support 15 selectors
- add loadFixture command support to `fileCreator` and the step form reducer
- fix test
- also wire up nicknames for the labware as the display name if it exists. apparently nicknames weren't being carried over to the json protocol this whole time 😅 

# Review requests

see test plan

# Risk assessment

low