### PR TITLE
docs(api): Remove "PAPIv2.14 unsupported" notes

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -14,9 +14,6 @@ Jupyter Notebook
 
 The OT-2 runs a `Jupyter Notebook <https://jupyter.org>`_ server on port 48888, which you can connect to with your web browser. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells and run a single cell at a time.
 
-.. note::
-    The Jupyter Notebook server only supports Python Protocol API versions 2.13 and earlier. Use the Opentrons App to run protocols that require functionality added in newer versions.
-
 Access the OT-2’s Jupyter Notebook by either:
 
 - Going to the **Advanced** tab of Robot Settings and clicking **Launch Jupyter Notebook**.
@@ -32,9 +29,10 @@ Jupyter Notebook is structured around `cells`: discrete chunks of code that can 
 Rather than writing a  ``run`` function and embedding commands within it, start your notebook by importing ``opentrons.execute`` and calling :py:meth:`opentrons.execute.get_protocol_api`. This function also replaces the ``metadata`` block of a standalone protocol by taking the minimum :ref:`API version <v2-versioning>` as its argument. Then you can call :py:class:`~opentrons.protocol_api.ProtocolContext` methods in subsequent lines or cells:
 
 .. code-block:: python
+    :substitutions:
 
     import opentrons.execute
-    protocol = opentrons.execute.get_protocol_api('2.13')
+    protocol = opentrons.execute.get_protocol_api('|apiLevel|')
     protocol.home()
 
 The first command you execute should always be :py:meth:`~opentrons.protocol_api.ProtocolContext.home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
@@ -57,8 +55,9 @@ You can also use Jupyter to run a protocol that you have already written. To do 
 Since a typical protocol only `defines` the ``run`` function but doesn't `call` it, this won't immediately cause the OT-2 to move. To begin the run, instantiate a :py:class:`.ProtocolContext` and pass it to the ``run`` function you just defined:
 
 .. code-block:: python
+    :substitutions:
 
-    protocol = opentrons.execute.get_protocol_api('2.13')
+    protocol = opentrons.execute.get_protocol_api('|apiLevel|')
     run(protocol)  # your protocol will now run
 
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -57,11 +57,6 @@ When choosing an API level, consider what features you need and how widely you p
 
 On the one hand, using the highest available version will give your protocol access to all the latest :ref:`features and fixes <version-notes>`. On the other hand, using the lowest possible version lets the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software. Specifying version 2.14 would limit the protocol to robots running 6.2.0 or higher.
 
-.. note::
-
-    Python protocols with an ``apiLevel`` of 2.14 or higher can't currently be simulated with the ``opentrons_simulate`` command-line tool, the :py:func:`opentrons.simulate.simulate` function, or the :py:func:`opentrons.simulate.get_protocol_api` function. If your protocol doesn't rely on new functionality added after version 2.13, use a lower ``apiLevel``. For protocols that require 2.14 or higher, analyze your protocol with the Opentrons App instead.
-
-
 Maximum Supported Versions
 ==========================
 


### PR DESCRIPTION
# Overview

docs.opentrons.com had some notes that PAPIv≥2.14 was unsupported by `opentrons_simulate`, `opentrons.simulate.simulate()`, and `opentrons.simulate.get_protocol_api()`. Now that #13709 is merged, it is, so we can remove those notes.

# Review requests

* docs.opentrons.com is deployed separately from the rest of the robot stack. Is it correct to merge this into `chore_release-7.0.1`, or should this go into `edge`?
* Any places that I missed?
* Do we want to wait until the v7.0.1 alpha is successfully QA'd to merge this, or is that excessively paranoid?

# Risk assessment

Very low.
