### PR TITLE
docs(api): update individual module pages for adapter split

### DIFF
--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -74,14 +74,36 @@ To prepare the deck before running a protocol, use the labware latch controls in
 Loading Labware
 ===============
 
-Like with all modules, use the Heater-Shaker’s :py:meth:`~.HeaterShakerContext.load_labware` method to specify what you will place on the module. For the Heater-Shaker, you must use a definition that describes the combination of a thermal adapter and labware that fits it.  See the :ref:`load-labware-module` section for an example of how to place labware on a module.
+Use the Heater-Shaker’s :py:meth:`~.HeaterShakerContext.load_adapter` and :py:meth:`~.HeaterShakerContext.load_labware` methods to specify what you will place on the module. For the Heater-Shaker, use one of the thermal adapters listed below and labware that fits on the adapter. See :ref:`labware-on-adapters` for examples of loading labware on modules.
 
-Currently, the `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes several pre-configured adapter–labware combinations and standalone adapter definitions that help make the Heater-Shaker ready to use right out of the box. See :ref:`labware-on-adapters` for examples of loading labware on modules.
+The `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes several standalone adapter definitions and pre-configured adapter–labware combinations that help make the Heater-Shaker ready to use right out of the box.
+
+.. note::
+    If you plan to :ref:`move labware <moving-labware>` onto or off of the Heater-Shaker during your protocol, you must use a standalone adapter definition, not an adapter–labware combination definiton.
+
+Standalone Adapters
+-------------------
+
+You can use these standalone adapter definitions to load Opentrons verified or custom labware on top of the Heater-Shaker. 
+
+.. list-table::
+   :header-rows: 1
+
+   * - Adapter Type
+     - API Load Name
+   * - Opentrons Universal Flat Adapter
+     - ``opentrons_universal_flat_adapter``
+   * - Opentrons 96 PCR Adapter
+     - ``opentrons_96_pcr_adapter``
+   * - Opentrons 96 Deep Well Adapter
+     - ``opentrons_96_deep_well_adapter``
+   * - Opentrons 96 Flat Bottom Adapter
+     - ``opentrons_96_flat_bottom_adapter``
 
 Pre-configured Combinations
 ---------------------------
 
-The Heater-Shaker supports these thermal adapter and labware combinations by default. These let you load the adapter and labware with a single definition.
+The Heater-Shaker supports these thermal adapter and labware combinations for backwards compatibility. If your protocol specifies an ``apiLevel`` of 2.15 or higher, you should use the standalone adapter definitions instead.
 
 .. list-table::
    :header-rows: 1
@@ -98,25 +120,6 @@ The Heater-Shaker supports these thermal adapter and labware combinations by def
      - ``opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt``
    * - Opentrons Universal Flat Adapter with Corning 384 Well Plate 112 µL Flat
      - ``opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat``
-
-Standalone Well-Plate Adapters
-------------------------------
-
-You can use these standalone adapter definitions to load Opentrons verified or custom labware on top of the Heater-Shaker.
-
-.. list-table::
-   :header-rows: 1
-
-   * - Adapter Type
-     - API Load Name
-   * - Opentrons Universal Flat Adapter
-     - ``opentrons_universal_flat_adapter``
-   * - Opentrons 96 PCR Adapter
-     - ``opentrons_96_pcr_adapter``
-   * - Opentrons 96 Deep Well Adapter
-     - ``opentrons_96_deep_well_adapter``
-   * - Opentrons 96 Flat Bottom Adapter
-     - ``opentrons_96_flat_bottom_adapter``
 
 Custom Flat-Bottom Labware
 --------------------------

--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -75,7 +75,7 @@ Loading Labware
 
 Use the Heater-Shaker’s :py:meth:`~.HeaterShakerContext.load_adapter` and :py:meth:`~.HeaterShakerContext.load_labware` methods to specify what you will place on the module. For the Heater-Shaker, use one of the thermal adapters listed below and labware that fits on the adapter. See :ref:`labware-on-adapters` for examples of loading labware on modules.
 
-The `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes several standalone adapter definitions and pre-configured adapter–labware combinations that help make the Heater-Shaker ready to use right out of the box.
+The `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes definitions for both standalone adapters and adapter–labware combinations. These labware definitions help make the Heater-Shaker ready to use right out of the box.
 
 .. note::
     If you plan to :ref:`move labware <moving-labware>` onto or off of the Heater-Shaker during your protocol, you must use a standalone adapter definition, not an adapter–labware combination definiton.

