### PR TITLE
feat(protocol-designer): error handling in create file wizard

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -110,7 +110,6 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     robotType,
     trashSlot,
   } = props
-  console.log(deckSlotsById)
   // NOTE: handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls.
   // But when swapping labware when at least one is on a module, we need to be aware

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -36,6 +36,9 @@ import {
   RobotType,
   FLEX_ROBOT_TYPE,
   Cutout,
+  TRASH_BIN_LOAD_NAME,
+  STAGING_AREA_LOAD_NAME,
+  WASTE_CHUTE_LOAD_NAME,
 } from '@opentrons/shared-data'
 import {
   FLEX_TRASH_DEF_URI,
@@ -107,7 +110,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     robotType,
     trashSlot,
   } = props
-
+  console.log(deckSlotsById)
   // NOTE: handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls.
   // But when swapping labware when at least one is on a module, we need to be aware
@@ -494,15 +497,15 @@ export const DeckSetup = (): JSX.Element => {
     {
       fixtureId: trash?.id,
       fixtureLocation: trash?.slot as Cutout,
-      loadName: 'trashBin',
+      loadName: TRASH_BIN_LOAD_NAME,
     },
   ]
   const wasteChuteFixtures = Object.values(
     activeDeckSetup.additionalEquipmentOnDeck
-  ).filter(aE => aE.name === 'wasteChute')
+  ).filter(aE => aE.name === WASTE_CHUTE_LOAD_NAME)
   const stagingAreaFixtures: AdditionalEquipmentEntity[] = Object.values(
     activeDeckSetup.additionalEquipmentOnDeck
-  ).filter(aE => aE.name === 'stagingArea')
+  ).filter(aE => aE.name === STAGING_AREA_LOAD_NAME)
   const locations = Object.values(
     activeDeckSetup.additionalEquipmentOnDeck
   ).map(aE => aE.location)
@@ -545,22 +548,26 @@ export const DeckSetup = (): JSX.Element => {
                       fixtureBaseColor={lightFill}
                     />
                   ))}
