### PR TITLE
fix(robot-server): create maintenance run if there is no protocol run

### DIFF
--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -121,6 +121,7 @@ async def get_engine_store(
     return engine_store
 
 
+# TODO (jh, 2023-10-31): Add test cases.
 async def get_is_okay_to_create_maintenance_run(
     engine_store: EngineStore = Depends(get_engine_store),
 ) -> bool:

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -128,7 +128,7 @@ async def get_is_okay_to_create_maintenance_run(
     try:
         protocol_run_state = engine_store.engine.state_view
     except AssertionError:
-        return False
+        return True
     return (
         not protocol_run_state.commands.has_been_played()
         or protocol_run_state.commands.get_is_terminal()


### PR DESCRIPTION
Closes RQA-1859

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The AssertionError case for protocol_run_state should return true (no protocol run exists) instead of false.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Perform any type of maintenance run. Confirm that you can move the gantry to the front.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix bug where users can't create maintenance runs if a protocol run doesn't exist.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

