### PR TITLE
fix(app) fix robotName spacing issue in RobotStatusHeader

### DIFF
--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -138,7 +138,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
 
   const RobotNameContainer = styled.div`
     max-width: ${(props: RobotNameContainerProps) =>
-      props.isGoToRun ? `149px` : undefined};
+      props.isGoToRun ? `150px` : undefined};
     @media screen and (max-width: 678px) {
       max-width: ${(props: RobotNameContainerProps) =>
         props.isGoToRun ? `105px` : undefined};

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import { Link, useHistory } from 'react-router-dom'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
@@ -19,7 +19,6 @@ import {
   SPACING,
   TYPOGRAPHY,
   truncateString,
-  DIRECTION_ROW,
 } from '@opentrons/components'
 
 import { QuaternaryButton } from '../../atoms/buttons'

--- a/app/src/organisms/Devices/RobotStatusHeader.tsx
+++ b/app/src/organisms/Devices/RobotStatusHeader.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import { Link, useHistory } from 'react-router-dom'
+import styled, { css } from 'styled-components'
 
 import { useProtocolQuery, useRunQuery } from '@opentrons/react-api-client'
 import { RUN_STATUS_IDLE } from '@opentrons/api-client'
@@ -18,6 +19,7 @@ import {
   SPACING,
   TYPOGRAPHY,
   truncateString,
+  DIRECTION_ROW,
 } from '@opentrons/components'
 
 import { QuaternaryButton } from '../../atoms/buttons'
@@ -43,6 +45,10 @@ type RobotStatusHeaderProps = StyleProps &
   }
 
 const STATUS_REFRESH_MS = 5000
+
+interface RobotNameContainerProps {
+  isGoToRun: boolean
+}
 
 export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
   const { name, local, robotModel, ...styleProps } = props
@@ -75,7 +81,7 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
           paddingRight={SPACING.spacing8}
           overflowWrap="anywhere"
         >
-          {`${truncateString(displayName, 80, 65)}; ${i18n.format(
+          {`${truncateString(displayName, 68)}; ${i18n.format(
             t(`run_details:status_${currentRunStatus}`),
             'lowerCase'
           )}`}
@@ -131,6 +137,18 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
 
   useInterval(() => dispatch(fetchStatus(name)), STATUS_REFRESH_MS, true)
 
+  const RobotNameContainer = styled.div`
+    max-width: ${(props: RobotNameContainerProps) =>
+      props.isGoToRun ? `149px` : undefined};
+    @media screen and (max-width: 678px) {
+      max-width: ${(props: RobotNameContainerProps) =>
+        props.isGoToRun ? `105px` : undefined};
+    }
+  `
+
+  const isGoToRun =
+    currentRunId != null && currentRunStatus != null && displayName != null
+
   return (
     <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} {...styleProps}>
       <Flex flexDirection={DIRECTION_COLUMN}>
@@ -146,13 +164,16 @@ export function RobotStatusHeader(props: RobotStatusHeaderProps): JSX.Element {
         </StyledText>
         <Flex alignItems={ALIGN_CENTER}>
           <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-            <StyledText
-              as="h3"
-              id={`RobotStatusHeader_${String(name)}_robotName`}
-              overflowWrap="anywhere"
-            >
-              {name}
-            </StyledText>
+            <RobotNameContainer isGoToRun={isGoToRun}>
+              <StyledText
+                as="h3"
+                id={`RobotStatusHeader_${String(name)}_robotName`}
+                overflow="hidden"
+                textOverflow="ellipsis"
+              >
+                {name}
+              </StyledText>
+            </RobotNameContainer>
             {iconName != null ? (
               <Btn
                 {...targetProps}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fix [this issue](https://opentrons.slack.com/archives/CSCLVUW3C/p1696620573224269).
Had a conversation on protocolName with Mel then we decided that we will fix protocolName part in the future.
I think after updating Electron version, we can use container query and that allows us to make RobotCard more flexible.

This PRs add the following rule.

When the card shows `Go to Run`
windows size less than 678px -> name space 105px (if the name is longer than the space, display ....)
otherwise use 150px  (if the name is longer than the space, display ....)

When no `Go to Run`
Display the name without using `...`

design
https://www.figma.com/file/l7BAJAGICr10ELsSqQD0Sr/Desktop-App-Component-Library?type=design&node-id=220-8246&mode=design&t=MrjSqY9f0J0zX7Qq-0

In the design, Mel mentioned to a specific length but we cannot do this right now since we decided to use css only to control the layout.

without Go to Run
![Screenshot 2023-10-10 at 4 06 31 PM](https://github.com/Opentrons/opentrons/assets/474225/2c73808f-996a-433d-924c-e303dbb66214)


with Go to Run
![Screenshot 2023-10-10 at 4 06 48 PM](https://github.com/Opentrons/opentrons/assets/474225/77b55705-5e69-4897-b972-a1f21d235a2d)



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Device landing page
2. Set up a protocol
3. Back to Device landing page
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
