### PR TITLE
fix(api): Flag pipette as not ready to aspirate after pushing out air

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1842,7 +1842,9 @@ class OT3API(
             raise
         else:
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
-            if push_out or dispense_spec.instr.push_out_volume:
+            bottom = dispense_spec.instr.plunger_positions.bottom
+            plunger_target_pos = target_pos[Axis.of_main_tool_actuator(realmount)]
+            if (push_out is not None and push_out > 0) or  plunger_target_pos > bottom:
                 dispense_spec.instr.ready_to_aspirate = False
 
     async def blow_out(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1844,7 +1844,7 @@ class OT3API(
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
             bottom = dispense_spec.instr.plunger_positions.bottom
             plunger_target_pos = target_pos[Axis.of_main_tool_actuator(realmount)]
-            if (push_out is not None and push_out > 0) or plunger_target_pos > bottom:
+            if plunger_target_pos > bottom:
                 dispense_spec.instr.ready_to_aspirate = False
 
     async def blow_out(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1844,7 +1844,7 @@ class OT3API(
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
             bottom = dispense_spec.instr.plunger_positions.bottom
             plunger_target_pos = target_pos[Axis.of_main_tool_actuator(realmount)]
-            if (push_out is not None and push_out > 0) or  plunger_target_pos > bottom:
+            if (push_out is not None and push_out > 0) or plunger_target_pos > bottom:
                 dispense_spec.instr.ready_to_aspirate = False
 
     async def blow_out(

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1842,6 +1842,8 @@ class OT3API(
             raise
         else:
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
+            if push_out or dispense_spec.instr.push_out_volume:
+                dispense_spec.instr.ready_to_aspirate = False
 
     async def blow_out(
         self,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1096,10 +1096,10 @@ async def test_prepare_for_aspirate(
 @pytest.mark.parametrize(
     "asp_vol,disp_vol,push_out,is_ready",
     (
-        [5, 1, None, True], # Partial Dispense
-        [5, 5, None, False], # Full dispense (default push_out)
-        [5, 5, 0.0, True], # explicit no push out
-        [5, 5, 1.0, False], # explicit push out
+        [5, 1, None, True],  # Partial Dispense
+        [5, 5, None, False],  # Full dispense (default push_out)
+        [5, 5, 0.0, True],  # explicit no push out
+        [5, 5, 1.0, False],  # explicit push out
     ),
 )
 async def test_plunger_ready_to_aspirate_after_dispense(
@@ -1129,7 +1129,9 @@ async def test_plunger_ready_to_aspirate_after_dispense(
 
     await ot3_hardware.aspirate(OT3Mount.LEFT, asp_vol)
     await ot3_hardware.dispense(OT3Mount.LEFT, disp_vol, push_out=push_out)
-    assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == is_ready
+    assert (
+        ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == is_ready
+    )
 
 
 async def test_move_to_plunger_bottom(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1093,6 +1093,45 @@ async def test_prepare_for_aspirate(
     mock_move_to_plunger_bottom.assert_called_once_with(OT3Mount.LEFT, 1.0)
 
 
+@pytest.mark.parametrize(
+    "asp_vol,disp_vol,push_out,is_ready",
+    (
+        [5, 1, None, True], # Partial Dispense
+        [5, 5, None, False], # Full dispense (default push_out)
+        [5, 5, 0.0, True], # explicit no push out
+        [5, 5, 1.0, False], # explicit push out
+    ),
+)
+async def test_plunger_ready_to_aspirate_after_dispense(
+    ot3_hardware: ThreadManager[OT3API],
+    asp_vol: float,
+    disp_vol: float,
+    push_out: Optional[float],
+    is_ready: bool,
+):
+    mount = OT3Mount.LEFT
+
+    instr_data = AttachedPipette(
+        config=load_pipette_data.load_definition(
+            PipetteModelType("p1000"),
+            PipetteChannelType(1),
+            PipetteVersionType(3, 4),
+        ),
+        id="fakepip",
+    )
+
+    await ot3_hardware.cache_pipette(mount, instr_data, None)
+    assert ot3_hardware.hardware_pipettes[mount.to_mount()]
+
+    await ot3_hardware.add_tip(mount, 100)
+    await ot3_hardware.prepare_for_aspirate(OT3Mount.LEFT)
+    assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == True
+
+    await ot3_hardware.aspirate(OT3Mount.LEFT, asp_vol)
+    await ot3_hardware.dispense(OT3Mount.LEFT, disp_vol, push_out=push_out)
+    assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == is_ready
+
+
 async def test_move_to_plunger_bottom(
     ot3_hardware: ThreadManager[OT3API],
     mock_move: AsyncMock,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1125,7 +1125,7 @@ async def test_plunger_ready_to_aspirate_after_dispense(
 
     await ot3_hardware.add_tip(mount, 100)
     await ot3_hardware.prepare_for_aspirate(OT3Mount.LEFT)
-    assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate == True
+    assert ot3_hardware.hardware_pipettes[mount.to_mount()].ready_to_aspirate
 
     await ot3_hardware.aspirate(OT3Mount.LEFT, asp_vol)
     await ot3_hardware.dispense(OT3Mount.LEFT, disp_vol, push_out=push_out)

--- a/hardware-testing/hardware_testing/examples/plunger_ot3.py
+++ b/hardware-testing/hardware_testing/examples/plunger_ot3.py
@@ -25,6 +25,7 @@ async def _main(is_simulating: bool) -> None:
     for vol in [max_vol, max_vol / 2, max_vol / 10]:
         await api.aspirate(mount, volume=vol)
         await api.dispense(mount, volume=vol)
+        await api.prepare_for_aspirate(mount)
     await api.remove_tip(mount)
 
     # move the plunger based on position (millimeters)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Set `ready_to_aspirate = False` if a push-out volume is used during dispense. The plunger would then be below the `bottom` position, and so would not be ready to aspirate.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
