### PR TITLE
feat(app): oDD labware setup map migration to using baseDeck

### DIFF
--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -132,7 +132,7 @@ export function parseInitialLoadedLabwareBySlot(
   )
 }
 
-interface LoadedLabwareByAdapter {
+export interface LoadedLabwareByAdapter {
   [labwareId: string]: LoadLabwareRunTimeCommand
 }
 export function parseInitialLoadedLabwareByAdapter(

--- a/app/src/organisms/ProtocolSetupLabware/LabwareMapViewModal.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/LabwareMapViewModal.tsx
@@ -1,0 +1,149 @@
+import * as React from 'react'
+import map from 'lodash/map'
+import { useTranslation } from 'react-i18next'
+import {
+  BaseDeck,
+  EXTENDED_DECK_CONFIG_FIXTURE,
+  LabwareRender,
+} from '@opentrons/components'
+import {
+  FLEX_ROBOT_TYPE,
+  getDeckDefFromRobotType,
+  LabwareDefinition2,
+  THERMOCYCLER_MODULE_V1,
+} from '@opentrons/shared-data'
+import { RunTimeCommand } from '@opentrons/shared-data'
+
+import { Modal } from '../../molecules/Modal'
+import { getDeckConfigFromProtocolCommands } from '../../resources/deck_configuration/utils'
+import { useFeatureFlag } from '../../redux/config'
+import { getStandardDeckViewLayerBlockList } from '../Devices/ProtocolRun/utils/getStandardDeckViewLayerBlockList'
+import { getLabwareRenderInfo } from '../Devices/ProtocolRun/utils/getLabwareRenderInfo'
+import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { AttachedProtocolModuleMatch } from '../ProtocolSetupModulesAndDeck/utils'
+
+import type { LoadedLabwareByAdapter } from '@opentrons/api-client'
+import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
+
+interface LabwareMapViewModalProps {
+  runId: string
+  attachedProtocolModuleMatches: AttachedProtocolModuleMatch[]
+  handleLabwareClick: (
+    labwareDef: LabwareDefinition2,
+    labwareId: string
+  ) => void
+  onCloseClick: () => void
+  initialLoadedLabwareByAdapter: LoadedLabwareByAdapter
+  commands: RunTimeCommand[]
+}
+
+export function LabwareMapViewModal({
+  handleLabwareClick,
+  runId,
+  onCloseClick,
+  attachedProtocolModuleMatches,
+  initialLoadedLabwareByAdapter,
+  commands,
+}: LabwareMapViewModalProps): JSX.Element {
+  const { t } = useTranslation('protocol_setup')
+  const enableDeckConfig = useFeatureFlag('enableDeckConfiguration')
+
+  const deckConfig = enableDeckConfig
+    ? EXTENDED_DECK_CONFIG_FIXTURE
+    : getDeckConfigFromProtocolCommands(commands)
+
+  const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
+  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+  const labwareRenderInfo =
+    mostRecentAnalysis != null
+      ? getLabwareRenderInfo(mostRecentAnalysis, deckDef)
+      : {}
+
+  const modalHeader: ModalHeaderBaseProps = {
+    title: t('map_view'),
+    hasExitIcon: true,
+  }
+
+  const moduleLocations = attachedProtocolModuleMatches.map(module => {
+    const {
+      moduleDef,
+      nestedLabwareDef,
+      nestedLabwareId,
+      slotName,
+      x,
+      y,
+    } = module
+    const labwareInAdapterInMod =
+      nestedLabwareId != null
+        ? initialLoadedLabwareByAdapter[nestedLabwareId]
+        : null
+    //  only rendering the labware on top most layer so
+    //  either the adapter or the labware are rendered but not both
+    const topLabwareDefinition =
+      labwareInAdapterInMod?.result?.definition ?? nestedLabwareDef
+    const topLabwareId =
+      labwareInAdapterInMod?.result?.labwareId ?? nestedLabwareId
+    return {
+      moduleModel: moduleDef.model,
+      moduleLocation: { slotName },
+      innerProps:
+        moduleDef.model === THERMOCYCLER_MODULE_V1
+          ? { lidMotorState: 'open' }
+          : {},
+      nestedLabwareDef: topLabwareDefinition,
+      moduleChildren:
+        topLabwareDefinition != null && topLabwareId != null ? (
+          <React.Fragment
+            key={`LabwareSetup_Labware_${topLabwareId}_${x}_${y}`}
+          >
+            <LabwareRender
+              definition={topLabwareDefinition}
+              onLabwareClick={() =>
+                handleLabwareClick(topLabwareDefinition, topLabwareId)
+              }
+            />
+          </React.Fragment>
+        ) : null,
+    }
+  })
+
+  const labwareLocations = map(
+    labwareRenderInfo,
+    ({ x, y, labwareDef, slotName }, labwareId) => {
+      const labwareInAdapter = initialLoadedLabwareByAdapter[labwareId]
+      //  only rendering the labware on top most layer so
+      //  either the adapter or the labware are rendered but not both
+      const topLabwareDefinition =
+        labwareInAdapter?.result?.definition ?? labwareDef
+      const topLabwareId = labwareInAdapter?.result?.labwareId ?? labwareId
+
+      return {
+        labwareLocation: { slotName },
+        definition: topLabwareDefinition,
+        topLabwareId,
+        labwareChildren: (
+          <React.Fragment key={`LabwareSetup_Labware_${topLabwareId}_${x}${y}`}>
+            <LabwareRender
+              definition={topLabwareDefinition}
+              onLabwareClick={() =>
+                handleLabwareClick(topLabwareDefinition, topLabwareId)
+              }
+            />
+          </React.Fragment>
+        ),
+      }
+    }
+  )
+
+  return (
+    <Modal header={modalHeader} modalSize="large" onOutsideClick={onCloseClick}>
+      <BaseDeck
+        deckConfig={deckConfig}
+        deckLayerBlocklist={getStandardDeckViewLayerBlockList(FLEX_ROBOT_TYPE)}
+        robotType={FLEX_ROBOT_TYPE}
+        labwareLocations={labwareLocations}
+        moduleLocations={moduleLocations}
+      />
+    </Modal>
+  )
+}

--- a/app/src/organisms/ProtocolSetupLabware/__tests__/LabwareMapViewModal.test.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/__tests__/LabwareMapViewModal.test.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react'
+import { StaticRouter } from 'react-router-dom'
+import { when, resetAllWhenMocks } from 'jest-when'
+import {
+  renderWithProviders,
+  BaseDeck,
+  EXTENDED_DECK_CONFIG_FIXTURE,
+} from '@opentrons/components'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import deckDefFixture from '@opentrons/shared-data/deck/fixtures/3/deckExample.json'
+import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
+import { i18n } from '../../../i18n'
+import { getDeckConfigFromProtocolCommands } from '../../../resources/deck_configuration/utils'
+import { useFeatureFlag } from '../../../redux/config'
+import { getLabwareRenderInfo } from '../../Devices/ProtocolRun/utils/getLabwareRenderInfo'
+import { getStandardDeckViewLayerBlockList } from '../../Devices/ProtocolRun/utils/getStandardDeckViewLayerBlockList'
+import { mockProtocolModuleInfo } from '../__fixtures__'
+import { LabwareMapViewModal } from '../LabwareMapViewModal'
+
+import type {
+  CompletedProtocolAnalysis,
+  DeckDefinition,
+  LabwareDefinition2,
+  ModuleModel,
+} from '@opentrons/shared-data'
+
+jest.mock('../../Devices/ProtocolRun/utils/getLabwareRenderInfo')
+jest.mock('@opentrons/components/src/hardware-sim/Labware/LabwareRender')
+jest.mock('@opentrons/components/src/hardware-sim/BaseDeck')
+jest.mock('../../../resources/deck_configuration/utils')
+jest.mock('../../../redux/config')
+
+const mockGetLabwareRenderInfo = getLabwareRenderInfo as jest.MockedFunction<
+  typeof getLabwareRenderInfo
+>
+const mockGetDeckConfigFromProtocolCommands = getDeckConfigFromProtocolCommands as jest.MockedFunction<
+  typeof getDeckConfigFromProtocolCommands
+>
+const mockUseFeatureFlag = useFeatureFlag as jest.MockedFunction<
+  typeof useFeatureFlag
+>
+
+const mockBaseDeck = BaseDeck as jest.MockedFunction<typeof BaseDeck>
+const MOCK_300_UL_TIPRACK_COORDS = [30, 40, 0]
+
+const render = (props: React.ComponentProps<typeof LabwareMapViewModal>) => {
+  return renderWithProviders(
+    <StaticRouter>
+      <LabwareMapViewModal {...props} />
+    </StaticRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('LabwareMapViewModal', () => {
+  beforeEach(() => {
+    mockGetLabwareRenderInfo.mockReturnValue({})
+    mockGetDeckConfigFromProtocolCommands.mockReturnValue([])
+    when(mockUseFeatureFlag)
+      .calledWith('enableDeckConfiguration')
+      .mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    resetAllWhenMocks()
+  })
+  it('should render nothing on the deck and calls exit button', () => {
+    mockBaseDeck.mockReturnValue(<div>mock base deck</div>)
+
+    const props = {
+      handleLabwareClick: jest.fn(),
+      onCloseClick: jest.fn(),
+      deckDef: (deckDefFixture as unknown) as DeckDefinition,
+      mostRecentAnalysis: ({
+        commands: [],
+        labware: [],
+      } as unknown) as CompletedProtocolAnalysis,
+      initialLoadedLabwareByAdapter: {},
+      attachedProtocolModuleMatches: [],
+    }
+
+    const { getByText, getByLabelText } = render(props)
+    getByText('Map View')
+    getByText('mock base deck')
+    getByLabelText('closeIcon').click()
+    expect(props.onCloseClick).toHaveBeenCalled()
+  })
+
+  it('should render a deck with modules and labware', () => {
+    const mockLabwareLocations = [
+      {
+        labwareLocation: { slotName: 'C1' },
+        definition: fixture_tiprack_300_ul as LabwareDefinition2,
+        topLabwareId: '300_ul_tiprack_id',
+        onLabwareClick: expect.any(Function),
+        labwareChildren: null,
+      },
+    ]
+    const mockModuleLocations = [
+      {
+        moduleModel: 'heaterShakerModuleV1' as ModuleModel,
+        moduleLocation: { slotName: 'B1' },
+        nestedLabwareDef: mockProtocolModuleInfo[0]
+          .nestedLabwareDef as LabwareDefinition2,
+        onLabwareClick: expect.any(Function),
+        moduleChildren: null,
+        innerProps: {},
+      },
+    ]
+    when(mockBaseDeck)
+      .calledWith({
+        robotType: FLEX_ROBOT_TYPE,
+        deckLayerBlocklist: getStandardDeckViewLayerBlockList(FLEX_ROBOT_TYPE),
+        deckConfig: EXTENDED_DECK_CONFIG_FIXTURE,
+        labwareLocations: mockLabwareLocations,
+        moduleLocations: mockModuleLocations,
+      })
+      .mockReturnValue(<div>mock base deck</div>)
+    mockGetLabwareRenderInfo.mockReturnValue({
+      '300_ul_tiprack_id': {
+        labwareDef: fixture_tiprack_300_ul as LabwareDefinition2,
+        displayName: 'fresh tips',
+        x: MOCK_300_UL_TIPRACK_COORDS[0],
+        y: MOCK_300_UL_TIPRACK_COORDS[1],
+        z: MOCK_300_UL_TIPRACK_COORDS[2],
+        slotName: 'C1',
+      },
+    })
+    render({
+      handleLabwareClick: jest.fn(),
+      onCloseClick: jest.fn(),
+      deckDef: (deckDefFixture as unknown) as DeckDefinition,
+      mostRecentAnalysis: ({} as unknown) as CompletedProtocolAnalysis,
+      initialLoadedLabwareByAdapter: {},
+      attachedProtocolModuleMatches: [
+        {
+          ...mockProtocolModuleInfo[0],
+        },
+      ],
+    })
+    expect(mockBaseDeck).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
-import map from 'lodash/map'
 import {
   ALIGN_CENTER,
   ALIGN_FLEX_START,
@@ -17,10 +16,7 @@ import {
   JUSTIFY_SPACE_EVENLY,
   LabwareRender,
   LocationIcon,
-  Module,
   MODULE_ICON_NAME_BY_TYPE,
-  RobotWorkSpace,
-  SlotLabels,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -30,10 +26,8 @@ import {
   getLabwareDefURI,
   getLabwareDisplayName,
   HEATERSHAKER_MODULE_TYPE,
-  inferModuleOrientationFromXCoordinate,
   LoadLabwareRunTimeCommand,
   RunTimeCommand,
-  THERMOCYCLER_MODULE_V1,
 } from '@opentrons/shared-data'
 import { parseInitialLoadedLabwareByAdapter } from '@opentrons/api-client'
 import {
@@ -51,7 +45,6 @@ import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostR
 import { getLabwareSetupItemGroups } from '../../pages/Protocols/utils'
 import { getProtocolModulesInfo } from '../Devices/ProtocolRun/utils/getProtocolModulesInfo'
 import { getAttachedProtocolModuleMatches } from '../ProtocolSetupModulesAndDeck/utils'
-import { getLabwareRenderInfo } from '../Devices/ProtocolRun/utils/getLabwareRenderInfo'
 import {
   getNestedLabwareInfo,
   NestedLabwareInfo,
@@ -66,17 +59,9 @@ import type {
 } from '@opentrons/shared-data'
 import type { HeaterShakerModule, Modules } from '@opentrons/api-client'
 import type { LabwareSetupItem } from '../../pages/Protocols/utils'
-import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { SetupScreens } from '../../pages/OnDeviceDisplay/ProtocolSetup'
 import type { AttachedProtocolModuleMatch } from '../ProtocolSetupModulesAndDeck/utils'
-
-const OT3_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST: string[] = [
-  'DECK_BASE',
-  'BARCODE_COVERS',
-  'SLOT_SCREWS',
-  'SLOT_10_EXPANSION',
-  'CALIBRATION_CUTOUTS',
-]
+import { LabwareMapViewModal } from './LabwareMapViewModal'
 
 const MODULE_REFETCH_INTERVAL = 5000
 
@@ -114,10 +99,6 @@ export function ProtocolSetupLabware({
   const { offDeckItems, onDeckItems } = getLabwareSetupItemGroups(
     mostRecentAnalysis?.commands ?? []
   )
-  const labwareRenderInfo =
-    mostRecentAnalysis != null
-      ? getLabwareRenderInfo(mostRecentAnalysis, deckDef)
-      : {}
   const moduleQuery = useModulesQuery({
     refetchInterval: MODULE_REFETCH_INTERVAL,
   })
@@ -219,120 +200,19 @@ export function ProtocolSetupLabware({
       }
     }
   }
-
-  const modalHeader: ModalHeaderBaseProps = {
-    title: t('map_view'),
-    hasExitIcon: true,
-  }
-
   const selectedLabwareLocation = selectedLabware?.location
   return (
     <>
       <Portal level="top">
         {showDeckMapModal ? (
-          <Modal
-            header={modalHeader}
-            modalSize="large"
-            onOutsideClick={() => setShowDeckMapModal(false)}
-          >
-            <RobotWorkSpace
-              deckDef={deckDef}
-              deckLayerBlocklist={OT3_STANDARD_DECK_VIEW_LAYER_BLOCK_LIST}
-              deckFill={COLORS.light1}
-              trashSlotName="A3"
-              id="LabwareSetup_deckMap"
-              trashColor={COLORS.darkGreyEnabled}
-            >
-              {() => (
-                <>
-                  {map(
-                    attachedProtocolModuleMatches,
-                    ({
-                      x,
-                      y,
-                      moduleDef,
-                      nestedLabwareDef,
-                      nestedLabwareId,
-                      moduleId,
-                    }) => {
-                      const labwareInAdapterInMod =
-                        nestedLabwareId != null
-                          ? initialLoadedLabwareByAdapter[nestedLabwareId]
-                          : null
-                      //  only rendering the labware on top most layer so
-                      //  either the adapter or the labware are rendered but not both
-                      const topLabwareDefinition =
-                        labwareInAdapterInMod?.result?.definition ??
-                        nestedLabwareDef
-                      const topLabwareId =
-                        labwareInAdapterInMod?.result?.labwareId ??
-                        nestedLabwareId
-
-                      return (
-                        <Module
-                          key={`LabwareSetup_Module_${moduleId}_${x}${y}`}
-                          x={x}
-                          y={y}
-                          orientation={inferModuleOrientationFromXCoordinate(x)}
-                          def={moduleDef}
-                          innerProps={
-                            moduleDef.model === THERMOCYCLER_MODULE_V1
-                              ? { lidMotorState: 'open' }
-                              : {}
-                          }
-                        >
-                          {topLabwareDefinition != null &&
-                          topLabwareId != null ? (
-                            <React.Fragment
-                              key={`LabwareSetup_Labware_${topLabwareId}_${x}${y}`}
-                            >
-                              <LabwareRender
-                                definition={topLabwareDefinition}
-                                onLabwareClick={() =>
-                                  handleLabwareClick(
-                                    topLabwareDefinition,
-                                    topLabwareId
-                                  )
-                                }
-                              />
-                            </React.Fragment>
-                          ) : null}
-                        </Module>
-                      )
-                    }
-                  )}
-                  {map(labwareRenderInfo, ({ x, y, labwareDef }, labwareId) => {
-                    const labwareInAdapter =
-                      initialLoadedLabwareByAdapter[labwareId]
-                    //  only rendering the labware on top most layer so
-                    //  either the adapter or the labware are rendered but not both
-                    const topLabwareDefinition =
-                      labwareInAdapter?.result?.definition ?? labwareDef
-                    const topLabwareId =
-                      labwareInAdapter?.result?.labwareId ?? labwareId
-                    return (
-                      <React.Fragment
-                        key={`LabwareSetup_Labware_${topLabwareId}_${x}${y}`}
-                      >
-                        <g transform={`translate(${x},${y})`}>
-                          <LabwareRender
-                            definition={topLabwareDefinition}
-                            onLabwareClick={() =>
-                              handleLabwareClick(
-                                topLabwareDefinition,
-                                topLabwareId
-                              )
-                            }
-                          />
-                        </g>
-                      </React.Fragment>
-                    )
-                  })}
-                  <SlotLabels robotType={FLEX_ROBOT_TYPE} />
-                </>
-              )}
-            </RobotWorkSpace>
-          </Modal>
+          <LabwareMapViewModal
+            commands={mostRecentAnalysis?.commands ?? []}
+            runId={runId}
+            attachedProtocolModuleMatches={attachedProtocolModuleMatches}
+            handleLabwareClick={handleLabwareClick}
+            onCloseClick={() => setShowDeckMapModal(false)}
+            initialLoadedLabwareByAdapter={initialLoadedLabwareByAdapter}
+          />
         ) : null}
         {showLabwareDetailsModal && selectedLabware != null ? (
           <Modal

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -206,8 +206,8 @@ export function ProtocolSetupLabware({
       <Portal level="top">
         {showDeckMapModal ? (
           <LabwareMapViewModal
-            commands={mostRecentAnalysis?.commands ?? []}
-            runId={runId}
+            mostRecentAnalysis={mostRecentAnalysis}
+            deckDef={deckDef}
             attachedProtocolModuleMatches={attachedProtocolModuleMatches}
             handleLabwareClick={handleLabwareClick}
             onCloseClick={() => setShowDeckMapModal(false)}

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -43,6 +43,7 @@ interface BaseDeckProps {
     definition: LabwareDefinition2
     // generic prop to render self-positioned children for each labware
     labwareChildren?: React.ReactNode
+    onLabwareClick?: () => void
   }>
   moduleLocations: Array<{
     moduleModel: ModuleModel
@@ -51,6 +52,7 @@ interface BaseDeckProps {
     innerProps?: React.ComponentProps<typeof Module>['innerProps']
     // generic prop to render self-positioned children for each module
     moduleChildren?: React.ReactNode
+    onLabwareClick?: () => void
   }>
   deckConfig?: DeckConfiguration
   deckLayerBlocklist?: string[]
@@ -150,6 +152,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
           nestedLabwareDef,
           innerProps,
           moduleChildren,
+          onLabwareClick,
         }) => {
           const slotDef = deckDef.locations.orderedSlots.find(
             s => s.id === moduleLocation.slotName
@@ -167,7 +170,10 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
               innerProps={innerProps}
             >
               {nestedLabwareDef != null ? (
-                <LabwareRender definition={nestedLabwareDef} />
+                <LabwareRender
+                  definition={nestedLabwareDef}
+                  onLabwareClick={onLabwareClick}
+                />
               ) : null}
               {moduleChildren}
             </Module>
@@ -175,7 +181,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
         }
       )}
       {labwareLocations.map(
-        ({ labwareLocation, definition, labwareChildren }) => {
+        ({ labwareLocation, definition, labwareChildren, onLabwareClick }) => {
           const slotDef = deckDef.locations.orderedSlots.find(
             s =>
               labwareLocation !== 'offDeck' &&
@@ -187,7 +193,10 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
               key={slotDef.id}
               transform={`translate(${slotDef.position[0]},${slotDef.position[1]})`}
             >
-              <LabwareRender definition={definition} />
+              <LabwareRender
+                definition={definition}
+                onLabwareClick={onLabwareClick}
+              />
               {labwareChildren}
             </g>
           ) : null

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -63,6 +63,7 @@ export interface LabwareRenderProps {
 export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
   const { gRef } = props
   const cornerOffsetFromSlot = props.definition.cornerOffsetFromSlot
+
   return (
     <g
       transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -63,7 +63,6 @@ export interface LabwareRenderProps {
 export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
   const { gRef } = props
   const cornerOffsetFromSlot = props.definition.cornerOffsetFromSlot
-  
   return (
     <g
       transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}

--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -63,7 +63,7 @@ export interface LabwareRenderProps {
 export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
   const { gRef } = props
   const cornerOffsetFromSlot = props.definition.cornerOffsetFromSlot
-
+  
   return (
     <g
       transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}


### PR DESCRIPTION
closes RAUT-822

# Overview

Splits the modal into its own component and then updates the map render to use base deck.

# Test Plan

Upload a protocol to the ODD and look at labware setup map view. See that the deck rendering correctly and clicking on the labware opens the correct labware details modal.

# Changelog

- extend `baseDeck` to have `onLabwareClick` prop 
- create new modal `LabwareMapViewModal` and create test
- clean up `ProtocolSetupLabware`

# Review requests

see test plan

# Risk assessment

low