### PR TITLE
fix(app): fix conditional rendering of cal dashboard completion screen

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -21,7 +21,6 @@
   "calibration_recommended": "Calibration recommended",
   "calibration_status": "Calibration Status",
   "calibration_status_description": "For accurate and precise movement, calibrate the robot's deck, pipette offsets, and tip lengths.",
-  "calibrations_aborted": "Using current calibrations.",
   "calibrations_complete": "Calibrations complete!",
   "change_tip_rack": "Change tip rack",
   "check_tip_on_block": "Check tip on block",
@@ -130,6 +129,7 @@
   "unknown_custom_tiprack": "unknown custom tip rack",
   "use_calibration_block": "Use Calibration Block",
   "use_trash_bin": "Use trash bin",
+  "using_current_calibrations": "Using current calibrations.",
   "you_can_remove_cal_block": "You can remove the Calibration Block from the deck now.",
   "you_will_need": "You will need:"
 }

--- a/app/src/organisms/CalibrateDeck/index.tsx
+++ b/app/src/organisms/CalibrateDeck/index.tsx
@@ -65,7 +65,7 @@ export function CalibrateDeck(
     dispatchRequests,
     showSpinner,
     isJogging,
-    wasExitBeforeCompletion,
+    exitBeforeDeckConfigCompletion,
     offsetInvalidationHandler,
   } = props
   const { currentStep, instrument, labware, supportedCommands } =
