### PR TITLE
feat(labware-library): render 3d labware image before 2d projection

### DIFF
--- a/labware-library/src/components/labware-ui/Gallery.tsx
+++ b/labware-library/src/components/labware-ui/Gallery.tsx
@@ -34,7 +34,7 @@ export function Gallery(props: GalleryProps): JSX.Element {
     labwareImages[params.loadName] || []
   ).map((src, key) => <img key={key} src={src} />)
 
-  const images = [render, ...staticImages]
+  const images = [...staticImages, render]
 
   return (
     <div className={className}>


### PR DESCRIPTION
# Overview

This PR renders labware images before 2d renders for labware in labware library. This fixes the awkwardness of showing adapter 2d renders that are just rectangles before their 3d renderings. 


# Changelog

- Render 3d labware image for 2d projection

# Review requests

View the labware list and labware details pages in LL and make sure it looks okay.

# Risk assessment

Low
