### PR TITLE
fix(api, hardware): allow OT3Controller to disable tip motors

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
@@ -5,6 +5,8 @@ from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     EnableMotorRequest,
     DisableMotorRequest,
+    GearEnableMotorRequest,
+    GearDisableMotorRequest,
 )
 from opentrons_hardware.firmware_bindings.constants import NodeId, ErrorCode
 
@@ -35,6 +37,36 @@ async def set_disable_motor(
         error = await can_messenger.ensure_send(
             node_id=node,
             message=DisableMotorRequest(),
+            expected_nodes=[node],
+        )
+        if error != ErrorCode.ok:
+            log.error(f"recieved error {str(error)} trying to disable {str(node)} ")
+
+
+async def set_enable_tip_motor(
+    can_messenger: CanMessenger,
+    nodes: Set[NodeId],
+) -> None:
+    """Set enable motor each node."""
+    for node in nodes:
+        error = await can_messenger.ensure_send(
+            node_id=node,
+            message=GearEnableMotorRequest(),
+            expected_nodes=[node],
+        )
+        if error != ErrorCode.ok:
+            log.error(f"recieved error {str(error)} trying to enable {str(node)} ")
+
+
+async def set_disable_tip_motor(
+    can_messenger: CanMessenger,
+    nodes: Set[NodeId],
+) -> None:
+    """Set disable motor each node."""
+    for node in nodes:
+        error = await can_messenger.ensure_send(
+            node_id=node,
+            message=GearDisableMotorRequest(),
             expected_nodes=[node],
         )
         if error != ErrorCode.ok:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motor_engage_disengage.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motor_engage_disengage.py
@@ -9,6 +9,8 @@ from opentrons_hardware.firmware_bindings.messages import (
 from opentrons_hardware.hardware_control.motor_enable_disable import (
     set_enable_motor,
     set_disable_motor,
+    set_enable_tip_motor,
+    set_disable_tip_motor,
 )
 
 
@@ -40,3 +42,28 @@ async def test_set_disable_current(mock_can_messenger: AsyncMock) -> None:
             message=md.DisableMotorRequest(),
             expected_nodes=[node_id],
         )
+
+
+async def test_set_enable_tip_motor(mock_can_messenger: AsyncMock) -> None:
+    """It should send a request to enable each node's motor."""
+    nodes_to_enable = {NodeId.pipette_left, NodeId.gantry_y}
+    await set_enable_tip_motor(mock_can_messenger, nodes_to_enable)
+    for node_id in nodes_to_enable:
+        mock_can_messenger.ensure_send.assert_any_call(
+            node_id=node_id,
+            message=md.GearEnableMotorRequest(),
+            expected_nodes=[node_id],
+        )
+
+
+async def test_set_disable_tip_motor(mock_can_messenger: AsyncMock) -> None:
+    """It should send a request to disable each node's motor."""
+    nodes_to_enable = {NodeId.gantry_x, NodeId.gantry_y}
+    await set_disable_tip_motor(mock_can_messenger, nodes_to_enable)
+    for node_id in nodes_to_enable:
+        mock_can_messenger.ensure_send.assert_any_call(
+            node_id=node_id,
+            message=md.GearDisableMotorRequest(),
+            expected_nodes=[node_id],
+        )
+

--- a/hardware/tests/opentrons_hardware/hardware_control/test_motor_engage_disengage.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_motor_engage_disengage.py
@@ -66,4 +66,3 @@ async def test_set_disable_tip_motor(mock_can_messenger: AsyncMock) -> None:
             message=md.GearDisableMotorRequest(),
             expected_nodes=[node_id],
         )
-


### PR DESCRIPTION


# Overview

The assembly process for the 96ch requires the tip motors to be disabled, and it was noticed that the hardware controller will never actually disable them. While there's a workaround to use the `can_comm` script for now, it would be useful for the hardware controller to be able to do this with the functions we already have.

# Test Plan

Pushed to Flexy with a 96ch. Used ot3repl to call `disengage_axes` and `engage_axes` with `Axis.Q` specified. Watched `can_mon` and confirmed that the `GearEnableMotorRequest` and `GearDisableMotorRequest` messages got sent instead of the non-gear variants.

# Changelog

- Added `opentrons_hardware` helper functions for sending `GearEnableMotorRequest` and `GearDisableMotorRequest`
- `OT3Controller` will send gear-specific enable/disable messages if relevant
- Added tests

# Review requests



# Risk assessment

