### PR TITLE
fix(app): use single source of truth for data in pipette settings slideout

### DIFF
--- a/api-client/src/pipettes/index.ts
+++ b/api-client/src/pipettes/index.ts
@@ -1,5 +1,6 @@
 export { getPipettes } from './getPipettes'
 export { getPipetteSettings } from './getPipetteSettings'
+export { updatePipetteSettings } from './updatePipetteSettings'
 
 export * from './types'
 export * from './__fixtures__'

--- a/api-client/src/pipettes/types.ts
+++ b/api-client/src/pipettes/types.ts
@@ -85,6 +85,7 @@ export interface PipetteSettingsUpdateFieldsMap {
 export type PipetteSettingsUpdateField = {
   value: PipetteSettingsField['value']
 } | null
+
 export interface UpdatePipetteSettingsData {
   fields: { [fieldId: string]: PipetteSettingsUpdateField }
 }

--- a/api-client/src/pipettes/types.ts
+++ b/api-client/src/pipettes/types.ts
@@ -51,8 +51,8 @@ export interface FetchPipettesResponseBody {
   right: FetchPipettesResponsePipette
 }
 
-interface PipetteSettingsField {
-  value: number | null | undefined
+export interface PipetteSettingsField {
+  value: number | null | boolean | undefined
   default: number
   min?: number
   max?: number
@@ -66,7 +66,7 @@ interface PipetteQuirksField {
 interface QuirksField {
   quirks?: PipetteQuirksField
 }
-type PipetteSettingsFieldsMap = QuirksField & {
+export type PipetteSettingsFieldsMap = QuirksField & {
   [fieldId: string]: PipetteSettingsField
 }
 export interface IndividualPipetteSettings {
@@ -77,3 +77,14 @@ export interface IndividualPipetteSettings {
 type PipetteSettingsById = Partial<{ [id: string]: IndividualPipetteSettings }>
 
 export type PipetteSettings = PipetteSettingsById
+
+export interface PipetteSettingsUpdateFieldsMap {
+  [fieldId: string]: PipetteSettingsUpdateField
+}
+
+export type PipetteSettingsUpdateField = {
+  value: PipetteSettingsField['value']
+} | null
+export interface UpdatePipetteSettingsData {
+  fields: { [fieldId: string]: PipetteSettingsUpdateField }
+}

--- a/api-client/src/pipettes/updatePipetteSettings.ts
+++ b/api-client/src/pipettes/updatePipetteSettings.ts
@@ -1,0 +1,21 @@
+import { PATCH, request } from '../request'
+
+import type { ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+import type {
+  IndividualPipetteSettings,
+  UpdatePipetteSettingsData,
+} from './types'
+
+export function updatePipetteSettings(
+  config: HostConfig,
+  pipetteId: string,
+  data: UpdatePipetteSettingsData
+): ResponsePromise<IndividualPipetteSettings> {
+  return request<IndividualPipetteSettings, UpdatePipetteSettingsData>(
+    PATCH,
+    `/settings/pipettes/${pipetteId}`,
+    data,
+    config
+  )
+}

--- a/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
+++ b/app/src/organisms/ConfigurePipette/ConfigFormGroup.tsx
@@ -96,7 +96,7 @@ export function ConfigInput(props: ConfigInputProps): JSX.Element {
   const { field } = props
   const { name, units, displayName } = field
   const id = makeId(field.name)
-  const _default = field.default.toString()
+  const _default = field.default?.toString()
   return (
     <ConfigFormRow label={displayName} labelFor={id}>
       <Field name={name}>

--- a/app/src/organisms/ConfigurePipette/__tests__/ConfigurePipette.test.tsx
+++ b/app/src/organisms/ConfigurePipette/__tests__/ConfigurePipette.test.tsx
@@ -35,9 +35,10 @@ describe('ConfigurePipette', () => {
 
   beforeEach(() => {
     props = {
+      isUpdateLoading: false,
+      updateError: null,
       settings: mockPipetteSettingsFieldsMap,
       robotName: mockRobotName,
-      updateRequest: { status: 'pending' },
       updateSettings: jest.fn(),
       closeModal: jest.fn(),
       formId: 'id',

--- a/app/src/organisms/ConfigurePipette/index.tsx
+++ b/app/src/organisms/ConfigurePipette/index.tsx
@@ -2,27 +2,31 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Box } from '@opentrons/components'
 
-import { SUCCESS, FAILURE, PENDING } from '../../redux/robot-api'
 import { ConfigForm } from './ConfigForm'
 import { ConfigErrorBanner } from './ConfigErrorBanner'
-
 import type {
-  PipetteSettingsFieldsUpdate,
   PipetteSettingsFieldsMap,
-} from '../../redux/pipettes/types'
-import type { RequestState } from '../../redux/robot-api/types'
+  UpdatePipetteSettingsData,
+} from '@opentrons/api-client'
 
 interface Props {
   closeModal: () => void
-  updateRequest: RequestState | null
-  updateSettings: (fields: PipetteSettingsFieldsUpdate) => void
+  updateSettings: (params: UpdatePipetteSettingsData) => void
+  updateError: Error | null
+  isUpdateLoading: boolean
   robotName: string
   formId: string
   settings: PipetteSettingsFieldsMap
 }
 
 export function ConfigurePipette(props: Props): JSX.Element {
-  const { closeModal, updateRequest, updateSettings, formId, settings } = props
+  const {
+    updateSettings,
+    updateError,
+    isUpdateLoading,
+    formId,
+    settings,
+  } = props
   const { t } = useTranslation('device_details')
 
   const groupLabels = [
@@ -31,25 +35,14 @@ export function ConfigurePipette(props: Props): JSX.Element {
     t('power_force'),
   ]
 
-  const updateError: string | null =
-    updateRequest && updateRequest.status === FAILURE
-      ? // @ts-expect-error(sa, 2021-05-27): avoiding src code change, need to type narrow
-        updateRequest.error.message || t('an_error_occurred_while_updating')
-      : null
-
-  // when an in-progress request completes, close modal if response was ok
-  React.useEffect(() => {
-    if (updateRequest?.status === SUCCESS) {
-      closeModal()
-    }
-  }, [updateRequest, closeModal])
-
   return (
     <Box zIndex={1}>
-      {updateError && <ConfigErrorBanner message={updateError} />}
+      {updateError != null && (
+        <ConfigErrorBanner message={updateError.message} />
+      )}
       <ConfigForm
         settings={settings}
-        updateInProgress={updateRequest?.status === PENDING}
+        updateInProgress={isUpdateLoading}
         updateSettings={updateSettings}
         groupLabels={groupLabels}
         formId={formId}

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -18,10 +18,8 @@ import {
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
 import { Divider } from '../../../atoms/structure'
 
-import type {
-  Mount,
-  PipetteSettingsFieldsMap,
-} from '../../../redux/pipettes/types'
+import type { Mount } from '../../../redux/pipettes/types'
+import type { PipetteSettingsFieldsMap } from '@opentrons/api-client'
 
 interface PipetteOverflowMenuProps {
   pipetteSpecs: PipetteModelSpecs | null

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteSettingsSlideout.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteSettingsSlideout.test.tsx
@@ -3,10 +3,11 @@ import { resetAllWhenMocks, when } from 'jest-when'
 import { waitFor } from '@testing-library/dom'
 import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
+import {
+  useHost,
+  useUpdatePipetteSettingsMutation,
+} from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
-import * as RobotApi from '../../../../redux/robot-api'
-import { updatePipetteSettings } from '../../../../redux/pipettes'
-import { getConfig } from '../../../../redux/config'
 import { PipetteSettingsSlideout } from '../PipetteSettingsSlideout'
 
 import {
@@ -14,22 +15,11 @@ import {
   mockPipetteSettingsFieldsMap,
 } from '../../../../redux/pipettes/__fixtures__'
 
-import type { DispatchApiRequestType } from '../../../../redux/robot-api'
-import type { UpdatePipetteSettingsAction } from '../../../../redux/pipettes/types'
+jest.mock('@opentrons/react-api-client')
 
-jest.mock('../../../../redux/robot-api')
-jest.mock('../../../../redux/config')
-jest.mock('../../../../redux/pipettes')
-
-const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
-const mockUseDispatchApiRequest = RobotApi.useDispatchApiRequest as jest.MockedFunction<
-  typeof RobotApi.useDispatchApiRequest
->
-const mockGetRequestById = RobotApi.getRequestById as jest.MockedFunction<
-  typeof RobotApi.getRequestById
->
-const mockUpdatePipetteSettings = updatePipetteSettings as jest.MockedFunction<
-  typeof updatePipetteSettings
+const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
+const mockUseUpdatePipetteSettingsMutation = useUpdatePipetteSettingsMutation as jest.MockedFunction<
+  typeof useUpdatePipetteSettingsMutation
 >
 
 const render = (
@@ -43,9 +33,8 @@ const render = (
 const mockRobotName = 'mockRobotName'
 
 describe('PipetteSettingsSlideout', () => {
-  let dispatchApiRequest: DispatchApiRequestType
-
   let props: React.ComponentProps<typeof PipetteSettingsSlideout>
+  let mockUpdatePipetteSettings: jest.Mock
 
   beforeEach(() => {
     props = {
@@ -56,20 +45,19 @@ describe('PipetteSettingsSlideout', () => {
       isExpanded: true,
       onCloseClick: jest.fn(),
     }
-    mockGetRequestById.mockReturnValue({
-      status: RobotApi.SUCCESS,
-      response: {
-        method: 'POST',
-        ok: true,
-        path: '/',
-        status: 200,
-      },
-    })
-    mockGetConfig.mockReturnValue({} as any)
-    dispatchApiRequest = jest.fn()
-    when(mockUseDispatchApiRequest)
+    when(mockUseHost)
       .calledWith()
-      .mockReturnValue([dispatchApiRequest, ['id']])
+      .mockReturnValue({} as any)
+
+    mockUpdatePipetteSettings = jest.fn()
+
+    when(mockUseUpdatePipetteSettingsMutation)
+      .calledWith(props.pipetteId, expect.anything())
+      .mockReturnValue({
+        updatePipetteSettings: mockUpdatePipetteSettings,
+        isLoading: false,
+        error: null,
+      } as any)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -96,30 +84,20 @@ describe('PipetteSettingsSlideout', () => {
     const { getByRole } = render(props)
     const button = getByRole('button', { name: 'Confirm' })
 
-    when(mockUpdatePipetteSettings)
-      .calledWith(
-        mockRobotName,
-        props.pipetteId,
-        expect.objectContaining({
-          blowout: 2,
-          bottom: 3,
-          dropTip: 1,
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(mockUpdatePipetteSettings).toHaveBeenCalledWith({
+        fields: expect.objectContaining({
+          blowout: { value: 2 },
+          bottom: { value: 3 },
+          dropTip: { value: 1 },
           dropTipCurrent: null,
           dropTipSpeed: null,
           pickUpCurrent: null,
           pickUpDistance: null,
           plungerCurrent: null,
-          top: 4,
-        })
-      )
-      .mockReturnValue({
-        type: 'pipettes:UPDATE_PIPETTE_SETTINGS',
-      } as UpdatePipetteSettingsAction)
-
-    fireEvent.click(button)
-    await waitFor(() => {
-      expect(dispatchApiRequest).toHaveBeenCalledWith({
-        type: 'pipettes:UPDATE_PIPETTE_SETTINGS',
+          top: { value: 4 },
+        }),
       })
     })
   })

--- a/react-api-client/src/pipettes/index.ts
+++ b/react-api-client/src/pipettes/index.ts
@@ -1,2 +1,3 @@
 export { usePipettesQuery } from './usePipettesQuery'
 export { usePipetteSettingsQuery } from './usePipetteSettingsQuery'
+export { useUpdatePipetteSettingsMutation } from './useUpdatePipetteSettingsMutation'

--- a/react-api-client/src/pipettes/usePipetteSettingsQuery.ts
+++ b/react-api-client/src/pipettes/usePipetteSettingsQuery.ts
@@ -9,7 +9,7 @@ export function usePipetteSettingsQuery(
 ): UseQueryResult<PipetteSettings> {
   const host = useHost()
   const query = useQuery<PipetteSettings>(
-    [host, 'pipettesSettings'],
+    [host, 'pipettes', 'settings'],
     () =>
       getPipetteSettings(host as HostConfig).then(response => response.data),
     { enabled: host !== null, ...options }

--- a/react-api-client/src/pipettes/useUpdatePipetteSettingsMutation.ts
+++ b/react-api-client/src/pipettes/useUpdatePipetteSettingsMutation.ts
@@ -1,0 +1,73 @@
+import {
+  HostConfig,
+  IndividualPipetteSettings,
+  updatePipetteSettings,
+  UpdatePipetteSettingsData,
+} from '@opentrons/api-client'
+import {
+  useMutation,
+  useQueryClient,
+  UseMutateAsyncFunction,
+  UseMutationOptions,
+  UseMutationResult,
+} from 'react-query'
+import { useHost } from '../api'
+import type { AxiosError } from 'axios'
+
+export type UpdatePipetteSettingsType = UseMutateAsyncFunction<
+  IndividualPipetteSettings,
+  AxiosError,
+  UpdatePipetteSettingsData
+>
+
+export type UseUpdatePipetteSettingsMutationResult = UseMutationResult<
+  IndividualPipetteSettings,
+  AxiosError,
+  UpdatePipetteSettingsData
+> & {
+  updatePipetteSettings: UpdatePipetteSettingsType
+}
+
+export type UseUpdatePipetteSettingsOptions = UseMutationOptions<
+  IndividualPipetteSettings,
+  AxiosError,
+  UpdatePipetteSettingsData
+>
+
+export function useUpdatePipetteSettingsMutation(
+  pipetteId: string,
+  options: UseUpdatePipetteSettingsOptions = {},
+  hostOverride?: HostConfig | null
+): UseUpdatePipetteSettingsMutationResult {
+  const contextHost = useHost()
+  const queryClient = useQueryClient()
+  const host =
+    hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const mutation = useMutation<
+    IndividualPipetteSettings,
+    AxiosError,
+    UpdatePipetteSettingsData
+  >(
+    [host, 'pipettes', 'settings'],
+    ({ fields }) =>
+      updatePipetteSettings(host as HostConfig, pipetteId, { fields })
+        .then(response => {
+          queryClient
+            .invalidateQueries([host, 'pipettes', 'settings'])
+            .catch((e: Error) =>
+              console.error(
+                `error invalidating pipette settings query: ${e.message}`
+              )
+            )
+          return response.data
+        })
+        .catch(e => {
+          throw e
+        }),
+    options
+  )
+  return {
+    ...mutation,
+    updatePipetteSettings: mutation.mutateAsync,
+  }
+}


### PR DESCRIPTION
# Overview

This PR changes the pipette settings slideout to both read from react query and write from react query, which should slow down the time it takes for the server to reflect accurate pipette settings after a user changes them

closes RQA-1768


# Changelog

- use single source of truth for data in pipette settings slideout

# Review requests

- In the app go to the device details page of an OT-2 with 7.0.1 installed on it
- Open up the pipette settings slideout from the pipette card on the instruments page
- Change a config value, and make sure the updated value is reflected in the pipette settings slideout

# Risk assessment

Low/med