### PR TITLE
feat(hardware): read tip update from firmware whenever a notification is received

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1311,7 +1311,11 @@ class OT3Controller:
 
     async def update_tip_detector(self, mount: OT3Mount, sensor_count: int) -> None:
         """Build indiviudal tip detector for a mount."""
+        await self.teardown_tip_detector(mount)
         await self._tip_presence_manager.build_detector(mount, sensor_count)
+
+    async def teardown_tip_detector(self, mount: OT3Mount) -> None:
+        await self._tip_presence_manager.clear_detector(mount)
 
     async def get_tip_status(self, mount: OT3Mount) -> TipStateType:
         return await self.tip_presence_manager.get_tip_status(mount)

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -47,6 +47,7 @@ from .ot3utils import (
     moving_axes_in_move_group,
     gripper_jaw_state_from_fw,
 )
+from .tip_presence_manager import TipPresenceManager
 
 try:
     import aionotify  # type: ignore[import]
@@ -86,7 +87,6 @@ from opentrons_hardware.hardware_control.motor_position_status import (
     update_motor_position_estimation,
 )
 from opentrons_hardware.hardware_control.limit_switches import get_limit_switches
-from opentrons_hardware.hardware_control.tip_presence import get_tip_ejector_state
 from opentrons_hardware.hardware_control.current_settings import (
     set_run_current,
     set_hold_current,
@@ -127,7 +127,6 @@ from opentrons.hardware_control.types import (
     SubSystemState,
     SubSystem,
     TipStateType,
-    FailedTipStateCheck,
     EstopState,
     GripperJawState,
 )
@@ -172,7 +171,6 @@ from opentrons_shared_data.gripper.gripper_definition import GripForceProfile
 from opentrons_shared_data.errors.exceptions import (
     EStopActivatedError,
     EStopNotPresentError,
-    UnmatchedTipPresenceStates,
     PipetteOverpressureError,
     FirmwareUpdateRequiredError,
 )
@@ -316,6 +314,7 @@ class OT3Controller:
                 "or door, likely because not running on linux"
             )
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
+        self._tip_presence_manager = TipPresenceManager(self._messenger)
 
     async def get_serial_number(self) -> Optional[str]:
         if not self.initialized:
@@ -867,34 +866,6 @@ class OT3Controller:
         res = await get_limit_switches(self._messenger, motor_nodes)
         return {node_to_axis(node): bool(val) for node, val in res.items()}
 
-    async def check_for_tip_presence(
-        self,
-        mount: OT3Mount,
-        tip_state: TipStateType,
-        expect_multiple_responses: bool = False,
-    ) -> None:
-        """Raise an error if the expected tip state does not match the current state."""
-        res = await self.get_tip_present_state(mount, expect_multiple_responses)
-        if res != tip_state.value:
-            raise FailedTipStateCheck(tip_state, res)
-
-    async def get_tip_present_state(
-        self,
-        mount: OT3Mount,
-        expect_multiple_responses: bool = False,
-    ) -> bool:
-        """Get the state of the tip ejector flag for a given mount."""
-        expected_responses = 2 if expect_multiple_responses else 1
-        node = sensor_node_for_mount(OT3Mount(mount.value))
-        assert node != NodeId.gripper
-        res = await get_tip_ejector_state(self._messenger, node, expected_responses)  # type: ignore[arg-type]
-        vals = list(res.values())
-        if not all([r == vals[0] for r in vals]):
-            states = {int(sensor): res[sensor] for sensor in res}
-            raise UnmatchedTipPresenceStates(states)
-        tip_present_state = bool(vals[0])
-        return tip_present_state
-
     @staticmethod
     def _tip_motor_nodes(axis_current_keys: KeysView[Axis]) -> List[NodeId]:
         return [axis_to_node(Axis.Q)] if Axis.Q in axis_current_keys else []
@@ -1333,3 +1304,17 @@ class OT3Controller:
     def estop_state_machine(self) -> EstopStateMachine:
         """Accessor for the API to get the state machine, if it exists."""
         return self._estop_state_machine
+
+    @property
+    def tip_presence_manager(self) -> TipPresenceManager:
+        return self._tip_presence_manager
+
+    async def update_tip_detector(self, mount: OT3Mount, sensor_count: int) -> None:
+        """Build indiviudal tip detector for a mount."""
+        await self._tip_presence_manager.build_detector(mount, sensor_count)
+
+    async def get_tip_status(self, mount: OT3Mount) -> TipStateType:
+        return await self.tip_presence_manager.get_tip_status(mount)
+
+    def current_tip_state(self, mount: OT3Mount) -> Optional[bool]:
+        return self.tip_presence_manager.current_tip_state(mount)

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -745,3 +745,6 @@ class OT3Simulator:
 
     async def update_tip_detector(self, mount: OT3Mount, sensor_count: int) -> None:
         pass
+
+    async def teardown_tip_detector(self, mount: OT3Mount) -> None:
+        pass

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -189,6 +189,10 @@ class OT3Simulator:
         self._present_nodes = nodes
         self._current_settings: Optional[OT3AxisMap[CurrentConfig]] = None
         self._sim_jaw_state = GripperJawState.HOMED_READY
+        self._sim_tip_state: Dict[OT3Mount, Optional[bool]] = {
+            mount: False if self._attached_instruments[mount] else None
+            for mount in [OT3Mount.LEFT, OT3Mount.RIGHT]
+        }
 
     async def get_serial_number(self) -> Optional[str]:
         return "simulator"
@@ -390,21 +394,6 @@ class OT3Simulator:
         _ = create_gripper_jaw_hold_group(encoder_position_um)
         self._encoder_position[NodeId.gripper_g] = encoder_position_um / 1000.0
         self._sim_jaw_state = GripperJawState.HOLDING
