### PR TITLE
fix(app): do not check mag block in calibration status

### DIFF
--- a/app/src/organisms/Devices/hooks/useModuleCalibrationStatus.ts
+++ b/app/src/organisms/Devices/hooks/useModuleCalibrationStatus.ts
@@ -1,3 +1,5 @@
+import omitBy from 'lodash/omitBy'
+import { MAGNETIC_BLOCK_TYPE } from '@opentrons/shared-data'
 import { useIsOT3 } from './useIsOT3'
 import { useModuleRenderInfoForProtocolById } from './useModuleRenderInfoForProtocolById'
 import { ProtocolCalibrationStatus } from './useRunCalibrationStatus'
@@ -7,10 +9,13 @@ export function useModuleCalibrationStatus(
   runId: string
 ): ProtocolCalibrationStatus {
   const isFlex = useIsOT3(robotName)
-  const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
-    robotName,
-    runId
+  // TODO: can probably use getProtocolModulesInfo but in a rush to get out 7.0.1
+  const moduleRenderInfoForProtocolById = omitBy(
+    useModuleRenderInfoForProtocolById(robotName, runId),
+    moduleRenderInfo =>
+      moduleRenderInfo.moduleDef.moduleType === MAGNETIC_BLOCK_TYPE
   )
+
   // only check module calibration for Flex
   if (!isFlex) {
     return { complete: true }


### PR DESCRIPTION

# Overview
There was a bug in the `useModuleCalibrationStatus` hook where we were looking for cal info for a mag block (which doesnt need to be calibrated).

closes RQA-1805



# Risk assessment

Low
