### PR TITLE
fix(app): remove redundant check isOnDevice ternary

### DIFF
--- a/app/src/organisms/DropTipWizard/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizard/JogToPosition.tsx
@@ -70,7 +70,7 @@ const ConfirmPosition = (props: ConfirmPositionProps): JSX.Element | null => {
           <Flex gridGap={SPACING.spacing24}>
             <Icon
               name="ot-alert"
-              size={'3.75rem'}
+              size="3.75rem"
               color={COLORS.warningEnabled}
               aria-label="ot-alert"
             />

--- a/app/src/organisms/DropTipWizard/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizard/JogToPosition.tsx
@@ -70,7 +70,7 @@ const ConfirmPosition = (props: ConfirmPositionProps): JSX.Element | null => {
           <Flex gridGap={SPACING.spacing24}>
             <Icon
               name="ot-alert"
-              size={isOnDevice ? '3.75rem' : '2.5rem'}
+              size={'3.75rem'}
               color={COLORS.warningEnabled}
               aria-label="ot-alert"
             />


### PR DESCRIPTION
# Overview

There is an isOnDevice ternary for an icon size in the JogToPosition tile for DropTipWizard. This check is within a return block that only executes if onDevice, so I remove the ternary here.

# Review requests

@koji spotted the redundant check

# Risk assessment

low