### PR TITLE
refactor(app): Remove robot admin restart logic

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -226,7 +226,7 @@
   "resets_cannot_be_undone": "Resets cannot be undone",
   "restart_now": "Restart now?",
   "restart_robot_confirmation_description": "<span>It will take a few minutes for <bold>{{robotName}}</bold> to restart.</span>",
-  "restart_taking_too_long": "{{robotName}} restart is taking longer than expected. If the robot appears unresponsive, try restarting the robot manually.",
+  "restart_taking_too_long": "{{robotName}} restart is taking longer than expected. Check your robot's settings page to verify whether or not the update was successful. If the robot appears unresponsive, try restarting the robot manually.",
   "restarting_robot": "Install complete, robot restarting...",
   "resume_robot_operations": "Resume robot operations",
   "returns_your_device_to_new_state": "This returns your device to a new state.",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -226,7 +226,7 @@
   "resets_cannot_be_undone": "Resets cannot be undone",
   "restart_now": "Restart now?",
   "restart_robot_confirmation_description": "<span>It will take a few minutes for <bold>{{robotName}}</bold> to restart.</span>",
-  "restart_taking_too_long": "{{robotName}} restart is taking longer than expected. Check your robot's settings page to verify whether or not the update was successful. If the robot appears unresponsive, try restarting the robot manually.",
+  "restart_taking_too_long": "{{robotName}} is taking longer than expected to restart. Check the Advanced tab of its settings page to see whether it updated successfully. If the robot is unresponsive, restart it manually.",
   "restarting_robot": "Install complete, robot restarting...",
   "resume_robot_operations": "Resume robot operations",
   "returns_your_device_to_new_state": "This returns your device to a new state.",

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/RobotUpdateProgressModal.test.tsx
@@ -177,6 +177,6 @@ describe('DownloadUpdateModal', () => {
     })
 
     findByText('Try restarting the update.')
-    findByText('testRobot restart is taking longer than expected.')
+    findByText('testRobot restart is taking longer than expected to restart.')
   })
 })

--- a/app/src/redux/robot-admin/__tests__/selectors.test.ts
+++ b/app/src/redux/robot-admin/__tests__/selectors.test.ts
@@ -1,4 +1,3 @@
-import { add } from 'date-fns'
 import { CONNECTABLE, REACHABLE } from '../../discovery'
 import {
   getRobotRestarting,
@@ -6,7 +5,6 @@ import {
   getResetConfigOptions,
 } from '../selectors'
 import { ConnectivityStatus } from '../../discovery/types'
-import { RESTART_TIMEOUT_SEC } from '../constants'
 import type { State } from '../../types'
 
 const START_TIME = new Date('2000-01-01')
@@ -196,43 +194,6 @@ describe('robot admin selectors', () => {
       )
 
       expect(result).toBe('restart-in-progress')
-    })
-
-    it('should return restart timed out if it takes too long', () => {
-      const startTime = new Date('2000-01-01')
-      const notLongEnough = add(startTime, { seconds: RESTART_TIMEOUT_SEC - 1 })
-      const tooLong = add(startTime, { seconds: RESTART_TIMEOUT_SEC + 1 })
-
-      const state: State = {
-        robotAdmin: {
-          robotName: {
-            restart: {
-              ...RESTART_BASE,
-              startTime,
-              status: 'restart-in-progress',
-            },
-          },
-        },
-      } as any
-
-      const before = getNextRestartStatus(
-        state,
-        'robotName',
-        REACHABLE,
-        null,
-        notLongEnough
-      )
-
-      const after = getNextRestartStatus(
-        state,
-        'robotName',
-        REACHABLE,
-        null,
-        tooLong
-      )
-
-      expect(before).toBe(null)
-      expect(after).toBe('restart-timed-out')
     })
   })
 })

--- a/app/src/redux/robot-admin/constants.ts
+++ b/app/src/redux/robot-admin/constants.ts
@@ -1,14 +1,10 @@
 // general constants
 
-// 15 minute restart timeout
-export const RESTART_TIMEOUT_SEC = 900
-
 // restart statuses
 export const RESTART_PENDING_STATUS: 'restart-pending' = 'restart-pending'
 export const RESTART_IN_PROGRESS_STATUS: 'restart-in-progress' =
   'restart-in-progress'
 export const RESTART_FAILED_STATUS: 'restart-failed' = 'restart-failed'
-export const RESTART_TIMED_OUT_STATUS: 'restart-timed-out' = 'restart-timed-out'
 export const RESTART_SUCCEEDED_STATUS: 'restart-succeeded' = 'restart-succeeded'
 
 // action type strings

--- a/app/src/redux/robot-admin/selectors.ts
+++ b/app/src/redux/robot-admin/selectors.ts
@@ -1,11 +1,8 @@
-import { add, isWithinInterval } from 'date-fns'
 import { CONNECTABLE } from '../discovery'
 import {
-  RESTART_TIMEOUT_SEC,
   RESTART_PENDING_STATUS,
   RESTART_IN_PROGRESS_STATUS,
   RESTART_SUCCEEDED_STATUS,
-  RESTART_TIMED_OUT_STATUS,
 } from './constants'
 
 import type { ConnectivityStatus } from '../discovery/types'
