### PR TITLE
refactor(shared-data): Delete `compatibleFixtureTypes` from schema v4

### DIFF
--- a/shared-data/deck/definitions/4/ot2_short_trash.json
+++ b/shared-data/deck/definitions/4/ot2_short_trash.json
@@ -218,74 +218,62 @@
       {
         "id": "1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout 1",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 1"
       },
       {
         "id": "2",
         "position": [132.5, 0.0, 0.0],
-        "displayName": "Cutout 2",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 2"
       },
       {
         "id": "3",
         "position": [265.0, 0.0, 0.0],
-        "displayName": "Cutout 3",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 3"
       },
       {
         "id": "4",
         "position": [0.0, 90.5, 0.0],
-        "displayName": "Cutout 4",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 4"
       },
       {
         "id": "5",
         "position": [132.5, 90.5, 0.0],
-        "displayName": "Cutout 5",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 5"
       },
       {
         "id": "6",
         "position": [265.0, 90.5, 0.0],
-        "displayName": "Cutout 6",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 6"
       },
       {
         "id": "7",
         "position": [0.0, 181.0, 0.0],
-        "displayName": "Cutout 7",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 7"
       },
       {
         "id": "8",
         "position": [132.5, 181.0, 0.0],
-        "displayName": "Cutout 8",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 8"
       },
       {
         "id": "9",
         "position": [265.0, 181.0, 0.0],
-        "displayName": "Cutout 9",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 9"
       },
       {
         "id": "10",
         "position": [0.0, 271.5, 0.0],
-        "displayName": "Slot 10",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Slot 10"
       },
       {
         "id": "11",
         "position": [132.5, 271.5, 0.0],
-        "displayName": "Cutout 11",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 11"
       },
       {
         "id": "12",
         "position": [265.0, 271.5, 0.0],
-        "displayName": "Cutout 12",
-        "compatibleFixtureTypes": ["fixedTrashSlot"]
+        "displayName": "Cutout 12"
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/4/ot2_standard.json
+++ b/shared-data/deck/definitions/4/ot2_standard.json
@@ -218,74 +218,62 @@
       {
         "id": "1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout 1",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 1"
       },
       {
         "id": "2",
         "position": [132.5, 0.0, 0.0],
-        "displayName": "Cutout 2",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 2"
       },
       {
         "id": "3",
         "position": [265.0, 0.0, 0.0],
-        "displayName": "Cutout 3",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 3"
       },
       {
         "id": "4",
         "position": [0.0, 90.5, 0.0],
-        "displayName": "Cutout 4",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 4"
       },
       {
         "id": "5",
         "position": [132.5, 90.5, 0.0],
-        "displayName": "Cutout 5",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 5"
       },
       {
         "id": "6",
         "position": [265.0, 90.5, 0.0],
-        "displayName": "Cutout 6",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 6"
       },
       {
         "id": "7",
         "position": [0.0, 181.0, 0.0],
-        "displayName": "Cutout 7",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 7"
       },
       {
         "id": "8",
         "position": [132.5, 181.0, 0.0],
-        "displayName": "Cutout 8",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 8"
       },
       {
         "id": "9",
         "position": [265.0, 181.0, 0.0],
-        "displayName": "Cutout 9",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 9"
       },
       {
         "id": "10",
         "position": [0.0, 271.5, 0.0],
-        "displayName": "Slot 10",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Slot 10"
       },
       {
         "id": "11",
         "position": [132.5, 271.5, 0.0],
-        "displayName": "Cutout 11",
-        "compatibleFixtureTypes": ["singleStandardSlot"]
+        "displayName": "Cutout 11"
       },
       {
         "id": "12",
         "position": [265.0, 271.5, 0.0],
-        "displayName": "Cutout 12",
-        "compatibleFixtureTypes": ["fixedTrashSlot"]
+        "displayName": "Cutout 12"
       }
     ],
     "calibrationPoints": [

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -306,92 +306,62 @@
       {
         "id": "D1",
         "position": [0.0, 0.0, 0.0],
-        "displayName": "Cutout D1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout D1"
       },
       {
         "id": "D2",
         "position": [164.0, 0.0, 0.0],
-        "displayName": "Cutout D2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout D2"
       },
       {
         "id": "D3",
         "position": [328.0, 0.0, 0.0],
-        "displayName": "Cutout D3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter",
-          "wasteChuteRightAdapter",
-          "wasteChuteRightAdapterWithStagingAreaSlot"
-        ]
+        "displayName": "Cutout D3"
       },
       {
         "id": "C1",
         "position": [0.0, 107, 0.0],
-        "displayName": "Cutout C1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout C1"
       },
       {
         "id": "C2",
         "position": [164.0, 107, 0.0],
-        "displayName": "Cutout C2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout C2"
       },
       {
         "id": "C3",
         "position": [328.0, 107, 0.0],
-        "displayName": "Cutout C3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter"
-        ]
+        "displayName": "Cutout C3"
       },
       {
         "id": "B1",
         "position": [0.0, 214.0, 0.0],
-        "displayName": "Cutout B1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout B1"
       },
       {
         "id": "B2",
         "position": [164.0, 214.0, 0.0],
-        "displayName": "Cutout B2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout B2"
       },
       {
         "id": "B3",
         "position": [328.0, 214.0, 0.0],
-        "displayName": "Cutout B3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter"
-        ]
+        "displayName": "Cutout B3"
       },
       {
         "id": "A1",
         "position": [0.0, 321.0, 0.0],
-        "displayName": "Cutout A1",
-        "compatibleFixtureTypes": ["singleLeftSlot", "trashBinAdapter"]
+        "displayName": "Cutout A1"
       },
       {
         "id": "A2",
         "position": [164.0, 321.0, 0.0],
-        "displayName": "Cutout A2",
-        "compatibleFixtureTypes": ["singleCenterSlot"]
+        "displayName": "Cutout A2"
       },
       {
         "id": "A3",
         "position": [328.0, 321.0, 0.0],
-        "displayName": "Cutout A3",
-        "compatibleFixtureTypes": [
-          "singleRightSlot",
-          "stagingAreaRightSlot",
-          "trashBinAdapter"
-        ]
+        "displayName": "Cutout A3"
       }
     ],
     "calibrationPoints": []

