### PR TITLE
feat(api): add resetAuthorizedKeys option for the OT-2

### DIFF
--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -49,6 +49,7 @@ _OT_2_RESET_OPTIONS = [
     ResetOptionId.pipette_offset,
     ResetOptionId.tip_length_calibrations,
     ResetOptionId.runs_history,
+    ResetOptionId.authorized_keys,
 ]
 _FLEX_RESET_OPTIONS = [
     ResetOptionId.boot_scripts,

--- a/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
+++ b/robot-server/tests/integration/test_settings_reset_options.tavern.yaml
@@ -27,6 +27,10 @@ stages:
           - id: runsHistory
             name: Clear Runs History
             description: !re_search 'Erase this device''s stored history of protocols and runs.'
+          - id: authorizedKeys
+            name: SSH Authorized Keys
+            description: !re_search 'Clear the ssh authorized keys'
+
 ---
 test_name: POST Reset bootScripts option
 marks:
@@ -122,6 +126,32 @@ stages:
       json:
         message: "gripperOffsetCalibrations is not a valid reset option."
         errorCode: "4000"
+---
+test_name: POST Reset authorizedKeys option
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+stages:
+  - name: POST Reset authorizedKeys true
+    request:
+      url: '{ot2_server_base_url}/settings/reset'
+      method: POST
+      json:
+        authorizedKeys: true
+    response:
+      status_code: 200
+      json:
+        message: "Options 'authorized_keys' were reset"
+  - name: POST Reset authorizedKeys false
+    request:
+      url: '{ot2_server_base_url}/settings/reset'
+      method: POST
+      json:
+        authorizedKeys: false
+    response:
+      status_code: 200
+      json:
+        message: 'Nothing to do'
 ---
 test_name: POST Reset non existant option
 marks:

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -437,6 +437,7 @@ def test_available_resets(api_client):
             "bootScripts",
             "tipLengthCalibrations",
             "runsHistory",
+            "authorizedKeys",
         ]
     ) == sorted([item["id"] for item in options_list])
 
@@ -474,6 +475,7 @@ def mock_persistence_resetter(
                 "pipetteOffsetCalibrations": False,
                 "tipLengthCalibrations": False,
                 "runsHistory": False,
+                "authorizedKeys": False,
             },
             set(),
         ],
@@ -485,6 +487,7 @@ def mock_persistence_resetter(
                 "tipLengthCalibrations": True,
                 "deckCalibration": True,
                 "runsHistory": True,
+                "authorizedKeys": True,
                 # TODO(mm, 2023-08-04): Figure out how to test Flex-only options,
                 # then add gripperOffsetCalibrations and onDeviceDisplay.
             },
@@ -498,8 +501,10 @@ def mock_persistence_resetter(
                 # mark_directory_reset() being an async method, and api_client having
                 # its own event loop that interferes with making this test async.
                 ResetOptionId.runs_history,
+                ResetOptionId.authorized_keys,
             },
         ],
+        [{"authorizedKeys": True}, {ResetOptionId.authorized_keys}],
         [{"bootScripts": True}, {ResetOptionId.boot_scripts}],
         [{"pipetteOffsetCalibrations": True}, {ResetOptionId.pipette_offset}],
         [{"tipLengthCalibrations": True}, {ResetOptionId.tip_length_calibrations}],


### PR DESCRIPTION
# Overview

We want to be able to reset the authorized_keys file for the OT-2 as well, so let's add the option to do so.

# Test Plan

- [x] Make sure that we can't ssh into an OT-2 after hitting the `/settings/reset` endpoint with the `AuthorizedKeys` option


# Changelog

- add `AuthorizedKeys` option to list of resettable options for the OT-2

# Review requests

# Risk assessment
