### PR TITLE
fix(app): keep run controls enabled if run is idle

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -61,7 +61,7 @@ export function InstrumentsAndModules({
   )?.data ?? { left: undefined, right: undefined }
   const isRobotViewable = useIsRobotViewable(robotName)
   const currentRunId = useCurrentRunId()
-  const { isRunTerminal } = useRunStatuses()
+  const { isRunTerminal, isRunRunning } = useRunStatuses()
   const isOT3 = useIsOT3(robotName)
   const [
     subsystemToUpdate,
@@ -214,7 +214,7 @@ export function InstrumentsAndModules({
                 pipetteIs96Channel={is96ChannelAttached}
                 pipetteIsBad={badLeftPipette != null}
                 updatePipette={() => setSubsystemToUpdate('pipette_left')}
-                isRunActive={currentRunId != null && !isRunTerminal}
+                isRunActive={currentRunId != null && isRunRunning}
               />
               {isOT3 && (
                 <GripperCard
@@ -225,7 +225,7 @@ export function InstrumentsAndModules({
                       null
                   }
                   setSubsystemToUpdate={setSubsystemToUpdate}
-                  isRunActive={currentRunId != null && !isRunTerminal}
+                  isRunActive={currentRunId != null && isRunRunning}
                 />
               )}
               {leftColumnModules.map((module, index) => (
@@ -266,7 +266,7 @@ export function InstrumentsAndModules({
                   pipetteIs96Channel={false}
                   pipetteIsBad={badRightPipette != null}
                   updatePipette={() => setSubsystemToUpdate('pipette_right')}
-                  isRunActive={currentRunId != null && !isRunTerminal}
+                  isRunActive={currentRunId != null && isRunRunning}
                 />
               )}
               {rightColumnModules.map((module, index) => (


### PR DESCRIPTION
fix RQA-1784

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Pipette card controls should remain accessible until the run is running.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. On an OT-2, proceed to run setup
2. Navigate back to the Devices page
3. Look at the overflow menu and see controls enabled
4. Start the run
5. See that the controls are now disabled
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Use `isRunRunning` instead of `!isRunTerminal` to determine whether to disable the pipette overflow menu controls
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test this out
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
