### PR TITLE
fix(api): add unit test for z axis moves in tip pickup

### DIFF
--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -482,7 +482,7 @@ def mock_verify_tip_presence(
         yield mock_check_tip
 
 
-load_blowout_configs = [
+load_pipette_configs = [
     {OT3Mount.LEFT: {"channels": 1, "version": (3, 3), "model": "p1000"}},
     {OT3Mount.RIGHT: {"channels": 8, "version": (3, 3), "model": "p50"}},
     {OT3Mount.LEFT: {"channels": 96, "model": "p1000", "version": (3, 3)}},
@@ -515,7 +515,122 @@ async def prepare_for_mock_blowout(
     return instr_data, ot3_hardware
 
 
-@pytest.mark.parametrize("load_configs", load_blowout_configs)
+@pytest.mark.parametrize("load_configs", load_pipette_configs)
+async def test_pickup_moves(
+        ot3_hardware: ThreadManager[OT3API],
+        mock_instrument_handlers: Tuple[Mock],
+        mock_ungrip: AsyncMock,
+        mock_move_to_plunger_bottom: AsyncMock,
+        mock_home_gear_motors: AsyncMock,
+        load_configs: List[Dict[str, Any]],
+) -> None:
+    mock_ungrip.return_value = None
+    await ot3_hardware.home()
+    _, pipette_handler = mock_instrument_handlers
+    backend = ot3_hardware.managed_obj._backend
+    for mount, configs in load_configs.items():
+        if configs["channels"] == 96:
+            gantry_load = GantryLoad.HIGH_THROUGHPUT
+        else:
+            gantry_load = GantryLoad.LOW_THROUGHPUT
+
+    await ot3_hardware.set_gantry_load(gantry_load)
+
+    z_tiprack_distance = 8.0
+    end_z_retract_dist = 9.0
+    move_plan_return_val = TipActionSpec(
+        shake_off_moves=[],
+        tip_action_moves=[
+            TipActionMoveSpec(
+                # Move onto the posts
+                distance=10,
+                speed=0,
+                currents={
+                    Axis.of_main_tool_actuator(Mount.LEFT): 0,
+                    Axis.Q: 0,
+                },
+            )
+        ],
+        z_distance_to_tiprack=z_tiprack_distance,
+        ending_z_retract_distance=end_z_retract_dist,
+    )
+    pipette_handler.plan_ht_pick_up_tip.return_value = move_plan_return_val
+    pipette_handler.plan_lt_pick_up_tip.return_value = move_plan_return_val
+
+    with patch.object(
+            ot3_hardware.managed_obj, "move_rel", AsyncMock(spec=ot3_hardware.managed_obj.move_rel)
+    ) as mock_move_rel:
+        await ot3_hardware.pick_up_tip(Mount.LEFT, 40.0)
+        move_call_list = [call.args for call in mock_move_rel.call_args_list]
+        if gantry_load == GantryLoad.HIGH_THROUGHPUT:
+            assert move_call_list == [
+                (OT3Mount.LEFT, Point(z=z_tiprack_distance)),
+                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
+            ]
+        else:
+            assert move_call_list == [
+                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
+            ]
+
+
+@pytest.mark.parametrize("load_configs", load_pipette_configs)
+async def test_droptip__moves(
+        ot3_hardware: ThreadManager[OT3API],
+        mock_instrument_handlers: Tuple[Mock],
+        mock_ungrip: AsyncMock,
+        mock_move_to_plunger_bottom: AsyncMock,
+        mock_home_gear_motors: AsyncMock,
+        load_configs: List[Dict[str, Any]],
+) -> None:
+    _, pipette_handler = mock_instrument_handlers
+    backend = ot3_hardware.managed_obj._backend
+    for mount, configs in load_configs.items():
+        if configs["channels"] == 96:
+            gantry_load = GantryLoad.HIGH_THROUGHPUT
+        else:
+            gantry_load = GantryLoad.LOW_THROUGHPUT
+
+    await ot3_hardware.set_gantry_load(gantry_load)
+
+    z_tiprack_distance = 8.0
+    end_z_retract_dist = 9.0
+    move_plan_return_val = TipActionSpec(
+        shake_off_moves=[],
+        tip_action_moves=[
+            TipActionMoveSpec(
+                # Move onto the posts
+                distance=10,
+                speed=0,
+                currents={
+                    Axis.of_main_tool_actuator(Mount.LEFT): 0,
+                    Axis.Q: 0,
+                },
+            )
+        ],
+        z_distance_to_tiprack=z_tiprack_distance,
+        ending_z_retract_distance=end_z_retract_dist,
+    )
+    pipette_handler.plan_ht_drop_tip.return_value = move_plan_return_val
+    pipette_handler.plan_lt_drop_tip.return_value = move_plan_return_val
+
+    with patch.object(
+            ot3_hardware.managed_obj, "move_rel", AsyncMock(spec=ot3_hardware.managed_obj.move_rel)
+    ) as mock_move_rel:
+        await ot3_hardware.pick_up_tip(Mount.LEFT, 40.0)
+        move_call_list = [call.args for call in mock_move_rel.call_args_list]
+        if gantry_load == GantryLoad.HIGH_THROUGHPUT:
+            assert move_call_list == [
+                (OT3Mount.LEFT, Point(z=z_tiprack_distance)),
+                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
+            ]
+        else:
+            assert move_call_list == [
+                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
+            ]
+
+
+
+@pytest.mark.parametrize("load_configs", load_pipette_configs)
 @given(blowout_volume=strategies.floats(min_value=0, max_value=10))
 @settings(suppress_health_check=[HealthCheck.function_scoped_fixture], max_examples=10)
 @example(blowout_volume=0.0)
@@ -560,7 +675,7 @@ async def test_blow_out_position(
         )
 
 
-@pytest.mark.parametrize("load_configs", load_blowout_configs)
+@pytest.mark.parametrize("load_configs", load_pipette_configs)
 @given(blowout_volume=strategies.floats(min_value=0, max_value=300))
 @settings(
     suppress_health_check=[

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -517,17 +517,13 @@ async def prepare_for_mock_blowout(
 
 @pytest.mark.parametrize("load_configs", load_pipette_configs)
 async def test_pickup_moves(
-        ot3_hardware: ThreadManager[OT3API],
-        mock_instrument_handlers: Tuple[Mock],
-        mock_ungrip: AsyncMock,
-        mock_move_to_plunger_bottom: AsyncMock,
-        mock_home_gear_motors: AsyncMock,
-        load_configs: List[Dict[str, Any]],
+    ot3_hardware: ThreadManager[OT3API],
+    mock_instrument_handlers: Tuple[Mock],
+    mock_move_to_plunger_bottom: AsyncMock,
+    mock_home_gear_motors: AsyncMock,
+    load_configs: List[Dict[str, Any]],
 ) -> None:
-    mock_ungrip.return_value = None
-    await ot3_hardware.home()
     _, pipette_handler = mock_instrument_handlers
-    backend = ot3_hardware.managed_obj._backend
     for mount, configs in load_configs.items():
         if configs["channels"] == 96:
             gantry_load = GantryLoad.HIGH_THROUGHPUT
@@ -558,76 +554,19 @@ async def test_pickup_moves(
     pipette_handler.plan_lt_pick_up_tip.return_value = move_plan_return_val
 
     with patch.object(
-            ot3_hardware.managed_obj, "move_rel", AsyncMock(spec=ot3_hardware.managed_obj.move_rel)
+        ot3_hardware.managed_obj,
+        "move_rel",
+        AsyncMock(spec=ot3_hardware.managed_obj.move_rel),
     ) as mock_move_rel:
         await ot3_hardware.pick_up_tip(Mount.LEFT, 40.0)
         move_call_list = [call.args for call in mock_move_rel.call_args_list]
         if gantry_load == GantryLoad.HIGH_THROUGHPUT:
             assert move_call_list == [
                 (OT3Mount.LEFT, Point(z=z_tiprack_distance)),
-                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
+                (OT3Mount.LEFT, Point(z=end_z_retract_dist)),
             ]
         else:
-            assert move_call_list == [
-                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
-            ]
-
-
-@pytest.mark.parametrize("load_configs", load_pipette_configs)
-async def test_droptip__moves(
-        ot3_hardware: ThreadManager[OT3API],
-        mock_instrument_handlers: Tuple[Mock],
-        mock_ungrip: AsyncMock,
-        mock_move_to_plunger_bottom: AsyncMock,
-        mock_home_gear_motors: AsyncMock,
-        load_configs: List[Dict[str, Any]],
-) -> None:
-    _, pipette_handler = mock_instrument_handlers
-    backend = ot3_hardware.managed_obj._backend
-    for mount, configs in load_configs.items():
-        if configs["channels"] == 96:
-            gantry_load = GantryLoad.HIGH_THROUGHPUT
-        else:
-            gantry_load = GantryLoad.LOW_THROUGHPUT
-
-    await ot3_hardware.set_gantry_load(gantry_load)
-
-    z_tiprack_distance = 8.0
-    end_z_retract_dist = 9.0
-    move_plan_return_val = TipActionSpec(
-        shake_off_moves=[],
-        tip_action_moves=[
-            TipActionMoveSpec(
-                # Move onto the posts
-                distance=10,
-                speed=0,
-                currents={
-                    Axis.of_main_tool_actuator(Mount.LEFT): 0,
-                    Axis.Q: 0,
-                },
-            )
-        ],
-        z_distance_to_tiprack=z_tiprack_distance,
-        ending_z_retract_distance=end_z_retract_dist,
-    )
-    pipette_handler.plan_ht_drop_tip.return_value = move_plan_return_val
-    pipette_handler.plan_lt_drop_tip.return_value = move_plan_return_val
-
-    with patch.object(
-            ot3_hardware.managed_obj, "move_rel", AsyncMock(spec=ot3_hardware.managed_obj.move_rel)
-    ) as mock_move_rel:
-        await ot3_hardware.pick_up_tip(Mount.LEFT, 40.0)
-        move_call_list = [call.args for call in mock_move_rel.call_args_list]
-        if gantry_load == GantryLoad.HIGH_THROUGHPUT:
-            assert move_call_list == [
-                (OT3Mount.LEFT, Point(z=z_tiprack_distance)),
-                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
-            ]
-        else:
-            assert move_call_list == [
-                (OT3Mount.LEFT, Point(z=end_z_retract_dist))
-            ]
-
+            assert move_call_list == [(OT3Mount.LEFT, Point(z=end_z_retract_dist))]
 
 
 @pytest.mark.parametrize("load_configs", load_pipette_configs)


### PR DESCRIPTION
## Overview
Just adds a unit test for non-tip motor moves in tip pickup. This wasn't done for dropoff  because we don't expect any such moves before and after drop-off.

## Review Request
Please let me know if there are any more tests I should add !