### PR TITLE
docs(api): additional 2.15 features on Versioning page

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -146,7 +146,7 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - The new :py:meth:`.configure_for_volume` method can place Flex 50 µL pipettes in a low-volume mode for dispensing very small volumes of liquid. See :ref:`pipette-volume-modes`. 
   
-  - The new ``push_out`` parameter of :py:meth:`.dispense` can also help ensure that the pipette dispenses all of its liquid when working with very small volumes.
+  - The new ``push_out`` parameter of the :py:meth:`.dispense` method helps ensure that the pipette dispenses all of its liquid when working with very small volumes.
   
 - Flex and OT-2 features
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -144,6 +144,10 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - The API does not enforce placement restrictions for the Heater-Shaker module on Flex, because it is installed below-deck in a module caddy. Pipetting restrictions are still in place when the Heater-Shaker is shaking or its labware latch is open.
   
+  - The new :py:meth:`.configure_for_volume` method can place Flex 50 µL pipettes in a low-volume mode for dispensing very small volumes of liquid. See :ref:`pipette-volume-modes`. 
+  
+  - The new ``push_out`` parameter of :py:meth:`.dispense` can also help ensure that the pipette dispenses all of its liquid when working with very small volumes.
+  
 - Flex and OT-2 features
 
   - Optionally specify ``apiLevel`` in the new ``requirements`` dictionary (otherwise, specify it in ``metadata``). 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -146,8 +146,6 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - The new :py:meth:`.configure_for_volume` method can place Flex 50 µL pipettes in a low-volume mode for dispensing very small volumes of liquid. See :ref:`pipette-volume-modes`. 
   
-  - The new ``push_out`` parameter of the :py:meth:`.dispense` method helps ensure that the pipette dispenses all of its liquid when working with very small volumes.
-  
 - Flex and OT-2 features
 
   - Optionally specify ``apiLevel`` in the new ``requirements`` dictionary (otherwise, specify it in ``metadata``). 
@@ -162,7 +160,9 @@ This version introduces support for the Opentrons Flex robot, instruments, modul
   
   - Manual labware moves support moving to or from the new :py:obj:`~.protocol_api.OFF_DECK` location (outside of the robot).
   
-  - :py:meth:`.load_labware` also accepts :py:obj:`~.protocol_api.OFF_DECK` as a location. This lets you prepare labware to be moved onto the deck later in a protocol.
+  - :py:meth:`.load_labware` also accepts :py:obj:`~.protocol_api.OFF_DECK` as a location. This lets you prepare labware to be moved onto the deck later in a protocol.  
+  
+  - The new ``push_out`` parameter of the :py:meth:`.dispense` method helps ensure that the pipette dispenses all of its liquid when working with very small volumes.
   
   - By default, repeated calls to :py:meth:`.drop_tip` cycle through multiple locations above the trash bin to prevent tips from stacking up.
   


### PR DESCRIPTION

# Overview

Adding some late-breaking features to the 2.15 section of the Versioning page.

# Test Plan

Check the sandbox.

# Changelog

- Added `configure_for_volume` and crossreference (as Flex-only feature)
- Added `push_out` (as Flex and OT-2 feature)

# Review requests

Is it accurate that these are Flex-only features for the moment? I can move things to a different section if need be.

# Risk assessment

nil, docs