### PR TITLE
fix(app): fix Flex protocol app analysis failing with ModuleNotFoundError

### DIFF
--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -124,8 +124,7 @@ module.exports = function beforeBuild(context) {
         'install',
         `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
-        path.join(__dirname, '../../hardware'),
-        path.join(__dirname, '../../api'),
+        path.join(__dirname, '../../api[flex-hardware]'),
         'pandas==1.4.3',
       ])
     })

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -124,7 +124,8 @@ module.exports = function beforeBuild(context) {
         'install',
         `--target=${path.join(PYTHON_DESTINATION, sitePackages)}`,
         path.join(__dirname, '../../shared-data/python'),
-        path.join(__dirname, '../../api[flex-hardware]'),
+        path.join(__dirname, '../../hardware[flex]'),
+        path.join(__dirname, '../../api'),
         'pandas==1.4.3',
       ])
     })


### PR DESCRIPTION


# Overview

When #13770 changed the `opentrons_hardware` package to allow installation without the `python-can` module, I neglected to update the app-shell packaging script to include that optional dependency. As a result, app builds were not including all of the required packages and analyzing any OT Flex protocols will fail erroneously. 

# Test Plan

Once the app builds for this PR, try to analyze a Flex protocol.

# Changelog

- Specify the `flex-hardware` optional dependency when importing `api` during app packaging

# Review requests

Anyplace else that uses `setup.py` that I should update while I'm at it?

# Risk assessment

Low, fixes broken builds
