### PR TITLE
test(api): Fix miscalled stub warning in test_protocol_runner.py

### DIFF
--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -444,10 +444,11 @@ async def test_load_legacy_python(
             python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         )
     ).then_return(legacy_protocol)
+    broker_captor = matchers.Captor()
     decoy.when(
         legacy_context_creator.create(
             protocol=legacy_protocol,
-            broker=matchers.IsA(LegacyBroker),
+            broker=broker_captor,
             equipment_broker=matchers.IsA(Broker),
         )
     ).then_return(legacy_context)
@@ -469,6 +470,7 @@ async def test_load_legacy_python(
             context=legacy_context,
         ),
     )
+    assert broker_captor.value is legacy_python_runner_subject.broker
 
 
 async def test_load_python_with_pe_papi_core(
@@ -514,9 +516,10 @@ async def test_load_python_with_pe_papi_core(
             python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         )
     ).then_return(legacy_protocol)
+    broker_captor = matchers.Captor()
     decoy.when(
         legacy_context_creator.create(
-            protocol=legacy_protocol, broker=None, equipment_broker=None
+            protocol=legacy_protocol, broker=broker_captor, equipment_broker=None
         )
     ).then_return(legacy_context)
 
@@ -526,6 +529,7 @@ async def test_load_python_with_pe_papi_core(
     )
 
     decoy.verify(protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)), times=0)
+    assert broker_captor.value is legacy_python_runner_subject.broker
 
 
 async def test_load_legacy_json(


### PR DESCRIPTION
# Overview

In PR #13767, I accidentally introduced this warning:

```
tests/opentrons/protocol_runner/test_protocol_runner.py::test_load_python_with_pe_papi_core
  .../opentrons/api/.venv/lib/python3.7/site-packages/decoy/warning_checker.py:60: MiscalledStubWarning: Stub was called but no matching rehearsal found.
  Found 1 rehearsal:
  1.  LegacyContextCreator.create(PythonProtocol(text='', filename='protocol.py', api_level=APIVersion(major=2, minor=14), robot_type='OT-3 Standard', contents='', metadata={'foo': 'bar'}, bundled_labware=None, bundled_data=None, bundled_python=None, extra_labware=None), None, None)
  Found 1 call:
  1.  LegacyContextCreator.create(PythonProtocol(text='', filename='protocol.py', api_level=APIVersion(major=2, minor=14), robot_type='OT-3 Standard', contents='', metadata={'foo': 'bar'}, bundled_labware=None, bundled_data=None, bundled_python=None, extra_labware=None), <opentrons.legacy_broker.LegacyBroker object at 0x10f3f2108>, None)
    warn(MiscalledStubWarning(calls=unmatched, rehearsals=past_stubs))
```

This updates the forgotten tests to resolve the warning.

# Test Plan

I've done this:

* [x] Make sure the warning mentioned above goes away. Note that there are still other warnings, which this PR doesn't resolve.

# Changelog

* Use Decoy magic to test that `runner.load()` passes `runner.broker` to `legacy_context_creator.create()`.

# Review requests

* Is the new test readable? Does it make sense?

# Risk assessment

No risk. Tests only.
