### PR TITLE
feat(app): add disabled text when door closed in run page

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -16,6 +16,7 @@
   "clear_protocol_to_make_available": "Clear protocol from robot to make it available.",
   "clear_protocol": "Clear protocol",
   "close_door_to_resume": "Close robot door to resume run",
+  "close_door": "Close robot door",
   "closing_protocol": "Closing Protocol",
   "comment_step": "Comment",
   "comment": "Comment",

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -551,6 +551,8 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     disableReason = t('shared:robot_is_busy')
   } else if (isRobotOnWrongVersionOfSoftware) {
     disableReason = t('shared:a_software_update_is_available')
+  } else if (runStatus != null && DISABLED_STATUSES.includes(runStatus)) {
+    disableReason = t('close_door')
   }
 
   if (isProtocolAnalyzing) {


### PR DESCRIPTION
# Overview
This PR adds a tooltip to the run CTA when the door is open

closes RQA-1705


# Risk assessment

Low
