### PR TITLE
fix(app): hide location conflict message behind feature flag

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/hooks/__tests__/useHardwareStatusText.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/hooks/__tests__/useHardwareStatusText.test.tsx
@@ -2,7 +2,14 @@ import * as React from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { renderHook } from '@testing-library/react-hooks'
 import { i18n } from '../../../../../i18n'
+import { useFeatureFlag } from '../../../../../redux/config'
 import { useHardwareStatusText } from '..'
+
+jest.mock('../../../../../redux/config')
+
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
 
 describe('useHardwareStatusText', () => {
   let wrapper: React.FunctionComponent<{}>
@@ -10,6 +17,8 @@ describe('useHardwareStatusText', () => {
     wrapper = ({ children }) => (
       <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
     )
+
+    mockUseFeatureFlag.mockReturnValue(true)
   })
   it('should return string for ready', () => {
     const { result } = renderHook(() => useHardwareStatusText([], []), {

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/hooks/useHardwareStatusText.ts
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/hooks/useHardwareStatusText.ts
@@ -1,4 +1,7 @@
 import { useTranslation } from 'react-i18next'
+
+import { useFeatureFlag } from '../../../../redux/config'
+
 import type { ProtocolHardware } from '../../../../pages/Protocols/hooks'
 
 export function useHardwareStatusText(
@@ -6,6 +9,8 @@ export function useHardwareStatusText(
   conflictedSlots: string[]
 ): string {
   const { t, i18n } = useTranslation('device_details')
+  const enableDeckConfig = useFeatureFlag('enableDeckConfiguration')
+
   const missingProtocolHardwareType = missingProtocolHardware.map(
     hardware => hardware.hardwareType
   )
@@ -17,7 +22,7 @@ export function useHardwareStatusText(
   const countMissingPipettes = countMissingHardwareType('pipette')
   const countMissingModules = countMissingHardwareType('module')
   let chipText: string = t('ready_to_run')
-  if (conflictedSlots.length > 0) {
+  if (enableDeckConfig && conflictedSlots.length > 0) {
     chipText = t('location_conflicts')
   } else if (countMissingPipettes === 0 && countMissingModules > 0) {
     if (countMissingModules === 1) {


### PR DESCRIPTION
# Overview

puts the "location conflicts" message returned by useHardwareStatusText behind the deck config feature flag until ready for testing

closes RQA-1832

# Test Plan

# Changelog

 - Hides location conflict message behind feature flag

# Review requests

# Risk assessment

low