### PR TITLE
docs(api): more InstrumentContext docstrings

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -13,7 +13,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.ProtocolContext
    :members:
-   :exclude-members: location_cache, cleanup, clear_commands
+   :exclude-members: location_cache, cleanup, clear_commands, load_waste_chute
 
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -56,23 +56,22 @@ _DROP_TIP_LOCATION_ALTERNATING_ADDED_IN = APIVersion(2, 15)
 
 
 class InstrumentContext(publisher.CommandPublisher):
-    """A context for a specific pipette or instrument.
+    """
+    A context for a specific pipette or instrument.
 
-       The InstrumentContext class provides the objects,
-       attributes, and methods that allow you to use pipettes in your protocols.
+    The InstrumentContext class provides the objects, attributes, and methods that allow
+    you to use pipettes in your protocols. 
 
-       Methods generally fall into one of two categories.
+    Methods generally fall into one of two categories. 
 
-         - They can change the state of the InstrumentContext object, such as how fast
-         it moves liquid or where it disposes of used tips).
-         - They can command the instrument to perform an action, like picking up tips, moving
-         to certain locations, and aspirating or dispensing liquid.
+      - They can change the state of the InstrumentContext object, like how fast 
+        it moves liquid or where it disposes of used tips. 
+ 
+      - They can command the instrument to perform an action, like picking up tips, moving
+        to certain locations, and aspirating or dispensing liquid. 
 
-       This class also includes action methods (e.g., ``aspirate()`` and ``distribute()``).
-       We’ve included and defined many of these here for convenience.
-
-       Finally, objects in this class should not be instantiated directly. Instead,
-       instances are returned by :py:meth:`ProtocolContext.load_instrument`.
+    Objects in this class should not be instantiated directly. Instead,
+    instances are returned by :py:meth:`ProtocolContext.load_instrument`.
 
     .. versionadded:: 2.0
 
@@ -168,12 +167,12 @@ class InstrumentContext(publisher.CommandPublisher):
                        unspecified, defaults to the maximum volume for
                        the pipette and its currently attached tip.
         :type volume: int or float
-        :param location: Tells the robot where to aspirate from. The location can be a
-                         :py:class:`.Well` or a :py:class:`.Location`.
+        :param location: Tells the robot where to aspirate from. The location can be
+                         a :py:class:`.Well` or a :py:class:`.Location`.
 
                             - If the location is a ``Well``, the robot will aspirate at or above
                               the bottom center of the well. The distance (in mm) from the
-                              well bottom is specified by :py:obj:`well_bottom_clearance.aspirate`.
+                              well bottom is specified by :py:obj:`well_bottom_clearance.aspirate <well_bottom_clearance>`.
 
                             - If the location is a ``Location`` (e.g., the result of :py:meth:`.Well.top`
                               or :py:meth:`.Well.bottom`), the robot will aspirate from that specified position.
@@ -187,10 +186,9 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
 
-            If ``aspirate`` is called with a single argument, it will not try
-            to guess whether the argument is a volume or location - it is
-            required to be a volume. If you want to call ``aspirate`` with only
-            a location, specify it as a keyword argument:
+            If ``aspirate`` is called with a single, unnamed argument, it will treat
+            that argument as ``volume``. If you want to call ``aspirate`` with only
+            ``location``, specify it as a keyword argument:
             ``pipette.aspirate(location=plate['A1'])``
 
         """
@@ -279,22 +277,22 @@ class InstrumentContext(publisher.CommandPublisher):
                          The location can be a :py:class:`.Well` or a
                          :py:class:`.Location`.
 
-                            - If the location is a ``well``, the pipette will dispense at or above
-                              the center of the bottom of the well. The distance from the well bottom
-                              (in mm) is specified by the :py:obj:`well_bottom_clearance.dispense <well_bottom_clearance>`
-                              object.
+                            - If the location is a ``Well``, the pipette will dispense at or above
+                              the bottom center of the well. The distance (in mm) from the well bottom
+                              is specified by :py:obj:`well_bottom_clearance.dispense <well_bottom_clearance>`.
 
-                            - If the location is a ``location`` (e.g., the result of :py:meth:`.Well.top` or
-                              :py:meth:`.Well.bottom`), the robot will dispense into the specified position.
-
-                            - If only a ``location`` is passed (e.g., ``(location=plate['A1'])``),
-                              all of the liquid aspirated into the pipette will be dispensed
-                              (the amount is accessible through :py:attr:`current_volume`).
+                            - If the location is a ``Location`` (e.g., the result of :py:meth:`.Well.top` or
+                              :py:meth:`.Well.bottom`), the robot will dispense into that specified position.
 
                             - If the ``location`` is unspecified, the robot will dispense into its
                               current position.
-        :param rate: How quickly a pipette dispenses liquid. Measured in µL/s.
-                     Calculated as ``rate`` multiplied by :py:attr:`flow_rate.dispense <flow_rate>`.
+                              
+                            If only a ``location`` is passed (e.g., ``pipette.dispense(location=plate['A1'])``),
+                            all of the liquid aspirated into the pipette will be dispensed
+                            (the amount is accessible through :py:attr:`current_volume`).
+
+        :param rate: How quickly a pipette dispenses liquid. The speed in µL/s is
+                     calculated as ``rate`` multiplied by :py:attr:`flow_rate.dispense <flow_rate>`.
                      If not specified, defaults to 1.0. See :ref:`new-plunger-flow-rates`.
         :type rate: float
         :param push_out: Continue past the plunger bottom to help ensure all liquid
@@ -305,10 +303,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
 
-            If ``dispense`` is called with a single argument, it will not try
-            to guess whether the argument is a volume or location - it is
-            required to be a volume. If you want to call ``dispense`` with only
-            a location, specify it as a keyword argument:
+            If ``dispense`` is called with a single, unnamed argument, it will treat that argument as ``volume``. If you want to call ``dispense`` with only
+            ``location``, specify it as a keyword argument:
             ``pipette.dispense(location=plate['A1'])``.
 
         """
@@ -393,38 +389,30 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Mix a volume of liquid by repeatedly aspirating and dispensing it in a single location.
 
-        See :ref:`mix`.
+        See :ref:`mix` for examples.
 
         :param repetitions: Number of times to mix (default is 1).
         :param volume: The volume to mix, measured in µL. If 0 or unspecified,
                        defaults to the maximum volume for the pipette and its
                        attached tip.
-        :param location: A well or a position relative to well
-                         (e.g, ``plate.rows()[0][0].bottom()``).
-                         If unspecified, the pipette will mix from
+        :param location: The :py:class:`.Well` or :py:class:`~.types.Location` where 
+                         the pipette will mix. If unspecified, the pipette will mix at
                          its current position.
-        :param rate: How quickly a pipette aspirates and dispenses liquid
+        :param rate: How quickly the pipette aspirates and dispenses liquid
                     while mixing. The aspiration flow rate is calculated as
                     ``rate`` multiplied by :py:attr:`flow_rate.aspirate <flow_rate>`.
-                    The dispense flow rate is calculated
+                    The dispensing flow rate is calculated
                     as ``rate`` multiplied by :py:attr:`flow_rate.dispense <flow_rate>`.
                     See :ref:`new-plunger-flow-rates`.
-        :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette.
+        :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
         :returns: This instance.
 
         .. note::
 
