### PR TITLE
test(robot-server): Add integration tests for maintenance run creation

### DIFF
--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -33,7 +33,7 @@ class EngineConflictError(RuntimeError):
     """
 
 
-class NoEngineError(RuntimeError):
+class NoRunnerEnginePairError(RuntimeError):
     """Raised if you try to get the current engine or runner while there is none."""
 
 
@@ -95,14 +95,14 @@ class MaintenanceEngineStore:
     def engine(self) -> ProtocolEngine:
         """Get the "current" ProtocolEngine."""
         if self._runner_engine_pair is None:
-            raise NoEngineError()
+            raise NoRunnerEnginePairError()
         return self._runner_engine_pair.engine
 
     @property
     def runner(self) -> LiveRunner:
         """Get the "current" ProtocolRunner."""
         if self._runner_engine_pair is None:
-            raise NoEngineError()
+            raise NoRunnerEnginePairError()
         return self._runner_engine_pair.runner
 
     @property

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -33,6 +33,10 @@ class EngineConflictError(RuntimeError):
     """
 
 
+class NoEngineError(RuntimeError):
+    """Raised if you try to get the current engine or runner while there is none."""
+
+
 class RunnerEnginePair(NamedTuple):
     """A stored ProtocolRunner/ProtocolEngine pair."""
 
@@ -90,13 +94,15 @@ class MaintenanceEngineStore:
     @property
     def engine(self) -> ProtocolEngine:
         """Get the "current" ProtocolEngine."""
-        assert self._runner_engine_pair is not None, "Engine not yet created."
+        if self._runner_engine_pair is None:
+            raise NoEngineError()
         return self._runner_engine_pair.engine
 
     @property
     def runner(self) -> LiveRunner:
         """Get the "current" ProtocolRunner."""
-        assert self._runner_engine_pair is not None, "Runner not yet created."
+        if self._runner_engine_pair is None:
+            raise NoEngineError()
         return self._runner_engine_pair.runner
 
     @property

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -23,7 +23,7 @@ from robot_server.settings import get_settings
 from robot_server.deletion_planner import RunDeletionPlanner
 
 from .run_auto_deleter import RunAutoDeleter
