### PR TITLE
fix(protocol-designer): grab defUri from labwareDefinitions key

### DIFF
--- a/protocol-designer/src/load-file/migration/7_1_0.ts
+++ b/protocol-designer/src/load-file/migration/7_1_0.ts
@@ -122,7 +122,7 @@ export const migrateFile = (
       },
     },
     labwareDefinitions: {
-      ...{ [trashId]: trashDefinition },
+      ...{ [trashDefUri]: trashDefinition },
       ...appData.labwareDefinitions,
     },
     commands: [...commands, ...trashLoadCommand],

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1154,23 +1154,19 @@ export const labwareInvariantProperties: Reducer<
         ...loadLabwareCommands.reduce(
           (acc: NormalizedLabwareById, command: LoadLabwareCreateCommand) => {
             const { labwareId, loadName } = command.params
-            const labwareDefintionForV7 = Object.entries(
+            const matchingLabwareDefintion = Object.entries(
               file.labwareDefinitions
             ).find(([key, value]) => value.parameters.loadName === loadName)
-            let defUri: string = ''
-            if (labwareDefintionForV7 != null) {
-              const [key] = labwareDefintionForV7
-              defUri = key
-            } else {
-              defUri = loadName
+            let labwareDefURI: string = ''
+            if (matchingLabwareDefintion != null) {
+              const [key] = matchingLabwareDefintion
+              labwareDefURI = key
             }
-
             const id = labwareId ?? ''
-
             return {
               ...acc,
               [id]: {
-                labwareDefURI: defUri,
+                labwareDefURI,
               },
             }
           },

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1154,14 +1154,14 @@ export const labwareInvariantProperties: Reducer<
         ...loadLabwareCommands.reduce(
           (acc: NormalizedLabwareById, command: LoadLabwareCreateCommand) => {
             const { labwareId, loadName } = command.params
-            const matchingLabwareDefintion = Object.entries(
+            const labwareDefinitionMatch = Object.entries(
               file.labwareDefinitions
-            ).find(([key, value]) => value.parameters.loadName === loadName)
-            let labwareDefURI: string = ''
-            if (matchingLabwareDefintion != null) {
-              const [key] = matchingLabwareDefintion
-              labwareDefURI = key
-            }
+            ).find(
+              ([definitionUri, labwareDef]) =>
+                labwareDef.parameters.loadName === loadName
+            )
+            const labwareDefURI =
+              labwareDefinitionMatch != null ? labwareDefinitionMatch[0] : ''
             const id = labwareId ?? ''
             return {
               ...acc,

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1157,19 +1157,20 @@ export const labwareInvariantProperties: Reducer<
             const labwareDefintionForV7 = Object.entries(
               file.labwareDefinitions
             ).find(([key, value]) => value.parameters.loadName === loadName)
-            let defUri
+            let defUri: string = ''
             if (labwareDefintionForV7 != null) {
-              const [key, value] = labwareDefintionForV7
+              const [key] = labwareDefintionForV7
               defUri = key
             } else {
               defUri = loadName
             }
 
             const id = labwareId ?? ''
+
             return {
               ...acc,
               [id]: {
-                labwareDefURI: defUri ?? '',
+                labwareDefURI: defUri,
               },
             }
           },

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1154,12 +1154,22 @@ export const labwareInvariantProperties: Reducer<
         ...loadLabwareCommands.reduce(
           (acc: NormalizedLabwareById, command: LoadLabwareCreateCommand) => {
             const { labwareId, loadName } = command.params
-            const defUri = labwareId?.split(':')[1]
+            const labwareDefintionForV7 = Object.entries(
+              file.labwareDefinitions
+            ).find(([key, value]) => value.parameters.loadName === loadName)
+            let defUri
+            if (labwareDefintionForV7 != null) {
+              const [key, value] = labwareDefintionForV7
+              defUri = key
+            } else {
+              defUri = loadName
+            }
+
             const id = labwareId ?? ''
             return {
               ...acc,
               [id]: {
-                labwareDefURI: loadName.includes('/') ? loadName : defUri ?? '',
+                labwareDefURI: defUri ?? '',
               },
             }
           },

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1153,12 +1153,14 @@ export const labwareInvariantProperties: Reducer<
       const labware = {
         ...loadLabwareCommands.reduce(
           (acc: NormalizedLabwareById, command: LoadLabwareCreateCommand) => {
-            const { labwareId, loadName } = command.params
+            const { labwareId, loadName, namespace, version } = command.params
             const labwareDefinitionMatch = Object.entries(
               file.labwareDefinitions
             ).find(
               ([definitionUri, labwareDef]) =>
-                labwareDef.parameters.loadName === loadName
+                labwareDef.parameters.loadName === loadName &&
+                labwareDef.namespace === namespace &&
+                labwareDef.version === version
             )
             const labwareDefURI =
               labwareDefinitionMatch != null ? labwareDefinitionMatch[0] : ''


### PR DESCRIPTION
addresses RESC-161 https://opentrons.atlassian.net/browse/RESC-161

# Overview

There was a bug reported from the Support team where a Protocol made from version 6.0.0 was imported into 7.0.0 and then reimported into 7.0.0 and white screened. This is because there was a mistake in `loadLabware` in the 7.0.0 migration where the `loadName` was accidentally set to the `definitionURI` And then resulted in very brittle splitting logic in the `labwareInvariantProperties` reducer to grab the definition URI either from the <v7 `loadName` or from splitting the =v7 `labwareId`.

# Test Plan

Upload the `Created 8 September` protocol attached to the ticket. See that it imports correctly. Export it and then change the software version to "7.1.0" and reimport that exported protocol. It should work as expected.

# Changelog

- add to te 7.1.0 migration to change the loadName param in `loadLabware` commands to the true `loadName` instead of the `definitionId` (which is actually the definition uri but in schema 6 the top level labware key refers to it was "definitionId".).
- change the logic in the reducer to not branch and convert that loadname into the definition uri. 

# Review requests

see test plan

# Risk assessment

low