### PR TITLE
fix(app): pipette recalibration banner conditional rendering and styling

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -182,9 +182,10 @@ export function InstrumentsAndModules({
             <Banner type="warning">{t('robot_control_not_available')}</Banner>
           </Flex>
         )}
-        {getShowPipetteCalibrationWarning(attachedInstruments) &&
-        (currentRunId == null || isRunTerminal) ? (
-          <Flex paddingBottom={SPACING.spacing16}>
+        {isRobotViewable &&
+        getShowPipetteCalibrationWarning(attachedInstruments) &&
+        (isRunTerminal || currentRunId == null) ? (
+          <Flex paddingBottom={SPACING.spacing16} width="100%">
             <PipetteRecalibrationWarning />
           </Flex>
         ) : null}

--- a/app/src/organisms/Devices/PipetteCard/PipetteRecalibrationWarning.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteRecalibrationWarning.tsx
@@ -16,7 +16,7 @@ export const PipetteRecalibrationWarning = (): JSX.Element | null => {
   if (!showBanner) return null
 
   return (
-    <Box marginTop={SPACING.spacing8}>
+    <Box marginTop={SPACING.spacing8} width="100%">
       <Banner
         iconMarginRight={SPACING.spacing16}
         iconMarginLeft={SPACING.spacing8}

--- a/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -184,9 +184,6 @@ describe('InstrumentsAndModules', () => {
     getByText('Mock PipetteCard')
   })
   it('renders pipette recalibration recommendation banner when offsets fail reasonability checks', () => {
-    mockPipetteRecalibrationWarning.mockReturnValue(
-      <div>Mock PipetteRecalibrationWarning</div>
-    )
     mockGetShowPipetteCalibrationWarning.mockReturnValue(true)
     mockUseIsRobotViewable.mockReturnValue(true)
     const [{ getByText }] = render()

--- a/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -15,7 +15,11 @@ import { ModuleCard } from '../../ModuleCard'
 import { InstrumentsAndModules } from '../InstrumentsAndModules'
 import { GripperCard } from '../../GripperCard'
 import { PipetteCard } from '../PipetteCard'
-import { getIs96ChannelPipetteAttached } from '../utils'
+import { PipetteRecalibrationWarning } from '../PipetteCard/PipetteRecalibrationWarning'
+import {
+  getIs96ChannelPipetteAttached,
+  getShowPipetteCalibrationWarning,
+} from '../utils'
 import {
   mockPipetteOffsetCalibration1,
   mockPipetteOffsetCalibration2,
@@ -34,6 +38,7 @@ jest.mock('../hooks')
 jest.mock('../../GripperCard')
 jest.mock('../../ModuleCard')
 jest.mock('../PipetteCard')
+jest.mock('../PipetteCard/PipetteRecalibrationWarning')
 jest.mock('../../ProtocolUpload/hooks')
 jest.mock('../../../atoms/Banner')
 jest.mock('../utils', () => {
@@ -41,6 +46,7 @@ jest.mock('../utils', () => {
   return {
     ...actualUtils,
     getIs96ChannelPipetteAttached: jest.fn(),
+    getShowPipetteCalibrationWarning: jest.fn(),
   }
 })
 jest.mock('../../RunTimeControl/hooks')
@@ -60,6 +66,9 @@ const mockUseAllPipetteOffsetCalibrationsQuery = useAllPipetteOffsetCalibrations
 const mockModuleCard = ModuleCard as jest.MockedFunction<typeof ModuleCard>
 const mockPipetteCard = PipetteCard as jest.MockedFunction<typeof PipetteCard>
 const mockGripperCard = GripperCard as jest.MockedFunction<typeof GripperCard>
+const mockPipetteRecalibrationWarning = PipetteRecalibrationWarning as jest.MockedFunction<
+  typeof PipetteRecalibrationWarning
+>
 const mockUsePipettesQuery = usePipettesQuery as jest.MockedFunction<
   typeof usePipettesQuery
 >
@@ -72,6 +81,9 @@ const mockUseRunStatuses = useRunStatuses as jest.MockedFunction<
 >
 const mockGetIs96ChannelPipetteAttached = getIs96ChannelPipetteAttached as jest.MockedFunction<
   typeof getIs96ChannelPipetteAttached
+>
+const mockGetShowPipetteCalibrationWarning = getShowPipetteCalibrationWarning as jest.MockedFunction<
+  typeof getShowPipetteCalibrationWarning
 >
 const mockUseIsOT3 = useIsOT3 as jest.MockedFunction<typeof useIsOT3>
 
@@ -91,12 +103,16 @@ describe('InstrumentsAndModules', () => {
       isRunTerminal: false,
     })
     mockGetIs96ChannelPipetteAttached.mockReturnValue(false)
+    mockGetShowPipetteCalibrationWarning.mockReturnValue(false)
     mockUseInstrumentsQuery.mockReturnValue({
       data: { data: [] },
     } as any)
     mockPipetteCard.mockReturnValue(<div>Mock PipetteCard</div>)
     mockGripperCard.mockReturnValue(<div>Mock GripperCard</div>)
     mockModuleCard.mockReturnValue(<div>Mock ModuleCard</div>)
+    mockPipetteRecalibrationWarning.mockReturnValue(
+      <div>Mock PipetteRecalibrationWarning</div>
+    )
     mockUseIsOT3.mockReturnValue(false)
   })
   afterEach(() => {
@@ -166,6 +182,15 @@ describe('InstrumentsAndModules', () => {
     mockUseIsRobotViewable.mockReturnValue(true)
     const [{ getByText }] = render()
     getByText('Mock PipetteCard')
+  })
+  it('renders pipette recalibration recommendation banner when offsets fail reasonability checks', () => {
+    mockPipetteRecalibrationWarning.mockReturnValue(
+      <div>Mock PipetteRecalibrationWarning</div>
+    )
+    mockGetShowPipetteCalibrationWarning.mockReturnValue(true)
+    mockUseIsRobotViewable.mockReturnValue(true)
+    const [{ getByText }] = render()
+    getByText('Mock PipetteRecalibrationWarning')
   })
   it('fetches offset calibrations on long poll and pipettes, instruments, and modules on short poll', () => {
     const { pipette: pipette1 } = mockPipetteOffsetCalibration1


### PR DESCRIPTION
closes [RQA-1746](https://opentrons.atlassian.net/browse/RQA-1746)

# Overview

Only render the pipette recal warning banner if the robot is viewable. Stretch banner to full width of instruments and modules flexbox if the window is expanded. Write test.

# Test Plan

- Verify that the banner displays only under the conditions that the robot is viewable, the pipette fail reasonability checks, and the current run status is null/terminal
- Verify that the banner stretches to the full width of the parent InstrumentsAndModules FlexBox even when the window width is resized:
<img width="1395" alt="Screen Shot 2023-10-05 at 10 12 48 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/9b1c8a78-9b2d-4891-b1a8-3f21978b4712">

# Changelog

- fix conditional rendering to meet the test criteria above
- stretch the warning banner to fill the instruments and modules parent
- update tests

# Risk assessment

low

[RQA-1746]: https://opentrons.atlassian.net/browse/RQA-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