### PR TITLE
test(api): make `test_filter_zero_duration_step`filter a zero-duration step

### DIFF
--- a/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_utils.py
@@ -72,7 +72,7 @@ def test_filter_zero_duration_step() -> None:
         Axis.P_R: 0,
     }
     moves = [Move.build_dummy([Axis.X, Axis.Y, Axis.Z_L, Axis.Z_R, Axis.P_L])]
-    for block in moves[0].blocks:
+    for block in (moves[0].blocks[0], moves[0].blocks[1]):
         block.distance = f64(25.0)
         block.time = f64(1.0)
         block.initial_speed = f64(25.0)
@@ -84,7 +84,7 @@ def test_filter_zero_duration_step() -> None:
         moves=moves,
         present_nodes=present_nodes,
     )
-    assert len(move_group) == 3
+    assert len(move_group) == 2
     for step in move_group:
         assert set(present_nodes) == set(step.keys())
 


### PR DESCRIPTION

# Overview

This test hasn't actually been testing anything for a while. This PR restores the original intention of the test, which is to ensure that move groups omit steps with a duration of 0.

# Test Plan

Ran the test and it worked


# Changelog

- Configure `test_filter_zero_duration_step` to filter out a step from a move group


# Review requests



# Risk assessment

None