### PR TITLE
feat(protocol-designer): add biorad, armadillo, and tough PCR plate c…

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -117,7 +117,7 @@ export const getLabwareIsRecommended = (
   //  since its different from V1
   if (moduleModel === THERMOCYCLER_MODULE_V2) {
     return (
-      'opentrons_96_wellplate_200ul_pcr_full_skirt' === def.parameters.loadName
+      def.parameters.loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt'
     )
   } else {
     return moduleType

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -110,17 +110,17 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
 
 export const getLabwareIsRecommended = (
   def: LabwareDefinition2,
-  moduleType?: ModuleType | null,
   moduleModel?: ModuleModel | null
 ): boolean => {
   //  special-casing the thermocycler module V2 recommended labware
   //  since its different from V1
+  const moduleType = moduleModel != null ? getModuleType(moduleModel) : null
   if (moduleModel === THERMOCYCLER_MODULE_V2) {
     return (
       def.parameters.loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt'
     )
   } else {
-    return moduleType
+    return moduleType != null
       ? RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
           def.parameters.loadName
         )
@@ -215,7 +215,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
         labwareDef.parameters.loadName === ADAPTER_96_CHANNEL
       return (
         (filterRecommended &&
-          !getLabwareIsRecommended(labwareDef, moduleType, moduleModel)) ||
+          !getLabwareIsRecommended(labwareDef, moduleModel)) ||
         (filterHeight &&
           getIsLabwareAboveHeight(
             labwareDef,
@@ -375,7 +375,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
     typeof LabwarePreview
   >['moduleCompatibility'] = null
   if (previewedLabware && moduleType) {
-    if (getLabwareIsRecommended(previewedLabware, moduleType, moduleModel)) {
+    if (getLabwareIsRecommended(previewedLabware, moduleModel)) {
       moduleCompatibility = 'recommended'
     } else if (getLabwareCompatible(previewedLabware)) {
       moduleCompatibility = 'potentiallyCompatible'
@@ -442,11 +442,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
                           <LabwareItem
                             key={index}
                             icon={
-                              getLabwareIsRecommended(
-                                labwareDef,
-                                moduleType,
-                                moduleModel
-                              )
+                              getLabwareIsRecommended(labwareDef, moduleModel)
                                 ? 'check-decagram'
                                 : null
                             }

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -87,7 +87,10 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'nest_96_wellplate_2ml_deep',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  [THERMOCYCLER_MODULE_TYPE]: ['nest_96_wellplate_100ul_pcr_full_skirt'],
+  [THERMOCYCLER_MODULE_TYPE]: [
+    'nest_96_wellplate_100ul_pcr_full_skirt',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  ],
   [HEATERSHAKER_MODULE_TYPE]: [
     'opentrons_96_deep_well_adapter',
     'opentrons_96_flat_bottom_adapter',

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -19,6 +19,9 @@ import {
   MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
   LabwareDefinition2,
   ModuleType,
+  ModuleModel,
+  getModuleType,
+  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import { SPAN7_8_10_11_SLOT } from '../../constants'
@@ -35,8 +38,9 @@ import { KnowledgeBaseLink } from '../KnowledgeBaseLink'
 import { LabwareItem } from './LabwareItem'
 import { LabwarePreview } from './LabwarePreview'
 import styles from './styles.css'
-import { DeckSlot } from '../../types'
-import { LabwareDefByDefURI } from '../../labware-defs'
+
+import type { DeckSlot } from '../../types'
+import type { LabwareDefByDefURI } from '../../labware-defs'
 
 export interface Props {
   onClose: (e?: any) => unknown
@@ -47,8 +51,8 @@ export interface Props {
   slot?: DeckSlot | null
   /** if adding to a module, the slot of the parent (for display) */
   parentSlot?: DeckSlot | null
-  /** if adding to a module, the module's type */
-  moduleType?: ModuleType | null
+  /** if adding to a module, the module's model */
+  moduleModel?: ModuleModel | null
   /** tipracks that may be added to deck (depends on pipette<>tiprack assignment) */
   permittedTipracks: string[]
   isNextToHeaterShaker: boolean
@@ -87,7 +91,10 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'nest_96_wellplate_2ml_deep',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  [THERMOCYCLER_MODULE_TYPE]: ['opentrons_96_wellplate_200ul_pcr_full_skirt'],
+  [THERMOCYCLER_MODULE_TYPE]: [
+    'nest_96_wellplate_100ul_pcr_full_skirt',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  ],
   [HEATERSHAKER_MODULE_TYPE]: [
     'opentrons_96_deep_well_adapter',
     'opentrons_96_flat_bottom_adapter',
@@ -103,14 +110,23 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
 
 export const getLabwareIsRecommended = (
   def: LabwareDefinition2,
-  moduleType?: ModuleType | null
-): boolean =>
-  moduleType
-    ? RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
-        def.parameters.loadName
-      )
-    : false
-
+  moduleType?: ModuleType | null,
+  moduleModel?: ModuleModel | null
+): boolean => {
+  //  special-casing the thermocycler module V2 recommended labware
+  //  since its different from V1
+  if (moduleModel === THERMOCYCLER_MODULE_V2) {
+    return (
+      'opentrons_96_wellplate_200ul_pcr_full_skirt' === def.parameters.loadName
+    )
+  } else {
+    return moduleType
+      ? RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
+          def.parameters.loadName
+        )
+      : false
+  }
+}
 export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
   const {
     customLabwareDefs,
@@ -119,13 +135,14 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
     onUploadLabware,
     slot,
     parentSlot,
-    moduleType,
+    moduleModel,
     selectLabware,
     isNextToHeaterShaker,
     adapterLoadName,
     has96Channel,
   } = props
   const defs = getOnlyLatestDefs()
+  const moduleType = moduleModel != null ? getModuleType(moduleModel) : null
   const URIs = Object.keys(defs)
   const [selectedCategory, setSelectedCategory] = React.useState<string | null>(
     null
@@ -198,7 +215,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
         labwareDef.parameters.loadName === ADAPTER_96_CHANNEL
       return (
         (filterRecommended &&
-          !getLabwareIsRecommended(labwareDef, moduleType)) ||
+          !getLabwareIsRecommended(labwareDef, moduleType, moduleModel)) ||
         (filterHeight &&
           getIsLabwareAboveHeight(
             labwareDef,
@@ -358,7 +375,7 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
     typeof LabwarePreview
   >['moduleCompatibility'] = null
   if (previewedLabware && moduleType) {
-    if (getLabwareIsRecommended(previewedLabware, moduleType)) {
+    if (getLabwareIsRecommended(previewedLabware, moduleType, moduleModel)) {
       moduleCompatibility = 'recommended'
     } else if (getLabwareCompatible(previewedLabware)) {
       moduleCompatibility = 'potentiallyCompatible'
@@ -425,7 +442,11 @@ export const LabwareSelectionModal = (props: Props): JSX.Element | null => {
                           <LabwareItem
                             key={index}
                             icon={
-                              getLabwareIsRecommended(labwareDef, moduleType)
+                              getLabwareIsRecommended(
+                                labwareDef,
+                                moduleType,
+                                moduleModel
+                              )
                                 ? 'check-decagram'
                                 : null
                             }

--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -87,10 +87,7 @@ const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'nest_96_wellplate_2ml_deep',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  [THERMOCYCLER_MODULE_TYPE]: [
-    'nest_96_wellplate_100ul_pcr_full_skirt',
-    'opentrons_96_wellplate_200ul_pcr_full_skirt',
-  ],
+  [THERMOCYCLER_MODULE_TYPE]: ['opentrons_96_wellplate_200ul_pcr_full_skirt'],
   [HEATERSHAKER_MODULE_TYPE]: [
     'opentrons_96_deep_well_adapter',
     'opentrons_96_flat_bottom_adapter',

--- a/protocol-designer/src/components/LabwareSelectionModal/index.ts
+++ b/protocol-designer/src/components/LabwareSelectionModal/index.ts
@@ -25,7 +25,7 @@ interface SP {
   customLabwareDefs: LabwareSelectionModalProps['customLabwareDefs']
   slot: LabwareSelectionModalProps['slot']
   parentSlot: LabwareSelectionModalProps['parentSlot']
-  moduleType: LabwareSelectionModalProps['moduleType']
+  moduleModel: LabwareSelectionModalProps['moduleModel']
   permittedTipracks: LabwareSelectionModalProps['permittedTipracks']
   isNextToHeaterShaker: boolean
   has96Channel: boolean
@@ -49,7 +49,7 @@ function mapStateToProps(state: BaseState): SP {
       initialModules.find(moduleOnDeck => moduleOnDeck.id === slot)) ||
     null
   const parentSlot = parentModule != null ? parentModule.slot : null
-  const moduleType = parentModule != null ? parentModule.type : null
+  const moduleModel = parentModule != null ? parentModule.model : null
   const isNextToHeaterShaker = initialModules.some(
     hardwareModule =>
       hardwareModule.type === HEATERSHAKER_MODULE_TYPE &&
@@ -63,7 +63,7 @@ function mapStateToProps(state: BaseState): SP {
     customLabwareDefs: labwareDefSelectors.getCustomLabwareDefsByURI(state),
     slot,
     parentSlot,
-    moduleType,
+    moduleModel,
     isNextToHeaterShaker,
     has96Channel,
     adapterDefUri: has96Channel ? adapter96ChannelDefUri : undefined,

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -63,6 +63,8 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
     'nest_96_wellplate_100ul_pcr_full_skirt',
     'nest_96_wellplate_2ml_deep',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
+    'armadillo_96_wellplate_200ul_pcr_full_skirt',
+    'biorad_96_wellplate_200ul_pcr',
   ],
 }
 export const getLabwareIsCompatible = (
@@ -94,6 +96,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   [FLAT_BOTTOM_ADAPTER_LOADNAME]: ['opentrons/nest_96_wellplate_200ul_flat/2'],
   [PCR_ADAPTER_LOADNAME]: [
     'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',
+    'opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
@@ -178,7 +181,8 @@ export const getAdapterLabwareIsAMatch = (
     draggedLabwareLoadname === 'nest_96_wellplate_200ul_flat'
   const pcrPair =
     loadName === PCR_ADAPTER_LOADNAME &&
-    draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt'
+    (draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt' ||
+      draggedLabwareLoadname === 'opentrons_96_wellplate_200ul_pcr_full_skirt')
   const universalPair =
     loadName === UNIVERSAL_FLAT_ADAPTER_LOADNAME &&
     (draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat' ||

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -52,6 +52,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
   [THERMOCYCLER_MODULE_TYPE]: [
     'biorad_96_wellplate_200ul_pcr',
     'nest_96_wellplate_100ul_pcr_full_skirt',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
   [HEATERSHAKER_MODULE_TYPE]: [
     'opentrons_96_deep_well_adapter',


### PR DESCRIPTION
…ompatibility

closes RAUT-820 RAUT-825

# Overview

Add a few labwares as compatible with the H-S pcr adapter and the magnetic block

# Test Plan

Create a Flex protocol and add a magnetic block, a thermocycler, and the heater-shaker. 

Go to the deck map. For the heater-shaker, add a Opentrons 96 PCR heater-shaker adapter. Look at the compatible labware and see that the `Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt` is selectable.

Now, for the magnetic block, click to add a labware, there should be 3 recommended labware. Uncheck the checkbox on the top left of the modal. See that 2 more labware were added which should include the Armadillo 96 well plate and the `Bio-Rad 96 Well Plate 200 µL PCR`.

For the thermocycler, see that the `Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt` is added to the list of recommended compatible labware and the NEST plate is removed from the list of recommended but is still compatible. So unchecking the box should reveal it.

Then go back and create a OT-2 protocol and add the Thermocycler gen 1, see that 2 labware are recommended

# Changelog

add labware defURIs and `loadNames` to compatibility list
make a split between TC GEn1 and GEN2 recommended labware

# Review requests

see test plan

# Risk assessment

low