-
-    async def check_for_tip_presence(
-        self,
-        mount: OT3Mount,
-        tip_state: TipStateType,
-        expect_multiple_responses: bool = False,
-    ) -> None:
-        """Raise an error if the given state doesn't match the physical state."""
-        pass
-
-    async def get_tip_present_state(
-        self, mount: OT3Mount, expect_multiple_responses: bool = False
-    ) -> bool:
-        """Get the state of the tip ejector flag for a given mount."""
-        pass
 
     async def get_jaw_state(self) -> GripperJawState:
         """Get the state of the gripper jaw."""
@@ -747,3 +736,12 @@ class OT3Simulator:
     def estop_state_machine(self) -> EstopStateMachine:
         """Return an estop state machine locked in the "disengaged" state."""
         return self._estop_state_machine
+
+    async def get_tip_status(self, mount: OT3Mount) -> TipStateType:
+        return TipStateType(self._sim_tip_state[mount])
+
+    def current_tip_state(self, mount: OT3Mount) -> Optional[bool]:
+        return self._sim_tip_state[mount]
+
+    async def update_tip_detector(self, mount: OT3Mount, sensor_count: int) -> None:
+        pass

--- a/api/src/opentrons/hardware_control/backends/tip_presence_manager.py
+++ b/api/src/opentrons/hardware_control/backends/tip_presence_manager.py
@@ -1,0 +1,95 @@
+import logging
+from functools import partial
+from typing import Callable, Optional, List, Dict
+
+
+from opentrons.hardware_control.types import TipStateType, OT3Mount
+
+from opentrons_hardware.drivers.can_bus import CanMessenger
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.hardware_control.tip_presence import (
+    TipDetector,
+    types as tip_types,
+)
+from opentrons_shared_data.errors.exceptions import UnmatchedTipPresenceStates
+
+log = logging.getLogger(__name__)
+
+TipListener = Callable[[OT3Mount, bool], None]
+TipDetectorByMount = Dict[OT3Mount, Optional[TipDetector]]
+TipUpdateByMount = Dict[OT3Mount, Optional[bool]]
+
+
+class TipDetectorNotFoundError(Exception):
+    pass
+
+
+def _mount_to_node(mount: OT3Mount) -> NodeId:
+    return {
+        OT3Mount.LEFT: NodeId.pipette_left,
+        OT3Mount.RIGHT: NodeId.pipette_right,
+    }[mount]
+
+
+class TipPresenceManager:
+    """Handle tip change notification coming from CAN."""
+
+    _listeners: List[TipListener]
+    _detectors: TipDetectorByMount
+    _last_state: TipUpdateByMount
+
+    def __init__(self, can_messenger: CanMessenger) -> None:
+        self._messenger = can_messenger
+        self._listeners = []
+        self._detectors = {m: None for m in OT3Mount}
+        self._last_state = {m: None for m in OT3Mount}
+
+    async def build_detector(self, mount: OT3Mount, sensor_count: int) -> None:
+        # clear detector if pipette does not exist
+        if not sensor_count > 0:
+            self._detectors[mount] = None
+        else:
+            # set up and subscribe to the detector
+            d = TipDetector(self._messenger, _mount_to_node(mount), sensor_count)
+            # listens to the detector so we can immediately notify listeners
+            # the most up-to-date tip state
+            d.add_subscriber(partial(self._handle_tip_update, mount))
+            self._detectors[mount] = d
+
+    def _handle_tip_update(
+        self, mount: OT3Mount, update: tip_types.TipNotification
+    ) -> None:
+        """Callback for detector."""
+        self._last_state[mount] = update.presence
+
+        for listener in self._listeners:
+            listener(mount, update.presence)
+
+    def current_tip_state(self, mount: OT3Mount) -> Optional[bool]:
+        state = self._last_state[mount]
+        if state is None:
+            log.warning("Tip state for {mount} is unknown")
+        return state
+
+    @staticmethod
+    def _get_tip_presence(results: List[tip_types.TipNotification]) -> TipStateType:
+        # more than one sensor reported, we have to check if their states match
+        if len(set(r.presence for r in results)) > 1:
+            raise UnmatchedTipPresenceStates(
+                {int(r.sensor): int(r.presence) for r in results}
+            )
+        return TipStateType(results[0].presence)
+
+    async def get_tip_status(self, mount: OT3Mount) -> TipStateType:
+        detector = self.get_detector(mount)
+        return self._get_tip_presence(await detector.request_tip_status())
+
+    def get_detector(self, mount: OT3Mount) -> TipDetector:
+        detector = self._detectors[mount]
+        if not detector:
+            raise TipDetectorNotFoundError(f"Tip detector not set up for {mount} mount")
+        return detector
+
+    def add_listener(self, listener: TipListener) -> None:
+        if listener not in self._listeners:
+            self._listeners.append(listener)

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -101,7 +101,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._working_volume = float(self._liquid_class.max_volume)
         self._current_tip_length = 0.0
         self._current_tiprack_diameter = 0.0
-        self._has_tip = False
         self._pipette_id = pipette_id
         self._log = mod_log.getChild(
             self._pipette_id if self._pipette_id else "<unknown>"
@@ -232,7 +231,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._working_volume = float(self.liquid_class.max_volume)
         self._current_tip_length = 0.0
         self._current_tiprack_diameter = 0.0
-        self._has_tip = False
         self.ready_to_aspirate = False
         #: True if ready to aspirate
         self.set_liquid_class_by_name("default")
@@ -322,7 +320,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             CriticalPoint.GRIPPER_REAR_CALIBRATION_PIN,
         ]:
             raise InvalidCriticalPoint(cp_override.name, "pipette")
-        if not self.has_tip or cp_override == CriticalPoint.NOZZLE:
+        if not self.has_tip_length or cp_override == CriticalPoint.NOZZLE:
             cp_type = CriticalPoint.NOZZLE
             tip_length = 0.0
         else:
@@ -492,8 +490,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         :return:
         """
         assert tip_length > 0.0, "tip_length must be greater than 0"
-        assert not self.has_tip
-        self._has_tip = True
+        assert not self.has_tip_length
         self._current_tip_length = tip_length
 
     def remove_tip(self) -> None:
@@ -501,17 +498,25 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         Remove the tip from the pipette (effectively updates the pipette's
         critical point)
         """
