### PR TITLE
docs(api): Change "OT-2" to "Opentrons robots" in opentrons_simulate help text

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -925,7 +925,8 @@ def _clear_live_protocol_engine_contexts() -> None:
 def main() -> int:
     """Run the simulation"""
     parser = argparse.ArgumentParser(
-        prog="opentrons_simulate", description="Simulate an OT-2 protocol"
+        prog="opentrons_simulate",
+        description="Simulate a protocol for an Opentrons robot",
     )
     parser = get_arguments(parser)
 


### PR DESCRIPTION
# Overview

Another good catch from @CaseyBatten.

`opentrons_simulate --help` said it would simulate "an OT-2 protocol." It should say it'll simulate "a protocol for an Opentrons robot" instead, to account for the Flex.

# Test Plan

None needed.

# Risk assessment

Very low.
