### PR TITLE
fix(app): style instrument and module slideouts

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
@@ -58,9 +58,8 @@ export const AboutPipetteSlideout = (
               as="h6"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               color={COLORS.darkGreyEnabled}
-              textTransform={TYPOGRAPHY.textTransformUppercase}
             >
-              {t('current_version')}
+              {i18n.format(t('current_version'), 'upperCase')}
             </StyledText>
             <StyledText
               as="p"
@@ -76,10 +75,9 @@ export const AboutPipetteSlideout = (
           as="h6"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkGreyEnabled}
-          textTransform={TYPOGRAPHY.textTransformUppercase}
           data-testid={`AboutPipetteSlideout_serial_number_text_${pipetteId}`}
         >
-          {t('serial_number')}
+          {i18n.format(t('serial_number'), 'upperCase')}
         </StyledText>
         <StyledText
           as="p"

--- a/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
@@ -65,7 +65,6 @@ export const AboutPipetteSlideout = (
               as="p"
               paddingTop={SPACING.spacing4}
               paddingBottom={SPACING.spacing16}
-              color={COLORS.darkBlackEnabled}
             >
               {instrumentInfo.firmwareVersion}
             </StyledText>

--- a/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
@@ -58,13 +58,15 @@ export const AboutPipetteSlideout = (
               as="h6"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               color={COLORS.darkGreyEnabled}
+              textTransform={TYPOGRAPHY.textTransformUppercase}
             >
               {t('current_version')}
             </StyledText>
             <StyledText
               as="p"
               paddingTop={SPACING.spacing4}
-              paddingBottom={SPACING.spacing12}
+              paddingBottom={SPACING.spacing16}
+              color={COLORS.darkBlackEnabled}
             >
               {instrumentInfo.firmwareVersion}
             </StyledText>
@@ -74,8 +76,8 @@ export const AboutPipetteSlideout = (
           as="h6"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkGreyEnabled}
-          data-testid={`AboutPipetteSlideout_serial_number_text_${pipetteId}`}
           textTransform={TYPOGRAPHY.textTransformUppercase}
+          data-testid={`AboutPipetteSlideout_serial_number_text_${pipetteId}`}
         >
           {t('serial_number')}
         </StyledText>

--- a/app/src/organisms/Devices/PipetteCard/__tests__/AboutPipetteSlideout.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/AboutPipetteSlideout.test.tsx
@@ -42,7 +42,7 @@ describe('AboutPipetteSlideout', () => {
 
     getByText('About Left Pipette Pipette')
     getByText('123')
-    getByText('Serial Number')
+    getByText('SERIAL NUMBER')
     const button = getByRole('button', { name: /exit/i })
     fireEvent.click(button)
     expect(props.onCloseClick).toHaveBeenCalled()
@@ -63,7 +63,7 @@ describe('AboutPipetteSlideout', () => {
 
     const { getByText } = render(props)
 
-    getByText('Current Version')
+    getByText('CURRENT VERSION')
     getByText('12')
   })
 })

--- a/app/src/organisms/GripperCard/AboutGripperSlideout.tsx
+++ b/app/src/organisms/GripperCard/AboutGripperSlideout.tsx
@@ -53,7 +53,6 @@ export const AboutGripperSlideout = (
               as="p"
               paddingTop={SPACING.spacing4}
               paddingBottom={SPACING.spacing16}
-              color={COLORS.darkBlackEnabled}
             >
               {firmwareVersion}
             </StyledText>

--- a/app/src/organisms/GripperCard/AboutGripperSlideout.tsx
+++ b/app/src/organisms/GripperCard/AboutGripperSlideout.tsx
@@ -46,9 +46,8 @@ export const AboutGripperSlideout = (
               as="h6"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               color={COLORS.darkGreyEnabled}
-              textTransform={TYPOGRAPHY.textTransformUppercase}
             >
-              {t('current_version')}
+              {i18n.format(t('current_version'), 'upperCase')}
             </StyledText>
             <StyledText
               as="p"
@@ -64,7 +63,6 @@ export const AboutGripperSlideout = (
           as="h6"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkGreyEnabled}
-          textTransform={TYPOGRAPHY.textTransformUppercase}
         >
           {i18n.format(t('serial_number'), 'upperCase')}
         </StyledText>

--- a/app/src/organisms/GripperCard/AboutGripperSlideout.tsx
+++ b/app/src/organisms/GripperCard/AboutGripperSlideout.tsx
@@ -46,13 +46,15 @@ export const AboutGripperSlideout = (
               as="h6"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               color={COLORS.darkGreyEnabled}
+              textTransform={TYPOGRAPHY.textTransformUppercase}
             >
               {t('current_version')}
             </StyledText>
             <StyledText
               as="p"
               paddingTop={SPACING.spacing4}
-              paddingBottom={SPACING.spacing12}
+              paddingBottom={SPACING.spacing16}
+              color={COLORS.darkBlackEnabled}
             >
               {firmwareVersion}
             </StyledText>

--- a/app/src/organisms/GripperCard/__tests__/AboutGripperSlideout.test.tsx
+++ b/app/src/organisms/GripperCard/__tests__/AboutGripperSlideout.test.tsx
@@ -34,7 +34,7 @@ describe('AboutGripperSlideout', () => {
     props = { ...props, firmwareVersion: '12' }
     const { getByText } = render(props)
 
-    getByText('Current Version')
+    getByText('CURRENT VERSION')
     getByText('12')
   })
 })

--- a/app/src/organisms/ModuleCard/AboutModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/AboutModuleSlideout.tsx
@@ -37,7 +37,7 @@ export const AboutModuleSlideout = (
   props: AboutModuleSlideoutProps
 ): JSX.Element | null => {
   const { module, isExpanded, onCloseClick, firmwareUpdateClick } = props
-  const { t } = useTranslation(['device_details', 'shared'])
+  const { i18n, t } = useTranslation(['device_details', 'shared'])
   const moduleName = getModuleDisplayName(module.moduleModel)
   const runStatus = useCurrentRunStatus()
   const [showBanner, setShowBanner] = React.useState<boolean>(true)
@@ -103,9 +103,8 @@ export const AboutModuleSlideout = (
               as="h6"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               color={COLORS.darkGreyEnabled}
-              textTransform={TYPOGRAPHY.textTransformUppercase}
             >
-              {t('current_version')}
+              {i18n.format(t('current_version'), 'upperCase')}
             </StyledText>
             <StyledText
               as="p"
@@ -121,12 +120,11 @@ export const AboutModuleSlideout = (
           as="h6"
           fontWeight={TYPOGRAPHY.fontWeightSemiBold}
           color={COLORS.darkGreyEnabled}
-          textTransform={TYPOGRAPHY.textTransformUppercase}
           data-testid={`alert_item_serial_number_text_${String(
             module.moduleModel
           )}`}
         >
-          {t('serial_number')}
+          {i18n.format(t('serial_number'), 'upperCase')}
         </StyledText>
         <StyledText
           as="p"

--- a/app/src/organisms/ModuleCard/AboutModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/AboutModuleSlideout.tsx
@@ -97,7 +97,6 @@ export const AboutModuleSlideout = (
           <Flex
             flexDirection={DIRECTION_COLUMN}
             data-testid={`alert_item_version_${String(module.moduleModel)}`}
-            color={COLORS.darkGreyEnabled}
           >
             <StyledText
               as="h6"
@@ -110,7 +109,6 @@ export const AboutModuleSlideout = (
               as="p"
               paddingTop={SPACING.spacing4}
               paddingBottom={SPACING.spacing16}
-              color={COLORS.darkBlackEnabled}
             >
               {module.firmwareVersion}
             </StyledText>

--- a/app/src/organisms/ModuleCard/AboutModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/AboutModuleSlideout.tsx
@@ -99,24 +99,37 @@ export const AboutModuleSlideout = (
             data-testid={`alert_item_version_${String(module.moduleModel)}`}
             color={COLORS.darkGreyEnabled}
           >
-            <StyledText as="h6">{t('current_version')}</StyledText>
-            <StyledText as="p" paddingTop={SPACING.spacing4}>
-              {t('version', { version: module.firmwareVersion })}
+            <StyledText
+              as="h6"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              color={COLORS.darkGreyEnabled}
+              textTransform={TYPOGRAPHY.textTransformUppercase}
+            >
+              {t('current_version')}
+            </StyledText>
+            <StyledText
+              as="p"
+              paddingTop={SPACING.spacing4}
+              paddingBottom={SPACING.spacing16}
+              color={COLORS.darkBlackEnabled}
+            >
+              {module.firmwareVersion}
             </StyledText>
           </Flex>
         </Flex>
         <StyledText
-          paddingTop={SPACING.spacing16}
           as="h6"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          color={COLORS.darkGreyEnabled}
+          textTransform={TYPOGRAPHY.textTransformUppercase}
           data-testid={`alert_item_serial_number_text_${String(
             module.moduleModel
           )}`}
-          color={COLORS.darkBlackEnabled}
         >
           {t('serial_number')}
         </StyledText>
         <StyledText
-          as="h6"
+          as="p"
           paddingTop={SPACING.spacing4}
           data-testid={`alert_item_serial_${String(module.moduleModel)}`}
         >

--- a/app/src/organisms/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
@@ -51,7 +51,7 @@ describe('AboutModuleSlideout', () => {
     getByText('def456')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
     const button = getByRole('button', { name: /exit/i })
     fireEvent.click(button)
     expect(props.onCloseClick).toHaveBeenCalled()
@@ -65,7 +65,7 @@ describe('AboutModuleSlideout', () => {
     getByText('def456')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
   })
 
   it('renders no banner when run is finishing', () => {
@@ -76,7 +76,7 @@ describe('AboutModuleSlideout', () => {
     getByText('def456')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
   })
 
   it('renders correct info when module is a magnetic module GEN2', () => {
@@ -92,7 +92,7 @@ describe('AboutModuleSlideout', () => {
     getByText('def456')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
   })
 
   it('renders correct info when module is a temperature module GEN2', () => {
@@ -108,7 +108,7 @@ describe('AboutModuleSlideout', () => {
     getByText('abc123')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
   })
 
   it('renders correct info when module is a temperature module GEN1', () => {
@@ -124,7 +124,7 @@ describe('AboutModuleSlideout', () => {
     getByText('abc123')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
   })
 
   it('renders correct info when module is a thermocycler module with an update available', () => {
@@ -140,7 +140,7 @@ describe('AboutModuleSlideout', () => {
     getByText('ghi789')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
     getByText('Firmware update available.')
     const viewUpdate = getByRole('button', { name: 'Update now' })
     fireEvent.click(viewUpdate)
@@ -165,7 +165,7 @@ describe('AboutModuleSlideout', () => {
     getByText('abc123')
     getByText('SERIAL NUMBER')
     getByText('CURRENT VERSION')
-    getByText(/v[0-9].[0-9].[0-9]$/)
+    getByText('v2.0.0')
     const button = getByRole('button', { name: 'close' })
     fireEvent.click(button)
     expect(props.onCloseClick).toHaveBeenCalled()

--- a/app/src/organisms/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/AboutModuleSlideout.test.tsx
@@ -49,9 +49,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Magnetic Module GEN1')
     getByText('def456')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
     const button = getByRole('button', { name: /exit/i })
     fireEvent.click(button)
     expect(props.onCloseClick).toHaveBeenCalled()
@@ -63,9 +63,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Magnetic Module GEN1')
     getByText('def456')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
   })
 
   it('renders no banner when run is finishing', () => {
@@ -74,9 +74,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Magnetic Module GEN1')
     getByText('def456')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
   })
 
   it('renders correct info when module is a magnetic module GEN2', () => {
@@ -90,9 +90,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Magnetic Module GEN2')
     getByText('def456')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
   })
 
   it('renders correct info when module is a temperature module GEN2', () => {
@@ -106,9 +106,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Temperature Module GEN2')
     getByText('abc123')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
   })
 
   it('renders correct info when module is a temperature module GEN1', () => {
@@ -122,9 +122,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Temperature Module GEN1')
     getByText('abc123')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
   })
 
   it('renders correct info when module is a thermocycler module with an update available', () => {
@@ -138,9 +138,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Thermocycler Module GEN1')
     getByText('ghi789')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
     getByText('Firmware update available.')
     const viewUpdate = getByRole('button', { name: 'Update now' })
     fireEvent.click(viewUpdate)
@@ -163,9 +163,9 @@ describe('AboutModuleSlideout', () => {
 
     getByText('About Temperature Module GEN1')
     getByText('abc123')
-    getByText('Serial Number')
-    getByText('Current Version')
-    getByText('Version v2.0.0')
+    getByText('SERIAL NUMBER')
+    getByText('CURRENT VERSION')
+    getByText(/v[0-9].[0-9].[0-9]$/)
     const button = getByRole('button', { name: 'close' })
     fireEvent.click(button)
     expect(props.onCloseClick).toHaveBeenCalled()


### PR DESCRIPTION
closes [RQA-1660](https://opentrons.atlassian.net/jira/software/c/projects/RQA/issues/RQA-1660)

# Overview

Change headers and content styling in slideout for current version and serial numbers for pipettes,
modules, and gripper. Adjust fontweight, colors, capitalization, and padding.

NOTE this PR cherrypicks commits from [here](https://github.com/Opentrons/opentrons/pull/13598) because they were merged into edge before creation of `chore_release-7.0.1`

# Test Plan

- Verify that pipette slideout styling matches design
- Verify that module slideout styling matches design
- Verify that gripper slideout styling matches design

# Changelog

- change StyledText props for all slideouts listed above to match design specifications

# Review requests

To recreate, connect to a robot with attached pipettes/modules/gripper, choose overflow menu -> About [module/pipette/gripper], and view text. 

# Risk assessment

low

[RQA-1660]: https://opentrons.atlassian.net/browse/RQA-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