### PR TITLE
fix(robot-server): add default to robot serial

### DIFF
--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -84,7 +84,7 @@ class Health(BaseResponseBody):
     )
     robot_serial: typing.Optional[str] = Field(
         default=None,
-        description="The robot serial number. Should be used if not present; if not present, use result of /server/update/health.",
+        description="The robot serial number. Should be used if present; if not present, use result of /server/update/health.",
     )
     links: HealthLinks
 

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -83,8 +83,8 @@ class Health(BaseResponseBody):
         max_items=2,
     )
     robot_serial: typing.Optional[str] = Field(
-        ...,
-        description="The robot serial number. Should be used if not none; if none, use result of /server/update/health.",
+        default=None,
+        description="The robot serial number. Should be used if not present; if not present, use result of /server/update/health.",
     )
     links: HealthLinks
 

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -47,6 +47,43 @@ def test_get_health(
     assert text == expected
 
 
+def test_get_health_with_none_version(
+    api_client: TestClient, hardware: MagicMock, versions: MagicMock
+) -> None:
+    """Test GET /health with no serial number."""
+    hardware.fw_version = "FW111"
+    hardware.board_revision = "BR2.1"
+    hardware.get_serial_number.return_value = None
+    versions.return_value = ComponentVersions(
+        api_version="mytestapiversion", system_version="mytestsystemversion"
+    )
+
+    expected = {
+        "name": "opentrons-dev",
+        "api_version": "mytestapiversion",
+        "fw_version": "FW111",
+        "board_revision": "BR2.1",
+        "logs": ["/logs/serial.log", "/logs/api.log", "/logs/server.log"],
+        "system_version": "mytestsystemversion",
+        "minimum_protocol_api_version": list(MIN_SUPPORTED_VERSION),
+        "maximum_protocol_api_version": list(MAX_SUPPORTED_VERSION),
+        "robot_model": "OT-2 Standard",
+        "links": {
+            "apiLog": "/logs/api.log",
+            "serialLog": "/logs/serial.log",
+            "serverLog": "/logs/server.log",
+            "apiSpec": "/openapi.json",
+            "systemTime": "/system/time",
+        },
+    }
+
+    resp = api_client.get("/health")
+    text = resp.json()
+
+    assert resp.status_code == 200
+    assert text == expected
+
+
 @pytest.fixture
 def mock_version_file_contents() -> Iterator[MagicMock]:
     """Returns a mock for version file contents."""


### PR DESCRIPTION
Some combination of pydantic and fastapi (fastapi, I'm pretty sure, due to things like https://github.com/pydantic/pydantic/issues/1223 ) conflate "null" and "not present" in weird ways. This means that in the health response pydantic class,
- If you create robot_serial in the proper way to have a pydantic field that can be either a string or null but must always be passed in to the constructor - annotation Optional[str] and do not provide a default - then pydantic will say there's a field missing if you explicitly pass in null (the bug this fixes, since this 500s the route)
- If you create robot_serial with a default value, which is _not correct_ because there is no default, then something (probably fastapi) will remove the _key_ from the model rather than issueing it with a null, which is terrible, but is better than the other way I guess.

Updating fastapi might help with this maybe. I don't know.

This changes the semantics of this field to "present and not-null or not present" rather than "always present and maybe null"; luckily, the app side of this will be fine without changes because it was written to handle older health responses that wouldn't have the field.

## testing
- [x] put this on a flex that does not have a serial number in its eeprom or in `/var/serial` and check that `GET /health` still works and now does not have a robot_serial field
- [x] put this on a flex that does have an eeprom serial and check that it works
- [x] put this on an ot2 that has a serial and check that it works
- [x] put this on an ot2 that doesn't have a serial and check that it works
where "works" means "doesn't 500"