### PR TITLE
docs(api): Fix spelling mistake in instrument_context.py

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -609,7 +609,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :type volume: float
 
         :param height: The number of millimeters to move above the current Well
-                       to air-gap aspirate. (Default: 5mm above current Well)
+                       to air-gap aspirate. (Default: 5 mm above current Well)
         :type height: float
 
         :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -608,7 +608,7 @@ class InstrumentContext(publisher.CommandPublisher):
                        (Default will use all remaining volume in tip)
         :type volume: float
 
-        :param height: The number of millimiters to move above the current Well
+        :param height: The number of millimeters to move above the current Well
                        to air-gap aspirate. (Default: 5mm above current Well)
         :type height: float
 


### PR DESCRIPTION
# Overview

This is a to fix a small spelling error in the instrument_context.py file for `air_gap`.

The word "millimeters" is misspelled as "millimiters." Line 611. Blame shows that this has been in there for 4 years.

There's another PR open ([13780](https://github.com/Opentrons/opentrons/pull/13780)) to review and recommend changes for this file, but maybe we can get a quick fix in before that.

# Test Plan

Check the revised spelling.

# Changelog

Replace a misspelled word "millimiters" with "millimeters."

# Review requests

n/a

# Risk assessment

Low. Text spelling change only.
