### PR TITLE
fix(app): Fix missed i18n key

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -131,7 +131,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
             subHeader = t('gantry_empty_for_96_channel_success')
             buttonText = t('attach_pip')
           } else {
-            buttonText = t('detach_next_pip')
+            buttonText = t('detach_next_pipette')
           }
         }
       }


### PR DESCRIPTION
While looking through https://opentrons.atlassian.net/browse/RQA-1834 I noticed a button that reads `detach_next_pip` - the i18n key needed to be updated to `detach_next_pipette`