### PR TITLE
fix(app): improve robot update via usb

### DIFF
--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -29,6 +29,7 @@ import type { Action, Dispatch } from './types'
 
 let usbHttpAgent: SerialPortHttpAgent | undefined
 const usbLog = createLogger('usb')
+let usbFetchInterval: NodeJS.Timeout
 
 export function getSerialPortHttpAgent(): SerialPortHttpAgent | undefined {
   return usbHttpAgent
@@ -110,6 +111,48 @@ async function usbListener(
   }
 }
 
+function pollSerialPortAndCreateAgent(dispatch: Dispatch): void {
+  // usb poll already initialized
+  if (usbFetchInterval != null) {
+    return
+  }
+  usbFetchInterval = setInterval(() => {
+    // already connected to an Opentrons robot via USB
+    if (getSerialPortHttpAgent() != null) {
+      return
+    }
+    usbLog.debug('fetching serialport list')
+    fetchSerialPortList()
+      .then((list: PortInfo[]) => {
+        const ot3UsbSerialPort = list.find(
+          port =>
+            port.productId?.localeCompare(DEFAULT_PRODUCT_ID, 'en-US', {
+              sensitivity: 'base',
+            }) === 0 &&
+            port.vendorId?.localeCompare(DEFAULT_VENDOR_ID, 'en-US', {
+              sensitivity: 'base',
+            }) === 0
+        )
+
+        if (ot3UsbSerialPort == null) {
+          usbLog.debug('no OT-3 serial port found')
+          return
+        }
+
+        createSerialPortHttpAgent(ot3UsbSerialPort.path)
+        // remove any existing handler
+        ipcMain.removeHandler('usb:request')
+        ipcMain.handle('usb:request', usbListener)
+
+        dispatch(usbRequestsStart())
+      })
+      .catch(e =>
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        usbLog.debug(`fetchSerialPortList error ${e?.message ?? 'unknown'}`)
+      )
+  }, 10000)
+}
+
 function startUsbHttpRequests(dispatch: Dispatch): void {
   fetchSerialPortList()
     .then((list: PortInfo[]) => {
@@ -150,6 +193,7 @@ export function registerUsb(dispatch: Dispatch): (action: Action) => unknown {
         if (action.payload.usbDevices.find(isUsbDeviceOt3) != null) {
           startUsbHttpRequests(dispatch)
         }
+        pollSerialPortAndCreateAgent(dispatch)
         break
       case USB_DEVICE_ADDED:
         if (isUsbDeviceOt3(action.payload.usbDevice)) {

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -44,6 +44,7 @@ export function createSerialPortHttpAgent(path: string): void {
     keepAliveMsecs: 10000,
     path,
     logger: usbLog,
+    timeout: 100000
   })
 
   usbHttpAgent = serialPortHttpAgent

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -44,7 +44,7 @@ export function createSerialPortHttpAgent(path: string): void {
     keepAliveMsecs: 10000,
     path,
     logger: usbLog,
-    timeout: 100000
+    timeout: 100000,
   })
 
   usbHttpAgent = serialPortHttpAgent

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -4,6 +4,7 @@ import { map, switchMap, catchError } from 'rxjs/operators'
 import mapValues from 'lodash/mapValues'
 import toString from 'lodash/toString'
 import omitBy from 'lodash/omitBy'
+import inRange from 'lodash/inRange'
 
 import { OPENTRONS_USB } from '../../redux/discovery'
 import { appShellRequestor } from '../../redux/shell/remote'
@@ -53,11 +54,6 @@ export function fetchRobotApi(
     options.body = reqForm
   }
 
-  const isFirstDigitTwo = function (statusCode: number): boolean {
-    const len = Math.floor(Math.log(statusCode) / Math.LN10)
-    return ((statusCode / Math.pow(10, len)) % 10 | 0) === 2
-  }
-
   return host.ip === OPENTRONS_USB
     ? from(
         appShellRequestor({
@@ -73,7 +69,7 @@ export function fetchRobotApi(
           body: response?.data,
           status: response?.status,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
-          ok: isFirstDigitTwo(response?.status),
+          ok: inRange(response?.status, 200, 300),
         }))
       )
     : from(fetch(url, options)).pipe(

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -53,6 +53,11 @@ export function fetchRobotApi(
     options.body = reqForm
   }
 
+  const isFirstDigitTwo = function (statusCode: number): boolean {
+    const len = Math.floor(Math.log(statusCode) / Math.LN10)
+    return ((statusCode / Math.pow(10, len)) % 10 | 0) === 2
+  }
+
   return host.ip === OPENTRONS_USB
     ? from(
         appShellRequestor({
@@ -68,7 +73,7 @@ export function fetchRobotApi(
           body: response?.data,
           status: response?.status,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
-          ok: response?.status.toString().startsWith('2'),
+          ok: isFirstDigitTwo(response?.status),
         }))
       )
     : from(fetch(url, options)).pipe(

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -68,7 +68,10 @@ export function fetchRobotApi(
           body: response?.data,
           status: response?.status,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
-          ok: response?.statusText === 'OK',
+          ok:
+            response?.statusText === 'OK' ||
+            response?.status === 200 ||
+            response?.status === 201,
         }))
       )
     : from(fetch(url, options)).pipe(

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -68,10 +68,7 @@ export function fetchRobotApi(
           body: response?.data,
           status: response?.status,
           // appShellRequestor eventually calls axios.request, which doesn't provide an ok boolean in the response
-          ok:
-            response?.statusText === 'OK' ||
-            response?.status === 200 ||
-            response?.status === 201,
+          ok: response?.status.toString().startsWith('2'),
         }))
       )
     : from(fetch(url, options)).pipe(

--- a/app/src/redux/robot-update/__tests__/epic.test.ts
+++ b/app/src/redux/robot-update/__tests__/epic.test.ts
@@ -286,22 +286,27 @@ describe('robot update epics', () => {
       })
     })
 