-            All the arguments to ``mix`` are optional; however, if you do
-            not want to specify one of them, all arguments after that one
-            should be keyword arguments. For instance, if you do not want
-            to specify volume, you would call
-            ``pipette.mix(1, location=wellplate['A1'])``. If you do not
-            want to specify repetitions, you would call
-            ``pipette.mix(volume=10, location=wellplate['A1'])``. Unlike
-            previous API versions, ``mix`` will not attempt to guess your
-            inputs; the first argument will always be interpreted as
-            ``repetitions``, the second as ``volume``, and the third as
-            ``location`` unless you use keywords.
+            All the arguments of ``mix`` are optional. However, if you omit one of them,
+            all subsequent arguments must be passed as keyword arguments. For instance,
+            ``pipette.mix(1, location=wellplate['A1'])`` is a valid call, but
+            ``pipette.mix(1, wellplate['A1'])`` is not. 
 
         """
         _log.debug(
@@ -462,7 +450,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Blow an extra amount of air through a pipette's tip to clear it.
 
-        If :py:attr:`dispense` is used to empty a pipette, usually
+        If :py:meth:`dispense` is used to empty a pipette, usually
         a small amount of liquid remains in the tip. During
         a blowout, the pipette moves the plunger beyond its normal
         limits to help remove all liquid from the pipette tip.
@@ -470,13 +458,12 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param location: The blowout location. If no location is specified,
                          the pipette will blow out from its current position.
-        :type location: :py:class:`.Well` or :py:class:`.Location` or None
+        :type location: :py:class:`.Well` or :py:class:`.Location` or ``None``
 
-        :raises RuntimeError: If no location is specified and location cache is
-                              ``None``. This should happen if ``blow_out`` is called
+        :raises RuntimeError: If no location is specified and the location cache is
+                              ``None``. This should happen if ``blow_out()`` is called
                               without first calling a method that takes a
-                              location (e.g., :py:meth:`.aspirate`,
-                              :py:meth:`dispense`)
+                              location, like :py:meth:`.aspirate` or :py:meth:`dispense`.
         :returns: This instance.
         """
         well: Optional[labware.Well] = None
@@ -534,16 +521,17 @@ class InstrumentContext(publisher.CommandPublisher):
         speed: float = 60.0,
     ) -> InstrumentContext:
         """
-        Touch the pipette tip to the sides of a well, with the intent of
-        removing leftover droplets. See also :ref:`touch-tip`.
+        Touch the pipette tip to the sides of a well, with the intent of removing leftover droplets. 
+        
+        See :ref:`touch-tip` for more details and examples.
 
         :param location: If no location is passed, the pipette will
-                         touch tip at current well's edges.
-        :type location: :py:class:`.Well` or None
-        :param radius: Describes the proportion of the target well's
-                       radius. When ``radius=1.0``, the pipette tip will move to
+                         touch its tip at the edges of the current well.
+        :type location: :py:class:`.Well` or ``None``
+        :param radius: How far to move, as a proportion of the target well's
+                       radius. When ``radius=1.0``, the pipette tip will move all the way to
                        the edge of the target well. When ``radius=0.5``, it will
-                       move to 50% of the well's radius. Default: 1.0 (100%)
+                       move to 50% of the well's radius. Default is 1.0 (100%)
         :type radius: float
         :param v_offset: How far above or below the well to touch the tip, measured in mm.
                          A positive offset moves the tip higher above the well.
@@ -556,19 +544,13 @@ class InstrumentContext(publisher.CommandPublisher):
                         - Maximum: 80.0 mm/s
                         - Minimum: 1.0 mm/s
         :type speed: float
-        :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette
-        :raises RuntimeError: If no location is specified and location cache is
+        :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
+        :raises RuntimeError: If no location is specified and the location cache is
                               ``None``. This should happen if ``touch_tip`` is called
                               without first calling a method that takes a
-                              location (e.g., :py:meth:`.aspirate`,
-                              :py:meth:`dispense`)
+                              location, like :py:meth:`.aspirate` or
+                              :py:meth:`dispense`.
         :returns: This instance.
-
-        .. note::
-
-            This is behavior change from legacy API (which accepts any
-            ``Placeable`` as the ``location`` parameter)
-
         """
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("touch_tip", self.name, self.mount)
@@ -630,14 +612,14 @@ class InstrumentContext(publisher.CommandPublisher):
 
 
         :param height: The height, in mm, to move above the current well
-                       before creating the air gap. The default is 5 mm above current well.
+                       before creating the air gap. The default is 5 mm above the current well.
 
         :type height: float
 
-        :raises: ``UnexpectedTipRemovalError`` -- if no tip is attached to the pipette
+        :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
 
-        :raises RuntimeError: If location cache is None.
-                              This should happen if ``touch_tip`` is called
+        :raises RuntimeError: If location cache is ``None``.
+                              This should happen if ``touch_tip()`` is called
                               without first calling a method that takes a
                               location (e.g., :py:meth:`.aspirate`,
                               :py:meth:`dispense`)
@@ -646,11 +628,10 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
 
-            Both ``volume`` and height are optional, but unlike previous API
-            versions, if you want to specify only ``height`` you must do it
-            as a keyword argument: ``pipette.air_gap(height=2)``. If you
-            call ``air_gap`` with only one unnamed argument, it will always
-            be interpreted as a volume.
+            Both ``volume`` and ``height`` are optional, but if you want to specify only
+            ``height`` you must do it as a keyword argument:
+            ``pipette.air_gap(height=2)``. If you call ``air_gap`` with a single,
+            unnamed argument, it will always be interpreted as a volume.
 
 
         """
@@ -671,14 +652,14 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 0)
     def return_tip(self, home_after: Optional[bool] = None) -> InstrumentContext:
         """
-        If a tip is currently attached to the pipette, then the pipette will
-        return the tip to its location in the tip rack.
+        Drop the currently attached tip in its original location in the tip rack.
 
-        This will not reset tip tracking, so the well flag will remain ``False``.
+        Returning a tip does not reset tip tracking, so :py:obj:`.Well.has_tip` will remain
+        ``False`` for the destination.
 
         :returns: This instance.
 
-        :param home_after: See the ``home_after`` parameter of :py:obj:`drop_tip`.
+        :param home_after: See the ``home_after`` parameter of :py:meth:`drop_tip`.
         """
         if not self._core.has_tip():
             _log.warning("Pipette has no tip to return")
@@ -702,59 +683,52 @@ class InstrumentContext(publisher.CommandPublisher):
     ) -> InstrumentContext:
         """
         Pick up a tip for the pipette to run liquid-handling commands.
+
         See :ref:`basic-tip-pickup`.
 
         If no location is passed, the pipette will pick up the next available
         tip in its :py:attr:`~.InstrumentContext.tip_racks` list.
         Within each tip rack, tips will be picked up in the order specified by
         the labware definition and :py:meth:`.Labware.wells`.
-        To adjust where the sequence starts, see :py:obj:`.starting_tip`.
+        To adjust where the sequence starts, use :py:obj:`.starting_tip`.
 
-        The tip to pick up can be manually specified with the ``location``
-        argument. The ``location`` argument can be specified in several ways:
+        :param location: The location from which to pick up a tip. The ``location``
+                         argument can be specified in several ways:
 
-        * If the only thing to specify is which well from which to pick up a tip, ``location``
-          can be a :py:class:`.Well`. For instance, if you have a tip rack in a variable
-          called ``tiprack``, you can pick up a specific tip from it with
-          ``instr.pick_up_tip(tiprack.wells()[0])``. You can use this style of call to
-          pick up a tip from a rack that is not a member of :py:obj:`.InstrumentContext.tip_racks`.
+                           * As a :py:class:`.Well`. For example,
+                             ``pipette.pick_up_tip(tiprack.wells()[0])`` will always pick
+                             up the first tip in ``tiprack``, even if the rack is not a
+                             member of :py:obj:`.InstrumentContext.tip_racks`.
 
-        * If you want to pick up the next available tip in a specific
-          tip rack, you may use the tip rack directly
-          (e.g. ``instr.pick_up_tip(tiprack)``).
+                           * As a labware. ``pipette.pick_up_tip(tiprack)`` will pick up
+                             the next available tip in ``tiprack``, even if the rack is
+                             not a member of :py:obj:`.InstrumentContext.tip_racks`.
 
-        * If the position to move to in the well needs to be specified,
-          for instance to tell the robot to run its pick up tip routine
-          starting closer to or farther from the top of the tip,
-          ``location`` can be a :py:class:`.types.Location`; for instance,
-          you can call ``instr.pick_up_tip(tiprack.wells()[0].top())``.
-
-        :param location: The location from which to pick up a tip.
-        :type location: :py:class:`.types.Location` or :py:class:`.Well`
+                           * As a :py:class:`~.types.Location`. Use this to make fine
+                             adjustments to the pickup location. For example, to tell
+                             the robot to start its pick up tip routine 1 mm closer to
+                             the top of the well in the tip rack, call
+                             ``pipette.pick_up_tip(tiprack["A1"].top(z=-1))``.
+        :type location: :py:class:`.Well` or :py:class:`.Labware` or :py:class:`.types.Location`
         :param presses: The number of times to lower and then raise the pipette
                         when picking up a tip, to ensure a good seal. Zero (``0``)
                         will result in the pipette hovering over the tip but
