### PR TITLE
feat(shared-data): Deck Definition V4 cutoutFixture updates

### DIFF
--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -367,7 +367,6 @@
         "10",
         "11"
       ],
-      "fixtureType": "singleStandardSlot",
       "displayName": "Standard Slot",
       "onFixtureAddressableAreas": {
         "1": ["1"],
@@ -386,7 +385,6 @@
     {
       "id": "fixedTrashSlot",
       "cutoutLocationIds": ["12"],
-      "fixtureType": "fixedTrashSlot",
       "displayName": "Fixed Trash",
       "onFixtureAddressableAreas": {
         "12": ["shortFixedTrash"]

--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -354,7 +354,7 @@
   "cutoutFixtures": [
     {
       "id": "singleStandardSlot",
-      "cutoutLocationIds": [
+      "mayMountTo": [
         "1",
         "2",
         "3",
@@ -368,7 +368,7 @@
         "11"
       ],
       "displayName": "Standard Slot",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "1": ["1"],
         "2": ["2"],
         "3": ["3"],
@@ -384,9 +384,9 @@
     },
     {
       "id": "fixedTrashSlot",
-      "cutoutLocationIds": ["12"],
+      "mayMountTo": ["12"],
       "displayName": "Fixed Trash",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "12": ["shortFixedTrash"]
       }
     }

--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -354,19 +354,7 @@
   "cutoutFixtures": [
     {
       "id": "singleStandardSlot",
-      "mayMountTo": [
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11"
-      ],
+      "mayMountTo": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
       "displayName": "Standard Slot",
       "providesAddressableAreas": {
         "1": ["1"],

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -367,7 +367,6 @@
         "10",
         "11"
       ],
-      "fixtureType": "singleStandardSlot",
       "displayName": "Standard Slot",
       "onFixtureAddressableAreas": {
         "1": ["1"],
@@ -386,7 +385,6 @@
     {
       "id": "fixedTrashSlot",
       "cutoutLocationIds": ["12"],
-      "fixtureType": "fixedTrashSlot",
       "displayName": "Fixed Trash",
       "onFixtureAddressableAreas": {
         "12": ["fixedTrash"]

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -354,7 +354,7 @@
   "cutoutFixtures": [
     {
       "id": "singleStandardSlot",
-      "cutoutLocationIds": [
+      "mayMountTo": [
         "1",
         "2",
         "3",
@@ -368,7 +368,7 @@
         "11"
       ],
       "displayName": "Standard Slot",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "1": ["1"],
         "2": ["2"],
         "3": ["3"],
@@ -384,9 +384,9 @@
     },
     {
       "id": "fixedTrashSlot",
-      "cutoutLocationIds": ["12"],
+      "mayMountTo": ["12"],
       "displayName": "Fixed Trash",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "12": ["fixedTrash"]
       }
     }

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -354,19 +354,7 @@
   "cutoutFixtures": [
     {
       "id": "singleStandardSlot",
-      "mayMountTo": [
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "10",
-        "11"
-      ],
+      "mayMountTo": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
       "displayName": "Standard Slot",
       "providesAddressableAreas": {
         "1": ["1"],

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -399,9 +399,9 @@
   "cutoutFixtures": [
     {
       "id": "singleLeftSlot",
-      "cutoutLocationIds": ["D1", "C1", "B1", "A1"],
+      "mayMountTo": ["D1", "C1", "B1", "A1"],
       "displayName": "Standard Slot Left",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D1": ["D1"],
         "C1": ["C1"],
         "B1": ["B1"],
@@ -410,9 +410,9 @@
     },
     {
       "id": "singleCenterSlot",
-      "cutoutLocationIds": ["D2", "C2", "B2", "A2"],
+      "mayMountTo": ["D2", "C2", "B2", "A2"],
       "displayName": "Standard Slot Center",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D2": ["D2"],
         "C2": ["C2"],
         "B2": ["B2"],
@@ -421,9 +421,9 @@
     },
     {
       "id": "singleRightSlot",
-      "cutoutLocationIds": ["D3", "C3", "B3", "A3"],
+      "mayMountTo": ["D3", "C3", "B3", "A3"],
       "displayName": "Standard Slot Right",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D3": ["D3"],
         "C3": ["C3"],
         "B3": ["B3"],
@@ -432,9 +432,9 @@
     },
     {
       "id": "stagingAreaRightSlot",
-      "cutoutLocationIds": ["D3", "C3", "B3", "A3"],
+      "mayMountTo": ["D3", "C3", "B3", "A3"],
       "displayName": "Staging Area Slot",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D3": ["D3", "D4"],
         "C3": ["C3", "C4"],
         "B3": ["B3", "B4"],
@@ -443,9 +443,9 @@
     },
     {
       "id": "trashBinAdapter",
-      "cutoutLocationIds": ["D1", "C1", "B1", "A1", "D3", "C3", "B3", "A3"],
+      "mayMountTo": ["D1", "C1", "B1", "A1", "D3", "C3", "B3", "A3"],
       "displayName": "Slot With Movable Trash",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D1": ["movableTrash"],
         "C1": ["movableTrash"],
         "B1": ["movableTrash"],
@@ -458,33 +458,33 @@
     },
     {
       "id": "wasteChuteRightAdapterCovered",
-      "cutoutLocationIds": ["D3"],
+      "mayMountTo": ["D3"],
       "displayName": "Waste Chute Adapter for 1 or 8 Channel Pipettes",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D3": ["1/8cWasteChute"]
       }
     },
     {
       "id": "wasteChuteRightAdapterNoCover",
-      "cutoutLocationIds": ["D3"],
+      "mayMountTo": ["D3"],
       "displayName": "Waste Chute Adapter for 96 Channel Pipette or Gripper",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute"]
       }
     },
     {
       "id": "stagingAreaSlotWithWasteChuteRightAdapterCovered",
-      "cutoutLocationIds": ["D3"],
+      "mayMountTo": ["D3"],
       "displayName": "Staging Slot With Waste Chute Adapter for 96 Channel Pipette or Gripper",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D3": ["1/8cWasteChute", "D4"]
       }
     },
     {
       "id": "stagingAreaSlotWithWasteChuteRightAdapterNoCover",
-      "cutoutLocationIds": ["D3"],
+      "mayMountTo": ["D3"],
       "displayName": "Staging Slot With Waste Chute Adapter and Staging Area Slot",
-      "onFixtureAddressableAreas": {
+      "providesAddressableAreas": {
         "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute", "D4"]
       }
     }

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -400,7 +400,6 @@
     {
       "id": "singleLeftSlot",
       "cutoutLocationIds": ["D1", "C1", "B1", "A1"],
-      "fixtureType": "singleLeftSlot",
       "displayName": "Standard Slot Left",
       "onFixtureAddressableAreas": {
         "D1": ["D1"],
@@ -412,7 +411,6 @@
     {
       "id": "singleCenterSlot",
       "cutoutLocationIds": ["D2", "C2", "B2", "A2"],
-      "fixtureType": "singleCenterSlot",
       "displayName": "Standard Slot Center",
       "onFixtureAddressableAreas": {
         "D2": ["D2"],
@@ -424,7 +422,6 @@
     {
       "id": "singleRightSlot",
       "cutoutLocationIds": ["D3", "C3", "B3", "A3"],
-      "fixtureType": "singleRightSlot",
       "displayName": "Standard Slot Right",
       "onFixtureAddressableAreas": {
         "D3": ["D3"],
@@ -436,7 +433,6 @@
     {
       "id": "stagingAreaRightSlot",
       "cutoutLocationIds": ["D3", "C3", "B3", "A3"],
-      "fixtureType": "stagingAreaRightSlot",
       "displayName": "Staging Area Slot",
       "onFixtureAddressableAreas": {
         "D3": ["D3", "D4"],
@@ -448,7 +444,6 @@
     {
       "id": "trashBinAdapter",
       "cutoutLocationIds": ["D1", "C1", "B1", "A1", "D3", "C3", "B3", "A3"],
-      "fixtureType": "trashBinAdapter",
       "displayName": "Slot With Movable Trash",
       "onFixtureAddressableAreas": {
         "D1": ["movableTrash"],
@@ -464,7 +459,6 @@
     {
       "id": "wasteChuteRightAdapter",
       "cutoutLocationIds": ["D3"],
-      "fixtureType": "wasteChuteRightAdapter",
       "displayName": "Slot With Waste Chute Adapter",
       "onFixtureAddressableAreas": {
         "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute"]
@@ -473,7 +467,6 @@
     {
       "id": "wasteChuteRightAdapterWithStagingAreaSlot",
       "cutoutLocationIds": ["D3"],
-      "fixtureType": "wasteChuteRightAdapterWithStagingAreaSlot",
       "displayName": "Slot With Waste Chute Adapter and Staging Area Slot",
       "onFixtureAddressableAreas": {
         "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute", "D4"]

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -457,17 +457,33 @@
       }
     },
     {
-      "id": "wasteChuteRightAdapter",
+      "id": "wasteChuteRightAdapterCovered",
       "cutoutLocationIds": ["D3"],
-      "displayName": "Slot With Waste Chute Adapter",
+      "displayName": "Waste Chute Adapter for 1 or 8 Channel Pipettes",
+      "onFixtureAddressableAreas": {
+        "D3": ["1/8cWasteChute"]
+      }
+    },
+    {
+      "id": "wasteChuteRightAdapterNoCover",
+      "cutoutLocationIds": ["D3"],
+      "displayName": "Waste Chute Adapter for 96 Channel Pipette or Gripper",
       "onFixtureAddressableAreas": {
         "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute"]
       }
     },
     {
-      "id": "wasteChuteRightAdapterWithStagingAreaSlot",
+      "id": "stagingAreaSlotWithWasteChuteRightAdapterCovered",
       "cutoutLocationIds": ["D3"],
-      "displayName": "Slot With Waste Chute Adapter and Staging Area Slot",
+      "displayName": "Staging Slot With Waste Chute Adapter for 96 Channel Pipette or Gripper",
+      "onFixtureAddressableAreas": {
+        "D3": ["1/8cWasteChute", "D4"]
+      }
+    },
+    {
+      "id": "stagingAreaSlotWithWasteChuteRightAdapterNoCover",
+      "cutoutLocationIds": ["D3"],
+      "displayName": "Staging Slot With Waste Chute Adapter and Staging Area Slot",
       "onFixtureAddressableAreas": {
         "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute", "D4"]
       }

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -469,7 +469,11 @@
       "mayMountTo": ["D3"],
       "displayName": "Waste Chute Adapter for 96 Channel Pipette or Gripper",
       "providesAddressableAreas": {
-        "D3": ["1and8ChannelWasteChute", "96ChannelWasteChute", "gripperWasteChute"]
+        "D3": [
+          "1and8ChannelWasteChute",
+          "96ChannelWasteChute",
+          "gripperWasteChute"
+        ]
       }
     },
     {
@@ -485,7 +489,12 @@
       "mayMountTo": ["D3"],
       "displayName": "Staging Slot With Waste Chute Adapter and Staging Area Slot",
       "providesAddressableAreas": {
-        "D3": ["1and8ChannelWasteChute", "96ChannelWasteChute", "gripperWasteChute", "D4"]
+        "D3": [
+          "1and8ChannelWasteChute",
+          "96ChannelWasteChute",
+          "gripperWasteChute",
+          "D4"
+        ]
       }
     }
   ],

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -263,7 +263,7 @@
         "dropTipsOffset": [123.25, 45.75, 40.0]
       },
       {
-        "id": "1/8cWasteChute",
+        "id": "1and8ChannelWasteChute",
         "areaType": "wasteChute",
         "offsetFromCutoutFixture": [-13.5, 0, 0],
         "boundingBox": {
@@ -276,7 +276,7 @@
         "dropTipsOffset": [64.0, 21.91, 144.0]
       },
       {
-        "id": "96cWasteChute",
+        "id": "96ChannelWasteChute",
         "areaType": "wasteChute",
         "offsetFromCutoutFixture": [-13.5, 0, 0],
         "boundingBox": {
@@ -461,7 +461,7 @@
       "mayMountTo": ["D3"],
       "displayName": "Waste Chute Adapter for 1 or 8 Channel Pipettes",
       "providesAddressableAreas": {
-        "D3": ["1/8cWasteChute"]
+        "D3": ["1and8ChannelWasteChute"]
       }
     },
     {
@@ -469,7 +469,7 @@
       "mayMountTo": ["D3"],
       "displayName": "Waste Chute Adapter for 96 Channel Pipette or Gripper",
       "providesAddressableAreas": {
-        "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute"]
+        "D3": ["1and8ChannelWasteChute", "96ChannelWasteChute", "gripperWasteChute"]
       }
     },
     {
@@ -477,7 +477,7 @@
       "mayMountTo": ["D3"],
       "displayName": "Staging Slot With Waste Chute Adapter for 96 Channel Pipette or Gripper",
       "providesAddressableAreas": {
-        "D3": ["1/8cWasteChute", "D4"]
+        "D3": ["1and8ChannelWasteChute", "D4"]
       }
     },
     {
@@ -485,7 +485,7 @@
       "mayMountTo": ["D3"],
       "displayName": "Staging Slot With Waste Chute Adapter and Staging Area Slot",
       "providesAddressableAreas": {
-        "D3": ["1/8cWasteChute", "96cWasteChute", "gripperWasteChute", "D4"]
+        "D3": ["1and8ChannelWasteChute", "96ChannelWasteChute", "gripperWasteChute", "D4"]
       }
     }
   ],

--- a/shared-data/deck/schemas/4.json
+++ b/shared-data/deck/schemas/4.json
@@ -238,7 +238,6 @@
         "required": [
           "id",
           "cutoutLocationIds",
-          "fixtureType",
           "displayName",
           "onFixtureAddressableAreas"
         ],
@@ -253,10 +252,6 @@
             "items": {
               "type": "string"
             }
-          },
-          "fixtureType": {
-            "description": "The type of cutout fixture.",
-            "type": "string"
           },
           "displayName": {
             "description": "A human-readable nickname for this area e.g. \"Standard Right Slot\" or \"Slot With Movable Trash\"",

--- a/shared-data/deck/schemas/4.json
+++ b/shared-data/deck/schemas/4.json
@@ -237,17 +237,17 @@
         "type": "object",
         "required": [
           "id",
-          "cutoutLocationIds",
+          "mayMountTo",
           "displayName",
-          "onFixtureAddressableAreas"
+          "providesAddressableAreas"
         ],
         "properties": {
           "id": {
             "description": "Unique identifier for the cutout fixture.",
             "type": "string"
           },
-          "cutoutLocationIds": {
-            "description": "A list of compatible cutout ids this cutout fixture can be placed on.",
+          "mayMountTo": {
+            "description": "A list of compatible cutouts this fixture may be mounted to.",
             "type": "array",
             "items": {
               "type": "string"
@@ -257,8 +257,8 @@
             "description": "A human-readable nickname for this area e.g. \"Standard Right Slot\" or \"Slot With Movable Trash\"",
             "type": "string"
           },
-          "onFixtureAddressableAreas": {
-            "description": "A mapping of cutout location ids (matching the entries in cutoutLocationIds) to compatible addressableArea ids.",
+          "providesAddressableAreas": {
+            "description": "A mapping of mayMountTo locations to addressableArea ids.",
             "type": "object",
             "additionalProperties": {
               "type": "array",

--- a/shared-data/python/opentrons_shared_data/deck/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/deck/dev_types.py
@@ -115,7 +115,6 @@ class Cutout(TypedDict):
 class CutoutFixture(TypedDict):
     id: str
     cutoutLocationIds: List[str]
-    fixtureType: str
     displayName: str
     onFixtureAddressableAreas: Dict[str, List[str]]
 

--- a/shared-data/python/opentrons_shared_data/deck/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/deck/dev_types.py
@@ -114,9 +114,9 @@ class Cutout(TypedDict):
 
 class CutoutFixture(TypedDict):
     id: str
-    cutoutLocationIds: List[str]
+    mayMountTo: List[str]
     displayName: str
-    onFixtureAddressableAreas: Dict[str, List[str]]
+    providesAddressableAreas: Dict[str, List[str]]
 
 
 Fixture = Union[


### PR DESCRIPTION
# Overview

Based on a couple days of discussion between robot services and Apps/UI, we've decided to make a change in how we define cutoutFixtures. 

The waste chute, since it has four possible combinations between cover/no cover and staging slot/no staging slot, now have four definitions that each provide all usable addressableAreas. This flat structure has been chosen for simplicity and moving forward in implementing it the fastest. The names chosen for the cutoutFixture properties have been adjusted to allow an easier migration path when moving to a more robust schema in the future, if we decide to go down that path.

The `fixtureType` property was also removed for redundancy reasons.

# Test Plan

The veracity of changes should be covered by the previously added schema validation tests and python unit tests.

# Changelog

- added two more `cutoutFixtures` to represent the waste chute with a cover on, with and without the staging slot adapter
- renamed waste chute `cutoutFixtures` to semantically describe the hierarchal relationship between staging slot, waste chute, and cover in a flat structure
- renamed `cutoutLocationIds` to `mayMountTo`
- renamed `onFixtureAddressableAreas` to `providesAddressableAreas`
- renamed `1/8cWasteChute` and `96cWasteChute` addressable areas to `1and8ChannelWasteChute` and `96ChannelWasteChute`
- removed `fixtureType` property since it had identical data with the `id` property

# Review requests

We should all agree on the names being used here for cutout fixtures since they will be used going forward across multiple stacks and we'd like them to be backwards compatible with any future deck schema v5.

# Risk assessment

Low.