### PR TITLE
fix(app): fix attachment flow firmware step filter

### DIFF
--- a/app/src/assets/localization/en/gripper_wizard_flows.json
+++ b/app/src/assets/localization/en/gripper_wizard_flows.json
@@ -12,6 +12,7 @@
   "continue_calibration": "Continue calibration",
   "detach_gripper": "Detach Gripper",
   "firmware_updating": "A firmware update is required, instrument is updating...",
+  "firmware_up_to_date": "Firmware is up to date.",
   "get_started": "Get started",
   "gripper_calibration": "Gripper Calibration",
   "gripper_recalibration": "Gripper Recalibration",

--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -20,6 +20,7 @@
   "error_prepping_module": "Error prepping module for calibration",
   "exit": "Exit",
   "firmware_updated": "{{module}} firmware updated!",
+  "firmware_up_to_date": "{{module}} firmware up to date.",
   "get_started": "<block>To get started, remove labware from the deck and clean up the working area to make the calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration adapter came with your module. The pipette probe came with your Flex pipette.</block>",
   "install_probe_8_channel": "<block>Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the <strong>backmost</strong> pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.</block>",
   "install_probe_96_channel": "<block>Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the <strong>A1 (back left corner)</strong> pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.</block>",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -39,6 +39,7 @@
   "detach": "Detaching Pipette",
   "exit_cal": "Exit calibration",
   "firmware_updating": "A firmware update is required, instrument is updating...",