-                        not picking it up--generally not desirable, but could
-                        be used for dry-run).
+                        not picking it up (generally not desirable, but could
+                        be used for a dry run).
 
-                        .. deprecated:: 2.14
-                            Use the Opentrons App to change pipette pick-up settings.
+                            .. deprecated:: 2.14
+                                Use the Opentrons App to change pipette pick-up settings.
         :type presses: int
-        :param increment: The additional distance to travel on each successive
-                          press (e.g.: if ``presses=3`` and ``increment=1.0``, then
-                          the first press will travel down into the tip by
-                          3.5 mm, the second by 4.5 mm, and the third by 5.5 mm).
+        :param increment: The additional distance to travel on each successive press.
+            For example, if ``presses=3`` and ``increment=1.0``, then the first press
+            will travel down into the tip by 3.5 mm, the second by 4.5 mm, and the
+            third by 5.5 mm).
 
-                        .. deprecated:: 2.14
-                            Use the Opentrons App to change pipette pick-up settings.
+                .. deprecated:: 2.14
+                    Use the Opentrons App to change pipette pick-up settings.
         :type increment: float
         :param prep_after: Whether the pipette plunger should prepare itself
                            to aspirate immediately after picking up a tip.
-
-                           .. warning::
-                               This is provided for compatibility with older
-                               Python Protocol API behavior. You should normally
-                               leave this unset.
 
                            If ``True``, the pipette will move its plunger position to
                            bottom in preparation for any following calls to
@@ -766,6 +740,10 @@ class InstrumentContext(publisher.CommandPublisher):
                            and positioning the plunger outside any potential liquids.
 
                            .. warning::
+                               This is provided for compatibility with older
+                               Python Protocol API behavior. You should normally
+                               leave this unset.
+
                                Setting ``prep_after=False`` may create an unintended
                                pipette movement, when the pipette automatically moves
                                the tip to the top of the well to prepare the plunger.
@@ -889,14 +867,13 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Drop the current tip.
 
-        See :ref:`pipette-drop-tip`.
+        See :ref:`pipette-drop-tip` for examples.
 
         If no location is passed (e.g. ``pipette.drop_tip()``), the pipette will drop the
-        attached tip into its default :py:attr:`trash_container`. For the Flex and OT-2 the
-        default slots for their trash containers are A3 and 12, respectively.
+        attached tip into its default :py:attr:`trash_container`. 
 
         Starting with API version 2.15, if the trash container is the default fixed trash,
-        the API will instruct the pipettes to drop their tips in different locations within
+        the API will instruct the pipette to drop tips in different locations within
         the trash container. Varying the tip drop location helps prevent tips from piling up
         in a single location.
 
@@ -904,29 +881,25 @@ class InstrumentContext(publisher.CommandPublisher):
         the ``location`` argument. The ``location`` argument can be specified in
         several ways:
 
-            - If the only thing to specify is the well into which to drop
-              a tip, ``location`` can be a :py:class:`.Well`. For instance,
-              if you have a tip rack in a variable called ``tiprack``, you can
-              drop a tip into a specific well on that tip rack with the call
-              ``instr.drop_tip(tiprack.wells()[0])``. This style of call can
-              be used to make the robot drop a tip into labware like a well plate or
-              a reservoir.
-            - If the drop position and :py:class:`.Well` to drop the tip into needs to be
-              specified, for instance to tell the robot to drop a tip from an unusually
-              large height above the tip rack, ``location`` can be a :py:class:`.types.Location`.
-              For instance, you can call ``instr.drop_tip(tiprack.wells()[0].top())``.
+            - As a :py:class:`.Well`. This uses a default location relative to the well.
+              This style of call can be used to make the robot drop a tip into labware
+              like a well plate or a reservoir. For example,
+              ``pipette.drop_tip(location=reservoir["A1"])``.
+            - As a :py:class:`~.types.Location`. For example, to drop a tip from an
+              unusually large height above the tip rack, you could call
+              ``pipette.drop_tip(tip_rack["A1"].top(z=10))``.
 
         :param location:
             The location to drop the tip.
         :type location:
-            :py:class:`.types.Location` or :py:class:`.Well` or ``None``
+            :py:class:`~.types.Location` or :py:class:`.Well` or ``None``
         :param home_after:
             Whether to home the pipette's plunger after dropping the tip.
             If not specified, defaults to ``True`` on an OT-2.
 
-            When ``home_after=False``, the pipette does not home its plunger. This can
-            save a few seconds, but is not recommended. Homing helps the robot track the
-            pipette's position.
+            When ``False``, the pipette does not home its plunger. This can save a few
+            seconds, but is not recommended. Homing helps the robot track the pipette's
+            position.
 
         :returns: This instance.
         """
@@ -1097,7 +1070,9 @@ class InstrumentContext(publisher.CommandPublisher):
         # TODO: What should happen if the user passes a non-first-row well
         # TODO: ..as src/dest *while using multichannel pipette?
         """
-        Transfer moves liquid from one well or group of wells to another. It is a
+        Move liquid from one well or group of wells to another. 
+        
+        Transfer is a
         higher-level command, incorporating other :py:class:`InstrumentContext`
         commands, like :py:meth:`aspirate` and :py:meth:`dispense`. It makes writing a
         protocol easier at the cost of specificity. See :ref:`v2-complex-commands` for
@@ -1310,20 +1285,28 @@ class InstrumentContext(publisher.CommandPublisher):
         publish: bool = True,
     ) -> InstrumentContext:
         """Move the instrument.
+        
+        See :ref:`move-to` for examples.
 
         :param location: The location to move to.
-        :type location: :py:class:`.types.Location`
-        :param force_direct: If set to true, move directly to destination
+        :type location: :py:class:`~.types.Location`
+        :param force_direct: If ``True``, move directly to the destination
                              without arc motion.
-        :param minimum_z_height: When specified, this Z margin is able to raise
-                                 (but never lower) the mid-arc height.
+                             
+                             .. warning::
+                                Forcing direct motion can cause the pipette to crash
+                                into labware, modules, or other objects on the deck.
+
+        :param minimum_z_height: An amount, measured in mm, to raise
+                                 the mid-arc height. The mid-arc height can't be lowered.
         :param speed: The speed at which to move. By default,
                       :py:attr:`InstrumentContext.default_speed`. This controls
-                      the straight linear speed of the motion; to limit
-                      individual axis speeds, you can use
+                      the straight linear speed of the motion. To limit
+                      individual axis speeds, use
                       :py:obj:`.ProtocolContext.max_speeds`.
-        :param publish: Whether a call to this function should publish to the
-                        run log or not.
+
+        :param publish: Whether to list this function call in the
+                        run preview. Default is ``True``. 
         """
         publish_ctx = nullcontext()
 
@@ -1351,7 +1334,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Return the name of the mount the pipette is attached to.
 
-        The possible names are ``left`` and ``right``.
+        The possible names are ``"left"`` and ``"right"``.
         """
         return self._core.get_mount().name.lower()
 
@@ -1365,19 +1348,8 @@ class InstrumentContext(publisher.CommandPublisher):
         operation.
 
         .. note::
-            This property is equivalent to :py:attr:`flow_rate`; the only
-            difference is the units in which this property is specified.
-            Specifying this attribute uses the units of the linear speed of
-            the plunger inside the pipette, while :py:attr:`flow_rate` uses
-            the units of the volumetric flow rate of liquid into or out of the
-            tip. Because :py:attr:`speed` and :py:attr:`flow_rate` modify the
-            same values, setting one will override the other.
-
-        For instance, to set the plunger speed during an aspirate action, do
-
-        .. code-block :: python
-
-            instrument.speed.aspirate = 50
+          Setting values of :py:attr:`flow_rate` will override the values in
+          :py:attr:`speed`.
 
         .. versionchanged:: 2.14
             This property has been removed because it's fundamentally misaligned
@@ -1403,23 +1375,11 @@ class InstrumentContext(publisher.CommandPublisher):
         See :ref:`new-plunger-flow-rates`.
 
         This is an object with attributes ``aspirate``, ``dispense``, and
-        ``blow_out`` holding the flow rates for the corresponding operation.
+        ``blow_out`` holding the flow rate for the corresponding operation.
 
         .. note::
-          This property is equivalent to :py:attr:`speed`; the only
-          difference is the units in which this property is specified.
-          specifying this property uses the units of the volumetric flow rate
-          of liquid into or out of the tip, while :py:attr:`speed` uses the
-          units of the linear speed of the plunger inside the pipette.
-          Because :py:attr:`speed` and :py:attr:`flow_rate` modify the
-          same values, setting one will override the other.
-
-        For instance, to change the flow rate for aspiration on an instrument
-        you would do:
-
-        .. code-block :: python
-
-            instrument.flow_rate.aspirate = 50
+          Setting values of :py:attr:`speed`, which is deprecated, will override the
+          values in :py:attr:`flow_rate`.
 
         """
         return self._core.get_flow_rate()
