### PR TITLE
docs(api): Fix description of run log payload

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -328,9 +328,9 @@ def execute(  # noqa: C901
             'name': command_name,
             'payload': {
               'text': string_command_text,
-               # The rest of this struct is
-               # command-dependent; see
-               # opentrons.commands.commands.
+              # The rest of this struct is
+              # command-dependent; see
+              # opentrons.commands.commands.
              }
           }
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -338,7 +338,7 @@ def execute(  # noqa: C901
           In older software versions, ``payload["text"]`` was a
           `format string <https://docs.python.org/3/library/string.html#formatstrings>`_.
           To get human-readable text, you had to do ``payload["text"].format(**payload)``.
-          That usage is deprecated now. If ``payload["text"]`` happens to contain any
+          Don't do that anymore. If ``payload["text"]`` happens to contain any
           ``{`` or ``}`` characters, it can confuse ``.format()`` and cause it to raise a
           ``KeyError``.
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -316,11 +316,32 @@ def execute(  # noqa: C901
                       ``"debug"``, ``"info"``, ``"warning"``, or ``"error"``.
                       Defaults to ``"warning"``.
     :param emit_runlog: A callback for printing the runlog. If specified, this
-                        will be called whenever a command adds an entry to the
-                        runlog, which can be used for display and progress
-                        estimation. If specified, the callback should take a
-                        single argument (the name doesn't matter) which will
-                        be a dictionary (see below). Default: ``None``
+        will be called whenever a command adds an entry to the
+        runlog, which can be used for display and progress
+        estimation. If specified, the callback should take a
+        single argument (the name doesn't matter) which will
+        be a dictionary:
+
+        .. code-block:: python
+
+          {
+            'name': command_name,
+            'payload': {
+              'text': string_command_text,
+               # The rest of this struct is
+               # command-dependent; see
+               # opentrons.commands.commands.
+             }
+          }
+
+        .. note::
+          In older software versions, ``payload["text"]`` was a
+          `format string <https://docs.python.org/3/library/string.html#formatstrings>`_.
+          To get human-readable text, you had to do ``payload["text"].format(**payload)``.
+          That usage is deprecated now. If ``payload["text"]`` happens to contain any
+          ``{`` or ``}`` characters, it can confuse ``.format()`` and cause it to raise a
+          ``KeyError``.
+
     :param custom_labware_paths: A list of directories to search for custom labware.
                                  Loads valid labware from these paths and makes them available
                                  to the protocol context. If this is ``None`` (the default), and
@@ -333,22 +354,6 @@ def execute(  # noqa: C901
                               non-recursive contents of specified directories
                               are presented by the protocol context in
                               ``ProtocolContext.bundled_data``.
-
-    The format of the runlog entries is as follows:
-
-    .. code-block:: python
-
-        {
-            'name': command_name,
-            'payload': {
-                 'text': string_command_text,
-                  # The rest of this struct is command-dependent; see
-                  # opentrons.commands.commands. Its keys match format
-                  # keys in 'text', so that
-                  # entry['payload']['text'].format(**entry['payload'])
-                  # will produce a string with information filled in
-             }
-        }
     """
     stack_logger = logging.getLogger("opentrons")
     stack_logger.propagate = propagate_logs

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -315,9 +315,9 @@ def execute(  # noqa: C901
     :param log_level: The level of logs to emit on the command line:
                       ``"debug"``, ``"info"``, ``"warning"``, or ``"error"``.
                       Defaults to ``"warning"``.
-    :param emit_runlog: A callback for printing the runlog. If specified, this
+    :param emit_runlog: A callback for printing the run log. If specified, this
         will be called whenever a command adds an entry to the
-        runlog, which can be used for display and progress
+        run log, which can be used for display and progress
         estimation. If specified, the callback should take a
         single argument (the name doesn't matter) which will
         be a dictionary:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1317,7 +1317,7 @@ class InstrumentContext(publisher.CommandPublisher):
                       individual axis speeds, you can use
                       :py:obj:`.ProtocolContext.max_speeds`.
         :param publish: Whether a call to this function should publish to the
-                        runlog or not.
+                        run log or not.
         """
         publish_ctx = nullcontext()
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -455,7 +455,7 @@ def simulate(
             ``KeyError``.
 
         - ``logs``: Any log messages that occurred during execution of this
-          command, as a :py:obj:`logging.LogRecord`.
+          command, as a standard Python :py:obj:`~logging.LogRecord`.
 
     :param protocol_file: The protocol file to simulate.
     :param file_name: The name of the file

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -450,7 +450,7 @@ def simulate(
             In older software versions, ``payload["text"]`` was a
             `format string <https://docs.python.org/3/library/string.html#formatstrings>`_.
             To get human-readable text, you had to do ``payload["text"].format(**payload)``.
-            That usage is deprecated now. If ``payload["text"]`` happens to contain any
+            Don't do that anymore. If ``payload["text"]`` happens to contain any
             ``{`` or ``}`` characters, it can confuse ``.format()`` and cause it to raise a
             ``KeyError``.
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -440,14 +440,22 @@ def simulate(
     Each dict element in the run log has the following keys:
 
         - ``level``: The depth at which this command is nested - if this an
-                     aspirate inside a mix inside a transfer, for instance,
-                     it would be 3.
-        - ``payload``: The command, its arguments, and how to format its text.
-                       For more specific details see
-                       ``opentrons.commands``. To format a message from
-                       a payload do ``payload['text'].format(**payload)``.
+          aspirate inside a mix inside a transfer, for instance, it would be 3.
+
+        - ``payload``: The command. The human-readable run log text is available at
+          ``payload["text"]``. The other keys of ``payload`` are command-dependent;
+          see ``opentrons.commands``.
+
+          .. note::
+            In older software versions, ``payload["text"]`` was a
+            `format string <https://docs.python.org/3/library/string.html#formatstrings>`_.
+            To get human-readable text, you had to do ``payload["text"].format(**payload)``.
+            That usage is deprecated now. If ``payload["text"]`` happens to contain any
+            ``{`` or ``}`` characters, it can confuse ``.format()`` and cause it to raise a
+            ``KeyError``.
+
         - ``logs``: Any log messages that occurred during execution of this
-                    command, as a logging.LogRecord
+          command, as a :py:obj:`logging.LogRecord`.
 
     :param protocol_file: The protocol file to simulate.
     :param file_name: The name of the file

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -439,7 +439,7 @@ def simulate(
 
     Each dict element in the run log has the following keys:
 
-        - ``level``: The depth at which this command is nested - if this an
+        - ``level``: The depth at which this command is nested. If this an
           aspirate inside a mix inside a transfer, for instance, it would be 3.
 
         - ``payload``: The command. The human-readable run log text is available at

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -482,7 +482,7 @@ def simulate(
                            occur during protocol simulation are best associated
                            with the actions in the protocol that cause them.
                            Default: ``False``
-    :param log_level: The level of logs to capture in the runlog:
+    :param log_level: The level of logs to capture in the run log:
                       ``"debug"``, ``"info"``, ``"warning"``, or ``"error"``.
                       Defaults to ``"warning"``.
     :returns: A tuple of a run log for user output, and possibly the required


### PR DESCRIPTION
# Overview

While working on #13709, I noticed some outdated documentation for `opentrons.simulate.simulate()` and `opentrons.execute.execute()`.

The docs say you're supposed to do this:

```python
command = ...  # get from opentrons.simulate.simulate() or opentrons.execute.execute()

run_log_text = command["payload"]["text"].format(command["payload"])
```

However, it's apparently been simplified to this now:

```python
command = ... # get from opentrons.simulate.simulate() or opentrons.execute.execute()

run_log_text = command["payload"]["text"]
```

I'm not sure how long this has been the case. PR #9799 suggests it's at least since v5.0.2 but doesn't provide further details ("`text` field is not a format string anymore"). I tried some Git archeology, but I couldn't get to the bottom of it quickly.

Unfortunately, if you try to do the old `.format()` thing today, it's actively harmful. If the string happens to contain any `{` or `}` characters, it will confuse `.format()` and raise a `KeyError`. This happens for Thermocycler commands (see issue #9988), and of course it can happen for `ProtocolContext.comment()` commands.

# Test Plan

* Preview changes on http://sandbox.docs.opentrons.com/fix_payload_docs/v2/.
   * http://sandbox.docs.opentrons.com/fix_payload_docs/v2/new_protocol_api.html#opentrons.simulate.simulate
   * http://sandbox.docs.opentrons.com/fix_payload_docs/v2/new_protocol_api.html#opentrons.execute.execute

# Changelog

* Document that you should just do `command["payload"]["text"]`.
* Document that you should *no longer* do `command["payload"]["text"].format(command["payload"])`.

# Review requests

* Do you see any other places where we encourage the `.format()` thing? Anything in the Support help center? Any demo files floating around?
* Does my flowery prose inspire joy in the depths of your heart?

# Risk assessment

Low.