-        assert self.has_tip
-        self._has_tip = False
+        assert self.has_tip_length
         self._current_tip_length = 0.0
 
     @property
     def has_tip(self) -> bool:
-        return self._has_tip
+        return self.has_tip_length
+
+    @property
+    def has_tip_length(self) -> bool:
+        return self.current_tip_length > 0.0
 
     @property
     def tip_presence_check_dist_mm(self) -> float:
         return self._config.tip_presence_check_distance_mm
+
+    @property
+    def tip_presence_responses(self) -> int:
+        # TODO: put this in shared-data
+        return 2 if self.channels > 8 else 1
 
     @property
     def connect_tiprack_distance_mm(self) -> float:
@@ -547,7 +552,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         return "{} current volume {}ul critical point: {} at {}".format(
             self._config.display_name,
             self.current_volume,
-            "tip end" if self.has_tip else "nozzle end",
+            "tip end" if self.has_tip_length else "nozzle end",
             0,
         )
 
@@ -565,7 +570,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
                 "name": self.name,
                 "model": self.model,
                 "pipette_id": self.pipette_id,
-                "has_tip": self.has_tip,
+                "has_tip": self.has_tip_length,
                 "working_volume": self.working_volume,
                 "aspirate_flow_rate": self.aspirate_flow_rate,
                 "dispense_flow_rate": self.dispense_flow_rate,
@@ -604,7 +609,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
                 },
             )
         if (
-            self.has_tip
+            self.has_tip_length
             and self._active_tip_setting_name not in new_class.supported_tips
         ):
             raise CommandPreconditionViolated(
@@ -616,7 +621,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
             )
         self._liquid_class_name = new_name
         self._liquid_class = new_class
