### PR TITLE
feat(protocol-designer): wire up thermocycler slots in DeckLocationSe…

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -382,6 +382,7 @@ const EditModulesModalComponent = (
                 deckDef={flexDeck}
                 selectedLocation={{ slotName: field.value }}
                 theme="grey"
+                isThermocycler={moduleType === THERMOCYCLER_MODULE_TYPE}
               />
             </Flex>
           )}


### PR DESCRIPTION
…lect

closes RAUT-760


# Overview

Just wires up the `isThermocycler` boolean since the change was previously only in 7.0.1 release branch until last week.

# Test Plan

create a Flex protocol in PD and try to add/edit a thermocycler. See that the TC slot is correct

<img width="788" alt="Screen Shot 2023-10-25 at 9 18 27 AM" src="https://github.com/Opentrons/opentrons/assets/66035149/14afbada-fbbe-418b-8442-a5d4db140612">

# Changelog

- wire up `isThermocycler` boolean in `DeckLocationSelect`

# Review requests

see test plan

# Risk assessment

low