### PR TITLE
fix(app, robot_server): allow non-standard tip racks in tip length calibration from dashboard

### DIFF
--- a/app/src/organisms/CalibrateDeck/index.tsx
+++ b/app/src/organisms/CalibrateDeck/index.tsx
@@ -175,6 +175,7 @@ export function CalibrateDeck(
             supportedCommands={supportedCommands}
             defaultTipracks={instrument?.defaultTipracks}
             calInvalidationHandler={offsetInvalidationHandler}
+            allowChangeTipRack
           />
         )}
       </LegacyModalShell>

--- a/app/src/organisms/CalibrateTipLength/index.tsx
+++ b/app/src/organisms/CalibrateTipLength/index.tsx
@@ -73,7 +73,8 @@ export function CalibrateTipLength(
     offsetInvalidationHandler,
     allowChangeTipRack = false,
   } = props
-  const { currentStep, instrument, labware, supportedCommands } = session?.details ?? {}
+  const { currentStep, instrument, labware, supportedCommands } =
+    session?.details ?? {}
 
   const queryClient = useQueryClient()
   const host = useHost()

--- a/app/src/organisms/CalibrateTipLength/index.tsx
+++ b/app/src/organisms/CalibrateTipLength/index.tsx
@@ -71,8 +71,9 @@ export function CalibrateTipLength(
     dispatchRequests,
     isJogging,
     offsetInvalidationHandler,
+    allowChangeTipRack = false,
   } = props
-  const { currentStep, instrument, labware } = session?.details ?? {}
+  const { currentStep, instrument, labware, supportedCommands } = session?.details ?? {}
 
   const queryClient = useQueryClient()
   const host = useHost()
@@ -171,7 +172,9 @@ export function CalibrateTipLength(
             calBlock={calBlock}
             currentStep={currentStep}
             sessionType={session.sessionType}
+            supportedCommands={supportedCommands}
             calInvalidationHandler={offsetInvalidationHandler}
+            allowChangeTipRack={allowChangeTipRack}
           />
         )}
       </LegacyModalShell>

--- a/app/src/organisms/CalibrateTipLength/types.ts
+++ b/app/src/organisms/CalibrateTipLength/types.ts
@@ -7,5 +7,6 @@ export interface CalibrateTipLengthParentProps {
   dispatchRequests: DispatchRequestsType
   showSpinner: boolean
   isJogging: boolean
+  allowChangeTipRack?: boolean
   offsetInvalidationHandler?: () => void
 }

--- a/app/src/organisms/CalibrationPanels/Introduction/__tests__/Introduction.test.tsx
+++ b/app/src/organisms/CalibrationPanels/Introduction/__tests__/Introduction.test.tsx
@@ -52,9 +52,10 @@ describe('Introduction', () => {
     getByRole('link', { name: 'Need help?' })
     expect(queryByRole('button', { name: 'Change tip rack' })).toBe(null)
   })
