### PR TITLE
fix(api, robot-server, shared-data): Flex and OT2 door check disparity correction

### DIFF
--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,6 +1,5 @@
 from opentrons.config import advanced_settings as advs
 from opentrons_shared_data.robot.dev_types import RobotTypeEnum
-from opentrons_shared_data.robot.dev_types import RobotType
 
 
 def short_fixed_trash() -> bool:
@@ -21,17 +20,8 @@ def use_old_aspiration_functions() -> bool:
     )
 
 
-def enable_door_safety_switch(robot_type: RobotType) -> bool:
-    if robot_type == "OT-2 Standard":
-        return advs.get_setting_with_env_overload(
-            "enableDoorSafetySwitch", RobotTypeEnum.OT2
-        )
-    elif robot_type == "OT-3 Standard":
-        return advs.get_setting_with_env_overload(
-            "enableDoorSafetySwitch", RobotTypeEnum.FLEX
-        )
-    else:
-        raise KeyError("Invalid Robot Type during Door Saftey switch check")
+def enable_door_safety_switch(robot_type: RobotTypeEnum) -> bool:
+    return advs.get_setting_with_env_overload("enableDoorSafetySwitch", robot_type)
 
 
 def disable_fast_protocol_upload() -> bool:

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,5 +1,6 @@
 from opentrons.config import advanced_settings as advs
 from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.dev_types import RobotType
 
 
 def short_fixed_trash() -> bool:
@@ -20,10 +21,17 @@ def use_old_aspiration_functions() -> bool:
     )
 
 
-def enable_door_safety_switch() -> bool:
-    return advs.get_setting_with_env_overload(
-        "enableDoorSafetySwitch", RobotTypeEnum.FLEX
-    )
+def enable_door_safety_switch(robot_type: RobotType) -> bool:
+    if robot_type == "OT-2 Standard":
+        return advs.get_setting_with_env_overload(
+            "enableDoorSafetySwitch", RobotTypeEnum.OT2
+        )
+    elif robot_type == "OT-3 Standard":
+        return advs.get_setting_with_env_overload(
+            "enableDoorSafetySwitch", RobotTypeEnum.FLEX
+        )
+    else:
+        raise KeyError("Invalid Robot Type during Door Saftey switch check")
 
 
 def disable_fast_protocol_upload() -> bool:

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -139,7 +139,9 @@ class MaintenanceEngineStore:
             config=ProtocolEngineConfig(
                 robot_type=self._robot_type,
                 deck_type=self._deck_type,
-                block_on_door_open=feature_flags.enable_door_safety_switch(),
+                block_on_door_open=feature_flags.enable_door_safety_switch(
+                    self._robot_type
+                ),
             ),
         )
 

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -4,6 +4,7 @@ from typing import List, NamedTuple, Optional
 
 from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
@@ -140,7 +141,7 @@ class MaintenanceEngineStore:
                 robot_type=self._robot_type,
                 deck_type=self._deck_type,
                 block_on_door_open=feature_flags.enable_door_safety_switch(
-                    self._robot_type
+                    RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
         )

--- a/robot-server/robot_server/robot/control/router.py
+++ b/robot-server/robot_server/robot/control/router.py
@@ -2,6 +2,9 @@
 from fastapi import APIRouter, status, Depends
 from typing import TYPE_CHECKING
 
+from opentrons_shared_data.robot.dev_types import RobotType
+from robot_server.hardware import get_robot_type
+
 from robot_server.errors import ErrorBody
 from robot_server.errors.robot_errors import NotSupportedOnOT2
 from robot_server.service.json_api import (
@@ -67,8 +70,8 @@ async def put_acknowledge_estop_disengage(
     return await _get_estop_status_response(estop_handler)
 
 
-def get_door_switch_required() -> bool:
-    return ff.enable_door_safety_switch()
+def get_door_switch_required(robot_type: RobotType = Depends(get_robot_type)) -> bool:
+    return ff.enable_door_safety_switch(robot_type)
 
 
 @control_router.get(

--- a/robot-server/robot_server/robot/control/router.py
+++ b/robot-server/robot_server/robot/control/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, status, Depends
 from typing import TYPE_CHECKING
 
 from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 from robot_server.hardware import get_robot_type
 
 from robot_server.errors import ErrorBody
@@ -71,7 +72,7 @@ async def put_acknowledge_estop_disengage(
 
 
 def get_door_switch_required(robot_type: RobotType = Depends(get_robot_type)) -> bool:
-    return ff.enable_door_safety_switch(robot_type)
+    return ff.enable_door_safety_switch(RobotTypeEnum.robot_literal_to_enum(robot_type))
 
 
 @control_router.get(

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -3,6 +3,7 @@ from typing import List, NamedTuple, Optional
 
 from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
@@ -164,7 +165,7 @@ class EngineStore:
                 robot_type=self._robot_type,
                 deck_type=self._deck_type,
                 block_on_door_open=feature_flags.enable_door_safety_switch(
-                    self._robot_type
+                    RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
         )

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -163,7 +163,9 @@ class EngineStore:
             config=ProtocolEngineConfig(
                 robot_type=self._robot_type,
                 deck_type=self._deck_type,
-                block_on_door_open=feature_flags.enable_door_safety_switch(),
+                block_on_door_open=feature_flags.enable_door_safety_switch(
+                    self._robot_type
+                ),
             ),
         )
         runner = create_protocol_runner(

--- a/shared-data/python/opentrons_shared_data/robot/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/robot/dev_types.py
@@ -19,6 +19,15 @@ class RobotTypeEnum(enum.Enum):
     OT2 = enum.auto()
     FLEX = enum.auto()
 
+    @classmethod
+    def robot_literal_to_enum(cls, robot_type: RobotType) -> "RobotTypeEnum":
+        """Convert Robot Type Literal to Robot Type Enum."""
+        if robot_type == "OT-2 Standard":
+            return cls.OT2
+        elif robot_type == "OT-3 Standard":
+            return cls.FLEX
+        # No final `else` statement, depend on mypy exhaustiveness checking
+
 
 class RobotDefinition(TypedDict):
     """A python version of the robot definition type."""


### PR DESCRIPTION

# Overview
This branch aims to fix the issue where OT2 would refuse to run with the door open. Full issue detailed in: https://opentrons.atlassian.net/browse/RSS-369


# Test Plan
Make push the changes to an OT2 and do the following:

1. In APP, disable "Pause protocol when robot door opens"
2. Run a Protocol with the door open, ensure process is not interrupted
3. After protocol ends, re-enable "Pause protocol when robot door opens"
4. Run protocol again, ensure process is interrupted.

Make push the changes to a Flex and do the following:
1. Begin to run a protocol
2. Open the door, ensure the Flex pauses and interrupts the process
