### PR TITLE
fix(api): Implicitly pre-home in opentrons.simulate.get_protocol_api()

### DIFF
--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -316,6 +316,11 @@ def get_protocol_api(
             extra_labware=extra_labware,
         )
 
+    # Intentional difference from simulate.get_protocol_api():
+    # For the caller's convenience, we home the virtual hardware so they don't get MustHomeErrors.
+    # Since this hardware is virtual, there's no harm in commanding this "movement" implicitly.
+    context.home()
+
     return context
 
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -316,7 +316,7 @@ def get_protocol_api(
             extra_labware=extra_labware,
         )
 
-    # Intentional difference from simulate.get_protocol_api():
+    # Intentional difference from execute.get_protocol_api():
     # For the caller's convenience, we home the virtual hardware so they don't get MustHomeErrors.
     # Since this hardware is virtual, there's no harm in commanding this "movement" implicitly.
     context.home()

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -277,6 +277,17 @@ class TestSimulatePythonLabware:
             simulate.simulate(protocol_file=protocol_filelike, file_name=file_name)
 
 
+def test_get_protocol_api_usable_without_homing(api_version: APIVersion) -> None:
+    """You should be able to move the simulated hardware without having to home explicitly.
+
+    https://opentrons.atlassian.net/browse/RQA-1801
+    """
+    protocol = simulate.get_protocol_api(api_version)
+    pipette = protocol.load_instrument("p300_single_gen2", mount="left")
+    tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+    pipette.pick_up_tip(tip_rack["A1"])  # Should not raise.
+
+
 class TestGetProtocolAPILabware:
     """Tests for making sure get_protocol_api() handles extra labware correctly."""
 


### PR DESCRIPTION
# Overview

This fixes RQA-1801, an unreleased bug introduced by #13709.

Normally, the robot needs to be homed before you can command it to move, or it will raise an error. This is good.

However, there is a slight difference between `opentrons.execute.get_protocol_api()` and `opentrons.simulate.get_protocol_api()`: the `execute` variant requires the *caller* to do that home, whereas the `simulate` variant does it *for the caller.* In #13709, I accidentally dropped the implicit home from the `simulate` variant, causing it to start raising `MustHomeError`s.

# Test Plan

See RQA-1801.

# Changelog

* Add a test to catch the bug.
* Fix the bug by always doing `protocol_context.home()` in `opentrons.simulate.get_protocol_api()`, just before we return `protocol_context`.

  For PAPIv≤2.13, this is required to preserve historically expected behavior and fix RQA-1801. For PAPIv≥2.14, this is unnecessary, but harmless.


# Review requests

None in particular.

# Risk assessment

Low.