### PR TITLE
feat(app): add useLoadedFixturesConfigStatus to diff protocol and deck config

### DIFF
--- a/app/src/resources/deck_configuration/__tests__/hooks.test.ts
+++ b/app/src/resources/deck_configuration/__tests__/hooks.test.ts
@@ -1,0 +1,142 @@
+import { when, resetAllWhenMocks } from 'jest-when'
+import { v4 as uuidv4 } from 'uuid'
+
+import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
+import {
+  STAGING_AREA_LOAD_NAME,
+  STANDARD_SLOT_LOAD_NAME,
+  TRASH_BIN_LOAD_NAME,
+  WASTE_CHUTE_LOAD_NAME,
+} from '@opentrons/shared-data'
+
+import {
+  CONFIGURED,
+  CONFLICTING,
+  NOT_CONFIGURED,
+  useLoadedFixturesConfigStatus,
+} from '../hooks'
+
+import type { UseQueryResult } from 'react-query'
+import type {
+  DeckConfiguration,
+  LoadFixtureRunTimeCommand,
+} from '@opentrons/shared-data'
+
+jest.mock('@opentrons/react-api-client')
+
+const mockUseDeckConfigurationQuery = useDeckConfigurationQuery as jest.MockedFunction<
+  typeof useDeckConfigurationQuery
+>
+
+const MOCK_DECK_CONFIG: DeckConfiguration = [
+  {
+    fixtureLocation: 'A1',
+    loadName: STANDARD_SLOT_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'B1',
+    loadName: STANDARD_SLOT_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'C1',
+    loadName: STANDARD_SLOT_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'D1',
+    loadName: STANDARD_SLOT_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'A3',
+    loadName: TRASH_BIN_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'B3',
+    loadName: STANDARD_SLOT_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'C3',
+    loadName: STAGING_AREA_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+  {
+    fixtureLocation: 'D3',
+    loadName: WASTE_CHUTE_LOAD_NAME,
+    fixtureId: uuidv4(),
+  },
+]
+
+const WASTE_CHUTE_LOADED_FIXTURE: LoadFixtureRunTimeCommand = {
+  id: 'stubbed_load_fixture',
+  commandType: 'loadFixture',
+  params: {
+    fixtureId: 'stubbedFixtureId',
+    loadName: WASTE_CHUTE_LOAD_NAME,
+    location: { cutout: 'D3' },
+  },
+  createdAt: 'fakeTimestamp',
+  startedAt: 'fakeTimestamp',
+  completedAt: 'fakeTimestamp',
+  status: 'succeeded',
+}
+
+const STAGING_AREA_LOADED_FIXTURE: LoadFixtureRunTimeCommand = {
+  id: 'stubbed_load_fixture',
+  commandType: 'loadFixture',
+  params: {
+    fixtureId: 'stubbedFixtureId',
+    loadName: STAGING_AREA_LOAD_NAME,
+    location: { cutout: 'D3' },
+  },
+  createdAt: 'fakeTimestamp',
+  startedAt: 'fakeTimestamp',
+  completedAt: 'fakeTimestamp',
+  status: 'succeeded',
+}
+
+describe('useLoadedFixturesConfigStatus', () => {
+  beforeEach(() => {
+    when(mockUseDeckConfigurationQuery)
+      .calledWith()
+      .mockReturnValue({
+        data: MOCK_DECK_CONFIG,
+      } as UseQueryResult<DeckConfiguration>)
+  })
+  afterEach(() => resetAllWhenMocks())
+
+  it('returns configured status if fixture is configured at location', () => {
+    const loadedFixturesConfigStatus = useLoadedFixturesConfigStatus([
+      WASTE_CHUTE_LOADED_FIXTURE,
+    ])
+    expect(loadedFixturesConfigStatus).toEqual([
+      { ...WASTE_CHUTE_LOADED_FIXTURE, configurationStatus: CONFIGURED },
+    ])
+  })
+  it('returns conflicted status if fixture is conflicted at location', () => {
+    const loadedFixturesConfigStatus = useLoadedFixturesConfigStatus([
+      STAGING_AREA_LOADED_FIXTURE,
+    ])
+    expect(loadedFixturesConfigStatus).toEqual([
+      { ...STAGING_AREA_LOADED_FIXTURE, configurationStatus: CONFLICTING },
+    ])
+  })
+  it('returns not configured status if fixture is not configured at location', () => {
+    when(mockUseDeckConfigurationQuery)
+      .calledWith()
+      .mockReturnValue({
+        data: MOCK_DECK_CONFIG.slice(0, -1),
+      } as UseQueryResult<DeckConfiguration>)
+
+    const loadedFixturesConfigStatus = useLoadedFixturesConfigStatus([
+      WASTE_CHUTE_LOADED_FIXTURE,
+    ])
+    expect(loadedFixturesConfigStatus).toEqual([
+      { ...WASTE_CHUTE_LOADED_FIXTURE, configurationStatus: NOT_CONFIGURED },
+    ])
+  })
+})

--- a/app/src/resources/deck_configuration/hooks.ts
+++ b/app/src/resources/deck_configuration/hooks.ts
@@ -1,0 +1,44 @@
+import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
+
+import type { Fixture, LoadFixtureRunTimeCommand } from '@opentrons/shared-data'
+
+export const CONFIGURED = 'configured'
+export const CONFLICTING = 'conflicting'
+export const NOT_CONFIGURED = 'not configured'
+
+type LoadedFixtureConfigurationStatus =
+  | typeof CONFIGURED
+  | typeof CONFLICTING
+  | typeof NOT_CONFIGURED
+
+type LoadedFixtureConfiguration = LoadFixtureRunTimeCommand & {
+  configurationStatus: LoadedFixtureConfigurationStatus
+}
+
+export function useLoadedFixturesConfigStatus(
+  loadedFixtures: LoadFixtureRunTimeCommand[]
+): LoadedFixtureConfiguration[] {
+  const deckConfig = useDeckConfigurationQuery().data ?? []
+
+  return loadedFixtures.map(loadedFixture => {
+    const deckConfigurationAtLocation = deckConfig.find(
+      (deckFixture: Fixture) =>
+        deckFixture.fixtureLocation === loadedFixture.params.location.cutout
+    )
+
+    let configurationStatus: LoadedFixtureConfigurationStatus = NOT_CONFIGURED
+    if (
+      deckConfigurationAtLocation != null &&
+      deckConfigurationAtLocation.loadName === loadedFixture.params.loadName
+    ) {
+      configurationStatus = CONFIGURED
+    } else if (
+      deckConfigurationAtLocation != null &&
+      deckConfigurationAtLocation.loadName !== loadedFixture.params.loadName
+    ) {
+      configurationStatus = CONFLICTING
+    }
+
+    return { ...loadedFixture, configurationStatus }
+  })
+}


### PR DESCRIPTION
# Overview

adds a hook `useLoadedFixturesConfigStatus` to provide the configuration status for each loaded protocol fixture according to the current robot deck config

closes RAUT-695

# Test Plan

 - added unit tests
 - manually verified output with stubs in app

# Changelog

 - Adds useLoadedFixturesConfigStatus hook

# Review requests

look at shape of hook input/output, will this work

# Risk assessment

low
