### PR TITLE
docs(api): additional low-volume pipetting information

### DIFF
--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -318,12 +318,13 @@ The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a l
     
 .. versionadded:: 2.15
 
-Setting the volume mode changes the minimum and maximum volume of Flex 50 µL pipettes as follows:
+Passing different values to ``configure_for_volume()`` changes the minimum and maximum volume of Flex 50 µL pipettes as follows:
 
 .. list-table::
     :header-rows: 1
+    :widths: 2 3 3
     
-    * - ``configure_for_volume()`` Value
+    * - Value
       - Minimum Volume (µL)
       - Maximum Volume (µL)
     * - 1–4.9

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -321,7 +321,7 @@ The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a l
 .. note::
     The pipette must not contain liquid when you call ``configure_for_volume()``, or the API will raise an error.
     
-    Also, if the pipette is in a well location that may contain liquid, it will move upward to ensure it is not immersed in liquid before changing its mode.
+    Also, if the pipette is in a well location that may contain liquid, it will move upward to ensure it is not immersed in liquid before changing its mode. Calling ``configure_for_volume()`` *before* ``pick_up_tip()`` helps to avoid this situation.
 
 In a protocol that handles many different volumes, it's a good practice to call this function immediately before each :py:meth:`.transfer` or :py:meth:`.aspirate`, specifying the volume that you are about to handle. When operating with a list of volumes, nest ``configure_for_volume()`` inside a ``for`` loop to ensure that the pipette is properly configured for each volume:
 
@@ -331,8 +331,8 @@ In a protocol that handles many different volumes, it's a good practice to call 
     sources = plate.columns()[0]
     destinations = plate.columns()[1]
     for i in range(8):
-        pipette50.pick_up_tip()
         pipette50.configure_for_volume(volumes[i])
+        pipette50.pick_up_tip()
         pipette50.aspirate(volume=volumes[i], location=sources[i])
         pipette50.dispense(location=destinations[i])
         pipette50.drop_tip()

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -310,7 +310,7 @@ The single- and multi-channel P50 GEN1 pipettes are the exceptions here. If your
 Volume Modes
 ============
 
-The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a low-volume mode to accurately dispense 1 µL of liquid. Set low-volume mode by calling :py:meth:`.InstrumentContext.configure_for_volume` with the amount of liquid you plan to aspirate, in µL::
+The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a low-volume mode to accurately dispense very small volumes of liquid. Set the volume mode by calling :py:meth:`.InstrumentContext.configure_for_volume` with the amount of liquid you plan to aspirate, in µL::
 
     pipette50.configure_for_volume(1)
     pipette50.pick_up_tip()
@@ -318,12 +318,27 @@ The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a l
     
 .. versionadded:: 2.15
 
+Setting the volume mode changes the minimum and maximum volume of Flex 50 µL pipettes as follows:
+
+.. list-table::
+    :header-rows: 1
+    
+    * - ``configure_for_volume()`` Value
+      - Minimum Volume (µL)
+      - Maximum Volume (µL)
+    * - 1–4.9
+      - 1
+      - 30
+    * - 5–50
+      - 5
+      - 50
+
 .. note::
     The pipette must not contain liquid when you call ``configure_for_volume()``, or the API will raise an error.
     
     Also, if the pipette is in a well location that may contain liquid, it will move upward to ensure it is not immersed in liquid before changing its mode. Calling ``configure_for_volume()`` *before* ``pick_up_tip()`` helps to avoid this situation.
 
-In a protocol that handles many different volumes, it's a good practice to call this function immediately before each :py:meth:`.transfer` or :py:meth:`.aspirate`, specifying the volume that you are about to handle. When operating with a list of volumes, nest ``configure_for_volume()`` inside a ``for`` loop to ensure that the pipette is properly configured for each volume:
+In a protocol that handles many different volumes, it's a good practice to call ``configure_for_volume()`` once for each :py:meth:`.transfer` or :py:meth:`.aspirate`, specifying the volume that you are about to handle. When operating with a list of volumes, nest ``configure_for_volume()`` inside a ``for`` loop to ensure that the pipette is properly configured for each volume:
 
 .. code-block:: python
     
@@ -337,7 +352,7 @@ In a protocol that handles many different volumes, it's a good practice to call 
         pipette50.dispense(location=destinations[i])
         pipette50.drop_tip()
 
-If you know that all your liquid handling will take place in a specific mode, then you can call ``configure_for_volume()`` just once with a nominal volume. Or if all the volumes correspond to the pipette's default mode, you don't have to call ``configure_for_volume()`` at all.
+If you know that all your liquid handling will take place in a specific mode, then you can call ``configure_for_volume()`` just once with a representative volume. Or if all the volumes correspond to the pipette's default mode, you don't have to call ``configure_for_volume()`` at all.
 
 
 .. _new-plunger-flow-rates:


### PR DESCRIPTION

# Overview

Adding some more information about low-volume mode:
- It's best practice to set the volume mode before picking up a tip.
- List concrete numbers for how `configure_for_volume` values affect pipette min and max volumes.

# Test Plan

- Checked local docs build and the [sandbox](http://sandbox.docs.opentrons.com/docs-low-volume-followup/v2/new_pipette.html#volume-modes).
- Confirmed bounds of `configure_for_volume()` values and min/max in simulation, e.g.:
``` python
    pipette50.configure_for_volume(4.999)
    pipette50.pick_up_tip()
    pipette50.aspirate(1, plate["A1"])
    protocol.comment(str([pipette50.min_volume, pipette50.max_volume]))  # [1.0, 30]
```

# Changelog

- Additions and line edits, all within the Volume Modes section of the Pipettes page.

# Review requests

Good and accurate advice for users?

# Risk assessment

nil, docs