### PR TITLE
ci(app-shell): use notarytool for OSX signing

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -2,7 +2,11 @@
 const path = require('path')
 const { versionForProject } = require('../scripts/git-version')
 
-const { OT_APP_DEPLOY_BUCKET, OT_APP_DEPLOY_FOLDER, APPLE_TEAM_ID } = process.env
+const {
+  OT_APP_DEPLOY_BUCKET,
+  OT_APP_DEPLOY_FOLDER,
+  APPLE_TEAM_ID,
+} = process.env
 const DEV_MODE = process.env.NODE_ENV !== 'production'
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
@@ -57,8 +61,8 @@ module.exports = async () => ({
     forceCodeSigning: !DEV_MODE,
     gatekeeperAssess: true,
     notarize: {
-      teamId: APPLE_TEAM_ID 
-    }
+      teamId: APPLE_TEAM_ID,
+    },
   },
   dmg: {
     icon: null,

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -2,7 +2,7 @@
 const path = require('path')
 const { versionForProject } = require('../scripts/git-version')
 
-const { OT_APP_DEPLOY_BUCKET, OT_APP_DEPLOY_FOLDER } = process.env
+const { OT_APP_DEPLOY_BUCKET, OT_APP_DEPLOY_FOLDER, APPLE_TEAM_ID } = process.env
 const DEV_MODE = process.env.NODE_ENV !== 'production'
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
@@ -56,6 +56,9 @@ module.exports = async () => ({
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
     forceCodeSigning: !DEV_MODE,
     gatekeeperAssess: true,
+    notarize: {
+      teamId: APPLE_TEAM_ID 
+    }
   },
   dmg: {
     icon: null,


### PR DESCRIPTION
# Overview

The legacy tool will no longer be supported, move to use notarytool

# Risk assessment
low