### PR TITLE
fix(api): don't move in x direction during tip pickup

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2035,7 +2035,7 @@ class OT3API(
         # can verify if a tip is properly attached
         if spec.ending_z_retract_distance:
             await self.move_rel(
-                realmount, top_types.Point(spec.ending_z_retract_distance)
+                realmount, top_types.Point(z=spec.ending_z_retract_distance)
             )
 
         # TODO: implement tip-detection sequence during pick-up-tip for 96ch,


### PR DESCRIPTION
Due to a testing oversight, when `_motor_pick_up_tip` is called, if there is an ending retract distance specified, the gantry will move the retract distance in the x direction instead of the z