### PR TITLE
fix(api): Addition of catch for missing argument for feature flag test

### DIFF
--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -32,6 +32,7 @@ try:
 except (OSError, ModuleNotFoundError):
     aionotify = None
 
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 from opentrons_shared_data.protocol.dev_types import JsonProtocol
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
@@ -104,9 +105,15 @@ def is_robot(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     for name, func in inspect.getmembers(config.feature_flags, inspect.isfunction):
-        mock_get_ff = decoy.mock(func=func)
-        decoy.when(mock_get_ff()).then_return(False)
-        monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
+        params = inspect.getfullargspec(func)
+        if any("robot_type" in p for p in params.args):
+            mock_get_ff = decoy.mock(func=func)
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+            monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
+        else:
+            mock_get_ff = decoy.mock(func=func)
+            decoy.when(mock_get_ff()).then_return(False)
+            monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
 
 
 @pytest.fixture

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -106,14 +106,12 @@ def is_robot(monkeypatch: pytest.MonkeyPatch) -> None:
 def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
     for name, func in inspect.getmembers(config.feature_flags, inspect.isfunction):
         params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
         if any("robot_type" in p for p in params.args):
-            mock_get_ff = decoy.mock(func=func)
             decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
-            monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
         else:
-            mock_get_ff = decoy.mock(func=func)
             decoy.when(mock_get_ff()).then_return(False)
-            monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
+        monkeypatch.setattr(config.feature_flags, name, mock_get_ff)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview
When door safety check under feature flags was updated to receive RobotTypeEnum as a parameter, the decoy test that called it was never updated to account for this. This caused it to raise the following warning:
```
.../opentrons/api/tests/opentrons/conftest.py:108: IncorrectCallWarning: missing a required argument: 'robot_type'
    decoy.when(mock_get_ff()).then_return(False)
```
With the addition of a parameter check case, we will handle these tests correctly now. Also, in the future if we add the RobotTypeEnum parameter to any of the other feature flags in the future, this should catch those cases as well so long as they use the "robot_type" parameter naming convention. 
