### PR TITLE
fix(app): fix selected mount for detach instrument 96 flow

### DIFF
--- a/api-client/src/instruments/types.ts
+++ b/api-client/src/instruments/types.ts
@@ -57,6 +57,9 @@ export interface PipetteData {
   instrumentType: 'pipette'
   mount: 'left' | 'right'
   serialNumber: string
+  state?: {
+    tipDetected: boolean
+  }
   subsystem: 'pipette_left' | 'pipette_right'
   ok: true
 }

--- a/api-client/src/instruments/types.ts
+++ b/api-client/src/instruments/types.ts
@@ -48,9 +48,6 @@ export interface PipetteData {
       reasonability_check_failures?: CalibrationReasonabilityCheckFailure[]
     }
   }
-  state: {
-    tipDetected: boolean
-  }
   firmwareVersion?: string
   instrumentName: string
   instrumentModel: PipetteModel

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -24,7 +24,7 @@
   "connect_96_channel": "connect and attach 96-channel pipette",
   "connect_and_secure_pipette": "connect and secure pipette",
   "continue": "Continue",
-  "critical_unskippable_step": "this is a critical step that cannot be skipped",
+  "critical_unskippable_step": "this is a critical step that should not be skipped",
   "detach_96_attach_mount": "Detach 96-Channel Pipette and Attach {{mount}} Pipette",
   "detach_96_channel": "Detach 96-Channel Pipette",
   "detach_and_reattach": "Detach and reattach pipette",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -80,6 +80,7 @@
   "something_seems_wrong": "There may be a problem with your pipette. Exit setup and contact Opentrons Support for assistance.",
   "stand_back": "Stand back, robot is in motion",
   "try_again": "try again",
+  "unable_to_detect_probe": "Unable to detect calibration probe",
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -49,7 +49,7 @@
   "install_probe": "Take the calibration probe from its storage location. Ensure its collar is fully unlocked. Push the pipette ejector up and press the probe firmly onto the <bold>{{location}}</bold> pipette nozzle as far as it can go. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.",
   "loose_detach": "Loosen screws and detach ",
   "move_gantry_to_front": "Move gantry to front",