-  it('renders change tip rack button if deck calibration', () => {
+  it('renders change tip rack button if allowChangeTipRack', () => {
     const { getByRole, getByText, queryByRole } = render({
       sessionType: Sessions.SESSION_TYPE_DECK_CALIBRATION,
+      allowChangeTipRack: true,
     })[0]
     const button = getByRole('button', { name: 'Change tip rack' })
     button.click()

--- a/app/src/organisms/CalibrationPanels/Introduction/index.tsx
+++ b/app/src/organisms/CalibrationPanels/Introduction/index.tsx
@@ -55,15 +55,15 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
   let equipmentList: Array<{ loadName: string; displayName: string }> =
     uniqueTipRacks.size > 1
       ? instruments?.map(instr => ({
-        loadName: instr.tipRackLoadName,
-        displayName: instr.tipRackDisplay,
-      })) ?? []
+          loadName: instr.tipRackLoadName,
+          displayName: instr.tipRackDisplay,
+        })) ?? []
       : [
-        {
-          loadName: tipRack.loadName,
-          displayName: getLabwareDisplayName(tipRack.definition),
-        },
-      ]
+          {
+            loadName: tipRack.loadName,
+            displayName: getLabwareDisplayName(tipRack.definition),
+          },
+        ]
 
   if (chosenTipRack != null) {
     equipmentList = [

--- a/app/src/organisms/CalibrationPanels/Introduction/index.tsx
+++ b/app/src/organisms/CalibrationPanels/Introduction/index.tsx
@@ -35,6 +35,7 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
     instruments,
     supportedCommands,
     calInvalidationHandler,
+    allowChangeTipRack = false,
   } = props
   const { t } = useTranslation('robot_calibration')
 
@@ -54,15 +55,15 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
   let equipmentList: Array<{ loadName: string; displayName: string }> =
     uniqueTipRacks.size > 1
       ? instruments?.map(instr => ({
-          loadName: instr.tipRackLoadName,
-          displayName: instr.tipRackDisplay,
-        })) ?? []
+        loadName: instr.tipRackLoadName,
+        displayName: instr.tipRackDisplay,
+      })) ?? []
       : [
-          {
-            loadName: tipRack.loadName,
-            displayName: getLabwareDisplayName(tipRack.definition),
-          },
-        ]
+        {
+          loadName: tipRack.loadName,
+          displayName: getLabwareDisplayName(tipRack.definition),
+        },
+      ]
 
   if (chosenTipRack != null) {
     equipmentList = [
@@ -167,7 +168,7 @@ export function Introduction(props: CalibrationPanelProps): JSX.Element {
       >
         <NeedHelpLink />
         <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-          {sessionType === Sessions.SESSION_TYPE_DECK_CALIBRATION ? (
+          {allowChangeTipRack ? (
             <SecondaryButton onClick={() => setShowChooseTipRack(true)}>
               {t('change_tip_rack')}
             </SecondaryButton>

--- a/app/src/organisms/CalibrationPanels/types.ts
+++ b/app/src/organisms/CalibrationPanels/types.ts
@@ -32,4 +32,5 @@ export interface CalibrationPanelProps {
   supportedCommands?: SessionCommandString[] | null
   defaultTipracks?: LabwareDefinition2[] | null
   calInvalidationHandler?: () => void
+  allowChangeTipRack?: boolean
 }

--- a/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
@@ -180,6 +180,7 @@ export function useDashboardCalibrateTipLength(
         dispatchRequests={dispatchRequests}
         isJogging={isJogging}
         offsetInvalidationHandler={invalidateHandlerRef.current}
+        allowChangeTipRack={sessionParams.current?.tipRackDefinition == null}
       />
     </Portal>
   )

--- a/app/src/redux/sessions/__fixtures__/tip-length-calibration.ts
+++ b/app/src/redux/sessions/__fixtures__/tip-length-calibration.ts
@@ -35,6 +35,7 @@ export const mockTipLengthCalibrationSessionDetails: TipLengthCalibrationSession
   },
   currentStep: 'labwareLoaded',
   labware: [mockTipLengthTipRack, mockTipLengthCalBlock],
+  supportedCommands: [],
 }
 
 export const mockTipLengthCalibrationSessionParams: TipLengthCalibrationSessionParams = {

--- a/app/src/redux/sessions/tip-length-calibration/types.ts
+++ b/app/src/redux/sessions/tip-length-calibration/types.ts
@@ -8,7 +8,7 @@ import {
   TIP_LENGTH_STEP_MEASURING_TIP_OFFSET,
   TIP_LENGTH_STEP_CALIBRATION_COMPLETE,
 } from '../constants'
-import type { CalibrationLabware } from '../types'
+import type { CalibrationLabware, SessionCommandString } from '../types'
 
 import type { LabwareDefinition2, PipetteModel } from '@opentrons/shared-data'
 
@@ -40,4 +40,5 @@ export interface TipLengthCalibrationSessionDetails {
   instrument: TipLengthCalibrationInstrument
   currentStep: TipLengthCalibrationStep
   labware: CalibrationLabware[]
+  supportedCommands: SessionCommandString[]
 }

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -82,6 +82,7 @@ class TipCalibrationUserFlow:
             cast(List[LabwareUri], self.hw_pipette.liquid_class.default_tipracks)
         )
         self._supported_commands = SupportedCommands(namespace="calibration")
+        self._supported_commands.loadLabware = True
 
     def _set_current_state(self, to_state: State):
         self._current_state = to_state
@@ -168,7 +169,13 @@ class TipCalibrationUserFlow:
         self,
         tiprackDefinition: Optional[LabwareDefinition] = None,
     ):
-        pass
+        self._supported_commands.loadLabware = False
+        if tiprackDefinition:
+            verified_definition = labware.verify_definition(tiprackDefinition)
+            self._tip_rack = self._get_tip_rack_lw(verified_definition)
+            if self._deck[TIP_RACK_SLOT]:
+                del self._deck[TIP_RACK_SLOT]
+            self._deck[TIP_RACK_SLOT] = self._tip_rack
 
     async def move_to_tip_rack(self):
         await self._move(Location(self.tip_origin, None))


### PR DESCRIPTION
# Overview

Mirror our approach for loading an alternate tip rack into a legacy calibration session from deck/pipette-offset to tip length calibration

Closes RAUT-809

# Review requests

- starting with no tip length calibration values on an OT-2 proceed to the calibration dashboard
- you should be able to select an alternate tip rack for performing TLC on a pipette. 
- that alternate tip rack should be used when calibrating the pipette offset in the next step

# Risk assessment
high, this touches both FE and BE and the code is quite old and brittle
