### PR TITLE
fix(app): clear redux wifi status data on disconnect

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
@@ -22,6 +22,7 @@ import { LegacyModal } from '../../../../molecules/LegacyModal'
 import { useRobot } from '../../../../organisms/Devices/hooks'
 import { CONNECTABLE } from '../../../../redux/discovery'
 import {
+  clearWifiStatus,
   getNetworkInterfaces,
   postWifiDisconnect,
 } from '../../../../redux/networking'
@@ -105,6 +106,8 @@ export const DisconnectModal = ({
     wifi?.ipAddress == null
 
   if (isDisconnected) {
+    // as a fallback, when in a disconnected state clear redux wifi status data to ensure no stale data
+    dispatch(clearWifiStatus(robotName))
     disconnectModalBody = t('disconnect_from_wifi_network_success')
   } else if (isRequestPending) {
     disconnectModalBody = t('disconnecting_from_wifi_network', { ssid })

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
@@ -106,14 +106,18 @@ export const DisconnectModal = ({
     wifi?.ipAddress == null
 
   if (isDisconnected) {
-    // as a fallback, when in a disconnected state clear redux wifi status data to ensure no stale data
-    dispatch(clearWifiStatus(robotName))
     disconnectModalBody = t('disconnect_from_wifi_network_success')
   } else if (isRequestPending) {
     disconnectModalBody = t('disconnecting_from_wifi_network', { ssid })
   } else if (isRequestFailed) {
     disconnectModalBody = t('disconnect_from_wifi_network_failure', { ssid })
   }
+
+  React.useEffect(() => {
+    if (isDisconnected) {
+      dispatch(clearWifiStatus(robotName))
+    }
+  }, [isDisconnected])
 
   return (
     <LegacyModal

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/__tests__/DisconnectModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/__tests__/DisconnectModal.test.tsx
@@ -11,6 +11,7 @@ import {
   mockReachableRobot,
 } from '../../../../../redux/discovery/__fixtures__'
 import {
+  clearWifiStatus,
   getNetworkInterfaces,
   INTERFACE_WIFI,
   postWifiDisconnect,
@@ -52,6 +53,9 @@ const mockDismissRequest = dismissRequest as jest.MockedFunction<
   typeof dismissRequest
 >
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
+const mockClearWifiStatus = clearWifiStatus as jest.MockedFunction<
+  typeof clearWifiStatus
+>
 
 const ROBOT_NAME = 'otie'
 const LAST_ID = 'a request id'
@@ -117,6 +121,7 @@ describe('DisconnectModal', () => {
     getByText('Disconnect from foo')
     getByText('Disconnecting from Wi-Fi network foo')
     getByRole('button', { name: 'cancel' })
+    expect(mockClearWifiStatus).not.toHaveBeenCalled()
   })
 
   it('renders success body when request is pending and robot is not connectable', () => {
@@ -133,6 +138,7 @@ describe('DisconnectModal', () => {
       'Your robot has successfully disconnected from the Wi-Fi network.'
     )
     getByRole('button', { name: 'Done' })
+    expect(mockClearWifiStatus).toHaveBeenCalled()
   })
 
   it('renders success body when request is successful', () => {
@@ -146,6 +152,7 @@ describe('DisconnectModal', () => {
       'Your robot has successfully disconnected from the Wi-Fi network.'
     )
     getByRole('button', { name: 'Done' })
+    expect(mockClearWifiStatus).toHaveBeenCalled()
   })
 
   it('renders success body when wifi is not connected', () => {
@@ -162,6 +169,7 @@ describe('DisconnectModal', () => {
       'Your robot has successfully disconnected from the Wi-Fi network.'
     )
     getByRole('button', { name: 'Done' })
+    expect(mockClearWifiStatus).toHaveBeenCalled()
   })
 
   it('renders error body when request is unsuccessful', () => {
@@ -181,6 +189,7 @@ describe('DisconnectModal', () => {
     )
     getByRole('button', { name: 'cancel' })
     getByRole('button', { name: 'Disconnect' })
+    expect(mockClearWifiStatus).not.toHaveBeenCalled()
   })
 
   it('dispatches postWifiDisconnect on click Disconnect', () => {

--- a/app/src/redux/networking/__tests__/actions.test.ts
+++ b/app/src/redux/networking/__tests__/actions.test.ts
@@ -265,6 +265,15 @@ describe('networking actions', () => {
         meta: mockRequestMeta,
       },
     },
+    {
+      name: 'can create networking:CLEAR_WIFI_STATUS',
+      creator: Actions.clearWifiStatus,
+      args: [mockRobot.name],
+      expected: {
+        type: 'networking:CLEAR_WIFI_STATUS',
+        payload: { robotName: mockRobot.name },
+      },
+    },
   ]
 
   SPECS.forEach(spec => {

--- a/app/src/redux/networking/__tests__/reducer.test.ts
+++ b/app/src/redux/networking/__tests__/reducer.test.ts
@@ -206,6 +206,29 @@ const SPECS: ReducerSpec[] = [
       },
     },
   },
+
+  {
+    name: 'handles clear wifi status action',
+    action: Actions.clearWifiStatus(ROBOT_NAME),
+    state: {
+      [ROBOT_NAME]: Fixtures.mockNetworkingStatus,
+    },
+    expected: {
+      [ROBOT_NAME]: {
+        ...Fixtures.mockNetworkingStatus,
+        interfaces: {
+          ...Fixtures.mockNetworkingStatus.interfaces,
+          wlan0: {
+            ipAddress: null,
+            macAddress: 'unknown',
+            gatewayAddress: null,
+            state: 'disconnected',
+            type: 'wifi',
+          },
+        },
+      },
+    },
+  },
 ]
 
 describe('networkingReducer', () => {

--- a/app/src/redux/networking/actions.ts
+++ b/app/src/redux/networking/actions.ts
@@ -174,3 +174,10 @@ export const postWifiDisconnectFailure = (
   payload: { robotName, error },
   meta,
 })
+
+export const clearWifiStatus = (
+  robotName: string
+): Types.ClearWifiStatusAction => ({
+  type: Constants.CLEAR_WIFI_STATUS,
+  payload: { robotName },
+})

--- a/app/src/redux/networking/constants.ts
+++ b/app/src/redux/networking/constants.ts
@@ -103,3 +103,8 @@ export const POST_WIFI_DISCONNECT_SUCCESS: 'networking:POST_WIFI_DISCONNECT_SUCC
 
 export const POST_WIFI_DISCONNECT_FAILURE: 'networking:POST_WIFI_DISCONNECT_FAILURE' =
   'networking:POST_WIFI_DISCONNECT_FAILURE'
+
+// clear wifi status
+
+export const CLEAR_WIFI_STATUS: 'networking:CLEAR_WIFI_STATUS' =
+  'networking:CLEAR_WIFI_STATUS'

--- a/app/src/redux/networking/reducer.ts
+++ b/app/src/redux/networking/reducer.ts
@@ -24,7 +24,7 @@ const getWifiInterfaceKey = (
     networkingState.interfaces ?? {}
   )
   const wifiInterfaceEntry = networkInterfacesEntries.find(
-    networkInterface => networkInterface[1]?.type === 'wifi'
+    networkInterface => networkInterface[1]?.type === Constants.INTERFACE_WIFI
   )
   const wifiInterfaceKey = wifiInterfaceEntry?.[0]
 
@@ -101,7 +101,7 @@ export const networkingReducer: Reducer<NetworkingState, Action> = (
               macAddress: 'unknown',
               gatewayAddress: null,
               state: 'disconnected',
-              type: 'wifi',
+              type: Constants.INTERFACE_WIFI,
             },
           },
         },

--- a/app/src/redux/networking/reducer.ts
+++ b/app/src/redux/networking/reducer.ts
@@ -17,6 +17,21 @@ const getRobotState = (
   robotName: string
 ): PerRobotNetworkingState => state[robotName] || INITIAL_ROBOT_STATE
 
+const getWifiInterfaceKey = (
+  networkingState: PerRobotNetworkingState
+): string => {
+  const networkInterfacesEntries = Object.entries(
+    networkingState.interfaces ?? {}
+  )
+  const wifiInterfaceEntry = networkInterfacesEntries.find(
+    networkInterface => networkInterface[1]?.type === 'wifi'
+  )
+  const wifiInterfaceKey = wifiInterfaceEntry?.[0]
+
+  // default to 'mlan0' for type safety
+  return wifiInterfaceKey ?? 'mlan0'
+}
+
 export const networkingReducer: Reducer<NetworkingState, Action> = (
   state = INITIAL_STATE,
   action
@@ -68,6 +83,28 @@ export const networkingReducer: Reducer<NetworkingState, Action> = (
       return {
         ...state,
         [robotName]: { ...robotState, eapOptions },
+      }
+    }
+
+    case Constants.CLEAR_WIFI_STATUS: {
+      const { robotName } = action.payload
+      const robotState = getRobotState(state, robotName)
+      const wifiInterfaceKey = getWifiInterfaceKey(robotState)
+      return {
+        ...state,
+        [robotName]: {
+          ...robotState,
+          interfaces: {
+            ...robotState.interfaces,
+            [wifiInterfaceKey]: {
+              ipAddress: null,
+              macAddress: 'unknown',
+              gatewayAddress: null,
+              state: 'disconnected',
+              type: 'wifi',
+            },
+          },
+        },
       }
     }
   }

--- a/app/src/redux/networking/types.ts
+++ b/app/src/redux/networking/types.ts
@@ -149,6 +149,11 @@ export interface PostWifiDisconnectFailureAction {
   meta: RobotApiRequestMeta
 }
 
+export interface ClearWifiStatusAction {
+  type: 'networking:CLEAR_WIFI_STATUS'
+  payload: { robotName: string }
+}
+
 export interface NetworkingDisconnectResponse {
   ssid: string
 }
@@ -174,6 +179,7 @@ export type NetworkingAction =
   | PostWifiDisconnectAction
   | PostWifiDisconnectSuccessAction
   | PostWifiDisconnectFailureAction
+  | ClearWifiStatusAction
 
 // state types
 


### PR DESCRIPTION
# Overview

provides a fallback to clear redux wifi interface data when the wifi disconnect modal is in a state where it has presumed a successful disconnection. based on observation of connected/disconnected state, provides a wifi interface reducer value of:
```
       [wifiInterfaceKey]: {
          ipAddress: null,
          macAddress: 'unknown',
          gatewayAddress: null,
          state: 'disconnected',
          type: 'wifi'
        },
```
This should clear the existing stale data in the case that wifi data hangs around too long due to lack of healthy HTTP communication. 

In the case that HTTP communication is healthy, the reducer value above should be replaced by the next successful `networking/status` call.

closes RQA-1745

# Test Plan

 - updated unit tests for redux and disconnect modal

# Changelog

 - Clears desktop app redux wifi status data on disconnect

# Review requests

 - check behavior of wifi disconnect on robot: 1) when only wifi connected 2) when also connected by ethernet. check for unexpected side effects of declaring reducer data 
 

# Risk assessment

low
