### PR TITLE
feat(step-generation): wire up missingAdapter() error creator

### DIFF
--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -157,8 +157,8 @@
         "body": "The Waste Chute or Trash Bin to drop tip in does not exist."
       },
       "MISSING_96_CHANNEL_TIPRACK_ADAPTER": {
-        "title": "Missing tiprack adapter for 96-channel",
-        "body": "A 96-channel cannot pick up a full tiprack without an adapter underneath."
+        "title": "Missing 96-channel tip rack adapter",
+        "body": "The tip rack must be placed in an adapter when picking up 96 tips simultaneously."
       }
     },
     "warning": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -155,6 +155,10 @@
       "DROP_TIP_LOCATION_DOES_NOT_EXIST": {
         "title": "Attempting to drop tip in an unknown location",
         "body": "The Waste Chute or Trash Bin to drop tip in does not exist."
+      },
+      "MISSING_96_CHANNEL_TIPRACK_ADAPTER": {
+        "title": "Missing tiprack adapter for 96-channel",
+        "body": "A 96-channel cannot pick up a full tiprack without an adapter underneath"
       }
     },
     "warning": {
@@ -173,10 +177,6 @@
       "TIPRACK_IN_WASTE_CHUTE_HAS_TIPS": {
         "title": "Moving tiprack into waste chute",
         "body": "This tiprack has remaining tips, be advised that once you dispose of it, there is no way to get it back later in the protocol. "
-      },
-      "MISSING_96_CHANNEL_TIPRACK_ADAPTER": {
-        "title": "Missing tiprack adapter for 96-channel",
-        "body": "A 96-channel cannot pick up a full tiprack without an adapter underneath"
       }
     }
   },

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -158,7 +158,7 @@
       },
       "MISSING_96_CHANNEL_TIPRACK_ADAPTER": {
         "title": "Missing tiprack adapter for 96-channel",
-        "body": "A 96-channel cannot pick up a full tiprack without an adapter underneath"
+        "body": "A 96-channel cannot pick up a full tiprack without an adapter underneath."
       }
     },
     "warning": {

--- a/step-generation/src/commandCreators/atomic/replaceTip.ts
+++ b/step-generation/src/commandCreators/atomic/replaceTip.ts
@@ -11,7 +11,11 @@ import {
   getIsHeaterShakerEastWestWithLatchOpen,
   getIsHeaterShakerEastWestMultiChannelPipette,
 } from '../../utils'
-import type { CurriedCommandCreator, CommandCreator } from '../../types'
+import type {
+  CommandCreatorError,
+  CurriedCommandCreator,
+  CommandCreator,
+} from '../../types'
 interface PickUpTipArgs {
   pipette: string
   tiprack: string
@@ -23,6 +27,20 @@ const _pickUpTip: CommandCreator<PickUpTipArgs> = (
   invariantContext,
   prevRobotState
 ) => {
+  const errors: CommandCreatorError[] = []
+  const tiprackSlot = prevRobotState.labware[args.tiprack].slot
+  const pipetteName = invariantContext.pipetteEntities[args.pipette].name
+  const adapterId =
+    invariantContext.labwareEntities[tiprackSlot] != null
+      ? invariantContext.labwareEntities[tiprackSlot]
+      : null
+  if (adapterId == null && pipetteName === 'p1000_96') {
+    errors.push(errorCreators.missingAdapter())
+  }
+
+  if (errors.length > 0) {
+    return { errors }
+  }
   return {
     commands: [
       {
@@ -55,8 +73,6 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
 ) => {
   const { pipette, dropTipLocation } = args
   const nextTiprack = getNextTiprack(pipette, invariantContext, prevRobotState)
-
-  // TODO(jr, 10/16/23): plug in missingAdapter() error creator, need to get current tiprackId
 
   if (nextTiprack == null) {
     // no valid next tip / tiprack, bail out

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -15,7 +15,7 @@ export function insufficientTips(): CommandCreatorError {
 export function missingAdapter(): CommandCreatorError {
   return {
     type: 'MISSING_96_CHANNEL_TIPRACK_ADAPTER',
-    message: 'A 96-channel cannot pick up tips fully without an adapter.',
+    message: 'A 96-channel cannot pick up tips fully without an adapter',
   }
 }
 

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -15,7 +15,7 @@ export function insufficientTips(): CommandCreatorError {
 export function missingAdapter(): CommandCreatorError {
   return {
     type: 'MISSING_96_CHANNEL_TIPRACK_ADAPTER',
-    message: 'A 96-channel cannot pick up tips fully without an adapter',
+    message: 'A 96-channel cannot pick up tips fully without an adapter.',
   }
 }
 


### PR DESCRIPTION
closes RAUT-798

# Overview

This Pr wires up an error creator in `_pickUpTip` so that if you try to pick up tips from the full 96-channel pipette and an adapter is not underneath, it errors.

# Test Plan

Create a Flex protocol with the 96-channel. Add a labware and then one transfer or mix step. See that NO timeline error occurs. Now, go to the starting deck state and move the tiprack to be on top of the deck and not on top of the adapter.See that the timeline error occurs now. Should match the screenshot below.

Finally, go back and create a new protocol with no 96-channel. See that the timeline error does not occur during transfer/mix steps.

<img width="827" alt="Screen Shot 2023-10-25 at 1 14 32 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/b66da59b-0eba-4f3f-af03-faed87f80ed2">

# Changelog

add `missingAdapter()` error creator to `_pickUpTip` and move the i18n text to the correct location for timeline errors instead of warnings

# Review requests

For partial tip, we probably need to extend the args to have knowledge of if the full 96 tips are being used, but that shouldn't be too bad since `transfer`/`mix`/`consolidate`/etc will have that arg extended as well. So we can just pass the arg down from those components to `replaceTip` and then to `pickUpTip`.

# Risk assessment

low