-        if not self.has_tip:
+        if not self.has_tip_length:
             new_tip_class = sorted(
                 [tip for tip in self._liquid_class.supported_tips.keys()],
                 key=lambda tt: tt.value,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -100,6 +100,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._current_volume = 0.0
         self._working_volume = float(self._liquid_class.max_volume)
         self._current_tip_length = 0.0
+        self._has_tip_length: Optional[bool] = None
         self._current_tiprack_diameter = 0.0
         self._pipette_id = pipette_id
         self._log = mod_log.getChild(
@@ -230,6 +231,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         self._current_volume = 0.0
         self._working_volume = float(self.liquid_class.max_volume)
         self._current_tip_length = 0.0
+        self._has_tip_length = None
         self._current_tiprack_diameter = 0.0
         self.ready_to_aspirate = False
         #: True if ready to aspirate
@@ -376,6 +378,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     @current_tip_length.setter
     def current_tip_length(self, tip_length: float) -> None:
         self._current_tip_length = tip_length
+        self._has_tip_length = True
 
     @property
     def current_tiprack_diameter(self) -> float:
@@ -492,6 +495,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         assert tip_length > 0.0, "tip_length must be greater than 0"
         assert not self.has_tip_length
         self._current_tip_length = tip_length
+        self._has_tip_length = True
 
     def remove_tip(self) -> None:
         """
@@ -500,6 +504,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         """
         assert self.has_tip_length
         self._current_tip_length = 0.0
+        self._has_tip_length = False
 
     @property
     def has_tip(self) -> bool:

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -273,6 +273,7 @@ class OT3PipetteHandler:
             result[
                 "default_push_out_volume"
             ] = instr.active_tip_settings.default_push_out_volume
+            result["tip_presence_responses"] = instr.tip_presence_responses
         return cast(PipetteDict, result)
 
     @property
@@ -892,3 +893,8 @@ class OT3PipetteHandler:
             pip.config.liquid_properties,
         )
         pip.set_liquid_class_by_name(new_class_name.name)
+
+    def get_tip_sensor_count(self, mount: OT3Mount) -> int:
+        if not self.has_pipette(mount):
+            return 0
+        return self.get_pipette(mount).tip_presence_responses

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -273,7 +273,6 @@ class OT3PipetteHandler:
             result[
                 "default_push_out_volume"
             ] = instr.active_tip_settings.default_push_out_volume
-            result["tip_presence_responses"] = instr.tip_presence_responses
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -721,9 +721,13 @@ class OT3API(
         for mount in [OT3Mount.LEFT, OT3Mount.RIGHT]:
             # rebuild tip detector using the attached instrument
             self._log.info(f"resetting tip detector for mount {mount}")
-            await self._backend.update_tip_detector(
-                mount, self._pipette_handler.get_tip_sensor_count(mount)
-            )
+            if self._pipette_handler.has_pipette(mount):
+                await self._backend.update_tip_detector(
+                    mount, self._pipette_handler.get_tip_sensor_count(mount)
+                )
+            else:
+                await self._backend.teardown_tip_detector(mount)
+
             if refresh_state and self._pipette_handler.has_pipette(mount):
                 await self.get_tip_presence_status(mount)
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -37,6 +37,10 @@ class OT3Mount(enum.Enum):
             return top_types.Mount.EXTENSION
         return top_types.Mount[self.name]
 
+    @classmethod
+    def pipette_mounts(cls) -> List["OT3Mount"]:
+        return [cls.LEFT, cls.RIGHT]
+
 
 class OT3AxisKind(enum.Enum):
     """An enum of the different kinds of axis we have.

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -38,7 +38,7 @@ class OT3Mount(enum.Enum):
         return top_types.Mount[self.name]
 
     @classmethod
-    def pipette_mounts(cls) -> List["OT3Mount"]:
+    def pipette_mounts(cls) -> List["Literal[OT3Mount.LEFT, OT3Mount.RIGHT]"]:
         return [cls.LEFT, cls.RIGHT]
 
 

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -49,8 +49,6 @@ from opentrons.hardware_control.types import (
     SubSystemState,
     UpdateStatus,
     UpdateState,
-    TipStateType,
-    FailedTipStateCheck,
     EstopState,
     CurrentConfig,
 )
@@ -1072,30 +1070,6 @@ async def test_monitor_pressure(
         await controller.home([Axis.P_L], GantryLoad.LOW_THROUGHPUT)
 
     mock_move_group_run.assert_called_once()
-
-
-@pytest.mark.parametrize(
-    "tip_state_type, mocked_ejector_response, expectation",
-    [
-        [TipStateType.PRESENT, {0: 1, 1: 1}, does_not_raise()],
-        [TipStateType.ABSENT, {0: 0, 1: 0}, does_not_raise()],
-        [TipStateType.PRESENT, {0: 0, 1: 0}, pytest.raises(FailedTipStateCheck)],
-        [TipStateType.ABSENT, {0: 1, 1: 1}, pytest.raises(FailedTipStateCheck)],
-    ],
-)
-async def test_get_tip_present(
-    controller: OT3Controller,
-    tip_state_type: TipStateType,
-    mocked_ejector_response: Dict[int, int],
-    expectation: ContextManager[None],
-) -> None:
-    mount = OT3Mount.LEFT
-    with mock.patch(
-        "opentrons.hardware_control.backends.ot3controller.get_tip_ejector_state",
-        return_value=mocked_ejector_response,
-    ):
-        with expectation:
-            await controller.check_for_tip_presence(mount, tip_state_type)
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/backends/test_tip_presence_manager.py
+++ b/api/tests/opentrons/hardware_control/backends/test_tip_presence_manager.py
@@ -63,7 +63,7 @@ async def subject(
 ) -> AsyncIterator[TipPresenceManager]:
     """Build a test subject using decoyed can messenger and tip detector."""
     manager = TipPresenceManager(can_messenger)
-    manager._detectors[OT3Mount.LEFT] = tip_detector
+    manager.set_detector(OT3Mount.LEFT, tip_detector)
     try:
         yield manager
     finally:

--- a/api/tests/opentrons/hardware_control/backends/test_tip_presence_manager.py
+++ b/api/tests/opentrons/hardware_control/backends/test_tip_presence_manager.py
@@ -1,0 +1,129 @@
+import pytest
+from typing import AsyncIterator, Dict
+from decoy import Decoy
+
+from opentrons.hardware_control.types import OT3Mount, TipStateType
+from opentrons.hardware_control.backends.tip_presence_manager import TipPresenceManager
+from opentrons_hardware.hardware_control.tip_presence import (
+    TipDetector,
+    types as tp_types,
+)
+from opentrons_hardware.firmware_bindings.constants import SensorId
+from opentrons_hardware.drivers import can_bus
+
+from opentrons_shared_data.errors.exceptions import UnmatchedTipPresenceStates
+
+
+@pytest.fixture
+def can_messenger(decoy: Decoy) -> can_bus.CanMessenger:
+    """Build a decoyed can messenger."""
+    return decoy.mock(cls=can_bus.CanMessenger)
+
+
+@pytest.fixture
+def tip_detector(decoy: Decoy) -> TipDetector:
+    return decoy.mock(cls=TipDetector)
+
+
+class TipDetectorController:
+    def __init__(self, tip_detector: TipDetector, decoy: Decoy) -> None:
+        self._tip_detector = tip_detector
+        self._decoy = decoy
+
+    async def retrieve_tip_status(self, tip_presence: bool) -> None:
+        tip_notif = tp_types.TipNotification(sensor=SensorId.S0, presence=tip_presence)
+        self._decoy.when(await self._tip_detector.request_tip_status()).then_return(
+            [tip_notif]
+        )
+
+    async def retrieve_tip_status_highthroughput(
+        self, tip_presences: Dict[SensorId, bool]
+    ) -> None:
+        tip_notif = [
+            tp_types.TipNotification(sensor=sensor_id, presence=presence)
+            for sensor_id, presence in tip_presences.items()
+        ]
+        self._decoy.when(await self._tip_detector.request_tip_status()).then_return(
+            tip_notif
+        )
+
+
+@pytest.fixture
+def tip_detector_controller(
+    tip_detector: TipDetector,
+    decoy: Decoy,
+) -> TipDetectorController:
+    return TipDetectorController(tip_detector, decoy)
+
+
+@pytest.fixture
+async def subject(
+    can_messenger: can_bus.CanMessenger,
+    tip_detector: TipDetector,
+) -> AsyncIterator[TipPresenceManager]:
+    """Build a test subject using decoyed can messenger and tip detector."""
+    manager = TipPresenceManager(can_messenger)
+    manager._detectors[OT3Mount.LEFT] = tip_detector
+    try:
+        yield manager
+    finally:
+        return
+
+
+@pytest.mark.parametrize(
+    "tip_presence,expected_type",
+    [
+        (False, TipStateType.ABSENT),
+        (True, TipStateType.PRESENT),
+    ],
+)
+async def test_get_tip_status_for_low_throughput(
+    subject: TipPresenceManager,
+    tip_detector_controller: TipDetectorController,
+    tip_presence: bool,
+    expected_type: TipStateType,
+) -> None:
+    mount = OT3Mount.LEFT
+    await tip_detector_controller.retrieve_tip_status(tip_presence)
+
+    result = await subject.get_tip_status(mount)
+    result == expected_type
+
+
+@pytest.mark.parametrize(
+    "tip_presence,expected_type",
+    [
+        ({SensorId.S0: False, SensorId.S1: False}, TipStateType.ABSENT),
+        ({SensorId.S0: True, SensorId.S1: True}, TipStateType.PRESENT),
+    ],
+)
+async def test_get_tip_status_for_high_throughput(
+    subject: TipPresenceManager,
+    tip_detector_controller: TipDetectorController,
+    tip_presence: Dict[SensorId, bool],
+    expected_type: TipStateType,
+) -> None:
+    mount = OT3Mount.LEFT
+    await tip_detector_controller.retrieve_tip_status_highthroughput(tip_presence)
+
+    result = await subject.get_tip_status(mount)
+    result == expected_type
+
+
+@pytest.mark.parametrize(
+    "tip_presence",
+    [
+        {SensorId.S0: True, SensorId.S1: False},
+        {SensorId.S0: False, SensorId.S1: True},
+    ],
+)
+async def test_unmatched_tip_responses_should_raise(
+    subject: TipPresenceManager,
+    tip_detector_controller: TipDetectorController,
+    tip_presence: Dict[SensorId, bool],
+) -> None:
+    mount = OT3Mount.LEFT
+    await tip_detector_controller.retrieve_tip_status_highthroughput(tip_presence)
+
+    with pytest.raises(UnmatchedTipPresenceStates):
+        await subject.get_tip_status(mount)

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -3,6 +3,7 @@ import mock
 
 import pytest
 from decoy import Decoy
+from typing import Iterator
 
 try:
     import aionotify
@@ -58,6 +59,14 @@ def dummy_instruments_ot3():
     return dummy_instruments_attached_ot3()
 
 
+@pytest.fixture
+def mock_api_verify_tip_presence() -> Iterator[mock.AsyncMock]:
+    from opentrons.hardware_control.ot3api import OT3API
+
+    with mock.patch.object(OT3API, "verify_tip_presence") as mock_tip_presence:
+        yield mock_tip_presence
+
+
 def wrap_build_ot3_sim():
     from opentrons.hardware_control.ot3api import OT3API
 
@@ -65,7 +74,7 @@ def wrap_build_ot3_sim():
 
 
 @pytest.fixture
-def ot3_api_obj(request):
+def ot3_api_obj(request, mock_api_verify_tip_presence):
     if request.config.getoption("--ot2-only"):
         pytest.skip("testing ot2 only")
     from opentrons.hardware_control.ot3api import OT3API
@@ -80,7 +89,7 @@ def ot3_api_obj(request):
     ],
     ids=["ot2", "ot3"],
 )
-def sim_and_instr(request):
+def sim_and_instr(request, mock_api_verify_tip_presence):
     if (
         request.node.get_closest_marker("ot2_only")
         and request.param[0] == wrap_build_ot3_sim

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -42,6 +42,7 @@ from opentrons.hardware_control.types import (
     StatusBarState,
     EstopState,
     EstopStateNotification,
+    TipStateType,
 )
 from opentrons.hardware_control.errors import InvalidCriticalPoint
 from opentrons.hardware_control.ot3api import OT3API
@@ -462,6 +463,25 @@ def mock_backend_capacitive_pass(
         yield mock_pass
 
 
+@pytest.fixture
+def mock_backend_get_tip_status(
+    ot3_hardware: ThreadManager[OT3API],
+) -> Iterator[AsyncMock]:
+    backend = ot3_hardware.managed_obj._backend
+    with patch.object(backend, "get_tip_status", AsyncMock()) as mock_tip_status:
+        yield mock_tip_status
+
+
+@pytest.fixture
+def mock_verify_tip_presence(
+    ot3_hardware: ThreadManager[OT3API],
+) -> Iterator[AsyncMock]:
+    with patch.object(
+        ot3_hardware.managed_obj, "verify_tip_presence", AsyncMock()
+    ) as mock_check_tip:
+        yield mock_check_tip
+
+
 load_blowout_configs = [
     {OT3Mount.LEFT: {"channels": 1, "version": (3, 3), "model": "p1000"}},
     {OT3Mount.RIGHT: {"channels": 8, "version": (3, 3), "model": "p50"}},
@@ -471,6 +491,7 @@ load_blowout_configs = [
 
 async def prepare_for_mock_blowout(
     ot3_hardware: ThreadManager[OT3API],
+    mock_backend_get_tip_status: AsyncMock,
     mount: OT3Mount,
     configs: Any,
 ) -> Tuple[Any, ThreadManager[OT3API]]:
@@ -482,8 +503,9 @@ async def prepare_for_mock_blowout(
     instr_data = AttachedPipette(config=pipette_config, id="fakepip")
     await ot3_hardware.cache_pipette(mount, instr_data, None)
     await ot3_hardware.refresh_positions()
+    mock_backend_get_tip_status.return_value = TipStateType.PRESENT
     with patch.object(
-        ot3_hardware, "pick_up_tip", AsyncMock(spec=ot3_hardware.liquid_probe)
+        ot3_hardware, "pick_up_tip", AsyncMock(spec=ot3_hardware.pick_up_tip)
     ) as mock_tip_pickup:
         mock_tip_pickup.side_effect = (
             ot3_hardware._pipette_handler.attached_instruments[mount]["has_tip"]
@@ -499,6 +521,7 @@ async def prepare_for_mock_blowout(
 @example(blowout_volume=0.0)
 async def test_blow_out_position(
     ot3_hardware: ThreadManager[OT3API],
+    mock_backend_get_tip_status: AsyncMock,
     load_configs: List[Dict[str, Any]],
     blowout_volume: float,
 ) -> None:
@@ -507,7 +530,7 @@ async def test_blow_out_position(
         if configs["channels"] == 96:
             await ot3_hardware.set_gantry_load(GantryLoad.HIGH_THROUGHPUT)
         instr_data, ot3_hardware = await prepare_for_mock_blowout(
-            ot3_hardware, mount, configs
+            ot3_hardware, mock_backend_get_tip_status, mount, configs
         )
 
         max_allowed_input_distance = (
@@ -548,6 +571,7 @@ async def test_blow_out_position(
 )
 async def test_blow_out_error(
     ot3_hardware: ThreadManager[OT3API],
+    mock_backend_get_tip_status: AsyncMock,
     load_configs: List[Dict[str, Any]],
     blowout_volume: float,
 ) -> None:
@@ -556,7 +580,7 @@ async def test_blow_out_error(
         if configs["channels"] == 96:
             await ot3_hardware.set_gantry_load(GantryLoad.HIGH_THROUGHPUT)
         instr_data, ot3_hardware = await prepare_for_mock_blowout(
-            ot3_hardware, mount, configs
+            ot3_hardware, mock_backend_get_tip_status, mount, configs
         )
 
         max_allowed_input_distance = (
@@ -1385,6 +1409,7 @@ async def test_pick_up_tip_full_tiprack(
     mock_ungrip: AsyncMock,
     mock_move_to_plunger_bottom: AsyncMock,
     mock_home_gear_motors: AsyncMock,
+    mock_verify_tip_presence: AsyncMock,
 ) -> None:
     mock_ungrip.return_value = None
     await ot3_hardware.home()
@@ -1419,9 +1444,9 @@ async def test_pick_up_tip_full_tiprack(
             if moves:
                 for move in moves:
                     for block in move.blocks:
-                        backend._gear_motor_position[
-                            NodeId.pipette_left
-                        ] += block.distance
+                        backend._gear_motor_position[NodeId.pipette_left] += (
+                            block.distance * move.unit_vector[Axis.Q]
+                        )
             elif distance:
                 backend._gear_motor_position[NodeId.pipette_left] += distance
 
@@ -1442,6 +1467,7 @@ async def test_drop_tip_full_tiprack(
     ot3_hardware: ThreadManager[OT3API],
     mock_instrument_handlers: Tuple[Mock],
     mock_home_gear_motors: AsyncMock,
+    mock_verify_tip_presence: AsyncMock,
 ) -> None:
     _, pipette_handler = mock_instrument_handlers
     backend = ot3_hardware.managed_obj._backend
@@ -1488,6 +1514,7 @@ async def test_drop_tip_full_tiprack(
         set_mock_plunger_configs()
 
         await ot3_hardware.set_gantry_load(GantryLoad.HIGH_THROUGHPUT)
+        mock_backend_get_tip_status.return_value = TipStateType.ABSENT
         await ot3_hardware.drop_tip(Mount.LEFT, home_after=True)
         pipette_handler.plan_ht_drop_tip.assert_called_once_with()
         # first call should be "clamp", moving down
@@ -1724,29 +1751,6 @@ async def test_status_bar_interface(
     for setting, response in settings.items():
         await ot3_hardware.set_status_bar_state(state=setting)
         assert ot3_hardware.get_status_bar_state() == response
-
-
-async def test_tip_presence_disabled_ninety_six_channel(
-    ot3_hardware: ThreadManager[OT3API],
-) -> None:
-    """Test 96 channel tip presence is disabled."""
-    # TODO remove this check once we enable tip presence for 96 chan.
-    with patch.object(
-        ot3_hardware.managed_obj._backend,
-        "check_for_tip_presence",
-        AsyncMock(spec=ot3_hardware.managed_obj._backend.check_for_tip_presence),
-    ) as tip_present:
-        pipette_config = load_pipette_data.load_definition(
-            PipetteModelType("p1000"),
-            PipetteChannelType(96),
-            PipetteVersionType(3, 3),
-        )
-        instr_data = AttachedPipette(config=pipette_config, id="fakepip")
-        await ot3_hardware.cache_pipette(OT3Mount.LEFT, instr_data, None)
-        await ot3_hardware._configure_instruments()
-        await ot3_hardware.pick_up_tip(OT3Mount.LEFT, 60)
-
-        tip_present.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -1202,7 +1202,7 @@ async def _jog_for_tip_state(
     async def _matches_state(_state: TipStateType) -> bool:
         try:
             await asyncio.sleep(0.2)
-            await api._backend.check_for_tip_presence(mount, _state)
+            await api.verify_tip_presence(mount, _state)
             return True
         except FailedTipStateCheck:
             return False

--- a/hardware/opentrons_hardware/hardware_control/tip_presence/__init__.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence/__init__.py
@@ -1,0 +1,6 @@
+"""Tip presence package."""
+
+from . import types
+from .detector import TipDetector
+
+__all__ = ["TipDetector", "types"]

--- a/hardware/opentrons_hardware/hardware_control/tip_presence/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence/detector.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from functools import partial
 from typing import List
 from typing_extensions import Literal
 
@@ -39,12 +40,13 @@ class TipDetector:
         self,
         messenger: CanMessenger,
         node: NodeId,
-        number_of_sensors: Literal[1, 2] = 1,
+        number_of_sensors: int = 1,
     ) -> None:
         self._messenger = messenger
         self._node = node
         self._number_of_responses = number_of_sensors
         self._subscribers: List[TipChangeListener] = []
+        self._messenger.add_listener(self._dispatch_tip_notification, self._filter)
 
     def add_subscriber(self, subscriber: TipChangeListener) -> None:
         """Add listener to tip change notification."""
@@ -61,9 +63,6 @@ class TipDetector:
             NodeId(arb_id.parts.originating_node_id) == self._node
         )
 
-    def start(self) -> None:
-        self._messenger.add_listener(self._dispatch_tip_notification, self._filter)
-    
     def __del__(self) -> None:
         self._messenger.remove_listener(self._dispatch_tip_notification)
 

--- a/hardware/opentrons_hardware/hardware_control/tip_presence/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence/detector.py
@@ -1,0 +1,106 @@
+"""Tip detector."""
+
+import asyncio
+import logging
+from typing import List
+from typing_extensions import Literal
+
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    MultipleMessagesWaitableCallback,
+    WaitableCallback,
+)
+
+from opentrons_hardware.firmware_bindings.constants import SensorId
+from opentrons_hardware.firmware_bindings.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    TipStatusQueryRequest,
+    PushTipPresenceNotification,
+)
+from opentrons_hardware.firmware_bindings import NodeId, ArbitrationId
+from opentrons_shared_data.errors.exceptions import CommandTimedOutError
+
+from .types import TipChangeListener, TipNotification
+
+log = logging.getLogger(__name__)
+
+
+def _parse_tip_status(response: MessageDefinition) -> TipNotification:
+    assert isinstance(response, PushTipPresenceNotification)
+    sensor_id = SensorId(response.payload.sensor_id.value)
+    status = bool(response.payload.ejector_flag_status.value)
+    return TipNotification(sensor_id, status)
+
+
+class TipDetector:
+    """Class to listen to tip presence notifications from pipette firmware."""
+
+    def __init__(
+        self,
+        messenger: CanMessenger,
+        node: NodeId,
+        number_of_sensors: Literal[1, 2] = 1,
+    ) -> None:
+        self._messenger = messenger
+        self._node = node
+        self._number_of_responses = number_of_sensors
+        self._subscribers: List[TipChangeListener] = []
+
+    def add_subscriber(self, subscriber: TipChangeListener) -> None:
+        """Add listener to tip change notification."""
+        if subscriber not in self._subscribers:
+            self._subscribers.append(subscriber)
+
+    def remove_subscriber(self, subscriber: TipChangeListener) -> None:
+        """Remove listener to tip change notification."""
+        if subscriber in self._subscribers:
+            self._subscribers.remove(subscriber)
+
+    def _filter(self, arb_id: ArbitrationId) -> bool:
+        return (arb_id.parts.message_id == PushTipPresenceNotification.message_id) and (
+            NodeId(arb_id.parts.originating_node_id) == self._node
+        )
+
+    def start(self) -> None:
+        self._messenger.add_listener(self._dispatch_tip_notification, self._filter)
+
+    def _dispatch_tip_notification(
+        self, response: MessageDefinition, arb_id: ArbitrationId
+    ) -> None:
+        if isinstance(response, PushTipPresenceNotification):
+            tip_change = _parse_tip_status(response)
+            for subscriber in self._subscribers:
+                subscriber(tip_change)
+
+    async def request_tip_status(
+        self,
+        timeout: float = 1.0,
+    ) -> List[TipNotification]:
+        """Explicitly send a request to get tip status value from a node."""
+
+        async def gather_responses(
+            reader: WaitableCallback,
+        ) -> List[TipNotification]:
+            data = []
+            async for response, _ in reader:
+                assert isinstance(response, PushTipPresenceNotification)
+                data.append(_parse_tip_status(response))
+                if len(data) == self._number_of_responses:
+                    return data
+            raise StopAsyncIteration
+
+        with MultipleMessagesWaitableCallback(
+            self._messenger,
+            self._filter,
+            self._number_of_responses,
+        ) as mc:
+            await self._messenger.send(
+                node_id=self._node, message=TipStatusQueryRequest()
+            )
+            try:
+                status = await asyncio.wait_for(gather_responses(mc), timeout)
+            except asyncio.TimeoutError as te:
+                msg = f"Tip presence poll of {self._node} timed out"
+                log.warning(msg)
+                raise CommandTimedOutError(message=msg) from te
+        return status

--- a/hardware/opentrons_hardware/hardware_control/tip_presence/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence/detector.py
@@ -63,6 +63,9 @@ class TipDetector:
 
     def start(self) -> None:
         self._messenger.add_listener(self._dispatch_tip_notification, self._filter)
+    
+    def __del__(self) -> None:
+        self._messenger.remove_listener(self._dispatch_tip_notification)
 
     def _dispatch_tip_notification(
         self, response: MessageDefinition, arb_id: ArbitrationId

--- a/hardware/opentrons_hardware/hardware_control/tip_presence/types.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence/types.py
@@ -1,0 +1,14 @@
+import dataclasses
+from typing import Callable
+from typing_extensions import Literal
+
+from opentrons_hardware.firmware_bindings.constants import SensorId
+
+
+@dataclasses.dataclass
+class TipNotification:
+    sensor: SensorId
+    presence: bool
+
+
+TipChangeListener = Callable[[TipNotification], None]

--- a/hardware/opentrons_hardware/hardware_control/tip_presence/types.py
+++ b/hardware/opentrons_hardware/hardware_control/tip_presence/types.py
@@ -1,12 +1,14 @@
+"""Tip presence types."""
 import dataclasses
 from typing import Callable
-from typing_extensions import Literal
 
 from opentrons_hardware.firmware_bindings.constants import SensorId
 
 
 @dataclasses.dataclass
 class TipNotification:
+    """Represents a tip update received from a pipette."""
+
     sensor: SensorId
     presence: bool
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tip_presence.py
@@ -2,8 +2,7 @@
 import pytest
 from mock import AsyncMock
 
-from typing import List, Tuple, cast
-from typing_extensions import Literal
+from typing import List, Tuple
 
 from opentrons_hardware.hardware_control.tip_presence import TipDetector, types
 from opentrons_hardware.firmware_bindings.messages import (
@@ -24,7 +23,6 @@ async def test_get_tip_ejector_state(
     mock_messenger: AsyncMock, message_send_loopback: CanLoopback
 ) -> None:
     """Test that get tip ejector state sends the correct request and receives a response."""
-
     node = NodeId.pipette_left
     detector = TipDetector(mock_messenger, node)
 

--- a/hardware/tests/opentrons_hardware/hardware_control/tip_presence/__init__.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tip_presence/__init__.py
@@ -1,0 +1,1 @@
+"""Tip presence tests."""

--- a/hardware/tests/opentrons_hardware/hardware_control/tip_presence/test_detector.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/tip_presence/test_detector.py
@@ -1,0 +1,160 @@
+"""Tests for Tip Detector."""
+from typing import AsyncGenerator, List, Tuple
+
+from opentrons_hardware.firmware_bindings import NodeId
+from opentrons_hardware.firmware_bindings.messages import (
+    MessageDefinition,
+    payloads,
+    message_definitions,
+)
+from opentrons_hardware.firmware_bindings.messages.fields import SensorIdField
+from opentrons_hardware.firmware_bindings.utils import UInt8Field
+from opentrons_hardware.firmware_bindings.constants import SensorId
+from tests.conftest import CanLoopback
+
+import pytest
+from mock import AsyncMock
+
+from opentrons_hardware.hardware_control.tip_presence.detector import TipDetector
+from opentrons_hardware.hardware_control.tip_presence.types import TipNotification
+from opentrons_shared_data.errors.exceptions import CommandTimedOutError
+
+
+@pytest.fixture
+async def subject(mock_messenger: AsyncMock) -> AsyncGenerator[TipDetector, None]:
+    """A tip detector subject."""
+    detector = TipDetector(mock_messenger, NodeId.pipette_left)
+    try:
+        yield detector
+    finally:
+        detector.cleanup()
+
+
+def create_push_tip_response(
+    ejector_value: int,
+    sensor_id: int,
+) -> MessageDefinition:
+    """Create a PushTipPresenceNotification."""
+    return message_definitions.PushTipPresenceNotification(
+        payload=payloads.PushTipPresenceNotificationPayload(
+            ejector_flag_status=UInt8Field(ejector_value),
+            sensor_id=SensorIdField(sensor_id),
+        )
+    )
+
+
+async def test_tip_request_listens_to_only_one_node(
+    subject: TipDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+) -> None:
+    """Test that the tip status request receives the correct response."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.TipStatusQueryRequest):
+            return [
+                # responds with push tip notifications from different nodes
+                (NodeId.host, create_push_tip_response(1, 1), NodeId.pipette_left),
+                (NodeId.host, create_push_tip_response(30, 30), NodeId.pipette_right),
+                (NodeId.host, create_push_tip_response(20, 20), NodeId.gantry_x),
+            ]
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    update = await subject.request_tip_status()
+    # ensure a tip status request was sent via CAN
+    mock_messenger.send.assert_called_once_with(
+        node_id=NodeId.pipette_left, message=message_definitions.TipStatusQueryRequest()
+    )
+    assert len(update) == 1
+    assert update[0] == TipNotification(
+        sensor=SensorId.S1,
+        presence=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [  # only from one message
+            (NodeId.host, create_push_tip_response(0, 0), NodeId.pipette_left)
+        ],
+        [  # two messages but from only one sensor
+            (NodeId.host, create_push_tip_response(0, 0), NodeId.pipette_left),
+            (NodeId.host, create_push_tip_response(1, 0), NodeId.pipette_left),
+        ],
+    ],
+)
+async def test_high_throughput_tip_detector_timeout(
+    subject: TipDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+    responses: List[Tuple[NodeId, MessageDefinition, NodeId]],
+) -> None:
+    """Test that a timeout is handled."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.TipStatusQueryRequest):
+            return responses
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    # subject expects two responses for high throughput pipettes
+    subject._number_of_responses = 2
+    with pytest.raises(CommandTimedOutError):
+        await subject.request_tip_status()
+        # ensure a tip status request was sent via CAN
+        mock_messenger.send.assert_called_once_with(
+            node_id=NodeId.pipette_left,
+            message=message_definitions.TipStatusQueryRequest(),
+        )
+
+
+@pytest.mark.parametrize(
+    "responses",
+    [
+        [  # messages from both sensors
+            (NodeId.host, create_push_tip_response(0, 0), NodeId.pipette_left),
+            (NodeId.host, create_push_tip_response(0, 1), NodeId.pipette_left),
+        ],
+        [  # two messages from one sensor, and one from the other
+            (NodeId.host, create_push_tip_response(1, 0), NodeId.pipette_left),
+            (NodeId.host, create_push_tip_response(0, 0), NodeId.pipette_left),
+            (NodeId.host, create_push_tip_response(0, 1), NodeId.pipette_left),
+        ],
+    ],
+)
+async def test_high_throughput_tip_detector_success(
+    subject: TipDetector,
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+    responses: List[Tuple[NodeId, MessageDefinition, NodeId]],
+) -> None:
+    """Test that only the latest message from each sensor is read."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, message_definitions.TipStatusQueryRequest):
+            return responses
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    # subject expects two responses for high throughput pipettes
+    subject._number_of_responses = 2
+    update = await subject.request_tip_status(3.0)
+    # ensure a tip status request was sent via CAN
+    mock_messenger.send.assert_called_once_with(
+        node_id=NodeId.pipette_left, message=message_definitions.TipStatusQueryRequest()
+    )
+
+    assert len(update) == 2
+    assert TipNotification(SensorId.S0, False) in update
+    assert TipNotification(SensorId.S1, False) in update

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -182,6 +182,10 @@
       "detail": "Invalid Liquid Class Name",
       "category": "roboticsInteractionError"
     },
