### PR TITLE
chore(api): Fix Sphinx language warning

### DIFF
--- a/api/docs/hardware/conf.py
+++ b/api/docs/hardware/conf.py
@@ -93,7 +93,7 @@ max_apiLevel = str(MAX_SUPPORTED_VERSION)
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/api/docs/v1/conf.py
+++ b/api/docs/v1/conf.py
@@ -85,7 +85,7 @@ release = _vers
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
# Overview

Fixes this warning when running `make docs`:

> WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).

# Test Plan

I've done this:

* [x] Run `make docs` and make sure the warning's gone away.
* [x] Spot-check the API docs (APIv1 and APIv2) and make sure they're not flagrantly broken.

# Risk assessment

Very low.
