### PR TITLE
feat(protocol-designer): correct step count in create file wizard

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -173,10 +173,23 @@ export function ModulesAndOtherTile(props: WizardTileProps): JSX.Element {
               if (!enableDeckModification || robotType === OT2_ROBOT_TYPE) {
                 if (values.pipettesByMount.left.pipetteName === 'p1000_96') {
                   goBack(4)
-                } else if (values.pipettesByMount.right.pipetteName === '') {
+                } else if (
+                  values.pipettesByMount.right.pipetteName === '' &&
+                  robotType === FLEX_ROBOT_TYPE
+                ) {
                   goBack(3)
-                } else {
+                } else if (
+                  values.pipettesByMount.right.pipetteName === '' &&
+                  robotType === OT2_ROBOT_TYPE
+                ) {
                   goBack(2)
+                } else if (
+                  values.pipettesByMount.right.pipetteName !== '' &&
+                  robotType === FLEX_ROBOT_TYPE
+                ) {
+                  goBack(2)
+                } else {
+                  goBack()
                 }
               } else {
                 goBack()

--- a/protocol-designer/src/components/modals/CreateFileWizard/PipetteTypeTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/PipetteTypeTile.tsx
@@ -88,7 +88,12 @@ export function PipetteTypeTile(props: PipetteTypeTileProps): JSX.Element {
 
   return (
     <HandleEnter onEnter={proceed}>
-      <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing32}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        padding={SPACING.spacing32}
+        height="auto"
+        overflowY="auto"
+      >
         <Flex
           flexDirection={DIRECTION_COLUMN}
           height="26rem"

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/CreateFileWizard.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/CreateFileWizard.test.tsx
@@ -116,27 +116,27 @@ describe('CreateFileWizard', () => {
     let next = getByRole('button', { name: 'Next' })
     next.click()
     //  add protocol name
-    getByText('Step 1 / 7')
+    getByText('Step 1 / 6')
     const inputField = getByLabelText('MetadataTile_protocolName')
     fireEvent.change(inputField, { target: { value: 'mockName' } })
     next = getByRole('button', { name: 'Next' })
     next.click()
-    getByText('Step 2 / 7')
+    getByText('Step 2 / 6')
     //  select P20 Single-Channel GEN2
     getByLabelText('EquipmentOption_flex_P20 Single-Channel GEN2').click()
     next = getByRole('button', { name: 'Next' })
     next.click()
-    getByText('Step 3 / 7')
+    getByText('Step 3 / 6')
     //  select 10uL tipracks
     getByLabelText('EquipmentOption_flex_10uL tipracks').click()
     next = getByRole('button', { name: 'Next' })
     next.click()
-    getByText('Step 4 / 7')
+    getByText('Step 4 / 6')
     //  select none for 2nd pipette
     getByLabelText('EquipmentOption_flex_None').click()
     next = getByRole('button', { name: 'Next' })
     next.click()
-    getByText('Step 7 / 7')
+    getByText('Step 6 / 6')
     //  no modules and continue
     getByRole('button', { name: 'Review file details' }).click()
     expect(mockCreateNewProtocol).toHaveBeenCalled()

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -86,23 +86,6 @@ const WIZARD_STEPS: WizardStep[] = [
   'staging_area',
   'modulesAndOther',
 ]
-// const WIZARD_STEPS_1_PIP: WizardStep[] = [
-//   'robotType',
-//   'metadata',
-//   'first_pipette_type',
-//   'first_pipette_tips',
-//   'second_pipette_type',
-//   'staging_area',
-//   'modulesAndOther',
-// ]
-// const WIZARD_STEPS_96_CHANNEL: WizardStep[] = [
-//   'robotType',
-//   'metadata',
-//   'first_pipette_type',
-//   'first_pipette_tips',
-//   'staging_area',
-//   'modulesAndOther',
-// ]
 const WIZARD_STEPS_OT2: WizardStep[] = [
   'robotType',
   'metadata',
@@ -112,14 +95,6 @@ const WIZARD_STEPS_OT2: WizardStep[] = [
   'second_pipette_tips',
   'modulesAndOther',
 ]
-// const WIZARD_STEPS_OT2_1_PIP: WizardStep[] = [
-//   'robotType',
-//   'metadata',
-//   'first_pipette_type',
-//   'first_pipette_tips',
-//   'second_pipette_type',
-//   'modulesAndOther',
-// ]
 
 export function CreateFileWizard(): JSX.Element | null {
   const { t } = useTranslation()
@@ -455,32 +430,6 @@ function CreateFileForm(props: CreateFileFormProps): JSX.Element {
       setWizardSteps(WIZARD_STEPS)
     }
   }
-  // const handleProceed96Channel = (
-  //   has96Channel: boolean,
-  //   robotType: string
-  // ): void => {
-  //   if (has96Channel) {
-  //     setWizardSteps(WIZARD_STEPS_96_CHANNEL)
-  //   } else if (robotType === OT2_ROBOT_TYPE) {
-  //     setWizardSteps(WIZARD_STEPS_OT2)
-  //   } else {
-  //     setWizardSteps(WIZARD_STEPS)
-  //   }
-  // }
-  // const handleProceed2ndPipette = (
-  //   has2ndPip: boolean,
-  //   robotType: string
-  // ): void => {
-  //   if (robotType === OT2_ROBOT_TYPE && !has2ndPip) {
-  //     setWizardSteps(WIZARD_STEPS_OT2_1_PIP)
-  //   } else if (robotType === FLEX_ROBOT_TYPE && !has2ndPip) {
-  //     setWizardSteps(WIZARD_STEPS_1_PIP)
-  //   } else if (robotType === OT2_ROBOT_TYPE && has2ndPip) {
-  //     setWizardSteps(WIZARD_STEPS_OT2)
-  //   } else {
-  //     setWizardSteps(WIZARD_STEPS)
-  //   }
-  // }
 
   const contentsByWizardStep: {
     [wizardStep in WizardStep]: (
@@ -501,33 +450,13 @@ function CreateFileForm(props: CreateFileFormProps): JSX.Element {
       <MetadataTile {...formikProps} proceed={proceed} goBack={goBack} />
     ),
     first_pipette_type: (formikProps: FormikProps<FormState>) => (
-      <FirstPipetteTypeTile
-        {...formikProps}
-        goBack={goBack}
-        proceed={() => {
-          // handleProceed96Channel(
-          //   formikProps.values.pipettesByMount.left.pipetteName === 'p1000_96',
-          //   formikProps.values.fields.robotType
-          // )
-          proceed()
-        }}
-      />
+      <FirstPipetteTypeTile {...{ ...formikProps, proceed, goBack }} />
     ),
     first_pipette_tips: (formikProps: FormikProps<FormState>) => (
       <FirstPipetteTipsTile {...{ ...formikProps, proceed, goBack }} />
     ),
     second_pipette_type: (formikProps: FormikProps<FormState>) => (
-      <SecondPipetteTypeTile
-        {...formikProps}
-        goBack={goBack}
-        proceed={() => {
-          // handleProceed2ndPipette(
-          //   formikProps.values.pipettesByMount.right.pipetteName == null,
-          //   formikProps.values.fields.robotType
-          // )
-          proceed()
-        }}
-      />
+      <SecondPipetteTypeTile {...{ ...formikProps, proceed, goBack }} />
     ),
     second_pipette_tips: (formikProps: FormikProps<FormState>) => (
       <SecondPipetteTipsTile {...{ ...formikProps, proceed, goBack }} />

--- a/protocol-designer/src/components/modules/FlexSlotMap.tsx
+++ b/protocol-designer/src/components/modules/FlexSlotMap.tsx
@@ -45,16 +45,14 @@ export function FlexSlotMap(props: FlexSlotMapProps): JSX.Element {
       viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${deckDef.cornerOffsetFromOrigin[1]} ${deckDef.dimensions[0]} ${deckDef.dimensions[1]}`}
     >
       {deckDef.locations.orderedSlots.map(slotDef => (
-        <>
-          <DeckSlotLocation
-            slotName={slotDef.id}
-            deckDefinition={deckDef}
-            slotClipColor={COLORS.transparent}
-            slotBaseColor={COLORS.light1}
-          />
-        </>
+        <DeckSlotLocation
+          slotName={slotDef.id}
+          deckDefinition={deckDef}
+          slotClipColor={COLORS.transparent}
+          slotBaseColor={COLORS.light1}
+        />
       ))}
-      {selectedSlots.map(selectedSlot => {
+      {selectedSlots.map((selectedSlot, index) => {
         const slot = deckDef.locations.orderedSlots.find(
           slot => slot.id === selectedSlot
         )
@@ -85,7 +83,7 @@ export function FlexSlotMap(props: FlexSlotMapProps): JSX.Element {
 
         return (
           <RobotCoordsForeignObject
-            key={`${selectedSlot}_${slot?.id}`}
+            key={`${selectedSlot}_${slot?.id}_${index}`}
             width={xDimension}
             height={yDimension}
             x={x}

--- a/protocol-designer/src/components/modules/FlexSlotMap.tsx
+++ b/protocol-designer/src/components/modules/FlexSlotMap.tsx
@@ -46,6 +46,7 @@ export function FlexSlotMap(props: FlexSlotMapProps): JSX.Element {
     >
       {deckDef.locations.orderedSlots.map(slotDef => (
         <DeckSlotLocation
+          key={slotDef.id}
           slotName={slotDef.id}
           deckDefinition={deckDef}
           slotClipColor={COLORS.transparent}


### PR DESCRIPTION
closes RAUT-775

# Overview

Now that a staging area slot tile was created for the Flex, the step count at the top of the create file wizard was incorrect for the Ot-2. This PR fixes that as well as fixing the go back button from the last page of the wizard.

NOTE: the total step counts stay as 7 for Flex and 6 for OT-2 regardless of if you end up skipping steps (if you don't add a 2nd pipette or if you add the 96-channel). I opted for this because a user will be aware of the total steps possible for the certain robot. Please let me know if you have any questions/concerns about this though!

# Test Plan

- turn on the deck modification & 96-channel feature flags. Create a Flex protocol and go thorugh the file wizard, make sure the step count work as expected for a total of 7 steps. See that if you add a 96-channel or don't add a 2nd pipette that the wizard skips to the appropriate page but the total step count remains at 7. Try to go back on the `Additional Items` (last page) and see that it goes to the appropriate page depending on if you have a 2nd pipette or not.

- now follow those steps for an Ot-2 protocol. See that the total number of steps is 6 and that the `Staging Area` tile is skipped. Try the variations of adding a 2nd pipette/not adding a 2nd pipette. Make sure the step counts work as expected.

- now turn off the deck modification feature flag and create a Flex protocol, see that it skips the `Staging Area` tile. 

# Changelog

- add `goback` logic for the `ModulesAndOtherTile`
- add logic for wizard step and total step count
- add test coverage
- fix the console warning for the `flexMap` component by adding keys to the children

# Review requests

see test plan

# Risk assessment

low