### PR TITLE
fix(app): truncate protocol receipt toast to 30 characters

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -5,7 +5,7 @@ import { useQueryClient } from 'react-query'
 import { useRouteMatch } from 'react-router-dom'
 import { useDispatch } from 'react-redux'
 
-import { useInterval } from '@opentrons/components'
+import { useInterval, truncateString } from '@opentrons/components'
 import {
   useAllProtocolIdsQuery,
   useAllRunsQuery,
@@ -91,12 +91,13 @@ export function useProtocolReceiptToast(): void {
           protocolNames.forEach(name => {
             makeToast(
               t('protocol_added', {
-                protocol_name: name,
+                protocol_name: truncateString(name, 30),
               }),
               'success',
               {
                 closeButton: true,
                 disableTimeout: true,
+                displayType: 'odd'
               }
             )
           })


### PR DESCRIPTION
closes [RQA-1598](https://opentrons.atlassian.net/browse/RQA-1598)

# Overview

Truncate protocol receipt toast on app to "Successfully received {protocol name truncated to 30characters}..." for long protocol names

# Test Plan

- Verify that protocol name is truncated in receipt toast on ODD
<img width="1104" alt="Screen Shot 2023-10-06 at 11 05 01 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/3ce475d8-eae6-4da5-87ca-21be5d990493">
- Verify that the protocol name is not affected elsewhere
<img width="1106" alt="Screen Shot 2023-10-06 at 11 05 14 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/d6c48e79-2309-423b-bafa-94ca68f7fde6">

# Risk assessment

low

[RQA-1598]: https://opentrons.atlassian.net/browse/RQA-1598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