### PR TITLE
fix(shared-data): Remove v7 parameters from the v6 schema

### DIFF
--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v6.py
@@ -53,8 +53,6 @@ class Params(BaseModel):
     offset: Optional[OffsetVector]
     profile: Optional[List[ProfileStep]]
     radius: Optional[float]
-    newLocation: Optional[Union[Location, Literal["offDeck"]]]
-    strategy: Optional[str]
 
 
 class Command(BaseModel):

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v7.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v7.py
@@ -54,7 +54,6 @@ class Params(BaseModel):
     newLocation: Optional[Union[Location, Literal["offDeck"]]]
     strategy: Optional[str]
     # schema v7 add-ons
-    adapterId: Optional[str]
     homeAfter: Optional[bool]
     alternateDropLocation: Optional[bool]
     holdTimeSeconds: Optional[float]


### PR DESCRIPTION

# Overview
Relates to: https://opentrons.atlassian.net/browse/RSS-293
v6 Schema edited to remove references to v7 Schema parameters. These parameters were in place during a stage in development when the two had yet to fully separate. Adapter ID also removed from V7 due to deprecation. 
