### PR TITLE
fix(api): remove gratuitous tip state check prior to blow out

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -662,7 +662,6 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plan_check_blow_out(self, mount):  # type: ignore[no-untyped-def]
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT, mount)
         speed = self.plunger_speed(
             instrument, instrument.blow_out_flow_rate, "dispense"
         )

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -674,7 +674,6 @@ class OT3PipetteHandler:
     ) -> LiquidActionSpec:
         """Check preconditions and calculate values for blowout."""
         instrument = self.get_pipette(mount)
-        self.ready_for_tip_action(instrument, HardwareAction.BLOWOUT, mount)
         speed = self.plunger_speed(instrument, instrument.blow_out_flow_rate, "blowout")
         acceleration = self.plunger_acceleration(
             instrument, instrument.flow_acceleration

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -226,7 +226,6 @@ class VirtualPipettingHandler(PipettingHandler):
         flow_rate: float,
     ) -> None:
         """Virtually blow out (no-op)."""
-        self._validate_tip_attached(pipette_id=pipette_id, command_name="blow-out")
 
     def _validate_tip_attached(self, pipette_id: str, command_name: str) -> None:
         """Validate if there is a tip attached."""

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_instrument_context.py
@@ -62,16 +62,6 @@ def test_dispense_no_tip(subject: InstrumentCore) -> None:
         )
 
 
-def test_blow_out_no_tip(subject: InstrumentCore, labware: LabwareCore) -> None:
-    """It should raise an error if a tip is not attached."""
-    with pytest.raises(UnexpectedTipRemovalError, match="Cannot perform BLOWOUT"):
-        subject.blow_out(
-            location=Location(point=Point(1, 2, 3), labware=None),
-            well_core=labware.get_well_core("A1"),
-            in_place=True,
-        )
-
-
 def test_pick_up_tip_no_tip(subject: InstrumentCore, tip_rack: LabwareCore) -> None:
     """It should raise an error if a tip is already attached."""
     tip_core = tip_rack.get_well_core("A1")

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -414,20 +414,6 @@ async def test_dispense_in_place_virtual_raises_invalid_dispense(
         )
 
 
-async def test_validate_tip_attached_in_blow_out(
-    mock_state_view: StateView, decoy: Decoy
-) -> None:
-    """Should raise an error that a tip is not attached."""
-    subject = VirtualPipettingHandler(state_view=mock_state_view)
-
-    decoy.when(mock_state_view.pipettes.get_attached_tip("pipette-id")).then_return(
-        None
-    )
-
-    with pytest.raises(TipNotAttachedError):
-        await subject.blow_out_in_place("pipette-id", flow_rate=1)
-
-
 async def test_validate_tip_attached_in_aspirate(
     mock_state_view: StateView, decoy: Decoy
 ) -> None:


### PR DESCRIPTION
# Overview

Do not assert, at the hardware control layer, that a tip must be present in the software tracker in order to move the plunger to the blowout position.

This is particularly important in recovery flows where the system may no longer have an accurate sense of what is attached to the pipette nozzles, and whether there is liquid inside.  In this case, there may actually be a tip present, but the system is not tracking it.  We should still allow the blowout action to occur, in the same way that we allow the drop tip action to occur.

# Review requests

- Issuing a `blowOutInPlace` command before a pick up tip should no longer fail.   

# Risk assessment
low