-                  {trashBinFixtures.map(fixture => (
-                    <React.Fragment key={fixture.fixtureId}>
-                      <SingleSlotFixture
-                        cutoutLocation={fixture.fixtureLocation}
-                        deckDefinition={deckDef}
-                        slotClipColor={COLORS.transparent}
-                        fixtureBaseColor={lightFill}
-                      />
-                      <FlexTrash
-                        robotType={robotType}
-                        trashIconColor={lightFill}
-                        trashLocation={fixture.fixtureLocation as TrashLocation}
-                        backgroundColor={darkFill}
-                      />
-                    </React.Fragment>
-                  ))}
+                  {trash != null
+                    ? trashBinFixtures.map(fixture => (
+                        <React.Fragment key={fixture.fixtureId}>
+                          <SingleSlotFixture
+                            cutoutLocation={fixture.fixtureLocation}
+                            deckDefinition={deckDef}
+                            slotClipColor={COLORS.transparent}
+                            fixtureBaseColor={lightFill}
+                          />
+                          <FlexTrash
+                            robotType={robotType}
+                            trashIconColor={lightFill}
+                            trashLocation={
+                              fixture.fixtureLocation as TrashLocation
+                            }
+                            backgroundColor={darkFill}
+                          />
+                        </React.Fragment>
+                      ))
+                    : null}
                   {wasteChuteFixtures.map(fixture => (
                     <WasteChuteFixture
                       key={fixture.id}

--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -204,7 +204,7 @@ function FlexModuleFields(props: FlexModuleFieldsProps): JSX.Element {
   const { values, setFieldValue, enableDeckModification } = props
 
   const isFlex = values.fields.robotType === FLEX_ROBOT_TYPE
-  const trashDisabled = getTrashBinOptionDisabled(values)
+  const trashBinDisabled = getTrashBinOptionDisabled(values)
 
   const handleSetEquipmentOption = (equipment: AdditionalEquipment): void => {
     if (values.additionalEquipment.includes(equipment)) {
@@ -221,13 +221,13 @@ function FlexModuleFields(props: FlexModuleFieldsProps): JSX.Element {
   }
 
   React.useEffect(() => {
-    if (trashDisabled) {
+    if (trashBinDisabled) {
       setFieldValue(
         'additionalEquipment',
         without(values.additionalEquipment, 'trashBin')
       )
     }
-  }, [trashDisabled, setFieldValue])
+  }, [trashBinDisabled, setFieldValue])
 
   return (
     <Flex flexWrap={WRAP} gridGap={SPACING.spacing4} alignSelf={ALIGN_CENTER}>
@@ -296,7 +296,7 @@ function FlexModuleFields(props: FlexModuleFieldsProps): JSX.Element {
             }
             text="Trash Bin"
             showCheckbox
-            disabled={trashDisabled}
+            disabled={trashBinDisabled}
           />
         </>
       ) : null}

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/CreateFileWizard.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/CreateFileWizard.test.tsx
@@ -209,7 +209,7 @@ describe('CreateFileWizard', () => {
     next.click()
     getByText('Step 6 / 7')
     //  select a staging area
-    getByText('Staging areas')
+    getByText('Staging area slots')
     next = getByRole('button', { name: 'Next' })
     next.click()
     getByText('Step 7 / 7')

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/StagingAreaTile.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/StagingAreaTile.test.tsx
@@ -54,7 +54,7 @@ describe('StagingAreaTile', () => {
   it('renders header and deck configurator', () => {
     props.values.fields.robotType = FLEX_ROBOT_TYPE
     const { getByText } = render(props)
-    getByText('Staging areas')
+    getByText('Staging area slots')
     getByText('mock deck configurator')
   })
 })

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
@@ -1,0 +1,81 @@
+import {
+  FLEX_ROBOT_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import {
+  FLEX_TRASH_DEFAULT_SLOT,
+  getLastCheckedEquipment,
+  getTrashSlot,
+} from '../utils'
+import type {
+  FormModulesByType,
+  FormPipettesByMount,
+} from '../../../../step-forms'
+import type { FormState } from '../types'
+
+let MOCK_FORM_STATE = {
+  fields: {
+    name: 'mockName',
+    description: 'mockDescription',
+    organizationOrAuthor: 'mockOrganizationOrAuthor',
+    robotType: FLEX_ROBOT_TYPE,
+  },
+  pipettesByMount: {
+    left: { pipetteName: 'mockPipetteName', tiprackDefURI: 'mocktip' },
+    right: { pipetteName: null, tiprackDefURI: null },
+  } as FormPipettesByMount,
+  modulesByType: {
+    heaterShakerModuleType: { onDeck: false, model: null, slot: 'D1' },
+    magneticBlockType: { onDeck: false, model: null, slot: 'D2' },
+    temperatureModuleType: { onDeck: false, model: null, slot: 'C1' },
+    thermocyclerModuleType: { onDeck: false, model: null, slot: 'B1' },
+  } as FormModulesByType,
+  additionalEquipment: [],
+} as FormState
+
+describe('getLastCheckedEquipment', () => {
+  it('should return null when there is no trash bin', () => {
+    const result = getLastCheckedEquipment(MOCK_FORM_STATE)
+    expect(result).toBe(null)
+  })
+  it('should return null if not all the modules are selected', () => {
+    MOCK_FORM_STATE = {
+      ...MOCK_FORM_STATE,
+      additionalEquipment: ['trashBin'],
+      modulesByType: {
+        ...MOCK_FORM_STATE.modulesByType,
+        temperatureModuleType: { onDeck: true, model: null, slot: 'C1' },
+      },
+    }
+    const result = getLastCheckedEquipment(MOCK_FORM_STATE)
+    expect(result).toBe(null)
+  })
+  it('should return temperature module if other modules are selected', () => {
+    MOCK_FORM_STATE = {
+      ...MOCK_FORM_STATE,
+      additionalEquipment: ['trashBin'],
+      modulesByType: {
+        ...MOCK_FORM_STATE.modulesByType,
+        heaterShakerModuleType: { onDeck: true, model: null, slot: 'D1' },
+        thermocyclerModuleType: { onDeck: true, model: null, slot: 'B1' },
+      },
+    }
+    const result = getLastCheckedEquipment(MOCK_FORM_STATE)
+    expect(result).toBe(TEMPERATURE_MODULE_TYPE)
+  })
+})
+
+describe('getTrashSlot', () => {
+  it('should return the default slot A3 when there is no staging area in that slot', () => {
+    const result = getTrashSlot(MOCK_FORM_STATE)
+    expect(result).toBe(FLEX_TRASH_DEFAULT_SLOT)
+  })
+  it('should return B3 when there is a staging area in slot A3', () => {
+    MOCK_FORM_STATE = {
+      ...MOCK_FORM_STATE,
+      additionalEquipment: ['stagingArea_A3'],
+    }
+    const result = getTrashSlot(MOCK_FORM_STATE)
+    expect(result).toBe('B3')
+  })
+})

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
@@ -38,7 +38,7 @@ describe('getLastCheckedEquipment', () => {
     const result = getLastCheckedEquipment(MOCK_FORM_STATE)
     expect(result).toBe(null)
   })
-  it('should return null if not all the modules are selected', () => {
+  it('should return null if not all the modules or staging areas are selected', () => {
     MOCK_FORM_STATE = {
       ...MOCK_FORM_STATE,
       additionalEquipment: ['trashBin'],
@@ -50,10 +50,16 @@ describe('getLastCheckedEquipment', () => {
     const result = getLastCheckedEquipment(MOCK_FORM_STATE)
     expect(result).toBe(null)
   })
-  it('should return temperature module if other modules are selected', () => {
+  it('should return temperature module if other modules and staging areas are selected', () => {
     MOCK_FORM_STATE = {
       ...MOCK_FORM_STATE,
-      additionalEquipment: ['trashBin'],
+      additionalEquipment: [
+        'trashBin',
+        'stagingArea_A3',
+        'stagingArea_B3',
+        'stagingArea_C3',
+        'stagingArea_D3',
+      ],
       modulesByType: {
         ...MOCK_FORM_STATE.modulesByType,
         heaterShakerModuleType: { onDeck: true, model: null, slot: 'D1' },
@@ -67,6 +73,10 @@ describe('getLastCheckedEquipment', () => {
 
 describe('getTrashSlot', () => {
   it('should return the default slot A3 when there is no staging area in that slot', () => {
+    MOCK_FORM_STATE = {
+      ...MOCK_FORM_STATE,
+      additionalEquipment: ['trashBin'],
+    }
     const result = getTrashSlot(MOCK_FORM_STATE)
     expect(result).toBe(FLEX_TRASH_DEFAULT_SLOT)
   })

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -8,6 +8,7 @@ import uniq from 'lodash/uniq'
 import { Formik, FormikProps } from 'formik'
 import * as Yup from 'yup'
 import { ModalShell } from '@opentrons/components'
+import { OT_2_TRASH_DEF_URI } from '@opentrons/step-generation'
 import {
   ModuleType,
   ModuleModel,
@@ -60,13 +61,10 @@ import { FirstPipetteTipsTile, SecondPipetteTipsTile } from './PipetteTipsTile'
 import { ModulesAndOtherTile } from './ModulesAndOtherTile'
 import { WizardHeader } from './WizardHeader'
 import { StagingAreaTile } from './StagingAreaTile'
-
-import {
-  NormalizedPipette,
-  OT_2_TRASH_DEF_URI,
-} from '@opentrons/step-generation'
-import type { FormState } from './types'
 import { getTrashSlot } from './utils'
+
+import type { NormalizedPipette } from '@opentrons/step-generation'
+import type { FormState } from './types'
 
 type WizardStep =
   | 'robotType'

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -66,6 +66,7 @@ import {
   OT_2_TRASH_DEF_URI,
 } from '@opentrons/step-generation'
 import type { FormState } from './types'
+import { getTrashSlot } from './utils'
 
 type WizardStep =
   | 'robotType'
@@ -201,28 +202,21 @@ export function CreateFileWizard(): JSX.Element | null {
 
       //  add trash
       if (
-        enableDeckModification &&
-        values.additionalEquipment.includes('trashBin')
+        (enableDeckModification &&
+          values.additionalEquipment.includes('trashBin')) ||
+        !enableDeckModification
       ) {
         // defaulting trash to appropriate locations
-        dispatch(
-          labwareIngredActions.createContainer({
-            labwareDefURI: FLEX_TRASH_DEF_URI,
-            slot: 'A3',
-          })
-        )
-      }
-      if (
-        !enableDeckModification ||
-        (enableDeckModification && values.fields.robotType === OT2_ROBOT_TYPE)
-      ) {
         dispatch(
           labwareIngredActions.createContainer({
             labwareDefURI:
               values.fields.robotType === FLEX_ROBOT_TYPE
                 ? FLEX_TRASH_DEF_URI
                 : OT_2_TRASH_DEF_URI,
-            slot: values.fields.robotType === FLEX_ROBOT_TYPE ? 'A3' : '12',
+            slot:
+              values.fields.robotType === FLEX_ROBOT_TYPE
+                ? getTrashSlot(values)
+                : '12',
           })
         )
       }
@@ -347,7 +341,9 @@ const initialFormState: FormState = {
       slot: SPAN7_8_10_11_SLOT,
     },
   },
-  additionalEquipment: [],
+  //  defaulting to selecting trashBin already to avoid user having to
+  //  click to add a trash bin/waste chute. Delete once we support returnTip()
+  additionalEquipment: ['trashBin'],
 }
 
 const pipetteValidationShape = Yup.object().shape({

--- a/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
@@ -1,0 +1,112 @@
+import {
+  getModuleType,
+  HEATERSHAKER_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import { OUTER_SLOTS_FLEX } from '../../../modules'
+import { isModuleWithCollisionIssue } from '../../modules'
+import {
+  FLEX_SUPPORTED_MODULE_MODELS,
+  DEFAULT_SLOT_MAP,
+} from './ModulesAndOtherTile'
+
+import type { ModuleType } from '@opentrons/shared-data'
+import type { FormModulesByType } from '../../../step-forms'
+import type { FormState } from './types'
+
+export const FLEX_TRASH_DEFAULT_SLOT = 'A3'
+
+export const getLastCheckedEquipment = (values: FormState): string | null => {
+  const hasTrash = values.additionalEquipment.includes('trashBin')
+
+  if (!hasTrash) {
+    return null
+  }
+
+  if (
+    values.modulesByType.heaterShakerModuleType.onDeck &&
+    values.modulesByType.thermocyclerModuleType.onDeck
+  ) {
+    return TEMPERATURE_MODULE_TYPE
+  }
+
+  if (
+    values.modulesByType.heaterShakerModuleType.onDeck &&
+    values.modulesByType.temperatureModuleType.onDeck
+  ) {
+    return THERMOCYCLER_MODULE_TYPE
+  }
+
+  if (
+    values.modulesByType.thermocyclerModuleType.onDeck &&
+    values.modulesByType.temperatureModuleType.onDeck
+  ) {
+    return HEATERSHAKER_MODULE_TYPE
+  }
+
+  return null
+}
+
+export const getCrashableModuleSelected = (
+  modules: FormModulesByType,
+  moduleType: ModuleType
+): boolean => {
+  const formModule = modules[moduleType]
+  const crashableModuleOnDeck =
+    formModule?.onDeck && formModule?.model != null
+      ? isModuleWithCollisionIssue(formModule.model)
+      : false
+
+  return crashableModuleOnDeck
+}
+
+export const getTrashBinOptionDisabled = (values: FormState): boolean => {
+  const allStagingAreasInUse =
+    values.additionalEquipment.filter(equipment =>
+      equipment.includes('stagingArea')
+    ).length === 4
+
+  const allModulesInSideSlotsOnDeck =
+    values.modulesByType.heaterShakerModuleType.onDeck &&
+    values.modulesByType.thermocyclerModuleType.onDeck &&
+    values.modulesByType.temperatureModuleType.onDeck
+
+  return allStagingAreasInUse && allModulesInSideSlotsOnDeck
+}
+
+export const getTrashSlot = (values: FormState): string => {
+  const stagingAreaLocations = values.additionalEquipment
+    .filter(equipment => equipment.includes('stagingArea'))
+    .map(stagingArea => stagingArea.split('_')[1])
+
+  //   return default trash slot A3 if staging area is not on slot
+  if (!stagingAreaLocations.includes(FLEX_TRASH_DEFAULT_SLOT)) {
+    return FLEX_TRASH_DEFAULT_SLOT
+  }
+
+  const moduleSlots: string[] = []
+  FLEX_SUPPORTED_MODULE_MODELS.map(model => {
+    const moduleType = getModuleType(model)
+    if (values.modulesByType[moduleType].onDeck) {
+      const slot = String(DEFAULT_SLOT_MAP[model])
+      return moduleType === THERMOCYCLER_MODULE_TYPE
+        ? moduleSlots.push('A1', slot)
+        : moduleSlots.push(slot)
+    }
+  })
+
+  const unoccupiedSlot = OUTER_SLOTS_FLEX.find(
+    slot =>
+      !stagingAreaLocations.includes(slot.value) &&
+      !moduleSlots.includes(slot.value)
+  )
+  if (unoccupiedSlot == null) {
+    console.error(
+      'Expected to find an unoccupied slot for the trash bin but could not'
+    )
+    return ''
+  }
+
+  return unoccupiedSlot?.value
+}

--- a/protocol-designer/src/components/modules/__tests__/StagingAreaModal.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/StagingAreaModal.test.tsx
@@ -44,7 +44,7 @@ describe('StagingAreasModal', () => {
   it('renders the deck, header, and buttons work as expected', () => {
     const { getByText, getByRole } = render(props)
     getByText('mock deck config')
-    getByText('Staging Areas')
+    getByText('Staging Area Slots')
     getByRole('button', { name: 'cancel' }).click()
     expect(props.onCloseClick).toHaveBeenCalled()
   })

--- a/protocol-designer/src/components/modules/__tests__/StagingAreasRow.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/StagingAreasRow.test.tsx
@@ -30,7 +30,7 @@ describe('StagingAreasRow', () => {
   })
   it('renders no staging areas', () => {
     const { getByRole, getByText } = render(props)
-    getByText('Staging Areas')
+    getByText('Staging Area Slots')
     getByRole('button', { name: 'add' }).click()
     getByText('mock portal')
   })

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -89,7 +89,7 @@
     "robot_type": "Robot Type",
     "upload_tiprack": "Upload a custom tiprack to select its definition",
     "upload": "Upload",
-    "staging_areas": "Staging areas"
+    "staging_areas": "Staging area slots"
   },
   "well_order": {
     "title": "Well Order",

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -1,7 +1,7 @@
 {
   "additional_equipment_display_names": {
     "gripper": "Flex Gripper",
-    "stagingAreas": "Staging Areas",
+    "stagingAreas": "Staging Area Slots",
     "trashBin": "Trash Bin",
     "wasteChute": "Waste Chute"
   },


### PR DESCRIPTION
closes RAUT-801, RAUT-802, RAUT-786

# Overview

This PR adds a few functions to the create file wizard:
1. wires up error handling for modules/staging area slots/trash bin so things are disabled or go to the correct slot if the default slot is full
2. changes naming from `Staging Areas` -> `Staging Area Slots`
3. selects the trash bin selection by default for smoother user experience

bonus:
4. fixes a small bug in the deck setup (trash fixture rendering)

# Test Plan

Turn on the deck configuration FF in PD and create a flex protocol. Add all 4 staging area slots and try to add all the modules, see that if you add the outer slot modules (H-S, Temp, TC) and the trash bin, that the one you add last is disabled. This goes both ways for trash bin and H-S/Temp/TC. And also notice that the trash bin is selected by default.

NOTE: the disabled state for the module equipment cards is gross and designs should be updated probably, that'll be done later.

When you hit `Review file details` to create the file, obverse on the deck map that nothing is overlapping and the trash renders in the correct slot.

# Changelog

- rename staging area -> staging area slot in create file wizard and additional items section
- fix trash fixture rendering in deck setup
- create utils file in `CreateFileWizard` folder and create a few new utils for error handling (`getTrashSlot` and `getLastCheckedEquipment`)
- add test coverage
- wire up trash bin to be selected by default

# Review requests

see test plan

# Risk assessment

low