### PR TITLE
fix(app): fix module calibration odd display

### DIFF
--- a/app/src/organisms/Devices/hooks/useModuleCalibrationStatus.ts
+++ b/app/src/organisms/Devices/hooks/useModuleCalibrationStatus.ts
@@ -23,7 +23,11 @@ export function useModuleCalibrationStatus(
   const moduleData = moduleInfoKeys.map(
     key => moduleRenderInfoForProtocolById[key]
   )
-  if (moduleData.some(m => m.attachedModuleMatch?.moduleOffset == null)) {
+  if (
+    moduleData.some(
+      m => m.attachedModuleMatch?.moduleOffset?.last_modified == null
+    )
+  ) {
     return { complete: false, reason: 'calibrate_module_failure_reason' }
   } else {
     return { complete: true }

--- a/app/src/organisms/ProtocolSetupModules/index.tsx
+++ b/app/src/organisms/ProtocolSetupModules/index.tsx
@@ -132,7 +132,6 @@ function RenderModuleStatus({
 
   if (
     isModuleReady &&
-    calibrationStatus.complete &&
     module.attachedModuleMatch?.moduleOffset?.last_modified != null
   ) {
     moduleStatus = (

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -24,6 +24,7 @@ import {
   useRunCreatedAtTimestamp,
   useModuleCalibrationStatus,
 } from '../../../../organisms/Devices/hooks'
+import { getLocalRobot } from '../../../../redux/discovery'
 import { useMostRecentCompletedAnalysis } from '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { ProtocolSetupLiquids } from '../../../../organisms/ProtocolSetupLiquids'
 import { getProtocolModulesInfo } from '../../../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
@@ -65,7 +66,6 @@ jest.mock(
 jest.mock(
   '../../../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
 )
-jest.mock('../../../../redux/discovery')
 jest.mock('../../../../organisms/ProtocolSetupModules')
 jest.mock('../../../../organisms/ProtocolSetupModules/utils')
 jest.mock('../../../../organisms/OnDeviceDisplay/RunningProtocol')
@@ -73,6 +73,7 @@ jest.mock('../../../../organisms/RunTimeControl/hooks')
 jest.mock('../../../../organisms/ProtocolSetupLiquids')
 jest.mock('../../../../organisms/ModuleCard/hooks')
 jest.mock('../../../../redux/config')
+jest.mock('../../../../redux/discovery/selectors')
 jest.mock('../ConfirmAttachedModal')
 jest.mock('../../../../organisms/ToasterOven')
 
@@ -137,6 +138,9 @@ const mockUseDoorQuery = useDoorQuery as jest.MockedFunction<
 const mockUseToaster = useToaster as jest.MockedFunction<typeof useToaster>
 const mockUseModuleCalibrationStatus = useModuleCalibrationStatus as jest.MockedFunction<
   typeof useModuleCalibrationStatus
+>
+const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
+  typeof getLocalRobot
 >
 
 const render = (path = '/') => {
@@ -221,6 +225,7 @@ describe('ProtocolSetup', () => {
       <div>Mock ConfirmCancelRunModal</div>
     )
     mockUseModuleCalibrationStatus.mockReturnValue({ complete: true })
+    mockGetLocalRobot.mockReturnValue({ name: '123' } as any)
     when(mockUseRunControls)
       .calledWith(RUN_ID)
       .mockReturnValue({

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -22,6 +22,7 @@ import {
   useAttachedModules,
   useLPCDisabledReason,
   useRunCreatedAtTimestamp,
+  useModuleCalibrationStatus,
 } from '../../../../organisms/Devices/hooks'
 import { useMostRecentCompletedAnalysis } from '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { ProtocolSetupLiquids } from '../../../../organisms/ProtocolSetupLiquids'
@@ -64,6 +65,7 @@ jest.mock(
 jest.mock(
   '../../../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
 )
+jest.mock('../../../../redux/discovery')
 jest.mock('../../../../organisms/ProtocolSetupModules')
 jest.mock('../../../../organisms/ProtocolSetupModules/utils')
 jest.mock('../../../../organisms/OnDeviceDisplay/RunningProtocol')
@@ -133,6 +135,9 @@ const mockUseDoorQuery = useDoorQuery as jest.MockedFunction<
   typeof useDoorQuery
 >
 const mockUseToaster = useToaster as jest.MockedFunction<typeof useToaster>
+const mockUseModuleCalibrationStatus = useModuleCalibrationStatus as jest.MockedFunction<
+  typeof useModuleCalibrationStatus
+>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -215,6 +220,7 @@ describe('ProtocolSetup', () => {
     mockConfirmCancelRunModal.mockReturnValue(
       <div>Mock ConfirmCancelRunModal</div>
     )
+    mockUseModuleCalibrationStatus.mockReturnValue({ complete: true })
     when(mockUseRunControls)
       .calledWith(RUN_ID)
       .mockReturnValue({


### PR DESCRIPTION
fix RQA-1789, RQA-1792

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
There were a few problems with module calibration data being displayed on ODD:
1. Module calibration status was sometimes being shown as not ready when it was (1789)
2. Modules with ok calibrations still had "calibration required, attach pipette" text if instrument cal was incomplete
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. On a Flex with some attached and not calibrated modules, setup a protocol that doesn't use all attached modules. Calibrate the required modules and see that the Modules item on the "Prepare to Run" screen is green.
2. Setup a protocol that use a module that is already calibrated. See that even before attaching and/or calibrating the instruments, the calibrated module list item is green and displays "Calibrated" text

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Use `useModuleCalibrationStatus` hook to determine whether _needed_ modules are calibrated as opposed to checking all attached modules for calibration data. This logic now mirrors what is shown on desktop
3. Update `useModuleCalibrationStatus` to look at `last_modified` date instead of whole object
4. Update `RenderModuleStatus` to show "calibrated" text if module is attached and calibrated even if pipettes are not attached and/or calibrated

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Sanity check the changes, I tested both changes locally and tested item 2 on a Flex but if there's a robot you can test item 1 on that would be great!
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
