### PR TITLE
fix(shared-data): reduce 96chan pickup distance

### DIFF
--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p1000/3_5.json
@@ -9,7 +9,7 @@
     "speed": 5.5,
     "increment": 0.0,
     "distance": 10.0,
-    "prep_move_distance": 9.0,
+    "prep_move_distance": 8.25,
     "prep_move_speed": 10.0
   },
   "dropTipConfigurations": {


### PR DESCRIPTION
Keeps the lifetime nice and long.

Numbers from hardware.