### PR TITLE
feat(protocol-designer): add unused modal logic for fixtures

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -11,11 +11,15 @@ import { resetScrollElements } from '../../ui/steps/utils'
 import { Portal } from '../portals/MainPageModalPortal'
 import { useBlockingHint } from '../Hints/useBlockingHint'
 import { KnowledgeBaseLink } from '../KnowledgeBaseLink'
-import { getUnusedEntities } from './utils'
+import {
+  getUnusedEntities,
+  getUnusedTrash,
+  getUnusedStagingAreas,
+} from './utils'
 import modalStyles from '../modals/modal.css'
 import styles from './FileSidebar.css'
 
-import { HintKey } from '../../tutorial'
+import type { HintKey } from '../../tutorial'
 import type {
   InitialDeckSetup,
   SavedStepFormState,
@@ -28,19 +32,6 @@ import type {
   RobotType,
 } from '@opentrons/shared-data'
 
-export interface Props {
-  loadFile: (event: React.ChangeEvent<HTMLInputElement>) => unknown
-  createNewFile?: () => unknown
-  canDownload: boolean
-  onDownload: () => unknown
-  fileData?: ProtocolFile | null
-  pipettesOnDeck: InitialDeckSetup['pipettes']
-  modulesOnDeck: InitialDeckSetup['modules']
-  savedStepForms: SavedStepFormState
-  robotType: RobotType
-  additionalEquipment: AdditionalEquipment
-}
-
 export interface AdditionalEquipment {
   [additionalEquipmentId: string]: {
     name: 'gripper' | 'wasteChute' | 'stagingArea'
@@ -49,16 +40,36 @@ export interface AdditionalEquipment {
   }
 }
 
+export interface Props {
+  loadFile: (event: React.ChangeEvent<HTMLInputElement>) => unknown
+  createNewFile?: () => unknown
+  canDownload: boolean
+  onDownload: () => unknown
+  fileData?: ProtocolFile | null
+  pipettesOnDeck: InitialDeckSetup['pipettes']
+  modulesOnDeck: InitialDeckSetup['modules']
+  labwareOnDeck: InitialDeckSetup['labware']
+  savedStepForms: SavedStepFormState
+  robotType: RobotType
+  additionalEquipment: AdditionalEquipment
+}
+
 interface WarningContent {
   content: React.ReactNode
   heading: string
 }
 
+interface Fixture {
+  trashBin: boolean
+  wasteChute: boolean
+  stagingAreaSlots: string[]
+}
 interface MissingContent {
   noCommands: boolean
   pipettesWithoutStep: PipetteOnDeck[]
   modulesWithoutStep: ModuleOnDeck[]
   gripperWithoutStep: boolean
+  fixtureWithoutStep: Fixture
 }
 
 const LOAD_COMMANDS: Array<CreateCommand['commandType']> = [
@@ -73,6 +84,7 @@ function getWarningContent({
   pipettesWithoutStep,
   modulesWithoutStep,
   gripperWithoutStep,
+  fixtureWithoutStep,
 }: MissingContent): WarningContent | null {
   if (noCommands) {
     return {
@@ -98,6 +110,18 @@ function getWarningContent({
         </>
       ),
       heading: i18n.t('alert.export_warnings.unused_gripper.heading'),
+    }
+  }
+
+  if (fixtureWithoutStep.wasteChute) {
+    return {
+      content: (
+        <>
+          <p>{i18n.t('alert.export_warnings.unused_waste_chute.body1')}</p>
+          <p>{i18n.t('alert.export_warnings.unused_waste_chute.body2')}</p>
+        </>
+      ),
+      heading: i18n.t('alert.export_warnings.unused_waste_chute.heading'),
     }
   }
 
@@ -164,6 +188,40 @@ function getWarningContent({
       heading: i18n.t(`alert.export_warnings.${moduleCase}.heading`),
     }
   }
+
+  if (fixtureWithoutStep.trashBin) {
+    return {
+      content: (
+        <>
+          <p>{i18n.t('alert.export_warnings.unused_trash_bin.body1')}</p>
+          <p>{i18n.t('alert.export_warnings.unused_trash_bin.body2')}</p>
+        </>
+      ),
+      heading: i18n.t('alert.export_warnings.unused_trash_bin.heading'),
+    }
+  }
+
+  if (fixtureWithoutStep.stagingAreaSlots.length > 0) {
+    return {
+      content: (
+        <>
+          <p>
+            {i18n.t('alert.export_warnings.unused_staging_area.body1', {
+              count: fixtureWithoutStep.stagingAreaSlots.length,
+              slot: fixtureWithoutStep.stagingAreaSlots,
+            })}
+          </p>
+          <p>
+            {i18n.t('alert.export_warnings.unused_staging_area.body2', {
+              count: fixtureWithoutStep.stagingAreaSlots.length,
+            })}
+          </p>
+        </>
+      ),
+      heading: i18n.t('alert.export_warnings.unused_staging_area.heading'),
+    }
+  }
+
   return null
 }
 
@@ -189,6 +247,7 @@ export function FileSidebar(props: Props): JSX.Element {
     savedStepForms,
     robotType,
     additionalEquipment,
+    labwareOnDeck,
   } = props
   const [
     showExportWarningModal,
@@ -197,7 +256,21 @@ export function FileSidebar(props: Props): JSX.Element {
   const isGripperAttached = Object.values(additionalEquipment).some(
     equipment => equipment?.name === 'gripper'
   )
+  const { trashBinUnused, wasteChuteUnused } = getUnusedTrash(
+    labwareOnDeck,
+    // additionalEquipment,
+    fileData?.commands
+  )
 
+  const fixtureWithoutStep: Fixture = {
+    trashBin: trashBinUnused,
+    //  TODO(jr, 10/30/23): wire this up later when we know waste chute commands
+    wasteChute: wasteChuteUnused,
+    stagingAreaSlots: getUnusedStagingAreas(
+      additionalEquipment,
+      fileData?.commands
+    ),
+  }
   const [showBlockingHint, setShowBlockingHint] = React.useState<boolean>(false)
 
   const cancelModal = (): void => setShowExportWarningModal(false)
@@ -232,9 +305,12 @@ export function FileSidebar(props: Props): JSX.Element {
 
   const hasWarning =
     noCommands ||
-    modulesWithoutStep.length ||
-    pipettesWithoutStep.length ||
-    gripperWithoutStep
+    modulesWithoutStep.length > 0 ||
+    pipettesWithoutStep.length > 0 ||
+    gripperWithoutStep ||
+    fixtureWithoutStep.trashBin ||
+    fixtureWithoutStep.wasteChute ||
+    fixtureWithoutStep.stagingAreaSlots.length > 0
 
   const warning =
     hasWarning &&
@@ -243,6 +319,7 @@ export function FileSidebar(props: Props): JSX.Element {
       pipettesWithoutStep,
       modulesWithoutStep,
       gripperWithoutStep,
+      fixtureWithoutStep,
     })
 
   const getExportHintContent = (): {

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -113,18 +113,6 @@ function getWarningContent({
     }
   }
 
-  if (fixtureWithoutStep.wasteChute) {
-    return {
-      content: (
-        <>
-          <p>{i18n.t('alert.export_warnings.unused_waste_chute.body1')}</p>
-          <p>{i18n.t('alert.export_warnings.unused_waste_chute.body2')}</p>
-        </>
-      ),
-      heading: i18n.t('alert.export_warnings.unused_waste_chute.heading'),
-    }
-  }
-
   const pipettesDetails = pipettesWithoutStep
     .map(pipette => `${pipette.mount} ${pipette.spec.displayName}`)
     .join(' and ')
@@ -189,15 +177,25 @@ function getWarningContent({
     }
   }
 
-  if (fixtureWithoutStep.trashBin) {
+  if (fixtureWithoutStep.trashBin || fixtureWithoutStep.wasteChute) {
     return {
-      content: (
-        <>
-          <p>{i18n.t('alert.export_warnings.unused_trash_bin.body1')}</p>
-          <p>{i18n.t('alert.export_warnings.unused_trash_bin.body2')}</p>
-        </>
-      ),
-      heading: i18n.t('alert.export_warnings.unused_trash_bin.heading'),
+      content:
+        (fixtureWithoutStep.trashBin && !fixtureWithoutStep.wasteChute) ||
+        (!fixtureWithoutStep.trashBin && fixtureWithoutStep.wasteChute) ? (
+          <p>
+            {i18n.t('alert.export_warnings.unused_trash.body', {
+              name: fixtureWithoutStep.trashBin ? 'trash bin' : 'waste chute',
+            })}
+          </p>
+        ) : (
+          <p>
+            {i18n.t('alert.export_warnings.unused_trash.body_both', {
+              trashName: 'trash bin',
+              wasteName: 'waste chute',
+            })}
+          </p>
+        ),
+      heading: i18n.t('alert.export_warnings.unused_trash.heading'),
     }
   }
 

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -179,7 +179,7 @@ describe('FileSidebar', () => {
     )
   })
 
-  it('warning modal is shown when export is clicked with unused trash bin', () => {
+  it('warning modal is shown when export is clicked with unused trash', () => {
     props.savedStepForms = savedStepForms
     const labwareId = 'mockLabwareId'
     // @ts-expect-error(sa, 2021-6-22): props.fileData might be null
@@ -194,7 +194,7 @@ describe('FileSidebar', () => {
     const alertModal = wrapper.find(AlertModal)
 
     expect(alertModal).toHaveLength(1)
-    expect(alertModal.prop('heading')).toEqual('Unused trash bin')
+    expect(alertModal.prop('heading')).toEqual('Unused trash')
   })
 
   it('warning modal is shown when export is clicked with unused gripper', () => {

--- a/protocol-designer/src/components/FileSidebar/index.ts
+++ b/protocol-designer/src/components/FileSidebar/index.ts
@@ -28,6 +28,7 @@ interface SP {
   savedStepForms: SavedStepFormState
   robotType: RobotType
   additionalEquipment: AdditionalEquipment
+  labwareOnDeck: InitialDeckSetup['labware']
 }
 export const FileSidebar = connect(
   mapStateToProps,
@@ -54,6 +55,7 @@ function mapStateToProps(state: BaseState): SP {
     // Ignore clicking 'CREATE NEW' button in these cases
     _canCreateNew: !selectors.getNewProtocolModal(state),
     _hasUnsavedChanges: loadFileSelectors.getHasUnsavedChanges(state),
+    labwareOnDeck: initialDeckSetup.labware,
   }
 }
 
@@ -73,6 +75,7 @@ function mergeProps(
     savedStepForms,
     robotType,
     additionalEquipment,
+    labwareOnDeck,
   } = stateProps
   const { dispatch } = dispatchProps
   return {
@@ -95,5 +98,6 @@ function mergeProps(
     savedStepForms,
     robotType,
     additionalEquipment,
+    labwareOnDeck,
   }
 }

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedStagingAreas.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedStagingAreas.ts
@@ -1,0 +1,45 @@
+import { getUnusedStagingAreas } from '../getUnusedStagingAreas'
+import type { CreateCommand } from '@opentrons/shared-data'
+import type { AdditionalEquipment } from '../../FileSidebar'
+
+describe('getUnusedStagingAreas', () => {
+  it('returns true for unused staging area', () => {
+    const stagingArea = 'stagingAreaId'
+    const mockAdditionalEquipment = {
+      [stagingArea]: { name: 'stagingArea', id: stagingArea, location: 'A3' },
+    } as AdditionalEquipment
+
+    expect(getUnusedStagingAreas(mockAdditionalEquipment, [])).toEqual(['A4'])
+  })
+  it('returns true for multi unused staging areas', () => {
+    const stagingArea = 'stagingAreaId'
+    const stagingArea2 = 'stagingAreaId2'
+    const mockAdditionalEquipment = {
+      [stagingArea]: { name: 'stagingArea', id: stagingArea, location: 'A3' },
+      [stagingArea2]: { name: 'stagingArea', id: stagingArea2, location: 'B3' },
+    } as AdditionalEquipment
+
+    expect(getUnusedStagingAreas(mockAdditionalEquipment, [])).toEqual([
+      'A4',
+      'B4',
+    ])
+  })
+  it('returns false for unused staging area', () => {
+    const stagingArea = 'stagingAreaId'
+    const mockAdditionalEquipment = {
+      [stagingArea]: { name: 'stagingArea', id: stagingArea, location: 'A3' },
+    } as AdditionalEquipment
+    const mockCommand = ([
+      {
+        stagingArea: {
+          commandType: 'loadLabware',
+          params: { location: { slotName: 'A4' } },
+        },
+      },
+    ] as unknown) as CreateCommand[]
+
+    expect(
+      getUnusedStagingAreas(mockAdditionalEquipment, mockCommand)
+    ).toEqual(['A4'])
+  })
+})

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedTrash.test.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedTrash.test.ts
@@ -1,0 +1,38 @@
+import { FLEX_TRASH_DEF_URI } from '../../../../constants'
+import { getUnusedTrash } from '../getUnusedTrash'
+import type { CreateCommand } from '@opentrons/shared-data'
+import type { InitialDeckSetup } from '../../../../step-forms'
+
+describe('getUnusedTrash', () => {
+  it('returns true for unused trash bin', () => {
+    const labwareId = 'mockLabwareId'
+    const mockTrash = ({
+      [labwareId]: { labwareDefURI: FLEX_TRASH_DEF_URI, id: labwareId },
+    } as unknown) as InitialDeckSetup['labware']
+
+    expect(getUnusedTrash(mockTrash, [])).toEqual({
+      trashBinUnused: true,
+      wasteChuteUnused: false,
+    })
+  })
+  it('returns false for unused trash bin', () => {
+    const labwareId = 'mockLabwareId'
+    const mockTrash = ({
+      [labwareId]: { labwareDefURI: FLEX_TRASH_DEF_URI, id: labwareId },
+    } as unknown) as InitialDeckSetup['labware']
+    const mockCommand = ([
+      {
+        labwareId: {
+          commandType: 'dropTip',
+          params: { labwareId: labwareId },
+        },
+      },
+    ] as unknown) as CreateCommand[]
+
+    expect(getUnusedTrash(mockTrash, mockCommand)).toEqual({
+      trashBinUnused: true,
+      wasteChuteUnused: false,
+    })
+  })
+  //    TODO(jr, 10/30/23): add test coverage for waste chute
+})

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedStagingAreas.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedStagingAreas.ts
@@ -1,0 +1,42 @@
+import type { CreateCommand } from '@opentrons/shared-data'
+import type { AdditionalEquipment } from '../FileSidebar'
+
+export const getUnusedStagingAreas = (
+  additionalEquipment: AdditionalEquipment,
+  commands?: CreateCommand[]
+): string[] => {
+  const stagingAreaSlots = Object.values(additionalEquipment)
+    .filter(equipment => equipment?.name === 'stagingArea')
+    .map(equipment => String(equipment.location))
+
+  const updatedStagingAreaSlots = stagingAreaSlots.map(slot => {
+    const letter = slot.charAt(0)
+    const correspondingLocation = stagingAreaSlots.find(slot =>
+      slot.startsWith(letter)
+    )
+    if (correspondingLocation) {
+      return letter + '4'
+    }
+
+    return slot
+  })
+
+  const stagingAreaCommandSlots: string[] = updatedStagingAreaSlots.filter(
+    location =>
+      commands?.filter(
+        command =>
+          (command.commandType === 'loadLabware' &&
+            command.params.location !== 'offDeck' &&
+            'slotName' in command.params.location &&
+            command.params.location.slotName === location) ||
+          (command.commandType === 'moveLabware' &&
+            command.params.newLocation !== 'offDeck' &&
+            'slotName' in command.params.newLocation &&
+            command.params.newLocation.slotName === location)
+      )
+        ? location
+        : null
+  )
+
+  return stagingAreaCommandSlots
+}

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedStagingAreas.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedStagingAreas.ts
@@ -7,9 +7,16 @@ export const getUnusedStagingAreas = (
 ): string[] => {
   const stagingAreaSlots = Object.values(additionalEquipment)
     .filter(equipment => equipment?.name === 'stagingArea')
-    .map(equipment => String(equipment.location))
+    .map(equipment => {
+      if (equipment.location == null) {
+        console.error(
+          `expected to find staging area slot location with id ${equipment.id} but could not.`
+        )
+      }
+      return equipment.location ?? ''
+    })
 
-  const updatedStagingAreaSlots = stagingAreaSlots.map(slot => {
+  const corresponding4thColumnSlots = stagingAreaSlots.map(slot => {
     const letter = slot.charAt(0)
     const correspondingLocation = stagingAreaSlots.find(slot =>
       slot.startsWith(letter)
@@ -21,7 +28,7 @@ export const getUnusedStagingAreas = (
     return slot
   })
 
-  const stagingAreaCommandSlots: string[] = updatedStagingAreaSlots.filter(
+  const stagingAreaCommandSlots: string[] = corresponding4thColumnSlots.filter(
     location =>
       commands?.filter(
         command =>

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedTrash.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedTrash.ts
@@ -5,7 +5,6 @@ import {
 
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { InitialDeckSetup } from '../../../step-forms'
-// import type { AdditionalEquipment } from '../FileSidebar'
 
 interface UnusedTrash {
   trashBinUnused: boolean
@@ -15,13 +14,8 @@ interface UnusedTrash {
 //  TODO(jr, 10/30/23): plug in waste chute logic when we know the commands!
 export const getUnusedTrash = (
   labwareOnDeck: InitialDeckSetup['labware'],
-  //   additionalEquipment: AdditionalEquipment,
   commands?: CreateCommand[]
 ): UnusedTrash => {
-  // const hasWasteChute = Object.values(additionalEquipment).some(
-  //   equipment => equipment?.name === 'wasteChute'
-  // )
-
   const trashBin = Object.values(labwareOnDeck).find(
     labware =>
       labware.labwareDefURI === FLEX_TRASH_DEF_URI ||

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedTrash.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedTrash.ts
@@ -1,0 +1,45 @@
+import {
+  FLEX_TRASH_DEF_URI,
+  OT_2_TRASH_DEF_URI,
+} from '@opentrons/step-generation'
+
+import type { CreateCommand } from '@opentrons/shared-data'
+import type { InitialDeckSetup } from '../../../step-forms'
+// import type { AdditionalEquipment } from '../FileSidebar'
+
+interface UnusedTrash {
+  trashBinUnused: boolean
+  wasteChuteUnused: boolean
+}
+
+//  TODO(jr, 10/30/23): plug in waste chute logic when we know the commands!
+export const getUnusedTrash = (
+  labwareOnDeck: InitialDeckSetup['labware'],
+  //   additionalEquipment: AdditionalEquipment,
+  commands?: CreateCommand[]
+): UnusedTrash => {
+  // const hasWasteChute = Object.values(additionalEquipment).some(
+  //   equipment => equipment?.name === 'wasteChute'
+  // )
+
+  const trashBin = Object.values(labwareOnDeck).find(
+    labware =>
+      labware.labwareDefURI === FLEX_TRASH_DEF_URI ||
+      labware.labwareDefURI === OT_2_TRASH_DEF_URI
+  )
+
+  const hasTrashBinCommands =
+    trashBin != null
+      ? commands?.some(
+          command =>
+            (command.commandType === 'dropTip' &&
+              command.params.labwareId === trashBin.id) ||
+            (command.commandType === 'dispense' &&
+              command.params.labwareId === trashBin.id)
+        )
+      : null
+  return {
+    trashBinUnused: trashBin != null && !hasTrashBinCommands,
+    wasteChuteUnused: false,
+  }
+}

--- a/protocol-designer/src/components/FileSidebar/utils/index.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/index.ts
@@ -1,1 +1,3 @@
 export * from './getUnusedEntities'
+export * from './getUnusedStagingAreas'
+export * from './getUnusedTrash'

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -241,6 +241,23 @@
       "heading": "Unused gripper",
       "body1": "The Flex Gripper specified in your protocol is not currently used in any step. In order to run this protocol you will need to connect it to your robot.",
       "body2": "If you don't intend to use the Flex Gripper, please consider removing it from your protocol."
+    },
+    "unused_waste_chute": {
+      "heading": "Unused waste chute",
+      "body1": "The waste chute specified in your protocol is not currently used in any step. It will not appear as a needed item on the deck when uploaded to the app.",
+      "body2": "If you don't intend to use the waste chute, please consider removing it from your protocol."
+    },
+    "unused_trash_bin": {
+      "heading": "Unused trash bin",
+      "body1": "The trash bin specified in your protocol is not currently used in any step. It will not appear as a needed item on the deck when uploaded to the app.",
+      "body2": "If you don't intend to use the trash bin, please consider removing it from your protocol."
+    },
+    "unused_staging_area": {
+      "heading": "One or more staging area slots are unused",
+      "body1_plural": "The {{count}} staging area slots in [{{slot}}] in your protocol are not currently in use. They will not appear as a needed item on the deck when uploaded to the app.",
+      "body1": "The staging area slot in {{slot}} in your protocol is not currently in use. It will not appear as a needed item on the deck when uploaded to the app.",
+      "body2_plural": "If you don't intend to use these staging area slots, please consider removing it from your protocol.",
+      "body2": "If you don't intend to use this staging area slot, please consider removing it from your protocol."
     }
   },
   "crash": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -242,15 +242,10 @@
       "body1": "The Flex Gripper specified in your protocol is not currently used in any step. In order to run this protocol you will need to connect it to your robot.",
       "body2": "If you don't intend to use the Flex Gripper, please consider removing it from your protocol."
     },
-    "unused_waste_chute": {
-      "heading": "Unused waste chute",
-      "body1": "The waste chute specified in your protocol is not currently used in any step. It will not appear as a needed item on the deck when uploaded to the app.",
-      "body2": "If you don't intend to use the waste chute, please consider removing it from your protocol."
-    },
-    "unused_trash_bin": {
-      "heading": "Unused trash bin",
-      "body1": "The trash bin specified in your protocol is not currently used in any step. It will not appear as a needed item on the deck when uploaded to the app.",
-      "body2": "If you don't intend to use the trash bin, please consider removing it from your protocol."
+    "unused_trash": {
+      "heading": "Unused trash",
+      "body": "The {{name}} specified in your protocol is not currently used in any step. It will not appear as a needed item on the deck when uploaded to the app.",
+      "body_both": "The {{trashName}} and {{wasteName}} specified in your protocol are not currently used in any step. They will not appear as a needed item on the deck when uploaded to the app."
     },
     "unused_staging_area": {
       "heading": "One or more staging area slots are unused",


### PR DESCRIPTION
closes RAUT-814 and partially closes RAUT-815

# Overview

The unused equipment modal logic is now extended for staging area slots, trash bin, and waste chute

<img width="629" alt="Screen Shot 2023-10-30 at 4 37 04 PM" src="https://github.com/Opentrons/opentrons/assets/66035149/f26307cc-a974-441a-a445-6d8067f8e319">
<img width="631" alt="Screen Shot 2023-10-31 at 9 36 16 AM" src="https://github.com/Opentrons/opentrons/assets/66035149/37c6334d-c479-470a-be2d-91219d9f2429">



# Test Plan

Turn on the deck configuration ff and create a flex protocol. Add a staging area and a waste chute. Create a transfer step and make sure it dispenses & drop tip into the waste chute. Export the protocol and you should see the `unused trash` modal

Now go back and change the transfer step to dispense or drop tip into the trash bin. Try to export again and you should see the `unused staging area` modal. 

NOTE: the waste chute modal logic is not wired up yet since commands for it are finalized.

# Changelog

- create 2 new utils `getUnusedStagingAreaSlots` and `getUnusedTrash`
- add i18n keys for the new unused options and extend props for `FileSidebar`
- add tests

# Review requests

So the order in which the unused logic shows up in the modal is: protocol has no commands -> unused gripper -> unused pipettes & modules -> unused pipettes -> unused modules -> unused waste chute and/or trash bin -> unused staging area slots.

It might be good to add a new modal for combining things? Probably in the future it can be refactored to take all unused things into consideration into 1 modal.

# Risk assessment

low