--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -102,7 +102,7 @@ You can use these standalone adapter definitions to load Opentrons verified or c
 For example, these commands load a well plate on top of the flat bottom adapter::
 
     hs_adapter = hs_mod.load_adapter('opentrons_96_flat_bottom_adapter')
-    hs_plate = hs_mod.load_labware('nest_96_wellplate_200ul_flat')
+    hs_plate = hs_adapter.load_labware('nest_96_wellplate_200ul_flat')
 
 .. versionadded:: 2.15
 

--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -105,6 +105,7 @@ For example, these commands load a well plate on top of the flat bottom adapter:
     hs_plate = hs_adapter.load_labware('nest_96_wellplate_200ul_flat')
 
 .. versionadded:: 2.15
+    The ``load_adapter()`` method.
 
 
 Pre-configured Combinations

--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -90,13 +90,13 @@ You can use these standalone adapter definitions to load Opentrons verified or c
 
    * - Adapter Type
      - API Load Name
-   * - Opentrons Universal Flat Adapter
+   * - Opentrons Universal Flat Heater-Shaker Adapter
      - ``opentrons_universal_flat_adapter``
-   * - Opentrons 96 PCR Adapter
+   * - Opentrons 96 PCR Heater-Shaker Adapter
      - ``opentrons_96_pcr_adapter``
-   * - Opentrons 96 Deep Well Adapter
+   * - Opentrons 96 Deep Well Heater-Shaker Adapter
      - ``opentrons_96_deep_well_adapter``
-   * - Opentrons 96 Flat Bottom Adapter
+   * - Opentrons 96 Flat Bottom Heater-Shaker Adapter
      - ``opentrons_96_flat_bottom_adapter``
 
 For example, these commands load a well plate on top of the flat bottom adapter::

--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -10,10 +10,9 @@ The Heater-Shaker Module provides on-deck heating and orbital shaking. The modul
 
 The Heater-Shaker Module is represented in code by a :py:class:`.HeaterShakerContext` object. For example::
 
-    def run(protocol: protocol_api.ProtocolContext):
-         hs_mod = protocol.load_module(
-          module_name='heaterShakerModuleV1',
-          location="D1")
+    hs_mod = protocol.load_module(
+        module_name="heaterShakerModuleV1", location="D1"
+    )
 
 .. versionadded:: 2.13
 
@@ -100,6 +99,14 @@ You can use these standalone adapter definitions to load Opentrons verified or c
    * - Opentrons 96 Flat Bottom Adapter
      - ``opentrons_96_flat_bottom_adapter``
 
+For example, these commands load a well plate on top of the flat bottom adapter::
+
+    hs_adapter = hs_mod.load_adapter('opentrons_96_flat_bottom_adapter')
+    hs_plate = hs_mod.load_labware('nest_96_wellplate_200ul_flat')
+
+.. versionadded:: 2.15
+
+
 Pre-configured Combinations
 ---------------------------
 
@@ -120,6 +127,14 @@ The Heater-Shaker supports these thermal adapter and labware combinations for ba
      - ``opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt``
    * - Opentrons Universal Flat Adapter with Corning 384 Well Plate 112 µL Flat
      - ``opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat``
+
+This command loads the same physical adapter and labware as the example in the previous section, but it is also compatible with API versions 2.13 and 2.14::
+
+    hs_combo = hs_mod.load_labware(
+        "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat"
+    )
+
+.. versionadded:: 2.13
 
 Custom Flat-Bottom Labware
 --------------------------

