### PR TITLE
fix(api): allow module poller to persist if it tries to complete a cancelled future

### DIFF
--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -80,7 +80,7 @@ class Poller:
         try:
             waiter.set_result(None) if e is None else waiter.set_exception(e)
         except asyncio.InvalidStateError:
-            log.warn("Poller waiter was already cancelled")
+            log.warning("Poller waiter was already cancelled")
 
     async def _poll_once(self) -> None:
         """Trigger a single read, notifying listeners of success or error."""

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -73,6 +73,15 @@ class Poller:
             await self._poll_once()
             await asyncio.sleep(self.interval)
 
+    @staticmethod
+    def _set_waiter_complete(
+        waiter: "asyncio.Future[None]", e: Optional[Exception] = None
+    ) -> None:
+        try:
+            waiter.set_result(None) if e is None else waiter.set_exception(e)
+        except asyncio.InvalidStateError:
+            log.warn("Poller waiter was already cancelled")
+
     async def _poll_once(self) -> None:
         """Trigger a single read, notifying listeners of success or error."""
         previous_waiters = self._poll_waiters
@@ -87,7 +96,7 @@ class Poller:
             log.exception("Polling exception")
             self._reader.on_error(e)
             for waiter in previous_waiters:
-                waiter.set_exception(e)
+                Poller._set_waiter_complete(waiter, e)
         else:
             for waiter in previous_waiters:
-                waiter.set_result(None)
+                Poller._set_waiter_complete(waiter)


### PR DESCRIPTION

# Overview

There have been a few cases where the module poller for a Heater Shaker or Thermocycler stops polling until the module is power cycled or the server is restarted. The poller is _supposed_ to ignore any exceptions (and just mark them on the waiter), so it seems weird that this happens.

In a recent ABR failure, we noticed that the poller stopped running at about the same time when a run was cancelled. The poller should never be getting cancelled by the protocol engine, but what _does_ get cancelled is the protocol engine command implementation that's running `wait_next_poll`. When that task gets cancelled, so does the associated future used to wait for a poll. Completing a cancelled future results in an exception that we were not catching.

Addresses RQA-1780

# Test Plan

Need to test on a robot still, I'm gonna run a protocol that just opens & closes the heater-shaker latch a bunch of times and cancel the protocol and make sure I can get the new log entry to show up.

The new unit test makes me pretty confident that this was an issue, it will fail if you run without the changes to the poller.

# Changelog

Added try/except to module poller Future completion to account for cancelled waiter tasks.

# Review requests


# Risk assessment

Not particularly high, this is just affecting error handling.