+    "3018": {
+      "detail": "Tip Detector Not Created",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -75,6 +75,7 @@ class ErrorCodes(Enum):
     MODULE_NOT_PRESENT = _code_from_dict_entry("3015")
     INVALID_INSTRUMENT_DATA = _code_from_dict_entry("3016")
     INVALID_LIQUID_CLASS_NAME = _code_from_dict_entry("3017")
+    TIP_DETECTOR_NOT_FOUND = _code_from_dict_entry("3018")
     GENERAL_ERROR = _code_from_dict_entry("4000")
     ROBOT_IN_USE = _code_from_dict_entry("4001")
     API_REMOVED = _code_from_dict_entry("4002")

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -806,6 +806,19 @@ class InvalidLiquidClassName(RoboticsInteractionError):
         )
 
 
+class TipDetectorNotFound(RoboticsInteractionError):
+    """An error indicating that a tip detector has not been created for a pipette."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a TipDetectorNotFound."""
+        super().__init__(ErrorCodes.TIP_DETECTOR_NOT_FOUND, message, detail, wrapping)
+
+
 class APIRemoved(GeneralError):
     """An error indicating that a specific API is no longer available."""
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
FLEX pipettes have tip sensing ability (thanks to tip presence sensors!); it would be nice if we could get real-time status of the attached tip from the pipette while the hardware controller is running.

This PR does it by creating a TipPresenceManager in the hardware controller that monitors tip updates from the pipettes. The tip presence manager is in charge of building a TipDetector dedicated to an attached pipette and pass any tip notification from the CAN bus to any of its listeners. 

The tip presence manager currently serves the two following purposes:
(1) prompting the firmware to confirm tip presence after pick up and drop tip actions
(2) caching the latest tip update from the detectors, and presenting that info to the `/instruments` endpoint

# Changelog
* the `has_tip` property of the OT3 pipette does not in fact reflect whether or not a tip is currently attached, but if a tip length has been added so we're changing the logic there
* removing the `tip_presence_detection_enabled` feature flag and make it the default behavior for all FLEX pipettes 


# What's next
This opens up an opportunity for the protocol engine to listen to the unexpected tip change during a protocol and issue the appropriate proper error/warning to the user. 