@@ -43,10 +40,6 @@ export function getNextRestartStatus(
     return RESTART_IN_PROGRESS_STATUS
   }
 
-  if (getRestartHasTimedOut(state, robotName, now)) {
-    return RESTART_TIMED_OUT_STATUS
-  }
-
   return null
 }
 
@@ -57,23 +50,6 @@ function getRestartHasBegun(
 ): boolean {
   const status = robotState(state, robotName)?.restart?.status
   return status === RESTART_PENDING_STATUS && connectivityStatus !== CONNECTABLE
-}
-
-function getRestartHasTimedOut(
-  state: State,
-  robotName: string,
-  now: Date
-): boolean {
-  const restartState = robotState(state, robotName)?.restart
-
-  if (!restartState?.startTime || !getRobotRestarting(state, robotName)) {
-    return false
-  }
-
-  const { startTime } = restartState
-  const endTime = add(startTime, { seconds: RESTART_TIMEOUT_SEC })
-
-  return !isWithinInterval(now, { start: startTime, end: endTime })
 }
 
 function getRestartIsComplete(

--- a/app/src/redux/robot-update/epic.ts
+++ b/app/src/redux/robot-update/epic.ts
@@ -25,7 +25,6 @@ import {
   RESTART_PATH,
   RESTART_STATUS_CHANGED,
   RESTART_SUCCEEDED_STATUS,
-  RESTART_TIMED_OUT_STATUS,
   restartRobotSuccess,
 } from '../robot-admin'
 
@@ -93,7 +92,6 @@ const UNABLE_TO_CANCEL_UPDATE_SESSION =
 const UNABLE_TO_COMMIT_UPDATE = 'Unable to commit update'
 const UNABLE_TO_RESTART_ROBOT = 'Unable to restart robot'
 const ROBOT_RECONNECTED_WITH_VERSION = 'Robot reconnected with version'
-const ROBOT_DID_NOT_RECONNECT = 'Robot did not successfully reconnect'
 const BUT_WE_EXPECTED = 'but we expected'
 const UNKNOWN = 'unknown'
 const CHECK_TO_VERIFY_UPDATE =
@@ -375,8 +373,7 @@ export const finishAfterRestartEpic: Epic = (action$, state$) => {
       const session = getRobotUpdateSession(state)
       const robot = getRobotUpdateRobot(state)
       const restartDone =
-        action.payload.restartStatus === RESTART_SUCCEEDED_STATUS ||
-        action.payload.restartStatus === RESTART_TIMED_OUT_STATUS
+        action.payload.restartStatus === RESTART_SUCCEEDED_STATUS
 
       return (
         restartDone &&
@@ -393,7 +390,6 @@ export const finishAfterRestartEpic: Epic = (action$, state$) => {
       )
 
       const robotVersion = getRobotApiVersion(robot)
-      const timedOut = action.payload.restartStatus === RESTART_TIMED_OUT_STATUS
       const actual = robotVersion ?? UNKNOWN
       const expected = targetVersion ?? UNKNOWN
       let finishAction
@@ -404,10 +400,6 @@ export const finishAfterRestartEpic: Epic = (action$, state$) => {
         robotVersion === targetVersion
       ) {
         finishAction = setRobotUpdateSessionStep(FINISHED)
-      } else if (timedOut) {
-        finishAction = unexpectedRobotUpdateError(
-          `${ROBOT_DID_NOT_RECONNECT}. ${CHECK_TO_VERIFY_UPDATE}.`
-        )
       } else {
         finishAction = unexpectedRobotUpdateError(
           `${ROBOT_RECONNECTED_WITH_VERSION} ${actual}, ${BUT_WE_EXPECTED} ${expected}. ${CHECK_TO_VERIFY_UPDATE}.`


### PR DESCRIPTION
Closes RAUT-771, RQA-1788

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR removes the old timeout logic for checking if a robot takes too long to reconnect during an update. It has already replaced by new, generalized timeout logic that isn't specific to only restarts. This older code intermittently causes an issue where the robot registers as taking too long to reconnect just seconds after the restart step initiates, so removing this code is more of a priority.

### Old
<img width="1024" alt="10_12 update did not successfully reconnect" src="https://github.com/Opentrons/opentrons/assets/64858653/6fd3b195-8c62-4431-a592-7f276d1072ea">

### New 

<img width="1023" alt="Screenshot 2023-10-12 at 2 51 05 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/3ae10d39-b17b-4442-b2ae-74581606b506">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Change TIME_BEFORE_ALLOWING_EXIT_MS in RobotUpdateProgressModal to 1 second, then initiate a robot update. During the restart step, the new text should display.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Cleaned up robot update restart timeout logic.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
