### PR TITLE
feat(protocol-designer): use correct types in 8_0_0 migration

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -167,7 +167,8 @@ describe('Protocol fixtures migrate and match snapshots', () => {
                       labwareId.includes(OT_2_TRASH_DEF_URI) ||
                       labwareId.includes(FLEX_TRASH_DEF_URI)
                     ) {
-                      labwareLocationUpdate['trashId'] = slot
+                      const trashId = 'trashId'
+                      labwareLocationUpdate[trashId] = slot
                       delete labwareLocationUpdate[labwareId]
                     }
                   }

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -12,64 +12,56 @@ describe('Protocol fixtures migrate and match snapshots', () => {
   })
 
   const testCases = [
-    //  TODO(jr, 10/31/23): when 8.0 is more developed, lets go back and fix these
-    //  {
-    //   title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 7.0.x, schema 7',
-    //   importFixture: '../../fixtures/protocol/1/example_1_1_0.json',
-    //   expectedExportFixture:
-    //     '../../fixtures/protocol/7/example_1_1_0MigratedFromV1_0_0.json',
-    //   unusedPipettes: true,
-    //   migrationModal: 'newLabwareDefs',
-    // },
-    // {
-    //   title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 7.0.x, schema 7',
-    //   importFixture: '../../fixtures/protocol/4/doItAllV3.json',
-    //   expectedExportFixture:
-    //     '../../fixtures/protocol/7/doItAllV3MigratedToV7.json',
-    //   unusedPipettes: false,
-    //   migrationModal: 'generic',
-    // },
-    // {
-    //   title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 7.0.x, schema 7',
-    //   importFixture: '../../fixtures/protocol/4/doItAllV4.json',
-    //   expectedExportFixture:
-    //     '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
-    //   unusedPipettes: false,
-    //   migrationModal: 'generic',
-    // },
-    // {
-    //   title: 'doItAllV6 (schema 6, PD version 6.1.0) -> PD 7.0.x, schema 7',
-    //   importFixture: '../../fixtures/protocol/6/doItAllV4MigratedToV6.json',
-    //   expectedExportFixture:
-    //     '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
-    //   unusedPipettes: false,
-    //   migrationModal: 'generic',
-    // },
+    {
+      title: 'example_1_1_0 (schema 1, PD version 1.1.1) -> PD 8.0.x, schema 8',
+      importFixture: '../../fixtures/protocol/1/example_1_1_0.json',
+      expectedExportFixture:
+        '../../fixtures/protocol/8/example_1_1_0MigratedToV8.json',
+      unusedPipettes: true,
+      migrationModal: 'newLabwareDefs',
+    },
+    {
+      title: 'doItAllV3 (schema 3, PD version 4.0.0) -> PD 8.0.x, schema 8',
+      importFixture: '../../fixtures/protocol/4/doItAllV3.json',
+      expectedExportFixture:
+        '../../fixtures/protocol/8/doItAllV3MigratedToV8.json',
+      unusedPipettes: false,
+      migrationModal: 'generic',
+    },
+    {
+      title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 8.0.x, schema 8',
+      importFixture: '../../fixtures/protocol/4/doItAllV4.json',
+      expectedExportFixture:
+        '../../fixtures/protocol/8/doItAllV4MigratedToV8.json',
+      unusedPipettes: false,
+      migrationModal: 'generic',
+    },
+    //  TODO(jr, 11/1/23): add a test for v8 migrated to v8 with the deck config commands
     // {
     //   title:
-    //     'doItAllV7 (schema 7, PD version 7.0.0) -> import and re-export should preserve data',
+    //     'doItAllV8 (schema 7, PD version 8.0.0) -> import and re-export should preserve data',
     //   importFixture: '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
     //   expectedExportFixture:
     //     '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
     //   unusedPipettes: false,
     //   migrationModal: null,
     // },
-    // {
-    //   title:
-    //     'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 7.0.x, schema 7',
-    //   importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
-    //   expectedExportFixture: '../../fixtures/protocol/7/mix_7_0_0.json',
-    //   migrationModal: 'generic',
-    //   unusedPipettes: false,
-    // },
-    // {
-    //   title: 'doItAllV4MigratedToV7 ot-2 robot (schema 8, PD version 8.0.0)',
-    //   importFixture: '../../fixtures/protocol/7/doItAllV4MigratedToV7.json',
-    //   expectedExportFixture:
-    //     '../../fixtures/protocol/8/doItAllV4MigratedToV8.json',
-    //   migrationModal: 'generic',
-    //   unusedPipettes: false,
-    // },
+    {
+      title:
+        'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 8.0.x, schema 8',
+      importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
+      expectedExportFixture: '../../fixtures/protocol/8/mix_8_0_0.json',
+      migrationModal: 'generic',
+      unusedPipettes: false,
+    },
+    {
+      title: 'doItAll7MigratedToV8 flex robot (schema 8, PD version 8.0.x)',
+      importFixture: '../../fixtures/protocol/7/doItAllV7.json',
+      expectedExportFixture:
+        '../../fixtures/protocol/8/doItAllV7MigratedToV8.json',
+      migrationModal: 'generic',
+      unusedPipettes: false,
+    },
   ]
 
   testCases.forEach(
@@ -161,9 +153,47 @@ describe('Protocol fixtures migrate and match snapshots', () => {
                 f.metadata.lastModified = 123
                 f.designerApplication.data._internalAppBuildDate = 'Foo Date'
                 f.designerApplication.version = 'x.x.x'
+
+                //  NOTE: labwareLocationUpdates, trash stubs can be removed for the release after 8.0.0
+                //  currently stubbed because of the newly created trash id for movable trash support
+                f.designerApplication.data.savedStepForms.__INITIAL_DECK_SETUP_STEP__.labwareLocationUpdate =
+                  'trash'
+
+                Object.values(f.designerApplication.data.savedStepForms).map(
+                  stepForm => {
+                    if (stepForm.stepType === 'moveLiquid') {
+                      stepForm.dropTip_location = 'trash drop tip location'
+                      stepForm.blowout_location = 'trash blowout location'
+                    }
+                    if (stepForm.stepType === 'mix') {
+                      if (stepForm.labware.includes('trash')) {
+                        stepForm.labware = 'trash'
+                      }
+                      stepForm.dropTip_location = 'trash drop tip location'
+                      stepForm.blowout_location = 'trash blowout location'
+                    }
+                  }
+                )
                 f.commands.forEach(command => {
                   if ('key' in command) {
                     command.key = '123'
+                  }
+                  if (
+                    command.commandType === 'loadLabware' &&
+                    command.params.displayName === 'Opentrons Fixed Trash'
+                  ) {
+                    command.params.labwareId = 'loadTrash'
+                  }
+                  if (command.commandType === 'dropTip') {
+                    command.params.labwareId = 'dropTipLabwareId'
+                  }
+                  if (
+                    (command.commandType === 'aspirate' ||
+                      command.commandType === 'dispense' ||
+                      command.commandType === 'blowout') &&
+                    command.params.labwareId.includes('trash')
+                  ) {
+                    command.params.labwareId = 'aspirateTrash'
                   }
                 })
               })

--- a/protocol-designer/fixtures/protocol/7/doItAllV7.json
+++ b/protocol-designer/fixtures/protocol/7/doItAllV7.json
@@ -11,7 +11,7 @@
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "7.1.0",
+    "version": "7.0.0",
     "data": {
       "_internalAppBuildDate": "Tue, 26 Sep 2023 18:58:15 GMT",
       "defaultValues": {

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -1,3020 +1,3019 @@
 {
-    "$otSharedSchema": "#/protocol/schemas/8",
-    "schemaVersion": 8,
-    "metadata": {
-      "protocolName": "Do it all v3",
-      "author": "Fixture",
-      "description": "Test all v3 commands",
-      "created": 1585930833548,
-      "lastModified": 1698855895745,
-      "category": null,
-      "subcategory": null,
-      "tags": []
-    },
-    "designerApplication": {
-      "name": "opentrons/protocol-designer",
-      "version": "8.0.0",
-      "data": {
-        "_internalAppBuildDate": "Wed, 01 Nov 2023 16:22:39 GMT",
-        "defaultValues": {
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Do it all v3",
+    "author": "Fixture",
+    "description": "Test all v3 commands",
+    "created": 1585930833548,
+    "lastModified": 1698855895745,
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "8.0.0",
+    "data": {
+      "_internalAppBuildDate": "Wed, 01 Nov 2023 16:22:39 GMT",
+      "defaultValues": {
+        "aspirate_mmFromBottom": 1,
+        "dispense_mmFromBottom": 0.5,
+        "touchTip_mmFromTop": -1,
+        "blowout_mmFromTop": 0
+      },
+      "pipetteTiprackAssignments": {
+        "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "opentrons/opentrons_96_tiprack_300ul/1"
+      },
+      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "ingredients": {
+        "0": {
+          "name": "Water",
+          "description": null,
+          "serialize": false,
+          "liquidGroupId": "0"
+        }
+      },
+      "ingredLocations": {
+        "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
+          "A1": { "0": { "volume": 100 } },
+          "B1": { "0": { "volume": 100 } },
+          "C1": { "0": { "volume": 100 } },
+          "D1": { "0": { "volume": 100 } },
+          "E1": { "0": { "volume": 100 } },
+          "F1": { "0": { "volume": 100 } },
+          "G1": { "0": { "volume": 100 } },
+          "H1": { "0": { "volume": 100 } },
+          "A2": { "0": { "volume": 100 } },
+          "B2": { "0": { "volume": 100 } },
+          "C2": { "0": { "volume": 100 } },
+          "D2": { "0": { "volume": 100 } },
+          "E2": { "0": { "volume": 100 } },
+          "F2": { "0": { "volume": 100 } },
+          "G2": { "0": { "volume": 100 } },
+          "H2": { "0": { "volume": 100 } }
+        }
+      },
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "labwareLocationUpdate": {
+            "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1": "12",
+            "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1": "2",
+            "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "1",
+            "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": "3"
+          },
+          "pipetteLocationUpdate": {
+            "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
+          },
+          "moduleLocationUpdate": {},
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__"
+        },
+        "3961e4c0-75c7-11ea-b42f-4b64e50f43e5": {
+          "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": "40",
+          "changeTip": "always",
+          "path": "multiDispense",
+          "aspirate_wells_grouped": false,
+          "aspirate_flowRate": null,
+          "aspirate_labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "aspirate_wells": ["A1"],
+          "aspirate_wellOrder_first": "t2b",
+          "aspirate_wellOrder_second": "l2r",
+          "aspirate_mix_checkbox": true,
+          "aspirate_mix_times": "2",
+          "aspirate_mix_volume": "30",
           "aspirate_mmFromBottom": 1,
+          "aspirate_touchTip_checkbox": true,
+          "aspirate_touchTip_mmFromBottom": 12.8,
+          "dispense_flowRate": null,
+          "dispense_labware": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "dispense_wells": ["A1", "A2"],
+          "dispense_wellOrder_first": "t2b",
+          "dispense_wellOrder_second": "l2r",
+          "dispense_mix_checkbox": false,
+          "dispense_mix_times": null,
+          "dispense_mix_volume": null,
           "dispense_mmFromBottom": 0.5,
-          "touchTip_mmFromTop": -1,
-          "blowout_mmFromTop": 0
+          "dispense_touchTip_checkbox": true,
+          "dispense_touchTip_mmFromBottom": 40,
+          "disposalVolume_checkbox": true,
+          "disposalVolume_volume": "20",
+          "blowout_checkbox": false,
+          "blowout_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "preWetTip": false,
+          "aspirate_airGap_checkbox": false,
+          "aspirate_airGap_volume": null,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_mmFromBottom": "1",
+          "aspirate_delay_seconds": "1",
+          "dispense_airGap_checkbox": false,
+          "dispense_airGap_volume": null,
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "dispense_delay_mmFromBottom": "0.5",
+          "dropTip_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "id": "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "moveLiquid",
+          "stepName": "transfer",
+          "stepDetails": ""
         },
-        "pipetteTiprackAssignments": {
-          "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "opentrons/opentrons_96_tiprack_300ul/1"
+        "54dc3200-75c7-11ea-b42f-4b64e50f43e5": {
+          "pauseAction": "untilResume",
+          "pauseHour": null,
+          "pauseMinute": null,
+          "pauseSecond": null,
+          "pauseMessage": "Wait until user intervention",
+          "moduleId": null,
+          "pauseTemperature": null,
+          "id": "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
         },
-        "dismissedWarnings": { "form": {}, "timeline": {} },
-        "ingredients": {
-          "0": {
-            "name": "Water",
-            "description": null,
-            "serialize": false,
-            "liquidGroupId": "0"
-          }
+        "5db07ad0-75c7-11ea-b42f-4b64e50f43e5": {
+          "pauseAction": "untilTime",
+          "pauseHour": null,
+          "pauseMinute": "1",
+          "pauseSecond": "2",
+          "pauseMessage": "",
+          "moduleId": null,
+          "pauseTemperature": null,
+          "id": "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
         },
-        "ingredLocations": {
-          "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
-            "A1": { "0": { "volume": 100 } },
-            "B1": { "0": { "volume": 100 } },
-            "C1": { "0": { "volume": 100 } },
-            "D1": { "0": { "volume": 100 } },
-            "E1": { "0": { "volume": 100 } },
-            "F1": { "0": { "volume": 100 } },
-            "G1": { "0": { "volume": 100 } },
-            "H1": { "0": { "volume": 100 } },
-            "A2": { "0": { "volume": 100 } },
-            "B2": { "0": { "volume": 100 } },
-            "C2": { "0": { "volume": 100 } },
-            "D2": { "0": { "volume": 100 } },
-            "E2": { "0": { "volume": 100 } },
-            "F2": { "0": { "volume": 100 } },
-            "G2": { "0": { "volume": 100 } },
-            "H2": { "0": { "volume": 100 } }
-          }
-        },
-        "savedStepForms": {
-          "__INITIAL_DECK_SETUP_STEP__": {
-            "labwareLocationUpdate": {
-              "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1": "12",
-              "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1": "2",
-              "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "1",
-              "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": "3"
-            },
-            "pipetteLocationUpdate": {
-              "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
-            },
-            "moduleLocationUpdate": {},
-            "stepType": "manualIntervention",
-            "id": "__INITIAL_DECK_SETUP_STEP__"
-          },
-          "3961e4c0-75c7-11ea-b42f-4b64e50f43e5": {
-            "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-            "volume": "40",
-            "changeTip": "always",
-            "path": "multiDispense",
-            "aspirate_wells_grouped": false,
-            "aspirate_flowRate": null,
-            "aspirate_labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-            "aspirate_wells": ["A1"],
-            "aspirate_wellOrder_first": "t2b",
-            "aspirate_wellOrder_second": "l2r",
-            "aspirate_mix_checkbox": true,
-            "aspirate_mix_times": "2",
-            "aspirate_mix_volume": "30",
-            "aspirate_mmFromBottom": 1,
-            "aspirate_touchTip_checkbox": true,
-            "aspirate_touchTip_mmFromBottom": 12.8,
-            "dispense_flowRate": null,
-            "dispense_labware": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
-            "dispense_wells": ["A1", "A2"],
-            "dispense_wellOrder_first": "t2b",
-            "dispense_wellOrder_second": "l2r",
-            "dispense_mix_checkbox": false,
-            "dispense_mix_times": null,
-            "dispense_mix_volume": null,
-            "dispense_mmFromBottom": 0.5,
-            "dispense_touchTip_checkbox": true,
-            "dispense_touchTip_mmFromBottom": 40,
-            "disposalVolume_checkbox": true,
-            "disposalVolume_volume": "20",
-            "blowout_checkbox": false,
-            "blowout_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-            "preWetTip": false,
-            "aspirate_airGap_checkbox": false,
-            "aspirate_airGap_volume": null,
-            "aspirate_delay_checkbox": false,
-            "aspirate_delay_mmFromBottom": "1",
-            "aspirate_delay_seconds": "1",
-            "dispense_airGap_checkbox": false,
-            "dispense_airGap_volume": null,
-            "dispense_delay_checkbox": false,
-            "dispense_delay_seconds": "1",
-            "dispense_delay_mmFromBottom": "0.5",
-            "dropTip_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-            "id": "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
-            "stepType": "moveLiquid",
-            "stepName": "transfer",
-            "stepDetails": ""
-          },
-          "54dc3200-75c7-11ea-b42f-4b64e50f43e5": {
-            "pauseAction": "untilResume",
-            "pauseHour": null,
-            "pauseMinute": null,
-            "pauseSecond": null,
-            "pauseMessage": "Wait until user intervention",
-            "moduleId": null,
-            "pauseTemperature": null,
-            "id": "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
-            "stepType": "pause",
-            "stepName": "pause",
-            "stepDetails": ""
-          },
-          "5db07ad0-75c7-11ea-b42f-4b64e50f43e5": {
-            "pauseAction": "untilTime",
-            "pauseHour": null,
-            "pauseMinute": "1",
-            "pauseSecond": "2",
-            "pauseMessage": "",
-            "moduleId": null,
-            "pauseTemperature": null,
-            "id": "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
-            "stepType": "pause",
-            "stepName": "pause",
-            "stepDetails": ""
-          },
-          "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5": {
-            "times": "3",
-            "changeTip": "always",
-            "labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-            "mix_wellOrder_first": "t2b",
-            "mix_wellOrder_second": "l2r",
-            "blowout_checkbox": true,
-            "blowout_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-            "mix_mmFromBottom": 0.5,
-            "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-            "volume": "35",
-            "wells": ["D2", "E2"],
-            "aspirate_flowRate": 40,
-            "dispense_flowRate": 35,
-            "aspirate_delay_checkbox": false,
-            "aspirate_delay_seconds": "1",
-            "dispense_delay_checkbox": false,
-            "dispense_delay_seconds": "1",
-            "mix_touchTip_checkbox": true,
-            "mix_touchTip_mmFromBottom": 11.8,
-            "dropTip_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-            "id": "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5",
-            "stepType": "mix",
-            "stepName": "mix",
-            "stepDetails": ""
-          }
-        },
-        "orderedStepIds": [
-          "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
-          "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
-          "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
-          "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5"
+        "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5": {
+          "times": "3",
+          "changeTip": "always",
+          "labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "mix_wellOrder_first": "t2b",
+          "mix_wellOrder_second": "l2r",
+          "blowout_checkbox": true,
+          "blowout_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "mix_mmFromBottom": 0.5,
+          "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": "35",
+          "wells": ["D2", "E2"],
+          "aspirate_flowRate": 40,
+          "dispense_flowRate": 35,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_seconds": "1",
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "mix_touchTip_checkbox": true,
+          "mix_touchTip_mmFromBottom": 11.8,
+          "dropTip_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "id": "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5",
+          "stepType": "mix",
+          "stepName": "mix",
+          "stepDetails": ""
+        }
+      },
+      "orderedStepIds": [
+        "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
+        "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
+        "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
+        "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5"
+      ]
+    }
+  },
+  "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_96_tiprack_300ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips"
         ]
+      },
+      "metadata": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.49
+      },
+      "wells": {
+        "A1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 5.39
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 59.3,
+        "tipOverlap": 7.47,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_300ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": [
+          "fixedTrash",
+          "centerMultichannelOnWells",
+          "touchTipDisabled"
+        ]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 0,
+          "x": 82.84,
+          "y": 80,
+          "z": 82
+        }
+      },
+      "brand": { "brand": "Opentrons" },
+      "groups": [{ "wells": ["A1"], "metadata": {} }],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "NEST",
+        "brandId": ["402501"],
+        "links": ["https://www.nest-biotech.com/pcr-plates/58773587.html"]
+      },
+      "metadata": {
+        "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 15.7
+      },
+      "wells": {
+        "A1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 0.92
+        }
+      },
+      "groups": [
+        {
+          "metadata": { "wellBottomShape": "v" },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": true,
+        "magneticModuleEngageHeight": 20,
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1"],
+        ["A2", "B2", "C2", "D2"],
+        ["A3", "B3", "C3", "D3"],
+        ["A4", "B4", "C4", "D4"],
+        ["A5", "B5", "C5", "D5"],
+        ["A6", "B6", "C6", "D6"]
+      ],
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "metadata": {
+        "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+        "displayVolumeUnits": "mL",
+        "displayCategory": "aluminumBlock",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.5,
+        "zDimension": 42
+      },
+      "parameters": {
+        "format": "irregular",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap"
+      },
+      "wells": {
+        "D1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 68.63,
+          "z": 6.7
+        }
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set"
+        ]
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "A6",
+            "B6",
+            "C6",
+            "D6"
+          ],
+          "metadata": {
+            "displayName": "Generic 2 mL Screwcap",
+            "displayCategory": "tubeRack",
+            "wellBottomShape": "v"
+          },
+          "brand": { "brand": "generic", "brandId": [], "links": [] }
+        }
+      ],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    }
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "0": {
+      "displayName": "Water",
+      "description": "",
+      "displayColor": "#b925ff"
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commands": [
+    {
+      "key": "34c465b6-567b-4562-af3d-fa7c0ae2463a",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p300_single_gen2",
+        "mount": "left",
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
       }
     },