-from .engine_store import EngineStore, NoEngineError
+from .engine_store import EngineStore, NoRunnerEnginePairError
 from .run_store import RunStore
 from .run_data_manager import RunDataManager
 from robot_server.errors.robot_errors import (
@@ -127,7 +127,7 @@ async def get_is_okay_to_create_maintenance_run(
     """Whether a maintenance run can be created if a protocol run already exists."""
     try:
         protocol_run_state = engine_store.engine.state_view
-    except NoEngineError:
+    except NoRunnerEnginePairError:
         return True
     return (
         not protocol_run_state.commands.has_been_played()

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -121,7 +121,6 @@ async def get_engine_store(
     return engine_store
 
 
-# TODO (jh, 2023-10-31): Add test cases.
 async def get_is_okay_to_create_maintenance_run(
     engine_store: EngineStore = Depends(get_engine_store),
 ) -> bool:

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -23,7 +23,7 @@ from robot_server.settings import get_settings
 from robot_server.deletion_planner import RunDeletionPlanner
 
 from .run_auto_deleter import RunAutoDeleter
-from .engine_store import EngineStore
+from .engine_store import EngineStore, NoEngineError
 from .run_store import RunStore
 from .run_data_manager import RunDataManager
 from robot_server.errors.robot_errors import (
@@ -128,7 +128,7 @@ async def get_is_okay_to_create_maintenance_run(
     """Whether a maintenance run can be created if a protocol run already exists."""
     try:
         protocol_run_state = engine_store.engine.state_view
-    except AssertionError:
+    except NoEngineError:
         return True
     return (
         not protocol_run_state.commands.has_been_played()

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -41,7 +41,7 @@ class EngineConflictError(RuntimeError):
     """
 
 
-class NoEngineError(RuntimeError):
+class NoRunnerEnginePairError(RuntimeError):
     """Raised if you try to get the current engine or runner while there is none."""
 
 
@@ -95,14 +95,14 @@ class EngineStore:
     def engine(self) -> ProtocolEngine:
         """Get the "current" persisted ProtocolEngine."""
         if self._runner_engine_pair is None:
-            raise NoEngineError()
+            raise NoRunnerEnginePairError()
         return self._runner_engine_pair.engine
 
     @property
     def runner(self) -> AnyRunner:
         """Get the "current" persisted ProtocolRunner."""
         if self._runner_engine_pair is None:
-            raise NoEngineError()
+            raise NoRunnerEnginePairError()
         return self._runner_engine_pair.runner
 
     @property

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -41,6 +41,10 @@ class EngineConflictError(RuntimeError):
     """
 
 
+class NoEngineError(RuntimeError):
+    """Raised if you try to get the current engine or runner while there is none."""
+
+
 class RunnerEnginePair(NamedTuple):
     """A stored Runner/ProtocolEngine pair."""
 
@@ -90,13 +94,15 @@ class EngineStore:
     @property
     def engine(self) -> ProtocolEngine:
         """Get the "current" persisted ProtocolEngine."""
-        assert self._runner_engine_pair is not None, "Engine not yet created."
+        if self._runner_engine_pair is None:
+            raise NoEngineError()
         return self._runner_engine_pair.engine
 
     @property
     def runner(self) -> AnyRunner:
         """Get the "current" persisted ProtocolRunner."""
-        assert self._runner_engine_pair is not None, "Runner not yet created."
+        if self._runner_engine_pair is None:
+            raise NoEngineError()
         return self._runner_engine_pair.runner
 
     @property

--- a/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
@@ -1,0 +1,117 @@
+test_name: Make sure you can create a maintenance run while there are no normal runs
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - &assert_no_runs
+    name: 'Setup check: Make sure there are no runs'
+    request:
+      url: '{ot2_server_base_url}/runs'
+    response:
+      json:
+        data: []
+        links: {}
+        meta:
+          cursor: 0
+          totalLength: 0
+
+  - &assert_no_maintenance_runs
+    name: 'Setup check: Make sure there are no maintenance runs'
+    request:
+      url: '{ot2_server_base_url}/maintenance_runs/current'
+    response:
+      status_code: 404
+
+  - &assert_can_create_maintenance_run
+    name: Make sure we can create a maintenance run
+    request:
+      url: '{ot2_server_base_url}/maintenance_runs'
+      method: POST
+    response:
+      status_code: 201
+
+---
+
+test_name: Make sure you can create a maintenance run while there is an inactive normal run
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - *assert_no_runs
+  - *assert_no_maintenance_runs
+
+  - name: Create a normal run
+    request:
+      url: '{ot2_server_base_url}/runs'
+      method: POST
+    response:
+      status_code: 201
+
+  - *assert_can_create_maintenance_run
+
+---
+
+test_name: Make sure you can create a maintenance run while there is a completed normal run
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - *assert_no_runs
+  - *assert_no_maintenance_runs
+
+  - name: Upload a protocol
+    request:
+      url: '{ot2_server_base_url}/protocols'
+      method: POST
+      files:
+        files: tests/integration/protocols/simple_v6.json
+    response:
+      status_code: 201
+      save:
+        json:
+          protocol_id: data.id
+
+  - name: Create a normal run from the protocol
+    request:
+      url: '{ot2_server_base_url}/runs'
+      method: POST
+      json:
+        data:
+          protocolId: '{protocol_id}'
+    response:
+      status_code: 201
+      save:
+        json:
+          run_id: data.id
+
+  - name: Issue a play action
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/actions'
+      json:
+        data:
+          actionType: play
+      method: POST
+    response:
+      status_code: 201
+
+  - name: Wait for the normal run to complete
+    max_retries: 10
+    delay_after: 0.1
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          status: succeeded
+
+  - *assert_can_create_maintenance_run

--- a/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
@@ -69,7 +69,7 @@ stages:
       status_code: 201
       save:
         json:
-          run_id: data.id
+          protocol_run_id: data.id
 
   - *assert_can_create_maintenance_run
 
@@ -90,7 +90,7 @@ stages:
 
   - name: Issue a play action
     request:
-      url: '{ot2_server_base_url}/runs/{run_id}/actions'
+      url: '{ot2_server_base_url}/runs/{protocol_run_id}/actions'
       json:
         data:
           actionType: play
@@ -98,11 +98,11 @@ stages:
     response:
       status_code: 201
 
-  - name: Wait for the normal run to complete
+  - name: Wait for the protocol run to complete
     max_retries: 10
     delay_after: 0.1
     request:
-      url: '{ot2_server_base_url}/runs/{run_id}'
+      url: '{ot2_server_base_url}/runs/{protocol_run_id}'
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
@@ -34,7 +34,7 @@ stages:
 
 ---
 
-test_name: Make sure you can create a maintenance run while there is an inactive normal run
+test_name: Make sure you can create a maintenance run while there is an unstarted protocol run
 
 marks:
   - usefixtures:

--- a/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
@@ -75,7 +75,7 @@ stages:
 
 ---
 
-test_name: Make sure you can create a maintenance run while there is a completed protococl run
+test_name: Make sure you can create a maintenance run while there is a completed protocol run
 
 marks:
   - usefixtures:

--- a/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_maintenance_run_creation.tavern.yaml
@@ -44,28 +44,8 @@ stages:
   - *assert_no_runs
   - *assert_no_maintenance_runs
 
-  - name: Create a normal run
-    request:
-      url: '{ot2_server_base_url}/runs'
-      method: POST
-    response:
-      status_code: 201
-
-  - *assert_can_create_maintenance_run
-
----
-
-test_name: Make sure you can create a maintenance run while there is a completed normal run
-
-marks:
-  - usefixtures:
-      - ot2_server_base_url
-
-stages:
-  - *assert_no_runs
-  - *assert_no_maintenance_runs
-
-  - name: Upload a protocol
+  - &upload_protocol_and_save_id
+    name: Upload a protocol
     request:
       url: '{ot2_server_base_url}/protocols'
       method: POST
@@ -77,7 +57,8 @@ stages:
         json:
           protocol_id: data.id
 
-  - name: Create a normal run from the protocol
+  - &create_protocol_run_and_save_id
+    name: Create a protocol run
     request:
       url: '{ot2_server_base_url}/runs'
       method: POST
@@ -89,6 +70,23 @@ stages:
       save:
         json:
           run_id: data.id
+
+  - *assert_can_create_maintenance_run
+
+---
+
+test_name: Make sure you can create a maintenance run while there is a completed protococl run
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - *assert_no_runs
+  - *assert_no_maintenance_runs
+
+  - *upload_protocol_and_save_id
+  - *create_protocol_run_and_save_id
 
   - name: Issue a play action
     request:

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -19,7 +19,7 @@ from opentrons.protocol_runner import LiveRunner, RunResult
 from robot_server.maintenance_runs.maintenance_engine_store import (
     MaintenanceEngineStore,
     EngineConflictError,
-    NoEngineError,
+    NoRunnerEnginePairError,
     get_estop_listener,
 )
 
@@ -112,10 +112,10 @@ async def test_clear_engine(subject: MaintenanceEngineStore) -> None:
     assert subject.current_run_id is None
     assert isinstance(result, RunResult)
 
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.engine
 
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.runner
 
 
@@ -143,9 +143,9 @@ async def test_clear_idle_engine(subject: MaintenanceEngineStore) -> None:
     await subject.clear()
 
     # TODO: test engine finish is called
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.engine
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.runner
 
 

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -19,6 +19,7 @@ from opentrons.protocol_runner import LiveRunner, RunResult
 from robot_server.maintenance_runs.maintenance_engine_store import (
     MaintenanceEngineStore,
     EngineConflictError,
+    NoEngineError,
     get_estop_listener,
 )
 
@@ -111,10 +112,10 @@ async def test_clear_engine(subject: MaintenanceEngineStore) -> None:
     assert subject.current_run_id is None
     assert isinstance(result, RunResult)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.engine
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.runner
 
 
@@ -142,9 +143,9 @@ async def test_clear_idle_engine(subject: MaintenanceEngineStore) -> None:
     await subject.clear()
 
     # TODO: test engine finish is called
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.engine
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.runner
 
 

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -22,7 +22,7 @@ from robot_server.protocols import ProtocolResource
 from robot_server.runs.engine_store import (
     EngineStore,
     EngineConflictError,
-    NoEngineError,
+    NoRunnerEnginePairError,
     get_estop_listener,
 )
 
@@ -148,10 +148,10 @@ async def test_clear_engine(subject: EngineStore) -> None:
     assert subject.current_run_id is None
     assert isinstance(result, RunResult)
 
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.engine
 
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.runner
 
 
@@ -175,9 +175,9 @@ async def test_clear_idle_engine(subject: EngineStore) -> None:
     await subject.clear()
 
     # TODO: test engine finish is called
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.engine
-    with pytest.raises(NoEngineError):
+    with pytest.raises(NoRunnerEnginePairError):
         subject.runner
 
 

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -22,6 +22,7 @@ from robot_server.protocols import ProtocolResource
 from robot_server.runs.engine_store import (
     EngineStore,
     EngineConflictError,
+    NoEngineError,
     get_estop_listener,
 )
 
@@ -147,10 +148,10 @@ async def test_clear_engine(subject: EngineStore) -> None:
     assert subject.current_run_id is None
     assert isinstance(result, RunResult)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.engine
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.runner
 
 
@@ -174,9 +175,9 @@ async def test_clear_idle_engine(subject: EngineStore) -> None:
     await subject.clear()
 
     # TODO: test engine finish is called
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.engine
-    with pytest.raises(AssertionError):
+    with pytest.raises(NoEngineError):
         subject.runner
 
 


### PR DESCRIPTION
# Changelog

Add Tavern integration tests for the following cases:

* You should be able to create a maintenance run while there is a normal run, but the normal run hasn't been started yet. (This has always worked.)
* You should be able to create a maintenance run while there is a normal run, but the normal run has completed. (This was added in #13818.)
* You should be able to create a maintenance run while there is no normal run. (This was accidentally broken in #13818 and fixed in #13877.)

This resolves a todo comment added in #13877.

Also, our production code was catching `AssertionError`s. This is generally a bug because it [relies on](https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement) `__debug__ == True`, and it was unclear what was raising it. So, replace it with an explicit exception type defined by `EngineStore`.

# Test plan

None needed.

# Review requests

Any other juicy cases we want to add while we're at it?

# Risk assessment

Low.