### PR TITLE
fix(app-shell)Fix python env contamination app build

### DIFF
--- a/app-shell/src/protocol-analysis/executeAnalyzeCli.ts
+++ b/app-shell/src/protocol-analysis/executeAnalyzeCli.ts
@@ -9,6 +9,7 @@ export function executeAnalyzeCli(
   sourcePaths: string[]
 ): Promise<void> {
   return execa(pythonPath, [
+    '-I',
     '-m',
     'opentrons.cli',
     'analyze',


### PR DESCRIPTION
This prevents python from picking up versions of dependencies installed on the system, which will break offline analysis if the dependencies installed globally are old.

# testing
- [x] on a compiled windows and compiled mac build, check that you can run offline analysis
