### PR TITLE
test: add Deck Configuration test cases

### DIFF
--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_AttemptToPutLabwareInColumn4WhenNoStagingArea.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_AttemptToPutLabwareInColumn4WhenNoStagingArea.py
@@ -1,0 +1,3 @@
+# The only way for the Flex to get a column 4 is by adding a Staging Area.
+# Otherwise, it simply doesn't exist
+# This protocol will attempt to put labware into a column 4 when no staging area exists

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_StagingAreaAttemptToPutInA1.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_StagingAreaAttemptToPutInA1.py
@@ -1,0 +1,2 @@
+# Staging areas can only be loaded into column 3. 
+# This protocol will attempt to load a staging area into column 1

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_StagingAreaAttemptToPutInA2.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_StagingAreaAttemptToPutInA2.py
@@ -1,0 +1,2 @@
+# Staging areas can only be loaded into column 3. 
+# This protocol will attempt to load a staging area into column 1

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_TrashBinAttemptToPutInColumn2.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_TrashBinAttemptToPutInColumn2.py
@@ -1,0 +1,2 @@
+# When using a movable trashbin, you cannot put a trashbin into column 2 of your deck
+# This protocol will attempt to put a trashbin into column 2 of your deck

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_TrashBinAttemptToPutInStagingAreaColumn3.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_TrashBinAttemptToPutInStagingAreaColumn3.py
@@ -1,0 +1,2 @@
+# When using a staging area, you cannot put a trashbin into column 3 or 4 of that staging area
+# This protocol will attempt to put a trashbin into column 3 of the staging area

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_TrashBinAttemptToPutInStagingAreaColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_TrashBinAttemptToPutInStagingAreaColumn4.py
@@ -1,0 +1,2 @@
+# When using a staging area, you cannot put a trashbin into column 3 or 4 of that staging area
+# This protocol will attempt to put a trashbin into column 4 of the staging area

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInB3.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInB3.py
@@ -1,0 +1,2 @@
+# The Waste Chute can only go in slot D3
+# This protocol will attempt to put the Waste Chute in slot B3

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInColumn1.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInColumn1.py
@@ -1,0 +1,2 @@
+# The Waste Chute can only go in slot D3
+# This protocol will attempt to put the Waste Chute in column 1

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInColumn2.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInColumn2.py
@@ -1,0 +1,2 @@
+# The Waste Chute can only go in slot D3
+# This protocol will attempt to put the Waste Chute in column 2

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInStagingAreaColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-configuration/OT3_None_None_2_15_WasteChuteAttemptToPutInStagingAreaColumn4.py
@@ -1,0 +1,2 @@
+# Although, the Waste Chute is compatible with a Staging Area, it can only go in slot D3
+# This protocol will attempt to put the Waste Chute on a Staging Area in column 4

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttempt96ChannelPickupFromColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttempt96ChannelPickupFromColumn4.py
@@ -1,0 +1,2 @@
+# When using a staging area, column 4 is only used for moving labware, with either the gripper or manually.
+# This protocol will use a 96-channel pipette to attempt to pick up tips from a tip rack in column 4 of a staging area.

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptInvalid96ChannelPickupFromColumn3.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptInvalid96ChannelPickupFromColumn3.py
@@ -1,0 +1,4 @@
+# When using a staging area, only certain tip pickups are valid with a 96-channel. 
+# This protocol will use a 96-channel pipette to attempt to perform a partial tip pick up
+# from right to left in slot 3. Although, picking up tips from slot 3 is valid.
+# Picking up from right to left would cause the 96 head to crash into the staging area.

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptMultiChannelPickupFromColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptMultiChannelPickupFromColumn4.py
@@ -1,0 +1,3 @@
+# When using a staging area, column 4 is only used for moving labware, with either the gripper or manually.
+# This protocol will use a 8-channel pipette to attempt to pick up tips from a tip rack in column 4 of a staging area.
+# This is invalid and should have an error thrown during initial analysis of the protocol

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptSingleChannelPickupFromColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptSingleChannelPickupFromColumn4.py
@@ -1,0 +1,3 @@
+# When using a staging area, column 4 is only used for moving labware, with either the gripper or manually.
+# This protocol will use a single channel pipette to attempt to pick up tips from a tip rack in column 4 of a staging area.
+# This is invalid and should have an error thrown during initial analysis of the protocol

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptToLoadModuleToColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptToLoadModuleToColumn4.py
@@ -1,0 +1,3 @@
+# When using a staging area, column 4 is for labware only.
+# This protocol will attempt to load a module into column 4 of a staging area.
+# This is invalid and should have an error thrown during initial analysis of the protocol

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptToPipetteToColumn4.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_StagingAreaAttemptToPipetteToColumn4.py
@@ -1,0 +1,2 @@
+# When using a staging area, column 4 is for labware only.
+# This protocol will attempt to pipette to column 4 of a staging area.

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_TrashBinAttemptToDropLabwareWithGripper.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_TrashBinAttemptToDropLabwareWithGripper.py
@@ -1,0 +1,2 @@
+# When using the Movable Trashbin, the only able to dispose to it are pipettes
+# This protocol will attempt to dispose of a tiprack, with the gripper, into the Movable Trashbin

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_TrashBinAttemptToMoveManually.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_TrashBinAttemptToMoveManually.py
@@ -1,0 +1,3 @@
+# When using the Movable Trashbin, it is only able to be moved outside of the protocol. 
+# This protocol will attempt to use the move_labware command to attempt to manually pick up and move
+# the Movable Trashbin.

--- a/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_TrashBinAttemptToMoveWithGripper.py
+++ b/app-testing/files/protocols/py/flex/deck-configuration/failure-cases/invalid-usage/OT3_None_None_2_15_TrashBinAttemptToMoveWithGripper.py
@@ -1,0 +1,3 @@
+# When using the Movable Trashbin, it is only able to be moved outside of the protocol. 
+# This protocol will attempt to use the move_labware command with the gripper to pick 
+# up and move the Movable Trashbin.


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