-  "must_detach_mounting_plate": "You must detach the mounting plate before using other pipettes.",
+  "must_detach_mounting_plate": "You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.",
   "name_and_volume_detected": "{{name}} Pipette Detected",
   "next": "next",
   "ninety_six_channel": "{{ninetySix}} pipette",

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -77,6 +77,7 @@ const WIZARD_CONTAINER_STYLE = css`
 `
 const FLEX_SPACING_STYLE = css`
   height: 1.75rem;
+  margin-bottom: ${SPACING.spacing32};
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     height: 0rem;
   }

--- a/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/AttachedInstrumentMountItem.tsx
@@ -5,8 +5,6 @@ import {
   getGripperDisplayName,
   getPipetteModelSpecs,
   GripperModel,
-  LEFT,
-  NINETY_SIX_CHANNEL,
   PipetteModel,
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
@@ -85,10 +83,7 @@ export function AttachedInstrumentMountItem(
         <ChoosePipette
           proceed={() => {
             setWizardProps({
-              mount:
-                selectedPipette === NINETY_SIX_CHANNEL
-                  ? LEFT
-                  : (mount as Mount),
+              mount: mount as Mount,
               flowType: FLOWS.ATTACH,
               selectedPipette,
               closeFlow: () => {

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -25,8 +25,8 @@ import pipetteProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Prob
 import probing96 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_96.webm'
 import { BODY_STYLE, SECTIONS, FLOWS } from './constants'
 import { getPipetteAnimations } from './utils'
+import type { PipetteData } from '@opentrons/api-client'
 import type { PipetteWizardStepProps } from './types'
-import { PipetteData } from '@opentrons/api-client'
 
 interface AttachProbeProps extends PipetteWizardStepProps {
   isExiting: boolean
@@ -113,7 +113,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     setIsPending(true)
     refetch()
       .then(() => {
-        if (attachedPipette?.state?.tipDetected === true) {
+        if (attachedPipette?.state?.tipDetected) {
           chainRunCommands?.(
             [
               {

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -213,6 +213,9 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     return (
       <SimpleWizardBody
         header={t('unable_to_detect_probe')}
+        subHeader={
+          numberOfTryAgains > 2 ? t('something_seems_wrong') : undefined
+        }
         iconColor={COLORS.errorEnabled}
         isSuccess={false}
       >

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -3,12 +3,19 @@ import { css } from 'styled-components'
 import { Trans, useTranslation } from 'react-i18next'
 import {
   Flex,
+  Btn,
+  PrimaryButton,
   TYPOGRAPHY,
   COLORS,
   SPACING,
   RESPONSIVENESS,
+  JUSTIFY_SPACE_BETWEEN,
+  ALIGN_FLEX_END,
+  ALIGN_CENTER,
 } from '@opentrons/components'
 import { LEFT, MotorAxes } from '@opentrons/shared-data'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import { SmallButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
@@ -19,6 +26,7 @@ import probing96 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_
 import { BODY_STYLE, SECTIONS, FLOWS } from './constants'
 import { getPipetteAnimations } from './utils'
 import type { PipetteWizardStepProps } from './types'
+import { PipetteData } from '@opentrons/api-client'
 
 interface AttachProbeProps extends PipetteWizardStepProps {
   isExiting: boolean
@@ -34,6 +42,33 @@ const IN_PROGRESS_STYLE = css`
     margin-top: ${SPACING.spacing4};
   }
 `
+
+const ALIGN_BUTTONS = css`
+  align-items: ${ALIGN_FLEX_END};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    align-items: ${ALIGN_CENTER};
+  }
+`
+const GO_BACK_BUTTON_STYLE = css`
+  ${TYPOGRAPHY.pSemiBold};
+  color: ${COLORS.darkGreyEnabled};
+  padding-left: ${SPACING.spacing32};
+
+  &:hover {
+    opacity: 70%;
+  }
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+    font-size: ${TYPOGRAPHY.fontSize22};
+    padding-left: 0rem;
+    &:hover {
+      opacity: 100%;
+    }
+  }
+`
+
 export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const {
     proceed,
@@ -50,46 +85,73 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   } = props
   const { t, i18n } = useTranslation('pipette_wizard_flows')
   const pipetteWizardStep = { mount, flowType, section: SECTIONS.ATTACH_PROBE }
+  const [isPending, setIsPending] = React.useState<boolean>(false)
+  const [showUnableToDetect, setShowUnableToDetect] = React.useState<boolean>(
+    false
+  )
+  const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
+
   const pipetteId = attachedPipettes[mount]?.serialNumber
   const displayName = attachedPipettes[mount]?.displayName
   const is8Channel = attachedPipettes[mount]?.data.channels === 8
   const is96Channel = attachedPipettes[mount]?.data.channels === 96
   const calSlotNum = 'C2'
   const axes: MotorAxes = mount === LEFT ? ['leftZ'] : ['rightZ']
+  const { refetch, data: attachedInstrumentsData } = useInstrumentsQuery({
+    enabled: false,
+    onSettled: () => {
+      setIsPending(false)
+    },
+  })
+  const attachedPipette = attachedInstrumentsData?.data.find(
+    (instrument): instrument is PipetteData =>
+      instrument.ok && instrument.mount === mount
+  )
 
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
-    chainRunCommands?.(
-      [
-        {
-          commandType: 'home' as const,
-          params: {
-            axes: axes,
-          },
-        },
-        {
-          commandType: 'home' as const,
-          params: {
-            skipIfMountPositionOk: mount,
-          },
-        },
-        {
-          commandType: 'calibration/calibratePipette' as const,
-          params: {
-            mount: mount,
-          },
-        },
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: mount,
-          },
-        },
-      ],
-      false
-    )
+    setIsPending(true)
+    refetch()
       .then(() => {
-        proceed()
+        if (attachedPipette?.state?.tipDetected === true) {
+          chainRunCommands?.(
+            [
+              {
+                commandType: 'home' as const,
+                params: {
+                  axes: axes,
+                },
+              },
+              {
+                commandType: 'home' as const,
+                params: {
+                  skipIfMountPositionOk: mount,
+                },
+              },
+              {
+                commandType: 'calibration/calibratePipette' as const,
+                params: {
+                  mount: mount,
+                },
+              },
+              {
+                commandType: 'calibration/moveToMaintenancePosition' as const,
+                params: {
+                  mount: mount,
+                },
+              },
+            ],
+            false
+          )
+            .then(() => {
+              proceed()
+            })
+            .catch(error => {
+              setShowErrorMessage(error.message)
+            })
+        } else {
+          setShowUnableToDetect(true)
+        }
       })
       .catch(error => {
         setShowErrorMessage(error.message)
@@ -147,6 +209,41 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         )}
       </InProgressModal>
     )
+  else if (showUnableToDetect)
+    return (
+      <SimpleWizardBody
+        header={t('unable_to_detect_probe')}
+        iconColor={COLORS.errorEnabled}
+        isSuccess={false}
+      >
+        <Flex
+          width="100%"
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          css={ALIGN_BUTTONS}
+          gridGap={SPACING.spacing8}
+        >
+          <Btn onClick={() => setShowUnableToDetect(false)}>
+            <StyledText css={GO_BACK_BUTTON_STYLE}>
+              {t('shared:go_back')}
+            </StyledText>
+          </Btn>
+          {isOnDevice ? (
+            <SmallButton
+              buttonText={t('try_again')}
+              disabled={isPending}
+              onClick={() => {
+                setNumberOfTryAgains(numberOfTryAgains + 1)
+                handleOnClick()
+              }}
+            />
+          ) : (
+            <PrimaryButton disabled={isPending} onClick={handleOnClick}>
+              {t('try_again')}
+            </PrimaryButton>
+          )}
+        </Flex>
+      </SimpleWizardBody>
+    )
 
   return errorMessage != null ? (
     <SimpleWizardBody
@@ -188,6 +285,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       }
       proceedButtonText={t('begin_calibration')}
       proceed={handleOnClick}
+      proceedIsDisabled={isPending}
       back={flowType === FLOWS.ATTACH ? undefined : goBack}
     />
   )

--- a/app/src/organisms/PipetteWizardFlows/Carriage.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Carriage.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import capitalize from 'lodash/capitalize'
-import {
-  TYPOGRAPHY,
-  COLORS,
-  SPACING,
-  PrimaryButton,
-} from '@opentrons/components'
+import { COLORS, SPACING, PrimaryButton } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -53,19 +48,7 @@ export const Carriage = (props: PipetteWizardStepProps): JSX.Element | null => {
       isSuccess={false}
       iconColor={COLORS.errorEnabled}
       header={t('shared:error_encountered')}
-      subHeader={
-        <Trans
-          t={t}
-          i18nKey={'detach_pipette_error'}
-          values={{ error: errorMessage }}
-          components={{
-            block: <StyledText as="p" />,
-            bold: (
-              <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold} />
-            ),
-          }}
-        />
-      }
+      subHeader={errorMessage}
     />
   ) : (
     <GenericWizardTile

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -170,7 +170,10 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           alignItems={isOnDevice ? ALIGN_CENTER : ALIGN_FLEX_END}
           gridGap={SPACING.spacing8}
         >
-          <Btn onClick={() => setShowPipetteStillAttached(false)}>
+          <Btn
+            onClick={() => setShowPipetteStillAttached(false)}
+            marginLeft={SPACING.spacing32}
+          >
             <StyledText css={GO_BACK_BUTTON_TEXT_STYLE}>
               {t('shared:go_back')}
             </StyledText>
@@ -178,12 +181,12 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           {isOnDevice ? (
             <SmallButton
               disabled={isFetching}
-              buttonText={t('try_again')}
+              buttonText={i18n.format(t('try_again'), 'capitalize')}
               onClick={handleOnClick}
             />
           ) : (
             <PrimaryButton disabled={isFetching} onClick={handleOnClick}>
-              {t('try_again')}
+              {i18n.format(t('try_again'), 'capitalize')}
             </PrimaryButton>
           )}
         </Flex>

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -157,7 +157,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
   }
 
   if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
-  if (showPipetteStillAttached)
+  if (showPipetteStillAttached) {
     return (
       <SimpleWizardBody
         iconColor={COLORS.errorEnabled}
@@ -192,6 +192,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
         </Flex>
       </SimpleWizardBody>
     )
+  }
   return errorMessage != null ? (
     <SimpleWizardBody
       isSuccess={false}

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -95,19 +95,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
       isSuccess={false}
       iconColor={COLORS.errorEnabled}
       header={t('shared:error_encountered')}
-      subHeader={
-        <Trans
-          t={t}
-          i18nKey={'detach_pipette_error'}
-          values={{ error: errorMessage }}
-          components={{
-            block: <StyledText as="p" />,
-            bold: (
-              <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold} />
-            ),
-          }}
-        />
-      }
+      subHeader={errorMessage}
     />
   ) : (
     <GenericWizardTile

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { LEFT } from '@opentrons/shared-data'
-import {
-  COLORS,
-  PrimaryButton,
-  SecondaryButton,
-  SPACING,
-} from '@opentrons/components'
-import { SmallButton } from '../../atoms/buttons'
+import { COLORS, SPACING } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
@@ -18,13 +12,17 @@ import type { PipetteWizardStepProps } from './types'
 export const MountingPlate = (
   props: PipetteWizardStepProps
 ): JSX.Element | null => {
-  const { goBack, proceed, flowType, chainRunCommands, isOnDevice } = props
+  const {
+    goBack,
+    proceed,
+    flowType,
+    chainRunCommands,
+    errorMessage,
+    setShowErrorMessage,
+  } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
-  const [errorMessage, setErrorMessage] = React.useState<boolean>(false)
-  const [numberOfTryAgains, setNumberOfTryAgains] = React.useState<number>(0)
 
   const handleAttachMountingPlate = (): void => {
-    setNumberOfTryAgains(numberOfTryAgains + 1)
     chainRunCommands?.(
       [
         {
@@ -44,50 +42,17 @@ export const MountingPlate = (
         proceed()
       })
       .catch(error => {
-        console.error(error.message)
-        setErrorMessage(true)
+        setShowErrorMessage(error.message)
       })
   }
 
   return errorMessage ? (
     <SimpleWizardBody
       iconColor={COLORS.errorEnabled}
-      header={i18n.format(t('z_axis_still_attached'), 'capitalize')}
-      subHeader={t(
-        numberOfTryAgains > 2
-          ? 'something_seems_wrong'
-          : 'detach_z_axis_screw_again'
-      )}
+      header={t('shared:error_encountered')}
       isSuccess={false}
-    >
-      {isOnDevice ? (
-        <>
-          <SmallButton
-            buttonType="alert"
-            onClick={goBack}
-            buttonText={i18n.format(t('cancel_attachment'), 'capitalize')}
-          />
-          <SmallButton
-            buttonType="primary"
-            onClick={handleAttachMountingPlate}
-            buttonText={i18n.format(t('shared:try_again'), 'capitalize')}
-          />
-        </>
-      ) : (
-        <>
-          <SecondaryButton
-            isDangerous
-            onClick={goBack}
-            marginRight={SPACING.spacing4}
-          >
-            {i18n.format(t('cancel_attachment'), 'capitalize')}
-          </SecondaryButton>
-          <PrimaryButton onClick={handleAttachMountingPlate}>
-            {i18n.format(t('shared:try_again'), 'capitalize')}
-          </PrimaryButton>
-        </>
-      )}
-    </SimpleWizardBody>
+      subHeader={errorMessage}
+    />
   ) : (
     <GenericWizardTile
       header={t(

--- a/app/src/organisms/PipetteWizardFlows/UnskippableModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/UnskippableModal.tsx
@@ -1,16 +1,23 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { COLORS, AlertPrimaryButton } from '@opentrons/components'
+import {
+  COLORS,
+  SPACING,
+  TYPOGRAPHY,
+  SecondaryButton,
+  AlertPrimaryButton,
+} from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 
 interface UnskippableModalProps {
   goBack: () => void
+  proceed: () => void
   isOnDevice: boolean | null
 }
 
 export function UnskippableModal(props: UnskippableModalProps): JSX.Element {
-  const { goBack, isOnDevice } = props
+  const { goBack, proceed, isOnDevice } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   return (
     <SimpleWizardBody
@@ -20,15 +27,28 @@ export function UnskippableModal(props: UnskippableModalProps): JSX.Element {
       isSuccess={false}
     >
       {isOnDevice ? (
-        <SmallButton
-          onClick={goBack}
-          buttonText={i18n.format(t('shared:return'), 'capitalize')}
-          buttonType="alert"
-        />
+        <>
+          <SmallButton
+            marginRight={SPACING.spacing8}
+            onClick={proceed}
+            buttonText={t('shared:exit')}
+            buttonType="alert"
+          />
+
+          <SmallButton buttonText={t('shared:go_back')} onClick={goBack} />
+        </>
       ) : (
-        <AlertPrimaryButton onClick={goBack}>
-          {i18n.format(t('shared:return'), 'capitalize')}
-        </AlertPrimaryButton>
+        <>
+          <SecondaryButton onClick={goBack} marginRight={SPACING.spacing4}>
+            {t('shared:go_back')}
+          </SecondaryButton>
+          <AlertPrimaryButton
+            textTransform={TYPOGRAPHY.textTransformCapitalize}
+            onClick={proceed}
+          >
+            {t('shared:exit')}
+          </AlertPrimaryButton>
+        </>
       )}
     </SimpleWizardBody>
   )

--- a/app/src/organisms/PipetteWizardFlows/UnskippableModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/UnskippableModal.tsx
@@ -13,11 +13,12 @@ import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 interface UnskippableModalProps {
   goBack: () => void
   proceed: () => void
+  isRobotMoving: boolean
   isOnDevice: boolean | null
 }
 
 export function UnskippableModal(props: UnskippableModalProps): JSX.Element {
-  const { goBack, proceed, isOnDevice } = props
+  const { goBack, proceed, isOnDevice, isRobotMoving } = props
   const { t, i18n } = useTranslation(['pipette_wizard_flows', 'shared'])
   return (
     <SimpleWizardBody
@@ -33,16 +34,26 @@ export function UnskippableModal(props: UnskippableModalProps): JSX.Element {
             onClick={proceed}
             buttonText={t('shared:exit')}
             buttonType="alert"
+            disabled={isRobotMoving}
           />
 
-          <SmallButton buttonText={t('shared:go_back')} onClick={goBack} />
+          <SmallButton
+            disabled={isRobotMoving}
+            buttonText={t('shared:go_back')}
+            onClick={goBack}
+          />
         </>
       ) : (
         <>
-          <SecondaryButton onClick={goBack} marginRight={SPACING.spacing4}>
+          <SecondaryButton
+            disabled={isRobotMoving}
+            onClick={goBack}
+            marginRight={SPACING.spacing4}
+          >
             {t('shared:go_back')}
           </SecondaryButton>
           <AlertPrimaryButton
+            disabled={isRobotMoving}
             textTransform={TYPOGRAPHY.textTransformCapitalize}
             onClick={proceed}
           >

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { LEFT, SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import {
@@ -17,9 +18,15 @@ const render = (props: React.ComponentProps<typeof AttachProbe>) => {
     i18nInstance: i18n,
   })[0]
 }
+jest.mock('@opentrons/react-api-client')
+
+const mockUseInstrumentsQuery = useInstrumentsQuery as jest.MockedFunction<
+  typeof useInstrumentsQuery
+>
 
 describe('AttachProbe', () => {
   let props: React.ComponentProps<typeof AttachProbe>
+  const refetch = jest.fn(() => Promise.resolve())
   beforeEach(() => {
     props = {
       mount: LEFT,
@@ -38,6 +45,20 @@ describe('AttachProbe', () => {
       selectedPipette: SINGLE_MOUNT_PIPETTES,
       isOnDevice: false,
     }
+    mockUseInstrumentsQuery.mockReturnValue({
+      data: {
+        data: [
+          {
+            ok: true,
+            mount: LEFT,
+            state: {
+              tipDetected: true,
+            },
+          },
+        ],
+      } as any,
+      refetch,
+    } as any)
   })
   it('returns the correct information, buttons work as expected', async () => {
     const { getByText, getByTestId, getByRole, getByLabelText } = render(props)
@@ -48,28 +69,29 @@ describe('AttachProbe', () => {
     getByTestId('Pipette_Attach_Probe_1.webm')
     const proceedBtn = getByRole('button', { name: 'Begin calibration' })
     fireEvent.click(proceedBtn)
-    expect(props.chainRunCommands).toHaveBeenCalledWith(
-      [
-        {
-          commandType: 'home',
-          params: { axes: ['leftZ'] },
-        },
-        {
-          commandType: 'home',
-          params: { skipIfMountPositionOk: 'left' },
-        },
-        {
-          commandType: 'calibration/calibratePipette',
-          params: { mount: 'left' },
-        },
-        {
-          commandType: 'calibration/moveToMaintenancePosition',
-          params: { mount: 'left' },
-        },
-      ],
-      false
-    )
+    expect(refetch).toHaveBeenCalled()
     await waitFor(() => {
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: { axes: ['leftZ'] },
+          },
+          {
+            commandType: 'home',
+            params: { skipIfMountPositionOk: 'left' },
+          },
+          {
+            commandType: 'calibration/calibratePipette',
+            params: { mount: 'left' },
+          },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: 'left' },
+          },
+        ],
+        false
+      )
       expect(props.proceed).toHaveBeenCalled()
     })
 
@@ -163,28 +185,29 @@ describe('AttachProbe', () => {
     )
     getByTestId('Pipette_Attach_Probe_1.webm')
     getByRole('button', { name: 'Begin calibration' }).click()
-    expect(props.chainRunCommands).toHaveBeenCalledWith(
-      [
-        {
-          commandType: 'home',
-          params: { axes: ['leftZ'] },
-        },
-        {
-          commandType: 'home',
-          params: { skipIfMountPositionOk: 'left' },
-        },
-        {
-          commandType: 'calibration/calibratePipette',
-          params: { mount: 'left' },
-        },
-        {
-          commandType: 'calibration/moveToMaintenancePosition',
-          params: { mount: 'left' },
-        },
-      ],
-      false
-    )
+    expect(refetch).toHaveBeenCalled()
     await waitFor(() => {
+      expect(props.chainRunCommands).toHaveBeenCalledWith(
+        [
+          {
+            commandType: 'home',
+            params: { axes: ['leftZ'] },
+          },
+          {
+            commandType: 'home',
+            params: { skipIfMountPositionOk: 'left' },
+          },
+          {
+            commandType: 'calibration/calibratePipette',
+            params: { mount: 'left' },
+          },
+          {
+            commandType: 'calibration/moveToMaintenancePosition',
+            params: { mount: 'left' },
+          },
+        ],
+        false
+      )
       expect(props.proceed).toHaveBeenCalled()
     })
     getByLabelText('back').click()

--- a/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/DetachPipette.test.tsx
@@ -15,16 +15,12 @@ import { InProgressModal } from '../../../molecules/InProgressModal/InProgressMo
 import { RUN_ID_1 } from '../../RunTimeControl/__fixtures__'
 import { FLOWS } from '../constants'
 import { DetachPipette } from '../DetachPipette'
-import { CheckPipetteButton } from '../CheckPipetteButton'
 
 jest.mock('../CheckPipetteButton')
 jest.mock('../../../molecules/InProgressModal/InProgressModal')
 
 const mockInProgressModal = InProgressModal as jest.MockedFunction<
   typeof InProgressModal
->
-const mockCheckPipetteButton = CheckPipetteButton as jest.MockedFunction<
-  typeof CheckPipetteButton
 >
 const render = (props: React.ComponentProps<typeof DetachPipette>) => {
   return renderWithProviders(<DetachPipette {...props} />, {
@@ -52,7 +48,6 @@ describe('DetachPipette', () => {
       isOnDevice: false,
     }
     mockInProgressModal.mockReturnValue(<div>mock in progress</div>)
-    mockCheckPipetteButton.mockReturnValue(<div>mock check pipette button</div>)
   })
   it('returns the correct information, buttons work as expected for single mount pipettes', () => {
     const { getByText, getByTestId, getByLabelText } = render(props)
@@ -61,7 +56,7 @@ describe('DetachPipette', () => {
       'Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette.'
     )
     getByTestId('Pipette_Detach_1_L.webm')
-    getByText('mock check pipette button')
+    getByText('Continue')
     const backBtn = getByLabelText('back')
     fireEvent.click(backBtn)
     expect(props.goBack).toHaveBeenCalled()
@@ -90,7 +85,7 @@ describe('DetachPipette', () => {
       'Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette.'
     )
     getByTestId('Pipette_Detach_96.webm')
-    getByText('mock check pipette button')
+    getByText('Continue')
     const backBtn = getByLabelText('back')
     fireEvent.click(backBtn)
     expect(props.goBack).toHaveBeenCalled()
@@ -118,7 +113,7 @@ describe('DetachPipette', () => {
       'Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette.'
     )
     getByTestId('Pipette_Detach_1_L.webm')
-    getByText('mock check pipette button')
+    getByText('Continue')
     getByLabelText('back').click()
     expect(props.goBack).toHaveBeenCalled()
   })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
@@ -14,6 +14,7 @@ describe('UnskippableModal', () => {
   it('returns the correct information for unskippable modal, pressing return button calls goBack prop', () => {
     props = {
       goBack: jest.fn(),
+      proceed: jest.fn(),
       isOnDevice: false,
     }
     const { getByText, getByRole } = render(props)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
@@ -18,7 +18,7 @@ describe('UnskippableModal', () => {
       isOnDevice: false,
     }
     const { getByText, getByRole } = render(props)
-    getByText('This is a critical step that cannot be skipped')
+    getByText('This is a critical step that should not be skipped')
     getByText(
       'You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.'
     )
@@ -32,7 +32,7 @@ describe('UnskippableModal', () => {
       isOnDevice: true,
     }
     const { getByText, getByLabelText } = render(props)
-    getByText('This is a critical step that cannot be skipped')
+    getByText('This is a critical step that should not be skipped')
     getByText(
       'You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.'
     )

--- a/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
@@ -16,6 +16,7 @@ describe('UnskippableModal', () => {
       goBack: jest.fn(),
       proceed: jest.fn(),
       isOnDevice: false,
+      isRobotMoving: false,
     }
     const { getByText, getByRole } = render(props)
     getByText('This is a critical step that should not be skipped')
@@ -30,6 +31,7 @@ describe('UnskippableModal', () => {
       goBack: jest.fn(),
       proceed: jest.fn(),
       isOnDevice: true,
+      isRobotMoving: false,
     }
     const { getByText, getByLabelText } = render(props)
     getByText('This is a critical step that should not be skipped')

--- a/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/UnskippableModal.test.tsx
@@ -18,19 +18,24 @@ describe('UnskippableModal', () => {
     }
     const { getByText, getByRole } = render(props)
     getByText('This is a critical step that cannot be skipped')
-    getByText('You must detach the mounting plate before using other pipettes.')
-    getByRole('button', { name: 'Return' }).click()
+    getByText(
+      'You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.'
+    )
+    getByRole('button', { name: 'Go back' }).click()
     expect(props.goBack).toHaveBeenCalled()
   })
   it('renders the is on device button with correct text when it is on device display', () => {
     props = {
       goBack: jest.fn(),
+      proceed: jest.fn(),
       isOnDevice: true,
     }
     const { getByText, getByLabelText } = render(props)
     getByText('This is a critical step that cannot be skipped')
-    getByText('You must detach the mounting plate before using other pipettes.')
+    getByText(
+      'You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.'
+    )
     getByLabelText('SmallButton_alert').click()
-    expect(props.goBack).toHaveBeenCalled()
+    expect(props.proceed).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardSteps.test.tsx
@@ -204,7 +204,12 @@ describe('getPipetteWizardSteps', () => {
         mount: RIGHT,
         flowType: FLOWS.DETACH,
       },
-      { section: SECTIONS.RESULTS, mount: RIGHT, flowType: FLOWS.DETACH },
+      {
+        section: SECTIONS.RESULTS,
+        mount: RIGHT,
+        flowType: FLOWS.DETACH,
+        nextMount: 'both',
+      },
       {
         section: SECTIONS.CARRIAGE,
         mount: LEFT,

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -75,6 +75,7 @@ export const getPipetteWizardSteps = (
               section: SECTIONS.RESULTS,
               mount: detachMount,
               flowType: FLOWS.DETACH,
+              nextMount: 'both',
             },
             {
               section: SECTIONS.CARRIAGE,

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -259,6 +259,7 @@ export const PipetteWizardFlows = (
       proceed={handleCleanUpAndClose}
       goBack={cancelExit}
       isOnDevice={isOnDevice}
+      isRobotMoving={isRobotMoving}
     />
   ) : (
     <ExitModal


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
fix: RQA-1833, RQA-1834, RQA-1836, RQA-940, RQA-1262, RQA-1835, RAUT-732, RAUT-733, RAUT-731
# Overview
This PR fixes and updates various 96-channel bugs and enhances error handling for them
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Tests I have run (corresponding to steps of changelog):
1. Launch 96 attach flow from device card with one other pipette on gantry and see that the mount moves down to detach z-axis after the other pipette is successfully removed
2. With one pipette on gantry, launch 96 attach flow from ODD and see that the correct mount moves down for detaching single channel pipette
3. Launch calibration flow for any pipette and try to proceed to calibration without attaching the probe, see that you are prompted to attach the calibration probe
4. Try to exit from `MountingPlate` step of 96 channel process and see that you are now able to exit from the critical step screen
5. Go through 96-channel detach flow and leave the pipette attached - see that you get the "pipette still attached" error on the first step instead of the last step
6. Successfully remove single channel pipettes in 96 attach flow and see that the button no longer overlaps with the text

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Add `nextMount` to results step in `getPipetteWizardSteps` so mount moves down after single channel detach before 96-channel attach
2. Stop overriding selected mount when selecting attach 96 channel from ODD - we need this info to determine what mount we need to detach a single channel from
3. Start checking `tipDetected` field on `PipetteData` to see whether calibration probe is attached before proceeding to calibration. Build in "try again" error handling loop for this.
4. Allow exiting from any step of the 96-channel process, but show a more serious warning message for steps that will leave the gantry in a weird state (mounting plate attached or z-axis detached)
5. Move logic to check for successful pipette detachment to the `DetachPipette` component so that you see the "pipette still detected" on this screen instead of once you get to results
6. Add margin to subheader in SimpleWizardBody so there isn't overlap with the button when text goes over one line
7. Remove z-axis still attached error loop since it is no longer necessary

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look through code, I've tested pretty robustly
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