@@ -97,8 +97,11 @@ export function CalibrateDeck(
   }
 
   function cleanUpAndExit(): void {
-    if (wasExitBeforeCompletion) {
-      wasExitBeforeCompletion.current = true
+    if (
+      exitBeforeDeckConfigCompletion &&
+      currentStep !== Sessions.DECK_STEP_CALIBRATION_COMPLETE
+    ) {
+      exitBeforeDeckConfigCompletion.current = true
     }
     if (session?.id) {
       dispatchRequests(

--- a/app/src/organisms/CalibrateDeck/types.ts
+++ b/app/src/organisms/CalibrateDeck/types.ts
@@ -7,6 +7,6 @@ export interface CalibrateDeckParentProps {
   dispatchRequests: DispatchRequestsType
   showSpinner: boolean
   isJogging: boolean
-  wasExitBeforeCompletion?: MutableRefObject<boolean>
+  exitBeforeDeckConfigCompletion?: MutableRefObject<boolean>
   offsetInvalidationHandler?: () => void
 }

--- a/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
+++ b/app/src/organisms/CalibrationTaskList/__tests__/CalibrationTaskList.test.tsx
@@ -43,7 +43,7 @@ const render = (robotName: string = 'otie') => {
         pipOffsetCalLauncher={mockPipOffsetCalLauncher}
         tipLengthCalLauncher={mockTipLengthCalLauncher}
         deckCalLauncher={mockDeckCalLauncher}
-        wasExitBeforeCompletion={false}
+        exitBeforeDeckConfigCompletion={false}
       />
     </StaticRouter>,
     {
@@ -94,7 +94,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -120,7 +120,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -145,7 +145,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -170,7 +170,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -194,7 +194,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -218,7 +218,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -240,7 +240,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={true}
+          exitBeforeDeckConfigCompletion={true}
         />
       </StaticRouter>
     )
@@ -265,7 +265,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )
@@ -293,7 +293,7 @@ describe('CalibrationTaskList', () => {
           pipOffsetCalLauncher={mockPipOffsetCalLauncher}
           tipLengthCalLauncher={mockTipLengthCalLauncher}
           deckCalLauncher={mockDeckCalLauncher}
-          wasExitBeforeCompletion={false}
+          exitBeforeDeckConfigCompletion={false}
         />
       </StaticRouter>
     )

--- a/app/src/organisms/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/CalibrationTaskList/index.tsx
@@ -35,7 +35,7 @@ interface CalibrationTaskListProps {
   pipOffsetCalLauncher: DashboardCalOffsetInvoker
   tipLengthCalLauncher: DashboardCalTipLengthInvoker
   deckCalLauncher: DashboardCalDeckInvoker
-  wasExitBeforeCompletion: boolean
+  exitBeforeDeckConfigCompletion: boolean
 }
 
 export function CalibrationTaskList({
@@ -43,7 +43,7 @@ export function CalibrationTaskList({
   pipOffsetCalLauncher,
   tipLengthCalLauncher,
   deckCalLauncher,
-  wasExitBeforeCompletion,
+  exitBeforeDeckConfigCompletion,
 }: CalibrationTaskListProps): JSX.Element {
   const prevActiveIndex = React.useRef<[number, number] | null>(null)
   const [hasLaunchedWizard, setHasLaunchedWizard] = React.useState<boolean>(
@@ -127,14 +127,14 @@ export function CalibrationTaskList({
             justifyContent={JUSTIFY_CENTER}
             alignItems={ALIGN_CENTER}
           >
-            {wasExitBeforeCompletion ? (
+            {exitBeforeDeckConfigCompletion ? (
               <Icon name="ot-alert" size="3rem" color={COLORS.warningEnabled} />
             ) : (
               <Icon name="ot-check" size="3rem" color={COLORS.successEnabled} />
             )}
             <StyledText as="h1" marginTop={SPACING.spacing24}>
-              {wasExitBeforeCompletion
-                ? t('calibrations_aborted')
+              {exitBeforeDeckConfigCompletion
+                ? t('using_current_calibrations')
                 : t('calibrations_complete')}
             </StyledText>
             <PrimaryButton

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateDeck.tsx
@@ -33,7 +33,7 @@ export function useDashboardCalibrateDeck(
   const trackedRequestId = React.useRef<string | null>(null)
   const createRequestId = React.useRef<string | null>(null)
   const jogRequestId = React.useRef<string | null>(null)
-  const wasExitBeforeCompletion = React.useRef<boolean>(false)
+  const exitBeforeDeckConfigCompletion = React.useRef<boolean>(false)
   const invalidateHandlerRef = React.useRef<(() => void) | undefined>()
   const { t } = useTranslation('robot_calibration')
 
@@ -119,7 +119,7 @@ export function useDashboardCalibrateDeck(
           showSpinner={showSpinner}
           dispatchRequests={dispatchRequests}
           isJogging={isJogging}
-          wasExitBeforeCompletion={wasExitBeforeCompletion}
+          exitBeforeDeckConfigCompletion={exitBeforeDeckConfigCompletion}
           offsetInvalidationHandler={invalidateHandlerRef.current}
         />
       )}
@@ -131,6 +131,6 @@ export function useDashboardCalibrateDeck(
   return [
     handleStartDashboardDeckCalSession,
     Wizard,
-    wasExitBeforeCompletion.current,
+    exitBeforeDeckConfigCompletion.current,
   ]
 }

--- a/app/src/pages/Devices/CalibrationDashboard/index.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/index.tsx
@@ -25,7 +25,7 @@ export function CalibrationDashboard(): JSX.Element {
   const [
     dashboardDeckCalLauncher,
     DashboardDeckCalWizard,
-    wasExitBeforeCompletion,
+    exitBeforeDeckConfigCompletion,
   ] = useDashboardCalibrateDeck(robotName)
   return (
     <ApiHostProvider
@@ -38,7 +38,7 @@ export function CalibrationDashboard(): JSX.Element {
         deckCalLauncher={dashboardDeckCalLauncher}
         tipLengthCalLauncher={dashboardTipLengthCalLauncher}
         pipOffsetCalLauncher={dashboardOffsetCalLauncher}
-        wasExitBeforeCompletion={wasExitBeforeCompletion}
+        exitBeforeDeckConfigCompletion={exitBeforeDeckConfigCompletion}
       />
       {DashboardDeckCalWizard}
       {DashboardOffsetCalWizard}


### PR DESCRIPTION
Closes RQA-1727

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR addresses an issue when running through all  OT-2 calibration wizard flows yields a "using current calibrations" completion screen at the very end instead of the correct "calibrations complete" screen.

The deck cal wizard incorrectly marks deck cal as being aborted when clicking the exit buttons on the final step of the flow. The fix is simply to conditionally mark the deck cal flow as aborted only if the exit occurs on a step that's not the success step.

### Current  Behavior
<img width="1101" alt="Screenshot 2023-10-02 at 11 58 25 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/846dd328-6bb0-4b59-b52f-ee942dd3c3a7">

### With Fix
<img width="1011" alt="Screenshot 2023-10-04 at 2 16 18 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/98e7d5ce-9f86-4e6c-abf7-8a120d74f72b">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- On an OT-2, run through deck calibration and all pipette calibration flows that are required. At the end of the final pipette calibration, there should be a "calibrations complete" message.
- Start deck recalibration, click past the "get started" screen, then exit the wizard. Observe the "using current calibrations" message.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
