### PR TITLE
fix(api): max discontinuity speed for gripper Z was too high

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -123,7 +123,7 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 5,
         OT3AxisKind.P: 5,
-        OT3AxisKind.Z_G: 10,
+        OT3AxisKind.Z_G: 5,
         OT3AxisKind.Q: 5,
     },
     low_throughput={
@@ -131,7 +131,7 @@ DEFAULT_MAX_SPEED_DISCONTINUITY: Final[
         OT3AxisKind.Y: 10,
         OT3AxisKind.Z: 5,
         OT3AxisKind.P: 10,
-        OT3AxisKind.Z_G: 10,
+        OT3AxisKind.Z_G: 5,
     },
 )
 


### PR DESCRIPTION
We've been seeing the gripper z stage drops unexpectedly during protocol cleanup phase in ABR testing. This happens  when the z stage is very close to the limit switch. It is because the motor is homing at a speed that's so fast that the firmware doesn't have enough time to register the limit switch has been triggered, hence not being to stop the motor in time.
 
I've tested this PR on two ABR robots that were seeing this issue - and the problem has disappeared after the fix.