### PR TITLE
fix(app): unload adapters after checking position of labware on adapter on heater shaker module

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LabwarePositionCheck/CheckItem.tsx
@@ -323,7 +323,18 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
         ]
 
   const handleConfirmPosition = (): void => {
-    let confirmPositionCommands: CreateCommand[] = [
+    const heaterShakerPrepCommands: CreateCommand[] =
+      moduleId != null &&
+      moduleType != null &&
+      moduleType === HEATERSHAKER_MODULE_TYPE
+        ? [
+            {
+              commandType: 'heaterShaker/openLabwareLatch',
+              params: { moduleId },
+            },
+          ]
+        : []
+    const confirmPositionCommands: CreateCommand[] = [
       {
         commandType: 'retractAxis' as const,
         params: {
@@ -338,23 +349,10 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
         commandType: 'retractAxis' as const,
         params: { axis: 'y' },
       },
+      ...heaterShakerPrepCommands,
       ...moveLabwareOffDeck,
     ]
 
-    if (
-      moduleId != null &&
-      moduleType != null &&
-      moduleType === HEATERSHAKER_MODULE_TYPE
-    ) {
-      confirmPositionCommands = [
-        confirmPositionCommands[0],
-        {
-          commandType: 'heaterShaker/openLabwareLatch',
-          params: { moduleId },
-        },
-        confirmPositionCommands[1],
-      ]
-    }
     chainRunCommands(
       [
         { commandType: 'savePosition', params: { pipetteId } },

--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -500,6 +500,152 @@ describe('CheckItem', () => {
     )
   })
 
+  it('executes correct chained commands when confirm position clicked with HS and adapter', async () => {
+    props = {
+      ...props,
+      location: { slotName: 'D1', moduleModel: HEATERSHAKER_MODULE_V1 },
+      adapterId: 'adapterId',
+      moduleId: 'heaterShakerId',
+      protocolData: {
+        ...props.protocolData,
+        modules: [
+          {
+            id: 'heaterShakerId',
+            model: HEATERSHAKER_MODULE_V1,
+            location: { slotName: 'D3' },
+            serialNumber: 'firstHSSerial',
+          },
+        ],
+      },
+      workingOffsets: [
+        {
+          location: { slotName: 'D1', moduleModel: HEATERSHAKER_MODULE_V1 },
+          labwareId: 'labwareId1',
+          initialPosition: { x: 1, y: 2, z: 3 },
+          finalPosition: null,
+        },
+      ],
+    }
+    when(mockChainRunCommands)
+      .calledWith(
+        [
+          {
+            commandType: 'savePosition',
+            params: { pipetteId: 'pipetteId1' },
+          },
+          {
+            commandType: 'retractAxis' as const,
+            params: {
+              axis: 'leftZ',
+            },
+          },
+          {
+            commandType: 'retractAxis' as const,
+            params: {
+              axis: 'x',
+            },
+          },
+          {
+            commandType: 'retractAxis' as const,
+            params: {
+              axis: 'y',
+            },
+          },
+          {
+            commandType: 'heaterShaker/openLabwareLatch',
+            params: { moduleId: 'heaterShakerId' },
+          },
+          {
+            commandType: 'moveLabware',
+            params: {
+              labwareId: 'labwareId1',
+              newLocation: 'offDeck',
+              strategy: 'manualMoveWithoutPause',
+            },
+          },
+          {
+            commandType: 'moveLabware',
+            params: {
+              labwareId: 'adapterId',
+              newLocation: 'offDeck',
+              strategy: 'manualMoveWithoutPause',
+            },
+          },
+        ],
+        false
+      )
+      .mockImplementation(() =>
+        Promise.resolve([
+          {
+            data: {
+              commandType: 'savePosition',
+              result: { position: mockEndPosition },
+            },
+          },
+          {},
+          {},
+          {},
+          {},
+          {},
+          {},
+        ])
+      )
+
+    const { getByRole } = render(props)
+    await getByRole('button', { name: 'Confirm position' }).click()
+
+    await expect(props.chainRunCommands).toHaveBeenNthCalledWith(
+      1,
+      [
+        {
+          commandType: 'savePosition',
+          params: { pipetteId: 'pipetteId1' },
+        },
+        {
+          commandType: 'retractAxis' as const,
+          params: {
+            axis: 'leftZ',
+          },
+        },
+        {
+          commandType: 'retractAxis' as const,
+          params: { axis: 'x' },
+        },
+        {
+          commandType: 'retractAxis' as const,
+          params: { axis: 'y' },
+        },
+        {
+          commandType: 'heaterShaker/openLabwareLatch',
+          params: { moduleId: 'heaterShakerId' },
+        },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'labwareId1',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+        {
+          commandType: 'moveLabware',
+          params: {
+            labwareId: 'adapterId',
+            newLocation: 'offDeck',
+            strategy: 'manualMoveWithoutPause',
+          },
+        },
+      ],
+      false
+    )
+    await expect(props.registerPosition).toHaveBeenNthCalledWith(1, {
+      type: 'finalPosition',
+      labwareId: 'labwareId1',
+      location: { slotName: 'D1', moduleModel: HEATERSHAKER_MODULE_V1 },
+      position: mockEndPosition,
+    })
+  })
+
   it('executes thermocycler open lid command on mount if checking labware on thermocycler', () => {
     props = {
       ...props,

--- a/app/src/organisms/ProtocolSetupModules/index.tsx
+++ b/app/src/organisms/ProtocolSetupModules/index.tsx
@@ -130,7 +130,10 @@ function RenderModuleStatus({
     </>
   )
 
-  if (isModuleReady) {
+  if (
+    isModuleReady &&
+    module.attachedModuleMatch?.moduleOffset?.last_modified != null
+  ) {
     moduleStatus = (
       <>
         <Chip
@@ -144,7 +147,11 @@ function RenderModuleStatus({
         ) : null}
       </>
     )
-  } else if (calibrationStatus.complete) {
+  } else if (
+    isModuleReady &&
+    calibrationStatus.complete &&
+    module.attachedModuleMatch?.moduleOffset?.last_modified == null
+  ) {
     moduleStatus = (
       <SmallButton
         buttonCategory="rounded"
@@ -193,8 +200,7 @@ function RowModule({
     module.moduleDef.moduleType
   )
   const isModuleReady =
-    isNonConnectingModule ||
-    module.attachedModuleMatch?.moduleOffset?.last_modified != null
+    isNonConnectingModule || module.attachedModuleMatch != null
 
   const [showModuleWizard, setShowModuleWizard] = React.useState<boolean>(false)
 
@@ -213,7 +219,12 @@ function RowModule({
       ) : null}
       <Flex
         alignItems={ALIGN_CENTER}
-        backgroundColor={isModuleReady ? COLORS.green3 : COLORS.yellow3}
+        backgroundColor={
+          isModuleReady &&
+          module.attachedModuleMatch?.moduleOffset?.last_modified != null
+            ? COLORS.green3
+            : COLORS.yellow3
+        }
         borderRadius={BORDERS.borderRadiusSize3}
         cursor={isDuplicateModuleModel ? 'pointer' : 'inherit'}
         gridGap={SPACING.spacing24}

--- a/app/src/organisms/ProtocolSetupModules/index.tsx
+++ b/app/src/organisms/ProtocolSetupModules/index.tsx
@@ -130,10 +130,7 @@ function RenderModuleStatus({
     </>
   )
 
-  if (
-    isModuleReady &&
-    module.attachedModuleMatch?.moduleOffset?.last_modified != null
-  ) {
+  if (isModuleReady) {
     moduleStatus = (
       <>
         <Chip
@@ -147,11 +144,7 @@ function RenderModuleStatus({
         ) : null}
       </>
     )
-  } else if (
-    isModuleReady &&
-    calibrationStatus.complete &&
-    module.attachedModuleMatch?.moduleOffset?.last_modified == null
-  ) {
+  } else if (calibrationStatus.complete) {
     moduleStatus = (
       <SmallButton
         buttonCategory="rounded"
@@ -200,7 +193,8 @@ function RowModule({
     module.moduleDef.moduleType
   )
   const isModuleReady =
-    isNonConnectingModule || module.attachedModuleMatch != null
+    isNonConnectingModule ||
+    module.attachedModuleMatch?.moduleOffset?.last_modified != null
 
   const [showModuleWizard, setShowModuleWizard] = React.useState<boolean>(false)
 
@@ -219,12 +213,7 @@ function RowModule({
       ) : null}
       <Flex
         alignItems={ALIGN_CENTER}
-        backgroundColor={
-          isModuleReady &&
-          module.attachedModuleMatch?.moduleOffset?.last_modified != null
-            ? COLORS.green3
-            : COLORS.yellow3
-        }
+        backgroundColor={isModuleReady ? COLORS.green3 : COLORS.yellow3}
         borderRadius={BORDERS.borderRadiusSize3}
         cursor={isDuplicateModuleModel ? 'pointer' : 'inherit'}
         gridGap={SPACING.spacing24}


### PR DESCRIPTION
# Overview

Properly combine dynamic logic for opening the heater shaker latch and offloading the labware and adapters in the correct order during LPC checks of labware on adapters on heater shaker modules

Closes RAUT-803

# Review requests

-  run LPC for a protocol that includes two unique labware loaded into the heatershaker on the same adapter

# Risk assessment
low