### PR TITLE
fix(app): fix choose robot slideout for usb

### DIFF
--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -14,6 +14,8 @@ import {
 } from '@opentrons/components'
 
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
+import { OPENTRONS_USB } from '../../redux/discovery'
+import { appShellRequestor } from '../../redux/shell/remote'
 import { useTrackCreateProtocolRunEvent } from '../Devices/hooks'
 import { ApplyHistoricOffsets } from '../ApplyHistoricOffsets'
 import { useOffsetCandidatesForAnalysis } from '../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
@@ -82,7 +84,13 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
         })
       },
     },
-    selectedRobot != null ? { hostname: selectedRobot.ip } : null,
+    selectedRobot != null
+      ? {
+          hostname: selectedRobot.ip,
+          requestor:
+            selectedRobot?.ip === OPENTRONS_USB ? appShellRequestor : undefined,
+        }
+      : null,
     shouldApplyOffsets
       ? offsetCandidates.map(({ vector, location, definitionUri }) => ({
           vector,

--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -15,6 +15,7 @@ import {
   getProtocolDisplayName,
 } from '../../organisms/ProtocolsLanding/utils'
 import { useToaster } from '../../organisms/ToasterOven'
+import { appShellRequestor } from '../../redux/shell/remote'
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 
 import type { AxiosError } from 'axios'
@@ -23,6 +24,7 @@ import type { Robot } from '../../redux/discovery/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
 import { getValidCustomLabwareFiles } from '../../redux/custom-labware'
+import { OPENTRONS_USB } from '../../redux/discovery'
 
 interface SendProtocolToOT3SlideoutProps extends StyleProps {
   storedProtocolData: StoredProtocolData
@@ -61,7 +63,13 @@ export function SendProtocolToOT3Slideout(
 
   const { mutateAsync: createProtocolAsync } = useCreateProtocolMutation(
     {},
-    selectedRobot != null ? { hostname: selectedRobot.ip } : null
+    selectedRobot != null
+      ? {
+          hostname: selectedRobot.ip,
+          requestor:
+            selectedRobot?.ip === OPENTRONS_USB ? appShellRequestor : undefined,
+        }
+      : null
   )
 
   const isAnalyzing = useSelector((state: State) =>

--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../organisms/ProtocolsLanding/utils'
 import { useToaster } from '../../organisms/ToasterOven'
 import { appShellRequestor } from '../../redux/shell/remote'
+import { OPENTRONS_USB } from '../../redux/discovery'
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 
 import type { AxiosError } from 'axios'
@@ -24,7 +25,6 @@ import type { Robot } from '../../redux/discovery/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
 import { getValidCustomLabwareFiles } from '../../redux/custom-labware'
-import { OPENTRONS_USB } from '../../redux/discovery'
 
 interface SendProtocolToOT3SlideoutProps extends StyleProps {
   storedProtocolData: StoredProtocolData


### PR DESCRIPTION
# Overview

This PR fixes the shoose a robot slideout when sending a protocol to a Flex and starting a protocol run on a Flex over usb.

# Test Plan


- Verified that I could send a protocol/start a protocol run on a Flex over USB
- Verified that I could send a protocol/start a protocol run on a Flex over the network


# Changelog

- Fix choose robot slideout for usb


Risk assessment

Low/med
