### PR TITLE
fix(app): fix pipette image size issue

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -236,11 +236,8 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
                     pipetteSpecs={pipetteModelSpecs}
                     mount={mount}
                     //  pipette images for Flex are slightly smaller so need to be scaled accordingly
-                    transform={isFlex ? 'scale(0.4)' : 'scale(0.3)'}
-                    size="3.125rem"
-                    transformOrigin={isFlex ? '-50% -10%' : '20% -10%'}
-                    width="100%"
-                    height="100%"
+                    transform="scale(0.3)"
+                    transformOrigin={isFlex ? '-10% 52%' : '20% 52%'}
                   />
                 ) : null}
               </Flex>


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue was `height` and the image size scale didn't match the design (60x54). 
Modify transform to align the pipette image size with the design.
I think this modification isn't an ideal fix since we will need to Desktop app's since it's not fully responsive right now.
I guess after 7.1.0 we will be able to dig into this type of layout issue.


design
https://www.figma.com/file/0hYQ4lFJbAAI33jQMRt1Di/Release%3A-Desktop-June-Flex-launch?node-id=17265%3A286113&mode=dev

### before
<img width="1024" alt="10_20 instrument images" src="https://github.com/Opentrons/opentrons/assets/474225/b0a4d528-cd01-42aa-ad68-939885fda5b7">

### after Flex
![Screenshot 2023-10-20 at 5 05 11 PM](https://github.com/Opentrons/opentrons/assets/474225/803e51f2-1d37-4b53-b8ce-7e9af89a29de)


### after OT-2
![Screenshot 2023-10-20 at 5 03 11 PM](https://github.com/Opentrons/opentrons/assets/474225/6ad785a1-ee8f-42f1-9c26-0b99be4af639)


close RQA-1825
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- modify PipetteCard component
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
This issue only happens to `edge` but I couldn't find out anything that causes this issue in [this PR](https://github.com/Opentrons/opentrons/pull/13813/files).
If there is a better way to fix this issue, please let me know.

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
