### PR TITLE
refactor(app): correct door open disabled tooltip logic on run page

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -551,7 +551,11 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     disableReason = t('shared:robot_is_busy')
   } else if (isRobotOnWrongVersionOfSoftware) {
     disableReason = t('shared:a_software_update_is_available')
-  } else if (runStatus != null && DISABLED_STATUSES.includes(runStatus)) {
+  } else if (
+    isDoorOpen &&
+    runStatus != null &&
+    START_RUN_STATUSES.includes(runStatus)
+  ) {
     disableReason = t('close_door')
   }
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -602,6 +602,28 @@ describe('ProtocolRunHeader', () => {
     getByText('Stop requested')
   })
 
+  it('renders a disabled button and when the robot door is open', () => {
+    when(mockUseRunQuery)
+      .calledWith(RUN_ID)
+      .mockReturnValue({
+        data: { data: mockRunningRun },
+      } as UseQueryResult<Run>)
+    when(mockUseRunStatus)
+      .calledWith(RUN_ID)
+      .mockReturnValue(RUN_STATUS_BLOCKED_BY_OPEN_DOOR)
+
+    const mockOpenDoorStatus = {
+      data: { status: 'open', doorRequiredClosedForProtocol: true },
+    }
+    mockUseDoorQuery.mockReturnValue({ data: mockOpenDoorStatus } as any)
+
+    const [{ getByText, getByRole }] = render()
+
+    const button = getByRole('button', { name: 'Resume run' })
+    expect(button).toBeDisabled()
+    getByText('Close robot door')
+  })
+
   it('renders a Run Again button and end time when run has stopped and calls trackProtocolRunEvent when run again button clicked', () => {
     when(mockUseRunQuery)
       .calledWith(RUN_ID)


### PR DESCRIPTION
# Overview

Oopsy went too fast when implementing https://github.com/Opentrons/opentrons/pull/13774 and didn't actually implement it correctly. This PR shows a `Close robot door` disabled tool tip when the door is open and pressing the CTA would result in the robot starting/continuing a run.

Actually fixes [RQA-1705](https://opentrons.atlassian.net/browse/RQA-1705)

# Test Plan

Verified this works as expected on a Flex and an OT-2

# Risk assessment

Low

[RQA-1705]: https://opentrons.atlassian.net/browse/RQA-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