--- a/shared-data/deck/schemas/4.json
+++ b/shared-data/deck/schemas/4.json
@@ -200,12 +200,7 @@
           "description": "The machined cutout slots on the deck surface.",
           "items": {
             "type": "object",
-            "required": [
-              "id",
-              "position",
-              "displayName",
-              "compatibleFixtureTypes"
-            ],
+            "required": ["id", "position", "displayName"],
             "properties": {
               "id": {
                 "description": "Unique identifier for the cutout",
@@ -218,13 +213,6 @@
               "displayName": {
                 "description": "An optional human-readable nickname for this cutout e.g. \"Cutout A1\"",
                 "type": "string"
-              },
-              "compatibleFixtureTypes": {
-                "description": "A list of cutout fixture types that can be loaded onto this cutout.",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
               }
             }
           }

--- a/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
+++ b/shared-data/python/opentrons_shared_data/deck/deck_definitions.py
@@ -148,10 +148,6 @@ class Cutout(BaseModel):
         ...,
         description='An optional human-readable nickname for this cutout e.g. "Cutout A1"',
     )
-    compatibleFixtureTypes: List[str] = Field(
-        ...,
-        description="A list of cutout fixture types that can be loaded onto this cutout.",
-    )
 
 
 class Locations(BaseModel):

--- a/shared-data/python/opentrons_shared_data/deck/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/deck/dev_types.py
@@ -109,7 +109,6 @@ class Cutout(TypedDict):
     id: str
     position: List[float]
     displayName: str
-    compatibleFixtureTypes: List[str]
 
 
 class CutoutFixture(TypedDict):


### PR DESCRIPTION
# Overview

Right now, every cutout has a list of `compatibleFixtureTypes`. That seems redundant. Every `cutoutFixture` defines the cutouts that it's allowed to mount to (via the `mayMountTo` field). So, there's no reason for every cutout to also define the `cutoutFixtures` that are allowed to mount to it.

This field used to link with the `fixtureType` field, but that was removed in #13785.

# Test Plan

Just CI.

# Review requests

Is this architecturally correct, or am I missing a use case for these fields?

# Risk assessment

Low. As far as I can tell, nothing was using these.
