### PR TITLE
feat(shared-data): add custom & default thermocycler overlap offsets …

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -560,10 +560,25 @@ class LabwareView(HasState[LabwareState]):
         """Get the labware's overlap with requested module model."""
         definition = self.get_definition(labware_id)
         stacking_overlap = definition.stackingOffsetWithModule.get(
-            str(module_model.value), OverlapOffset(x=0, y=0, z=0)
+            str(module_model.value)
         )
+        if not stacking_overlap:
+            if self._is_thermocycler_on_ot2(module_model):
+                return OverlapOffset(x=0, y=0, z=10.7)
+            else:
+                return OverlapOffset(x=0, y=0, z=0)
+
         return OverlapOffset(
             x=stacking_overlap.x, y=stacking_overlap.y, z=stacking_overlap.z
+        )
+
+    def _is_thermocycler_on_ot2(self, module_model: ModuleModel) -> bool:
+        """Whether the given module is a thermocycler with the current deck being an OT2 deck."""
+        robot_model = self.get_deck_definition()["robot"]["model"]
+        return (
+            module_model
+            in [ModuleModel.THERMOCYCLER_MODULE_V1, ModuleModel.THERMOCYCLER_MODULE_V2]
+            and robot_model == "OT-2 Standard"
         )
 
     def get_default_magnet_height(self, module_id: str, offset: float) -> float:

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -2415,6 +2415,13 @@
       "stackingOffsetWithLabware": {
         "opentrons_96_pcr_adapter": { "x": 0, "y": 0, "z": 10.2 },
         "opentrons_96_well_aluminum_block": { "x": 0, "y": 0, "z": 12.66 }
+      },
+      "stackingOffsetWithModule": {
+        "thermocyclerModuleV2": {
+          "x": 0,
+          "y": 0,
+          "z": 10.8
+        }
       }
     },
     "opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1": {

--- a/shared-data/labware/definitions/2/biorad_96_wellplate_200ul_pcr/2.json
+++ b/shared-data/labware/definitions/2/biorad_96_wellplate_200ul_pcr/2.json
@@ -1025,5 +1025,12 @@
       "y": 0,
       "z": 15.41
     }
+  },
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 10.75
+    }
   }
 }

--- a/shared-data/labware/definitions/2/nest_96_wellplate_100ul_pcr_full_skirt/2.json
+++ b/shared-data/labware/definitions/2/nest_96_wellplate_100ul_pcr_full_skirt/2.json
@@ -1028,5 +1028,12 @@
       "y": 0,
       "z": 12.66
     }
+  },
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 10.8
+    }
   }
 }


### PR DESCRIPTION
…for labware (#13630)

* added TC overlaps for nest & biorad pcr plates
* added a backwards-compatible default overlap for TC labware on OT2
* fix pd e2e migration fixture ---------

# Overview

cherry picked this pr: https://github.com/Opentrons/opentrons/pull/13630 to add to PD 7.0.0 release

# Test Plan

[TC testing Flex.json](https://github.com/Opentrons/opentrons/files/12858407/TC.testing.Flex.json)
[testing TC OT-2.json](https://github.com/Opentrons/opentrons/files/12858408/testing.TC.OT-2.json)
[custom_labware_96_wells.json](https://github.com/Opentrons/opentrons/files/12858411/custom_labware_96_wells.json)

See protocols + custom labware attached to this PR and please test on `chore_release-7.0.1`, the cherry-picked commit isn't in an alpha yet so just make sure you're up to date with that branch.

**This test plan is copied over from the cherry picked PR**:
The protocols place a nest PCR plate, a biorad plate and a custom pcr plate on the thermocycler one ofter the other to check for location precision.

Upload Flex protocol and check that:

- when you run LPC, the pipette moves to accurate z-positions for the NEST and Biorad plates, and moves too high for the custom pcr plate

Upload OT-2 protocol and check that:

- when you run LPC, the pipette moves to accurate z-positions for the NEST and Biorad plates, and an okay position for custom pcr plate. Also note that positional accuracy of the OT2 for labware on modules is not as high as the Flex so I wouldn't stress too much if there is an offset of a couple of mm.

# Changelog

# Review requests

# Risk assessment

low, already has been tested on the release branch
