### PR TITLE
docs(api): minor changes to Advanced Control page

### DIFF
--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -77,7 +77,7 @@ Creating the dummy protocol requires you to:
     1. Use the ``metadata`` or ``requirements`` dictionary to specify the API version. (See :ref:`v2-versioning` for details.) Use the same API version as you did in :py:meth:`opentrons.execute.get_protocol_api`.
     2. Define a ``run()`` function.
     3. Load all of your labware in their initial locations.
-    4. Load your smallest capacity pipette and specify its ``tipracks``.
+    4. Load your smallest capacity pipette and specify its ``tip_racks``.
     5. Call ``pick_up_tip()``. Labware Position Check can't run if you don't pick up a tip.
     
 For example, the following dummy protocol will use a P300 Single-Channel GEN2 pipette to enable Labware Position Check for an OT-2 tip rack, NEST reservoir, and NEST flat well plate.
@@ -116,13 +116,13 @@ This automatically generated code uses generic names for the loaded labware. If 
     
 .. versionadded:: 2.12
 
-Once you've executed this code in Jupyter Notebook, all subsequent positional calculations for this reservoir in slot D2 will be adjusted 0.1 mm to the right, 0.2 mm to the back, and 0.3 mm up.
+Once you've executed this code in Jupyter Notebook, all subsequent positional calculations for this reservoir in slot 2 will be adjusted 0.1 mm to the right, 0.2 mm to the back, and 0.3 mm up.
 
-Remember, you should only add ``.set_offset()`` commands to protocols run outside of the Opentrons App. And you should follow the behavior of Labware Position Check, i.e., *do not* reuse offset measurements unless they apply to the *same labware* in the *same deck slot* on the *same robot*.
+Remember, you should only add ``set_offset()`` commands to protocols run outside of the Opentrons App. And you should follow the behavior of Labware Position Check, i.e., *do not* reuse offset measurements unless they apply to the *same labware* in the *same deck slot* on the *same robot*.
 
 .. warning::
 
-	Improperly reusing offset data may cause your robot to move to an unexpected position or crash against other labware, which can lead to incorrect protocol execution or damage your equipment. The same applies when running protocols with ``.set_offset()`` commands in the Opentrons App. When in doubt: run Labware Position Check again and update your code!
+	Improperly reusing offset data may cause your robot to move to an unexpected position or crash against other labware, which can lead to incorrect protocol execution or damage your equipment. The same applies when running protocols with ``set_offset()`` commands in the Opentrons App. When in doubt: run Labware Position Check again and update your code!
 
 Using Custom Labware
 --------------------

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -122,7 +122,7 @@ Remember, you should only add ``set_offset()`` commands to protocols run outside
 
 .. warning::
 
-	Improperly reusing offset data may cause your robot to move to an unexpected position or crash against other labware, which can lead to incorrect protocol execution or damage your equipment. The same applies when running protocols with ``set_offset()`` commands in the Opentrons App. When in doubt: run Labware Position Check again and update your code!
+	Improperly reusing offset data may cause your robot to move to an unexpected position or crash against labware, which can lead to incorrect protocol execution or damage your equipment. The same applies when running protocols with ``set_offset()`` commands in the Opentrons App. When in doubt: run Labware Position Check again and update your code!
 
 Using Custom Labware
 --------------------
@@ -144,6 +144,7 @@ To disable the robot server, open a Jupyter terminal session by going to **New >
 Command Line
 ------------
 
+.. TODO update with separate links to OT-2 and Flex setup, when new Flex process is in manual or on help site
 The robot's command line is accessible either by going to **New > Terminal** in Jupyter or `via SSH <https://support.opentrons.com/s/article/Connecting-to-your-OT-2-with-SSH>`_.
 
 To execute a protocol from the robot's command line, copy the protocol file to the robot with ``scp`` and then run the protocol with ``opentrons_execute``:


### PR DESCRIPTION


# Overview

This PR addresses RTC-357, which anticipated that there were several changes needed to this page in order to have it cover both Flex and OT-2. Those changes were actually done, but were only in `edge` and not in the 7.0.1 release branch. As a result, this PR is pretty minor in scope.

# Test Plan

Built locally and checked the [Advanced Control page in the sandbox](http://sandbox.docs.opentrons.com/RTC-357-advanced-control/v2/new_advanced_running.html).

# Changelog

All changes are minor:
- Changed slot `D2` to `2` in OT-2 example.
- Don't include leading period in method names.
- Fix a typo referencing the `tip_racks` parameter.
- Add TODO for linking to separate SSH setup instructions for OT-2 and Flex. (Flex now requires delivering the key physically on a USB drive.)

# Review requests

- Li'l changes good? 
- TODO makes sense for now? We don't have Flex setup instructions in a public place yet. They will go in the next revision of the PDF manual and I suspect there will be a corresponding help center page soon.

# Risk assessment

nil, docs.