### PR TITLE
chore(app): point updates at dns not s3

### DIFF
--- a/app-shell/dev-app-update-robot-stack.yml
+++ b/app-shell/dev-app-update-robot-stack.yml
@@ -1,4 +1,3 @@
-provider: s3
-bucket: opentrons-app
-path: builds
+provider: generic
+bucket: https://builds.opentrons.com/app/
 channel: latest

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -7,20 +7,14 @@ const DEV_MODE = process.env.NODE_ENV !== 'production'
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
 
-const ot3PublishConfig =
+// this will generate either
+// https://builds.opentrons.com/app/ or https://ot3-development.builds.opentrons.com/app/
+// because these environment variables are provided by ci
+const publishConfig =
   OT_APP_DEPLOY_BUCKET && OT_APP_DEPLOY_FOLDER
     ? {
         provider: 'generic',
         url: `https://${OT_APP_DEPLOY_BUCKET}/${OT_APP_DEPLOY_FOLDER}/`,
-      }
-    : null
-
-const robotStackPublishConfig =
-  OT_APP_DEPLOY_BUCKET && OT_APP_DEPLOY_FOLDER
-    ? {
-        provider: 's3',
-        bucket: OT_APP_DEPLOY_BUCKET,
-        path: OT_APP_DEPLOY_FOLDER,
       }
     : null
 
@@ -80,7 +74,7 @@ module.exports = async () => ({
     category: 'Science',
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
   },
-  publish: project === 'ot3' ? ot3PublishConfig : robotStackPublishConfig,
+  publish: publishConfig,
   generateUpdatesFilesForAllChannels: true,
   beforePack: path.join(__dirname, './scripts/before-pack.js'),
 })


### PR DESCRIPTION
We're properly pointing at the builds.opentrons.com _bucket_ for release
installs, but we were using the s3 provider config which will hit the s3
bucket's public url and not hit the CDN (or the DNS, for that matter,
which is like half the point of doing this...). So change that to look
at the actual normal url https://builds.opentrons.com/app in the same
way we do for internal releases.
