### PR TITLE
feat(app): add Deck configuration screen to ProtocolSetup

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.stories.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import { touchScreenViewport } from '../../DesignTokens/constants'
-import { AddDeckConfigurationModal } from './AddDeckConfigurationModal'
+import { AddFixtureModal } from './AddFixtureModal'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'ODD/Organisms/AddDeckConfigurationModal',
+  title: 'ODD/Organisms/AddFixtureModal',
   argTypes: {
     modalSize: {
       options: ['small', 'medium', 'large'],
@@ -17,11 +17,9 @@ export default {
 } as Meta
 
 const queryClient = new QueryClient()
-const Template: Story<
-  React.ComponentProps<typeof AddDeckConfigurationModal>
-> = args => (
+const Template: Story<React.ComponentProps<typeof AddFixtureModal>> = args => (
   <QueryClientProvider client={queryClient}>
-    <AddDeckConfigurationModal {...args} />
+    <AddFixtureModal {...args} />
   </QueryClientProvider>
 )
 

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -33,14 +33,16 @@ import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { LegacyModalProps } from '../../molecules/LegacyModal'
 
 interface AddFixtureModalProps {
-  fixtureLocation: Cutout | null
+  fixtureLocation: Cutout
   setShowAddFixtureModal: (showAddFixtureModal: boolean) => void
+  providedFixtureOptions?: FixtureLoadName[]
   isOnDevice?: boolean
 }
 
 export function AddFixtureModal({
   fixtureLocation,
   setShowAddFixtureModal,
+  providedFixtureOptions,
   isOnDevice = false,
 }: AddFixtureModalProps): JSX.Element | null {
   const { t } = useTranslation('device_details')
@@ -74,6 +76,8 @@ export function AddFixtureModal({
     availableFixtures.push(STAGING_AREA_LOAD_NAME, WASTE_CHUTE_LOAD_NAME)
   }
 
+  const fixtureOptions = providedFixtureOptions ?? availableFixtures
+
   const handleClickAdd = (fixtureLoadName: FixtureLoadName): void => {
     updateDeckConfiguration({
       fixtureLocation,
@@ -92,7 +96,7 @@ export function AddFixtureModal({
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
             <StyledText as="p">{t('add_to_slot_description')}</StyledText>
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-              {availableFixtures.map(fixture => (
+              {fixtureOptions.map(fixture => (
                 <React.Fragment key={fixture}>
                   <AddFixtureButton
                     fixtureLoadName={fixture}
@@ -108,7 +112,7 @@ export function AddFixtureModal({
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
             <StyledText as="p">{t('add_fixture_description')}</StyledText>
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-              {availableFixtures.map(fixture => (
+              {fixtureOptions.map(fixture => (
                 <React.Fragment key={fixture}>
                   <Flex
                     flexDirection={DIRECTION_ROW}

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -48,8 +48,6 @@ export function AddFixtureModal({
   const { t } = useTranslation('device_details')
   const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
 
-  if (fixtureLocation == null) return null
-
   const modalHeader: ModalHeaderBaseProps = {
     title: t('add_to_slot', { slotName: fixtureLocation }),
     hasExitIcon: true,

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -32,18 +32,21 @@ import type { Cutout, FixtureLoadName } from '@opentrons/shared-data'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { LegacyModalProps } from '../../molecules/LegacyModal'
 
-interface AddDeckConfigurationModalProps {
-  fixtureLocation: Cutout
+interface AddFixtureModalProps {
+  fixtureLocation: Cutout | null
   setShowAddFixtureModal: (showAddFixtureModal: boolean) => void
   isOnDevice?: boolean
 }
 
-export function AddDeckConfigurationModal({
+export function AddFixtureModal({
   fixtureLocation,
   setShowAddFixtureModal,
   isOnDevice = false,
-}: AddDeckConfigurationModalProps): JSX.Element {
+}: AddFixtureModalProps): JSX.Element | null {
   const { t } = useTranslation('device_details')
+  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
+
+  if (fixtureLocation == null) return null
 
   const modalHeader: ModalHeaderBaseProps = {
     title: t('add_to_slot', { slotName: fixtureLocation }),
@@ -58,8 +61,6 @@ export function AddDeckConfigurationModal({
     childrenPadding: SPACING.spacing24,
     width: '23.125rem',
   }
-
-  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
 
   const availableFixtures: FixtureLoadName[] = [TRASH_BIN_LOAD_NAME]
   if (

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddDeckConfigurationModal.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddDeckConfigurationModal.test.tsx
@@ -5,7 +5,7 @@ import { i18n } from '../../../i18n'
 import { renderWithProviders } from '@opentrons/components'
 import { useUpdateDeckConfigurationMutation } from '@opentrons/react-api-client'
 import { TRASH_BIN_LOAD_NAME } from '@opentrons/shared-data'
-import { AddDeckConfigurationModal } from '../AddDeckConfigurationModal'
+import { AddFixtureModal } from '../AddFixtureModal'
 
 jest.mock('@opentrons/react-api-client')
 const mockSetShowAddFixtureModal = jest.fn()
@@ -15,16 +15,14 @@ const mockUseUpdateDeckConfigurationMutation = useUpdateDeckConfigurationMutatio
   typeof useUpdateDeckConfigurationMutation
 >
 
-const render = (
-  props: React.ComponentProps<typeof AddDeckConfigurationModal>
-) => {
-  return renderWithProviders(<AddDeckConfigurationModal {...props} />, {
+const render = (props: React.ComponentProps<typeof AddFixtureModal>) => {
+  return renderWithProviders(<AddFixtureModal {...props} />, {
     i18nInstance: i18n,
   })
 }
 
-describe('Touchscreen AddDeckConfigurationModal', () => {
-  let props: React.ComponentProps<typeof AddDeckConfigurationModal>
+describe('Touchscreen AddFixtureModal', () => {
+  let props: React.ComponentProps<typeof AddFixtureModal>
 
   beforeEach(() => {
     props = {
@@ -52,8 +50,8 @@ describe('Touchscreen AddDeckConfigurationModal', () => {
   it.todo('should a mock function when tapping a button')
 })
 
-describe('Desktop AddDeckConfigurationModal', () => {
-  let props: React.ComponentProps<typeof AddDeckConfigurationModal>
+describe('Desktop AddFixtureModal', () => {
+  let props: React.ComponentProps<typeof AddFixtureModal>
 
   beforeEach(() => {
     props = {

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -27,7 +27,7 @@ import {
 
 import { StyledText } from '../../atoms/text'
 import { DeckFixtureSetupInstructionsModal } from './DeckFixtureSetupInstructionsModal'
-import { AddDeckConfigurationModal } from './AddDeckConfigurationModal'
+import { AddFixtureModal } from './AddFixtureModal'
 
 import type { Cutout } from '@opentrons/shared-data'
 
@@ -74,7 +74,7 @@ export function DeviceDetailsDeckConfiguration({
   return (
     <>
       {showAddFixtureModal && targetFixtureLocation != null ? (
-        <AddDeckConfigurationModal
+        <AddFixtureModal
           fixtureLocation={targetFixtureLocation}
           setShowAddFixtureModal={setShowAddFixtureModal}
         />

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
@@ -25,6 +25,7 @@ describe('ProtocolSetupDeckConfiguration', () => {
 
   beforeEach(() => {
     props = {
+      fixtureLocation: 'D3',
       setSetupScreen: mockSetSetupScreen,
     }
     mockDeckConfigurator.mockReturnValue(<div>mock DeckConfigurator</div>)
@@ -36,5 +37,9 @@ describe('ProtocolSetupDeckConfiguration', () => {
     getByText('mock DeckConfigurator')
   })
 
-  it('should call a mock function when tapping the back button', () => {})
+  it('should call a mock function when tapping the back button', () => {
+    const [{ getByTestId }] = render(props)
+    getByTestId('ChildNavigation_Back_Button').click()
+    expect(mockSetSetupScreen).toHaveBeenCalledWith('modules')
+  })
 })

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+
+import { renderWithProviders, DeckConfigurator } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+import { ProtocolSetupDeckConfiguration } from '..'
+
+jest.mock('@opentrons/components/src/hardware-sim/DeckConfigurator/index')
+
+const mockSetSetupScreen = jest.fn()
+
+const mockDeckConfigurator = DeckConfigurator as jest.MockedFunction<
+  typeof DeckConfigurator
+>
+
+const render = (
+  props: React.ComponentProps<typeof ProtocolSetupDeckConfiguration>
+) => {
+  return renderWithProviders(<ProtocolSetupDeckConfiguration {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('ProtocolSetupDeckConfiguration', () => {
+  let props: React.ComponentProps<typeof ProtocolSetupDeckConfiguration>
+
+  beforeEach(() => {
+    props = {
+      setSetupScreen: mockSetSetupScreen,
+    }
+    mockDeckConfigurator.mockReturnValue(<div>mock DeckConfigurator</div>)
+  })
+
+  it('should render text, button, and DeckConfigurator', () => {
+    const [{ getByText }] = render(props)
+    getByText('Deck configuration')
+    getByText('mock DeckConfigurator')
+  })
+
+  it('should call a mock function when tapping the back button', () => {})
+})

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
@@ -1,15 +1,34 @@
 import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
 
 import { renderWithProviders, DeckConfigurator } from '@opentrons/components'
+import { useUpdateDeckConfigurationMutation } from '@opentrons/react-api-client'
+
 import { i18n } from '../../../i18n'
+import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { ProtocolSetupDeckConfiguration } from '..'
 
 jest.mock('@opentrons/components/src/hardware-sim/DeckConfigurator/index')
+jest.mock('@opentrons/react-api-client')
+jest.mock('../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
 
 const mockSetSetupScreen = jest.fn()
+const mockUpdateDeckConfiguration = jest.fn()
+const PROTOCOL_DETAILS = {
+  displayName: 'fake protocol',
+  protocolData: [],
+  protocolKey: 'fakeProtocolKey',
+  robotType: 'OT-3 Standard' as const,
+}
 
 const mockDeckConfigurator = DeckConfigurator as jest.MockedFunction<
   typeof DeckConfigurator
+>
+const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
+  typeof useMostRecentCompletedAnalysis
+>
+const mockUseUpdateDeckConfigurationMutation = useUpdateDeckConfigurationMutation as jest.MockedFunction<
+  typeof useUpdateDeckConfigurationMutation
 >
 
 const render = (
@@ -26,9 +45,20 @@ describe('ProtocolSetupDeckConfiguration', () => {
   beforeEach(() => {
     props = {
       fixtureLocation: 'D3',
+      runId: 'mockRunId',
       setSetupScreen: mockSetSetupScreen,
     }
     mockDeckConfigurator.mockReturnValue(<div>mock DeckConfigurator</div>)
+    when(mockUseMostRecentCompletedAnalysis)
+      .calledWith('mockRunId')
+      .mockReturnValue(PROTOCOL_DETAILS.protocolData as any)
+    mockUseUpdateDeckConfigurationMutation.mockReturnValue({
+      updateDeckConfiguration: mockUpdateDeckConfiguration,
+    } as any)
+  })
+
+  afterEach(() => {
+    resetAllWhenMocks()
   })
 
   it('should render text, button, and DeckConfigurator', () => {

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/__tests__/ProtocolSetupDeckConfiguration.test.tsx
@@ -47,6 +47,7 @@ describe('ProtocolSetupDeckConfiguration', () => {
       fixtureLocation: 'D3',
       runId: 'mockRunId',
       setSetupScreen: mockSetSetupScreen,
+      providedFixtureOptions: [],
     }
     mockDeckConfigurator.mockReturnValue(<div>mock DeckConfigurator</div>)
     when(mockUseMostRecentCompletedAnalysis)

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useHistory } from 'react-router-dom'
 
 import {
   DeckConfigurator,
@@ -15,22 +14,26 @@ import {
 } from '@opentrons/react-api-client'
 import { STANDARD_SLOT_LOAD_NAME } from '@opentrons/shared-data'
 
-import { SmallButton } from '../../atoms/buttons'
-import { ChildNavigation } from '../../organisms/ChildNavigation'
-import { AddFixtureModal } from '../../organisms/DeviceDetailsDeckConfiguration/AddFixtureModal'
-import { DeckFixtureSetupInstructionsModal } from '../../organisms/DeviceDetailsDeckConfiguration/DeckFixtureSetupInstructionsModal'
-import { DeckConfigurationDiscardChangesModal } from '../../organisms/DeviceDetailsDeckConfiguration/DeckConfigurationDiscardChangesModal'
+import { ChildNavigation } from '../ChildNavigation'
+import { AddFixtureModal } from '../DeviceDetailsDeckConfiguration/AddFixtureModal'
+import { DeckFixtureSetupInstructionsModal } from '../DeviceDetailsDeckConfiguration/DeckFixtureSetupInstructionsModal'
+import { DeckConfigurationDiscardChangesModal } from '../DeviceDetailsDeckConfiguration/DeckConfigurationDiscardChangesModal'
 import { Portal } from '../../App/portal'
 
 import type { Cutout } from '@opentrons/shared-data'
+import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 
-export function DeckConfiguration(): JSX.Element {
-  const { t, i18n } = useTranslation([
-    'protocol_setup',
-    'devices_landing',
-    'shared',
-  ])
-  const history = useHistory()
+interface ProtocolSetupDeckConfigurationProps {
+  notConfiguredLocation: Cutout | null
+  setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
+}
+
+export function ProtocolSetupDeckConfiguration({
+  notConfiguredLocation,
+  setSetupScreen,
+}: ProtocolSetupDeckConfigurationProps): JSX.Element {
+  const { t } = useTranslation(['protocol_setup', 'devices_landing', 'shared'])
+
   const [
     showSetupInstructionsModal,
     setShowSetupInstructionsModal,
@@ -38,7 +41,7 @@ export function DeckConfiguration(): JSX.Element {
   const [
     showConfigurationModal,
     setShowConfigurationModal,
-  ] = React.useState<boolean>(false)
+  ] = React.useState<boolean>(true)
   const [
     targetFixtureLocation,
     setTargetFixtureLocation,
@@ -64,21 +67,7 @@ export function DeckConfiguration(): JSX.Element {
   }
 
   const handleClickConfirm = (): void => {
-    // ToDo (kk:10/13/2023) add a function for the confirmation
-  }
-
-  const handleClickBack = (): void => {
-    // ToDo If there is any unsaved change, display DeckConfigurationDiscardChangesModal
-    // setShowDiscardChangeModal(true)
-    history.goBack()
-  }
-
-  const secondaryButtonProps: React.ComponentProps<typeof SmallButton> = {
-    onClick: () => setShowSetupInstructionsModal(true),
-    buttonText: i18n.format(t('setup_instructions'), 'titleCase'),
-    buttonType: 'tertiaryLowLight',
-    iconName: 'information',
-    iconPlacement: 'startIcon',
+    // ToDo (kk:10/17/2023) add a function for the confirmation in a following PR for RAUT-804
   }
 
   return (
@@ -95,9 +84,14 @@ export function DeckConfiguration(): JSX.Element {
             isOnDevice
           />
         ) : null}
-        {showConfigurationModal && targetFixtureLocation != null ? (
+        {showConfigurationModal &&
+        (notConfiguredLocation != null || targetFixtureLocation != null) ? (
           <AddFixtureModal
-            fixtureLocation={targetFixtureLocation}
+            fixtureLocation={
+              targetFixtureLocation != null
+                ? targetFixtureLocation
+                : notConfiguredLocation
+            }
             setShowAddFixtureModal={setShowConfigurationModal}
             isOnDevice
           />
@@ -106,10 +100,9 @@ export function DeckConfiguration(): JSX.Element {
       <Flex flexDirection={DIRECTION_COLUMN}>
         <ChildNavigation
           header={t('devices_landing:deck_configuration')}
-          onClickBack={handleClickBack}
+          onClickBack={() => setSetupScreen('modules')}
           buttonText={t('shared:confirm')}
           onClickButton={handleClickConfirm}
-          secondaryButtonProps={secondaryButtonProps}
         />
         <Flex
           marginTop="7.75rem"

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
@@ -16,7 +16,6 @@ import {
 
 import { ChildNavigation } from '../ChildNavigation'
 import { AddFixtureModal } from '../DeviceDetailsDeckConfiguration/AddFixtureModal'
-import { DeckFixtureSetupInstructionsModal } from '../DeviceDetailsDeckConfiguration/DeckFixtureSetupInstructionsModal'
 import { DeckConfigurationDiscardChangesModal } from '../DeviceDetailsDeckConfiguration/DeckConfigurationDiscardChangesModal'
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { Portal } from '../../App/portal'
@@ -25,27 +24,26 @@ import type {
   Cutout,
   DeckConfiguration,
   Fixture,
+  FixtureLoadName,
   LoadFixtureRunTimeCommand,
 } from '@opentrons/shared-data'
 import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 
 interface ProtocolSetupDeckConfigurationProps {
-  fixtureLocation: Cutout | null
+  fixtureLocation: Cutout
   runId: string
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
+  providedFixtureOptions: FixtureLoadName[]
 }
 
 export function ProtocolSetupDeckConfiguration({
   fixtureLocation,
   runId,
   setSetupScreen,
+  providedFixtureOptions,
 }: ProtocolSetupDeckConfigurationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing', 'shared'])
 
-  const [
-    showSetupInstructionsModal,
-    setShowSetupInstructionsModal,
-  ] = React.useState<boolean>(false)
   const [
     showConfigurationModal,
     setShowConfigurationModal,
@@ -53,7 +51,7 @@ export function ProtocolSetupDeckConfiguration({
   const [
     targetFixtureLocation,
     setTargetFixtureLocation,
-  ] = React.useState<Cutout | null>(null)
+  ] = React.useState<Cutout>(fixtureLocation)
   const [
     showDiscardChangeModal,
     setShowDiscardChangeModal,
@@ -118,21 +116,12 @@ export function ProtocolSetupDeckConfiguration({
             setShowConfirmationModal={setShowDiscardChangeModal}
           />
         ) : null}
-        {showSetupInstructionsModal ? (
-          <DeckFixtureSetupInstructionsModal
-            setShowSetupInstructionsModal={setShowSetupInstructionsModal}
-            isOnDevice
-          />
-        ) : null}
         {showConfigurationModal &&
         (fixtureLocation != null || targetFixtureLocation != null) ? (
           <AddFixtureModal
-            fixtureLocation={
-              targetFixtureLocation != null
-                ? targetFixtureLocation
-                : fixtureLocation
-            }
+            fixtureLocation={targetFixtureLocation}
             setShowAddFixtureModal={setShowConfigurationModal}
+            providedFixtureOptions={providedFixtureOptions}
             isOnDevice
           />
         ) : null}
@@ -150,6 +139,7 @@ export function ProtocolSetupDeckConfiguration({
           paddingBottom={SPACING.spacing40}
           justifyContent={JUSTIFY_CENTER}
         >
+          DeckConfigurator will be replaced by BaseDeck when RAUT-793 is ready
           <DeckConfigurator
             deckConfig={deckConfig}
             handleClickAdd={handleClickAdd}

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
@@ -24,12 +24,12 @@ import type { Cutout } from '@opentrons/shared-data'
 import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 
 interface ProtocolSetupDeckConfigurationProps {
-  notConfiguredLocation: Cutout | null
+  fixtureLocation: Cutout | null
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
 }
 
 export function ProtocolSetupDeckConfiguration({
-  notConfiguredLocation,
+  fixtureLocation,
   setSetupScreen,
 }: ProtocolSetupDeckConfigurationProps): JSX.Element {
   const { t } = useTranslation(['protocol_setup', 'devices_landing', 'shared'])
@@ -85,12 +85,12 @@ export function ProtocolSetupDeckConfiguration({
           />
         ) : null}
         {showConfigurationModal &&
-        (notConfiguredLocation != null || targetFixtureLocation != null) ? (
+        (fixtureLocation != null || targetFixtureLocation != null) ? (
           <AddFixtureModal
             fixtureLocation={
               targetFixtureLocation != null
                 ? targetFixtureLocation
-                : notConfiguredLocation
+                : fixtureLocation
             }
             setShowAddFixtureModal={setShowConfigurationModal}
             isOnDevice

--- a/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
+++ b/app/src/organisms/ProtocolSetupDeckConfiguration/index.tsx
@@ -139,7 +139,7 @@ export function ProtocolSetupDeckConfiguration({
           paddingBottom={SPACING.spacing40}
           justifyContent={JUSTIFY_CENTER}
         >
-          DeckConfigurator will be replaced by BaseDeck when RAUT-793 is ready
+          {/* DeckConfigurator will be replaced by BaseDeck when RAUT-793 is ready */}
           <DeckConfigurator
             deckConfig={deckConfig}
             handleClickAdd={handleClickAdd}

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -81,10 +81,6 @@ export function FixtureTable({
 
   const configurations = useLoadedFixturesConfigStatus(requiredFixtureDetails)
 
-  const pickedFixtureOptions = requiredFixtureDetails.map(
-    fixture => fixture.params.loadName
-  )
-
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
       <Flex
@@ -131,7 +127,7 @@ export function FixtureTable({
               ? () => setShowLocationConflictModal(true)
               : () => {
                   setFixtureLocation(fixture.params.location.cutout)
-                  setProvidedFixtureOptions(pickedFixtureOptions)
+                  setProvidedFixtureOptions([fixture.params.loadName])
                   setSetupScreen('deck configuration')
                 }
         } else if (configurationStatus === CONFIGURED) {

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -32,6 +32,7 @@ import { useFeatureFlag } from '../../redux/config'
 import type {
   CompletedProtocolAnalysis,
   Cutout,
+  FixtureLoadName,
   LoadFixtureRunTimeCommand,
 } from '@opentrons/shared-data'
 import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
@@ -40,12 +41,14 @@ interface FixtureTableProps {
   mostRecentAnalysis: CompletedProtocolAnalysis | null
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
   setFixtureLocation: (fixtureLocation: Cutout) => void
+  setProvidedFixtureOptions: (providedFixtureOptions: FixtureLoadName[]) => void
 }
 
 export function FixtureTable({
   mostRecentAnalysis,
   setSetupScreen,
   setFixtureLocation,
+  setProvidedFixtureOptions,
 }: FixtureTableProps): JSX.Element {
   const { t, i18n } = useTranslation('protocol_setup')
   const enableDeckConfig = useFeatureFlag('enableDeckConfiguration')
@@ -77,6 +80,10 @@ export function FixtureTable({
       : []
 
   const configurations = useLoadedFixturesConfigStatus(requiredFixtureDetails)
+
+  const pickedFixtureOptions = requiredFixtureDetails.map(
+    fixture => fixture.params.loadName
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
@@ -124,6 +131,7 @@ export function FixtureTable({
               ? () => setShowLocationConflictModal(true)
               : () => {
                   setFixtureLocation(fixture.params.location.cutout)
+                  setProvidedFixtureOptions(pickedFixtureOptions)
                   setSetupScreen('deck configuration')
                 }
         } else if (configurationStatus === CONFIGURED) {

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -31,15 +31,21 @@ import { useFeatureFlag } from '../../redux/config'
 
 import type {
   CompletedProtocolAnalysis,
+  Cutout,
   LoadFixtureRunTimeCommand,
 } from '@opentrons/shared-data'
+import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 
 interface FixtureTableProps {
   mostRecentAnalysis: CompletedProtocolAnalysis | null
+  setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
+  setFixtureLocation: (fixtureLocation: Cutout) => void
 }
 
 export function FixtureTable({
   mostRecentAnalysis,
+  setSetupScreen,
+  setFixtureLocation,
 }: FixtureTableProps): JSX.Element {
   const { t, i18n } = useTranslation('protocol_setup')
   const enableDeckConfig = useFeatureFlag('enableDeckConfiguration')
@@ -113,7 +119,13 @@ export function FixtureTable({
               <Icon name="more" size="3rem" />
             </>
           )
-          handleClick = () => setShowLocationConflictModal(true)
+          handleClick =
+            configurationStatus === CONFLICTING
+              ? () => setShowLocationConflictModal(true)
+              : () => {
+                  setFixtureLocation(fixture.params.location.cutout)
+                  setSetupScreen('deck configuration')
+                }
         } else if (configurationStatus === CONFIGURED) {
           chipLabel = (
             <Chip

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/FixtureTable.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/FixtureTable.test.tsx
@@ -56,6 +56,7 @@ const mockLoadedStagingAreaFixture = {
 
 const mockSetSetupScreen = jest.fn()
 const mockSetFixtureLocation = jest.fn()
+const mockSetProvidedFixtureOptions = jest.fn()
 
 const render = (props: React.ComponentProps<typeof FixtureTable>) => {
   return renderWithProviders(<FixtureTable {...props} />, {
@@ -70,6 +71,7 @@ describe('FixtureTable', () => {
       mostRecentAnalysis: [] as any,
       setSetupScreen: mockSetSetupScreen,
       setFixtureLocation: mockSetFixtureLocation,
+      setProvidedFixtureOptions: mockSetProvidedFixtureOptions,
     }
     when(mockUseFeatureFlag)
       .calledWith('enableDeckConfiguration')
@@ -131,5 +133,6 @@ describe('FixtureTable', () => {
     getByText('Not configured').click()
     expect(mockSetFixtureLocation).toHaveBeenCalledWith('D3')
     expect(mockSetSetupScreen).toHaveBeenCalledWith('deck configuration')
+    expect(mockSetProvidedFixtureOptions).toHaveBeenCalledWith(['wasteChute'])
   })
 })

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/FixtureTable.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/FixtureTable.test.tsx
@@ -54,6 +54,9 @@ const mockLoadedStagingAreaFixture = {
   status: 'succeeded',
 } as LoadFixtureRunTimeCommand
 
+const mockSetSetupScreen = jest.fn()
+const mockSetFixtureLocation = jest.fn()
+
 const render = (props: React.ComponentProps<typeof FixtureTable>) => {
   return renderWithProviders(<FixtureTable {...props} />, {
     i18nInstance: i18n,
@@ -65,6 +68,8 @@ describe('FixtureTable', () => {
   beforeEach(() => {
     props = {
       mostRecentAnalysis: [] as any,
+      setSetupScreen: mockSetSetupScreen,
+      setFixtureLocation: mockSetFixtureLocation,
     }
     when(mockUseFeatureFlag)
       .calledWith('enableDeckConfiguration')
@@ -85,6 +90,7 @@ describe('FixtureTable', () => {
   })
   it('should render the current status - configured', () => {
     props = {
+      ...props,
       mostRecentAnalysis: { commands: [mockLoadedFixture] } as any,
     }
     const [{ getByText }] = render(props)
@@ -95,6 +101,7 @@ describe('FixtureTable', () => {
       { ...mockLoadedFixture, configurationStatus: 'not configured' },
     ])
     props = {
+      ...props,
       mostRecentAnalysis: { commands: [mockLoadedStagingAreaFixture] } as any,
     }
     const [{ getByText }] = render(props)
@@ -105,10 +112,24 @@ describe('FixtureTable', () => {
       { ...mockLoadedFixture, configurationStatus: 'conflicting' },
     ])
     props = {
+      ...props,
       mostRecentAnalysis: { commands: [mockLoadedStagingAreaFixture] } as any,
     }
     const [{ getByText, getAllByText }] = render(props)
     getByText('Location conflict').click()
     getAllByText('mock location conflict modal')
+  })
+  it('should call a mock function when tapping not configured row', () => {
+    mockUseLoadedFixturesConfigStatus.mockReturnValue([
+      { ...mockLoadedFixture, configurationStatus: 'not configured' },
+    ])
+    props = {
+      ...props,
+      mostRecentAnalysis: { commands: [mockLoadedStagingAreaFixture] } as any,
+    }
+    const [{ getByText }] = render(props)
+    getByText('Not configured').click()
+    expect(mockSetFixtureLocation).toHaveBeenCalledWith('D3')
+    expect(mockSetSetupScreen).toHaveBeenCalledWith('deck configuration')
   })
 })

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -131,7 +131,6 @@ const render = () => {
         runId={RUN_ID}
         setSetupScreen={mockSetSetupScreen}
         setFixtureLocation={mockSetFixtureLocation}
-        providedFixtureOptions={[]}
         setProvidedFixtureOptions={mockSetProvidedFixtureOptions}
       />
     </MemoryRouter>,

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -103,6 +103,8 @@ const mockLocationConflictModal = LocationConflictModal as jest.MockedFunction<
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
 const mockSetSetupScreen = jest.fn()
+const mockSetFixtureLocation = jest.fn()
+const mockSetProvidedFixtureOptions = jest.fn()
 
 const calibratedMockApiHeaterShaker = {
   ...mockApiHeaterShaker,
@@ -122,8 +124,6 @@ const mockFixture = {
   loadName: STAGING_AREA_LOAD_NAME,
 } as Fixture
 
-const mockSetFixtureLocation = jest.fn()
-
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
@@ -131,6 +131,8 @@ const render = () => {
         runId={RUN_ID}
         setSetupScreen={mockSetSetupScreen}
         setFixtureLocation={mockSetFixtureLocation}
+        providedFixtureOptions={[]}
+        setProvidedFixtureOptions={mockSetProvidedFixtureOptions}
       />
     </MemoryRouter>,
     {

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -122,12 +122,15 @@ const mockFixture = {
   loadName: STAGING_AREA_LOAD_NAME,
 } as Fixture
 
+const mockSetFixtureLocation = jest.fn()
+
 const render = () => {
   return renderWithProviders(
     <MemoryRouter>
       <ProtocolSetupModulesAndDeck
         runId={RUN_ID}
         setSetupScreen={mockSetSetupScreen}
+        setFixtureLocation={mockSetFixtureLocation}
       />
     </MemoryRouter>,
     {

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -324,7 +324,6 @@ interface ProtocolSetupModulesAndDeckProps {
   runId: string
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
   setFixtureLocation: (fixtureLocation: Cutout) => void
-  providedFixtureOptions: FixtureLoadName[]
   setProvidedFixtureOptions: (providedFixtureOptions: FixtureLoadName[]) => void
 }
 

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -63,7 +63,7 @@ import { getModuleTooHot } from '../Devices/getModuleTooHot'
 import { FixtureTable } from './FixtureTable'
 
 import type { CommandData } from '@opentrons/api-client'
-import type { Cutout, Fixture } from '@opentrons/shared-data'
+import type { Cutout, Fixture, FixtureLoadName } from '@opentrons/shared-data'
 import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { ProtocolCalibrationStatus } from '../../organisms/Devices/hooks'
@@ -324,6 +324,8 @@ interface ProtocolSetupModulesAndDeckProps {
   runId: string
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
   setFixtureLocation: (fixtureLocation: Cutout) => void
+  providedFixtureOptions: FixtureLoadName[]
+  setProvidedFixtureOptions: (providedFixtureOptions: FixtureLoadName[]) => void
 }
 
 /**
@@ -333,6 +335,8 @@ export function ProtocolSetupModulesAndDeck({
   runId,
   setSetupScreen,
   setFixtureLocation,
+  providedFixtureOptions,
+  setProvidedFixtureOptions,
 }: ProtocolSetupModulesAndDeckProps): JSX.Element {
   const { i18n, t } = useTranslation('protocol_setup')
   const { chainLiveCommands, isCommandMutationLoading } = useChainLiveCommands()
@@ -521,6 +525,7 @@ export function ProtocolSetupModulesAndDeck({
               mostRecentAnalysis={mostRecentAnalysis}
               setSetupScreen={setSetupScreen}
               setFixtureLocation={setFixtureLocation}
+              setProvidedFixtureOptions={setProvidedFixtureOptions}
             />
           ) : null}
         </Flex>

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -19,7 +19,6 @@ import {
 } from '@opentrons/components'
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
 import {
-  Fixture,
   getDeckDefFromRobotType,
   getModuleDisplayName,
   getModuleType,
@@ -64,6 +63,7 @@ import { getModuleTooHot } from '../Devices/getModuleTooHot'
 import { FixtureTable } from './FixtureTable'
 
 import type { CommandData } from '@opentrons/api-client'
+import type { Cutout, Fixture } from '@opentrons/shared-data'
 import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { ProtocolCalibrationStatus } from '../../organisms/Devices/hooks'
@@ -323,6 +323,7 @@ function RowModule({
 interface ProtocolSetupModulesAndDeckProps {
   runId: string
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
+  setFixtureLocation: (fixtureLocation: Cutout) => void
 }
 
 /**
@@ -331,6 +332,7 @@ interface ProtocolSetupModulesAndDeckProps {
 export function ProtocolSetupModulesAndDeck({
   runId,
   setSetupScreen,
+  setFixtureLocation,
 }: ProtocolSetupModulesAndDeckProps): JSX.Element {
   const { i18n, t } = useTranslation('protocol_setup')
   const { chainLiveCommands, isCommandMutationLoading } = useChainLiveCommands()
@@ -515,7 +517,11 @@ export function ProtocolSetupModulesAndDeck({
             })}
           </Flex>
           {enableDeckConfig ? (
-            <FixtureTable mostRecentAnalysis={mostRecentAnalysis} />
+            <FixtureTable
+              mostRecentAnalysis={mostRecentAnalysis}
+              setSetupScreen={setSetupScreen}
+              setFixtureLocation={setFixtureLocation}
+            />
           ) : null}
         </Flex>
       </Flex>

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -335,7 +335,6 @@ export function ProtocolSetupModulesAndDeck({
   runId,
   setSetupScreen,
   setFixtureLocation,
-  providedFixtureOptions,
   setProvidedFixtureOptions,
 }: ProtocolSetupModulesAndDeckProps): JSX.Element {
   const { i18n, t } = useTranslation('protocol_setup')

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/Buttons.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/Buttons.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+
+import {
+  ALIGN_CENTER,
+  Btn,
+  COLORS,
+  DISPLAY_FLEX,
+  JUSTIFY_CENTER,
+  Icon,
+} from '@opentrons/components'
+
+import { ODD_FOCUS_VISIBLE } from '../../../atoms/buttons/constants'
+
+// ToDo (kk:10/17/2023) This component will be modified more later.
+// This is the initial step to reduce ProtocolSetup component's code.
+// For PlayButton, we can extend the play button that is existing under RunningProtocol
+// For CloseButton we can would be able to use the close button that is existing under RunningProtocol
+interface PlayButtonProps {
+  ready: boolean
+  onPlay?: () => void
+  disabled?: boolean
+  isDoorOpen: boolean
+}
+
+export function PlayButton({
+  disabled = false,
+  onPlay,
+  ready,
+  isDoorOpen,
+}: PlayButtonProps): JSX.Element {
+  const playButtonStyle = css`
+    -webkit-tap-highlight-color: transparent;
+    &:focus {
+      background-color: ${ready && !isDoorOpen
+        ? COLORS.bluePressed
+        : COLORS.darkBlack40};
+      color: ${COLORS.white};
+    }
+
+    &:hover {
+      background-color: ${ready && !isDoorOpen
+        ? COLORS.blueEnabled
+        : COLORS.darkBlack20};
+      color: ${COLORS.white};
+    }
+
+    &:focus-visible {
+      box-shadow: ${ODD_FOCUS_VISIBLE};
+      background-color: ${ready && !isDoorOpen
+        ? COLORS.blueEnabled
+        : COLORS.darkBlack20};
+    }
+
+    &:active {
+      background-color: ${ready && !isDoorOpen
+        ? COLORS.bluePressed
+        : COLORS.darkBlack40};
+      color: ${COLORS.white};
+    }
+
+    &:disabled {
+      background-color: ${COLORS.darkBlack20};
+      color: ${COLORS.darkBlack60};
+    }
+  `
+  return (
+    <Btn
+      alignItems={ALIGN_CENTER}
+      backgroundColor={
+        disabled || !ready || isDoorOpen
+          ? COLORS.darkBlack20
+          : COLORS.blueEnabled
+      }
+      borderRadius="6.25rem"
+      display={DISPLAY_FLEX}
+      height="6.25rem"
+      justifyContent={JUSTIFY_CENTER}
+      width="6.25rem"
+      disabled={disabled}
+      onClick={onPlay}
+      aria-label="play"
+      css={playButtonStyle}
+    >
+      <Icon
+        color={
+          disabled || !ready || isDoorOpen ? COLORS.darkBlack60 : COLORS.white
+        }
+        name="play-icon"
+        size="2.5rem"
+      />
+    </Btn>
+  )
+}
+
+interface CloseButtonProps {
+  onClose: () => void
+}
+
+export function CloseButton({ onClose }: CloseButtonProps): JSX.Element {
+  return (
+    <Btn
+      alignItems={ALIGN_CENTER}
+      backgroundColor={COLORS.red2}
+      borderRadius="6.25rem"
+      display={DISPLAY_FLEX}
+      height="6.25rem"
+      justifyContent={JUSTIFY_CENTER}
+      width="6.25rem"
+      onClick={onClose}
+      aria-label="close"
+      css={CLOSE_BUTTON_STYLE}
+    >
+      <Icon color={COLORS.white} name="close-icon" size="2.5rem" />
+    </Btn>
+  )
+}
+
+const CLOSE_BUTTON_STYLE = css`
+  -webkit-tap-highlight-color: transparent;
+  &:focus {
+    background-color: ${COLORS.red2Pressed};
+    color: ${COLORS.white};
+  }
+
+  &:hover {
+    background-color: ${COLORS.red2};
+    color: ${COLORS.white};
+  }
+
+  &:focus-visible {
+    box-shadow: ${ODD_FOCUS_VISIBLE};
+    background-color: ${COLORS.red2};
+  }
+
+  &:active {
+    background-color: ${COLORS.red2Pressed};
+    color: ${COLORS.white};
+  }
+
+  &:disabled {
+    background-color: ${COLORS.darkBlack20};
+    color: ${COLORS.darkBlack60};
+  }
+`

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -592,6 +592,7 @@ export function ProtocolSetup(): JSX.Element {
     'deck configuration': (
       <ProtocolSetupDeckConfiguration
         fixtureLocation={fixtureLocation}
+        runId={runId}
         setSetupScreen={setSetupScreen}
       />
     ),

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -585,7 +585,6 @@ export function ProtocolSetup(): JSX.Element {
         setSetupScreen={setSetupScreen}
         setFixtureLocation={setFixtureLocation}
         setProvidedFixtureOptions={setProvidedFixtureOptions}
-        providedFixtureOptions={providedFixtureOptions}
       />
     ),
     labware: (

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -12,10 +12,8 @@ import {
   Btn,
   COLORS,
   DIRECTION_COLUMN,
-  DISPLAY_FLEX,
   Flex,
   Icon,
-  JUSTIFY_CENTER,
   JUSTIFY_END,
   JUSTIFY_SPACE_BETWEEN,
   POSITION_STICKY,
@@ -41,7 +39,6 @@ import {
   ProtocolSetupTitleSkeleton,
   ProtocolSetupStepSkeleton,
 } from '../../../organisms/OnDeviceDisplay/ProtocolSetup'
-import { ODD_FOCUS_VISIBLE } from '../../../atoms/buttons/constants'
 import {
   useAttachedModules,
   useLPCDisabledReason,
@@ -52,6 +49,7 @@ import { ProtocolSetupLabware } from '../../../organisms/ProtocolSetupLabware'
 import { ProtocolSetupModulesAndDeck } from '../../../organisms/ProtocolSetupModulesAndDeck'
 import { ProtocolSetupLiquids } from '../../../organisms/ProtocolSetupLiquids'
 import { ProtocolSetupInstruments } from '../../../organisms/ProtocolSetupInstruments'
+import { ProtocolSetupDeckConfiguration } from '../../../organisms/ProtocolSetupDeckConfiguration'
 import { useLaunchLPC } from '../../../organisms/LabwarePositionCheck/useLaunchLPC'
 import { getUnmatchedModulesForProtocol } from '../../../organisms/ProtocolSetupModulesAndDeck/utils'
 import { ConfirmCancelRunModal } from '../../../organisms/OnDeviceDisplay/RunningProtocol'
@@ -77,7 +75,9 @@ import {
 } from '../../../redux/config'
 import { ConfirmAttachedModal } from './ConfirmAttachedModal'
 import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
+import { CloseButton, PlayButton } from './Buttons'
 
+import type { Cutout } from '@opentrons/shared-data'
 import type { OnDeviceRouteParams } from '../../../App/types'
 
 const FETCH_DURATION_MS = 5000
@@ -189,134 +189,6 @@ export function ProtocolSetupStep({
           />
         )}
       </Flex>
-    </Btn>
-  )
-}
-
-const CLOSE_BUTTON_STYLE = css`
-  -webkit-tap-highlight-color: transparent;
-  &:focus {
-    background-color: ${COLORS.red2Pressed};
-    color: ${COLORS.white};
-  }
-
-  &:hover {
-    background-color: ${COLORS.red2};
-    color: ${COLORS.white};
-  }
-
-  &:focus-visible {
-    box-shadow: ${ODD_FOCUS_VISIBLE};
-    background-color: ${COLORS.red2};
-  }
-
-  &:active {
-    background-color: ${COLORS.red2Pressed};
-    color: ${COLORS.white};
-  }
-
-  &:disabled {
-    background-color: ${COLORS.darkBlack20};
-    color: ${COLORS.darkBlack60};
-  }
-`
-// TODO(ew, 05/03/2023): refactor the run buttons into a shared component
-interface CloseButtonProps {
-  onClose: () => void
-}
-
-function CloseButton({ onClose }: CloseButtonProps): JSX.Element {
-  return (
-    <Btn
-      alignItems={ALIGN_CENTER}
-      backgroundColor={COLORS.red2}
-      borderRadius="6.25rem"
-      display={DISPLAY_FLEX}
-      height="6.25rem"
-      justifyContent={JUSTIFY_CENTER}
-      width="6.25rem"
-      onClick={onClose}
-      aria-label="close"
-      css={CLOSE_BUTTON_STYLE}
-    >
-      <Icon color={COLORS.white} name="close-icon" size="2.5rem" />
-    </Btn>
-  )
-}
-
-interface PlayButtonProps {
-  ready: boolean
-  onPlay?: () => void
-  disabled?: boolean
-  isDoorOpen: boolean
-}
-
-function PlayButton({
-  disabled = false,
-  onPlay,
-  ready,
-  isDoorOpen,
-}: PlayButtonProps): JSX.Element {
-  const playButtonStyle = css`
-    -webkit-tap-highlight-color: transparent;
-    &:focus {
-      background-color: ${ready && !isDoorOpen
-        ? COLORS.bluePressed
-        : COLORS.darkBlack40};
-      color: ${COLORS.white};
-    }
-
-    &:hover {
-      background-color: ${ready && !isDoorOpen
-        ? COLORS.blueEnabled
-        : COLORS.darkBlack20};
-      color: ${COLORS.white};
-    }
-
-    &:focus-visible {
-      box-shadow: ${ODD_FOCUS_VISIBLE};
-      background-color: ${ready && !isDoorOpen
-        ? COLORS.blueEnabled
-        : COLORS.darkBlack20};
-    }
-
-    &:active {
-      background-color: ${ready && !isDoorOpen
-        ? COLORS.bluePressed
-        : COLORS.darkBlack40};
-      color: ${COLORS.white};
-    }
-
-    &:disabled {
-      background-color: ${COLORS.darkBlack20};
-      color: ${COLORS.darkBlack60};
-    }
-  `
-  return (
-    <Btn
-      alignItems={ALIGN_CENTER}
-      backgroundColor={
-        disabled || !ready || isDoorOpen
-          ? COLORS.darkBlack20
-          : COLORS.blueEnabled
-      }
-      borderRadius="6.25rem"
-      display={DISPLAY_FLEX}
-      height="6.25rem"
-      justifyContent={JUSTIFY_CENTER}
-      width="6.25rem"
-      disabled={disabled}
-      onClick={onPlay}
-      aria-label="play"
-      css={playButtonStyle}
-    >
-      <Icon
-        color={
-          disabled || !ready || isDoorOpen ? COLORS.darkBlack60 : COLORS.white
-        }
-        name="play-icon"
-        size="2.5rem"
-      />
     </Btn>
   )
 }
@@ -662,6 +534,7 @@ export type SetupScreens =
   | 'modules'
   | 'labware'
   | 'liquids'
+  | 'deck configuration'
 
 export function ProtocolSetup(): JSX.Element {
   const { runId } = useParams<OnDeviceRouteParams>()
@@ -681,6 +554,9 @@ export function ProtocolSetup(): JSX.Element {
   } = useConditionalConfirm(
     handleProceedToRunClick,
     !configBypassHeaterShakerAttachmentConfirmation
+  )
+  const [fixtureLocation, setFixtureLocation] = React.useState<Cutout | null>(
+    null
   )
 
   // orchestrate setup subpages/components
@@ -704,6 +580,7 @@ export function ProtocolSetup(): JSX.Element {
       <ProtocolSetupModulesAndDeck
         runId={runId}
         setSetupScreen={setSetupScreen}
+        setFixtureLocation={setFixtureLocation}
       />
     ),
     labware: (
@@ -711,6 +588,12 @@ export function ProtocolSetup(): JSX.Element {
     ),
     liquids: (
       <ProtocolSetupLiquids runId={runId} setSetupScreen={setSetupScreen} />
+    ),
+    'deck configuration': (
+      <ProtocolSetupDeckConfiguration
+        notConfiguredLocation={fixtureLocation}
+        setSetupScreen={setSetupScreen}
+      />
     ),
   }
 

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -77,7 +77,7 @@ import { ConfirmAttachedModal } from './ConfirmAttachedModal'
 import { getLatestCurrentOffsets } from '../../../organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/utils'
 import { CloseButton, PlayButton } from './Buttons'
 
-import type { Cutout } from '@opentrons/shared-data'
+import type { Cutout, FixtureLoadName } from '@opentrons/shared-data'
 import type { OnDeviceRouteParams } from '../../../App/types'
 
 const FETCH_DURATION_MS = 5000
@@ -555,9 +555,12 @@ export function ProtocolSetup(): JSX.Element {
     handleProceedToRunClick,
     !configBypassHeaterShakerAttachmentConfirmation
   )
-  const [fixtureLocation, setFixtureLocation] = React.useState<Cutout | null>(
-    null
+  const [fixtureLocation, setFixtureLocation] = React.useState<Cutout>(
+    '' as Cutout
   )
+  const [providedFixtureOptions, setProvidedFixtureOptions] = React.useState<
+    FixtureLoadName[]
+  >([])
 
   // orchestrate setup subpages/components
   const [setupScreen, setSetupScreen] = React.useState<SetupScreens>(
@@ -581,6 +584,8 @@ export function ProtocolSetup(): JSX.Element {
         runId={runId}
         setSetupScreen={setSetupScreen}
         setFixtureLocation={setFixtureLocation}
+        setProvidedFixtureOptions={setProvidedFixtureOptions}
+        providedFixtureOptions={providedFixtureOptions}
       />
     ),
     labware: (
@@ -594,6 +599,7 @@ export function ProtocolSetup(): JSX.Element {
         fixtureLocation={fixtureLocation}
         runId={runId}
         setSetupScreen={setSetupScreen}
+        providedFixtureOptions={providedFixtureOptions}
       />
     ),
   }

--- a/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolSetup/index.tsx
@@ -591,7 +591,7 @@ export function ProtocolSetup(): JSX.Element {
     ),
     'deck configuration': (
       <ProtocolSetupDeckConfiguration
-        notConfiguredLocation={fixtureLocation}
+        fixtureLocation={fixtureLocation}
         setSetupScreen={setSetupScreen}
       />
     ),

--- a/app/src/resources/deck_configuration/hooks.ts
+++ b/app/src/resources/deck_configuration/hooks.ts
@@ -7,7 +7,7 @@ export const CONFIGURED = 'configured'
 export const CONFLICTING = 'conflicting'
 export const NOT_CONFIGURED = 'not configured'
 
-type LoadedFixtureConfigurationStatus =
+export type LoadedFixtureConfigurationStatus =
   | typeof CONFIGURED
   | typeof CONFLICTING
   | typeof NOT_CONFIGURED

--- a/app/src/resources/deck_configuration/hooks.ts
+++ b/app/src/resources/deck_configuration/hooks.ts
@@ -7,7 +7,7 @@ export const CONFIGURED = 'configured'
 export const CONFLICTING = 'conflicting'
 export const NOT_CONFIGURED = 'not configured'
 
-export type LoadedFixtureConfigurationStatus =
+type LoadedFixtureConfigurationStatus =
   | typeof CONFIGURED
   | typeof CONFLICTING
   | typeof NOT_CONFIGURED


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
- Add Deck configuration screen to ProtocolSetup.
- Export CloseButton and PlayButton from ProtocolSetup component to reduce the lines.
- Rename `AddDeckConfigurationModal` to `AddFixtureModal`
- Add a new prop fixtureLocation to FixtureTable and ProtocolSetupModuleAndDeck to pass the slotName to AddFixtureModal.

For `Confirm` button, I will wire up in another PR (RAUT-804)

design
https://www.figma.com/file/eMAHM8g07dtTKr2RsFjkzB/OCT-Release%3A-Touchscreen-%5BDeck-configuration-%26-Drop-tips%5D?type=design&node-id=1-386&mode=design&t=rydOLM2zP7FPNv6j-0

close RAUT-672
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Add ProtocolSetupDeckConfiguration
- update FixtureTable and ProtocolSetupModulesAndDeck to add props to pass slotName to AddFixtureModal
- export CloseButton and PlayButton (Currently Buttons.tsx under ProtocolSetup folder)
They can be a part of `atomes/buttons` in the future.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
