### PR TITLE
fix(app): Persist UpdateBuildroot during robot restart

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/Opentrons/opentrons",
   "dependencies": {
+    "@ebay/nice-modal-react": "1.2.13",
     "@fontsource/dejavu-sans": "5.0.3",
     "@fontsource/public-sans": "5.0.3",
     "@hot-loader/react-dom": "17.0.1",

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -97,7 +97,7 @@ export function useProtocolReceiptToast(): void {
               {
                 closeButton: true,
                 disableTimeout: true,
-                displayType: 'odd'
+                displayType: 'odd',
               }
             )
           })

--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { hot } from 'react-hot-loader/root'
+import NiceModal from '@ebay/nice-modal-react'
 
 import { Flex, POSITION_FIXED, DIRECTION_ROW } from '@opentrons/components'
 
@@ -29,7 +30,9 @@ export const AppComponent = (): JSX.Element | null => {
         onDrop={stopEvent}
       >
         <TopPortalRoot />
-        {isOnDevice ? <OnDeviceDisplayApp /> : <DesktopApp />}
+        <NiceModal.Provider>
+          {isOnDevice ? <OnDeviceDisplayApp /> : <DesktopApp />}
+        </NiceModal.Provider>
       </Flex>
     </>
   ) : null

--- a/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverviewOverflowMenu.tsx
@@ -22,7 +22,7 @@ import { Divider } from '../../atoms/structure'
 import { Tooltip } from '../../atoms/Tooltip'
 import { ChooseProtocolSlideout } from '../../organisms/ChooseProtocolSlideout'
 import { DisconnectModal } from '../../organisms/Devices/RobotSettings/ConnectNetwork/DisconnectModal'
-import { UpdateBuildroot } from '../../organisms/Devices/RobotSettings/UpdateBuildroot'
+import { handleUpdateBuildroot } from '../../organisms/Devices/RobotSettings/UpdateBuildroot'
 import { useCurrentRunId } from '../../organisms/ProtocolUpload/hooks'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
 import { UNREACHABLE, CONNECTABLE, REACHABLE } from '../../redux/discovery'
@@ -66,10 +66,6 @@ export const RobotOverviewOverflowMenu = (
   }
 
   const [
-    showSoftwareUpdateModal,
-    setShowSoftwareUpdateModal,
-  ] = React.useState<boolean>(false)
-  const [
     showChooseProtocolSlideout,
     setShowChooseProtocolSlideout,
   ] = React.useState<boolean>(false)
@@ -87,10 +83,6 @@ export const RobotOverviewOverflowMenu = (
     dispatch(checkShellUpdate())
   })
 
-  const handleClickUpdateBuildroot: React.MouseEventHandler = () => {
-    setShowSoftwareUpdateModal(true)
-  }
-
   const handleClickRun: React.MouseEventHandler<HTMLButtonElement> = () => {
     setShowChooseProtocolSlideout(true)
   }