@@ -1427,7 +1387,7 @@ class InstrumentContext(publisher.CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def type(self) -> str:
-        """One of `'single'` or `'multi'`."""
+        """One of ``'single'`` or ``'multi'``."""
         model = self.name
         if "single" in model:
             return "single"
@@ -1459,6 +1419,8 @@ class InstrumentContext(publisher.CommandPublisher):
         This is the property used to determine where to drop tips and blow out
         liquids when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without
         arguments.
+        
+        By default, the trash container is in slot A3 on Flex and in slot 12 on OT-2.
         """
         return self._trash
 
@@ -1478,7 +1440,7 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 0)
     def model(self) -> str:
         """
-        The model string for the pipette (e.g. 'p300_single_v1.3')
+        The model string for the pipette (e.g., ``'p300_single_v1.3'``)
         """
         return self._core.get_model()
 
@@ -1517,7 +1479,12 @@ class InstrumentContext(publisher.CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 7)
     def has_tip(self) -> bool:
-        """Return whether this instrument has a tip attached or not."""
+        """Whether this instrument has a tip attached or not.
+        
+        The value of this property is determined logically by the API, not by detecting
+        the physical presence of a tip. This is the case even on Flex, which has sensors
+        to detect tip attachment.
+        """
         return self._core.has_tip()
 
     @property
@@ -1543,7 +1510,7 @@ class InstrumentContext(publisher.CommandPublisher):
     def channels(self) -> int:
         """The number of channels on the pipette.
 
-        See :ref:`new-pipette`."""
+        Possible values are 1, 8, or 96."""
         return self._core.get_channels()
 
     @property  # type: ignore
@@ -1552,8 +1519,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """The height to return a tip to its tip rack.
 
         :returns: A scaling factor to apply to the tip length.
-                  During a drop tip, this factor will be multiplied by the tip length
-                  to get the distance from the top of the well where the tip is dropped.
+                  During :py:meth:`.drop_tip`, this factor is multiplied by the tip length
+                  to get the distance from the top of the well to drop the tip.
         """
         return self._core.get_return_height()
 
@@ -1563,7 +1530,7 @@ class InstrumentContext(publisher.CommandPublisher):
         """The distance above the bottom of a well to aspirate or dispense.
 
         This is an object with attributes ``aspirate`` and ``dispense``,
-        describing the default heights of the corresponding operation. The
+        describing the default height of the corresponding operation. The
         default is 1.0 mm for both aspirate and dispense.
 
         When :py:meth:`aspirate` or :py:meth:`dispense` is given a
@@ -1571,11 +1538,9 @@ class InstrumentContext(publisher.CommandPublisher):
         will move this distance above the bottom of the well to aspirate or
         dispense.
 
-        To change, set the corresponding attribute. For instance:
+        To change, set the corresponding attribute::
 
-        .. code-block:: python
-
-            instr.well_bottom_clearance.aspirate = 1
+            pipette.well_bottom_clearance.aspirate = 2
 
         """
         return self._well_bottom_clearances
@@ -1610,8 +1575,9 @@ class InstrumentContext(publisher.CommandPublisher):
         in the mode set by this function until it is called again.
 
         The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a
-        low-volume mode to accurately dispense 1 µL of liquid. Low-volume mode can
-        only be set by calling ``configure_for_volume``. See :ref:`pipette-volume-modes`.
+        low-volume mode to accurately dispense very small volumes of liquid. Low-volume
+        mode can only be set by calling ``configure_for_volume()``. See
+        :ref:`pipette-volume-modes`.
 
         .. note ::
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -622,7 +622,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
 
         :raises RuntimeError: If location cache is ``None``. This should happen if
-                              ``touch_tip()`` is called without first calling a method
+                              ``air_gap()`` is called without first calling a method
                               that takes a location (e.g., :py:meth:`.aspirate`,
                               :py:meth:`dispense`)
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -64,14 +64,14 @@ class InstrumentContext(publisher.CommandPublisher):
 
     Methods generally fall into one of two categories. 
 
-      - They can change the state of the InstrumentContext object, like how fast 
-        it moves liquid or where it disposes of used tips. 
+      - They can change the state of the InstrumentContext object, like how fast it
+        moves liquid or where it disposes of used tips. 
  
-      - They can command the instrument to perform an action, like picking up tips, moving
-        to certain locations, and aspirating or dispensing liquid. 
+      - They can command the instrument to perform an action, like picking up tips,
+        moving to certain locations, and aspirating or dispensing liquid. 
 
-    Objects in this class should not be instantiated directly. Instead,
-    instances are returned by :py:meth:`ProtocolContext.load_instrument`.
+    Objects in this class should not be instantiated directly. Instead, instances are
+    returned by :py:meth:`ProtocolContext.load_instrument`.
 
     .. versionadded:: 2.0
 
@@ -117,9 +117,10 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
 
-            In robot software versions 6.3.0 and 6.3.1, protocols specifying API level 2.14 ignored ``starting_tip`` on the second and subsequent calls to
-            :py:meth:`.InstrumentContext.pick_up_tip` with no argument. This is fixed for all API
-            levels as of robot software version 7.0.0.
+            In robot software versions 6.3.0 and 6.3.1, protocols specifying API level
+            2.14 ignored ``starting_tip`` on the second and subsequent calls to
+            :py:meth:`.InstrumentContext.pick_up_tip` with no argument. This is fixed
+            for all API levels as of robot software version 7.0.0.
         """
         return self._starting_tip
 
@@ -139,11 +140,10 @@ class InstrumentContext(publisher.CommandPublisher):
     def default_speed(self) -> float:
         """The speed at which the robot's gantry moves in mm/s.
 
-        The default speed for Flex varies between 300 and 350 mm/s.
-        The OT-2 default is 400 mm/s. In addition to changing the
-        default, the speed of individual motions can be changed with the
-        ``speed`` argument of the :py:meth:`InstrumentContext.move_to` method.
-        See :ref:`gantry_speed`.
+        The default speed for Flex varies between 300 and 350 mm/s. The OT-2 default is
+        400 mm/s. In addition to changing the default, the speed of individual motions
+        can be changed with the ``speed`` argument of the
+        :py:meth:`InstrumentContext.move_to` method. See :ref:`gantry_speed`.
         """
         return self._core.get_default_speed()
 
@@ -163,24 +163,29 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-aspirate` for more details and examples.
 
-        :param volume: The volume to aspirate, measured in µL. If 0 or
-                       unspecified, defaults to the maximum volume for
-                       the pipette and its currently attached tip.
+        :param volume: The volume to aspirate, measured in µL. If 0 or unspecified,
+                    defaults to the maximum volume for the pipette and its currently
+                    attached tip.
         :type volume: int or float
         :param location: Tells the robot where to aspirate from. The location can be
                          a :py:class:`.Well` or a :py:class:`.Location`.
 
-                            - If the location is a ``Well``, the robot will aspirate at or above
-                              the bottom center of the well. The distance (in mm) from the
-                              well bottom is specified by :py:obj:`well_bottom_clearance.aspirate <well_bottom_clearance>`.
+                            - If the location is a ``Well``, the robot will aspirate at
+                              or above the bottom center of the well. The distance (in mm)
+                              from the well bottom is specified by
+                              :py:obj:`well_bottom_clearance.aspirate
+                              <well_bottom_clearance>`.
 
-                            - If the location is a ``Location`` (e.g., the result of :py:meth:`.Well.top`
-                              or :py:meth:`.Well.bottom`), the robot will aspirate from that specified position.
+                            - If the location is a ``Location`` (e.g., the result of
+                              :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the robot
+                              will aspirate from that specified position.
 
-                            - If the ``location`` is unspecified, the robot will aspirate from its current position.
-        :param rate: A multiplier for the default flow rate of the pipette.
-                     Calculated as ``rate`` multiplied by :py:attr:`flow_rate.aspirate <flow_rate>`.
-                     If not specified, defaults to 1.0. See :ref:`new-plunger-flow-rates`.
+                            - If the ``location`` is unspecified, the robot will
+                              aspirate from its current position.
+        :param rate: A multiplier for the default flow rate of the pipette. Calculated
+                     as ``rate`` multiplied by :py:attr:`flow_rate.aspirate
+                     <flow_rate>`. If not specified, defaults to 1.0. See
+                     :ref:`new-plunger-flow-rates`.
         :type rate: float
         :returns: This instance.
 
@@ -266,44 +271,48 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-dispense` for more details and examples.
 
-        :param volume: The volume to dispense, measured in µL.
-                        If 0 or unspecified, defaults to
-                        :py:attr:`current_volume`.
-                        If only a volume is passed, the pipette
-                        will dispense from its current position.
+        :param volume: The volume to dispense, measured in µL. If 0 or unspecified,
+                       defaults to :py:attr:`current_volume`. If only a volume is
+                       passed, the pipette will dispense from its current position.
         :type volume: int or float
 
         :param location: Tells the robot where to dispense liquid held in the pipette.
                          The location can be a :py:class:`.Well` or a
                          :py:class:`.Location`.
 
-                            - If the location is a ``Well``, the pipette will dispense at or above
-                              the bottom center of the well. The distance (in mm) from the well bottom
-                              is specified by :py:obj:`well_bottom_clearance.dispense <well_bottom_clearance>`.
+                            - If the location is a ``Well``, the pipette will dispense
+                              at or above the bottom center of the well. The distance (in
+                              mm) from the well bottom is specified by
+                              :py:obj:`well_bottom_clearance.dispense
+                              <well_bottom_clearance>`.
 
-                            - If the location is a ``Location`` (e.g., the result of :py:meth:`.Well.top` or
-                              :py:meth:`.Well.bottom`), the robot will dispense into that specified position.
+                            - If the location is a ``Location`` (e.g., the result of
+                              :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the robot
+                              will dispense into that specified position.
 
-                            - If the ``location`` is unspecified, the robot will dispense into its
-                              current position.
+                            - If the ``location`` is unspecified, the robot will
+                              dispense into its current position.
                               
-                            If only a ``location`` is passed (e.g., ``pipette.dispense(location=plate['A1'])``),
-                            all of the liquid aspirated into the pipette will be dispensed
-                            (the amount is accessible through :py:attr:`current_volume`).
+                            If only a ``location`` is passed (e.g.,
+                            ``pipette.dispense(location=plate['A1'])``), all of the
+                            liquid aspirated into the pipette will be dispensed (the
+                            amount is accessible through :py:attr:`current_volume`).
 
         :param rate: How quickly a pipette dispenses liquid. The speed in µL/s is
-                     calculated as ``rate`` multiplied by :py:attr:`flow_rate.dispense <flow_rate>`.
-                     If not specified, defaults to 1.0. See :ref:`new-plunger-flow-rates`.
+                     calculated as ``rate`` multiplied by :py:attr:`flow_rate.dispense
+                     <flow_rate>`. If not specified, defaults to 1.0. See
+                     :ref:`new-plunger-flow-rates`.
         :type rate: float
         :param push_out: Continue past the plunger bottom to help ensure all liquid
-                        leaves the tip. Measured in µL. The default value is ``None``.
+                         leaves the tip. Measured in µL. The default value is ``None``.
         :type push_out: float
 
         :returns: This instance.
 
         .. note::
 
-            If ``dispense`` is called with a single, unnamed argument, it will treat that argument as ``volume``. If you want to call ``dispense`` with only
+            If ``dispense`` is called with a single, unnamed argument, it will treat
+            that argument as ``volume``. If you want to call ``dispense`` with only
             ``location``, specify it as a keyword argument:
             ``pipette.dispense(location=plate['A1'])``.
 
@@ -392,18 +401,17 @@ class InstrumentContext(publisher.CommandPublisher):
         See :ref:`mix` for examples.
 
         :param repetitions: Number of times to mix (default is 1).
-        :param volume: The volume to mix, measured in µL. If 0 or unspecified,
-                       defaults to the maximum volume for the pipette and its
-                       attached tip.
-        :param location: The :py:class:`.Well` or :py:class:`~.types.Location` where 
-                         the pipette will mix. If unspecified, the pipette will mix at
-                         its current position.
-        :param rate: How quickly the pipette aspirates and dispenses liquid
-                    while mixing. The aspiration flow rate is calculated as
-                    ``rate`` multiplied by :py:attr:`flow_rate.aspirate <flow_rate>`.
-                    The dispensing flow rate is calculated
-                    as ``rate`` multiplied by :py:attr:`flow_rate.dispense <flow_rate>`.
-                    See :ref:`new-plunger-flow-rates`.
+        :param volume: The volume to mix, measured in µL. If 0 or unspecified, defaults
+                       to the maximum volume for the pipette and its attached tip.
+        :param location: The :py:class:`.Well` or :py:class:`~.types.Location` where the
+                        pipette will mix. If unspecified, the pipette will mix at its
+                        current position.
+        :param rate: How quickly the pipette aspirates and dispenses liquid while
+                     mixing. The aspiration flow rate is calculated as ``rate``
+                     multiplied by :py:attr:`flow_rate.aspirate <flow_rate>`. The
+                     dispensing flow rate is calculated as ``rate`` multiplied by
+                     :py:attr:`flow_rate.dispense <flow_rate>`. See
+                     :ref:`new-plunger-flow-rates`.
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
         :returns: This instance.
 
@@ -450,20 +458,19 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Blow an extra amount of air through a pipette's tip to clear it.
 
-        If :py:meth:`dispense` is used to empty a pipette, usually
-        a small amount of liquid remains in the tip. During
-        a blowout, the pipette moves the plunger beyond its normal
-        limits to help remove all liquid from the pipette tip.
-        See :ref:`blow-out`.
+        If :py:meth:`dispense` is used to empty a pipette, usually a small amount of
+        liquid remains in the tip. During a blowout, the pipette moves the plunger
+        beyond its normal limits to help remove all liquid from the pipette tip. See
+        :ref:`blow-out`.
 
-        :param location: The blowout location. If no location is specified,
-                         the pipette will blow out from its current position.
+        :param location: The blowout location. If no location is specified, the pipette
+                         will blow out from its current position.
         :type location: :py:class:`.Well` or :py:class:`.Location` or ``None``
 
         :raises RuntimeError: If no location is specified and the location cache is
                               ``None``. This should happen if ``blow_out()`` is called
-                              without first calling a method that takes a
-                              location, like :py:meth:`.aspirate` or :py:meth:`dispense`.
+                              without first calling a method that takes a location, like
+                              :py:meth:`.aspirate` or :py:meth:`dispense`.
         :returns: This instance.
         """
         well: Optional[labware.Well] = None
@@ -525,13 +532,13 @@ class InstrumentContext(publisher.CommandPublisher):
         
         See :ref:`touch-tip` for more details and examples.
 
-        :param location: If no location is passed, the pipette will
-                         touch its tip at the edges of the current well.
+        :param location: If no location is passed, the pipette will touch its tip at the
+                         edges of the current well.
         :type location: :py:class:`.Well` or ``None``
-        :param radius: How far to move, as a proportion of the target well's
-                       radius. When ``radius=1.0``, the pipette tip will move all the way to
-                       the edge of the target well. When ``radius=0.5``, it will
-                       move to 50% of the well's radius. Default is 1.0 (100%)
+        :param radius: How far to move, as a proportion of the target well's radius.
+                       When ``radius=1.0``, the pipette tip will move all the way to the
+                       edge of the target well. When ``radius=0.5``, it will move to 50%
+                       of the well's radius. Default is 1.0 (100%)
         :type radius: float
         :param v_offset: How far above or below the well to touch the tip, measured in mm.
                          A positive offset moves the tip higher above the well.
@@ -547,9 +554,8 @@ class InstrumentContext(publisher.CommandPublisher):
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
         :raises RuntimeError: If no location is specified and the location cache is
                               ``None``. This should happen if ``touch_tip`` is called
-                              without first calling a method that takes a
-                              location, like :py:meth:`.aspirate` or
-                              :py:meth:`dispense`.
+                              without first calling a method that takes a location, like
+                              :py:meth:`.aspirate` or :py:meth:`dispense`.
         :returns: This instance.
         """
         if not self._core.has_tip():
@@ -605,23 +611,19 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`air-gap`.
 
-        :param volume: The amount of air, measured in µL.
-                       Calling ``air_gap()`` with no arguments uses
-                       the entire remaining volume in the pipette.
+        :param volume: The amount of air, measured in µL. Calling ``air_gap()`` with no
+                       arguments uses the entire remaining volume in the pipette.
         :type volume: float
 
-
-        :param height: The height, in mm, to move above the current well
-                       before creating the air gap. The default is 5 mm above the current well.
-
+        :param height: The height, in mm, to move above the current well before creating
+                       the air gap. The default is 5 mm above the current well.
         :type height: float
 
         :raises: ``UnexpectedTipRemovalError`` -- If no tip is attached to the pipette.
 
-        :raises RuntimeError: If location cache is ``None``.
-                              This should happen if ``touch_tip()`` is called
-                              without first calling a method that takes a
-                              location (e.g., :py:meth:`.aspirate`,
+        :raises RuntimeError: If location cache is ``None``. This should happen if
+                              ``touch_tip()`` is called without first calling a method
+                              that takes a location (e.g., :py:meth:`.aspirate`,
                               :py:meth:`dispense`)
 
         :returns: This instance.
@@ -654,8 +656,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Drop the currently attached tip in its original location in the tip rack.
 
-        Returning a tip does not reset tip tracking, so :py:obj:`.Well.has_tip` will remain
-        ``False`` for the destination.
+        Returning a tip does not reset tip tracking, so :py:obj:`.Well.has_tip` will
+        remain ``False`` for the destination.
 
         :returns: This instance.
 
@@ -686,11 +688,11 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`basic-tip-pickup`.
 
-        If no location is passed, the pipette will pick up the next available
-        tip in its :py:attr:`~.InstrumentContext.tip_racks` list.
-        Within each tip rack, tips will be picked up in the order specified by
-        the labware definition and :py:meth:`.Labware.wells`.
-        To adjust where the sequence starts, use :py:obj:`.starting_tip`.
+        If no location is passed, the pipette will pick up the next available tip in its
+        :py:attr:`~.InstrumentContext.tip_racks` list. Within each tip rack, tips will
+        be picked up in the order specified by the labware definition and
+        :py:meth:`.Labware.wells`. To adjust where the sequence starts, use
+        :py:obj:`.starting_tip`.
 
         :param location: The location from which to pick up a tip. The ``location``
                          argument can be specified in several ways:
@@ -710,25 +712,24 @@ class InstrumentContext(publisher.CommandPublisher):
                              the top of the well in the tip rack, call
                              ``pipette.pick_up_tip(tiprack["A1"].top(z=-1))``.
         :type location: :py:class:`.Well` or :py:class:`.Labware` or :py:class:`.types.Location`
-        :param presses: The number of times to lower and then raise the pipette
-                        when picking up a tip, to ensure a good seal. Zero (``0``)
-                        will result in the pipette hovering over the tip but
-                        not picking it up (generally not desirable, but could
-                        be used for a dry run).
+        :param presses: The number of times to lower and then raise the pipette when
+                        picking up a tip, to ensure a good seal. Zero (``0``) will
+                        result in the pipette hovering over the tip but not picking it
+                        up (generally not desirable, but could be used for a dry run).
 
                             .. deprecated:: 2.14
                                 Use the Opentrons App to change pipette pick-up settings.
         :type presses: int
         :param increment: The additional distance to travel on each successive press.
-            For example, if ``presses=3`` and ``increment=1.0``, then the first press
-            will travel down into the tip by 3.5 mm, the second by 4.5 mm, and the
-            third by 5.5 mm).
+                          For example, if ``presses=3`` and ``increment=1.0``, then the
+                          first press will travel down into the tip by 3.5 mm, the
+                          second by 4.5 mm, and the third by 5.5 mm).
 
-                .. deprecated:: 2.14
-                    Use the Opentrons App to change pipette pick-up settings.
+                              .. deprecated:: 2.14
+                                  Use the Opentrons App to change pipette pick-up settings.
         :type increment: float
-        :param prep_after: Whether the pipette plunger should prepare itself
-                           to aspirate immediately after picking up a tip.
+        :param prep_after: Whether the pipette plunger should prepare itself to aspirate
+                           immediately after picking up a tip.
 
                            If ``True``, the pipette will move its plunger position to
                            bottom in preparation for any following calls to
@@ -736,13 +737,13 @@ class InstrumentContext(publisher.CommandPublisher):
 
                            If ``False``, the pipette will prepare its plunger later,
                            during the next call to :py:meth:`.aspirate`. This is
-                           accomplished by moving the tip to the top of the well,
-                           and positioning the plunger outside any potential liquids.
+                           accomplished by moving the tip to the top of the well, and
+                           positioning the plunger outside any potential liquids.
 
                            .. warning::
-                               This is provided for compatibility with older
-                               Python Protocol API behavior. You should normally
-                               leave this unset.
+                               This is provided for compatibility with older Python
+                               Protocol API behavior. You should normally leave this
+                               unset.
 
                                Setting ``prep_after=False`` may create an unintended
                                pipette movement, when the pipette automatically moves
@@ -750,10 +751,10 @@ class InstrumentContext(publisher.CommandPublisher):
         :type prep_after: bool
 
         .. versionchanged:: 2.13
-            Adds the ``prep_after`` argument. In version 2.12 and earlier, the plunger can't prepare
-            itself for aspiration during :py:meth:`.pick_up_tip`, and will instead always
-            prepare during :py:meth:`.aspirate`. Version 2.12 and earlier will raise an
-            ``APIVersionError`` if a value is set for ``prep_after``.
+            Adds the ``prep_after`` argument. In version 2.12 and earlier, the plunger
+            can't prepare itself for aspiration during :py:meth:`.pick_up_tip`, and will
+            instead always prepare during :py:meth:`.aspirate`. Version 2.12 and earlier
+            will raise an ``APIVersionError`` if a value is set for ``prep_after``.
 
         :returns: This instance.
         """
@@ -869,17 +870,17 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`pipette-drop-tip` for examples.
 
-        If no location is passed (e.g. ``pipette.drop_tip()``), the pipette will drop the
-        attached tip into its default :py:attr:`trash_container`. 
+        If no location is passed (e.g. ``pipette.drop_tip()``), the pipette will drop
+        the attached tip into its default :py:attr:`trash_container`. 
 
-        Starting with API version 2.15, if the trash container is the default fixed trash,
-        the API will instruct the pipette to drop tips in different locations within
-        the trash container. Varying the tip drop location helps prevent tips from piling up
-        in a single location.
+        Starting with API version 2.15, if the trash container is the default fixed
+        trash, the API will instruct the pipette to drop tips in different locations
+        within the trash container. Varying the tip drop location helps prevent tips
+        from piling up in a single location.
 
-        The location in which to drop the tip can be manually specified with
-        the ``location`` argument. The ``location`` argument can be specified in
-        several ways:
+        The location in which to drop the tip can be manually specified with the
+        ``location`` argument. The ``location`` argument can be specified in several
+        ways:
 
             - As a :py:class:`.Well`. This uses a default location relative to the well.
               This style of call can be used to make the robot drop a tip into labware
@@ -894,8 +895,8 @@ class InstrumentContext(publisher.CommandPublisher):
         :type location:
             :py:class:`~.types.Location` or :py:class:`.Well` or ``None``
         :param home_after:
-            Whether to home the pipette's plunger after dropping the tip.
-            If not specified, defaults to ``True`` on an OT-2.
+            Whether to home the pipette's plunger after dropping the tip. If not
+            specified, defaults to ``True`` on an OT-2.
 
             When ``False``, the pipette does not home its plunger. This can save a few
             seconds, but is not recommended. Homing helps the robot track the pipette's
@@ -1001,7 +1002,9 @@ class InstrumentContext(publisher.CommandPublisher):
         :param kwargs: See :py:meth:`transfer` and the :ref:`complex_params` page.
             Some parameters behave differently than when transferring.
 
-              - ``disposal_volume`` aspirates additional liquid to improve the accuracy of each dispense. Defaults to the minimum volume of the pipette. See :ref:`param-disposal-volume` for details.
+              - ``disposal_volume`` aspirates additional liquid to improve the accuracy
+                of each dispense. Defaults to the minimum volume of the pipette. See
+                :ref:`param-disposal-volume` for details.
 
               - ``mix_after`` is ignored.
 
@@ -1072,25 +1075,24 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         Move liquid from one well or group of wells to another. 
         
-        Transfer is a
-        higher-level command, incorporating other :py:class:`InstrumentContext`
-        commands, like :py:meth:`aspirate` and :py:meth:`dispense`. It makes writing a
-        protocol easier at the cost of specificity. See :ref:`v2-complex-commands` for
-        details on how transfer and other complex commands perform their component steps.
+        Transfer is a higher-level command, incorporating other
+        :py:class:`InstrumentContext` commands, like :py:meth:`aspirate` and
+        :py:meth:`dispense`. It makes writing a protocol easier at the cost of
+        specificity. See :ref:`v2-complex-commands` for details on how transfer and
+        other complex commands perform their component steps.
 
-        :param volume: The amount, in µL, to aspirate from each source and
-                       dispense to each destination.
-                       If ``volume`` is a list, each amount will be used for the source
-                       and destination at the matching index. A list item of ``0`` will
-                       skip the corresponding wells entirely. See
+        :param volume: The amount, in µL, to aspirate from each source and dispense to
+                       each destination. If ``volume`` is a list, each amount will be
+                       used for the source and destination at the matching index. A list
+                       item of ``0`` will skip the corresponding wells entirely. See
                        :ref:`complex-list-volumes` for details and examples.
         :param source: A single well or a list of wells to aspirate liquid from.
         :param dest: A single well or a list of wells to dispense liquid into.
 
         :Keyword Arguments: Transfer accepts a number of optional parameters that give
-            you greater control over the exact steps it performs. See :ref:`complex_params`
-            or the links under each argument's entry below for additional details and
-            examples.
+            you greater control over the exact steps it performs. See
+            :ref:`complex_params` or the links under each argument's entry below for
+            additional details and examples.
 
             * **new_tip** (*string*) --
               When to pick up and drop tips during the command. Defaults to ``"once"``.
@@ -1129,7 +1131,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
               If ``blow_out`` is ``True`` and this parameter is not set:
 
-                - Blow out into the trash, if the pipette is empty or only contains the disposal volume.
+                - Blow out into the trash, if the pipette is empty or only contains the
+                  disposal volume.
 
                 - Blow out into the source well, if the pipette otherwise contains liquid.
 
@@ -1290,23 +1293,22 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param location: The location to move to.
         :type location: :py:class:`~.types.Location`
-        :param force_direct: If ``True``, move directly to the destination
-                             without arc motion.
+        :param force_direct: If ``True``, move directly to the destination without arc
+                             motion.
                              
                              .. warning::
                                 Forcing direct motion can cause the pipette to crash
                                 into labware, modules, or other objects on the deck.
 
-        :param minimum_z_height: An amount, measured in mm, to raise
-                                 the mid-arc height. The mid-arc height can't be lowered.
+        :param minimum_z_height: An amount, measured in mm, to raise the mid-arc height.
+                                 The mid-arc height can't be lowered.
         :param speed: The speed at which to move. By default,
-                      :py:attr:`InstrumentContext.default_speed`. This controls
-                      the straight linear speed of the motion. To limit
-                      individual axis speeds, use
-                      :py:obj:`.ProtocolContext.max_speeds`.
+                      :py:attr:`InstrumentContext.default_speed`. This controls the
+                      straight linear speed of the motion. To limit individual axis
+                      speeds, use :py:obj:`.ProtocolContext.max_speeds`.
 
-        :param publish: Whether to list this function call in the
-                        run preview. Default is ``True``. 
+        :param publish: Whether to list this function call in the run preview. 
+                        Default is ``True``. 
         """
         publish_ctx = nullcontext()
 
@@ -1343,18 +1345,17 @@ class InstrumentContext(publisher.CommandPublisher):
     def speed(self) -> "PlungerSpeeds":
         """The speeds (in mm/s) configured for the pipette plunger.
 
-        This is an object with attributes ``aspirate``, ``dispense``, and
-        ``blow_out`` holding the plunger speeds for the corresponding
-        operation.
+        This is an object with attributes ``aspirate``, ``dispense``, and ``blow_out``
+        holding the plunger speeds for the corresponding operation.
 
         .. note::
           Setting values of :py:attr:`flow_rate` will override the values in
           :py:attr:`speed`.
 
         .. versionchanged:: 2.14
-            This property has been removed because it's fundamentally misaligned
-            with the step-wise nature of a pipette's plunger speed configuration.
-            Use :py:attr:`.flow_rate` instead.
+            This property has been removed because it's fundamentally misaligned with
+            the step-wise nature of a pipette's plunger speed configuration. Use
+            :py:attr:`.flow_rate` instead.
         """
         if self._api_version >= ENGINE_CORE_API_VERSION:
             raise APIVersionError(
@@ -1374,8 +1375,8 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-plunger-flow-rates`.
 
-        This is an object with attributes ``aspirate``, ``dispense``, and
-        ``blow_out`` holding the flow rate for the corresponding operation.
+        This is an object with attributes ``aspirate``, ``dispense``, and ``blow_out``
+        holding the flow rate for the corresponding operation.
 
         .. note::
           Setting values of :py:attr:`speed`, which is deprecated, will override the
@@ -1402,8 +1403,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The tip racks that have been linked to this pipette.
 
-        This is the property used to determine which tips to pick up next when
-        calling :py:meth:`pick_up_tip` without arguments. See :ref:`basic-tip-pickup`.
+        This is the property used to determine which tips to pick up next when calling
+        :py:meth:`pick_up_tip` without arguments. See :ref:`basic-tip-pickup`.
         """
         return self._tip_racks
 
@@ -1416,9 +1417,8 @@ class InstrumentContext(publisher.CommandPublisher):
     def trash_container(self) -> labware.Labware:
         """The trash container associated with this pipette.
 
-        This is the property used to determine where to drop tips and blow out
-        liquids when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without
-        arguments.
+        This is the property used to determine where to drop tips and blow out liquids
+        when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without arguments.
         
         By default, the trash container is in slot A3 on Flex and in slot 12 on OT-2.
         """
@@ -1449,8 +1449,8 @@ class InstrumentContext(publisher.CommandPublisher):
     def min_volume(self) -> float:
         """
         The minimum volume, in µL, that the pipette can hold. This value may change
-        based on the :ref:`volume mode <pipette-volume-modes>` that the pipette
-        is currently configured for.
+        based on the :ref:`volume mode <pipette-volume-modes>` that the pipette is
+        currently configured for.
         """
         return self._core.get_min_volume()
 
@@ -1460,11 +1460,10 @@ class InstrumentContext(publisher.CommandPublisher):
         """
         The maximum volume, in µL, that the pipette can hold.
 
-        The maximum volume that you can actually aspirate might be lower than
-        this, depending on what kind of tip is attached to this pipette. For
-        example, a P300 Single-Channel pipette always has a ``max_volume`` of
-        300 µL, but if it's using a 200 µL filter tip, its usable volume would
-        be limited to 200 µL.
+        The maximum volume that you can actually aspirate might be lower than this,
+        depending on what kind of tip is attached to this pipette. For example, a P300
+        Single-Channel pipette always has a ``max_volume`` of 300 µL, but if it's using
+        a 200 µL filter tip, its usable volume would be limited to 200 µL.
         """
         return self._core.get_max_volume()
 
@@ -1519,8 +1518,8 @@ class InstrumentContext(publisher.CommandPublisher):
         """The height to return a tip to its tip rack.
 
         :returns: A scaling factor to apply to the tip length.
-                  During :py:meth:`.drop_tip`, this factor is multiplied by the tip length
-                  to get the distance from the top of the well to drop the tip.
+                  During :py:meth:`.drop_tip`, this factor is multiplied by the tip
+                  length to get the distance from the top of the well to drop the tip.
         """
         return self._core.get_return_height()
 
@@ -1529,14 +1528,13 @@ class InstrumentContext(publisher.CommandPublisher):
     def well_bottom_clearance(self) -> "Clearances":
         """The distance above the bottom of a well to aspirate or dispense.
 
-        This is an object with attributes ``aspirate`` and ``dispense``,
-        describing the default height of the corresponding operation. The
-        default is 1.0 mm for both aspirate and dispense.
+        This is an object with attributes ``aspirate`` and ``dispense``, describing the
+        default height of the corresponding operation. The default is 1.0 mm for both
+        aspirate and dispense.
 
-        When :py:meth:`aspirate` or :py:meth:`dispense` is given a
-        :py:class:`.Well` rather than a full :py:class:`.Location`, the robot
-        will move this distance above the bottom of the well to aspirate or
-        dispense.
+        When :py:meth:`aspirate` or :py:meth:`dispense` is given a :py:class:`.Well`
+        rather than a full :py:class:`.Location`, the robot will move this distance
+        above the bottom of the well to aspirate or dispense.
 
         To change, set the corresponding attribute::
 
@@ -1569,10 +1567,11 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 15)
     def configure_for_volume(self, volume: float) -> None:
         """Configure a pipette to handle a specific volume of liquid, measured in µL.
-        The pipette enters a volume mode depending on the volume provided. Changing pipette
-        modes alters properties of the instance of :py:class:`.InstrumentContext`,
-        such as default flow rate, minimum volume, and maximum volume. The pipette remains
-        in the mode set by this function until it is called again.
+        The pipette enters a volume mode depending on the volume provided. Changing
+        pipette modes alters properties of the instance of
+        :py:class:`.InstrumentContext`, such as default flow rate, minimum volume, and
+        maximum volume. The pipette remains in the mode set by this function until it is
+        called again.
 
         The Flex 1-Channel 50 µL and Flex 8-Channel 50 µL pipettes must operate in a
         low-volume mode to accurately dispense very small volumes of liquid. Low-volume
@@ -1581,14 +1580,16 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note ::
 
-            Changing a pipette's mode will reset its :ref:`flow rates <new-plunger-flow-rates>`.
+            Changing a pipette's mode will reset its :ref:`flow rates
+            <new-plunger-flow-rates>`.
 
-        This function will raise an error if called when the pipette's tip contains liquid.
-        It won't raise an error if a tip is not attached, but changing modes may affect which
-        tips the pipette can subsequently pick up without raising an error.
+        This function will raise an error if called when the pipette's tip contains
+        liquid. It won't raise an error if a tip is not attached, but changing modes may
+        affect which tips the pipette can subsequently pick up without raising an error.
 
-        This function will also raise an error if ``volume`` is outside of the :ref:`minimum
-        and maximum capacities <new-pipette-models>` of the pipette (e.g., setting ``volume=1`` for a Flex 1000 µL pipette).
+        This function will also raise an error if ``volume`` is outside of the
+        :ref:`minimum and maximum capacities <new-pipette-models>` of the pipette (e.g.,
+        setting ``volume=1`` for a Flex 1000 µL pipette).
 
         :param volume: The volume, in µL, that the pipette will prepare to handle.
         :type volume: float

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -60,15 +60,15 @@ class InstrumentContext(publisher.CommandPublisher):
     A context for a specific pipette or instrument.
 
     The InstrumentContext class provides the objects, attributes, and methods that allow
-    you to use pipettes in your protocols. 
+    you to use pipettes in your protocols.
 
-    Methods generally fall into one of two categories. 
+    Methods generally fall into one of two categories.
 
       - They can change the state of the InstrumentContext object, like how fast it
-        moves liquid or where it disposes of used tips. 
- 
+        moves liquid or where it disposes of used tips.
+
       - They can command the instrument to perform an action, like picking up tips,
-        moving to certain locations, and aspirating or dispensing liquid. 
+        moving to certain locations, and aspirating or dispensing liquid.
 
     Objects in this class should not be instantiated directly. Instead, instances are
     returned by :py:meth:`ProtocolContext.load_instrument`.
@@ -292,7 +292,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
                             - If the ``location`` is unspecified, the robot will
                               dispense into its current position.
-                              
+
                             If only a ``location`` is passed (e.g.,
                             ``pipette.dispense(location=plate['A1'])``), all of the
                             liquid aspirated into the pipette will be dispensed (the
@@ -420,7 +420,7 @@ class InstrumentContext(publisher.CommandPublisher):
             All the arguments of ``mix`` are optional. However, if you omit one of them,
             all subsequent arguments must be passed as keyword arguments. For instance,
             ``pipette.mix(1, location=wellplate['A1'])`` is a valid call, but
-            ``pipette.mix(1, wellplate['A1'])`` is not. 
+            ``pipette.mix(1, wellplate['A1'])`` is not.
 
         """
         _log.debug(
@@ -528,8 +528,8 @@ class InstrumentContext(publisher.CommandPublisher):
         speed: float = 60.0,
     ) -> InstrumentContext:
         """
-        Touch the pipette tip to the sides of a well, with the intent of removing leftover droplets. 
-        
+        Touch the pipette tip to the sides of a well, with the intent of removing leftover droplets.
+
         See :ref:`touch-tip` for more details and examples.
 
         :param location: If no location is passed, the pipette will touch its tip at the
@@ -871,7 +871,7 @@ class InstrumentContext(publisher.CommandPublisher):
         See :ref:`pipette-drop-tip` for examples.
 
         If no location is passed (e.g. ``pipette.drop_tip()``), the pipette will drop
-        the attached tip into its default :py:attr:`trash_container`. 
+        the attached tip into its default :py:attr:`trash_container`.
 
         Starting with API version 2.15, if the trash container is the default fixed
         trash, the API will instruct the pipette to drop tips in different locations
@@ -1073,8 +1073,8 @@ class InstrumentContext(publisher.CommandPublisher):
         # TODO: What should happen if the user passes a non-first-row well
         # TODO: ..as src/dest *while using multichannel pipette?
         """
-        Move liquid from one well or group of wells to another. 
-        
+        Move liquid from one well or group of wells to another.
+
         Transfer is a higher-level command, incorporating other
         :py:class:`InstrumentContext` commands, like :py:meth:`aspirate` and
         :py:meth:`dispense`. It makes writing a protocol easier at the cost of
@@ -1288,14 +1288,14 @@ class InstrumentContext(publisher.CommandPublisher):
         publish: bool = True,
     ) -> InstrumentContext:
         """Move the instrument.
-        
+
         See :ref:`move-to` for examples.
 
         :param location: The location to move to.
         :type location: :py:class:`~.types.Location`
         :param force_direct: If ``True``, move directly to the destination without arc
                              motion.
-                             
+
                              .. warning::
                                 Forcing direct motion can cause the pipette to crash
                                 into labware, modules, or other objects on the deck.
@@ -1307,8 +1307,8 @@ class InstrumentContext(publisher.CommandPublisher):
                       straight linear speed of the motion. To limit individual axis
                       speeds, use :py:obj:`.ProtocolContext.max_speeds`.
 
-        :param publish: Whether to list this function call in the run preview. 
-                        Default is ``True``. 
+        :param publish: Whether to list this function call in the run preview.
+                        Default is ``True``.
         """
         publish_ctx = nullcontext()
 
@@ -1419,7 +1419,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         This is the property used to determine where to drop tips and blow out liquids
         when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without arguments.
-        
+
         By default, the trash container is in slot A3 on Flex and in slot 12 on OT-2.
         """
         return self._trash
@@ -1479,7 +1479,7 @@ class InstrumentContext(publisher.CommandPublisher):
     @requires_version(2, 7)
     def has_tip(self) -> bool:
         """Whether this instrument has a tip attached or not.
-        
+
         The value of this property is determined logically by the API, not by detecting
         the physical presence of a tip. This is the case even on Flex, which has sensors
         to detect tip attachment.


### PR DESCRIPTION

# Overview

Following up on #13780 with some additional improvements to docstrings within `InstrumentContext`.

# Changelog

- various text changes _passim_
- fixed up some broken bullet formatting
- enforcing 88-character lines (except for ✨ special ✨ first lines, which may run long)

# Review requests

Please make sure that nothing from 2.16 is getting swept up into the [API Reference](http://sandbox.docs.opentrons.com/more-instrumentcontext-docstrings/v2/new_protocol_api.html). If it is, we can make a temporary exclusion so we can deploy these changes.

# Risk assessment

v low, just the possibility of surfacing some pre-release stuff, mitigated by above