--- a/api/docs/v2/modules/magnetic_block.rst
+++ b/api/docs/v2/modules/magnetic_block.rst
@@ -17,20 +17,17 @@ The Magnetic Block is represented by a :py:class:`~opentrons.protocol_api.Magnet
 
 .. code-block:: python
 
-    def run(protocol: protocol_api.ProtocolContext):
-        
-        # Load the Magnetic Block in deck slot D1
-        magnetic_block = protocol.load_module(
-          module_name='magneticBlockV1',
-          location='D1')
-        
-        # Load a 96-well plate on the magnetic block
-        well_plate = magnetic_block.load_labware(
-          name="biorad_96_wellplate_200ul_pcr")
+    # Load the Magnetic Block in deck slot D1
+    magnetic_block = protocol.load_module(
+        module_name="magneticBlockV1", location="D1"
+    )
 
-        # Use the Gripper to move labware
-        protocol.move_labware(well_plate,
-                         new_location="B2",
-                         use_gripper=True)
+    # Load a 96-well plate on the magnetic block
+    mag_plate = magnetic_block.load_labware(
+        name="biorad_96_wellplate_200ul_pcr"
+    )
+
+    # Use the Gripper to move labware
+    protocol.move_labware(mag_plate, new_location="B2", use_gripper=True)
 
 .. versionadded:: 2.15

--- a/api/docs/v2/modules/temperature_module.rst
+++ b/api/docs/v2/modules/temperature_module.rst
@@ -23,7 +23,7 @@ Loading Labware
 
 Use the Temperature Module’s :py:meth:`~.TemperatureModuleContext.load_adapter` and :py:meth:`~.TemperatureModuleContext.load_labware` methods to specify what you will place on the module. You may use one or both of the methods, depending on the labware you're using. See :ref:`labware-on-adapters` for examples of loading labware on modules.
 
-The `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes standalone adapter definitions and pre-configured adapter–labware combinations that help make the Temperature Module ready to use right out of the box.
+The `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes definitions for both standalone adapters and adapter–labware combinations. These labware definitions help make the Temperature Module ready to use right out of the box.
 
 Standalone Adapters
 -------------------

--- a/api/docs/v2/modules/temperature_module.rst
+++ b/api/docs/v2/modules/temperature_module.rst
@@ -42,10 +42,15 @@ You can use these standalone adapter definitions to load Opentrons verified or c
      
 For example, these commands load a PCR plate on top of the 96-well block::
 
-    temp_adapter = temp_mod.load_adapter('opentrons_96_well_aluminum_block')
-    temp_plate = temp_adapter.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
+    temp_adapter = temp_mod.load_adapter(
+        'opentrons_96_well_aluminum_block'
+    )
+    temp_plate = temp_adapter.load_labware(
+        'nest_96_wellplate_100ul_pcr_full_skirt'
+    )
 
 .. versionadded:: 2.15
+    The ``load_adapter()`` method.
 
 .. note::
     You can also load labware directly onto the Temperature Module. In API version 2.14 and earlier, this was the correct way to load labware on top of the flat bottom plate. In API version 2.15 and later, you should load both the adapter and the labware with separate commands.

--- a/api/docs/v2/modules/temperature_module.rst
+++ b/api/docs/v2/modules/temperature_module.rst
@@ -11,16 +11,101 @@ The Temperature Module acts as both a cooling and heating device. It can control
 The Temperature Module is represented in code by a :py:class:`.TemperatureModuleContext` object, which has methods for setting target temperatures and reading the module's status. This example demonstrates loading a Temperature Module GEN2 and loading a well plate on top of it.
 
 .. code-block:: python
-    :substitutions:
 
-    def run(protocol: protocol_api.ProtocolContext):
-        temp_mod = protocol.load_module(
-          module_name='temperature module gen2',
-          location='D3')
-        plate = temp_mod.load_labware(
-          name='corning_96_wellplate_360ul_flat')
+    temp_mod = protocol.load_module(
+        module_name="temperature module gen2", location="D3"
+    )
 
 .. versionadded:: 2.3
+
+Loading Labware
+===============
+
+Use the Temperature Module’s :py:meth:`~.TemperatureModuleContext.load_adapter` and :py:meth:`~.TemperatureModuleContext.load_labware` methods to specify what you will place on the module. You may use one or both of the methods, depending on the labware you're using. See :ref:`labware-on-adapters` for examples of loading labware on modules.
+
+The `Opentrons Labware Library <https://labware.opentrons.com/>`_ includes standalone adapter definitions and pre-configured adapter–labware combinations that help make the Temperature Module ready to use right out of the box.
+
+Standalone Adapters
+-------------------
+
+You can use these standalone adapter definitions to load Opentrons verified or custom labware on top of the Temperature Module. 
+
+.. list-table::
+   :header-rows: 1
+
+   * - Adapter Type
+     - API Load Name
+   * - Opentrons Aluminum Flat Bottom Plate
+     - ``opentrons_aluminum_flat_bottom_plate``
+   * - Opentrons 96 Well Aluminum Block
+     - ``opentrons_96_well_aluminum_block``
+     
+For example, these commands load a PCR plate on top of the 96-well block::
+
+    temp_adapter = temp_mod.load_adapter('opentrons_96_well_aluminum_block')
+    temp_plate = temp_adapter.load_labware('nest_96_wellplate_100ul_pcr_full_skirt')
+
+.. versionadded:: 2.15
+
+.. note::
+    You can also load labware directly onto the Temperature Module. In API version 2.14 and earlier, this was the correct way to load labware on top of the flat bottom plate. In API version 2.15 and later, you should load both the adapter and the labware with separate commands.
+
+Block-and-tube combinations
+---------------------------
+
+You can use these combination labware definitions to load various types of tubes into the 24-well thermal block on top of the Temperature Module. There is no standalone definition for the 24-well block.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tube Type
+     - API Load Name
+   * - Generic 2 mL screw cap
+     - ``opentrons_24_aluminumblock_generic_2ml_screwcap``
+   * - NEST 0.5 mL screw cap
+     - ``opentrons_24_aluminumblock_nest_0.5ml_screwcap``
+   * - NEST 1.5 mL screw cap
+     - ``opentrons_24_aluminumblock_nest_1.5ml_screwcap``
+   * - NEST 1.5 mL snap cap
+     - ``opentrons_24_aluminumblock_nest_1.5ml_snapcap``
+   * - NEST 2 mL screw cap
+     - ``opentrons_24_aluminumblock_nest_2ml_screwcap``
+   * - NEST 2 mL snap cap
+     - ``opentrons_24_aluminumblock_nest_2ml_snapcap``
+     
+For example, this command loads the 24-well block with generic 2 mL tubes::
+
+    temp_tubes = temp_mod.load_labware(
+        'opentrons_24_aluminumblock_generic_2ml_screwcap'
+    )
+
+.. versionadded:: 2.0
+
+Block-and-plate combinations
+----------------------------
+
+The Temperature Module supports these 96-well block and labware combinations for backwards compatibility. If your protocol specifies an ``apiLevel`` of 2.15 or higher, you should use the standalone 96-well block definition instead.
+
+.. list-table::
+   :header-rows: 1
+
+   * - 96-well block contents
+     - API Load Name
+   * - Bio-Rad well plate 200 μL
+     - ``opentrons_96_aluminumblock_biorad_wellplate_200uL``
+   * - Generic PCR strip 200 μL
+     - ``opentrons_96_aluminumblock_generic_pcr_strip_200uL``
+   * - NEST well plate 100 μL
+     - ``opentrons_96_aluminumblock_nest_wellplate_100uL``
+
+This command loads the same physical adapter and labware as the example in the Standalone Adapters section above, but it is also compatible with earlier API versions::
+
+    temp_combo = temp_mod.load_labware(
+        "opentrons_96_aluminumblock_nest_wellplate_100uL"
+    )
+
+.. versionadded:: 2.0
+
 
 Temperature Control
 ===================

