### PR TITLE
fix(app,api,robot-server): expose flex serial

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -286,6 +286,9 @@ class API(
     def __repr__(self) -> str:
         return "<{} using backend {}>".format(type(self), type(self._backend))
 
+    async def get_serial_number(self) -> Optional[str]:
+        return await self._backend.get_serial_number()
+
     @property
     def loop(self) -> asyncio.AbstractEventLoop:
         """The event loop used by this instance."""

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -16,6 +16,7 @@ from typing import (
     cast,
 )
 from typing_extensions import Final
+from pathlib import Path
 
 try:
     import aionotify  # type: ignore[import]
@@ -131,6 +132,12 @@ class Controller:
     @module_controls.setter
     def module_controls(self, module_controls: AttachedModulesControl) -> None:
         self._module_controls = module_controls
+
+    async def get_serial_number(self) -> Optional[str]:
+        try:
+            return Path("/var/serial").read_text().strip()
+        except OSError:
+            return None
 
     def start_gpio_door_watcher(
         self,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -308,6 +308,11 @@ class OT3Controller:
             )
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
 
+    async def get_serial_number(self) -> Optional[str]:
+        if not self.initialized:
+            return None
+        return self.eeprom_data.serial_number
+
     @property
     def initialized(self) -> bool:
         """True when the hardware controller has initialized and is ready."""

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -190,6 +190,9 @@ class OT3Simulator:
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
         self._sim_jaw_state = GripperJawState.HOMED_READY
 
+    async def get_serial_number(self) -> Optional[str]:
+        return "simulator"
+
     @property
     def initialized(self) -> bool:
         """True when the hardware controller has initialized and is ready."""

--- a/api/src/opentrons/hardware_control/backends/simulator.py
+++ b/api/src/opentrons/hardware_control/backends/simulator.py
@@ -169,6 +169,9 @@ class Simulator:
         # to the hardware api controller.
         self._module_controls: Optional[AttachedModulesControl] = None
 
+    async def get_serial_number(self) -> Optional[str]:
+        return "simulator"
+
     @property
     def gpio_chardev(self) -> GPIODriverLike:
         return self._gpio_chardev

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -260,6 +260,9 @@ class OT3API(
         )
         await self._backend.update_to_default_current_settings(gantry_load)
 
+    async def get_serial_number(self) -> Optional[str]:
+        return await self._backend.get_serial_number()
+
     async def set_system_constraints_for_calibration(self) -> None:
         self._move_manager.update_constraints(
             get_system_constraints_for_calibration(

--- a/api/src/opentrons/hardware_control/protocols/hardware_manager.py
+++ b/api/src/opentrons/hardware_control/protocols/hardware_manager.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 from typing_extensions import Protocol
 
 from ..types import SubSystem, SubSystemState
@@ -40,4 +40,8 @@ class HardwareManager(Protocol):
         In general, callers should not use the presence or absence of a specific subsystem to decide
         whether or not the hardware is operating properly.
         """
+        ...
+
+    async def get_serial_number(self) -> Optional[str]:
+        """Get the robot serial number, if provisioned. If not provisioned, will be None."""
         ...

--- a/app/src/redux/discovery/__fixtures__/index.ts
+++ b/app/src/redux/discovery/__fixtures__/index.ts
@@ -22,6 +22,11 @@ export const mockHealthResponse = {
   protocol_api_version: [2, 0] as [number, number],
 }
 
+export const mockHealthResponseWithSerial = {
+  ...mockHealthResponse,
+  robot_serial: 'this is a robot serial from robot server',
+}
+
 export const mockUpdateServerHealthResponse = {
   name: 'robot-name',
   apiServerVersion: '0.0.0-mock',
@@ -46,6 +51,11 @@ export const mockDiscoveryClientRobot = {
       serverHealthError: null,
     },
   ],
+}
+
+export const mockDiscoveryClientRobotWithHealthSerial = {
+  ...mockDiscoveryClientRobot,
+  health: mockHealthResponseWithSerial,
 }
 
 export const mockBaseRobot: BaseRobot = {

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -643,3 +643,30 @@ describe('discovery selectors', () => {
     it(name, () => expect(selector(state as State, ...args)).toEqual(expected))
   })
 })
+
+describe('getRobotSerialNumber', () => {
+  const SPECS: [{ name: string; robot: any; expected: string | null }][] = [
+    {
+      name: 'returns health serial on flex',
+      robot: MOCK_STATE.discovery.robotsByName.fizzbuzz,
+      expected: 'this is a flex serial',
+    },
+    {
+      name: 'getRobotSerial returns health serial on ot2 if available',
+      robot: MOCK_STATE.discovery.robotsByName.baz,
+      expected: 'this is an ot2 serial',
+    },
+    {
+      name: 'getRobotSerial falls back to update server if necessary',
+      robot: MOCK_STATE.discovery.robotsByName.bar,
+      expected: '12345',
+    },
+  ]
+  SPECS.forEach(spec => {
+    it(spec.name, () => {
+      expect(discovery.getRobotSerialNumber(spec.robot as any)).toEqual(
+        spec.expected
+      )
+    })
+  })
+})

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -645,7 +645,7 @@ describe('discovery selectors', () => {
 })
 
 describe('getRobotSerialNumber', () => {
-  const SPECS: [{ name: string; robot: any; expected: string | null }][] = [
+  const SPECS: Array<{ name: string; robot: any; expected: string | null }> = [
     {
       name: 'returns health serial on flex',
       robot: MOCK_STATE.discovery.robotsByName.fizzbuzz,

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -197,8 +197,10 @@ export const getDiscoverableRobotByName: (
   (robots, robotName) => robots.find(r => r.name === robotName) ?? null
 )
 
-export const getRobotSerialNumber = (robot: DiscoveredRobot): string | null =>
-  (robot.serverHealth && robot.serverHealth.serialNumber) ?? null
+export const getRobotSerialNumber = (robot: DiscoveredRobot): string | null => {
+  console.log(robot)
+  return robot.health?.robot_serial ?? robot.serverHealth?.serialNumber ?? null
+}
 
 export const getRobotApiVersion = (robot: DiscoveredRobot): string | null =>
   (robot.health && semver.valid(robot.health.api_version)) ??

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -197,10 +197,8 @@ export const getDiscoverableRobotByName: (
   (robots, robotName) => robots.find(r => r.name === robotName) ?? null
 )
 
-export const getRobotSerialNumber = (robot: DiscoveredRobot): string | null => {
-  console.log(robot)
-  return robot.health?.robot_serial ?? robot.serverHealth?.serialNumber ?? null
-}
+export const getRobotSerialNumber = (robot: DiscoveredRobot): string | null =>
+  robot.health?.robot_serial ?? robot.serverHealth?.serialNumber ?? null
 
 export const getRobotApiVersion = (robot: DiscoveredRobot): string | null =>
   (robot.health && semver.valid(robot.health.api_version)) ??

--- a/discovery-client/src/__fixtures__/health.ts
+++ b/discovery-client/src/__fixtures__/health.ts
@@ -12,6 +12,7 @@ export const mockOT3HealthResponse = {
   fw_version: '4.5.6',
   system_version: '7.8.9',
   robot_model: 'OT-3 Standard',
+  robot_serial: 'this is a flex serial',
 }
 
 export const mockOT2HealthResponse = {
@@ -20,6 +21,7 @@ export const mockOT2HealthResponse = {
   fw_version: '4.5.6',
   system_version: '7.8.9',
   robot_model: 'OT-2 Standard',
+  robot_serial: 'this is an ot2 serial',
 }
 
 export const mockLegacyServerHealthResponse = {
@@ -34,7 +36,7 @@ export const mockLegacyServerHealthResponse = {
 export const mockOT3ServerHealthResponse = {
   name: 'opentrons-dev',
   apiServerVersion: '1.2.3',
-  serialNumber: '12345',
+  serialNumber: 'unknown',
   updateServerVersion: '1.2.3',
   smoothieVersion: '4.5.6',
   systemVersion: '7.8.9',

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -20,6 +20,7 @@ export interface HealthResponse {
   minimum_protocol_api_version?: [number, number]
   maximum_protocol_api_version?: [number, number]
   robot_model?: string
+  robot_serial?: string | null
 }
 
 export type Capability =

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -84,7 +84,7 @@ class Health(BaseResponseBody):
     )
     robot_serial: typing.Optional[str] = Field(
         ...,
-        description='The robot serial number. Should be used if not none; if none, use result of /server/update/health.'
+        description="The robot serial number. Should be used if not none; if none, use result of /server/update/health.",
     )
     links: HealthLinks
 
@@ -107,6 +107,6 @@ class Health(BaseResponseBody):
                     "apiSpec": "/openapi.json",
                     "systemTime": "/system/time",
                 },
-                "robot_serial": None
+                "robot_serial": None,
             }
         }

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -82,6 +82,10 @@ class Health(BaseResponseBody):
         min_items=2,
         max_items=2,
     )
+    robot_serial: typing.Optional[str] = Field(
+        ...,
+        description='The robot serial number. Should be used if not none; if none, use result of /server/update/health.'
+    )
     links: HealthLinks
 
     class Config:
@@ -103,5 +107,6 @@ class Health(BaseResponseBody):
                     "apiSpec": "/openapi.json",
                     "systemTime": "/system/time",
                 },
+                "robot_serial": None
             }
         }

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -159,5 +159,5 @@ async def get_health(
         minimum_protocol_api_version=list(minimum_protocol_api_version),
         robot_model=robot_type,
         links=health_links,
-        robot_serial=(await hardware.get_serial_number())
+        robot_serial=(await hardware.get_serial_number()),
     )

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -159,4 +159,5 @@ async def get_health(
         minimum_protocol_api_version=list(minimum_protocol_api_version),
         robot_model=robot_type,
         links=health_links,
+        robot_serial=(await hardware.get_serial_number())
     )

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -15,6 +15,7 @@ def test_get_health(
     """Test GET /health."""
     hardware.fw_version = "FW111"
     hardware.board_revision = "BR2.1"
+    hardware.get_serial_number.return_value = 'mytestserial'
     versions.return_value = ComponentVersions(
         api_version="mytestapiversion", system_version="mytestsystemversion"
     )
@@ -36,6 +37,7 @@ def test_get_health(
             "apiSpec": "/openapi.json",
             "systemTime": "/system/time",
         },
+        'robot_serial': 'mytestserial'
     }
 
     resp = api_client.get("/health")

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -15,7 +15,7 @@ def test_get_health(
     """Test GET /health."""
     hardware.fw_version = "FW111"
     hardware.board_revision = "BR2.1"
-    hardware.get_serial_number.return_value = 'mytestserial'
+    hardware.get_serial_number.return_value = "mytestserial"
     versions.return_value = ComponentVersions(
         api_version="mytestapiversion", system_version="mytestsystemversion"
     )
@@ -37,7 +37,7 @@ def test_get_health(
             "apiSpec": "/openapi.json",
             "systemTime": "/system/time",
         },
-        'robot_serial': 'mytestserial'
+        "robot_serial": "mytestserial",
     }
 
     resp = api_client.get("/health")

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -30,11 +30,11 @@ def check_health_response(response: Response) -> None:
             "systemTime": "/system/time",
             "serverLog": "/logs/server.log",
         },
-        'robot_serial': 'simulator'
+        "robot_serial": "simulator",
     }
     got = response.json()
 
-    assert got == expected, f'health response failed:\n {got}'
+    assert got == expected, f"health response failed:\n {got}"
 
 
 def check_ot3_health_response(response: Response) -> None:
@@ -61,11 +61,11 @@ def check_ot3_health_response(response: Response) -> None:
             "systemTime": "/system/time",
             "serverLog": "/logs/server.log",
         },
-        'robot_serial': 'simulator'
+        "robot_serial": "simulator",
     }
     got = response.json()
 
-    assert got == expected, f'health response failed:\n {got}'
+    assert got == expected, f"health response failed:\n {got}"
 
 
 def get_module_id(response: Response, module_model: ModuleModel) -> Box:

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -30,9 +30,11 @@ def check_health_response(response: Response) -> None:
             "systemTime": "/system/time",
             "serverLog": "/logs/server.log",
         },
+        'robot_serial': 'simulator'
     }
+    got = response.json()
 
-    assert response.json() == expected
+    assert got == expected, f'health response failed:\n {got}'
 
 
 def check_ot3_health_response(response: Response) -> None:
@@ -59,9 +61,11 @@ def check_ot3_health_response(response: Response) -> None:
             "systemTime": "/system/time",
             "serverLog": "/logs/server.log",
         },
+        'robot_serial': 'simulator'
     }
+    got = response.json()
 
-    assert response.json() == expected
+    assert got == expected, f'health response failed:\n {got}'
 
 
 def get_module_id(response: Response, module_model: ModuleModel) -> Box:


### PR DESCRIPTION
The flex doesn't store its serial number in /var/serial; instead, it stores it in an onboard eeprom. While we had the code to read it, we weren't using that code anywhere, and we should expose it to the app for display.

However, the update server doesn't (and shouldn't) know how to talk to the onboard eeprom. That's a problem, because it knows perfectly well how to read a file, and thus is the current source of truth for the serial.

So this PR
- adds the serial to the robot server health endpoint, on both ot-2 and flex
- changes the app to try and prefer the serial from the robot server health endpoint, falling back to the update server health endpoint if necessary

## risk
low, this is really only about displaying the serial number in the advanced settings page

## tests
- [x] push to a flex and use the dev app and see that you get a serial number
- [x] use the dev app and check that a flex still has an unknown serial (i.e. and not a whitescreen)
- [x] use the dev app and check that an OT-2 still displays its serial (and not unknown or null)
- [x] use the dev app and push to an OT-2 and see that it still displays the same serial (and not unknown or null)