-    "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
-    "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
-    "labwareDefinitions": {
-      "opentrons/opentrons_96_tiprack_300ul/1": {
-        "ordering": [
-          ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
-          ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
-          ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
-          ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
-          ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
-          ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
-          ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
-          ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
-          ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
-          ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
-          ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
-          ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
-        ],
-        "brand": {
-          "brand": "Opentrons",
-          "brandId": [],
-          "links": [
-            "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips"
-          ]
-        },
-        "metadata": {
-          "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
-          "displayCategory": "tipRack",
-          "displayVolumeUnits": "µL",
-          "tags": []
-        },
-        "dimensions": {
-          "xDimension": 127.76,
-          "yDimension": 85.48,
-          "zDimension": 64.49
-        },
-        "wells": {
-          "A1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H1": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 14.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H2": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 23.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H3": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 32.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H4": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 41.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H5": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 50.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H6": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 59.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H7": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 68.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H8": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 77.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H9": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 86.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H10": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 95.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H11": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 104.38,
-            "y": 11.24,
-            "z": 5.39
-          },
-          "A12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 74.24,
-            "z": 5.39
-          },
-          "B12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 65.24,
-            "z": 5.39
-          },
-          "C12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 56.24,
-            "z": 5.39
-          },
-          "D12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 47.24,
-            "z": 5.39
-          },
-          "E12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 38.24,
-            "z": 5.39
-          },
-          "F12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 29.24,
-            "z": 5.39
-          },
-          "G12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 20.24,
-            "z": 5.39
-          },
-          "H12": {
-            "depth": 59.3,
-            "shape": "circular",
-            "diameter": 5.23,
-            "totalLiquidVolume": 300,
-            "x": 113.38,
-            "y": 11.24,
-            "z": 5.39
-          }
-        },
-        "groups": [
-          {
-            "metadata": {},
-            "wells": [
-              "A1",
-              "B1",
-              "C1",
-              "D1",
-              "E1",
-              "F1",
-              "G1",
-              "H1",
-              "A2",
-              "B2",
-              "C2",
-              "D2",
-              "E2",
-              "F2",
-              "G2",
-              "H2",
-              "A3",
-              "B3",
-              "C3",
-              "D3",
-              "E3",
-              "F3",
-              "G3",
-              "H3",
-              "A4",
-              "B4",
-              "C4",
-              "D4",
-              "E4",
-              "F4",
-              "G4",
-              "H4",
-              "A5",
-              "B5",
-              "C5",
-              "D5",
-              "E5",
-              "F5",
-              "G5",
-              "H5",
-              "A6",
-              "B6",
-              "C6",
-              "D6",
-              "E6",
-              "F6",
-              "G6",
-              "H6",
-              "A7",
-              "B7",
-              "C7",
-              "D7",
-              "E7",
-              "F7",
-              "G7",
-              "H7",
-              "A8",
-              "B8",
-              "C8",
-              "D8",
-              "E8",
-              "F8",
-              "G8",
-              "H8",
-              "A9",
-              "B9",
-              "C9",
-              "D9",
-              "E9",
-              "F9",
-              "G9",
-              "H9",
-              "A10",
-              "B10",
-              "C10",
-              "D10",
-              "E10",
-              "F10",
-              "G10",
-              "H10",
-              "A11",
-              "B11",
-              "C11",
-              "D11",
-              "E11",
-              "F11",
-              "G11",
-              "H11",
-              "A12",
-              "B12",
-              "C12",
-              "D12",
-              "E12",
-              "F12",
-              "G12",
-              "H12"
-            ]
-          }
-        ],
-        "parameters": {
-          "format": "96Standard",
-          "isTiprack": true,
-          "tipLength": 59.3,
-          "tipOverlap": 7.47,
-          "isMagneticModuleCompatible": false,
-          "loadName": "opentrons_96_tiprack_300ul"
-        },
+    {
+      "key": "1c3d76e3-4b7a-463d-9713-d30ba2f9be98",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Fixed Trash",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "loadName": "opentrons_1_trash_1100ml_fixed",
         "namespace": "opentrons",
         "version": 1,
-        "schemaVersion": 2,
-        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-      },
-      "opentrons/opentrons_1_trash_1100ml_fixed/1": {
-        "ordering": [["A1"]],
-        "metadata": {
-          "displayCategory": "trash",
-          "displayVolumeUnits": "mL",
-          "displayName": "Opentrons Fixed Trash",
-          "tags": []
-        },
-        "schemaVersion": 2,
-        "version": 1,
-        "namespace": "opentrons",
-        "dimensions": {
-          "xDimension": 172.86,
-          "yDimension": 165.86,
-          "zDimension": 82
-        },
-        "parameters": {
-          "format": "trash",
-          "isTiprack": false,
-          "loadName": "opentrons_1_trash_1100ml_fixed",
-          "isMagneticModuleCompatible": false,
-          "quirks": [
-            "fixedTrash",
-            "centerMultichannelOnWells",
-            "touchTipDisabled"
-          ]
-        },
-        "wells": {
-          "A1": {
-            "shape": "rectangular",
-            "yDimension": 165.67,
-            "xDimension": 107.11,
-            "totalLiquidVolume": 1100000,
-            "depth": 0,
-            "x": 82.84,
-            "y": 80,
-            "z": 82
-          }
-        },
-        "brand": { "brand": "Opentrons" },
-        "groups": [{ "wells": ["A1"], "metadata": {} }],
-        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-      },
-      "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
-        "ordering": [
-          ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
-          ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
-          ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
-          ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
-          ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
-          ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
-          ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
-          ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
-          ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
-          ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
-          ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
-          ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
-        ],
-        "brand": {
-          "brand": "NEST",
-          "brandId": ["402501"],
-          "links": ["https://www.nest-biotech.com/pcr-plates/58773587.html"]
-        },
-        "metadata": {
-          "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
-          "displayCategory": "wellPlate",
-          "displayVolumeUnits": "µL",
-          "tags": []
-        },
-        "dimensions": {
-          "xDimension": 127.76,
-          "yDimension": 85.48,
-          "zDimension": 15.7
-        },
-        "wells": {
-          "A1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H1": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 14.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H2": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 23.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H3": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 32.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H4": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 41.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H5": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 50.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H6": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 59.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H7": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 68.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H8": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 77.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H9": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 86.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H10": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 95.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H11": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 104.38,
-            "y": 11.24,
-            "z": 0.92
-          },
-          "A12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 74.24,
-            "z": 0.92
-          },
-          "B12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 65.24,
-            "z": 0.92
-          },
-          "C12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 56.24,
-            "z": 0.92
-          },
-          "D12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 47.24,
-            "z": 0.92
-          },
-          "E12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 38.24,
-            "z": 0.92
-          },
-          "F12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 29.24,
-            "z": 0.92
-          },
-          "G12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 20.24,
-            "z": 0.92
-          },
-          "H12": {
-            "depth": 14.78,
-            "shape": "circular",
-            "diameter": 5.34,
-            "totalLiquidVolume": 100,
-            "x": 113.38,
-            "y": 11.24,
-            "z": 0.92
-          }
-        },
-        "groups": [
-          {
-            "metadata": { "wellBottomShape": "v" },
-            "wells": [
-              "A1",
-              "B1",
-              "C1",
-              "D1",
-              "E1",
-              "F1",
-              "G1",
-              "H1",
-              "A2",
-              "B2",
-              "C2",
-              "D2",
-              "E2",
-              "F2",
-              "G2",
-              "H2",
-              "A3",
-              "B3",
-              "C3",
-              "D3",
-              "E3",
-              "F3",
-              "G3",
-              "H3",
-              "A4",
-              "B4",
-              "C4",
-              "D4",
-              "E4",
-              "F4",
-              "G4",
-              "H4",
-              "A5",
-              "B5",
-              "C5",
-              "D5",
-              "E5",
-              "F5",
-              "G5",
-              "H5",
-              "A6",
-              "B6",
-              "C6",
-              "D6",
-              "E6",
-              "F6",
-              "G6",
-              "H6",
-              "A7",
-              "B7",
-              "C7",
-              "D7",
-              "E7",
-              "F7",
-              "G7",
-              "H7",
-              "A8",
-              "B8",
-              "C8",
-              "D8",
-              "E8",
-              "F8",
-              "G8",
-              "H8",
-              "A9",
-              "B9",
-              "C9",
-              "D9",
-              "E9",
-              "F9",
-              "G9",
-              "H9",
-              "A10",
-              "B10",
-              "C10",
-              "D10",
-              "E10",
-              "F10",
-              "G10",
-              "H10",
-              "A11",
-              "B11",
-              "C11",
-              "D11",
-              "E11",
-              "F11",
-              "G11",
-              "H11",
-              "A12",
-              "B12",
-              "C12",
-              "D12",
-              "E12",
-              "F12",
-              "G12",
-              "H12"
-            ]
-          }
-        ],
-        "parameters": {
-          "format": "96Standard",
-          "isTiprack": false,
-          "isMagneticModuleCompatible": true,
-          "magneticModuleEngageHeight": 20,
-          "loadName": "nest_96_wellplate_100ul_pcr_full_skirt"
-        },
-        "namespace": "opentrons",
-        "version": 1,
-        "schemaVersion": 2,
-        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-      },
-      "opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": {
-        "ordering": [
-          ["A1", "B1", "C1", "D1"],
-          ["A2", "B2", "C2", "D2"],
-          ["A3", "B3", "C3", "D3"],
-          ["A4", "B4", "C4", "D4"],
-          ["A5", "B5", "C5", "D5"],
-          ["A6", "B6", "C6", "D6"]
-        ],
-        "schemaVersion": 2,
-        "version": 1,
-        "namespace": "opentrons",
-        "metadata": {
-          "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
-          "displayVolumeUnits": "mL",
-          "displayCategory": "aluminumBlock",
-          "tags": []
-        },
-        "dimensions": {
-          "xDimension": 127.75,
-          "yDimension": 85.5,
-          "zDimension": 42
-        },
-        "parameters": {
-          "format": "irregular",
-          "isTiprack": false,
-          "isMagneticModuleCompatible": false,
-          "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap"
-        },
-        "wells": {
-          "D1": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 20.75,
-            "y": 16.88,
-            "z": 6.7
-          },
-          "C1": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 20.75,
-            "y": 34.13,
-            "z": 6.7
-          },
-          "B1": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 20.75,
-            "y": 51.38,
-            "z": 6.7
-          },
-          "A1": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 20.75,
-            "y": 68.63,
-            "z": 6.7
-          },
-          "D2": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 38,
-            "y": 16.88,
-            "z": 6.7
-          },
-          "C2": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 38,
-            "y": 34.13,
-            "z": 6.7
-          },
-          "B2": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 38,
-            "y": 51.38,
-            "z": 6.7
-          },
-          "A2": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 38,
-            "y": 68.63,
-            "z": 6.7
-          },
-          "D3": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 55.25,
-            "y": 16.88,
-            "z": 6.7
-          },
-          "C3": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 55.25,
-            "y": 34.13,
-            "z": 6.7
-          },
-          "B3": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 55.25,
-            "y": 51.38,
-            "z": 6.7
-          },
-          "A3": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 55.25,
-            "y": 68.63,
-            "z": 6.7
-          },
-          "D4": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 72.5,
-            "y": 16.88,
-            "z": 6.7
-          },
-          "C4": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 72.5,
-            "y": 34.13,
-            "z": 6.7
-          },
-          "B4": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 72.5,
-            "y": 51.38,
-            "z": 6.7
-          },
-          "A4": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 72.5,
-            "y": 68.63,
-            "z": 6.7
-          },
-          "D5": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 89.75,
-            "y": 16.88,
-            "z": 6.7
-          },
-          "C5": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 89.75,
-            "y": 34.13,
-            "z": 6.7
-          },
-          "B5": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 89.75,
-            "y": 51.38,
-            "z": 6.7
-          },
-          "A5": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 89.75,
-            "y": 68.63,
-            "z": 6.7
-          },
-          "D6": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 107,
-            "y": 16.88,
-            "z": 6.7
-          },
-          "C6": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 107,
-            "y": 34.13,
-            "z": 6.7
-          },
-          "B6": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 107,
-            "y": 51.38,
-            "z": 6.7
-          },
-          "A6": {
-            "shape": "circular",
-            "depth": 42,
-            "diameter": 8.5,
-            "totalLiquidVolume": 2000,
-            "x": 107,
-            "y": 68.63,
-            "z": 6.7
-          }
-        },
-        "brand": {
-          "brand": "Opentrons",
-          "brandId": [],
-          "links": [
-            "https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set"
-          ]
-        },
-        "groups": [
-          {
-            "wells": [
-              "A1",
-              "B1",
-              "C1",
-              "D1",
-              "A2",
-              "B2",
-              "C2",
-              "D2",
-              "A3",
-              "B3",
-              "C3",
-              "D3",
-              "A4",
-              "B4",
-              "C4",
-              "D4",
-              "A5",
-              "B5",
-              "C5",
-              "D5",
-              "A6",
-              "B6",
-              "C6",
-              "D6"
-            ],
-            "metadata": {
-              "displayName": "Generic 2 mL Screwcap",
-              "displayCategory": "tubeRack",
-              "wellBottomShape": "v"
-            },
-            "brand": { "brand": "generic", "brandId": [], "links": [] }
-          }
-        ],
-        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+        "location": { "slotName": "12" }
       }
     },
