### PR TITLE
fix(api): cancellation bug on legacy core api

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -509,13 +509,22 @@ class API(
         robot. After this call, no further recovery is necessary.
         """
         await self._backend.halt()  # calls smoothie_driver.kill()
-        await self._execution_manager.cancel()
+        await self.cancel_execution_and_running_tasks()
         self._log.info("Recovering from halt")
         await self.reset()
         await self.cache_instruments()
 
         if home_after:
             await self.home()
+
+    def is_movement_execution_taskified(self) -> bool:
+        return self.taskify_movement_execution
+
+    def should_taskify_movement_execution(self, taskify: bool) -> None:
+        self.taskify_movement_execution = taskify
+
+    async def cancel_execution_and_running_tasks(self) -> None:
+        await self._execution_manager.cancel()
 
     async def reset(self) -> None:
         """Reset the stored state of the system."""

--- a/api/src/opentrons/hardware_control/execution_manager.py
+++ b/api/src/opentrons/hardware_control/execution_manager.py
@@ -135,6 +135,10 @@ class ExecutionManagerProvider:
             if not inst._em_simulate:
                 await inst.execution_manager.wait_for_is_running()
             if inst.taskify_movement_execution:
+                # Running these functions inside cancellable tasks makes it easier and
+                # faster to cancel protocol runs. In the higher, runner & engine layers,
+                # a cancellation request triggers cancellation of the running move task
+                # and hence, prevents any further communication with hardware.
                 decorated_task: "asyncio.Task[DecoratedReturn]" = asyncio.create_task(
                     decorated(inst, *args, **kwargs)
                 )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -732,12 +732,17 @@ class OT3API(
 
         asyncio.run_coroutine_threadsafe(_chained_calls(), self._loop)
 
+    def is_movement_execution_taskified(self) -> bool:
+        return self.taskify_movement_execution
+
+    def should_taskify_movement_execution(self, taskify: bool) -> None:
+        self.taskify_movement_execution = taskify
+
     async def _stop_motors(self) -> None:
         """Immediately stop motors."""
         await self._backend.halt()
 
-    async def _cancel_execution_and_running_tasks(self) -> None:
-        """Cancel execution manager and all running (hardware module) tasks."""
+    async def cancel_execution_and_running_tasks(self) -> None:
         await self._execution_manager.cancel()
 
     async def halt(self, disengage_before_stopping: bool = False) -> None:
@@ -751,7 +756,7 @@ class OT3API(
     async def stop(self, home_after: bool = True) -> None:
         """Stop motion as soon as possible, reset, and optionally home."""
         await self._stop_motors()
-        await self._cancel_execution_and_running_tasks()
+        await self.cancel_execution_and_running_tasks()
         self._log.info("Resetting OT3API")
         await self.reset()
         if home_after:

--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -215,11 +215,11 @@ class MotionController(Protocol):
         ...
 
     def is_movement_execution_taskified(self) -> bool:
-        """Get whether move tasks are being executed inside cancellable tasks."""
+        """Get whether move functions are being executed inside cancellable tasks."""
         ...
 
     def should_taskify_movement_execution(self, taskify: bool) -> None:
-        """Specify whether move methods should be executed inside cancellable tasks."""
+        """Specify whether move functions should be executed inside cancellable tasks."""
         ...
 
     async def cancel_execution_and_running_tasks(self) -> None:

--- a/api/src/opentrons/hardware_control/protocols/motion_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/motion_controller.py
@@ -213,3 +213,15 @@ class MotionController(Protocol):
     async def retract_axis(self, axis: Axis) -> None:
         """Retract the specified axis to its home position."""
         ...
+
+    def is_movement_execution_taskified(self) -> bool:
+        """Get whether move tasks are being executed inside cancellable tasks."""
+        ...
+
+    def should_taskify_movement_execution(self, taskify: bool) -> None:
+        """Specify whether move methods should be executed inside cancellable tasks."""
+        ...
+
+    async def cancel_execution_and_running_tasks(self) -> None:
+        """Cancel all tasks and set execution manager state to Cancelled."""
+        ...

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -325,6 +325,13 @@ class ProtocolEngine:
         self._action_dispatcher.dispatch(action)
         self._queue_worker.cancel()
         if self._hardware_api.is_movement_execution_taskified():
+            # We 'taskify' hardware controller movement functions when running protocols
+            # that are not backed by the engine. Such runs cannot be stopped by cancelling
+            # the queue worker and hence need to be stopped via the execution manager.
+            # `cancel_execution_and_running_tasks()` sets the execution manager in a CANCELLED state
+            # and cancels the running tasks, which raises an error and gets us out of the
+            # run function execution, just like `_queue_worker.cancel()` does for
+            # engine-backed runs.
             await self._hardware_api.cancel_execution_and_running_tasks()
 
     async def wait_until_complete(self) -> None:

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -324,6 +324,8 @@ class ProtocolEngine:
         action = self._state_store.commands.validate_action_allowed(StopAction())
         self._action_dispatcher.dispatch(action)
         self._queue_worker.cancel()
+        if self._hardware_api.is_movement_execution_taskified():
+            await self._hardware_api.cancel_execution_and_running_tasks()
 
     async def wait_until_complete(self) -> None:
         """Wait until there are no more commands to execute.
@@ -412,7 +414,6 @@ class ProtocolEngine:
         # order will be backwards because the stack is first-in-last-out.
         exit_stack = AsyncExitStack()
         exit_stack.push_async_callback(self._plugin_starter.stop)  # Last step.
-
         exit_stack.push_async_callback(
             # Cleanup after hardware halt and reset the hardware controller
             self._hardware_stopper.do_stop_and_recover,
@@ -432,7 +433,6 @@ class ProtocolEngine:
             disengage_before_stopping=disengage_before_stopping,
         )
         exit_stack.push_async_callback(self._queue_worker.join)  # First step.
-
         try:
             # If any teardown steps failed, this will raise something.
             await exit_stack.aclose()

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -142,10 +142,12 @@ class PythonAndLegacyRunner(AbstractRunner):
         if protocol.api_level < LEGACY_PYTHON_API_VERSION_CUTOFF:
             broker = LegacyBroker()
             equipment_broker = Broker[LegacyLoadInfo]()
-
             self._protocol_engine.add_plugin(
                 LegacyContextPlugin(broker=broker, equipment_broker=equipment_broker)
             )
+            self._hardware_api.should_taskify_movement_execution(taskify=True)
+        else:
+            self._hardware_api.should_taskify_movement_execution(taskify=False)
 
         context = self._legacy_context_creator.create(
             protocol=protocol,
@@ -205,6 +207,7 @@ class JsonRunner(AbstractRunner):
         # TODO(mc, 2022-01-11): replace task queue with specific implementations
         # of runner interface
         self._task_queue = task_queue or TaskQueue(cleanup_func=protocol_engine.finish)
+        self._hardware_api.should_taskify_movement_execution(taskify=False)
 
     async def load(self, protocol_source: ProtocolSource) -> None:
         """Load a JSONv6+ ProtocolSource into managed ProtocolEngine."""
@@ -292,6 +295,7 @@ class LiveRunner(AbstractRunner):
         # of runner interface
         self._hardware_api = hardware_api
         self._task_queue = task_queue or TaskQueue(cleanup_func=protocol_engine.finish)
+        self._hardware_api.should_taskify_movement_execution(taskify=False)
 
     def prepare(self) -> None:
         """Set the task queue to wait until all commands are executed."""

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -670,7 +670,7 @@ async def test_stop(
     state_store: StateStore,
     subject: ProtocolEngine,
 ) -> None:
-    """It should be able to stop the engine and halt the hardware."""
+    """It should be able to stop the engine and run execution."""
     expected_action = StopAction()
 
     decoy.when(
@@ -682,6 +682,33 @@ async def test_stop(
     decoy.verify(
         action_dispatcher.dispatch(expected_action),
         queue_worker.cancel(),
+    )
+
+
+async def test_stop_for_legacy_core_protocols(
+    decoy: Decoy,
+    action_dispatcher: ActionDispatcher,
+    queue_worker: QueueWorker,
+    hardware_stopper: HardwareStopper,
+    hardware_api: HardwareControlAPI,
+    state_store: StateStore,
+    subject: ProtocolEngine,
+) -> None:
+    """It should be able to stop the engine & run execution and cancel movement tasks."""
+    expected_action = StopAction()
+
+    decoy.when(
+        state_store.commands.validate_action_allowed(expected_action),
+    ).then_return(expected_action)
+
+    decoy.when(hardware_api.is_movement_execution_taskified()).then_return(True)
+
+    await subject.stop()
+
+    decoy.verify(
+        action_dispatcher.dispatch(expected_action),
+        queue_worker.cancel(),
+        await hardware_api.cancel_execution_and_running_tasks(),
     )
 
 


### PR DESCRIPTION
Closes RQA-1553

# Overview

Fixes a bug that was causing protocols running on PAPI legacy core would freeze in 'stop-requested' state upon cancellation.

The issue was caused because #13339 readjusted the sequence of events that happen when cancelling a run such that it doesn't cause race conditions that were present before. But in that fix, we forgot that protocols running on legacy core are not controlled by the engine directly and hence need to be stopped differently- i.e., by invoking the hardware control's execution manager to cancel the execution.

This PR fixes this issue by doing 2 things-
1. makes the hardware controller run all blocking hardware access methods in cancellable tasks
2. calls `cancel()` on these tasks as soon as a `stop()` request comes in to the engine.

The combination of these two things makes the run cancel as soon as the running task is able to be cancelled, and calls the cleanup function (`engine.finish()`)

# Test Plan

1. Run any protocol on an OT-2 with API level <= 2.13 and cancel it mid-run
    - [x] verify that if a cancellation comes in mid-movement, the run cancels before the movement ends (can test with a slow-speed pipette movement)
    - [x] verify that if you cancel protocol with a tip on the pipette, then the protocol cancels and drops tips in fixed trash
    - [x] verify that if you cancel the protocol while it's on a non-api-based, `time.delay()`, the protocol ends after the delay is over
2. Run any protocol on an OT-2 & Flex with api level >= 2.14 and cancel it mid-run and verify that all the above still happen

# Changelog

- added 'taskification' of movement (& delay) functions of the hardware controller, inside the `wait_for_is_running` wrapper
- added option to taskify the functions based on the type of run
- call task cancellation from `engine.stop()` for runs with 'taskified' functions

# Review requests

Usual stuff. Make sure the PR's not causing any regression.

# Risk assessment

High for protocols running on legacy core API since it moves the behavior of core movement functions inside tasks. 
Shouldn't have any effect on engine-backed protocols.
