### PR TITLE
chore: 7.0.1 release notes typo fix and clarification

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -14,10 +14,7 @@ This update may take longer than usual if you are updating from v6.x. Allow **ap
 
 ### Known Issues
 
-Some protocols can't be simulated with the `opentrons_simulate` command-line tool:
-
-- JSON protocols created or modified with Protocol Designer v6.0.0 or higher.
-- Python protocols specifying an `apiLevel` of 2.14 or higher.
+JSON protocols created or modified with Protocol Designer v6.0.0 or higher can't be simulated with the `opentrons_simulate` command-line tool.
 
 ---
 
@@ -65,6 +62,7 @@ Python API features
 Some protocols can't be simulated with the `opentrons_simulate` command-line tool:
 
 - JSON protocols created or modified with Protocol Designer v6.0.0 or higher.
+- Python protocols specifying an `apiLevel` of 2.14 or higher.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -8,7 +8,7 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ## Opentrons App Changes in 7.0.1
 
-Welcome to the v7.0.0 release of the Opentrons App! This release builds on the major release that added support for Opentrons Flex.
+Welcome to the v7.0.1 release of the Opentrons App! This release builds on the major release that added support for Opentrons Flex.
 
 ### Improved Features
 


### PR DESCRIPTION
# Overview

Fixing up some mistakes in the release notes found in alpha 5 update flow.

# Test Plan

Read the markdown words very carefully.

# Changelog

- say `7.0.1` instead of `7.0.0` in the section about 7.0.1 🤪 
- fix up which versions have which `opentrons_simulate` capabilities. we had some PRs crossing paths on this 🔀 

# Review requests

Please please please make sure I don't have any more dumb typos.

# Risk assessment

None, embarrassment potential only.