-    it('issues error if begin request fails without 409', () => {
+    it('sends request to cancel URL if a non 409 occurs and reissues CREATE_SESSION', () => {
       testScheduler.run(({ hot, cold, expectObservable, flush }) => {
         const action = actions.createSession(robot, '/server/update/begin')
 
-        mockFetchRobotApi.mockReturnValueOnce(
-          cold('r', { r: Fixtures.mockUpdateBeginFailure })
-        )
+        mockFetchRobotApi
+          .mockReturnValueOnce(
+            cold<RobotApiResponse>('r', { r: Fixtures.mockUpdateBeginConflict })
+          )
+          .mockReturnValueOnce(
+            cold<RobotApiResponse>('r', { r: Fixtures.mockUpdateCancelSuccess })
+          )
 
         const action$ = hot<Action>('-a', { a: action })
         const state$ = hot<State>('a-', { a: state } as any)
         const output$ = epics.createSessionEpic(action$, state$)
 
-        expectObservable(output$).toBe('-e', {
-          e: actions.unexpectedRobotUpdateError(
-            'Unable to start update session'
-          ),
+        expectObservable(output$).toBe('-a', { a: action })
+        flush()
+        expect(mockFetchRobotApi).toHaveBeenCalledWith(robot, {
+          method: 'POST',
+          path: '/server/update/cancel',
         })
       })
     })

--- a/app/src/redux/robot-update/epic.ts
+++ b/app/src/redux/robot-update/epic.ts
@@ -219,7 +219,16 @@ export const createSessionEpic: Epic = action$ => {
         )
       }
 
-      return of(unexpectedRobotUpdateError(UNABLE_TO_START_UPDATE_SESSION))
+      return fetchRobotApi(host, {
+        method: POST,
+        path: `${pathPrefix}/cancel`,
+      }).pipe(
+        map(cancelResp => {
+          return cancelResp.ok
+            ? createSession(host, path)
+            : unexpectedRobotUpdateError(UNABLE_TO_START_UPDATE_SESSION)
+        })
+      )
     })
   )
 }

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -239,9 +239,8 @@ function installListeners(
   }
   s.on('free', onFree)
 
-  function onError(): void {
-    agent.log('error', 'CLIENT socket onError')
-    // need to emit free to attach listeners to serialport
+  function onError(err: Error): void {
+    agent.log('error', `CLIENT socket onError: ${err?.message}`)
   }
   s.on('error', onError)
 

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -108,6 +108,7 @@ export function createSerialPortListMonitor(
   return { start, stop }
 }
 
+const SOCKET_OPEN_RETRY_TIME = 10000
 class SerialPortSocket extends SerialPort {
   // allow node socket destroy
   destroy(): void {}
@@ -198,7 +199,15 @@ class SerialPortHttpAgent extends http.Agent {
       baudRate: 115200,
     })
     if (!socket.isOpen && !socket.opening) {
-      socket.open()
+      socket.open(error => {
+        this.log(
+          'error',
+          `could not open serialport socket: ${error?.message}. Retrying in ${SOCKET_OPEN_RETRY_TIME} ms`
+        )
+        setTimeout(() => {
+          socket.open()
+        }, SOCKET_OPEN_RETRY_TIME)
+      })
     }
     if (socket != null) oncreate(null, socket)
   }

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -263,7 +263,7 @@ function installListeners(
     s.close()
     setTimeout(() => {
       s.open()
-    }, 1000)
+    }, 3000)
   }
   s.on('timeout', onTimeout)
 

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -196,7 +196,7 @@ class SerialPortHttpAgent extends http.Agent {
 
     const socket = new SerialPortSocket({
       path: this.options.path,
-      baudRate: 115200,
+      baudRate: 1152000,
     })
     if (!socket.isOpen && !socket.opening) {
       socket.open(error => {


### PR DESCRIPTION
Closes RQA-1844
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

After making the initial query to the robot server to create the robot update session, Robot updates utilize the top-level ok property of the response body to determine whether the robot-server is ready to begin the update. The ok property is special cased for USB and expects a status text to exist in the response body, however this status text does not match the usual expectation when uploading a file to initiate the update. 

FIX: The ok property for USB is now determined by a 2XX status code.

This PR also handles cases where the robot-server has an existing session and a new USB robot update is initiated (such as during connectivity loss). The session is cleared on the robot-server before a new session is initiated.


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Unplug laptop & robot from wifi/ethernet and plug in USB.
- Test that updating via zip-file works.
- Restart the app and initiate another update. Unplug the USB sometime during the update.
- See the error occur, replug the USB, click exit (try again is not working with zip-files, this is a separate, known issue), and initiate the update with a _different_ zip file. Alternatively, unplug the USB during the update and close/reopen the app. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Improve robot updates via USB.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
problem = high
solution = low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
