### PR TITLE
chore(hardware-testing): Never liquid probe in gravimetric tests

### DIFF
--- a/hardware-testing/hardware_testing/data/ui.py
+++ b/hardware-testing/hardware_testing/data/ui.py
@@ -64,6 +64,11 @@ def print_error(message: str) -> None:
     print(f"ERROR: {message}")
 
 
+def print_warning(message: str) -> None:
+    """Print warning."""
+    print(f"WARNING: {message}")
+
+
 def print_info(message: str) -> None:
     """Print information."""
     print(message)

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -461,6 +461,11 @@ def _main(
     volumes: List[float],
 ) -> None:
     union_cfg: Union[PhotometricConfig, GravimetricConfig]
+    if not args.jog:
+        ui.print_warning(
+            "overwriting --jog to True, because liquid-probe "
+            "is not repeatable enough for gravimetric tests"
+        )
     if args.photometric:
         cfg_pm: PhotometricConfig = build_photometric_cfg(
             run_args.ctx,
@@ -471,7 +476,7 @@ def _main(
             args.touch_tip,
             args.refill,
             args.extra,
-            args.jog,
+            True,  # NOTE: (andy s) always jog
             args.same_tip,
             args.ignore_fail,
             args.channels,
@@ -495,7 +500,7 @@ def _main(
             args.isolate_channels if args.isolate_channels else [],
             args.isolate_volumes if args.isolate_volumes else [],
             args.extra,
-            args.jog,
+            True,  # NOTE: (andy s) always jog
             args.same_tip,
             args.ignore_fail,
             args.mode,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Liquid-probe's repeatability is not good enough to reach our %D specs at 1ul, so out of precaution this PR removes the ability to run gravimetric/photometric testing with liquid probing.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
