### PR TITLE
fix(app): fix pipette wizard flows always showing "recalibrate" on results step

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -97,17 +97,15 @@ export const PipetteWizardFlows = (
   const [isFetchingPipettes, setIsFetchingPipettes] = React.useState<boolean>(
     false
   )
-  const hasCalData = React.useRef<boolean | null>(null)
-  if (hasCalData.current == null) {
-    hasCalData.current =
-      attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
-  }
   const memoizedAttachedPipettes = React.useMemo(() => attachedPipettes, [])
+  const hasCalData =
+    memoizedAttachedPipettes[mount]?.data.calibratedOffset?.last_modified !=
+    null
   const wizardTitle = usePipetteFlowWizardHeaderText({
     flowType,
     mount,
     selectedPipette,
-    hasCalData: hasCalData.current,
+    hasCalData,
     isGantryEmpty,
     attachedPipettes: memoizedAttachedPipettes,
     pipetteInfo: memoizedPipetteInfo,
@@ -331,7 +329,7 @@ export const PipetteWizardFlows = (
         totalStepCount={totalStepCount}
         isFetching={isFetchingPipettes}
         setFetching={setIsFetchingPipettes}
-        hasCalData={hasCalData.current}
+        hasCalData={hasCalData}
         requiredPipette={requiredPipette}
       />
     )

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -97,14 +97,17 @@ export const PipetteWizardFlows = (
   const [isFetchingPipettes, setIsFetchingPipettes] = React.useState<boolean>(
     false
   )
-  const hasCalData =
-    attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
+  const hasCalData = React.useRef<boolean | null>(null)
+  if (hasCalData.current == null) {
+    hasCalData.current =
+      attachedPipettes[mount]?.data.calibratedOffset?.last_modified != null
+  }
   const memoizedAttachedPipettes = React.useMemo(() => attachedPipettes, [])
   const wizardTitle = usePipetteFlowWizardHeaderText({
     flowType,
     mount,
     selectedPipette,
-    hasCalData,
+    hasCalData: hasCalData.current,
     isGantryEmpty,
     attachedPipettes: memoizedAttachedPipettes,
     pipetteInfo: memoizedPipetteInfo,
@@ -328,7 +331,7 @@ export const PipetteWizardFlows = (
         totalStepCount={totalStepCount}
         isFetching={isFetchingPipettes}
         setFetching={setIsFetchingPipettes}
-        hasCalData={hasCalData}
+        hasCalData={hasCalData.current}
         requiredPipette={requiredPipette}
       />
     )


### PR DESCRIPTION
Closes RQA-1800

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Persists hasCalData between renders so as not to return true during the attach/calibration wizard flow after the calibration step.

hasCalData is only used for displaying correct wizard text and will not impact any wizard functionality.

### Before
<img width="1225" alt="Screenshot 2023-10-16 at 1 29 03 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/464e3b77-a4c7-4179-b9de-02f01cda9aad">

### After

<img width="879" alt="Screenshot 2023-10-16 at 1 14 32 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/72ea3553-d132-4f59-af77-c744280a3984">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Make sure your device has at least one mount empty, if not, detach a pipette to free the mount
- On the ODD, select instruments
- Select the empty mount, and select attach pipette
- Follow the wizard through the prompt for attach and calibrate
- Notice that on the results step (final step), the correct text is displayed.
- 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix attach pipette calibration wizard text. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
