### PR TITLE
fix(app): render labware correctly in move labware intervention modal

### DIFF
--- a/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/MoveLabwareInterventionContent.tsx
@@ -221,7 +221,10 @@ export function MoveLabwareInterventionContent({
                     .filter(l => l.labwareId !== command.params.labwareId)
                     .map(({ x, y, labwareDef, labwareId }) => (
                       <g key={labwareId} transform={`translate(${x},${y})`}>
-                        <LabwareRender definition={labwareDef} />
+                        {labwareDef != null &&
+                        labwareId !== command.params.labwareId ? (
+                          <LabwareRender definition={labwareDef} />
+                        ) : null}
                       </g>
                     ))}
                 </>


### PR DESCRIPTION
closes RQA-1222

# Overview

This fixes how we render labware in the move labware intervention modal for labware directly on the deck. Now, when you move a labware to a new spot and another labware into that spot later, the spot is clear of the previous labware. 

# Test Plan

create a protocol for the Flex or Ot-2 that has manual move labware steps:
1. labware directly on the deck to another slot
2. another labware to that spot on the deck

Make sure when 2 happens, the slot is not covered by the previous labware

# Changelog

- add logic to the move labware intervention modal, only render the labware if it does not equal the command's labware id and if a `labwareId` exists for the step.

# Review requests

see test plan

# Risk assessment

low