### PR TITLE
test(protocol-designer): fix display name in e2e test

### DIFF
--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -1380,7 +1380,7 @@
       "ordering": [],
       "brand": { "brand": "Opentrons", "brandId": [] },
       "metadata": {
-        "displayName": "Opentrons 96 Flat Bottom Adapter",
+        "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
         "displayCategory": "adapter",
         "displayVolumeUnits": "µL",
         "tags": []
@@ -3847,7 +3847,7 @@
       "key": "1db38ee9-dd4d-4a4c-9c13-24801e2ddc78",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "Opentrons 96 Flat Bottom Adapter",
+        "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
         "labwareId": "d95bb3be-b453-457c-a947-bd03dc8e56b9:opentrons/opentrons_96_flat_bottom_adapter/1",
         "loadName": "opentrons_96_flat_bottom_adapter",
         "namespace": "opentrons",

--- a/protocol-designer/src/load-file/migration/__tests__/7_1_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/7_1_0.test.ts
@@ -26,7 +26,7 @@ describe('v7.1 migration', () => {
         commandType: 'loadLabware',
         key: expect.any(String),
         params: {
-          displayName: 'Opentrons 96 Flat Bottom Adapter',
+          displayName: 'Opentrons 96 Flat Bottom Heater-Shaker Adapter',
           labwareId:
             'd95bb3be-b453-457c-a947-bd03dc8e56b9:opentrons/opentrons_96_flat_bottom_adapter/1',
           loadName: 'opentrons_96_flat_bottom_adapter',


### PR DESCRIPTION
# Overview

After https://github.com/Opentrons/opentrons/pull/13812 merged we forgot to update PD e2e tests to reflect the updated display names. This PR updates the e2e test.

# Risk assessment

Low