@@ -105,12 +97,6 @@ export const RobotOverviewOverflowMenu = (
   return (
     <Flex data-testid="RobotOverview_overflowMenu" position={POSITION_RELATIVE}>
       <Portal level="top">
-        {showSoftwareUpdateModal ? (
-          <UpdateBuildroot
-            robot={robot}
-            close={() => setShowSoftwareUpdateModal(false)}
-          />
-        ) : null}
         {showDisconnectModal ? (
           <DisconnectModal
             onCancel={() => setShowDisconnectModal(false)}
@@ -138,7 +124,7 @@ export const RobotOverviewOverflowMenu = (
         >
           {isRobotOnWrongVersionOfSoftware && !isRobotUnavailable ? (
             <MenuItem
-              onClick={handleClickUpdateBuildroot}
+              onClick={() => handleUpdateBuildroot(robot)}
               data-testid={`RobotOverviewOverflowMenu_updateSoftware_${String(
                 robot.name
               )}`}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
@@ -18,7 +18,7 @@ import { getRobotApiVersion } from '../../../../redux/discovery'
 import { getRobotUpdateDisplayInfo } from '../../../../redux/robot-update'
 import { UpdateRobotBanner } from '../../../UpdateRobotBanner'
 import { useIsOT3, useRobot } from '../../hooks'
-import { UpdateBuildroot } from '../UpdateBuildroot'
+import { handleUpdateBuildroot } from '../UpdateBuildroot'
 
 import type { State } from '../../../../redux/types'
 
@@ -35,7 +35,6 @@ export function RobotServerVersion({
   const { t } = useTranslation(['device_settings', 'shared'])
   const robot = useRobot(robotName)
   const isOT3 = useIsOT3(robotName)
-  const [showVersionInfoModal, setShowVersionInfoModal] = React.useState(false)
   const { autoUpdateAction } = useSelector((state: State) => {
     return getRobotUpdateDisplayInfo(state, robotName)
   })
@@ -45,12 +44,6 @@ export function RobotServerVersion({
 
   return (
     <>
-      {showVersionInfoModal ? (
-        <UpdateBuildroot
-          robot={robot}
-          close={() => setShowVersionInfoModal(false)}
-        />
-      ) : null}
       {autoUpdateAction !== 'reinstall' && robot != null ? (
         <Box marginBottom={SPACING.spacing16} width="100%">
           <UpdateRobotBanner robot={robot} />
@@ -95,7 +88,7 @@ export function RobotServerVersion({
               {t('up_to_date')}
             </StyledText>
             <TertiaryButton
-              onClick={() => setShowVersionInfoModal(true)}
+              onClick={() => handleUpdateBuildroot(robot)}
               textTransform={TYPOGRAPHY.textTransformCapitalize}
             >
               {t('reinstall')}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/SoftwareUpdateModal.tsx
@@ -21,7 +21,7 @@ import { LegacyModal } from '../../../../molecules/LegacyModal'
 import { CONNECTABLE, REACHABLE } from '../../../../redux/discovery'
 import { Divider } from '../../../../atoms/structure'
 import { useRobot } from '../../hooks'
-import { UpdateBuildroot } from '../UpdateBuildroot'
+import { handleUpdateBuildroot } from '../UpdateBuildroot'
 
 const TECHNICAL_CHANGE_LOG_URL =
   'https://github.com/Opentrons/opentrons/blob/edge/CHANGELOG.md'
@@ -50,22 +50,9 @@ export function SoftwareUpdateModal({
   const [showUpdateModal, setShowUpdateModal] = React.useState<boolean>(false)
   const robot = useRobot(robotName)
 
-  const handleCloseModal = (): void => {
-    setShowUpdateModal(false)
-    closeModal()
-  }
-
-  const handleLaunchUpdateModal: React.MouseEventHandler = e => {
-    e.preventDefault()
-    e.stopPropagation()
-    setShowUpdateModal(true)
-  }
-
   if (robot?.status !== CONNECTABLE && robot?.status !== REACHABLE) return null
 
-  return showUpdateModal ? (
-    <UpdateBuildroot robot={robot} close={handleCloseModal} />
-  ) : (
+  return !showUpdateModal ? (
     <LegacyModal title={t('robot_update_available')} onClose={closeModal}>
       <Banner type="informing">{t('requires_restarting_the_robot')}</Banner>
       <Flex flexDirection={DIRECTION_COLUMN} marginTop={SPACING.spacing16}>
@@ -119,7 +106,10 @@ export function SoftwareUpdateModal({
             {t('remind_me_later')}
           </SecondaryButton>
           <PrimaryButton
-            onClick={handleLaunchUpdateModal}
+            onClick={() => {
+              setShowUpdateModal(true)
+              handleUpdateBuildroot(robot)
+            }}
             disabled={currentRunId != null}
           >
             {t('update_robot_now')}
@@ -127,5 +117,5 @@ export function SoftwareUpdateModal({
         </Flex>
       </Flex>
     </LegacyModal>
-  )
+  ) : null
 }

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
@@ -7,7 +7,7 @@ import { getRobotApiVersion } from '../../../../../redux/discovery'
 import { getRobotUpdateDisplayInfo } from '../../../../../redux/robot-update'
 import { mockConnectableRobot } from '../../../../../redux/discovery/__fixtures__'
 import { useRobot } from '../../../hooks'
-import { UpdateBuildroot } from '../../UpdateBuildroot'
+import { handleUpdateBuildroot } from '../../UpdateBuildroot'
 import { RobotServerVersion } from '../RobotServerVersion'
 
 jest.mock('../../../hooks')
@@ -24,8 +24,8 @@ const mockGetBuildrootUpdateDisplayInfo = getRobotUpdateDisplayInfo as jest.Mock
 
 const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 
-const mockUpdateBuildroot = UpdateBuildroot as jest.MockedFunction<
-  typeof UpdateBuildroot
+const mockUpdateBuildroot = handleUpdateBuildroot as jest.MockedFunction<
+  typeof handleUpdateBuildroot
 >
 
 const MOCK_ROBOT_VERSION = '7.7.7'
@@ -40,7 +40,6 @@ const render = () => {
 
 describe('RobotSettings RobotServerVersion', () => {
   beforeEach(() => {
-    mockUpdateBuildroot.mockReturnValue(<div>mock update buildroot</div>)
     mockUseRobot.mockReturnValue(mockConnectableRobot)
     mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
       autoUpdateAction: 'reinstall',
@@ -66,7 +65,7 @@ describe('RobotSettings RobotServerVersion', () => {
     getByText('up to date')
     const reinstall = getByRole('button', { name: 'reinstall' })
     fireEvent.click(reinstall)
-    getByText('mock update buildroot')
+    expect(mockUpdateBuildroot).toHaveBeenCalled()
   })
 
   it('should render the warning message if the robot server version needs to upgrade', () => {
@@ -81,7 +80,7 @@ describe('RobotSettings RobotServerVersion', () => {
     )
     const btn = getByText('View update')
     fireEvent.click(btn)
-    getByText('mock update buildroot')
+    expect(mockUpdateBuildroot).toHaveBeenCalled()
   })
 
   it('should render the warning message if the robot server version needs to downgrade', () => {
@@ -96,7 +95,7 @@ describe('RobotSettings RobotServerVersion', () => {
     )
     const btn = getByText('View update')
     fireEvent.click(btn)
-    getByText('mock update buildroot')
+    expect(mockUpdateBuildroot).toHaveBeenCalled()
   })
 
   it('the link should have the correct href', () => {

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -38,7 +38,7 @@ import {
 import { RenameRobotSlideout } from './AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout'
 import { DeviceResetSlideout } from './AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout'
 import { DeviceResetModal } from './AdvancedTab/AdvancedTabSlideouts/DeviceResetModal'
-import { UpdateBuildroot } from './UpdateBuildroot'
+import { handleUpdateBuildroot } from './UpdateBuildroot'
 import { UNREACHABLE } from '../../../redux/discovery'
 import { Portal } from '../../../App/portal'
 
@@ -69,10 +69,6 @@ export function RobotSettingsAdvanced({
   const [
     showDeviceResetModal,
     setShowDeviceResetModal,
-  ] = React.useState<boolean>(false)
-  const [
-    showSoftwareUpdateModal,
-    setShowSoftwareUpdateModal,
   ] = React.useState<boolean>(false)
 
   const isRobotBusy = useIsRobotBusy({ poll: true })
@@ -124,12 +120,6 @@ export function RobotSettingsAdvanced({
 
   return (
     <>
-      {showSoftwareUpdateModal ? (
-        <UpdateBuildroot
-          robot={robot}
-          close={() => setShowSoftwareUpdateModal(false)}
-        />
-      ) : null}
       <Box>
         {showRenameRobotSlideout && (
           <RenameRobotSlideout
@@ -194,7 +184,7 @@ export function RobotSettingsAdvanced({
         <UpdateRobotSoftware
           robotName={robotName}
           isRobotBusy={isRobotBusy}
-          onUpdateStart={() => setShowSoftwareUpdateModal(true)}
+          onUpdateStart={() => handleUpdateBuildroot(robot)}
         />
         <Troubleshooting robotName={robotName} />
         <Divider marginY={SPACING.spacing16} />

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
+import NiceModal, { useModal } from '@ebay/nice-modal-react'
+
 import {
   setRobotUpdateSeen,
   robotUpdateIgnored,
@@ -12,49 +14,56 @@ import { UNREACHABLE } from '../../../../redux/discovery'
 import type { Dispatch } from '../../../../redux/types'
 import type { DiscoveredRobot } from '../../../../redux/discovery/types'
 
-export interface UpdateBuildrootProps {
-  close: () => void
-  robot?: DiscoveredRobot | null
+interface UpdateBuildrootProps {
+  robot: DiscoveredRobot | null
 }
 
-export function UpdateBuildroot(
-  props: UpdateBuildrootProps
-): JSX.Element | null {
-  const { robot, close } = props
-  const hasSeenSessionOnce = React.useRef<boolean>(false)
-  const robotName = React.useRef<string>(robot?.name ?? '')
-  const dispatch = useDispatch<Dispatch>()
-  const session = useSelector(getRobotUpdateSession)
-  if (!hasSeenSessionOnce.current && session) hasSeenSessionOnce.current = true
-
-  React.useEffect(() => {
-    if (robotName.current) {
-      dispatch(setRobotUpdateSeen(robotName.current))
-    }
-  }, [robotName])
-
-  const ignoreUpdate = React.useCallback(() => {
-    if (robotName.current) {
-      dispatch(robotUpdateIgnored(robotName.current))
-    }
-    close()
-  }, [robotName, close])
-
-  if (hasSeenSessionOnce.current)
-    return (
-      <RobotUpdateProgressModal
-        robotName={robotName.current}
-        session={session}
-        closeUpdateBuildroot={close}
-      />
-    )
-  else if (robot != null && robot.status !== UNREACHABLE)
-    return (
-      <ViewUpdateModal
-        robotName={robotName.current}
-        robot={robot}
-        closeModal={ignoreUpdate}
-      />
-    )
-  else return null
+export const handleUpdateBuildroot = (
+  robot: UpdateBuildrootProps['robot']
+): void => {
+  NiceModal.show(UpdateBuildroot, { robot })
 }
+
+const UpdateBuildroot = NiceModal.create(
+  (props: UpdateBuildrootProps): JSX.Element | null => {
+    const { robot } = props
+    const hasSeenSessionOnce = React.useRef<boolean>(false)
+    const modal = useModal()
+    const robotName = React.useRef<string>(robot?.name ?? '')
+    const dispatch = useDispatch<Dispatch>()
+    const session = useSelector(getRobotUpdateSession)
+    if (!hasSeenSessionOnce.current && session)
+      hasSeenSessionOnce.current = true
+
+    React.useEffect(() => {
+      if (robotName.current) {
+        dispatch(setRobotUpdateSeen(robotName.current))
+      }
+    }, [robotName])
+
+    const ignoreUpdate = React.useCallback(() => {
+      if (robotName.current) {
+        dispatch(robotUpdateIgnored(robotName.current))
+      }
+      modal.remove()
+    }, [robotName, close])
+
+    if (hasSeenSessionOnce.current)
+      return (
+        <RobotUpdateProgressModal
+          robotName={robotName.current}
+          session={session}
+          closeUpdateBuildroot={modal.remove}
+        />
+      )
+    else if (robot != null && robot.status !== UNREACHABLE)
+      return (
+        <ViewUpdateModal
+          robotName={robotName.current}
+          robot={robot}
+          closeModal={ignoreUpdate}
+        />
+      )
+    else return null
+  }
+)

--- a/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -20,7 +20,7 @@ import { ChooseProtocolSlideout } from '../../ChooseProtocolSlideout'
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { RobotOverviewOverflowMenu } from '../RobotOverviewOverflowMenu'
 import { useIsRobotBusy } from '../hooks'
-import { UpdateBuildroot } from '../RobotSettings/UpdateBuildroot'
+import { handleUpdateBuildroot } from '../RobotSettings/UpdateBuildroot'
 
 import type { State } from '../../../redux/types'
 
@@ -49,8 +49,8 @@ const mockRestartRobot = restartRobot as jest.MockedFunction<
 const mockUseIsRobotBusy = useIsRobotBusy as jest.MockedFunction<
   typeof useIsRobotBusy
 >
-const mockUpdateBuildroot = UpdateBuildroot as jest.MockedFunction<
-  typeof UpdateBuildroot
+const mockUpdateBuildroot = handleUpdateBuildroot as jest.MockedFunction<
+  typeof handleUpdateBuildroot
 >
 const mockChooseProtocolSlideout = ChooseProtocolSlideout as jest.MockedFunction<
   typeof ChooseProtocolSlideout
@@ -90,7 +90,7 @@ describe('RobotOverviewOverflowMenu', () => {
       })
     when(mockUseCurrentRunId).calledWith().mockReturnValue(null)
     when(mockUseIsRobotBusy).calledWith().mockReturnValue(false)
-    when(mockUpdateBuildroot).mockReturnValue(<div>mock update buildroot</div>)
+    when(mockUpdateBuildroot).mockReturnValue()
     when(mockChooseProtocolSlideout).mockReturnValue(
       <div>choose protocol slideout</div>
     )
@@ -137,7 +137,7 @@ describe('RobotOverviewOverflowMenu', () => {
         updateFromFileDisabledReason: null,
       })
 
-    const { getByRole, getByText } = render(props)
+    const { getByRole } = render(props)
 
     const btn = getByRole('button')
     fireEvent.click(btn)
@@ -158,7 +158,7 @@ describe('RobotOverviewOverflowMenu', () => {
     expect(homeBtn).toBeEnabled()
     expect(settingsBtn).toBeEnabled()
     fireEvent.click(updateRobotSoftwareBtn)
-    getByText('mock update buildroot')
+    expect(mockUpdateBuildroot).toHaveBeenCalled()
   })
 
   it('should render disabled run a protocol, restart, disconnect, and home gantry menu items when robot is busy', () => {

--- a/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
+++ b/app/src/organisms/UpdateRobotBanner/__tests__/UpdateRobotBanner.test.tsx
@@ -7,7 +7,7 @@ import {
   mockConnectableRobot,
   mockReachableRobot,
 } from '../../../redux/discovery/__fixtures__'
-import { UpdateBuildroot } from '../../Devices/RobotSettings/UpdateBuildroot'
+import { handleUpdateBuildroot } from '../../Devices/RobotSettings/UpdateBuildroot'
 import { UpdateRobotBanner } from '..'
 
 jest.mock('../../../redux/robot-update')
@@ -16,8 +16,8 @@ jest.mock('../../Devices/RobotSettings/UpdateBuildroot')
 const getRobotUpdateDisplayInfo = Buildroot.getRobotUpdateDisplayInfo as jest.MockedFunction<
   typeof Buildroot.getRobotUpdateDisplayInfo
 >
-const mockUpdateBuildroot = UpdateBuildroot as jest.MockedFunction<
-  typeof UpdateBuildroot
+const mockUpdateBuildroot = handleUpdateBuildroot as jest.MockedFunction<
+  typeof handleUpdateBuildroot
 >
 const render = (props: React.ComponentProps<typeof UpdateRobotBanner>) => {
   return renderWithProviders(<UpdateRobotBanner {...props} />, {
@@ -32,7 +32,6 @@ describe('UpdateRobotBanner', () => {
     props = {
       robot: mockConnectableRobot,
     }
-    mockUpdateBuildroot.mockReturnValue(<div>mockUpdateBuildroot</div>)
     getRobotUpdateDisplayInfo.mockReturnValue({
       autoUpdateAction: 'upgrade',
       autoUpdateDisabledReason: null,
@@ -51,7 +50,7 @@ describe('UpdateRobotBanner', () => {
     )
     const btn = getByRole('button', { name: 'View update' })
     fireEvent.click(btn)
-    getByText('mockUpdateBuildroot')
+    expect(mockUpdateBuildroot).toHaveBeenCalled()
   })
 
   it('should render nothing if update is not available when autoUpdateAction returns reinstall', () => {

--- a/app/src/organisms/UpdateRobotBanner/index.tsx
+++ b/app/src/organisms/UpdateRobotBanner/index.tsx
@@ -11,7 +11,7 @@ import {
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
-import { UpdateBuildroot } from '../Devices/RobotSettings/UpdateBuildroot'
+import { handleUpdateBuildroot } from '../Devices/RobotSettings/UpdateBuildroot'
 
 import type { StyleProps } from '@opentrons/components'
 import type { State } from '../../redux/types'
@@ -30,16 +30,6 @@ export function UpdateRobotBanner(
   const { autoUpdateAction } = useSelector((state: State) => {
     return getRobotUpdateDisplayInfo(state, robot?.name)
   })
-  const [
-    showSoftwareUpdateModal,
-    setShowSoftwareUpdateModal,
-  ] = React.useState<boolean>(false)
-
-  const handleLaunchModal: React.MouseEventHandler = e => {
-    e.preventDefault()
-    e.stopPropagation()
-    setShowSoftwareUpdateModal(true)
-  }
 
   return (autoUpdateAction === 'upgrade' || autoUpdateAction === 'downgrade') &&
     robot !== null &&
@@ -50,19 +40,13 @@ export function UpdateRobotBanner(
           {t('robot_software_update_required')}
         </StyledText>
         <Btn
-          onClick={handleLaunchModal}
+          onClick={() => handleUpdateBuildroot(robot)}
           css={TYPOGRAPHY.pRegular}
           textDecoration={TYPOGRAPHY.textDecorationUnderline}
         >
           {t('view_update')}
         </Btn>
       </Banner>
-      {showSoftwareUpdateModal ? (
-        <UpdateBuildroot
-          robot={robot}
-          close={() => setShowSoftwareUpdateModal(false)}
-        />
-      ) : null}
     </Flex>
   ) : null
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,6 +1425,11 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@ebay/nice-modal-react@^1.2.13":
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/@ebay/nice-modal-react/-/nice-modal-react-1.2.13.tgz#7e8229fe3a48a11f27cd7f5e21190d82d6f609ce"
+  integrity sha512-jx8xIWe/Up4tpNuM02M+rbnLoxdngTGk3Y8LjJsLGXXcSoKd/+eZStZcAlIO/jwxyz/bhPZnpqPJZWAmhOofuA==
+
 "@electron/asar@^3.2.1":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.2.2.tgz#f6ae4eb4343ad00b994c40db3f09f71f968ff9c0"


### PR DESCRIPTION
Closes RAUT-571, RAUT-769

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds the nice-modal-react library to create a top-level modal manager and refactors UpdateBuildroot to utilize the new modal manager. This enables the robot update flow to persist throughout the entire update process - no longer will UpdateBuildroot abruptly close during robot restart. 

See RAUT-571, the nice-modal-react library's Motivation section, and recent slack conversations addressing the need for a top level modal solution (and why nice-modal-react is a good choice). In short - decoupling modal rendering from conditions that control the rendering of ancestor components makes controlling modal rendering much simpler and helps future-proof modal development. NMR is a lightweight and zero-dependency solution.

### UpdateBuildroot persisting through robot restart
<img width="1024" alt="persistent update" src="https://github.com/Opentrons/opentrons/assets/64858653/38b1343d-736f-4014-a33d-1fbfe87037db">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Build this branch (make -C app-shell package). The signature validation warning is ok to ignore. 
- If necessary, downgrade a robot via zip-file.
- Update the robot to the latest version through the update banner that appears on DevicesLanding.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added the nice-modal-react library.
- Refactored UpdateBuildroot to the top-level modal manager.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Test on a physical robot, please!
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