+  "firmware_up_to_date": "Firmware is up to date.",
   "gantry_empty_for_96_channel_success": "Now that both mounts are empty, you can begin the 96-Channel Pipette attachment process.",
   "get_started_detach": "<block>To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right.</block>",
   "grab_screwdriver": "While continuing to hold in place, grab your 2.5mm driver and tighten screws as shown in the animation. Test the pipette attachment by giving it a wiggle before pressing continue",

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -154,6 +154,7 @@ export function InstrumentsAndModules({
             proceed={() => setSubsystemToUpdate(null)}
             description={t('updating_firmware')}
             proceedDescription={t('firmware_up_to_date')}
+            isODD={isFlex}
           />
         </ModalShell>
       )}

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -154,7 +154,7 @@ export function InstrumentsAndModules({
             proceed={() => setSubsystemToUpdate(null)}
             description={t('updating_firmware')}
             proceedDescription={t('firmware_up_to_date')}
-            isODD={false}
+            isOnDevice={false}
           />
         </ModalShell>
       )}

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -154,7 +154,7 @@ export function InstrumentsAndModules({
             proceed={() => setSubsystemToUpdate(null)}
             description={t('updating_firmware')}
             proceedDescription={t('firmware_up_to_date')}
-            isODD={isFlex}
+            isODD={false}
           />
         </ModalShell>
       )}

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -153,6 +153,7 @@ export function InstrumentsAndModules({
             subsystem={subsystemToUpdate}
             proceed={() => setSubsystemToUpdate(null)}
             description={t('updating_firmware')}
+            proceedDescription={t('firmware_up_to_date')}
           />
         </ModalShell>
       )}

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateModal.test.tsx
@@ -42,6 +42,7 @@ describe('FirmwareUpdateModal', () => {
       description: 'A firmware update is required, instrument is updating',
       subsystem: 'pipette_left',
       proceedDescription: 'Firmware is up to date.',
+      isODD: true,
     }
     mockUseInstrumentQuery.mockReturnValue({
       data: {
@@ -73,6 +74,31 @@ describe('FirmwareUpdateModal', () => {
       updateSubsystem,
     } as any)
   })
+  it('initially renders a spinner and text', () => {
+    mockUseInstrumentQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            subsystem: 'pipette_left',
+            ok: true,
+          } as PipetteData,
+        ],
+      },
+      refetch,
+    } as any)
+    mockUseSubsystemUpdateQuery.mockReturnValue({
+      data: {
+        data: {
+          id: 'update id',
+          updateStatus: null,
+        } as any,
+      } as SubsystemUpdateProgressData,
+    } as any)
+    jest.useFakeTimers()
+    const { getByText, getByLabelText } = render(props)
+    getByLabelText('spinner')
+    getByText('Checking for updates...')
+  })
   it('calls proceed if no update is needed', async () => {
     mockUseInstrumentQuery.mockReturnValue({
       data: {
@@ -95,10 +121,10 @@ describe('FirmwareUpdateModal', () => {
     } as any)
     jest.useFakeTimers()
     const { getByText } = render(props)
-    getByText('Firmware is up to date.')
     act(() => {
       jest.advanceTimersByTime(3000)
     })
+    getByText('Firmware is up to date.')
     await waitFor(() => expect(props.proceed).toHaveBeenCalled())
   })
   it('does not render text or a progress bar until instrument update status is known', () => {
@@ -128,7 +154,11 @@ describe('FirmwareUpdateModal', () => {
         } as any,
       } as SubsystemUpdateProgressData,
     } as any)
+    jest.useFakeTimers()
     const { getByText } = render(props)
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
     getByText('A firmware update is required, instrument is updating')
     expect(updateSubsystem).toHaveBeenCalled()
   })

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateModal.test.tsx
@@ -41,6 +41,7 @@ describe('FirmwareUpdateModal', () => {
       proceed: jest.fn(),
       description: 'A firmware update is required, instrument is updating',
       subsystem: 'pipette_left',
+      proceedDescription: 'Firmware is up to date.',
     }
     mockUseInstrumentQuery.mockReturnValue({
       data: {
@@ -72,7 +73,7 @@ describe('FirmwareUpdateModal', () => {
       updateSubsystem,
     } as any)
   })
-  it('calls proceed if no update is needed', () => {
+  it('calls proceed if no update is needed', async () => {
     mockUseInstrumentQuery.mockReturnValue({
       data: {
         data: [
@@ -82,14 +83,51 @@ describe('FirmwareUpdateModal', () => {
           } as PipetteData,
         ],
       },
+      refetch,
     } as any)
-    mockUseSubsystemUpdateQuery.mockReturnValue({} as any)
+    mockUseSubsystemUpdateQuery.mockReturnValue({
+      data: {
+        data: {
+          id: 'update id',
+          updateStatus: null,
+        } as any,
+      } as SubsystemUpdateProgressData,
+    } as any)
+    jest.useFakeTimers()
     const { getByText } = render(props)
-    getByText('A firmware update is required, instrument is updating')
-    expect(props.proceed).toHaveBeenCalled()
+    getByText('Firmware is up to date.')
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+    await waitFor(() => expect(props.proceed).toHaveBeenCalled())
+  })
+  it('does not render text or a progress bar until instrument update status is known', () => {
+    mockUseSubsystemUpdateQuery.mockReturnValue({
+      data: {
+        data: {
+          id: 'update id',
+          updateStatus: undefined,
+        } as any,
+      } as SubsystemUpdateProgressData,
+    } as any)
+    mockUseInstrumentQuery.mockReturnValue({
+      data: undefined,
+      refetch,
+    } as any)
+    const { queryByText } = render(props)
+    expect(
+      queryByText('A firmware update is required, instrument is updating')
+    ).not.toBeInTheDocument()
   })
   it('calls update subsystem if update is needed', () => {
-    mockUseSubsystemUpdateQuery.mockReturnValue({} as any)
+    mockUseSubsystemUpdateQuery.mockReturnValue({
+      data: {
+        data: {
+          id: 'update id',
+          updateStatus: 'in progress',
+        } as any,
+      } as SubsystemUpdateProgressData,
+    } as any)
     const { getByText } = render(props)
     getByText('A firmware update is required, instrument is updating')
     expect(updateSubsystem).toHaveBeenCalled()

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/FirmwareUpdateModal.test.tsx
@@ -42,7 +42,7 @@ describe('FirmwareUpdateModal', () => {
       description: 'A firmware update is required, instrument is updating',
       subsystem: 'pipette_left',
       proceedDescription: 'Firmware is up to date.',
-      isODD: true,
+      isOnDevice: true,
     }
     mockUseInstrumentQuery.mockReturnValue({
       data: {

--- a/app/src/organisms/FirmwareUpdateModal/index.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/index.tsx
@@ -26,7 +26,7 @@ interface FirmwareUpdateModalProps {
   proceedDescription: string
   proceed: () => void
   subsystem: Subsystem
-  isODD: boolean
+  isOnDevice: boolean
 }
 
 const DESCRIPTION_STYLE = css`
@@ -73,7 +73,13 @@ const SPINNER_STYLE = css`
 export const FirmwareUpdateModal = (
   props: FirmwareUpdateModalProps
 ): JSX.Element => {
-  const { proceed, proceedDescription, subsystem, description, isODD } = props
+  const {
+    proceed,
+    proceedDescription,
+    subsystem,
+    description,
+    isOnDevice,
+  } = props
   const [updateId, setUpdateId] = React.useState('')
   const [firmwareText, setFirmwareText] = React.useState('')
   const {
@@ -147,7 +153,7 @@ export const FirmwareUpdateModal = (
         <Icon
           name="ot-spinner"
           aria-label="spinner"
-          size={isODD ? '6.25rem' : '5.125rem'}
+          size={isOnDevice ? '6.25rem' : '5.125rem'}
           css={SPINNER_STYLE}
           spin
         />

--- a/app/src/organisms/FirmwareUpdateModal/index.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/index.tsx
@@ -6,6 +6,7 @@ import {
   TYPOGRAPHY,
   SPACING,
   Flex,
+  Icon,
   RESPONSIVENESS,
   JUSTIFY_CENTER,
   BORDERS,
@@ -25,6 +26,7 @@ interface FirmwareUpdateModalProps {
   proceedDescription: string
   proceed: () => void
   subsystem: Subsystem
+  isODD: boolean
 }
 
 const DESCRIPTION_STYLE = css`
@@ -59,10 +61,19 @@ const OUTER_STYLES = css`
   width: 13.374rem;
 `
 
+const SPINNER_STYLE = css`
+  color: ${COLORS.darkGreyEnabled};
+  opacity: 100%;
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    color: ${COLORS.darkBlackEnabled};
+    opacity: 70%;
+  }
+`
+
 export const FirmwareUpdateModal = (
   props: FirmwareUpdateModalProps
 ): JSX.Element => {
-  const { proceed, proceedDescription, subsystem, description } = props
+  const { proceed, proceedDescription, subsystem, description, isODD } = props
   const [updateId, setUpdateId] = React.useState('')
   const [firmwareText, setFirmwareText] = React.useState('')
   const {
@@ -83,14 +94,16 @@ export const FirmwareUpdateModal = (
     ) ?? false
 
   React.useEffect(() => {
-    if (!updateNeeded) {
-      setFirmwareText(proceedDescription)
-      setTimeout(() => {
-        proceed()
-      }, 2000)
-    } else {
-      updateSubsystem(subsystem)
-    }
+    setTimeout(() => {
+      if (!updateNeeded) {
+        setFirmwareText(proceedDescription)
+        setTimeout(() => {
+          proceed()
+        }, 2000)
+      } else {
+        updateSubsystem(subsystem)
+      }
+    }, 2000)
   }, [])
   const { data: updateData } = useSubsystemUpdateQuery(updateId)
   const status = updateData?.data.updateStatus
@@ -121,13 +134,24 @@ export const FirmwareUpdateModal = (
 
   return (
     <Flex css={MODAL_STYLE}>
-      <StyledText css={DESCRIPTION_STYLE}>{firmwareText}</StyledText>
+      <StyledText css={DESCRIPTION_STYLE}>
+        {firmwareText.length ? firmwareText : 'Checking for updates...'}
+      </StyledText>
       {status != null || updateNeeded ? (
         <ProgressBar
           percentComplete={percentComplete}
           outerStyles={OUTER_STYLES}
         />
       ) : null}
+      {firmwareText.length ? null : (
+        <Icon
+          name="ot-spinner"
+          aria-label="spinner"
+          size={isODD ? '6.25rem' : '5.125rem'}
+          css={SPINNER_STYLE}
+          spin
+        />
+      )}
     </Flex>
   )
 }

--- a/app/src/organisms/GripperWizardFlows/getGripperWizardSteps.ts
+++ b/app/src/organisms/GripperWizardFlows/getGripperWizardSteps.ts
@@ -12,8 +12,7 @@ import {
 import type { GripperWizardStep, GripperWizardFlowType } from './types'
 
 export const getGripperWizardSteps = (
-  flowType: GripperWizardFlowType,
-  requiresFirmwareUpdate: boolean
+  flowType: GripperWizardFlowType
 ): GripperWizardStep[] => {
   switch (flowType) {
     case GRIPPER_FLOW_TYPES.RECALIBRATE: {
@@ -32,7 +31,7 @@ export const getGripperWizardSteps = (
       ]
     }
     case GRIPPER_FLOW_TYPES.ATTACH: {
-      const ALL_STEPS = [
+      return [
         { section: SECTIONS.BEFORE_BEGINNING },
         { section: SECTIONS.MOUNT_GRIPPER },
         { section: SECTIONS.FIRMWARE_UPDATE },
@@ -48,10 +47,6 @@ export const getGripperWizardSteps = (
           successfulAction: SUCCESSFULLY_ATTACHED_AND_CALIBRATED,
         },
       ]
-
-      return requiresFirmwareUpdate
-        ? ALL_STEPS
-        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     }
     case GRIPPER_FLOW_TYPES.DETACH: {
       return [

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -209,11 +209,7 @@ export const GripperWizard = (
   } = props
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('gripper_wizard_flows')
-  const requiresFirmwareUpdate = !attachedGripper?.ok
-  const gripperWizardSteps = getGripperWizardSteps(
-    flowType,
-    requiresFirmwareUpdate
-  )
+  const gripperWizardSteps = getGripperWizardSteps(flowType)
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
   const [
     frontJawOffset,
@@ -309,6 +305,7 @@ export const GripperWizard = (
         proceed={handleProceed}
         subsystem="gripper"
         description={t('firmware_updating')}
+        proceedDescription={t('firmware_up_to_date')}
       />
     )
   } else if (currentStep.section === SECTIONS.UNMOUNT_GRIPPER) {

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -306,7 +306,7 @@ export const GripperWizard = (
         subsystem="gripper"
         description={t('firmware_updating')}
         proceedDescription={t('firmware_up_to_date')}
-        isODD={isOnDevice}
+        isOnDevice={isOnDevice}
       />
     )
   } else if (currentStep.section === SECTIONS.UNMOUNT_GRIPPER) {

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -306,6 +306,7 @@ export const GripperWizard = (
         subsystem="gripper"
         description={t('firmware_updating')}
         proceedDescription={t('firmware_up_to_date')}
+        isODD={isOnDevice}
       />
     )
   } else if (currentStep.section === SECTIONS.UNMOUNT_GRIPPER) {

--- a/app/src/organisms/ModuleWizardFlows/getModuleCalibrationSteps.ts
+++ b/app/src/organisms/ModuleWizardFlows/getModuleCalibrationSteps.ts
@@ -1,10 +1,8 @@
 import { SECTIONS } from './constants'
 import type { ModuleCalibrationWizardStep } from './types'
 
-export const getModuleCalibrationSteps = (
-  requiresFirmwareUpdate: boolean
-): ModuleCalibrationWizardStep[] => {
-  const ALL_STEPS = [
+export const getModuleCalibrationSteps = (): ModuleCalibrationWizardStep[] => {
+  return [
     { section: SECTIONS.BEFORE_BEGINNING },
     { section: SECTIONS.FIRMWARE_UPDATE },
     { section: SECTIONS.SELECT_LOCATION },
@@ -13,8 +11,4 @@ export const getModuleCalibrationSteps = (
     { section: SECTIONS.DETACH_PROBE },
     { section: SECTIONS.SUCCESS },
   ]
-
-  return requiresFirmwareUpdate
-    ? ALL_STEPS
-    : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
 }

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -269,7 +269,7 @@ export const ModuleWizardFlows = (
         proceedDescription={t('firmware_up_to_date', {
           module: getModuleDisplayName(attachedModule.moduleModel),
         })}
-        isODD={isOnDevice}
+        isOnDevice={isOnDevice}
       />
     )
   } else if (currentStep.section === SECTIONS.SELECT_LOCATION) {

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -8,9 +8,9 @@ import {
 import { COLORS } from '@opentrons/components'
 import {
   CreateCommand,
-  LEFT,
   getModuleType,
   getModuleDisplayName,
+  LEFT,
 } from '@opentrons/shared-data'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
@@ -61,14 +61,7 @@ export const ModuleWizardFlows = (
   const { t } = useTranslation('module_wizard_flows')
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
   const attachedPipette = attachedPipettes.left ?? attachedPipettes.right
-  const requiresFirmwareUpdate = !attachedPipette?.ok
-  const attachedPipetteMount =
-    attachedPipette?.mount === LEFT ? 'pipette_left' : 'pipette_right'
-
-  const moduleCalibrationSteps = getModuleCalibrationSteps(
-    requiresFirmwareUpdate
-  )
-
+  const moduleCalibrationSteps = getModuleCalibrationSteps()
   const availableSlotNames =
     FLEX_SLOT_NAMES_BY_MOD_TYPE[getModuleType(attachedModule.moduleModel)] ?? []
   const [slotName, setSlotName] = React.useState(
@@ -269,8 +262,13 @@ export const ModuleWizardFlows = (
     modalContent = (
       <FirmwareUpdateModal
         proceed={proceed}
-        subsystem={attachedPipetteMount}
+        subsystem={
+          attachedPipette.mount === LEFT ? 'pipette_left' : 'pipette_right'
+        }
         description={t('firmware_update')}
+        proceedDescription={t('firmware_up_to_date', {
+          module: getModuleDisplayName(attachedModule.moduleModel),
+        })}
       />
     )
   } else if (currentStep.section === SECTIONS.SELECT_LOCATION) {

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -269,6 +269,7 @@ export const ModuleWizardFlows = (
         proceedDescription={t('firmware_up_to_date', {
           module: getModuleDisplayName(attachedModule.moduleModel),
         })}
+        isODD={isOnDevice}
       />
     )
   } else if (currentStep.section === SECTIONS.SELECT_LOCATION) {

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -34,16 +34,9 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.CALIBRATE,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        true
-      )
+      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
-
   it('returns the correct array of info for attach pipette flow single channel', () => {
     const mockAttachPipetteFlowSteps = [
       {
@@ -84,58 +77,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.ATTACH,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        true
-      )
-    ).toStrictEqual(mockAttachPipetteFlowSteps)
-  })
-
-  it('returns the correct array of info when a firmware update is not required', () => {
-    const mockAttachPipetteFlowSteps = [
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.MOUNT_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.ATTACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.DETACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.CALIBRATE,
-      },
-    ] as PipetteWizardStep[]
-
-    expect(
-      getPipetteWizardSteps(
-        FLOWS.ATTACH,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        false
-      )
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -159,13 +101,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.DETACH,
-        LEFT,
-        SINGLE_MOUNT_PIPETTES,
-        false,
-        true
-      )
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, SINGLE_MOUNT_PIPETTES, false)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
 
@@ -219,7 +155,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true, true)
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, true)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
 
@@ -253,7 +189,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true, true)
+      getPipetteWizardSteps(FLOWS.DETACH, LEFT, NINETY_SIX_CHANNEL, true)
     ).toStrictEqual(mockDetachPipetteFlowSteps)
   })
   it('returns the correct array when 96-channel is going to be attached and there is a pipette already on the mount', () => {
@@ -312,7 +248,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false, true)
+      getPipetteWizardSteps(FLOWS.ATTACH, LEFT, NINETY_SIX_CHANNEL, false)
     ).toStrictEqual(mockAttachPipetteFlowSteps)
   })
   it('returns the corect array of info for calibrate pipette 96 channel', () => {
@@ -340,13 +276,7 @@ describe('getPipetteWizardSteps', () => {
     ] as PipetteWizardStep[]
 
     expect(
-      getPipetteWizardSteps(
-        FLOWS.CALIBRATE,
-        LEFT,
-        NINETY_SIX_CHANNEL,
-        false,
-        true
-      )
+      getPipetteWizardSteps(FLOWS.CALIBRATE, LEFT, NINETY_SIX_CHANNEL, false)
     ).toStrictEqual(mockCalibrateFlowSteps)
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -36,20 +36,14 @@ describe('getPipetteWizardStepsForProtocol', () => {
             mount: 'left',
           },
         ],
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
   it('returns an empty array when there is no pipette attached and no pipette is needed', () => {
     const mockFlowSteps = [] as PipetteWizardStep[]
     expect(
-      getPipetteWizardStepsForProtocol(
-        { left: null, right: null },
-        [],
-        LEFT,
-        true
-      )
+      getPipetteWizardStepsForProtocol({ left: null, right: null }, [], LEFT)
     ).toStrictEqual(mockFlowSteps)
   })
   it('returns the calibration flow only when correct pipette is attached but there is no pip cal data', () => {
@@ -81,8 +75,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
           } as any,
         },
         [{ id: '123', pipetteName: 'p1000_single_flex', mount: 'right' }],
-        RIGHT,
-        true
+        RIGHT
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -130,55 +123,11 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         mockSingleMountPipetteAttached,
         mockPipettesInProtocolMulti as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
-  it('returns the correct array of info when the attached pipette does not require a firmware update', () => {
-    const mockFlowSteps = [
-      {
-        section: SECTIONS.BEFORE_BEGINNING,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-      },
-      {
-        section: SECTIONS.DETACH_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.DETACH,
-      },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.DETACH },
-      {
-        section: SECTIONS.MOUNT_PIPETTE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
-      {
-        section: SECTIONS.ATTACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.DETACH_PROBE,
-        mount: LEFT,
-        flowType: FLOWS.ATTACH,
-      },
-      {
-        section: SECTIONS.RESULTS,
-        mount: LEFT,
-        flowType: FLOWS.CALIBRATE,
-      },
-    ] as PipetteWizardStep[]
-    expect(
-      getPipetteWizardStepsForProtocol(
-        mockSingleMountPipetteAttached,
-        mockPipettesInProtocolMulti as any,
-        LEFT,
-        false
-      )
-    ).toStrictEqual(mockFlowSteps)
-  })
+
   it('returns the correct array of info when the attached 96-channel pipette needs to be switched out for single mount', () => {
     const mockFlowSteps = [
       {
@@ -238,8 +187,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: mock96ChannelAttachedPipetteInformation, right: null },
         mockPipettesInProtocolNotEmpty as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -302,8 +250,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: mockAttachedPipetteInformation, right: null },
         mockPipetteInfo as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -366,8 +313,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: null, right: mockAttachedPipetteInformation },
         mockPipetteInfo as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -444,8 +390,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
           right: mockAttachedPipetteInformation,
         },
         mockPipetteInfo as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -487,8 +432,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: null, right: null },
         mockPipettesInProtocolNotEmpty as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })
@@ -540,8 +484,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol(
         { left: null, right: null },
         mockPipetteInfo as any,
-        LEFT,
-        true
+        LEFT
       )
     ).toStrictEqual(mockFlowSteps)
   })

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -11,8 +11,7 @@ export const getPipetteWizardSteps = (
   flowType: PipetteWizardFlow,
   mount: PipetteMount,
   selectedPipette: SelectablePipettes,
-  isGantryEmpty: boolean,
-  requiresFirmwareUpdate: boolean
+  isGantryEmpty: boolean
 ): PipetteWizardStep[] => {
   switch (flowType) {
     case FLOWS.CALIBRATE: {
@@ -33,7 +32,7 @@ export const getPipetteWizardSteps = (
     }
     case FLOWS.ATTACH: {
       if (selectedPipette === SINGLE_MOUNT_PIPETTES) {
-        const ALL_STEPS = [
+        return [
           {
             section: SECTIONS.BEFORE_BEGINNING,
             mount: mount,
@@ -54,9 +53,6 @@ export const getPipetteWizardSteps = (
             flowType: FLOWS.CALIBRATE,
           },
         ]
-        return requiresFirmwareUpdate
-          ? ALL_STEPS
-          : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
       } else {
         //  pipette needs to be detached before attached 96 channel
         if (!isGantryEmpty) {
@@ -64,7 +60,7 @@ export const getPipetteWizardSteps = (
           if (mount === LEFT) {
             detachMount = RIGHT
           }
-          const ALL_STEPS = [
+          return [
             {
               section: SECTIONS.BEFORE_BEGINNING,
               mount: detachMount,
@@ -117,14 +113,9 @@ export const getPipetteWizardSteps = (
               flowType: FLOWS.CALIBRATE,
             },
           ]
-          return requiresFirmwareUpdate
-            ? ALL_STEPS
-            : ALL_STEPS.filter(
-                step => step.section !== SECTIONS.FIRMWARE_UPDATE
-              )
           //  gantry empty to attach 96 channel
         } else {
-          const ALL_STEPS = [
+          return [
             {
               section: SECTIONS.BEFORE_BEGINNING,
               mount: LEFT,
@@ -167,11 +158,6 @@ export const getPipetteWizardSteps = (
               flowType: FLOWS.CALIBRATE,
             },
           ]
-          return requiresFirmwareUpdate
-            ? ALL_STEPS
-            : ALL_STEPS.filter(
-                step => step.section !== SECTIONS.FIRMWARE_UPDATE
-              )
         }
       }
     }

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -7,8 +7,7 @@ import type { PipetteWizardStep } from './types'
 export const getPipetteWizardStepsForProtocol = (
   attachedPipettes: AttachedPipettesFromInstrumentsQuery,
   pipetteInfo: LoadedPipette[],
-  mount: Mount,
-  requiresFirmwareUpdate: boolean
+  mount: Mount
 ): PipetteWizardStep[] => {
   const requiredPipette = pipetteInfo.find(pipette => pipette.mount === mount)
   const nintySixChannelAttached =
@@ -51,7 +50,7 @@ export const getPipetteWizardStepsForProtocol = (
   ) {
     //    96-channel pipette attached and need to attach single mount pipette
     if (nintySixChannelAttached) {
-      const ALL_STEPS = [
+      return [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: LEFT,
@@ -105,12 +104,9 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
-      return requiresFirmwareUpdate
-        ? ALL_STEPS
-        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
       //    Single mount pipette attached and need to attach new single mount pipette
     } else {
-      const ALL_STEPS = [
+      return [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: mount,
@@ -149,9 +145,6 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
-      return requiresFirmwareUpdate
-        ? ALL_STEPS
-        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     }
     //  Single mount pipette attached to both mounts and need to attach 96-channel pipette
   } else if (
@@ -159,7 +152,7 @@ export const getPipetteWizardStepsForProtocol = (
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] != null
   ) {
-    const ALL_STEPS = [
+    return [
       {
         section: SECTIONS.BEFORE_BEGINNING,
         mount: LEFT,
@@ -224,16 +217,13 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.CALIBRATE,
       },
     ]
-    return requiresFirmwareUpdate
-      ? ALL_STEPS
-      : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     //  Single mount pipette attached to left mount and need to attach 96-channel pipette
   } else if (
     requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] != null &&
     attachedPipettes[RIGHT] == null
   ) {
-    const ALL_STEPS = [
+    return [
       {
         section: SECTIONS.BEFORE_BEGINNING,
         mount: LEFT,
@@ -287,16 +277,13 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.CALIBRATE,
       },
     ]
-    return requiresFirmwareUpdate
-      ? ALL_STEPS
-      : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     //  Single mount pipette attached to right mount and need to attach 96-channel pipette
   } else if (
     requiredPipette.pipetteName === 'p1000_96' &&
     attachedPipettes[LEFT] == null &&
     attachedPipettes[RIGHT] != null
   ) {
-    const ALL_STEPS = [
+    return [
       {
         section: SECTIONS.BEFORE_BEGINNING,
         mount: RIGHT,
@@ -350,14 +337,11 @@ export const getPipetteWizardStepsForProtocol = (
         flowType: FLOWS.CALIBRATE,
       },
     ]
-    return requiresFirmwareUpdate
-      ? ALL_STEPS
-      : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     //  if no pipette is attached to gantry
   } else {
     //  Gantry empty and need to attach 96-channel pipette
     if (requiredPipette.pipetteName === 'p1000_96') {
-      const ALL_STEPS = [
+      return [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: LEFT,
@@ -400,12 +384,9 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
-      return requiresFirmwareUpdate
-        ? ALL_STEPS
-        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
       //    Gantry empty and need to attach single mount pipette
     } else {
-      const ALL_STEPS = [
+      return [
         {
           section: SECTIONS.BEFORE_BEGINNING,
           mount: mount,
@@ -438,9 +419,6 @@ export const getPipetteWizardStepsForProtocol = (
           flowType: FLOWS.CALIBRATE,
         },
       ]
-      return requiresFirmwareUpdate
-        ? ALL_STEPS
-        : ALL_STEPS.filter(step => step.section !== SECTIONS.FIRMWARE_UPDATE)
     }
   }
 }

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -343,7 +343,7 @@ export const PipetteWizardFlows = (
         subsystem={mount === LEFT ? 'pipette_left' : 'pipette_right'}
         description={t('firmware_updating')}
         proceedDescription={t('firmware_up_to_date')}
-        isODD={isOnDevice}
+        isOnDevice={isOnDevice}
       />
     )
   } else if (currentStep.section === SECTIONS.DETACH_PIPETTE) {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -64,26 +64,17 @@ export const PipetteWizardFlows = (
   const { t } = useTranslation('pipette_wizard_flows')
 
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
-  const attachedPipette = attachedPipettes.left ?? attachedPipettes.right
-  const requiresFirmwareUpdate = !attachedPipette?.ok
   const memoizedPipetteInfo = React.useMemo(() => props.pipetteInfo ?? null, [])
   const isGantryEmpty =
     attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null
   const pipetteWizardSteps = React.useMemo(
     () =>
       memoizedPipetteInfo == null
-        ? getPipetteWizardSteps(
-            flowType,
-            mount,
-            selectedPipette,
-            isGantryEmpty,
-            requiresFirmwareUpdate
-          )
+        ? getPipetteWizardSteps(flowType, mount, selectedPipette, isGantryEmpty)
         : getPipetteWizardStepsForProtocol(
             attachedPipettes,
             memoizedPipetteInfo,
-            mount,
-            requiresFirmwareUpdate
+            mount
           ),
     []
   )
@@ -351,6 +342,7 @@ export const PipetteWizardFlows = (
         proceed={proceed}
         subsystem={mount === LEFT ? 'pipette_left' : 'pipette_right'}
         description={t('firmware_updating')}
+        proceedDescription={t('firmware_up_to_date')}
       />
     )
   } else if (currentStep.section === SECTIONS.DETACH_PIPETTE) {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -343,6 +343,7 @@ export const PipetteWizardFlows = (
         subsystem={mount === LEFT ? 'pipette_left' : 'pipette_right'}
         description={t('firmware_updating')}
         proceedDescription={t('firmware_up_to_date')}
+        isODD={isOnDevice}
       />
     )
   } else if (currentStep.section === SECTIONS.DETACH_PIPETTE) {


### PR DESCRIPTION
Closes RQA-1827

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes the logic for determining whether or not the firmware step is necessary during an attachment flow. Because it's not possible to check whether an instrument or module needs a firmware update until it is attached, do not filter out the step entirely. Instead, if the instrument is known to have the latest firmware, gracefully proceed to the next step. 

Before we know whether an update is required (or not), let's use a dummy loading spinner and then render the appropriate "updated" or "update in progress" text.

https://github.com/Opentrons/opentrons/assets/64858653/74dff5d2-1ecd-4632-b00d-bd771f576380



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Attach a pipette

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix issue with firmware update screen not displaying.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
