### PR TITLE
fix(app): show pipette settings in pipette settings slideout

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteSettingsSlideout.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import last from 'lodash/last'
-import { useDispatch, useSelector } from 'react-redux'
-import { Flex, useInterval } from '@opentrons/components'
+import { useSelector } from 'react-redux'
+import { Flex } from '@opentrons/components'
 import { PipetteModelSpecs } from '@opentrons/shared-data'
-import {
-  fetchPipetteSettings,
-  updatePipetteSettings,
-} from '../../../redux/pipettes'
+import { updatePipetteSettings } from '../../../redux/pipettes'
 import { Slideout } from '../../../atoms/Slideout'
 import {
   getRequestById,
@@ -22,10 +19,7 @@ import type {
   PipetteSettingsFieldsUpdate,
   PipetteSettingsFieldsMap,
 } from '../../../redux/pipettes/types'
-import type { Dispatch, State } from '../../../redux/types'
-
-const FETCH_PIPETTES_INTERVAL_MS = 5000
-
+import type { State } from '../../../redux/types'
 interface PipetteSettingsSlideoutProps {
   robotName: string
   pipetteName: PipetteModelSpecs['displayName']
@@ -47,7 +41,6 @@ export const PipetteSettingsSlideout = (
     settings,
   } = props
   const { t } = useTranslation('device_details')
-  const dispatch = useDispatch<Dispatch>()
   const [dispatchRequest, requestIds] = useDispatchApiRequest()
   const updateSettings = (fields: PipetteSettingsFieldsUpdate): void => {
     dispatchRequest(updatePipetteSettings(robotName, pipetteId, fields))
@@ -57,15 +50,6 @@ export const PipetteSettingsSlideout = (
     latestRequestId != null ? getRequestById(state, latestRequestId) : null
   )
   const FORM_ID = `configurePipetteForm_${pipetteId}`
-
-  // TODO(bc, 2023-02-10): replace this with the usePipetteSettingsQuery for poll and data access in the child components
-  useInterval(
-    () => {
-      dispatch(fetchPipetteSettings(robotName))
-    },
-    FETCH_PIPETTES_INTERVAL_MS,
-    true
-  )
 
   return (
     <Slideout

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -3,11 +3,13 @@ import { resetAllWhenMocks, when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 import { LEFT, RIGHT } from '@opentrons/shared-data'
-import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
+import {
+  useCurrentSubsystemUpdateQuery,
+  usePipetteSettingsQuery,
+} from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
 import { getHasCalibrationBlock } from '../../../../redux/config'
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
-import { getAttachedPipetteSettingsFieldsById } from '../../../../redux/pipettes'
 import { AskForCalibrationBlockModal } from '../../../CalibrateTipLength'
 import { useCalibratePipetteOffset } from '../../../CalibratePipetteOffset/useCalibratePipetteOffset'
 import { useDeckCalibrationData, useIsOT3 } from '../../hooks'
@@ -18,11 +20,9 @@ import { PipetteCard } from '..'
 import {
   mockLeftSpecs,
   mockRightSpecs,
-  mockPipetteSettingsFieldsMap,
 } from '../../../../redux/pipettes/__fixtures__'
 import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
 
-import type { State } from '../../../../redux/types'
 import type { DispatchApiRequestType } from '../../../../redux/robot-api'
 
 jest.mock('../PipetteOverflowMenu')
@@ -60,8 +60,8 @@ const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 const mockUseCurrentSubsystemUpdateQuery = useCurrentSubsystemUpdateQuery as jest.MockedFunction<
   typeof useCurrentSubsystemUpdateQuery
 >
-const mockGetAttachedPipetteSettingsFieldsById = getAttachedPipetteSettingsFieldsById as jest.MockedFunction<
-  typeof getAttachedPipetteSettingsFieldsById
+const mockUsePipetteSettingsQuery = usePipetteSettingsQuery as jest.MockedFunction<
+  typeof usePipetteSettingsQuery
 >
 
 const render = (props: React.ComponentProps<typeof PipetteCard>) => {
@@ -113,9 +113,9 @@ describe('PipetteCard', () => {
     mockUseCurrentSubsystemUpdateQuery.mockReturnValue({
       data: undefined,
     } as any)
-    when(mockGetAttachedPipetteSettingsFieldsById)
-      .calledWith({} as State, mockRobotName, 'id')
-      .mockReturnValue(mockPipetteSettingsFieldsMap)
+    when(mockUsePipetteSettingsQuery)
+      .calledWith({ refetchInterval: 5000, enabled: true })
+      .mockReturnValue({} as any)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -296,9 +296,6 @@ describe('PipetteCard', () => {
     getByText('Firmware update in progress...')
   })
   it('does not render a pipette settings slideout card if the pipette has no settings', () => {
-    when(mockGetAttachedPipetteSettingsFieldsById)
-      .calledWith({} as State, mockRobotName, 'id')
-      .mockReturnValue(null)
     const { queryByTestId } = render(props)
     expect(
       queryByTestId(

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -130,7 +130,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const settings = usePipetteSettingsQuery({
     refetchInterval: 5000,
     enabled: pipetteId != null,
-  }).data?.[pipetteId ?? '']?.fields
+  })?.data?.[pipetteId ?? '']?.fields
 
   const [
     selectedPipette,

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -21,7 +21,10 @@ import {
   NINETY_SIX_CHANNEL,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
-import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
+import {
+  useCurrentSubsystemUpdateQuery,
+  usePipetteSettingsQuery,
+} from '@opentrons/react-api-client'
 
 import {
   LEFT,
@@ -124,9 +127,10 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
     }
   )
-  const settings = useSelector((state: State) =>
-    getAttachedPipetteSettingsFieldsById(state, robotName, pipetteId ?? '')
-  )
+  const settings = usePipetteSettingsQuery({
+    refetchInterval: 5000,
+    enabled: pipetteId != null,
+  }).data?.[pipetteId ?? '']?.fields
 
   const [
     selectedPipette,

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
-import { useSelector } from 'react-redux'
 
 import {
   Box,
@@ -26,10 +25,7 @@ import {
   usePipetteSettingsQuery,
 } from '@opentrons/react-api-client'
 
-import {
-  LEFT,
-  getAttachedPipetteSettingsFieldsById,
-} from '../../../redux/pipettes'
+import { LEFT } from '../../../redux/pipettes'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
 import { StyledText } from '../../../atoms/text'
 import { Banner } from '../../../atoms/Banner'
@@ -44,7 +40,6 @@ import { PipetteOverflowMenu } from './PipetteOverflowMenu'
 import { PipetteSettingsSlideout } from './PipetteSettingsSlideout'
 import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 
-import type { State } from '../../../redux/types'
 import type {
   PipetteModelSpecs,
   PipetteMount,
@@ -127,10 +122,11 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
     }
   )
-  const settings = usePipetteSettingsQuery({
-    refetchInterval: 5000,
-    enabled: pipetteId != null,
-  })?.data?.[pipetteId ?? '']?.fields
+  const settings =
+    usePipetteSettingsQuery({
+      refetchInterval: 5000,
+      enabled: pipetteId != null,
+    })?.data?.[pipetteId ?? '']?.fields ?? null
 
   const [
     selectedPipette,


### PR DESCRIPTION
# Overview
This PR enables the pipette settings slide out to render. Settings were not showing up because we were fetching pipette settings inside of the slide out, but we conditionally render the slide out component if settings are available. 

closes RQA-1223

- Added unit tests to validate that changes to pydantic model are correct


# Changelog

- Show pipette settings in pipette settings slide out


# Review requests
Open up pipette settings slideout on an OT-2 and make sure settings show up

# Risk assessment

Low