### PR TITLE
fix(hardware_testing): Few minor fixes to enable p50m photometric

### DIFF
--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -97,6 +97,12 @@ test-photometric-single:
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 50 --channels 1 --tip 50 --dye-well-col-offset 3
 	-$(MAKE) remove-patches-gravimetric
 
+.PHONY: test-photometric-multi
+test-photometric-multi:
+	-$(MAKE) apply-patches-gravimetric
+	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 50 --channels 8 --tip 50
+	-$(MAKE) remove-patches-gravimetric
+
 .PHONY: test-photometric
 test-photometric:
 	-$(MAKE) apply-patches-gravimetric

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -195,6 +195,7 @@ class RunArgs:
             args.pipette,
             "left",
             args.increment,
+            args.photometric,
             args.gantry_speed if not args.photometric else None,
         )
         pipette_tag = helpers._get_tag_from_pipette(

--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -301,6 +301,7 @@ QC_DEFAULT_TRIALS: Dict[ConfigType, Dict[int, int]] = {
     },
     ConfigType.photometric: {
         1: 8,
+        8: 12,
         96: 5,
     },
 }

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -319,7 +319,7 @@ def execute_trials(
     trial_count = 0
     for volume in trials.keys():
         ui.print_title(f"{volume} uL")
-        if cfg.pipette_channels == 1 and not resources.ctx.is_simulating():
+        if cfg.pipette_channels != 96 and not resources.ctx.is_simulating():
             ui.get_user_ready(
                 f"put PLATE with prepped column {cfg.photoplate_column_offset} and remove SEAL"
             )
@@ -336,7 +336,7 @@ def execute_trials(
                     resources.ctx, resources.pipette, cfg, location=next_tip_location
                 )
             _run_trial(trial)
-        if not trial.ctx.is_simulating() and trial.channel_count == 1:
+        if not trial.ctx.is_simulating() and trial.channel_count != 96:
             ui.get_user_ready("add SEAL to plate and remove from DECK")
 
 

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -352,6 +352,7 @@ def _load_pipette(
     pipette_volume: int,
     pipette_mount: str,
     increment: bool,
+    photometric: bool,
     gantry_speed: Optional[int] = None,
 ) -> InstrumentContext:
     pip_name = f"flex_{pipette_channels}channel_{pipette_volume}"
@@ -372,7 +373,7 @@ def _load_pipette(
 
     # NOTE: 8ch QC testing means testing 1 channel at a time,
     #       so we need to decrease the pick-up current to work with 1 tip.
-    if pipette.channels == 8 and not increment:
+    if pipette.channels == 8 and not increment and not photometric:
         hwapi = get_sync_hw_api(ctx)
         mnt = OT3Mount.LEFT if pipette_mount == "left" else OT3Mount.RIGHT
         hwpipette: Pipette = hwapi.hardware_pipettes[mnt.to_mount()]

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -8,8 +8,8 @@ from .definition import (
     interpolate,
 )
 
-_default_submerge_aspirate_mm = 1.5
-_default_submerge_dispense_mm = 1.5
+_default_submerge_aspirate_mm = 2.5
+_default_submerge_dispense_mm = 2.5
 _default_retract_mm = 5.0
 _default_retract_discontinuity = 20
 

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/defaults.py
@@ -8,8 +8,8 @@ from .definition import (
     interpolate,
 )
 
-_default_submerge_aspirate_mm = 2.5
-_default_submerge_dispense_mm = 2.5
+_default_submerge_aspirate_mm = 1.5
+_default_submerge_dispense_mm = 1.5
 _default_retract_mm = 5.0
 _default_retract_discontinuity = 20
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