-    "liquidSchemaId": "opentronsLiquidSchemaV1",
-    "liquids": {
-      "0": {
-        "displayName": "Water",
-        "description": "",
-        "displayColor": "#b925ff"
+    {
+      "key": "d118489e-8376-4906-815c-0dbe228790ec",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "loadName": "opentrons_96_tiprack_300ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "2" }
       }
     },
-    "commandSchemaId": "opentronsCommandSchemaV8",
-    "commands": [
-      {
-        "key": "34c465b6-567b-4562-af3d-fa7c0ae2463a",
-        "commandType": "loadPipette",
-        "params": {
-          "pipetteName": "p300_single_gen2",
-          "mount": "left",
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
-        }
-      },
-      {
-        "key": "1c3d76e3-4b7a-463d-9713-d30ba2f9be98",
-        "commandType": "loadLabware",
-        "params": {
-          "displayName": "Opentrons Fixed Trash",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "loadName": "opentrons_1_trash_1100ml_fixed",
-          "namespace": "opentrons",
-          "version": 1,
-          "location": { "slotName": "12" }
-        }
-      },
-      {
-        "key": "d118489e-8376-4906-815c-0dbe228790ec",
-        "commandType": "loadLabware",
-        "params": {
-          "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
-          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
-          "loadName": "opentrons_96_tiprack_300ul",
-          "namespace": "opentrons",
-          "version": 1,
-          "location": { "slotName": "2" }
-        }
-      },
-      {
-        "key": "3a96b3ae-0980-4b03-97bd-3d8bf6ec146c",
-        "commandType": "loadLabware",
-        "params": {
-          "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
-          "namespace": "opentrons",
-          "version": 1,
-          "location": { "slotName": "1" }
-        }
-      },
-      {
-        "key": "4f51e840-b2d0-4753-bce8-1f9d7243b04a",
-        "commandType": "loadLabware",
-        "params": {
-          "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
-          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
-          "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap",
-          "namespace": "opentrons",
-          "version": 1,
-          "location": { "slotName": "3" }
-        }
-      },
-      {
-        "commandType": "loadLiquid",
-        "key": "a200ffe3-2b99-4432-9aca-366dd6d02938",
-        "params": {
-          "liquidId": "0",
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "volumeByWell": {
-            "A1": 100,
-            "B1": 100,
-            "C1": 100,
-            "D1": 100,
-            "E1": 100,
-            "F1": 100,
-            "G1": 100,
-            "H1": 100,
-            "A2": 100,
-            "B2": 100,
-            "C2": 100,
-            "D2": 100,
-            "E2": 100,
-            "F2": 100,
-            "G2": 100,
-            "H2": 100
-          }
-        }
-      },
-      {
-        "commandType": "waitForDuration",
-        "key": "5c00d76e-1cf3-4ce5-9444-d77fbad34e84",
-        "params": { "seconds": 62, "message": "" }
-      },
-      {
-        "commandType": "pickUpTip",
-        "key": "d60cd221-137c-4272-bfe9-5c2fa0efd83b",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
-          "wellName": "A1"
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "d6e88ec6-9388-45ec-b738-e03715172cdc",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 30,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "5715d558-7d18-41e9-ac59-affa60b84a2e",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 30,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "516260d4-87cf-4f97-a85e-e4b91143f251",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 30,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "ea891e74-cf28-4a81-a17d-aa2e923bcc12",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 30,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "258c48c2-cf75-4562-9e6d-5ae573e9f477",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 100,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "touchTip",
-        "key": "2832e22f-4516-4fa0-9346-53443faa1326",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 12.8 } }
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "b0577ca1-79bb-4959-9a2c-3bc3164e7078",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 40,
-          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "touchTip",
-        "key": "ab515880-dbc3-4978-a0e1-d74c89fd5b62",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
-          "wellName": "A1",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 40 } }
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "2fcc9508-c0d6-4ffe-aa95-5ce5c4062aca",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 40,
-          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
-          "wellName": "A2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 46.43
-        }
-      },
-      {
-        "commandType": "touchTip",
-        "key": "1757c703-09b4-4576-ba3f-a30150464a11",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
-          "wellName": "A2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 40 } }
-        }
-      },
-      {
-        "commandType": "blowout",
-        "key": "5369e38c-b482-4aa3-9bb3-5736a0f80a24",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "wellName": "A1",
-          "flowRate": 46.43,
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
-        }
-      },
-      {
-        "commandType": "dropTip",
-        "key": "d673d107-80a7-4367-a566-92285b3a9e27",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "wellName": "A1"
-        }
-      },
-      {
-        "commandType": "waitForResume",
-        "key": "14178816-28cd-400e-8ef2-766bb0537f68",
-        "params": { "message": "Wait until user intervention" }
-      },
-      {
-        "commandType": "pickUpTip",
-        "key": "eb2c9c4c-731f-4c5f-92a4-1dd67edb43e0",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
-          "wellName": "B1"
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "609bf9a5-c94a-4f90-bf25-28af2a21bd17",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 40
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "dfcf64ef-d71d-414e-8d3f-92fd59a57fe9",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 35
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "add3104c-71b3-461c-9250-f6f089760085",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 40
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "81793def-491e-4dc6-8e78-e00d8e93cc0f",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 35
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "8d25f9d8-2b6c-4f80-a652-9399bc5af637",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 40
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "1cd3aaba-1165-42ff-91e8-45cf5d9969f6",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 35
-        }
-      },
-      {
-        "commandType": "blowout",
-        "key": "344d8868-2e47-482b-9520-e6f1790ad3cc",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "wellName": "A1",
-          "flowRate": 35,
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
-        }
-      },
-      {
-        "commandType": "touchTip",
-        "key": "4b3071a2-5120-494f-8f7e-4cbea6d0fc90",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "D2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 11.8 } }
-        }
-      },
-      {
-        "commandType": "dropTip",
-        "key": "a7f80136-b151-4ba3-b3c1-79fb21fd977a",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "wellName": "A1"
-        }
-      },
-      {
-        "commandType": "pickUpTip",
-        "key": "1c9c3d91-1fd4-46e5-a416-81515f351e41",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
-          "wellName": "C1"
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "9320e70d-f2b1-41ea-85df-809f72245d4f",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 40
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "d84de4b2-ebab-4740-8602-6fccfc2f7057",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 35
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "58cd9595-97a4-4423-a348-c8892badb6a8",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 40
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "ee9ec831-643f-4024-9b49-c51b6e7276bf",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 35
-        }
-      },
-      {
-        "commandType": "aspirate",
-        "key": "8bc7c0d2-b566-4a96-8c76-f6b130d68f4f",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 40
-        }
-      },
-      {
-        "commandType": "dispense",
-        "key": "e5afcb2f-d7bb-46b9-af9b-b5a4880ce371",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "volume": 35,
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-          "flowRate": 35
-        }
-      },
-      {
-        "commandType": "blowout",
-        "key": "f7c27507-6442-48f4-b632-e4c27cfd3449",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "wellName": "A1",
-          "flowRate": 35,
-          "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
-        }
-      },
-      {
-        "commandType": "touchTip",
-        "key": "439d2f90-7825-4503-8015-4b5b5e57bce6",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
-          "wellName": "E2",
-          "wellLocation": { "origin": "bottom", "offset": { "z": 11.8 } }
-        }
-      },
-      {
-        "commandType": "dropTip",
-        "key": "4b999639-2e8d-4ce9-9828-50dce0939a3a",
-        "params": {
-          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
-          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
-          "wellName": "A1"
+    {
+      "key": "3a96b3ae-0980-4b03-97bd-3d8bf6ec146c",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "key": "4f51e840-b2d0-4753-bce8-1f9d7243b04a",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "3" }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "a200ffe3-2b99-4432-9aca-366dd6d02938",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "volumeByWell": {
+          "A1": 100,
+          "B1": 100,
+          "C1": 100,
+          "D1": 100,
+          "E1": 100,
+          "F1": 100,
+          "G1": 100,
+          "H1": 100,
+          "A2": 100,
+          "B2": 100,
+          "C2": 100,
+          "D2": 100,
+          "E2": 100,
+          "F2": 100,
+          "G2": 100,
+          "H2": 100
         }
       }
-    ],
-    "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
-    "commandAnnotations": []
-  }
-  
+    },
+    {
+      "commandType": "waitForDuration",
+      "key": "5c00d76e-1cf3-4ce5-9444-d77fbad34e84",
+      "params": { "seconds": 62, "message": "" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "d60cd221-137c-4272-bfe9-5c2fa0efd83b",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "d6e88ec6-9388-45ec-b738-e03715172cdc",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "5715d558-7d18-41e9-ac59-affa60b84a2e",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "516260d4-87cf-4f97-a85e-e4b91143f251",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "ea891e74-cf28-4a81-a17d-aa2e923bcc12",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "258c48c2-cf75-4562-9e6d-5ae573e9f477",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 100,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "2832e22f-4516-4fa0-9346-53443faa1326",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 12.8 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "b0577ca1-79bb-4959-9a2c-3bc3164e7078",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 40,
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "ab515880-dbc3-4978-a0e1-d74c89fd5b62",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "2fcc9508-c0d6-4ffe-aa95-5ce5c4062aca",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 40,
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "wellName": "A2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "1757c703-09b4-4576-ba3f-a30150464a11",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "wellName": "A2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "5369e38c-b482-4aa3-9bb3-5736a0f80a24",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 46.43,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "d673d107-80a7-4367-a566-92285b3a9e27",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "waitForResume",
+      "key": "14178816-28cd-400e-8ef2-766bb0537f68",
+      "params": { "message": "Wait until user intervention" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "eb2c9c4c-731f-4c5f-92a4-1dd67edb43e0",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "609bf9a5-c94a-4f90-bf25-28af2a21bd17",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "dfcf64ef-d71d-414e-8d3f-92fd59a57fe9",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 35
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "add3104c-71b3-461c-9250-f6f089760085",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "81793def-491e-4dc6-8e78-e00d8e93cc0f",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 35
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "8d25f9d8-2b6c-4f80-a652-9399bc5af637",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "1cd3aaba-1165-42ff-91e8-45cf5d9969f6",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 35
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "344d8868-2e47-482b-9520-e6f1790ad3cc",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 35,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "4b3071a2-5120-494f-8f7e-4cbea6d0fc90",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "D2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 11.8 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "a7f80136-b151-4ba3-b3c1-79fb21fd977a",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "1c9c3d91-1fd4-46e5-a416-81515f351e41",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "wellName": "C1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9320e70d-f2b1-41ea-85df-809f72245d4f",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "d84de4b2-ebab-4740-8602-6fccfc2f7057",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 35
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "58cd9595-97a4-4423-a348-c8892badb6a8",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "ee9ec831-643f-4024-9b49-c51b6e7276bf",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 35
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "8bc7c0d2-b566-4a96-8c76-f6b130d68f4f",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 40
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "e5afcb2f-d7bb-46b9-af9b-b5a4880ce371",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 35,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 35
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "f7c27507-6442-48f4-b632-e4c27cfd3449",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 35,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "439d2f90-7825-4503-8015-4b5b5e57bce6",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "E2",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 11.8 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "4b999639-2e8d-4ce9-9828-50dce0939a3a",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -1,0 +1,3020 @@
+{
+    "$otSharedSchema": "#/protocol/schemas/8",
+    "schemaVersion": 8,
+    "metadata": {
+      "protocolName": "Do it all v3",
+      "author": "Fixture",
+      "description": "Test all v3 commands",
+      "created": 1585930833548,
+      "lastModified": 1698855895745,
+      "category": null,
+      "subcategory": null,
+      "tags": []
+    },
+    "designerApplication": {
+      "name": "opentrons/protocol-designer",
+      "version": "8.0.0",
+      "data": {
+        "_internalAppBuildDate": "Wed, 01 Nov 2023 16:22:39 GMT",
+        "defaultValues": {
+          "aspirate_mmFromBottom": 1,
+          "dispense_mmFromBottom": 0.5,
+          "touchTip_mmFromTop": -1,
+          "blowout_mmFromTop": 0
+        },
+        "pipetteTiprackAssignments": {
+          "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "opentrons/opentrons_96_tiprack_300ul/1"
+        },
+        "dismissedWarnings": { "form": {}, "timeline": {} },
+        "ingredients": {
+          "0": {
+            "name": "Water",
+            "description": null,
+            "serialize": false,
+            "liquidGroupId": "0"
+          }
+        },
+        "ingredLocations": {
+          "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
+            "A1": { "0": { "volume": 100 } },
+            "B1": { "0": { "volume": 100 } },
+            "C1": { "0": { "volume": 100 } },
+            "D1": { "0": { "volume": 100 } },
+            "E1": { "0": { "volume": 100 } },
+            "F1": { "0": { "volume": 100 } },
+            "G1": { "0": { "volume": 100 } },
+            "H1": { "0": { "volume": 100 } },
+            "A2": { "0": { "volume": 100 } },
+            "B2": { "0": { "volume": 100 } },
+            "C2": { "0": { "volume": 100 } },
+            "D2": { "0": { "volume": 100 } },
+            "E2": { "0": { "volume": 100 } },
+            "F2": { "0": { "volume": 100 } },
+            "G2": { "0": { "volume": 100 } },
+            "H2": { "0": { "volume": 100 } }
+          }
+        },
+        "savedStepForms": {
+          "__INITIAL_DECK_SETUP_STEP__": {
+            "labwareLocationUpdate": {
+              "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1": "12",
+              "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1": "2",
+              "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "1",
+              "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": "3"
+            },
+            "pipetteLocationUpdate": {
+              "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
+            },
+            "moduleLocationUpdate": {},
+            "stepType": "manualIntervention",
+            "id": "__INITIAL_DECK_SETUP_STEP__"
+          },
+          "3961e4c0-75c7-11ea-b42f-4b64e50f43e5": {
+            "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+            "volume": "40",
+            "changeTip": "always",
+            "path": "multiDispense",
+            "aspirate_wells_grouped": false,
+            "aspirate_flowRate": null,
+            "aspirate_labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+            "aspirate_wells": ["A1"],
+            "aspirate_wellOrder_first": "t2b",
+            "aspirate_wellOrder_second": "l2r",
+            "aspirate_mix_checkbox": true,
+            "aspirate_mix_times": "2",
+            "aspirate_mix_volume": "30",
+            "aspirate_mmFromBottom": 1,
+            "aspirate_touchTip_checkbox": true,
+            "aspirate_touchTip_mmFromBottom": 12.8,
+            "dispense_flowRate": null,
+            "dispense_labware": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+            "dispense_wells": ["A1", "A2"],
+            "dispense_wellOrder_first": "t2b",
+            "dispense_wellOrder_second": "l2r",
+            "dispense_mix_checkbox": false,
+            "dispense_mix_times": null,
+            "dispense_mix_volume": null,
+            "dispense_mmFromBottom": 0.5,
+            "dispense_touchTip_checkbox": true,
+            "dispense_touchTip_mmFromBottom": 40,
+            "disposalVolume_checkbox": true,
+            "disposalVolume_volume": "20",
+            "blowout_checkbox": false,
+            "blowout_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+            "preWetTip": false,
+            "aspirate_airGap_checkbox": false,
+            "aspirate_airGap_volume": null,
+            "aspirate_delay_checkbox": false,
+            "aspirate_delay_mmFromBottom": "1",
+            "aspirate_delay_seconds": "1",
+            "dispense_airGap_checkbox": false,
+            "dispense_airGap_volume": null,
+            "dispense_delay_checkbox": false,
+            "dispense_delay_seconds": "1",
+            "dispense_delay_mmFromBottom": "0.5",
+            "dropTip_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+            "id": "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
+            "stepType": "moveLiquid",
+            "stepName": "transfer",
+            "stepDetails": ""
+          },
+          "54dc3200-75c7-11ea-b42f-4b64e50f43e5": {
+            "pauseAction": "untilResume",
+            "pauseHour": null,
+            "pauseMinute": null,
+            "pauseSecond": null,
+            "pauseMessage": "Wait until user intervention",
+            "moduleId": null,
+            "pauseTemperature": null,
+            "id": "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
+            "stepType": "pause",
+            "stepName": "pause",
+            "stepDetails": ""
+          },
+          "5db07ad0-75c7-11ea-b42f-4b64e50f43e5": {
+            "pauseAction": "untilTime",
+            "pauseHour": null,
+            "pauseMinute": "1",
+            "pauseSecond": "2",
+            "pauseMessage": "",
+            "moduleId": null,
+            "pauseTemperature": null,
+            "id": "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
+            "stepType": "pause",
+            "stepName": "pause",
+            "stepDetails": ""
+          },
+          "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5": {
+            "times": "3",
+            "changeTip": "always",
+            "labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+            "mix_wellOrder_first": "t2b",
+            "mix_wellOrder_second": "l2r",
+            "blowout_checkbox": true,
+            "blowout_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+            "mix_mmFromBottom": 0.5,
+            "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+            "volume": "35",
+            "wells": ["D2", "E2"],
+            "aspirate_flowRate": 40,
+            "dispense_flowRate": 35,
+            "aspirate_delay_checkbox": false,
+            "aspirate_delay_seconds": "1",
+            "dispense_delay_checkbox": false,
+            "dispense_delay_seconds": "1",
+            "mix_touchTip_checkbox": true,
+            "mix_touchTip_mmFromBottom": 11.8,
+            "dropTip_location": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+            "id": "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5",
+            "stepType": "mix",
+            "stepName": "mix",
+            "stepDetails": ""
+          }
+        },
+        "orderedStepIds": [
+          "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
+          "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
+          "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
+          "a4cee9a0-75dc-11ea-b42f-4b64e50f43e5"
+        ]
+      }
+    },
+    "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
+    "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+    "labwareDefinitions": {
+      "opentrons/opentrons_96_tiprack_300ul/1": {
+        "ordering": [
+          ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+          ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+          ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+          ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+          ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+          ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+          ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+          ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+          ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+          ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+          ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+          ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+        ],
+        "brand": {
+          "brand": "Opentrons",
+          "brandId": [],
+          "links": [
+            "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips"
+          ]
+        },
+        "metadata": {
+          "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+          "displayCategory": "tipRack",
+          "displayVolumeUnits": "µL",
+          "tags": []
+        },
+        "dimensions": {
+          "xDimension": 127.76,
+          "yDimension": 85.48,
+          "zDimension": 64.49
+        },
+        "wells": {
+          "A1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H1": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 14.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H2": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 23.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H3": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 32.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H4": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 41.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H5": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 50.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H6": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 59.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H7": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 68.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H8": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 77.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H9": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 86.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H10": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 95.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H11": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 104.38,
+            "y": 11.24,
+            "z": 5.39
+          },
+          "A12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 74.24,
+            "z": 5.39
+          },
+          "B12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 65.24,
+            "z": 5.39
+          },
+          "C12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 56.24,
+            "z": 5.39
+          },
+          "D12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 47.24,
+            "z": 5.39
+          },
+          "E12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 38.24,
+            "z": 5.39
+          },
+          "F12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 29.24,
+            "z": 5.39
+          },
+          "G12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 20.24,
+            "z": 5.39
+          },
+          "H12": {
+            "depth": 59.3,
+            "shape": "circular",
+            "diameter": 5.23,
+            "totalLiquidVolume": 300,
+            "x": 113.38,
+            "y": 11.24,
+            "z": 5.39
+          }
+        },
+        "groups": [
+          {
+            "metadata": {},
+            "wells": [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1",
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2",
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3",
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4",
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5",
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6",
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7",
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8",
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9",
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10",
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11",
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ]
+          }
+        ],
+        "parameters": {
+          "format": "96Standard",
+          "isTiprack": true,
+          "tipLength": 59.3,
+          "tipOverlap": 7.47,
+          "isMagneticModuleCompatible": false,
+          "loadName": "opentrons_96_tiprack_300ul"
+        },
+        "namespace": "opentrons",
+        "version": 1,
+        "schemaVersion": 2,
+        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+      },
+      "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+        "ordering": [["A1"]],
+        "metadata": {
+          "displayCategory": "trash",
+          "displayVolumeUnits": "mL",
+          "displayName": "Opentrons Fixed Trash",
+          "tags": []
+        },
+        "schemaVersion": 2,
+        "version": 1,
+        "namespace": "opentrons",
+        "dimensions": {
+          "xDimension": 172.86,
+          "yDimension": 165.86,
+          "zDimension": 82
+        },
+        "parameters": {
+          "format": "trash",
+          "isTiprack": false,
+          "loadName": "opentrons_1_trash_1100ml_fixed",
+          "isMagneticModuleCompatible": false,
+          "quirks": [
+            "fixedTrash",
+            "centerMultichannelOnWells",
+            "touchTipDisabled"
+          ]
+        },
+        "wells": {
+          "A1": {
+            "shape": "rectangular",
+            "yDimension": 165.67,
+            "xDimension": 107.11,
+            "totalLiquidVolume": 1100000,
+            "depth": 0,
+            "x": 82.84,
+            "y": 80,
+            "z": 82
+          }
+        },
+        "brand": { "brand": "Opentrons" },
+        "groups": [{ "wells": ["A1"], "metadata": {} }],
+        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+      },
+      "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
+        "ordering": [
+          ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+          ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+          ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+          ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+          ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+          ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+          ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+          ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+          ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+          ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+          ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+          ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+        ],
+        "brand": {
+          "brand": "NEST",
+          "brandId": ["402501"],
+          "links": ["https://www.nest-biotech.com/pcr-plates/58773587.html"]
+        },
+        "metadata": {
+          "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+          "displayCategory": "wellPlate",
+          "displayVolumeUnits": "µL",
+          "tags": []
+        },
+        "dimensions": {
+          "xDimension": 127.76,
+          "yDimension": 85.48,
+          "zDimension": 15.7
+        },
+        "wells": {
+          "A1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H1": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 14.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H2": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 23.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H3": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 32.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H4": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 41.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H5": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 50.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H6": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 59.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H7": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 68.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H8": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 77.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H9": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 86.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H10": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 95.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H11": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 104.38,
+            "y": 11.24,
+            "z": 0.92
+          },
+          "A12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 74.24,
+            "z": 0.92
+          },
+          "B12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 65.24,
+            "z": 0.92
+          },
+          "C12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 56.24,
+            "z": 0.92
+          },
+          "D12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 47.24,
+            "z": 0.92
+          },
+          "E12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 38.24,
+            "z": 0.92
+          },
+          "F12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 29.24,
+            "z": 0.92
+          },
+          "G12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 20.24,
+            "z": 0.92
+          },
+          "H12": {
+            "depth": 14.78,
+            "shape": "circular",
+            "diameter": 5.34,
+            "totalLiquidVolume": 100,
+            "x": 113.38,
+            "y": 11.24,
+            "z": 0.92
+          }
+        },
+        "groups": [
+          {
+            "metadata": { "wellBottomShape": "v" },
+            "wells": [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1",
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2",
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3",
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4",
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5",
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6",
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7",
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8",
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9",
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10",
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11",
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ]
+          }
+        ],
+        "parameters": {
+          "format": "96Standard",
+          "isTiprack": false,
+          "isMagneticModuleCompatible": true,
+          "magneticModuleEngageHeight": 20,
+          "loadName": "nest_96_wellplate_100ul_pcr_full_skirt"
+        },
+        "namespace": "opentrons",
+        "version": 1,
+        "schemaVersion": 2,
+        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+      },
+      "opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": {
+        "ordering": [
+          ["A1", "B1", "C1", "D1"],
+          ["A2", "B2", "C2", "D2"],
+          ["A3", "B3", "C3", "D3"],
+          ["A4", "B4", "C4", "D4"],
+          ["A5", "B5", "C5", "D5"],
+          ["A6", "B6", "C6", "D6"]
+        ],
+        "schemaVersion": 2,
+        "version": 1,
+        "namespace": "opentrons",
+        "metadata": {
+          "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+          "displayVolumeUnits": "mL",
+          "displayCategory": "aluminumBlock",
+          "tags": []
+        },
+        "dimensions": {
+          "xDimension": 127.75,
+          "yDimension": 85.5,
+          "zDimension": 42
+        },
+        "parameters": {
+          "format": "irregular",
+          "isTiprack": false,
+          "isMagneticModuleCompatible": false,
+          "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap"
+        },
+        "wells": {
+          "D1": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 20.75,
+            "y": 16.88,
+            "z": 6.7
+          },
+          "C1": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 20.75,
+            "y": 34.13,
+            "z": 6.7
+          },
+          "B1": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 20.75,
+            "y": 51.38,
+            "z": 6.7
+          },
+          "A1": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 20.75,
+            "y": 68.63,
+            "z": 6.7
+          },
+          "D2": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 38,
+            "y": 16.88,
+            "z": 6.7
+          },
+          "C2": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 38,
+            "y": 34.13,
+            "z": 6.7
+          },
+          "B2": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 38,
+            "y": 51.38,
+            "z": 6.7
+          },
+          "A2": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 38,
+            "y": 68.63,
+            "z": 6.7
+          },
+          "D3": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 55.25,
+            "y": 16.88,
+            "z": 6.7
+          },
+          "C3": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 55.25,
+            "y": 34.13,
+            "z": 6.7
+          },
+          "B3": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 55.25,
+            "y": 51.38,
+            "z": 6.7
+          },
+          "A3": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 55.25,
+            "y": 68.63,
+            "z": 6.7
+          },
+          "D4": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 72.5,
+            "y": 16.88,
+            "z": 6.7
+          },
+          "C4": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 72.5,
+            "y": 34.13,
+            "z": 6.7
+          },
+          "B4": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 72.5,
+            "y": 51.38,
+            "z": 6.7
+          },
+          "A4": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 72.5,
+            "y": 68.63,
+            "z": 6.7
+          },
+          "D5": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 89.75,
+            "y": 16.88,
+            "z": 6.7
+          },
+          "C5": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 89.75,
+            "y": 34.13,
+            "z": 6.7
+          },
+          "B5": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 89.75,
+            "y": 51.38,
+            "z": 6.7
+          },
+          "A5": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 89.75,
+            "y": 68.63,
+            "z": 6.7
+          },
+          "D6": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 107,
+            "y": 16.88,
+            "z": 6.7
+          },
+          "C6": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 107,
+            "y": 34.13,
+            "z": 6.7
+          },
+          "B6": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 107,
+            "y": 51.38,
+            "z": 6.7
+          },
+          "A6": {
+            "shape": "circular",
+            "depth": 42,
+            "diameter": 8.5,
+            "totalLiquidVolume": 2000,
+            "x": 107,
+            "y": 68.63,
+            "z": 6.7
+          }
+        },
+        "brand": {
+          "brand": "Opentrons",
+          "brandId": [],
+          "links": [
+            "https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set"
+          ]
+        },
+        "groups": [
+          {
+            "wells": [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "A6",
+              "B6",
+              "C6",
+              "D6"
+            ],
+            "metadata": {
+              "displayName": "Generic 2 mL Screwcap",
+              "displayCategory": "tubeRack",
+              "wellBottomShape": "v"
+            },
+            "brand": { "brand": "generic", "brandId": [], "links": [] }
+          }
+        ],
+        "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    "liquidSchemaId": "opentronsLiquidSchemaV1",
+    "liquids": {
+      "0": {
+        "displayName": "Water",
+        "description": "",
+        "displayColor": "#b925ff"
+      }
+    },
+    "commandSchemaId": "opentronsCommandSchemaV8",
+    "commands": [
+      {
+        "key": "34c465b6-567b-4562-af3d-fa7c0ae2463a",
+        "commandType": "loadPipette",
+        "params": {
+          "pipetteName": "p300_single_gen2",
+          "mount": "left",
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
+        }
+      },
+      {
+        "key": "1c3d76e3-4b7a-463d-9713-d30ba2f9be98",
+        "commandType": "loadLabware",
+        "params": {
+          "displayName": "Opentrons Fixed Trash",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "loadName": "opentrons_1_trash_1100ml_fixed",
+          "namespace": "opentrons",
+          "version": 1,
+          "location": { "slotName": "12" }
+        }
+      },
+      {
+        "key": "d118489e-8376-4906-815c-0dbe228790ec",
+        "commandType": "loadLabware",
+        "params": {
+          "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+          "loadName": "opentrons_96_tiprack_300ul",
+          "namespace": "opentrons",
+          "version": 1,
+          "location": { "slotName": "2" }
+        }
+      },
+      {
+        "key": "3a96b3ae-0980-4b03-97bd-3d8bf6ec146c",
+        "commandType": "loadLabware",
+        "params": {
+          "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+          "namespace": "opentrons",
+          "version": 1,
+          "location": { "slotName": "1" }
+        }
+      },
+      {
+        "key": "4f51e840-b2d0-4753-bce8-1f9d7243b04a",
+        "commandType": "loadLabware",
+        "params": {
+          "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap",
+          "namespace": "opentrons",
+          "version": 1,
+          "location": { "slotName": "3" }
+        }
+      },
+      {
+        "commandType": "loadLiquid",
+        "key": "a200ffe3-2b99-4432-9aca-366dd6d02938",
+        "params": {
+          "liquidId": "0",
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "volumeByWell": {
+            "A1": 100,
+            "B1": 100,
+            "C1": 100,
+            "D1": 100,
+            "E1": 100,
+            "F1": 100,
+            "G1": 100,
+            "H1": 100,
+            "A2": 100,
+            "B2": 100,
+            "C2": 100,
+            "D2": 100,
+            "E2": 100,
+            "F2": 100,
+            "G2": 100,
+            "H2": 100
+          }
+        }
+      },
+      {
+        "commandType": "waitForDuration",
+        "key": "5c00d76e-1cf3-4ce5-9444-d77fbad34e84",
+        "params": { "seconds": 62, "message": "" }
+      },
+      {
+        "commandType": "pickUpTip",
+        "key": "d60cd221-137c-4272-bfe9-5c2fa0efd83b",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+          "wellName": "A1"
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "d6e88ec6-9388-45ec-b738-e03715172cdc",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 30,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "5715d558-7d18-41e9-ac59-affa60b84a2e",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 30,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "516260d4-87cf-4f97-a85e-e4b91143f251",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 30,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "ea891e74-cf28-4a81-a17d-aa2e923bcc12",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 30,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "258c48c2-cf75-4562-9e6d-5ae573e9f477",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 100,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "touchTip",
+        "key": "2832e22f-4516-4fa0-9346-53443faa1326",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 12.8 } }
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "b0577ca1-79bb-4959-9a2c-3bc3164e7078",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 40,
+          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "touchTip",
+        "key": "ab515880-dbc3-4978-a0e1-d74c89fd5b62",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "wellName": "A1",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 40 } }
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "2fcc9508-c0d6-4ffe-aa95-5ce5c4062aca",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 40,
+          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "wellName": "A2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 46.43
+        }
+      },
+      {
+        "commandType": "touchTip",
+        "key": "1757c703-09b4-4576-ba3f-a30150464a11",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "wellName": "A2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 40 } }
+        }
+      },
+      {
+        "commandType": "blowout",
+        "key": "5369e38c-b482-4aa3-9bb3-5736a0f80a24",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "wellName": "A1",
+          "flowRate": 46.43,
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+        }
+      },
+      {
+        "commandType": "dropTip",
+        "key": "d673d107-80a7-4367-a566-92285b3a9e27",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "wellName": "A1"
+        }
+      },
+      {
+        "commandType": "waitForResume",
+        "key": "14178816-28cd-400e-8ef2-766bb0537f68",
+        "params": { "message": "Wait until user intervention" }
+      },
+      {
+        "commandType": "pickUpTip",
+        "key": "eb2c9c4c-731f-4c5f-92a4-1dd67edb43e0",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+          "wellName": "B1"
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "609bf9a5-c94a-4f90-bf25-28af2a21bd17",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 40
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "dfcf64ef-d71d-414e-8d3f-92fd59a57fe9",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 35
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "add3104c-71b3-461c-9250-f6f089760085",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 40
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "81793def-491e-4dc6-8e78-e00d8e93cc0f",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 35
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "8d25f9d8-2b6c-4f80-a652-9399bc5af637",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 40
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "1cd3aaba-1165-42ff-91e8-45cf5d9969f6",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 35
+        }
+      },
+      {
+        "commandType": "blowout",
+        "key": "344d8868-2e47-482b-9520-e6f1790ad3cc",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "wellName": "A1",
+          "flowRate": 35,
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+        }
+      },
+      {
+        "commandType": "touchTip",
+        "key": "4b3071a2-5120-494f-8f7e-4cbea6d0fc90",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "D2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 11.8 } }
+        }
+      },
+      {
+        "commandType": "dropTip",
+        "key": "a7f80136-b151-4ba3-b3c1-79fb21fd977a",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "wellName": "A1"
+        }
+      },
+      {
+        "commandType": "pickUpTip",
+        "key": "1c9c3d91-1fd4-46e5-a416-81515f351e41",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+          "wellName": "C1"
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "9320e70d-f2b1-41ea-85df-809f72245d4f",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 40
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "d84de4b2-ebab-4740-8602-6fccfc2f7057",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 35
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "58cd9595-97a4-4423-a348-c8892badb6a8",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 40
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "ee9ec831-643f-4024-9b49-c51b6e7276bf",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 35
+        }
+      },
+      {
+        "commandType": "aspirate",
+        "key": "8bc7c0d2-b566-4a96-8c76-f6b130d68f4f",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 40
+        }
+      },
+      {
+        "commandType": "dispense",
+        "key": "e5afcb2f-d7bb-46b9-af9b-b5a4880ce371",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": 35,
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+          "flowRate": 35
+        }
+      },
+      {
+        "commandType": "blowout",
+        "key": "f7c27507-6442-48f4-b632-e4c27cfd3449",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "wellName": "A1",
+          "flowRate": 35,
+          "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+        }
+      },
+      {
+        "commandType": "touchTip",
+        "key": "439d2f90-7825-4503-8015-4b5b5e57bce6",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "wellName": "E2",
+          "wellLocation": { "origin": "bottom", "offset": { "z": 11.8 } }
+        }
+      },
+      {
+        "commandType": "dropTip",
+        "key": "4b999639-2e8d-4ce9-9828-50dce0939a3a",
+        "params": {
+          "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "labwareId": "85358485-aa9b-4518-8ca9-9b74c5c0beac:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "wellName": "A1"
+        }
+      }
+    ],
+    "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+    "commandAnnotations": []
+  }
+  

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -1,0 +1,2828 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Do it all v4",
+    "author": "Fixture",
+    "description": "Test all v4 commands",
+    "created": 1585930833548,
+    "lastModified": 1698855792001,
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "8.0.0",
+    "data": {
+      "_internalAppBuildDate": "Wed, 01 Nov 2023 16:22:39 GMT",
+      "defaultValues": {
+        "aspirate_mmFromBottom": 1,
+        "dispense_mmFromBottom": 0.5,
+        "touchTip_mmFromTop": -1,
+        "blowout_mmFromTop": 0
+      },
+      "pipetteTiprackAssignments": {
+        "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "opentrons/opentrons_96_tiprack_300ul/1"
+      },
+      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "ingredients": {
+        "0": {
+          "name": "Water",
+          "description": null,
+          "serialize": false,
+          "liquidGroupId": "0"
+        }
+      },
+      "ingredLocations": {
+        "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
+          "A1": { "0": { "volume": 100 } },
+          "B1": { "0": { "volume": 100 } },
+          "C1": { "0": { "volume": 100 } },
+          "D1": { "0": { "volume": 100 } },
+          "E1": { "0": { "volume": 100 } },
+          "F1": { "0": { "volume": 100 } },
+          "G1": { "0": { "volume": 100 } },
+          "H1": { "0": { "volume": 100 } },
+          "A2": { "0": { "volume": 100 } },
+          "B2": { "0": { "volume": 100 } },
+          "C2": { "0": { "volume": 100 } },
+          "D2": { "0": { "volume": 100 } },
+          "E2": { "0": { "volume": 100 } },
+          "F2": { "0": { "volume": 100 } },
+          "G2": { "0": { "volume": 100 } },
+          "H2": { "0": { "volume": 100 } }
+        }
+      },
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "labwareLocationUpdate": {
+            "f59af982-7eeb-4c76-bb74-6b167b77964b:opentrons/opentrons_1_trash_1100ml_fixed/1": "12",
+            "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1": "2",
+            "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
+            "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType"
+          },
+          "pipetteLocationUpdate": {
+            "0b3f2210-75c7-11ea-b42f-4b64e50f43e5": "left"
+          },
+          "moduleLocationUpdate": {
+            "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType": "1",
+            "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType": "3"
+          },
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__"
+        },
+        "2e48b500-75c7-11ea-b42f-4b64e50f43e5": {
+          "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
+          "magnetAction": "engage",
+          "engageHeight": "6",
+          "id": "2e48b500-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "magnet",
+          "stepName": "magnet",
+          "stepDetails": ""
+        },
+        "3153f930-75c7-11ea-b42f-4b64e50f43e5": {
+          "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+          "setTemperature": "true",
+          "targetTemperature": "25",
+          "id": "3153f930-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "temperature",
+          "stepName": "temperature",
+          "stepDetails": ""
+        },
+        "364a4480-75c7-11ea-b42f-4b64e50f43e5": {
+          "pauseAction": "untilTemperature",
+          "pauseHour": null,
+          "pauseMinute": null,
+          "pauseSecond": null,
+          "pauseMessage": "",
+          "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+          "pauseTemperature": "25",
+          "id": "364a4480-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
+        },
+        "3961e4c0-75c7-11ea-b42f-4b64e50f43e5": {
+          "pipette": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+          "volume": "30",
+          "changeTip": "always",
+          "path": "single",
+          "aspirate_wells_grouped": false,
+          "aspirate_flowRate": null,
+          "aspirate_labware": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+          "aspirate_wells": ["A1", "B1"],
+          "aspirate_wellOrder_first": "t2b",
+          "aspirate_wellOrder_second": "l2r",
+          "aspirate_mix_checkbox": false,
+          "aspirate_mix_times": null,
+          "aspirate_mix_volume": null,
+          "aspirate_mmFromBottom": 1,
+          "aspirate_touchTip_checkbox": false,
+          "aspirate_touchTip_mmFromBottom": null,
+          "dispense_flowRate": null,
+          "dispense_labware": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+          "dispense_wells": ["A1"],
+          "dispense_wellOrder_first": "t2b",
+          "dispense_wellOrder_second": "l2r",
+          "dispense_mix_checkbox": false,
+          "dispense_mix_times": null,
+          "dispense_mix_volume": null,
+          "dispense_mmFromBottom": 0.5,
+          "dispense_touchTip_checkbox": false,
+          "dispense_touchTip_mmFromBottom": null,
+          "disposalVolume_checkbox": true,
+          "disposalVolume_volume": "20",
+          "blowout_checkbox": false,
+          "blowout_location": "f59af982-7eeb-4c76-bb74-6b167b77964b:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "preWetTip": false,
+          "aspirate_airGap_checkbox": false,
+          "aspirate_airGap_volume": null,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_mmFromBottom": "1",
+          "aspirate_delay_seconds": "1",
+          "dispense_airGap_checkbox": false,
+          "dispense_airGap_volume": null,
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "dispense_delay_mmFromBottom": "0.5",
+          "dropTip_location": "f59af982-7eeb-4c76-bb74-6b167b77964b:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "id": "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "moveLiquid",
+          "stepName": "transfer",
+          "stepDetails": ""
+        },
+        "4f4057e0-75c7-11ea-b42f-4b64e50f43e5": {
+          "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
+          "magnetAction": "disengage",
+          "engageHeight": "6",
+          "id": "4f4057e0-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "magnet",
+          "stepName": "magnet",
+          "stepDetails": ""
+        },
+        "54dc3200-75c7-11ea-b42f-4b64e50f43e5": {
+          "pauseAction": "untilResume",
+          "pauseHour": null,
+          "pauseMinute": null,
+          "pauseSecond": null,
+          "pauseMessage": "Wait until user intervention",
+          "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+          "pauseTemperature": null,
+          "id": "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
+        },
+        "5db07ad0-75c7-11ea-b42f-4b64e50f43e5": {
+          "pauseAction": "untilTime",
+          "pauseHour": null,
+          "pauseMinute": "1",
+          "pauseSecond": "2",
+          "pauseMessage": "",
+          "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+          "pauseTemperature": null,
+          "id": "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
+        },
+        "80c00130-75c7-11ea-b42f-4b64e50f43e5": {
+          "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+          "setTemperature": "false",
+          "targetTemperature": null,
+          "id": "80c00130-75c7-11ea-b42f-4b64e50f43e5",
+          "stepType": "temperature",
+          "stepName": "temperature",
+          "stepDetails": ""
+        }
+      },
+      "orderedStepIds": [
+        "2e48b500-75c7-11ea-b42f-4b64e50f43e5",
+        "3153f930-75c7-11ea-b42f-4b64e50f43e5",
+        "5db07ad0-75c7-11ea-b42f-4b64e50f43e5",
+        "3961e4c0-75c7-11ea-b42f-4b64e50f43e5",
+        "364a4480-75c7-11ea-b42f-4b64e50f43e5",
+        "4f4057e0-75c7-11ea-b42f-4b64e50f43e5",
+        "54dc3200-75c7-11ea-b42f-4b64e50f43e5",
+        "80c00130-75c7-11ea-b42f-4b64e50f43e5"
+      ]
+    }
+  },
+  "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_96_tiprack_300ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.49
+      },
+      "wells": {
+        "A1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H1": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H2": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H3": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H4": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H5": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H6": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H7": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H8": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H9": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H10": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H11": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 5.39
+        },
+        "A12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 5.39
+        },
+        "B12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 5.39
+        },
+        "C12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 5.39
+        },
+        "D12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 5.39
+        },
+        "E12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 5.39
+        },
+        "F12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 5.39
+        },
+        "G12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 5.39
+        },
+        "H12": {
+          "depth": 59.3,
+          "shape": "circular",
+          "diameter": 5.23,
+          "totalLiquidVolume": 300,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 5.39
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 59.3,
+        "tipOverlap": 7.47,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_300ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "NEST",
+        "brandId": ["402501"],
+        "links": ["https://www.nest-biotech.com/pcr-plates/58773587.html"]
+      },
+      "metadata": {
+        "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 15.7
+      },
+      "wells": {
+        "A1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H1": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H2": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H3": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H4": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H5": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H6": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H7": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H8": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H9": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H10": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H11": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 0.92
+        },
+        "A12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 0.92
+        },
+        "B12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 0.92
+        },
+        "C12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 0.92
+        },
+        "D12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 0.92
+        },
+        "E12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 0.92
+        },
+        "F12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 0.92
+        },
+        "G12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 0.92
+        },
+        "H12": {
+          "depth": 14.78,
+          "shape": "circular",
+          "diameter": 5.34,
+          "totalLiquidVolume": 100,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 0.92
+        }
+      },
+      "groups": [
+        {
+          "metadata": { "wellBottomShape": "v" },
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": true,
+        "magneticModuleEngageHeight": 20,
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1"],
+        ["A2", "B2", "C2", "D2"],
+        ["A3", "B3", "C3", "D3"],
+        ["A4", "B4", "C4", "D4"],
+        ["A5", "B5", "C5", "D5"],
+        ["A6", "B6", "C6", "D6"]
+      ],
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "metadata": {
+        "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+        "displayVolumeUnits": "mL",
+        "displayCategory": "aluminumBlock",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.5,
+        "zDimension": 42
+      },
+      "parameters": {
+        "format": "irregular",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap"
+      },
+      "wells": {
+        "D1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A1": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 20.75,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A2": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 38,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A3": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 55.25,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A4": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 72.5,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A5": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 89.75,
+          "y": 68.63,
+          "z": 6.7
+        },
+        "D6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 16.88,
+          "z": 6.7
+        },
+        "C6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 34.13,
+          "z": 6.7
+        },
+        "B6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 51.38,
+          "z": 6.7
+        },
+        "A6": {
+          "shape": "circular",
+          "depth": 42,
+          "diameter": 8.5,
+          "totalLiquidVolume": 2000,
+          "x": 107,
+          "y": 68.63,
+          "z": 6.7
+        }
+      },
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/hardware-modules/products/aluminum-block-set"
+        ]
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "A6",
+            "B6",
+            "C6",
+            "D6"
+          ],
+          "metadata": {
+            "displayName": "Generic 2 mL Screwcap",
+            "displayCategory": "tubeRack",
+            "wellBottomShape": "v"
+          },
+          "brand": { "brand": "generic", "brandId": [], "links": [] }
+        }
+      ],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": [
+          "fixedTrash",
+          "centerMultichannelOnWells",
+          "touchTipDisabled"
+        ]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 0,
+          "x": 82.84,
+          "y": 80,
+          "z": 82
+        }
+      },
+      "brand": { "brand": "Opentrons" },
+      "groups": [{ "wells": ["A1"], "metadata": {} }],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    }
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "0": {
+      "displayName": "Water",
+      "description": "",
+      "displayColor": "#b925ff"
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commands": [
+    {
+      "key": "5c6ea1c3-3aa7-470d-b8d6-7c164ef9f5cf",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p300_single_gen2",
+        "mount": "left",
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5"
+      }
+    },
+    {
+      "key": "3b9eb9d7-cbd9-4ed2-b53b-4ead223db8cd",
+      "commandType": "loadModule",
+      "params": {
+        "model": "magneticModuleV2",
+        "location": { "slotName": "1" },
+        "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType"
+      }
+    },
+    {
+      "key": "0ac500bf-fb0b-4ac4-99fb-82cc168da65b",
+      "commandType": "loadModule",
+      "params": {
+        "model": "temperatureModuleV2",
+        "location": { "slotName": "3" },
+        "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType"
+      }
+    },
+    {
+      "key": "27493f0c-fdcc-4f10-9134-6a36b91bde05",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Fixed Trash",
+        "labwareId": "f59af982-7eeb-4c76-bb74-6b167b77964b:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "12" }
+      }
+    },
+    {
+      "key": "63c19761-39b0-45b8-b1cb-df1ea99bf8d4",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "loadName": "opentrons_96_tiprack_300ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "2" }
+      }
+    },
+    {
+      "key": "446395ee-4830-41c1-bf6b-a8c0a5541839",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType"
+        }
+      }
+    },
+    {
+      "key": "65d4c36b-f444-4592-9de3-d9ee19e5ad6d",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap",
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "loadName": "opentrons_24_aluminumblock_generic_2ml_screwcap",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType"
+        }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "c0faf39a-503e-4873-9a04-9d2692a6dd1f",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "volumeByWell": {
+          "A1": 100,
+          "B1": 100,
+          "C1": 100,
+          "D1": 100,
+          "E1": 100,
+          "F1": 100,
+          "G1": 100,
+          "H1": 100,
+          "A2": 100,
+          "B2": 100,
+          "C2": 100,
+          "D2": 100,
+          "E2": 100,
+          "F2": 100,
+          "G2": 100,
+          "H2": 100
+        }
+      }
+    },
+    {
+      "commandType": "magneticModule/engage",
+      "key": "5c2495b3-a9c2-442b-9427-ecc7572045f0",
+      "params": {
+        "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType",
+        "height": 6
+      }
+    },
+    {
+      "commandType": "temperatureModule/setTargetTemperature",
+      "key": "1af4a020-cdff-4c95-8dbd-3b336d5ae083",
+      "params": {
+        "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+        "celsius": 25
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "key": "7eb56717-d65d-4411-84e3-6cd91fd5a36d",
+      "params": { "seconds": 62, "message": "" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "4537f511-0df4-4b9b-ad8b-d73a1574cc71",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "27de7cf3-6e93-453c-96c2-cb2307641f6b",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "258f9f85-6bb8-43df-8e1f-25d87146ebd8",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "e014c1cd-a0f6-432e-9289-e3404a0250d1",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "f59af982-7eeb-4c76-bb74-6b167b77964b:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "c25caf0a-9d08-4048-8292-bdd49b2fa3f7",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "350bfb92-6802-4292-b3cd-74d5389ba706",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "1e610d40-75c7-11ea-b42f-4b64e50f43e5:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
+        "wellName": "B1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a0ce98ea-9aae-45f6-8414-a01af9fd287d",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "volume": 30,
+        "labwareId": "21ed8f60-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 46.43
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "1422b491-a35f-45fa-b735-0762ae4ef8f6",
+      "params": {
+        "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5",
+        "labwareId": "f59af982-7eeb-4c76-bb74-6b167b77964b:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "temperatureModule/waitForTemperature",
+      "key": "f686fd82-cb95-4d3f-8c02-b565f03140f7",
+      "params": {
+        "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType",
+        "celsius": 25
+      }
+    },
+    {
+      "commandType": "magneticModule/disengage",
+      "key": "b15307d2-33a0-4d4b-887f-ebc9a1569eb4",
+      "params": {
+        "moduleId": "0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType"
+      }
+    },
+    {
+      "commandType": "waitForResume",
+      "key": "2a30ba22-fb2d-4e1c-931e-f73fbec4eefd",
+      "params": { "message": "Wait until user intervention" }
+    },
+    {
+      "commandType": "temperatureModule/deactivate",
+      "key": "66919698-0193-4930-8fba-eebec3291b76",
+      "params": {
+        "moduleId": "0b4319b0-75c7-11ea-b42f-4b64e50f43e5:temperatureModuleType"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -1,19 +1,21 @@
 {
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
   "metadata": {
     "protocolName": "Flex protocol do it all",
     "author": "",
     "description": "",
     "created": 1689346890165,
-    "lastModified": 1695755031556,
+    "lastModified": 1698852165996,
     "category": null,
     "subcategory": null,
     "tags": []
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "7.1.0",
+    "version": "8.0.0",
     "data": {
-      "_internalAppBuildDate": "Tue, 26 Sep 2023 18:58:15 GMT",
+      "_internalAppBuildDate": "Wed, 01 Nov 2023 15:21:53 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 0.5,
@@ -59,7 +61,7 @@
       "savedStepForms": {
         "__INITIAL_DECK_SETUP_STEP__": {
           "labwareLocationUpdate": {
-            "fixedTrash": "12",
+            "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1": "A3",
             "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1": "C1",
             "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
             "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
@@ -174,7 +176,7 @@
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
           "blowout_checkbox": false,
-          "blowout_location": "fixedTrash",
+          "blowout_location": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
           "preWetTip": false,
           "aspirate_airGap_checkbox": false,
           "aspirate_airGap_volume": "0",
@@ -186,6 +188,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_delay_mmFromBottom": null,
+          "dropTip_location": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
           "id": "f9a294f1-f42b-4cae-893a-592405349d56",
           "stepType": "moveLiquid",
           "stepName": "transfer",
@@ -198,7 +201,7 @@
           "mix_wellOrder_first": "t2b",
           "mix_wellOrder_second": "l2r",
           "blowout_checkbox": false,
-          "blowout_location": "fixedTrash",
+          "blowout_location": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
           "mix_mmFromBottom": 0.5,
           "pipette": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
           "volume": "10",
@@ -211,6 +214,7 @@
           "dispense_delay_seconds": "1",
           "mix_touchTip_checkbox": false,
           "mix_touchTip_mmFromBottom": null,
+          "dropTip_location": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
           "id": "5fdb9a12-fab4-42fd-886f-40af107b15d6",
           "stepType": "mix",
           "stepName": "mix",
@@ -346,18 +350,7 @@
     }
   },
   "robot": { "model": "OT-3 Standard", "deckId": "ot3_standard" },
-  "liquids": {
-    "0": {
-      "displayName": "Water",
-      "description": "",
-      "displayColor": "#b925ff"
-    },
-    "1": {
-      "displayName": "Samples",
-      "description": "",
-      "displayColor": "#ffd600"
-    }
-  },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
   "labwareDefinitions": {
     "opentrons/opentrons_flex_96_filtertiprack_50ul/1": {
       "ordering": [
@@ -2417,11 +2410,7 @@
         "opentrons_96_well_aluminum_block": { "x": 0, "y": 0, "z": 12.66 }
       },
       "stackingOffsetWithModule": {
-        "thermocyclerModuleV2": {
-          "x": 0,
-          "y": 0,
-          "z": 10.8
-        }
+        "thermocyclerModuleV2": { "x": 0, "y": 0, "z": 10.8 }
       }
     },
     "opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1": {
@@ -3784,11 +3773,23 @@
       "cornerOffsetFromSlot": { "x": -17, "y": -2.75, "z": 0 }
     }
   },
-  "$otSharedSchema": "#/protocol/schemas/7",
-  "schemaVersion": 7,
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "0": {
+      "displayName": "Water",
+      "description": "",
+      "displayColor": "#b925ff"
+    },
+    "1": {
+      "displayName": "Samples",
+      "description": "",
+      "displayColor": "#ffd600"
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "de14fbc1-e2e8-4a3b-aa12-89d508c2a80a",
+      "key": "b9cc8c24-7d6c-49a2-af98-1119d9e7bd3c",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p1000_single_flex",
@@ -3797,7 +3798,7 @@
       }
     },
     {
-      "key": "2b1ed982-6505-4de0-ba3d-1f3e7e593f94",
+      "key": "c1b8ae3f-4622-4ffe-ba29-e3e4a59e2f74",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_multi_flex",
@@ -3806,7 +3807,7 @@
       }
     },
     {
-      "key": "2078d6a5-48fd-4510-b9d2-63b494397087",
+      "key": "ef757909-cbfb-4235-be10-c167e8f8d2c4",
       "commandType": "loadModule",
       "params": {
         "model": "magneticBlockV1",
@@ -3815,7 +3816,7 @@
       }
     },
     {
-      "key": "d81a5961-f42d-4378-94bb-2ba2c62d40db",
+      "key": "bd526e67-aaa7-410d-aaf0-e9229f97de72",
       "commandType": "loadModule",
       "params": {
         "model": "heaterShakerModuleV1",
@@ -3824,7 +3825,7 @@
       }
     },
     {
-      "key": "cb87fd96-fed6-4661-bf65-bb751ddce333",
+      "key": "f2edc3da-645a-4f3a-9ff6-078e6ae76d7f",
       "commandType": "loadModule",
       "params": {
         "model": "temperatureModuleV2",
@@ -3833,7 +3834,7 @@
       }
     },
     {
-      "key": "99316c37-bd11-48d7-b8d2-2901a6248169",
+      "key": "39548c7d-fd77-4822-90f4-249fe89b6521",
       "commandType": "loadModule",
       "params": {
         "model": "thermocyclerModuleV2",
@@ -3842,7 +3843,7 @@
       }
     },
     {
-      "key": "1db38ee9-dd4d-4a4c-9c13-24801e2ddc78",
+      "key": "21f403f2-9882-499f-9075-bd8b426773ea",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter",
@@ -3856,7 +3857,19 @@
       }
     },
     {
-      "key": "84129019-df06-4786-8284-6247d102b82f",
+      "key": "86e96eb7-871b-4c86-a48d-5e46dec38dbb",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Fixed Trash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
+        "loadName": "opentrons_1_trash_3200ml_fixed",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "A3" }
+      }
+    },
+    {
+      "key": "a0f159b2-99d7-4fa4-8fa8-85224be73485",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons Flex 96 Filter Tip Rack 50 µL",
@@ -3868,7 +3881,7 @@
       }
     },
     {
-      "key": "b77ccba9-a6a3-482c-943e-2e39297c01f0",
+      "key": "7b79a157-c6f6-4c83-85b8-5768bed63496",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
@@ -3882,7 +3895,7 @@
       }
     },
     {
-      "key": "c0303c6c-a462-4659-93e3-ee9401bab21f",
+      "key": "993c8cc0-4830-406b-bccc-0e98831c0f05",
       "commandType": "loadLabware",
       "params": {
         "displayName": "Opentrons 24 Well Aluminum Block with NEST 1.5 mL Snapcap",
@@ -3896,7 +3909,7 @@
       }
     },
     {
-      "key": "aece300b-8a5e-4120-8b0d-441a81b8cc3a",
+      "key": "355ad6c3-eb8b-402f-9b93-da595b10017c",
       "commandType": "loadLabware",
       "params": {
         "displayName": "NEST 96 Well Plate 200 µL Flat",
@@ -3911,7 +3924,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "5e8b91c8-a3e9-4464-9231-44fd122ea1b0",
+      "key": "0e8c514a-4e9d-48df-9bbf-f8112e601eb7",
       "params": {
         "liquidId": "1",
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
@@ -3920,7 +3933,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "ca09c741-542e-4af2-9a9a-02cc893176b2",
+      "key": "526b5048-4b70-45d2-bf4e-ed7ffc9977d8",
       "params": {
         "liquidId": "0",
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
@@ -3938,7 +3951,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "key": "ef759a65-e434-43d6-b5bb-8eea4dcc7376",
+      "key": "92212e3e-7df6-4677-b136-ff9461f9a49d",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType",
         "celsius": 4
@@ -3946,7 +3959,7 @@
     },
     {
       "commandType": "heaterShaker/waitForTemperature",
-      "key": "9c4194d3-3ec3-4e9f-9ddc-7a8a5532785c",
+      "key": "5b443878-88bc-455b-9208-655efa6b8aa4",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "celsius": 4
@@ -3954,14 +3967,14 @@
     },
     {
       "commandType": "thermocycler/closeLid",
-      "key": "72f8e0b9-a0f6-4a0b-892d-c54cfd3f7059",
+      "key": "2d447fcd-043c-4483-b9a6-dbebdfb21124",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/setTargetLidTemperature",
-      "key": "99235250-9c9f-4dfc-b0fc-f3d1f5f45fb5",
+      "key": "61181be7-36a7-4054-a676-bb9b8999f352",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "celsius": 40
@@ -3969,14 +3982,14 @@
     },
     {
       "commandType": "thermocycler/waitForLidTemperature",
-      "key": "6d134c76-b6d6-464e-adc7-45f1e6338384",
+      "key": "4785b542-8282-4c0f-8e92-0e405446d011",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/runProfile",
-      "key": "f7d5f044-f4e7-4666-ac30-344d933b1c1a",
+      "key": "e364ba5d-f8b7-44b9-beac-5787dbf7951d",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType",
         "profile": [
@@ -3988,28 +4001,28 @@
     },
     {
       "commandType": "thermocycler/deactivateBlock",
-      "key": "cef9592a-f598-48c6-95b4-3ec0e3180bc6",
+      "key": "dac9356a-398f-4958-8b2a-ed27357547ca",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/deactivateLid",
-      "key": "e8aff517-52e1-4389-a7d5-305bc4972901",
+      "key": "7dd1c1d4-fc48-4a06-8f53-c72534948d30",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "thermocycler/openLid",
-      "key": "0c7ef0c5-e6cb-4198-b6e5-5c88aca952d5",
+      "key": "e943f642-aede-452c-8a14-d2382c524b52",
       "params": {
         "moduleId": "627b7a27-5bb7-46de-a530-67af45652e3b:thermocyclerModuleType"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "239a95ce-61f3-4453-b7ff-474b1d74e8c6",
+      "key": "d00f7bef-fc8d-4add-85a3-7c871cfdddd6",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4018,7 +4031,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "759eaeaf-e6b6-4259-a4b9-c0d8cb8f74bd",
+      "key": "828474eb-41a9-4f3a-869d-1a43a5f7bcec",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4030,7 +4043,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f841c259-3ea3-4680-adb9-00b86a352000",
+      "key": "5e085675-4618-47b2-9aec-f28bdfe79663",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4042,16 +4055,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "1a6fc406-0502-4580-893b-f81ffd7731d7",
+      "key": "92c6718d-c39f-408f-a212-212d78e87f20",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7cde6dde-776f-4e1e-9fca-5675144c6769",
+      "key": "42c86bee-88cb-45c1-9766-e79e750b379c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4060,7 +4073,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "23a6653d-f063-4e2c-a4fc-f62fc943fdb4",
+      "key": "947a087b-6e42-49ea-a5ef-ed4936214f0a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4072,7 +4085,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f900ce0b-c4d2-4917-814e-508b5b6e1f5c",
+      "key": "d43ef33f-5555-41c2-ae09-3717711606c0",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4084,16 +4097,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "44851df5-60c4-413b-86a3-9e318782adae",
+      "key": "ad71bf42-c3d2-4877-9ab0-5f72e223a22d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "8729d44e-9d84-4a84-9dad-fe0e01bae92e",
+      "key": "f6134895-9683-412b-be88-9bb08580e0d5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4102,7 +4115,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "0e53b1fa-48ee-48f0-b070-0dc7d71eca27",
+      "key": "e806aece-664c-4440-a798-f574e0a15d2d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4114,7 +4127,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "977e26bf-e824-4fe1-8d62-7ec245f0556c",
+      "key": "a5de2e6d-b0e9-4bc0-9d2f-c598f38cc446",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4126,16 +4139,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "419e1de0-f1f8-4f43-833d-06ce3c32d20d",
+      "key": "447e41d4-e9d8-45dd-9ec6-deba306dacd3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "dcf59a8b-257c-4bee-bffe-266507a5aab3",
+      "key": "40139870-8b73-42d5-b74a-498fc4a2a3dc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4144,7 +4157,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e969e6d2-0092-42ab-8deb-1e27cfecb557",
+      "key": "c97ad218-c70d-4ceb-9034-7e038b65f4e1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4156,7 +4169,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "287cbe62-02d9-4fdb-93d2-d595aa637526",
+      "key": "bad80b76-e6cf-4fa4-90cf-14058ab0268e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4168,16 +4181,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "84f31ede-7edd-447c-9449-6f494c91a621",
+      "key": "1eeb8fe5-9981-4a86-a566-b34ed638ac9f",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "25678478-e8ed-4187-98fd-d4d1d47a93fa",
+      "key": "590b2fc4-8a00-4a15-a908-a6d694ee277a",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4186,7 +4199,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "76389897-c6e1-43c3-ba45-155ddbfc920a",
+      "key": "74963c67-1601-4879-8a18-e50b66f1a52e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4198,7 +4211,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "ed1cf7c7-a249-4ccd-ac82-1e870f048362",
+      "key": "522b0ccc-2637-4efa-8f21-6bd11ccdf9fa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4210,16 +4223,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "916c823e-3c94-4cf9-8346-81eed082f8db",
+      "key": "ec66fe64-fa95-4c0f-8fca-4b8ea46f8634",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "b5fd3e9e-6827-4513-9f56-439c869a029f",
+      "key": "4dc3e4b7-85de-43a7-b9a5-2bef2e76d89e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4228,7 +4241,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cbadf8b4-a8ee-4573-ab7d-f2b88ef662f2",
+      "key": "1e8cfecd-f901-4ac6-807f-8839c9d3ffde",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4240,7 +4253,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "45811f6a-9ba1-474d-8af3-681297f14d43",
+      "key": "723ea4fd-dae4-4669-a315-0386d8046959",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4252,16 +4265,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "63a99616-95ea-465b-af11-79b8f35537ac",
+      "key": "598b75ff-be77-42a6-98e5-d19cb51ba564",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "8ed81f11-9fe1-4f18-a84c-42b353faaf30",
+      "key": "bf6f1e06-bc3a-4750-8955-9ba5ed94f6a4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4270,7 +4283,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8344fb4f-27cb-4611-8a01-849a5757f4c5",
+      "key": "df3e0fe0-455f-4b2b-994e-84de594f48ed",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4282,7 +4295,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "752dd11b-a824-4a96-96d0-ddd28858d47f",
+      "key": "f9b0f7c1-71ca-4de6-bab1-bad55b9d4b30",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4294,16 +4307,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "bd16d128-3817-40b1-8c3d-5c9f7f0e560f",
+      "key": "5603836d-96e4-4499-b356-8c8c270198ae",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "bf97f499-e025-4dd5-9e9b-09f4bb567a83",
+      "key": "5d4bf579-ce71-46b8-8f62-32c59459e240",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4312,7 +4325,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9c3f5b5b-bda3-4485-b48e-45bf4938b9ab",
+      "key": "aa64f179-4a76-4992-b474-dd5edbb5a957",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4324,7 +4337,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b5ff2126-fc5a-420c-a232-3ff5f341fc63",
+      "key": "376dccac-4992-43e7-b26e-d2c929c45aaa",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4336,16 +4349,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "49324cc8-34c2-4398-b30a-2a052deab15e",
+      "key": "0e814e22-a644-45cc-be5c-c832aad124a2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "08212567-5c9f-47dd-ac29-15b5e1449f11",
+      "key": "06f5d129-d0a7-4222-8427-34e84504892e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4354,7 +4367,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "81144f12-50f4-499b-b98f-1161fc4b6913",
+      "key": "106dfcfc-16c3-450d-9d4a-7d66e2e9a5b1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4366,7 +4379,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4a2f97c3-6575-4509-875c-afc87400070f",
+      "key": "879fdf97-0dca-4044-8815-44c11d5515c1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4378,16 +4391,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "518237bc-d1b8-4fc8-87fe-3ca23e2cc33d",
+      "key": "b65d5fb9-71b8-40da-8e48-5ead2a8391a4",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "8d4bb1ea-b967-4486-8dab-817e0111db6f",
+      "key": "dabf5206-1e08-4bde-a3ca-c45abf9f5382",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4396,7 +4409,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "19f35977-b861-45be-adc1-7a733424b5d5",
+      "key": "ca39acdb-7bf6-4504-bd82-968431bf0a56",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4408,7 +4421,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a8fce22a-997e-4c4c-8b77-0c4db0e1d6fe",
+      "key": "d14e3dfa-5ad0-40a5-9014-60cfd99d35b5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4420,16 +4433,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "e3339560-6b34-485e-a61b-e80cbcf803be",
+      "key": "2b30bfc6-4f13-42e0-9268-5f1d48f7e033",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "24b8d8e6-8949-4474-8f84-5eef0512f978",
+      "key": "fa7b71d1-40a7-4786-8a75-56b21c5b5c86",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4438,7 +4451,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "510a44ff-fced-4cce-adaf-b38172a99c62",
+      "key": "17878b68-0d68-458e-ad61-c0449e0ccc35",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4450,7 +4463,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "85d9ef05-6642-4afa-8d00-7a47349b9612",
+      "key": "2052caf2-819a-41c8-bac0-fa6ef86f38cc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4462,16 +4475,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "ad2f40ed-df71-4227-9c3b-0558275f93c0",
+      "key": "f0102cff-1014-4dd2-ae5f-a30b1f601de5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "6aaab560-e0a2-4fef-9511-96dcfbcd4184",
+      "key": "d352eb3f-0643-4f3c-afa3-71918e562e4b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4480,7 +4493,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "451a190d-4e36-4e6a-b868-ddb6a055a8d2",
+      "key": "ebe59d72-d573-4efa-9a47-4e81413ee97c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4492,7 +4505,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6271db77-4cd4-4498-a9ad-50651afc2df9",
+      "key": "65ea9eae-954b-478d-ac03-35cae87f38dc",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4504,16 +4517,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "a37ba6ab-824b-43c4-97cc-19dc199032b9",
+      "key": "c47101a2-c07e-4499-98f9-f4376fd2d5f8",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "e6f6f706-1b2a-4480-b098-565f120ca2be",
+      "key": "2ff454a8-db5d-40de-b0da-4a86b13f2e26",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4522,7 +4535,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f9c8e826-baa9-4129-bda7-ae3e3f73c483",
+      "key": "3381fd66-37d6-4768-b116-cf6e2a69839e",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4534,7 +4547,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "70dcdcd8-4214-49d5-b182-79d04cb58683",
+      "key": "8d090c0b-6285-4517-a34a-b60977dd79ea",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4546,16 +4559,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "1a483fdc-0575-45fb-9e92-975222f043b6",
+      "key": "e630aad0-5871-4f74-9a56-5188b986f5c1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "bb9c56b4-9c64-4247-9a3e-6864cc85a639",
+      "key": "a4886849-2fbb-49a4-833a-ec8b51ee0a8d",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4564,7 +4577,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "260578b7-796b-418d-bf12-56484a9e593a",
+      "key": "e6d321fe-ca0b-4ef9-a92a-0a3fcc3f5df3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4576,7 +4589,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "44f27994-6a7b-400a-b3d3-bc80357e8931",
+      "key": "d12ec4f7-a4fc-45ec-aa41-dc09d60a5ea5",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4588,16 +4601,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "50eccd27-1248-4d3d-9170-d9ab7c34355b",
+      "key": "45ece9e3-5ad7-43df-9087-b86284ab1ed1",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3e5313bc-7d97-45d3-bbaf-adf8e1f332ba",
+      "key": "3d754dc5-2291-41eb-8356-29c39d087971",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4606,7 +4619,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f7b14872-dfdf-4b8d-8de5-2c16e65506ae",
+      "key": "51162cf8-3912-4997-bf94-816d119e60a3",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4618,7 +4631,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "3d904fbc-82fe-488c-9ad3-c012c9435ec8",
+      "key": "7e85c0f2-efca-41dd-99c0-ed5d12e4f61c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4630,16 +4643,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "ff218f5b-4af0-4ac5-bdea-a65fbe0c9baf",
+      "key": "af99c99d-ae79-4034-ab74-548a16a35e38",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f3441996-ac73-401f-acff-249c6434c9f4",
+      "key": "8b2005e8-b0d6-40e3-ac23-4ab6ccc64d1c",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4648,7 +4661,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "970a51c0-1d10-4386-a9eb-8ea60512f081",
+      "key": "933142ae-c5cb-4e88-91c6-9ced20a8068b",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4660,7 +4673,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "72834ef3-db72-48f8-883e-0a24e7f31dd8",
+      "key": "54e49fb8-c126-43d5-94f3-bccee4b54aa2",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
         "volume": 50,
@@ -4672,16 +4685,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "7404ee18-8e3b-49f0-a6f8-661c9200722f",
+      "key": "68bc1e8b-f8f5-4c6d-a2a5-23c4a3847724",
       "params": {
         "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "pickUpTip",
-      "key": "afd3f406-69b1-46d9-8867-4e5a6a30a73e",
+      "key": "02d2d484-8e57-43e9-b5e9-390349edd1d3",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "labwareId": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
@@ -4690,7 +4703,7 @@
     },
     {
       "commandType": "configureForVolume",
-      "key": "4fc3002d-05ac-41fb-aacc-277c352c075c",
+      "key": "0586a78f-f735-4321-bd66-773e8ff19c04",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10
@@ -4698,7 +4711,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ba0c95b8-bbef-400f-beb5-6892a5bb4972",
+      "key": "26b6b498-b67c-44ad-8fb0-2a9456fd5cf9",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4710,7 +4723,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "71944e92-038c-49c4-bf60-88285fc70678",
+      "key": "aaec55f0-eeb5-4d3e-8bd9-ceda51509a53",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4722,7 +4735,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "bcc4091c-d33b-44a6-9ef8-47991722cde3",
+      "key": "c03e2dcf-0d00-4b4f-99f9-9ffa57fe269d",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4734,7 +4747,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "1bf6f1c3-ba91-4c53-8e35-5c3b762f20c7",
+      "key": "d1b59dbd-211e-4abc-bf19-e5443654ea30",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
         "volume": 10,
@@ -4746,16 +4759,16 @@
     },
     {
       "commandType": "dropTip",
-      "key": "fa3753fd-aa3f-4eb3-be8c-a01c15e2c81a",
+      "key": "e03a8717-26e4-45da-8934-b575e44aa634",
       "params": {
         "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
-        "labwareId": "fixedTrash",
+        "labwareId": "eb672b1d-e7c1-4cfa-ad4c-2a2a8de27813:opentrons/opentrons_1_trash_3200ml_fixed/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "e1ddc500-2dd7-45e0-9c2b-93dde844ff35",
+      "key": "f139c2e7-368b-48c4-8e4c-d24d13cd0e15",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4764,12 +4777,12 @@
     },
     {
       "commandType": "waitForDuration",
-      "key": "5e9e2998-5f91-463b-841f-d4fae592e209",
+      "key": "9e0db352-bc06-4291-b982-b0e9dee498ee",
       "params": { "seconds": 60, "message": "" }
     },
     {
       "commandType": "moveLabware",
-      "key": "ea23ae98-614f-4fdb-bebe-a5936b5136c7",
+      "key": "3f636140-0e87-4c8a-a4c8-7d5918694682",
       "params": {
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "strategy": "usingGripper",
@@ -4778,21 +4791,21 @@
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "key": "b4aaf1b6-8606-4624-9d9d-4bd3594e631e",
+      "key": "172c24c0-a502-4dce-94ca-36d74736e715",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "a55b8261-4248-4a6e-9e65-5cfafdc55a21",
+      "key": "f2dc8bda-d9b7-410a-bb6a-e99bc83e1885",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "key": "fe2feff0-8212-4e4d-9062-e4625d5cfbd2",
+      "key": "e069573a-9df0-485c-87a3-f7e4f0f87bdd",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType",
         "rpm": 500
@@ -4800,28 +4813,28 @@
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "key": "a46cc743-4319-4e36-b676-310af4d04acf",
+      "key": "d41fc1b4-2bea-493c-ae44-3f7f41f386af",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/deactivateShaker",
-      "key": "04f9174c-67a0-457b-9153-7b00a8bb5fcd",
+      "key": "bc3faf1c-0ca0-4bf2-bd16-8245cd52f922",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "key": "db8af8b2-9746-494a-b3c6-5d0ae2efeb2a",
+      "key": "f50c42c9-ea6c-45a0-b981-66414be43e20",
       "params": {
         "moduleId": "c19dffa3-cb34-4702-bcf6-dcea786257d1:heaterShakerModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "80002463-dd63-4fac-b2f8-bf46d01794bf",
+      "key": "9e00a1d0-e8fe-487e-9a15-34eda63a3d27",
       "params": {
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "strategy": "manualMoveWithPause",
@@ -4830,19 +4843,21 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "key": "02fc0295-a55a-432c-b34e-d5131ad93b67",
+      "key": "b5112a35-0b0a-4e34-9eb4-b5d4aa413d12",
       "params": {
         "moduleId": "ef44ad7f-0fd9-46d6-8bc0-c70785644cc8:temperatureModuleType"
       }
     },
     {
       "commandType": "moveLabware",
-      "key": "754107ac-2d9e-46e7-afcf-30964892020b",
+      "key": "3b732f93-4ef7-47ee-a99c-1d46da87210e",
       "params": {
         "labwareId": "239ceac8-23ec-4900-810a-70aeef880273:opentrons/nest_96_wellplate_200ul_flat/2",
         "strategy": "manualMoveWithPause",
         "newLocation": { "slotName": "C2" }
       }
     }
-  ]
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
 }

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -1,0 +1,5320 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Some name!",
+    "author": "Author name",
+    "description": "Description here",
+    "created": 1560957631666,
+    "lastModified": 1698855969857,
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "8.0.0",
+    "data": {
+      "_internalAppBuildDate": "Wed, 01 Nov 2023 16:22:39 GMT",
+      "defaultValues": {
+        "aspirate_mmFromBottom": 1,
+        "dispense_mmFromBottom": 0.5,
+        "touchTip_mmFromTop": -1,
+        "blowout_mmFromTop": 0
+      },
+      "pipetteTiprackAssignments": {
+        "c6f45030-92a5-11e9-ac62-1b173f839d9e": "opentrons/opentrons_96_tiprack_10ul/1",
+        "c6f47740-92a5-11e9-ac62-1b173f839d9e": "opentrons/tipone_96_tiprack_200ul/1"
+      },
+      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "ingredients": {
+        "0": {
+          "name": "samples",
+          "description": null,
+          "serialize": false,
+          "liquidGroupId": "0"
+        },
+        "1": {
+          "name": "dna",
+          "description": null,
+          "serialize": false,
+          "liquidGroupId": "1"
+        }
+      },
+      "ingredLocations": {
+        "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well": {
+          "A1": { "0": { "volume": 121 } },
+          "B1": { "0": { "volume": 121 } },
+          "C1": { "0": { "volume": 121 } },
+          "D1": { "0": { "volume": 121 } },
+          "E1": { "0": { "volume": 121 } },
+          "F1": { "1": { "volume": 44 } },
+          "G1": { "1": { "volume": 44 } },
+          "H1": { "1": { "volume": 44 } }
+        }
+      },
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "labwareLocationUpdate": {
+            "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1": "12",
+            "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul": "1",
+            "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul": "2",
+            "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well": "10"
+          },
+          "pipetteLocationUpdate": {
+            "c6f45030-92a5-11e9-ac62-1b173f839d9e": "left",
+            "c6f47740-92a5-11e9-ac62-1b173f839d9e": "right"
+          },
+          "moduleLocationUpdate": {},
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__"
+        },
+        "e7d36200-92a5-11e9-ac62-1b173f839d9e": {
+          "pipette": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+          "volume": "6",
+          "changeTip": "always",
+          "path": "single",
+          "aspirate_wells_grouped": false,
+          "aspirate_flowRate": 0.6,
+          "aspirate_labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+          "aspirate_wells": ["A1"],
+          "aspirate_wellOrder_first": "t2b",
+          "aspirate_wellOrder_second": "l2r",
+          "aspirate_mix_checkbox": true,
+          "aspirate_mix_times": 3,
+          "aspirate_mix_volume": "2",
+          "aspirate_mmFromBottom": 1,
+          "aspirate_touchTip_checkbox": true,
+          "aspirate_touchTip_mmFromBottom": 28.5,
+          "dispense_flowRate": null,
+          "dispense_labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+          "dispense_wells": [
+            "C6",
+            "D6",
+            "E6",
+            "C7",
+            "D7",
+            "E7",
+            "C8",
+            "D8",
+            "E8"
+          ],
+          "dispense_wellOrder_first": "b2t",
+          "dispense_wellOrder_second": "r2l",
+          "dispense_mix_checkbox": true,
+          "dispense_mix_times": 2,
+          "dispense_mix_volume": "3",
+          "dispense_mmFromBottom": 2.5,
+          "dispense_touchTip_checkbox": true,
+          "dispense_touchTip_mmFromBottom": null,
+          "disposalVolume_checkbox": true,
+          "disposalVolume_volume": "1",
+          "blowout_checkbox": true,
+          "blowout_location": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "preWetTip": false,
+          "aspirate_airGap_checkbox": false,
+          "aspirate_airGap_volume": null,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_mmFromBottom": "1",
+          "aspirate_delay_seconds": "1",
+          "dispense_airGap_checkbox": false,
+          "dispense_airGap_volume": null,
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "dispense_delay_mmFromBottom": "0.5",
+          "dropTip_location": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "id": "e7d36200-92a5-11e9-ac62-1b173f839d9e",
+          "stepType": "moveLiquid",
+          "stepName": "transfer things",
+          "stepDetails": "yeah notes"
+        },
+        "18113c80-92a6-11e9-ac62-1b173f839d9e": {
+          "times": 3,
+          "changeTip": "always",
+          "labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+          "mix_wellOrder_first": "t2b",
+          "mix_wellOrder_second": "l2r",
+          "blowout_checkbox": true,
+          "blowout_location": "dest_well",
+          "mix_mmFromBottom": 0.5,
+          "pipette": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+          "volume": "5.5",
+          "wells": ["F1"],
+          "aspirate_flowRate": 8,
+          "dispense_flowRate": 7,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_seconds": "1",
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "mix_touchTip_checkbox": true,
+          "mix_touchTip_mmFromBottom": 30.5,
+          "dropTip_location": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "id": "18113c80-92a6-11e9-ac62-1b173f839d9e",
+          "stepType": "mix",
+          "stepName": "mix",
+          "stepDetails": ""
+        },
+        "2e622080-92a6-11e9-ac62-1b173f839d9e": {
+          "pauseAction": "untilTime",
+          "pauseHour": 1,
+          "pauseMinute": 2,
+          "pauseSecond": 3,
+          "pauseMessage": "Delay plz",
+          "moduleId": null,
+          "pauseTemperature": null,
+          "id": "2e622080-92a6-11e9-ac62-1b173f839d9e",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
+        }
+      },
+      "orderedStepIds": [
+        "e7d36200-92a5-11e9-ac62-1b173f839d9e",
+        "18113c80-92a6-11e9-ac62-1b173f839d9e",
+        "2e622080-92a6-11e9-ac62-1b173f839d9e"
+      ]
+    }
+  },
+  "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_96_tiprack_10ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 10 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.69
+      },
+      "wells": {
+        "A1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 25.49
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 39.2,
+        "tipOverlap": 3.29,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_10ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/tipone_96_tiprack_200ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "TipOne",
+        "brandId": ["1111-0200"],
+        "links": ["https://www.usascientific.com/200ul-tipone-stacks.aspx"]
+      },
+      "metadata": {
+        "displayName": "TipOne 96 Tip Rack 200 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 63.9
+      },
+      "namespace": "opentrons",
+      "schemaVersion": 2,
+      "version": 1,
+      "wells": {
+        "H1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A1": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 13.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A2": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 22.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A3": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 31.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A4": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 40.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A5": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 49.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A6": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 58.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A7": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 67.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A8": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 76.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A9": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 85.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A10": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 94.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A11": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 103.69,
+          "y": 72.25,
+          "z": 53.36
+        },
+        "H12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 9.25,
+          "z": 53.36
+        },
+        "G12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 18.25,
+          "z": 53.36
+        },
+        "F12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 27.25,
+          "z": 53.36
+        },
+        "E12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 36.25,
+          "z": 53.36
+        },
+        "D12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 45.25,
+          "z": 53.36
+        },
+        "C12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 54.25,
+          "z": 53.36
+        },
+        "B12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 63.25,
+          "z": 53.36
+        },
+        "A12": {
+          "depth": 10.54,
+          "shape": "circular",
+          "diameter": 6.4,
+          "totalLiquidVolume": 200,
+          "x": 112.69,
+          "y": 72.25,
+          "z": 53.36
+        }
+      },
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipOverlap": 6.1,
+        "tipLength": 50.93,
+        "isMagneticModuleCompatible": false,
+        "loadName": "tipone_96_tiprack_200ul"
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": [
+          "fixedTrash",
+          "centerMultichannelOnWells",
+          "touchTipDisabled"
+        ]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 0,
+          "x": 82.84,
+          "y": 80,
+          "z": 82
+        }
+      },
+      "brand": { "brand": "Opentrons" },
+      "groups": [{ "wells": ["A1"], "metadata": {} }],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/usascientific_96_wellplate_2.4ml_deep/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "USA Scientific",
+        "brandId": ["1896-2000"],
+        "links": [
+          "https://www.usascientific.com/2ml-deep96-well-plateone-bulk.aspx"
+        ]
+      },
+      "metadata": {
+        "displayName": "USA Scientific 96 Deep Well Plate 2.4 mL",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "mL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.8,
+        "yDimension": 85.5,
+        "zDimension": 44.1
+      },
+      "wells": {
+        "H1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A1": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 14.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A2": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 23.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A3": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 32.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A4": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 41.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A5": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 50.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A6": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 59.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A7": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 68.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A8": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 77.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A9": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 86.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A10": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 95.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A11": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 104.4,
+          "y": 74.2,
+          "z": 2.8
+        },
+        "H12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 11.2,
+          "z": 2.8
+        },
+        "G12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 20.2,
+          "z": 2.8
+        },
+        "F12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 29.2,
+          "z": 2.8
+        },
+        "E12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 38.2,
+          "z": 2.8
+        },
+        "D12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 47.2,
+          "z": 2.8
+        },
+        "C12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 56.2,
+          "z": 2.8
+        },
+        "B12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 65.2,
+          "z": 2.8
+        },
+        "A12": {
+          "depth": 41.3,
+          "shape": "rectangular",
+          "xDimension": 8.2,
+          "yDimension": 8.2,
+          "totalLiquidVolume": 2400,
+          "x": 113.4,
+          "y": 74.2,
+          "z": 2.8
+        }
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ],
+          "metadata": { "wellBottomShape": "u" }
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": false,
+        "isMagneticModuleCompatible": true,
+        "magneticModuleEngageHeight": 14.94,
+        "loadName": "usascientific_96_wellplate_2.4ml_deep"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    }
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "0": {
+      "displayName": "samples",
+      "description": "",
+      "displayColor": "#b925ff"
+    },
+    "1": { "displayName": "dna", "description": "", "displayColor": "#ffd600" }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commands": [
+    {
+      "key": "10490d30-b30f-41e6-af23-63c890aff43a",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p10_single",
+        "mount": "left",
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e"
+      }
+    },
+    {
+      "key": "d06bff13-49fd-4334-bad0-5be9530e773f",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p50_single",
+        "mount": "right",
+        "pipetteId": "c6f47740-92a5-11e9-ac62-1b173f839d9e"
+      }
+    },
+    {
+      "key": "dbdd37ae-154e-474b-87aa-758f4a7d20da",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Fixed Trash",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "12" }
+      }
+    },
+    {
+      "key": "8be9048f-849c-4ee5-a87f-0e76e56096bb",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 10 µL",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "loadName": "opentrons_96_tiprack_10ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "key": "36f44450-4641-4150-8a60-5fd6c4963544",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "(Retired) TipOne 96 Tip Rack 200 µL",
+        "labwareId": "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul",
+        "loadName": "tipone_96_tiprack_200ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "2" }
+      }
+    },
+    {
+      "key": "cbc12f40-2054-47a6-9c77-955aad1cb131",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "USA Scientific 96 Deep Well Plate 2.4 mL",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "loadName": "usascientific_96_wellplate_2.4ml_deep",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "10" }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "bb6af72c-fe97-4646-a577-d9f8c663bde0",
+      "params": {
+        "liquidId": "1",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "volumeByWell": { "F1": 44, "G1": 44, "H1": 44 }
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "key": "e33b2f5e-213a-42cd-949e-f6709858c4b2",
+      "params": {
+        "liquidId": "0",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "volumeByWell": {
+          "A1": 121,
+          "B1": 121,
+          "C1": 121,
+          "D1": 121,
+          "E1": 121
+        }
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "ddcf8842-d757-4b1c-b442-968c2a3d6c90",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "abc54166-dbeb-423e-9885-2dd2581f08b3",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "6866d78a-e080-4d1d-9dd6-c2de6638f594",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "8edb653f-4c38-4972-af4a-5f85c34bc42e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "2f93d115-47db-41da-9776-c26653d58dba",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "447e8a2a-b355-4d37-bf44-e7228c147b5c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "4b362abb-dfee-4e45-9bde-14b0911b5f0a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "f254821d-a7ec-466a-9bb6-aeef0b833020",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "93ff1c04-c163-4c6e-bc52-3e959da45fb2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a26a76a2-36df-425e-85ef-fa7a2173db81",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "f78dae7e-ce13-4f34-9dc8-f4a639bfc4d9",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "d37cfd16-1e0b-4a43-9ec4-72ef27669289",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "afa12da7-f947-4a80-bbb7-5d4016d606cd",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "05958719-9184-4648-8e5b-5b3789ccdd52",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "3849541a-4f6e-4c51-b415-1070aaa2de88",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "fd9eaa99-8b6d-458f-90d8-f1375db06212",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "fd938091-986e-40fd-8ace-97a0675b9033",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "4cc99062-a715-4d52-a0d3-eebce9f0ebe3",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4a0603eb-79b6-4e7c-a8f2-05362e4d82db",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "0c53fb8b-b2fc-4431-9326-2d884c82858b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "14b4ffea-bd96-447d-ae08-96d84dd0564a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "7b67b875-927a-49b1-b6e0-24d7dd318379",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4d8b0beb-e4dd-4808-a3a3-fa71ae3ca010",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "782eb84c-8dc8-4759-a7a0-50fc98820ec1",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "ec687525-373e-419f-8b25-4ef6e3b8edc0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "b4359cc2-a00d-41a0-ab4d-1101427d8523",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "33dd1e94-713d-4d96-8b93-b59971097f65",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "78ceed3b-af35-43e9-bc4f-c8c06a905332",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "d9f83ed3-8fee-4d3d-9df8-598c31e7532b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2006b089-bacc-4f55-b9eb-fd8be206fb8d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "c1d223dc-48b4-43bc-aa75-0068bbe78495",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "f46d742d-5c69-41ab-963c-9245ab024a38",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "472381a3-7d18-414f-80e0-72ef890e2ba6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "6926d70d-f8b2-47a3-9947-5def32d10650",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "9d4332a9-1a08-4636-87c3-ed35ec1b7a66",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "C1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "f952266a-aa63-4f9e-9148-e4cb9c7f791b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "e8f08e07-8af8-498e-b702-a5bacc71bd83",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "ebd71897-bda3-4e94-8dde-84a116ec6954",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "7cc1ad60-a61b-41df-b125-c4d05b1abf8a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "80f92251-3a98-43ba-aec1-650c12850d4c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "553e5234-d25e-4f03-88d5-f16df8ca618f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "3c5d2144-3ee0-4cf3-ba3a-0b6eba607b96",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "dd1b0732-ad01-405a-a2f2-3cc54c1262dd",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "dcae2b0e-a03d-4bfa-95f9-034b60552698",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "ea2ddcfd-41ec-4de4-8e74-443a4fbf7f9f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "f1448790-3505-4dc9-b141-ff8b9c7b3f94",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "883b3351-0f40-4ffb-8859-129f4070e979",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "8922ec66-a4d0-4d30-b732-582fef687654",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "452bd6ca-f099-4a8c-aace-9400cb3e67d1",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "bb4426a9-c41b-4d32-80c4-eea39895a05e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "239401b1-999b-4607-99c6-f9b2d78e85f8",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "7aa9910a-8f0f-493a-a15c-aeb7036b1223",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "D1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "c1528676-5271-45b2-9736-acf95a216b43",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "83d8183f-0817-4c05-9d8d-1461b1c0cc51",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "91a4065f-e85a-4d46-8ece-ad85de3c51c2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "1ac856c1-65fb-414f-b571-92a2bf59881a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4b94a27f-3d30-4318-ac34-15fe23ccdab4",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a11e69c6-21b2-41db-95a0-708b3f91fe0a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "b0976d49-629f-4652-a228-248e4ada6fd9",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "ae8865b0-d186-429e-8af3-965635484e52",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "9807cc62-54ef-4453-b7cb-a2ba58bf3276",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4e0f91a8-94ad-4b8f-a681-0a7ae4061489",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "e38a70c0-0e37-4302-8034-6d86bd30adef",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4d477202-6665-498c-a033-35a684860299",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "327198e1-4572-4636-bd8e-87826bb26518",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "8d882fc2-8b31-45c9-b413-bd0af852b264",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "06ec3733-9197-4a9e-a841-cc5be2fcb8b5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "2fc19bc6-87e3-439f-807c-8f604317771c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "792e5e38-f2c8-4bf4-a3c2-00d59cd6edd0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "E1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "c582bd36-3f43-43c2-b96a-7abf81a36f14",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "6f05b509-e93a-429f-a94d-274bab463246",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "e6b4b610-3433-47a2-99ca-1bea8ecfda34",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "c25fe82f-1781-4912-b624-bcb74cda9521",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "b9c0a710-8b44-47bc-8165-007ea6086d21",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "c9e0f9d9-1380-4066-8a23-da4183a5ad37",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9d91e374-98fb-45ab-836f-501c9dcdbf6f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "26b25c10-1619-40bb-83b7-4f9e4c4d8a31",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "efc2f04b-9ec5-4ca4-9303-0e4783479bb3",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "babe915b-503b-4d27-89e0-c96bcfd3ea9c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "037898d8-7827-488f-b319-96e3bc472f18",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "6f1962ac-fb92-4cff-9519-f63eaf2f2052",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "016aa372-b1e8-4ab8-9b66-7265099af1b0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "d2f9c4af-0430-46b6-8262-d405e2d57fb0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "d14cb460-44ef-4f42-817f-ad5c58348f87",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "887f144f-90a7-4883-8029-6d069fa96706",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "48983d29-6c4b-48bf-81e2-fcbc0e86281a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "F1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "d3a62da8-670a-4d92-9deb-293235df4db4",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "b4709140-520a-49dc-98bb-f5d8826cbb2f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "bce13939-d717-4e33-bbc8-c4cf68dd17bf",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "bb0e80f5-6bd9-46d7-95b6-af38234ca295",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2afb3d0e-07f8-4d5a-b05b-5a532e01e991",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "88fe3503-e3a2-4c7a-b0a8-db580baf414d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "c8ef1483-95a8-4661-bf44-6babb755b288",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "264f5cdc-8650-45e8-91a9-806795f30bc8",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "438a574c-8730-4083-af36-ef7d09bd364c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "691080be-0bbd-4be0-be94-ac8d34202dae",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "5d6a01d1-9189-4c23-ae1b-9482c37d6751",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2e05b531-e624-4c07-9071-7149f7221335",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "8b423fd0-2618-4b87-970d-60a4faf61a57",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "a105d18f-8b9d-4b8e-9363-faa62d1f99b9",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "d8dab320-a9ef-4449-8f43-e57e60e41427",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "d1bc3bfe-77b2-4ad2-9cec-dad5b6b72d89",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "e868f3cd-41bf-44c4-8278-02c276564e36",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "G1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "6e21c33d-f3a8-4629-8b99-91e49ae6487a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "fc152c99-7992-4dfd-9c5c-62bf3dd4bb52",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "aedb3bf0-7e71-454a-8a33-167a5b50ccac",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "112d537a-63ff-4cbf-afcc-10bcfd2bc560",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9a1f4f79-ef7b-48ab-8bdb-c2ed60e3e245",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "506b9ed6-9c0f-4f4b-9597-37e4170ce351",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "a8112429-8d68-4cd8-8acd-8d56f44651a6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "13fd50ae-c7ac-4d82-b924-e576ee9f1011",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "10059ec2-5f30-470a-964b-d9e8e7d6a287",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "7e10811a-3ebb-497c-895d-1141cd5cbffc",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "8ae8efa4-303e-456c-8ffc-734be857a19a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9e6fa5d6-f443-4c7b-8309-c00f8fbe63e8",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "d59c772e-22b2-4f20-9c5f-e6e6f7edef91",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "b3a7dcec-9a39-4e9e-9b5c-413dd795b61b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "e15cb327-53f1-49c5-8e1d-b2d33ac679af",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "e5b04e34-cf2b-4181-a5cc-3737774bb66d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "cece71c9-da4c-429f-8a5a-1d4e0b7f7b3a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "H1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "b2e3a107-36e0-4e4f-b1b7-d0bb9592d8f0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "128f331b-bd74-41f3-83d1-35591a9d6cb5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "0102846f-ca86-487a-9760-ae6da952b73a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "9167ff8c-af10-48bb-8537-b07b62ac9dfd",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "1abcaafd-7d19-4d68-ab4a-3128f05b176b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "f6d6984c-2492-4e39-ba91-fdbac332f60a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "82ed4f39-63e1-4200-94e2-3ee37a37c13a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "0ceb99e9-dd68-4cb3-a75a-d18808953bea",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a21407fa-e542-4036-8cd7-f47628ec37f0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "000cd287-04be-41ab-a55f-78c57e1ec344",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3db19200-9dc5-4b70-8519-a2d3f263e096",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "5d25da83-b1dc-4c87-84b5-9fde3f1a0788",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "51b4455e-9bcb-4cc1-a874-c006e774d94a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "a311a28f-2909-4fb4-b178-9b432a926021",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "40f9cc2c-7052-46a8-9ea1-7614dad45ca0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "1499c089-210e-4074-a80f-17f4d544e2d3",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "c67723e3-3f5b-47e5-99a8-58c688c1f889",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "A2"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "ac5f3058-c256-4aca-ae23-b104ede6e5ed",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "45699ee9-5546-4677-ab4b-3945be9d7bfe",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "ce0965a9-6b5b-4520-9164-4353166a5507",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "7fa4064e-e14e-47e1-9fce-85a9a8476e46",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "6f959c9c-c0fc-46f5-bc7e-84a1b2d23020",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "6616fc0c-cbe5-4f75-80cb-51183c0826b0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "ac728c08-f5d6-46c2-9c4d-3bdeae690733",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "8f1d01ff-7646-42bb-99d8-1caddf458c75",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "0726f420-1fd4-4e67-af7d-28d2100f4b3d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "1bb939b4-6bd1-46e9-ae18-8bf6ac6a9f84",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a8bcd111-03b0-4c7d-af3b-ac77058dfd29",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "33e6bc40-9f85-44f3-8514-9cec9505d384",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "fdcddf51-9f17-481b-a590-0c790981918a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 2.5 } },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "28031375-1a51-446d-afaf-add397279dbb",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "4cfcc5c1-7f5f-46aa-9d76-35e93696bb8d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "flowRate": 10,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "1264fdbe-e29e-4519-9edd-8b0c32e23a4b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "e0cd280c-0ab0-4b4d-a4e0-d858ac3597fc",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "wellName": "B2"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "8f1cb41f-792c-45b1-b3b7-165d0e5bd22a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 8
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3eb444e3-ca80-4e1e-a5cd-57123d5870b0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 7
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "7ba054a3-04a0-4b80-b6ba-6f74a691f667",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 8
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "841d80e8-9027-4f9f-8261-87417ec7b818",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 7
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "f391b154-1154-4219-8928-bcd8c0edc04e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 8
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "45b3fca4-e821-4d84-944e-a3015c039cda",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 7
+      }
+    },
+    {
+      "commandType": "blowout",
+      "key": "9ea61ca4-ddf7-4ea4-910d-0477bb6adc7f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "flowRate": 7,
+        "wellLocation": { "origin": "bottom", "offset": { "z": 41.3 } }
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "0a45babc-a25e-450a-8a38-30d7e88d6a15",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 30.5 } }
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "6e459ebb-5081-40c4-8a7e-9f9e1a1e78e9",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "1db05991-1a06-4210-b448-7427d029da57:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "key": "e0b12bd3-db8b-4ca6-9aba-0c5a4f349a95",
+      "params": { "seconds": 3723, "message": "Delay plz" }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -1,0 +1,2288 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Pause and mix v5.0.0",
+    "author": "",
+    "description": "A test for 5.0.0 -> 5.1.0 migration",
+    "created": 1600714068238,
+    "lastModified": 1698856063990,
+    "category": null,
+    "subcategory": null,
+    "tags": []
+  },
+  "designerApplication": {
+    "name": "opentrons/protocol-designer",
+    "version": "8.0.0",
+    "data": {
+      "_internalAppBuildDate": "Wed, 01 Nov 2023 16:22:39 GMT",
+      "defaultValues": {
+        "aspirate_mmFromBottom": 1,
+        "dispense_mmFromBottom": 0.5,
+        "touchTip_mmFromTop": -1,
+        "blowout_mmFromTop": 0
+      },
+      "pipetteTiprackAssignments": {
+        "pipetteId": "opentrons/opentrons_96_tiprack_10ul/1"
+      },
+      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "ingredients": {},
+      "ingredLocations": {},
+      "savedStepForms": {
+        "__INITIAL_DECK_SETUP_STEP__": {
+          "labwareLocationUpdate": {
+            "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1": "12",
+            "f1c677c0-fc3a-11ea-8809-e959e7d61d96:opentrons/opentrons_96_tiprack_10ul/1": "1",
+            "fe572c50-fc3a-11ea-8809-e959e7d61d96:opentrons/biorad_96_wellplate_200ul_pcr/1": "7"
+          },
+          "pipetteLocationUpdate": { "pipetteId": "left" },
+          "moduleLocationUpdate": {},
+          "stepType": "manualIntervention",
+          "id": "__INITIAL_DECK_SETUP_STEP__"
+        },
+        "f59ea8e0-fc3a-11ea-8809-e959e7d61d96": {
+          "pauseAction": "untilTime",
+          "pauseHour": "1",
+          "pauseMinute": "2",
+          "pauseSecond": "3",
+          "pauseMessage": "",
+          "moduleId": null,
+          "pauseTemperature": null,
+          "id": "f59ea8e0-fc3a-11ea-8809-e959e7d61d96",
+          "stepType": "pause",
+          "stepName": "pause",
+          "stepDetails": ""
+        },
+        "fc4dc7c0-fc3a-11ea-8809-e959e7d61d96": {
+          "times": "2",
+          "changeTip": "always",
+          "labware": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "mix_wellOrder_first": "t2b",
+          "mix_wellOrder_second": "l2r",
+          "blowout_checkbox": false,
+          "blowout_location": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "mix_mmFromBottom": 0.5,
+          "pipette": "pipetteId",
+          "volume": "5",
+          "wells": ["A1"],
+          "aspirate_flowRate": null,
+          "dispense_flowRate": null,
+          "aspirate_delay_checkbox": false,
+          "aspirate_delay_seconds": "1",
+          "dispense_delay_checkbox": false,
+          "dispense_delay_seconds": "1",
+          "mix_touchTip_checkbox": false,
+          "mix_touchTip_mmFromBottom": null,
+          "dropTip_location": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+          "id": "fc4dc7c0-fc3a-11ea-8809-e959e7d61d96",
+          "stepType": "mix",
+          "stepName": "mix",
+          "stepDetails": ""
+        }
+      },
+      "orderedStepIds": [
+        "f59ea8e0-fc3a-11ea-8809-e959e7d61d96",
+        "fc4dc7c0-fc3a-11ea-8809-e959e7d61d96"
+      ]
+    }
+  },
+  "robot": { "model": "OT-2 Standard", "deckId": "ot2_standard" },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_96_tiprack_10ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 10 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.69
+      },
+      "wells": {
+        "A1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 25.49
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 39.2,
+        "tipOverlap": 3.29,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_10ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/biorad_96_wellplate_200ul_pcr/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "metadata": {
+        "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "yDimension": 85.48,
+        "xDimension": 127.76,
+        "zDimension": 16.06
+      },
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": false,
+        "loadName": "biorad_96_wellplate_200ul_pcr",
+        "isMagneticModuleCompatible": true,
+        "magneticModuleEngageHeight": 18
+      },
+      "wells": {
+        "H1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A1": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A2": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A3": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A4": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A5": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A6": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A7": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A8": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A9": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A10": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A11": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 1.25
+        },
+        "H12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 1.25
+        },
+        "G12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 1.25
+        },
+        "F12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 1.25
+        },
+        "E12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 1.25
+        },
+        "D12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 1.25
+        },
+        "C12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 1.25
+        },
+        "B12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 1.25
+        },
+        "A12": {
+          "depth": 14.81,
+          "shape": "circular",
+          "diameter": 5.46,
+          "totalLiquidVolume": 200,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 1.25
+        }
+      },
+      "brand": {
+        "brand": "Bio-Rad",
+        "brandId": ["hsp9601"],
+        "links": [
+          "http://www.bio-rad.com/en-us/sku/hsp9601-hard-shell-96-well-pcr-plates-low-profile-thin-wall-skirted-white-clear?ID=hsp9601"
+        ]
+      },
+      "groups": [
+        {
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ],
+          "metadata": { "wellBottomShape": "v" }
+        }
+      ],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    },
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": [
+          "fixedTrash",
+          "centerMultichannelOnWells",
+          "touchTipDisabled"
+        ]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 0,
+          "x": 82.84,
+          "y": 80,
+          "z": 82
+        }
+      },
+      "brand": { "brand": "Opentrons" },
+      "groups": [{ "wells": ["A1"], "metadata": {} }],
+      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
+    }
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {},
+  "commandSchemaId": "opentronsCommandSchemaV8",
+  "commands": [
+    {
+      "key": "b9692f92-0f90-43b4-9011-cb6f1dce93f3",
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteName": "p20_single_gen2",
+        "mount": "left",
+        "pipetteId": "pipetteId"
+      }
+    },
+    {
+      "key": "a699da37-b119-4513-bc89-8d12bfb04d11",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons Fixed Trash",
+        "labwareId": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "12" }
+      }
+    },
+    {
+      "key": "8a5654da-305b-40db-b709-00aaba4e432a",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Opentrons OT-2 96 Tip Rack 10 µL",
+        "labwareId": "f1c677c0-fc3a-11ea-8809-e959e7d61d96:opentrons/opentrons_96_tiprack_10ul/1",
+        "loadName": "opentrons_96_tiprack_10ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "key": "dd5ec77d-196d-4a1d-885b-1515a42b50c2",
+      "commandType": "loadLabware",
+      "params": {
+        "displayName": "Bio-Rad 96 Well Plate 200 µL PCR",
+        "labwareId": "fe572c50-fc3a-11ea-8809-e959e7d61d96:opentrons/biorad_96_wellplate_200ul_pcr/1",
+        "loadName": "biorad_96_wellplate_200ul_pcr",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": { "slotName": "7" }
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "key": "40f6c875-d477-47a5-a35a-8653242875e3",
+      "params": { "seconds": 3723, "message": "" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "81de545d-5f36-4a94-a779-15cd80055f69",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "f1c677c0-fc3a-11ea-8809-e959e7d61d96:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "238e649e-e4ab-42d7-b673-039e3d1eaf85",
+      "params": {
+        "pipetteId": "pipetteId",
+        "volume": 5,
+        "labwareId": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 3.78
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "e7334c9f-7c7d-4ffb-9f23-79b166c5e4ed",
+      "params": {
+        "pipetteId": "pipetteId",
+        "volume": 5,
+        "labwareId": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 3.78
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "367fd252-0da1-4c13-8b84-1f7a7d787d30",
+      "params": {
+        "pipetteId": "pipetteId",
+        "volume": 5,
+        "labwareId": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 3.78
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "1bd4c905-bc16-4af8-8ea9-f41bb6437892",
+      "params": {
+        "pipetteId": "pipetteId",
+        "volume": 5,
+        "labwareId": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
+        "flowRate": 3.78
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "key": "09a770c7-3078-4c91-9209-20c1745850f3",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "ffc02dfb-f8b2-4dd8-89f4-13ca4c606944:opentrons/opentrons_1_trash_1100ml_fixed/1",
+        "wellName": "A1"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": []
+}

--- a/protocol-designer/src/__tests__/validateProtocolFixtures.test.ts
+++ b/protocol-designer/src/__tests__/validateProtocolFixtures.test.ts
@@ -8,6 +8,7 @@ import protocolV4Schema from '@opentrons/shared-data/protocol/schemas/4.json'
 import protocolV5Schema from '@opentrons/shared-data/protocol/schemas/5.json'
 import protocolV6Schema from '@opentrons/shared-data/protocol/schemas/6.json'
 import protocolV7Schema from '@opentrons/shared-data/protocol/schemas/7.json'
+import protocolV8Schema from '@opentrons/shared-data/protocol/schemas/8.json'
 import labwareV2Schema from '@opentrons/shared-data/labware/schemas/2.json'
 import commandV7Schema from '@opentrons/shared-data/command/schemas/7.json'
 
@@ -44,8 +45,8 @@ const expectResultToMatchSchema = (
 
 const getSchemaDefForProtocol = (protocol: any): any => {
   // For reference, possibilities are, from newest to oldest:
-  // "$otSharedSchema": "#/protocol/schemas/7"
-  // "schemaVersion": 7
+  // "$otSharedSchema": "#/protocol/schemas/8"
+  // "schemaVersion": 8
   // "protocol-schema": "1.0.0"
   let n
   if (typeof protocol.$otSharedSchema === 'string') {
@@ -69,6 +70,8 @@ const getSchemaDefForProtocol = (protocol: any): any => {
       return protocolV6Schema
     case '7':
       return protocolV7Schema
+    case '8':
+      return protocolV8Schema
   }
 
   const errorMessage = `bad schema for protocol!: ${

--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -1,5 +1,10 @@
 import mapValues from 'lodash/mapValues'
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import {
+  FLEX_ROBOT_TYPE,
+  FLEX_STANDARD_DECKID,
+  OT2_STANDARD_DECKID,
+  OT2_STANDARD_MODEL,
+} from '@opentrons/shared-data'
 import { getOnlyLatestDefs } from '../../labware-defs'
 import { uuid } from '../../utils'
 import {
@@ -7,24 +12,38 @@ import {
   INITIAL_DECK_SETUP_STEP_ID,
   OT_2_TRASH_DEF_URI,
 } from '../../constants'
+import type { ProtocolFileV7 } from '@opentrons/shared-data'
 import type {
+  CommandAnnotationV1Mixin,
+  CommandV8Mixin,
+  LabwareV2Mixin,
+  LiquidV1Mixin,
   LoadLabwareCreateCommand,
+  OT2RobotMixin,
+  OT3RobotMixin,
+  ProtocolBase,
   ProtocolFile,
-} from '@opentrons/shared-data'
+} from '@opentrons/shared-data/protocol/types/schemaV8'
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 
-// NOTE: this migration updates fixed trash by treating it as an entity
-// additionally, drop tip location is now selectable
+// NOTE: this migration is to schema v8 and updates fixed trash by
+// treating it as an entity. Additionally, drop tip location is now selectable
 const PD_VERSION = '8.0.0'
-
+const SCHEMA_VERSION = 8
 interface LabwareLocationUpdate {
   [id: string]: string
 }
 
 export const migrateFile = (
-  appData: ProtocolFile<DesignerApplicationData>
+  appData: ProtocolFileV7<DesignerApplicationData>
 ): ProtocolFile => {
-  const { designerApplication, robot, commands, labwareDefinitions } = appData
+  const {
+    designerApplication,
+    commands,
+    robot,
+    labwareDefinitions,
+    liquids,
+  } = appData
   const labwareLocationUpdate: LabwareLocationUpdate =
     designerApplication?.data?.savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
       .labwareLocationUpdate
@@ -136,13 +155,33 @@ export const migrateFile = (
     command => command.commandType !== 'loadLabware'
   )
 
-  return {
-    ...appData,
+  const flexDeckSpec: OT3RobotMixin = {
+    robot: {
+      model: FLEX_ROBOT_TYPE,
+      deckId: FLEX_STANDARD_DECKID,
+    },
+  }
+  const ot2DeckSpec: OT2RobotMixin = {
+    robot: {
+      model: OT2_STANDARD_MODEL,
+      deckId: OT2_STANDARD_DECKID,
+    },
+  }
+  const deckStructure =
+    robotType === FLEX_ROBOT_TYPE ? flexDeckSpec : ot2DeckSpec
+
+  const protocolBase: ProtocolBase<any> = {
+    $otSharedSchema: '#/protocol/schemas/8',
+    schemaVersion: SCHEMA_VERSION,
+    metadata: {
+      ...appData.metadata,
+    },
     designerApplication: {
       ...appData.designerApplication,
       version: PD_VERSION,
       data: {
         ...appData.designerApplication?.data,
+
         savedStepForms: {
           [INITIAL_DECK_SETUP_STEP_ID]: {
             ...appData.designerApplication?.data?.savedStepForms[
@@ -156,14 +195,41 @@ export const migrateFile = (
         },
       },
     },
+  }
+
+  const labwareV2Mixin: LabwareV2Mixin = {
+    labwareDefinitionSchemaId: 'opentronsLabwareSchemaV2',
     labwareDefinitions: {
       ...{ [trashDefUri]: trashDefinition },
       ...appData.labwareDefinitions,
     },
+  }
+
+  const liquidV1Mixin: LiquidV1Mixin = {
+    liquidSchemaId: 'opentronsLiquidSchemaV1',
+    liquids,
+  }
+
+  const commandv8Mixin: CommandV8Mixin = {
+    commandSchemaId: 'opentronsCommandSchemaV8',
     commands: [
       ...migratedCommandsV8,
       ...loadLabwareCommands,
       ...trashLoadCommand,
     ],
+  }
+
+  const commandAnnotionaV1Mixin: CommandAnnotationV1Mixin = {
+    commandAnnotationSchemaId: 'opentronsCommandAnnotationSchemaV1',
+    commandAnnotations: [],
+  }
+
+  return {
+    ...protocolBase,
+    ...deckStructure,
+    ...labwareV2Mixin,
+    ...liquidV1Mixin,
+    ...commandv8Mixin,
+    ...commandAnnotionaV1Mixin,
   }
 }

--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -170,7 +170,7 @@ export const migrateFile = (
   const deckStructure =
     robotType === FLEX_ROBOT_TYPE ? flexDeckSpec : ot2DeckSpec
 
-  const protocolBase: ProtocolBase<any> = {
+  const protocolBase: ProtocolBase<DesignerApplicationData> = {
     $otSharedSchema: '#/protocol/schemas/8',
     schemaVersion: SCHEMA_VERSION,
     metadata: {
@@ -181,7 +181,6 @@ export const migrateFile = (
       version: PD_VERSION,
       data: {
         ...appData.designerApplication?.data,
-
         savedStepForms: {
           [INITIAL_DECK_SETUP_STEP_ID]: {
             ...appData.designerApplication?.data?.savedStepForms[

--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -44,8 +44,13 @@ export const migrateFile = (
     labwareDefinitions,
     liquids,
   } = appData
+
+  if (designerApplication == null || designerApplication.data == null) {
+    throw Error('The designerApplication key in your file is corrupt.')
+  }
+
   const labwareLocationUpdate: LabwareLocationUpdate =
-    designerApplication?.data?.savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
+    designerApplication.data.savedStepForms[INITIAL_DECK_SETUP_STEP_ID]
       .labwareLocationUpdate
   const allLatestDefs = getOnlyLatestDefs()
 
@@ -180,10 +185,10 @@ export const migrateFile = (
       ...appData.designerApplication,
       version: PD_VERSION,
       data: {
-        ...appData.designerApplication?.data,
+        ...designerApplication.data,
         savedStepForms: {
           [INITIAL_DECK_SETUP_STEP_ID]: {
-            ...appData.designerApplication?.data?.savedStepForms[
+            ...designerApplication.data.savedStepForms[
               INITIAL_DECK_SETUP_STEP_ID
             ],
             labwareLocationUpdate: {

--- a/protocol-designer/src/load-file/migration/__tests__/8_0_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/8_0_0.test.ts
@@ -2,11 +2,11 @@ import { migrateFile } from '../8_0_0'
 import fixture_trash from '@opentrons/shared-data/labware/fixtures/2/fixture_trash.json'
 import _oldDoItAllProtocol from '../../../../fixtures/protocol/7/doItAllV7.json'
 import { getOnlyLatestDefs, LabwareDefByDefURI } from '../../../labware-defs'
-import type { ProtocolFile } from '@opentrons/shared-data'
+import type { ProtocolFileV7 } from '@opentrons/shared-data'
 
 jest.mock('../../../labware-defs')
 
-const oldDoItAllProtocol = (_oldDoItAllProtocol as unknown) as ProtocolFile<any>
+const oldDoItAllProtocol = (_oldDoItAllProtocol as unknown) as ProtocolFileV7<any>
 
 const mockGetOnlyLatestDefs = getOnlyLatestDefs as jest.MockedFunction<
   typeof getOnlyLatestDefs

--- a/protocol-designer/src/load-file/migration/__tests__/8_0_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/8_0_0.test.ts
@@ -42,21 +42,6 @@ describe('v8.0 migration', () => {
         commandType: 'loadLabware',
         key: expect.any(String),
         params: {
-          displayName: 'Opentrons Fixed Trash',
-          labwareId:
-            '89d0e1b6-4d51-447b-b01b-3726a1f54137:opentrons/opentrons_1_trash_3200ml_fixed/1',
-          loadName: 'opentrons_1_trash_3200ml_fixed',
-          location: {
-            slotName: 'A3',
-          },
-          namespace: 'opentrons',
-          version: 1,
-        },
-      },
-      {
-        commandType: 'loadLabware',
-        key: expect.any(String),
-        params: {
           displayName: 'Opentrons Flex 96 Filter Tip Rack 50 µL',
           labwareId:
             '23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1',

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
@@ -3,21 +3,21 @@ import { uuid } from '../../../utils'
 import type { LoadLiquidCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
 export interface DesignerApplicationData {
-  ingredients: Record<
+  ingredients?: Record<
     string,
     {
-      name: string | null | undefined
-      description: string | null | undefined
+      name?: string | null
+      description?: string | null
       serialize: boolean
     }
   >
-  ingredLocations: {
+  ingredLocations?: {
     [labwareId: string]: {
       [wellName: string]: { [liquidId: string]: { volume: number } }
     }
   }
   savedStepForms: Record<string, any>
-  orderedStepIds: string[]
+  orderedStepIds?: string[]
 }
 
 export const getLoadLiquidCommands = (

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
@@ -3,7 +3,7 @@ import { uuid } from '../../../utils'
 import type { LoadLiquidCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
 
 export interface DesignerApplicationData {
-  ingredients?: Record<
+  ingredients: Record<
     string,
     {
       name?: string | null
@@ -11,13 +11,13 @@ export interface DesignerApplicationData {
       serialize: boolean
     }
   >
-  ingredLocations?: {
+  ingredLocations: {
     [labwareId: string]: {
       [wellName: string]: { [liquidId: string]: { volume: number } }
     }
   }
   savedStepForms: Record<string, any>
-  orderedStepIds?: string[]
+  orderedStepIds: string[]
 }
 
 export const getLoadLiquidCommands = (


### PR DESCRIPTION
closes RAUT-759

# Overview

Followup to the schemav8 migration. I accidentally forgot to update the `ProtocolFile` types in the `8_0_0` migration to be from V7 -> V8. This is to ensure protocols imported into PD follow the proper schema.

# Test Plan

Import a protocol to PD and make sure it imports as expected.

# Changelog

- update the types in `8_0_0` migration and fix the test
- add test cases to the cypress migrations test

# Review requests

see test plan

# Risk assessment

low