### PR TITLE
refactor(shared-data): Make cutout IDs more obviously different from addressable area IDs

### DIFF
--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -216,73 +216,73 @@
     ],
     "cutouts": [
       {
-        "id": "1",
+        "id": "cutout1",
         "position": [0.0, 0.0, 0.0],
         "displayName": "Cutout 1",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "2",
+        "id": "cutout2",
         "position": [132.5, 0.0, 0.0],
         "displayName": "Cutout 2",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "3",
+        "id": "cutout3",
         "position": [265.0, 0.0, 0.0],
         "displayName": "Cutout 3",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "4",
+        "id": "cutout4",
         "position": [0.0, 90.5, 0.0],
         "displayName": "Cutout 4",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "5",
+        "id": "cutout5",
         "position": [132.5, 90.5, 0.0],
         "displayName": "Cutout 5",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "6",
+        "id": "cutout6",
         "position": [265.0, 90.5, 0.0],
         "displayName": "Cutout 6",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "7",
+        "id": "cutout7",
         "position": [0.0, 181.0, 0.0],
         "displayName": "Cutout 7",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "8",
+        "id": "cutout8",
         "position": [132.5, 181.0, 0.0],
         "displayName": "Cutout 8",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "9",
+        "id": "cutout9",
         "position": [265.0, 181.0, 0.0],
         "displayName": "Cutout 9",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "10",
+        "id": "cutout10",
         "position": [0.0, 271.5, 0.0],
         "displayName": "Slot 10",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "11",
+        "id": "cutout11",
         "position": [132.5, 271.5, 0.0],
         "displayName": "Cutout 11",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "12",
+        "id": "cutout12",
         "position": [265.0, 271.5, 0.0],
         "displayName": "Cutout 12",
         "compatibleFixtureTypes": ["fixedTrashSlot"]
@@ -354,28 +354,40 @@
   "cutoutFixtures": [
     {
       "id": "singleStandardSlot",
-      "mayMountTo": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
+      "mayMountTo": [
+        "cutout1",
+        "cutout2",
+        "cutout3",
+        "cutout4",
+        "cutout5",
+        "cutout6",
+        "cutout7",
+        "cutout8",
+        "cutout9",
+        "cutout10",
+        "cutout11"
+      ],
       "displayName": "Standard Slot",
       "providesAddressableAreas": {
-        "1": ["1"],
-        "2": ["2"],
-        "3": ["3"],
-        "4": ["4"],
-        "5": ["5"],
-        "6": ["6"],
-        "7": ["7"],
-        "8": ["8"],
-        "9": ["9"],
-        "10": ["10"],
-        "11": ["11"]
+        "cutout1": ["1"],
+        "cutout2": ["2"],
+        "cutout3": ["3"],
+        "cutout4": ["4"],
+        "cutout5": ["5"],
+        "cutout6": ["6"],
+        "cutout7": ["7"],
+        "cutout8": ["8"],
+        "cutout9": ["9"],
+        "cutout10": ["10"],
+        "cutout11": ["11"]
       }
     },
     {
       "id": "fixedTrashSlot",
-      "mayMountTo": ["12"],
+      "mayMountTo": ["cutout12"],
       "displayName": "Fixed Trash",
       "providesAddressableAreas": {
-        "12": ["shortFixedTrash"]
+        "cutout12": ["shortFixedTrash"]
       }
     }
   ]

--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -218,74 +218,62 @@
       {
         "id": "cutout1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout 1",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 1"
       },
       {
         "id": "cutout2",
         "position": [132.5, 0.0, 0.0],
-        "displayName": "Cutout 2",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 2"
       },
       {
         "id": "cutout3",
         "position": [265.0, 0.0, 0.0],
-        "displayName": "Cutout 3",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 3"
       },
       {
         "id": "cutout4",
         "position": [0.0, 90.5, 0.0],
-        "displayName": "Cutout 4",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 4"
       },
       {
         "id": "cutout5",
         "position": [132.5, 90.5, 0.0],
-        "displayName": "Cutout 5",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 5"
       },
       {
         "id": "cutout6",
         "position": [265.0, 90.5, 0.0],
-        "displayName": "Cutout 6",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 6"
       },
       {
         "id": "cutout7",
         "position": [0.0, 181.0, 0.0],
-        "displayName": "Cutout 7",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 7"
       },
       {
         "id": "cutout8",
         "position": [132.5, 181.0, 0.0],
-        "displayName": "Cutout 8",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 8"
       },
       {
         "id": "cutout9",
         "position": [265.0, 181.0, 0.0],
-        "displayName": "Cutout 9",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 9"
       },
       {
         "id": "cutout10",
         "position": [0.0, 271.5, 0.0],
-        "displayName": "Slot 10",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Slot 10"
       },
       {
         "id": "cutout11",
         "position": [132.5, 271.5, 0.0],
-        "displayName": "Cutout 11",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 11"
       },
       {
         "id": "cutout12",
         "position": [265.0, 271.5, 0.0],
-        "displayName": "Cutout 12",
-        "compatibleFixtureTypes": ["fixedTrashSlot"]
+        "displayName": "Cutout 12"
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -218,62 +218,74 @@
       {
         "id": "cutout1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout 1"
+        "displayName": "Cutout 1",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout2",
         "position": [132.5, 0.0, 0.0],
-        "displayName": "Cutout 2"
+        "displayName": "Cutout 2",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout3",
         "position": [265.0, 0.0, 0.0],
-        "displayName": "Cutout 3"
+        "displayName": "Cutout 3",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout4",
         "position": [0.0, 90.5, 0.0],
-        "displayName": "Cutout 4"
+        "displayName": "Cutout 4",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout5",
         "position": [132.5, 90.5, 0.0],
-        "displayName": "Cutout 5"
+        "displayName": "Cutout 5",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout6",
         "position": [265.0, 90.5, 0.0],
-        "displayName": "Cutout 6"
+        "displayName": "Cutout 6",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout7",
         "position": [0.0, 181.0, 0.0],
-        "displayName": "Cutout 7"
+        "displayName": "Cutout 7",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout8",
         "position": [132.5, 181.0, 0.0],
-        "displayName": "Cutout 8"
+        "displayName": "Cutout 8",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout9",
         "position": [265.0, 181.0, 0.0],
-        "displayName": "Cutout 9"
+        "displayName": "Cutout 9",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout10",
         "position": [0.0, 271.5, 0.0],
-        "displayName": "Slot 10"
+        "displayName": "Slot 10",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout11",
         "position": [132.5, 271.5, 0.0],
-        "displayName": "Cutout 11"
+        "displayName": "Cutout 11",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout12",
         "position": [265.0, 271.5, 0.0],
-        "displayName": "Cutout 12"
+        "displayName": "Cutout 12",
+        "compatibleFixtureTypes": ["fixedTrashSlot"]
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -216,73 +216,73 @@
     ],
     "cutouts": [
       {
-        "id": "1",
+        "id": "cutout1",
         "position": [0.0, 0.0, 0.0],
         "displayName": "Cutout 1",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "2",
+        "id": "cutout2",
         "position": [132.5, 0.0, 0.0],
         "displayName": "Cutout 2",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "3",
+        "id": "cutout3",
         "position": [265.0, 0.0, 0.0],
         "displayName": "Cutout 3",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "4",
+        "id": "cutout4",
         "position": [0.0, 90.5, 0.0],
         "displayName": "Cutout 4",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "5",
+        "id": "cutout5",
         "position": [132.5, 90.5, 0.0],
         "displayName": "Cutout 5",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "6",
+        "id": "cutout6",
         "position": [265.0, 90.5, 0.0],
         "displayName": "Cutout 6",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "7",
+        "id": "cutout7",
         "position": [0.0, 181.0, 0.0],
         "displayName": "Cutout 7",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "8",
+        "id": "cutout8",
         "position": [132.5, 181.0, 0.0],
         "displayName": "Cutout 8",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "9",
+        "id": "cutout9",
         "position": [265.0, 181.0, 0.0],
         "displayName": "Cutout 9",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "10",
+        "id": "cutout10",
         "position": [0.0, 271.5, 0.0],
         "displayName": "Slot 10",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "11",
+        "id": "cutout11",
         "position": [132.5, 271.5, 0.0],
         "displayName": "Cutout 11",
         "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
-        "id": "12",
+        "id": "cutout12",
         "position": [265.0, 271.5, 0.0],
         "displayName": "Cutout 12",
         "compatibleFixtureTypes": ["fixedTrashSlot"]
@@ -354,28 +354,40 @@
   "cutoutFixtures": [
     {
       "id": "singleStandardSlot",
-      "mayMountTo": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"],
+      "mayMountTo": [
+        "cutout1",
+        "cutout2",
+        "cutout3",
+        "cutout4",
+        "cutout5",
+        "cutout6",
+        "cutout7",
+        "cutout8",
+        "cutout9",
+        "cutout10",
+        "cutout11"
+      ],
       "displayName": "Standard Slot",
       "providesAddressableAreas": {
-        "1": ["1"],
-        "2": ["2"],
-        "3": ["3"],
-        "4": ["4"],
-        "5": ["5"],
-        "6": ["6"],
-        "7": ["7"],
-        "8": ["8"],
-        "9": ["9"],
-        "10": ["10"],
-        "11": ["11"]
+        "cutout1": ["1"],
+        "cutout2": ["2"],
+        "cutout3": ["3"],
+        "cutout4": ["4"],
+        "cutout5": ["5"],
+        "cutout6": ["6"],
+        "cutout7": ["7"],
+        "cutout8": ["8"],
+        "cutout9": ["9"],
+        "cutout10": ["10"],
+        "cutout11": ["11"]
       }
     },
     {
       "id": "fixedTrashSlot",
-      "mayMountTo": ["12"],
+      "mayMountTo": ["cutout12"],
       "displayName": "Fixed Trash",
       "providesAddressableAreas": {
-        "12": ["fixedTrash"]
+        "cutout12": ["fixedTrash"]
       }
     }
   ]

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -218,74 +218,62 @@
       {
         "id": "cutout1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout 1",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 1"
       },
       {
         "id": "cutout2",
         "position": [132.5, 0.0, 0.0],
-        "displayName": "Cutout 2",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 2"
       },
       {
         "id": "cutout3",
         "position": [265.0, 0.0, 0.0],
-        "displayName": "Cutout 3",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 3"
       },
       {
         "id": "cutout4",
         "position": [0.0, 90.5, 0.0],
-        "displayName": "Cutout 4",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 4"
       },
       {
         "id": "cutout5",
         "position": [132.5, 90.5, 0.0],
-        "displayName": "Cutout 5",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 5"
       },
       {
         "id": "cutout6",
         "position": [265.0, 90.5, 0.0],
-        "displayName": "Cutout 6",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 6"
       },
       {
         "id": "cutout7",
         "position": [0.0, 181.0, 0.0],
-        "displayName": "Cutout 7",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 7"
       },
       {
         "id": "cutout8",
         "position": [132.5, 181.0, 0.0],
-        "displayName": "Cutout 8",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 8"
       },
       {
         "id": "cutout9",
         "position": [265.0, 181.0, 0.0],
-        "displayName": "Cutout 9",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 9"
       },
       {
         "id": "cutout10",
         "position": [0.0, 271.5, 0.0],
-        "displayName": "Slot 10",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Slot 10"
       },
       {
         "id": "cutout11",
         "position": [132.5, 271.5, 0.0],
-        "displayName": "Cutout 11",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 11"
       },
       {
         "id": "cutout12",
         "position": [265.0, 271.5, 0.0],
-        "displayName": "Cutout 12",
-        "compatibleFixtureTypes": ["fixedTrashSlot"]
+        "displayName": "Cutout 12"
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -218,62 +218,74 @@
       {
         "id": "cutout1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout 1"
+        "displayName": "Cutout 1",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout2",
         "position": [132.5, 0.0, 0.0],
-        "displayName": "Cutout 2"
+        "displayName": "Cutout 2",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout3",
         "position": [265.0, 0.0, 0.0],
-        "displayName": "Cutout 3"
+        "displayName": "Cutout 3",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout4",
         "position": [0.0, 90.5, 0.0],
-        "displayName": "Cutout 4"
+        "displayName": "Cutout 4",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout5",
         "position": [132.5, 90.5, 0.0],
-        "displayName": "Cutout 5"
+        "displayName": "Cutout 5",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout6",
         "position": [265.0, 90.5, 0.0],
-        "displayName": "Cutout 6"
+        "displayName": "Cutout 6",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout7",
         "position": [0.0, 181.0, 0.0],
-        "displayName": "Cutout 7"
+        "displayName": "Cutout 7",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout8",
         "position": [132.5, 181.0, 0.0],
-        "displayName": "Cutout 8"
+        "displayName": "Cutout 8",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout9",
         "position": [265.0, 181.0, 0.0],
-        "displayName": "Cutout 9"
+        "displayName": "Cutout 9",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout10",
         "position": [0.0, 271.5, 0.0],
-        "displayName": "Slot 10"
+        "displayName": "Slot 10",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout11",
         "position": [132.5, 271.5, 0.0],
-        "displayName": "Cutout 11"
+        "displayName": "Cutout 11",
+        "compatibleFixtureTypes": ["singleStandardSlot"]
       },
       {
         "id": "cutout12",
         "position": [265.0, 271.5, 0.0],
-        "displayName": "Cutout 12"
+        "displayName": "Cutout 12",
+        "compatibleFixtureTypes": ["fixedTrashSlot"]
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -304,19 +304,19 @@
     ],
     "cutouts": [
       {
-        "id": "D1",
+        "id": "cutoutD1",
         "position": [0.0, 0.0, 0.0],
         "displayName": "Cutout D1",
         "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
-        "id": "D2",
+        "id": "cutoutD2",
         "position": [164.0, 0.0, 0.0],
         "displayName": "Cutout D2",
         "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
-        "id": "D3",
+        "id": "cutoutD3",
         "position": [328.0, 0.0, 0.0],
         "displayName": "Cutout D3",
         "compatibleFixtureTypes": [
@@ -328,19 +328,19 @@
         ]
       },
       {
-        "id": "C1",
+        "id": "cutoutC1",
         "position": [0.0, 107, 0.0],
         "displayName": "Cutout C1",
         "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
-        "id": "C2",
+        "id": "cutoutC2",
         "position": [164.0, 107, 0.0],
         "displayName": "Cutout C2",
         "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
-        "id": "C3",
+        "id": "cutoutC3",
         "position": [328.0, 107, 0.0],
         "displayName": "Cutout C3",
         "compatibleFixtureTypes": [
@@ -350,19 +350,19 @@
         ]
       },
       {
-        "id": "B1",
+        "id": "cutoutB1",
         "position": [0.0, 214.0, 0.0],
         "displayName": "Cutout B1",
         "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
-        "id": "B2",
+        "id": "cutoutB2",
         "position": [164.0, 214.0, 0.0],
         "displayName": "Cutout B2",
         "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
-        "id": "B3",
+        "id": "cutoutB3",
         "position": [328.0, 214.0, 0.0],
         "displayName": "Cutout B3",
         "compatibleFixtureTypes": [
@@ -372,19 +372,19 @@
         ]
       },
       {
-        "id": "A1",
+        "id": "cutoutA1",
         "position": [0.0, 321.0, 0.0],
         "displayName": "Cutout A1",
         "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
-        "id": "A2",
+        "id": "cutoutA2",
         "position": [164.0, 321.0, 0.0],
         "displayName": "Cutout A2",
         "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
-        "id": "A3",
+        "id": "cutoutA3",
         "position": [328.0, 321.0, 0.0],
         "displayName": "Cutout A3",
         "compatibleFixtureTypes": [
@@ -399,77 +399,86 @@
   "cutoutFixtures": [
     {
       "id": "singleLeftSlot",
-      "mayMountTo": ["D1", "C1", "B1", "A1"],
+      "mayMountTo": ["cutoutD1", "cutoutC1", "cutoutB1", "cutoutA1"],
       "displayName": "Standard Slot Left",
       "providesAddressableAreas": {
-        "D1": ["D1"],
-        "C1": ["C1"],
-        "B1": ["B1"],
-        "A1": ["A1"]
+        "cutoutD1": ["D1"],
+        "cutoutC1": ["C1"],
+        "cutoutB1": ["B1"],
+        "cutoutA1": ["A1"]
       }
     },
     {
       "id": "singleCenterSlot",
-      "mayMountTo": ["D2", "C2", "B2", "A2"],
+      "mayMountTo": ["cutoutD2", "cutoutC2", "cutoutB2", "cutoutA2"],
       "displayName": "Standard Slot Center",
       "providesAddressableAreas": {
-        "D2": ["D2"],
-        "C2": ["C2"],
-        "B2": ["B2"],
-        "A2": ["A2"]
+        "cutoutD2": ["D2"],
+        "cutoutC2": ["C2"],
+        "cutoutB2": ["B2"],
+        "cutoutA2": ["A2"]
       }
     },
     {
       "id": "singleRightSlot",
-      "mayMountTo": ["D3", "C3", "B3", "A3"],
+      "mayMountTo": ["cutoutD3", "cutoutC3", "cutoutB3", "cutoutA3"],
       "displayName": "Standard Slot Right",
       "providesAddressableAreas": {
-        "D3": ["D3"],
-        "C3": ["C3"],
-        "B3": ["B3"],
-        "A3": ["A3"]
+        "cutoutD3": ["D3"],
+        "cutoutC3": ["C3"],
+        "cutoutB3": ["B3"],
+        "cutoutA3": ["A3"]
       }
     },
     {
       "id": "stagingAreaRightSlot",
-      "mayMountTo": ["D3", "C3", "B3", "A3"],
+      "mayMountTo": ["cutoutD3", "cutoutC3", "cutoutB3", "cutoutA3"],
       "displayName": "Staging Area Slot",
       "providesAddressableAreas": {
-        "D3": ["D3", "D4"],
-        "C3": ["C3", "C4"],
-        "B3": ["B3", "B4"],
-        "A3": ["A3", "A4"]
+        "cutoutD3": ["D3", "D4"],
+        "cutoutC3": ["C3", "C4"],
+        "cutoutB3": ["B3", "B4"],
+        "cutoutA3": ["A3", "A4"]
       }
     },
     {
       "id": "trashBinAdapter",
-      "mayMountTo": ["D1", "C1", "B1", "A1", "D3", "C3", "B3", "A3"],
+      "mayMountTo": [
+        "cutoutD1",
+        "cutoutC1",
+        "cutoutB1",
+        "cutoutA1",
+        "cutoutD3",
+        "cutoutC3",
+        "cutoutB3",
+        "cutoutA3"
+      ],
       "displayName": "Slot With Movable Trash",
       "providesAddressableAreas": {
-        "D1": ["movableTrash"],
-        "C1": ["movableTrash"],
-        "B1": ["movableTrash"],
-        "A1": ["movableTrash"],
-        "D3": ["movableTrash"],
-        "C3": ["movableTrash"],
-        "B3": ["movableTrash"],
-        "A3": ["movableTrash"]
+        "cutoutD1": ["movableTrash"],
+        "cutoutC1": ["movableTrash"],
+        "cutoutB1": ["movableTrash"],
+        "cutoutA1": ["movableTrash"],
+        "cutoutD3": ["movableTrash"],
+        "cutoutC3": ["movableTrash"],
+        "cutoutB3": ["movableTrash"],
+        "cutoutA3": ["movableTrash"]
       }
     },
     {
       "id": "wasteChuteRightAdapterCovered",
-      "mayMountTo": ["D3"],
+      "mayMountTo": ["cutoutD3"],
       "displayName": "Waste Chute Adapter for 1 or 8 Channel Pipettes",
       "providesAddressableAreas": {
-        "D3": ["1and8ChannelWasteChute"]
+        "cutoutD3": ["1and8ChannelWasteChute"]
       }
     },
     {
       "id": "wasteChuteRightAdapterNoCover",
-      "mayMountTo": ["D3"],
+      "mayMountTo": ["cutoutD3"],
       "displayName": "Waste Chute Adapter for 96 Channel Pipette or Gripper",
       "providesAddressableAreas": {
-        "D3": [
+        "cutoutD3": [
           "1and8ChannelWasteChute",
           "96ChannelWasteChute",
           "gripperWasteChute"
@@ -478,18 +487,18 @@
     },
     {
       "id": "stagingAreaSlotWithWasteChuteRightAdapterCovered",
-      "mayMountTo": ["D3"],
+      "mayMountTo": ["cutoutD3"],
       "displayName": "Staging Slot With Waste Chute Adapter for 96 Channel Pipette or Gripper",
       "providesAddressableAreas": {
-        "D3": ["1and8ChannelWasteChute", "D4"]
+        "cutoutD3": ["1and8ChannelWasteChute", "D4"]
       }
     },
     {
       "id": "stagingAreaSlotWithWasteChuteRightAdapterNoCover",
-      "mayMountTo": ["D3"],
+      "mayMountTo": ["cutoutD3"],
       "displayName": "Staging Slot With Waste Chute Adapter and Staging Area Slot",
       "providesAddressableAreas": {
-        "D3": [
+        "cutoutD3": [
           "1and8ChannelWasteChute",
           "96ChannelWasteChute",
           "gripperWasteChute",

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -306,62 +306,92 @@
       {
         "id": "cutoutD1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout D1"
+        "displayName": "Cutout D1",
+        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
         "id": "cutoutD2",
         "position": [164.0, 0.0, 0.0],
-        "displayName": "Cutout D2"
+        "displayName": "Cutout D2",
+        "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
         "id": "cutoutD3",
         "position": [328.0, 0.0, 0.0],
-        "displayName": "Cutout D3"
+        "displayName": "Cutout D3",
+        "compatibleFixtureTypes": [
+          "singleRightSlot",
+          "stagingAreaRightSlot",
+          "trashBinAdapter",
+          "wasteChuteRightAdapter",
+          "wasteChuteRightAdapterWithStagingAreaSlot"
+        ]
       },
       {
         "id": "cutoutC1",
         "position": [0.0, 107, 0.0],
-        "displayName": "Cutout C1"
+        "displayName": "Cutout C1",
+        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
         "id": "cutoutC2",
         "position": [164.0, 107, 0.0],
-        "displayName": "Cutout C2"
+        "displayName": "Cutout C2",
+        "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
         "id": "cutoutC3",
         "position": [328.0, 107, 0.0],
-        "displayName": "Cutout C3"
+        "displayName": "Cutout C3",
+        "compatibleFixtureTypes": [
+          "singleRightSlot",
+          "stagingAreaRightSlot",
+          "trashBinAdapter"
+        ]
       },
       {
         "id": "cutoutB1",
         "position": [0.0, 214.0, 0.0],
-        "displayName": "Cutout B1"
+        "displayName": "Cutout B1",
+        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
         "id": "cutoutB2",
         "position": [164.0, 214.0, 0.0],
-        "displayName": "Cutout B2"
+        "displayName": "Cutout B2",
+        "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
         "id": "cutoutB3",
         "position": [328.0, 214.0, 0.0],
-        "displayName": "Cutout B3"
+        "displayName": "Cutout B3",
+        "compatibleFixtureTypes": [
+          "singleRightSlot",
+          "stagingAreaRightSlot",
+          "trashBinAdapter"
+        ]
       },
       {
         "id": "cutoutA1",
         "position": [0.0, 321.0, 0.0],
-        "displayName": "Cutout A1"
+        "displayName": "Cutout A1",
+        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
       },
       {
         "id": "cutoutA2",
         "position": [164.0, 321.0, 0.0],
-        "displayName": "Cutout A2"
+        "displayName": "Cutout A2",
+        "compatibleFixtureTypes": ["singleCenterSlot"]
       },
       {
         "id": "cutoutA3",
         "position": [328.0, 321.0, 0.0],
-        "displayName": "Cutout A3"
+        "displayName": "Cutout A3",
+        "compatibleFixtureTypes": [
+          "singleRightSlot",
+          "stagingAreaRightSlot",
+          "trashBinAdapter"
+        ]
       }
     ],
     "calibrationPoints": []

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -306,92 +306,62 @@
       {
         "id": "cutoutD1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout D1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout D1"
       },
       {
         "id": "cutoutD2",
         "position": [164.0, 0.0, 0.0],
-        "displayName": "Cutout D2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout D2"
       },
       {
         "id": "cutoutD3",
         "position": [328.0, 0.0, 0.0],
-        "displayName": "Cutout D3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter",
-          "wasteChuteRightAdapter",
-          "wasteChuteRightAdapterWithStagingAreaSlot"
-        ]
+        "displayName": "Cutout D3"
       },
       {
         "id": "cutoutC1",
         "position": [0.0, 107, 0.0],
-        "displayName": "Cutout C1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout C1"
       },
       {
         "id": "cutoutC2",
         "position": [164.0, 107, 0.0],
-        "displayName": "Cutout C2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout C2"
       },
       {
         "id": "cutoutC3",
         "position": [328.0, 107, 0.0],
-        "displayName": "Cutout C3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter"
-        ]
+        "displayName": "Cutout C3"
       },
       {
         "id": "cutoutB1",
         "position": [0.0, 214.0, 0.0],
-        "displayName": "Cutout B1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout B1"
       },
       {
         "id": "cutoutB2",
         "position": [164.0, 214.0, 0.0],
-        "displayName": "Cutout B2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout B2"
       },
       {
         "id": "cutoutB3",
         "position": [328.0, 214.0, 0.0],
-        "displayName": "Cutout B3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter"
-        ]
+        "displayName": "Cutout B3"
       },
       {
         "id": "cutoutA1",
         "position": [0.0, 321.0, 0.0],
-        "displayName": "Cutout A1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout A1"
       },
       {
         "id": "cutoutA2",
         "position": [164.0, 321.0, 0.0],
-        "displayName": "Cutout A2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout A2"
       },
       {
         "id": "cutoutA3",
         "position": [328.0, 321.0, 0.0],
-        "displayName": "Cutout A3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter"
-        ]
+        "displayName": "Cutout A3"
       }
     ],
     "calibrationPoints": []

--- a/shared-data/deck/schemas/4.json
+++ b/shared-data/deck/schemas/4.json
@@ -200,7 +200,12 @@
           "description": "The machined cutout slots on the deck surface.",
           "items": {
             "type": "object",
-            "required": ["id", "position", "displayName"],
+            "required": [
+              "id",
+              "position",
+              "displayName",
+              "compatibleFixtureTypes"
+            ],
             "properties": {
               "id": {
                 "description": "Unique identifier for the cutout",
@@ -213,6 +218,13 @@
               "displayName": {
                 "description": "An optional human-readable nickname for this cutout e.g. \"Cutout A1\"",
                 "type": "string"
+              },
+              "compatibleFixtureTypes": {
+                "description": "A list of cutout fixture types that can be loaded onto this cutout.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/shared-data/deck/schemas/4.json
+++ b/shared-data/deck/schemas/4.json
@@ -200,12 +200,7 @@
           "description": "The machined cutout slots on the deck surface.",
           "items": {
             "type": "object",
-            "required": [
-              "id",
-              "position",
-              "displayName",
-              "compatibleFixtureTypes"
-            ],
+            "required": ["id", "position", "displayName"],
             "properties": {
               "id": {
                 "description": "Unique identifier for the cutout",
@@ -218,13 +213,6 @@
               "displayName": {
                 "description": "An optional human-readable nickname for this cutout e.g. \"Cutout A1\"",
                 "type": "string"
-              },
-              "compatibleFixtureTypes": {
-                "description": "A list of cutout fixture types that can be loaded onto this cutout.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
               }
             }
           }

--- a/shared-data/deck/schemas/4.json
+++ b/shared-data/deck/schemas/4.json
@@ -247,7 +247,7 @@
             "type": "string"
           },
           "mayMountTo": {
-            "description": "A list of compatible cutouts this fixture may be mounted to.",
+            "description": "A list of compatible cutouts this fixture may be mounted to. These must match `id`s in `cutouts`.",
             "type": "array",
             "items": {
               "type": "string"

--- a/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
+++ b/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
@@ -149,10 +149,6 @@ class Cutout(BaseModel):
         ...,
         description='An optional human-readable nickname for this cutout e.g. "Cutout A1"',
     )
-    compatibleFixtureTypes: List[str] = Field(
-        ...,
-        description="A list of cutout fixture types that can be loaded onto this cutout.",
-    )
 
 
 class Locations(BaseModel):

--- a/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
+++ b/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
@@ -149,6 +149,10 @@ class Cutout(BaseModel):
         ...,
         description='An optional human-readable nickname for this cutout e.g. "Cutout A1"',
     )
+    compatibleFixtureTypes: List[str] = Field(
+        ...,
+        description="A list of cutout fixture types that can be loaded onto this cutout.",
+    )
 
 
 class Locations(BaseModel):

--- a/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
+++ b/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
@@ -43,7 +43,8 @@ class AreaType(Enum):
 class CutoutFixture(BaseModel):
     id: str = Field(..., description="Unique identifier for the cutout fixture.")
     mayMountTo: List[str] = Field(
-        ..., description="A list of compatible cutouts this fixture may be mounted to."
+        ...,
+        description="A list of compatible cutouts this fixture may be mounted to. These must match `id`s in `cutouts`.",
     )
     displayName: str = Field(
         ...,

--- a/shared-data/python/opentrons_shared_data/deck/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/deck/dev_types.py
@@ -109,7 +109,6 @@ class Cutout(TypedDict):
     id: str
     position: List[float]
     displayName: str
-    compatibleFixtureTypes: List[str]
 
 
 class CutoutFixture(TypedDict):

--- a/shared-data/python/opentrons_shared_data/deck/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/deck/dev_types.py
@@ -109,6 +109,7 @@ class Cutout(TypedDict):
     id: str
     position: List[float]
     displayName: str
+    compatibleFixtureTypes: List[str]
 
 
 class CutoutFixture(TypedDict):

--- a/shared-data/python/tests/deck/test_position.py
+++ b/shared-data/python/tests/deck/test_position.py
@@ -1,8 +1,94 @@
+from typing import Dict, Generator, List, Set, Tuple
+
 import pytest
 
 from opentrons_shared_data.deck import load as load_deck_definition
+from opentrons_shared_data.deck.dev_types import (
+    AddressableArea,
+    Cutout,
+    CutoutFixture,
+    DeckDefinitionV3,
+    DeckDefinitionV4,
+)
 
 from . import list_deck_def_paths
+
+
+def as_tuple(list: List[float]) -> Tuple[float, float, float]:
+    """Convert an [x,y,z] list from the definitions to an (x,y,z) tuple, for hashability."""
+    [x, y, z] = list
+    return (x, y, z)
+
+
+def get_v3_slot_positions(
+    definition: DeckDefinitionV3,
+) -> Set[Tuple[str, Tuple[float, float, float]]]:
+    """Return all the slot positions defined by the deck definition, as (slot_id, [x,y,z]) tuples."""
+    return set(
+        (ordered_slot["id"], as_tuple(ordered_slot["position"]))
+        for ordered_slot in definition["locations"]["orderedSlots"]
+    )
+
+
+def get_v4_stacks(
+    definition: DeckDefinitionV4,
+) -> Generator[Tuple[Cutout, CutoutFixture, AddressableArea], None, None]:
+    """Yield all the (cutout, cutoutFixture, addressableArea) combinations that the def allows."""
+    cutout_fixtures = definition["cutoutFixtures"]
+    cutouts_by_id: Dict[str, Cutout] = {
+        cutout["id"]: cutout for cutout in definition["locations"]["cutouts"]
+    }
+    addressable_areas_by_id: Dict[str, AddressableArea] = {
+        addressable_area["id"]: addressable_area
+        for addressable_area in definition["locations"]["addressableAreas"]
+    }
+
+    for cutout_fixture in cutout_fixtures:
+        for cutout_id, addressable_area_ids in cutout_fixture[
+            "providesAddressableAreas"
+        ].items():
+            for addressable_area_id in addressable_area_ids:
+                cutout = cutouts_by_id[cutout_id]
+                addressable_area = addressable_areas_by_id[addressable_area_id]
+                yield cutout, cutout_fixture, addressable_area
+
+
+def compute_v4_position(
+    cutout: Cutout, addressable_area: AddressableArea
+) -> List[float]:
+    return [
+        a + b
+        for a, b in zip(cutout["position"], addressable_area["offsetFromCutoutFixture"])
+    ]
+
+
+def get_v4_slot_positions(
+    definition: DeckDefinitionV4,
+) -> Set[Tuple[str, Tuple[float, float, float]]]:
+    """Return all the slot positions defined by the deck definition, as (addressable_area_id, [x,y,z]) tuples.
+
+    It's important that this returns a set of (addressable_area_id, [x,y,z]) tuples instead of a
+    dict {addressable_area_id: [x,y,z]}. Deck schema v4 theoretically allows a single addressable
+    area ID to be associated with multiple positions. If that happens, we don't want to accidentally
+    overwrite any.
+    """
+    stacks_with_slots = (
+        (cutout, cutout_fixture, addressable_area)
+        for (cutout, cutout_fixture, addressable_area) in get_v4_stacks(definition)
+        # v3 has a "slot" for the fixed trash, but in v4, fixedTrash is its own area type. Count
+        # it as a "slot," since we still want to compare the positions across schema versions.
+        if addressable_area["areaType"] in {"slot", "fixedTrash"}
+    )
+
+    slot_positions = (
+        (
+            addressable_area["id"],
+            as_tuple(compute_v4_position(cutout, addressable_area)),
+        )
+        for (cutout, cutout_fixture, addressable_area) in stacks_with_slots
+    )
+
+    return set(slot_positions)
 
 
 @pytest.mark.parametrize("definition_name", list_deck_def_paths(version=4))
@@ -10,34 +96,24 @@ def test_v3_and_v4_positional_equivalence(definition_name: str) -> None:
     deck_v3 = load_deck_definition(name=definition_name, version=3)
     deck_v4 = load_deck_definition(name=definition_name, version=4)
 
-    # Get a mapping of v3 slot names (ids) to the position
-    deck_v3_locations = {
-        orderedSlot["id"]: orderedSlot["position"]
-        for orderedSlot in deck_v3["locations"]["orderedSlots"]
-    }
+    v3_slot_positions = get_v3_slot_positions(deck_v3)
+    v4_slot_positions = get_v4_slot_positions(deck_v4)
 
-    # Get the base cutout locations (id is also slot name)
-    deck_v4_locations = {
-        cutout["id"]: cutout["position"] for cutout in deck_v4["locations"]["cutouts"]
-    }
+    # Exclude v4 staging area slots from this comparison, because they won't be present in v3 deck schemas.
+    v4_slot_positions = set(
+        (slot_id, slot_position)
+        for slot_id, slot_position in v4_slot_positions
+        if slot_id not in {"A4", "B4", "C4", "D4"}
+    )
 
-    # Iterate through addressable areas that match to slot names and add their position to the cutout
-    # for the final slot position
-    for addressable_area in deck_v4["locations"]["addressableAreas"]:
-        addressable_area_id = addressable_area["id"]
-        try:
-            cutout_position = deck_v4_locations[addressable_area_id]
-        except KeyError:
-            continue
-        else:
-            area_offset = addressable_area["offsetFromCutoutFixture"]
-            x = cutout_position[0] + area_offset[0]
-            y = cutout_position[1] + area_offset[1]
-            z = cutout_position[2] + area_offset[2]
-            deck_v4_locations[addressable_area_id] = [x, y, z]
+    # For the purposes of this comparison, the v4 addressable areas named "fixedTrash" and
+    # "shortFixedTrash" should be compared to slot 12 in v3.
+    v4_slot_positions = set(
+        (
+            "12" if slot_id in {"fixedTrash", "shortFixedTrash"} else slot_id,
+            slot_position,
+        )
+        for slot_id, slot_position in v4_slot_positions
+    )
 
-    assert len(deck_v3_locations.keys()) == len(deck_v4_locations.keys())
-    slot_names = list(deck_v4_locations.keys())
-
-    for slot_name in slot_names:
-        assert deck_v3_locations[slot_name] == deck_v4_locations[slot_name]
+    assert v3_slot_positions == v4_slot_positions


### PR DESCRIPTION
# Overview

Our latest thinking in deck definitions is that *cutouts* can have *cutout fixtures* mounted onto them, and those cutout fixtures provide *addressable areas* to protocols. Cutouts, cutout fixtures, and addressable areas are all separate things.

Our cutouts happen to have the same `id` strings as some of our addressable areas, like `"C2"`. This is confusing because it baits us into conflating the two concepts, or assuming a link where one does not necessarily exist. So this makes the `id` strings different, so the distinction is more obvious.

This goes towards RSS-333 in general.

# Test Plan

I don't think we've built anything so far that is actually looking at cutout `id`s and would actually be in danger of breaking, have we?

If that's correct, we're good with just CI testing.

# Changelog

* Rename cutout `id`s like `"C2"` to be like `"cutoutC2"`.
* Leave the addressable area `id`s like `"C2"` alone, so they will continue to generally match what protocols write.
* Rewrite a test that assumed, for example, that slot C2 was defined by addressable area C2 and cutout C2. It now traverses the deck definition's `providesAddressableAreas` fields to avoid assuming anything about the cutout IDs.

# Review requests

* Double-check my work in the JSON files to make sure I didn't miss anywhere.
* This will surface problems in any code that assumes anything about cutout fixture IDs. For example, if we improperly have something like `CutoutFixtureID = Literal["A1", "A2", ...]` anywhere, that will break. Are you aware of any code that does that?

# Risk assessment

Low.
