### PR TITLE
feat(components): add A1 expansion to base deck and deck configurator

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -138,7 +138,7 @@ export function DeviceDetailsDeckConfiguration({
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               marginLeft={`-${SPACING.spacing32}`}
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              marginTop={`-${SPACING.spacing60}`}
+              marginTop={`-${SPACING.spacing6}`}
               flexDirection={DIRECTION_COLUMN}
             >
               <DeckConfigurator

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -56,6 +56,7 @@ interface BaseDeckProps {
   }>
   deckConfig?: DeckConfiguration
   deckLayerBlocklist?: string[]
+  showExpansion?: boolean
   lightFill?: string
   darkFill?: string
   children?: React.ReactNode
@@ -72,6 +73,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
     // TODO(bh, 2023-10-09): remove deck config fixture for Flex after migration to v4
     // deckConfig = EXTENDED_DECK_CONFIG_FIXTURE,
     deckConfig = STANDARD_SLOT_DECK_CONFIG_FIXTURE,
+    showExpansion = true,
     children,
   } = props
   const deckDef = getDeckDefFromRobotType(robotType)
@@ -104,6 +106,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
               deckDefinition={deckDef}
               slotClipColor={darkFill}
               fixtureBaseColor={lightFill}
+              showExpansion={showExpansion}
             />
           ))}
           {stagingAreaFixtures.map(fixture => (

--- a/components/src/hardware-sim/BaseDeck/SingleSlotFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/SingleSlotFixture.tsx
@@ -11,7 +11,7 @@ interface SingleSlotFixtureProps extends React.SVGProps<SVGGElement> {
   moduleType?: ModuleType
   fixtureBaseColor?: React.SVGProps<SVGPathElement>['fill']
   slotClipColor?: React.SVGProps<SVGPathElement>['stroke']
-  showExtensions?: boolean
+  showExpansion?: boolean
 }
 
 export function SingleSlotFixture(
@@ -22,7 +22,7 @@ export function SingleSlotFixture(
     deckDefinition,
     fixtureBaseColor,
     slotClipColor,
-    showExtensions,
+    showExpansion = false,
     ...restProps
   } = props
 
@@ -42,7 +42,7 @@ export function SingleSlotFixture(
   } = {
     A1: (
       <>
-        {showExtensions ? (
+        {showExpansion ? (
           <SlotBase
             fill={fixtureBaseColor}
             d="M-97.8,496.6h239c2.3,0,4.2-1.9,4.2-4.2v-70c0-2.3-1.9-4.2-4.2-4.2h-239c-2.3,0-4.2,1.9-4.2,4.2v70 C-102,494.7-100.1,496.6-97.8,496.6z"

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -27,6 +27,7 @@ interface DeckConfiguratorProps {
   lightFill?: string
   darkFill?: string
   readOnly?: boolean
+  showExpansion?: boolean
   children?: React.ReactNode
 }
 
@@ -38,6 +39,7 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
     lightFill = COLORS.light1,
     darkFill = COLORS.darkGreyEnabled,
     readOnly = false,
+    showExpansion = true,
     children,
   } = props
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
@@ -86,6 +88,7 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
           deckDefinition={deckDef}
           slotClipColor={COLORS.transparent}
           fixtureBaseColor={lightFill}
+          showExpansion={showExpansion}
         />
       ))}
       {stagingAreaFixtures.map(fixture => (

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -535,6 +535,7 @@ export const DeckSetup = (): JSX.Element => {
                       cutoutLocation={fixture.fixtureLocation as Cutout}
                       deckDefinition={deckDef}
                       slotClipColor={darkFill}
+                      showExpansion={fixture.fixtureLocation === 'A1'}
                       fixtureBaseColor={lightFill}
                     />
                   ))}


### PR DESCRIPTION
# Overview

adds props with defaults to true to show the A1 expansion "slot" in BaseDeck and DeckConfigurator renders

<img width="1136" alt="Screen Shot 2023-11-01 at 2 56 06 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/6fc1352b-764a-4388-b7b6-1bc3af510650">

# Test Plan

 - visually verified A1 expansion rendering and positioning in desktop and ODD

# Changelog

 - Adds A1 expansion to base deck and deck configurator

# Review requests

view the A1 expansion

# Risk assessment

low
