### PR TITLE
fix(hardware-testing): Longer scale stabilize time, and 2.5mm submerge

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -68,9 +68,9 @@ class PhotometricConfig(VolumetricConfig):
 GRAV_CONFIG_EXCLUDE_FROM_REPORT = ["labware_offsets", "slots_tiprack"]
 PHOTO_CONFIG_EXCLUDE_FROM_REPORT = ["labware_offsets", "slots_tiprack"]
 
-NUM_BLANK_TRIALS: Final = 3
+NUM_BLANK_TRIALS: Final = 10
 NUM_MIXES_BEFORE_ASPIRATE = 5
-SCALE_SECONDS_TO_TRUE_STABILIZE = 30
+SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 
 LOW_VOLUME_UPPER_LIMIT_UL: Final = 2.0
 

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -8,9 +8,8 @@ from .definition import (
     interpolate,
 )
 
-_default_submerge_aspirate_mm = 1.5
-_p50_multi_submerge_aspirate_mm = 3.0
-_default_submerge_dispense_mm = 1.5
+_default_submerge_aspirate_mm = 2.5
+_default_submerge_dispense_mm = 2.5
 _default_retract_mm = 5.0
 _default_retract_discontinuity = 20
 
@@ -499,7 +498,7 @@ _aspirate_defaults: Dict[int, Dict[int, Dict[int, Dict[int, AspirateSettings]]]]
         50: {  # P50
             50: {  # T50
                 1: AspirateSettings(  # 1uL
-                    z_submerge_depth=_p50_multi_submerge_aspirate_mm,
+                    z_submerge_depth=_default_submerge_aspirate_mm,
                     plunger_acceleration=_default_accel_p50_ul_sec_sec,
                     plunger_flow_rate=35,  # ul/sec
                     delay=_default_aspirate_delay_seconds,
@@ -509,7 +508,7 @@ _aspirate_defaults: Dict[int, Dict[int, Dict[int, Dict[int, AspirateSettings]]]]
                     trailing_air_gap=0.1,
                 ),
                 10: AspirateSettings(  # 10uL
-                    z_submerge_depth=_p50_multi_submerge_aspirate_mm,
+                    z_submerge_depth=_default_submerge_aspirate_mm,
                     plunger_acceleration=_default_accel_p50_ul_sec_sec,
                     plunger_flow_rate=23.5,  # ul/sec
                     delay=_default_aspirate_delay_seconds,
@@ -519,7 +518,7 @@ _aspirate_defaults: Dict[int, Dict[int, Dict[int, Dict[int, AspirateSettings]]]]
                     trailing_air_gap=0.1,
                 ),
                 50: AspirateSettings(  # 50uL
-                    z_submerge_depth=_p50_multi_submerge_aspirate_mm,
+                    z_submerge_depth=_default_submerge_aspirate_mm,
                     plunger_acceleration=_default_accel_p50_ul_sec_sec,
                     plunger_flow_rate=35,  # ul/sec
                     delay=_default_aspirate_delay_seconds,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

These updates were found to create more stable results in factory.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