--- a/api/docs/v2/modules/thermocycler.rst
+++ b/api/docs/v2/modules/thermocycler.rst
@@ -14,9 +14,8 @@ The examples in this section will use a Thermocycler Module GEN2 loaded as follo
 
 .. code-block:: python
 
-    def run(protocol: protocol_api.ProtocolContext):
-        tc_mod = protocol.load_module(module_name='thermocyclerModuleV2')
-        plate = tc_mod.load_labware(name='nest_96_wellplate_100ul_pcr_full_skirt')
+    tc_mod = protocol.load_module(module_name='thermocyclerModuleV2')
+    plate = tc_mod.load_labware(name='nest_96_wellplate_100ul_pcr_full_skirt')
 
 .. versionadded:: 2.13
 

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -100,7 +100,7 @@ The ``load_adapter()`` method is available on ``ProtocolContext`` and module con
 
     hs_mod = protocol.load_module('heaterShakerModuleV1', 'D1')
     hs_adapter = hs_mod.load_adapter('opentrons_96_flat_bottom_adapter')
-    hs_plate = hs_mod.load_labware('nest_96_wellplate_200ul_flat')
+    hs_plate = hs_adapter.load_labware('nest_96_wellplate_200ul_flat')
     
 .. versionadded:: 2.15
     The ``load_adapter()`` method.


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Improve the documentation for working with labware on top of modules in a post-adapter-split world. The docs now capture the current situation for Heater-Shaker and Temperature Module, and set us up to add the new Temperature Module adapters once their definitions are created.

Addresses RTC-356 and more.

# Test Plan

- Checked all formatting in the [sandbox](http://sandbox.docs.opentrons.com/docs-module-adapter-split/v2/).
- Analyzed new and modified code with API v2.15 and latest app 7.0.1 alpha.

# Changelog

- Add new Loading Labware section to the Temperature Module page.
- Restructure Loading Labware section on the Heater-Shaker page to put Standalone Adapters first.
- Fix incorrect code snippet on Labware page (loaded labware on module instead of on adapter).
- Clean up and simplify code (remove `def run` line) on Magnetic Block and Thermocycler pages.

# Review requests

- Is it OK that module-specific methods (like heating, cooling, shaking) get pushed so far down these pages? I think the order is logical — you do need to load a module, load adapters and labware on it, and _then_ finally issue commands. But it might be burying the lede or be annoying to users who already know the loading basics.
- Double check code plz.

# Risk assessment

None, docs.