### PR TITLE
feat(components): readonly deck configurator version

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/DeckConfigurator.stories.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/DeckConfigurator.stories.tsx
@@ -69,3 +69,12 @@ Default.args = {
   handleClickRemove: fixtureLocation =>
     console.log(`remove at ${fixtureLocation}`),
 }
+
+export const ReadOnly = Template.bind({})
+ReadOnly.args = {
+  deckConfig,
+  handleClickAdd: fixtureLocation => console.log(`add at ${fixtureLocation}`),
+  handleClickRemove: fixtureLocation =>
+    console.log(`remove at ${fixtureLocation}`),
+  readOnly: true,
+}

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -26,6 +26,7 @@ interface DeckConfiguratorProps {
   handleClickRemove: (fixtureLocation: Cutout) => void
   lightFill?: string
   darkFill?: string
+  readOnly?: boolean
   children?: React.ReactNode
 }
 
@@ -36,6 +37,7 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
     handleClickRemove,
     lightFill = COLORS.light1,
     darkFill = COLORS.darkGreyEnabled,
+    readOnly = false,
     children,
   } = props
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
@@ -61,9 +63,11 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
   const wasteChuteFixtures = configurableDeckConfig.filter(
     fixture => fixture.loadName === WASTE_CHUTE_LOAD_NAME
   )
-  const emptyFixtures = configurableDeckConfig.filter(
-    fixture => fixture.loadName === STANDARD_SLOT_LOAD_NAME
-  )
+  const emptyFixtures = readOnly
+    ? []
+    : configurableDeckConfig.filter(
+        fixture => fixture.loadName === STANDARD_SLOT_LOAD_NAME
+      )
   const trashBinFixtures = configurableDeckConfig.filter(
     fixture => fixture.loadName === TRASH_BIN_LOAD_NAME
   )
@@ -87,7 +91,7 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
       {stagingAreaFixtures.map(fixture => (
         <StagingAreaConfigFixture
           key={fixture.fixtureId}
-          handleClickRemove={handleClickRemove}
+          handleClickRemove={readOnly ? undefined : handleClickRemove}
           fixtureLocation={fixture.fixtureLocation}
         />
       ))}
@@ -101,14 +105,14 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
       {wasteChuteFixtures.map(fixture => (
         <WasteChuteConfigFixture
           key={fixture.fixtureId}
-          handleClickRemove={handleClickRemove}
+          handleClickRemove={readOnly ? undefined : handleClickRemove}
           fixtureLocation={fixture.fixtureLocation}
         />
       ))}
       {trashBinFixtures.map(fixture => (
         <TrashBinConfigFixture
           key={fixture.fixtureId}
-          handleClickRemove={handleClickRemove}
+          handleClickRemove={readOnly ? undefined : handleClickRemove}
           fixtureLocation={fixture.fixtureLocation}
         />
       ))}


### PR DESCRIPTION

# Overview

provides a readOnly prop to the deck configurator that eliminates add and remove UI from the deck configurator deck map. for eventual use on desktop device details page during an active run.

closes RAUT-780

<img width="1476" alt="Screen Shot 2023-10-26 at 6 01 49 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/2df5f54d-dc77-49d5-9dbb-646300c87a81">

# Test Plan

updated Deck Configurator story

# Changelog

 - Creates readonly deck configurator version

# Review requests

# Risk assessment

low
