### PR TITLE
fix(protocol-designer): loadName in loadLabware is now true loadName

### DIFF
--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -173,7 +173,9 @@ export const migrateFile = (
     .map(command => {
       const labwareId = command.params.labwareId
       const definitionId = labware[labwareId].definitionId
-      const { namespace, version } = labwareDefinitions[definitionId]
+      const { namespace, version, parameters } = labwareDefinitions[
+        definitionId
+      ]
       const labwareLocation = command.params.location
       let location: LabwareLocation = 'offDeck'
       if (labwareLocation === 'offDeck') {
@@ -188,7 +190,7 @@ export const migrateFile = (
         ...command,
         params: {
           ...command.params,
-          loadName: definitionId,
+          loadName: parameters.loadName,
           namespace,
           version,
           location,

--- a/protocol-designer/src/load-file/migration/__tests__/7_0_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/7_0_0.test.ts
@@ -69,7 +69,7 @@ describe('v7 migration', () => {
             '0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1',
           location: { slotName: '2' },
           displayName: 'Opentrons 96 Tip Rack 300 µL',
-          loadName: 'opentrons/opentrons_96_tiprack_300ul/1',
+          loadName: 'opentrons_96_tiprack_300ul',
           namespace: 'opentrons',
           version: 1,
         },
@@ -84,7 +84,7 @@ describe('v7 migration', () => {
             moduleId: '0b419310-75c7-11ea-b42f-4b64e50f43e5:magneticModuleType',
           },
           displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
-          loadName: 'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1',
+          loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
           namespace: 'opentrons',
           version: 1,
         },
@@ -101,8 +101,7 @@ describe('v7 migration', () => {
           },
           namespace: 'opentrons',
           version: 1,
-          loadName:
-            'opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/1',
+          loadName: 'opentrons_24_aluminumblock_generic_2ml_screwcap',
           displayName:
             'Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap',
         },

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1157,6 +1157,11 @@ export const labwareInvariantProperties: Reducer<
                 labwareDef.namespace === namespace &&
                 labwareDef.version === version
             )
+            if (labwareDefinitionMatch == null) {
+              console.error(
+                `expected to find labware definition match with loadname ${loadName} but could not`
+              )
+            }
             const labwareDefURI =
               labwareDefinitionMatch != null ? labwareDefinitionMatch[0] : ''
             const id = labwareId ?? ''

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1148,13 +1148,22 @@ export const labwareInvariantProperties: Reducer<
       const labware = {
         ...loadLabwareCommands.reduce(
           (acc: NormalizedLabwareById, command: LoadLabwareCreateCommand) => {
-            const { labwareId, loadName } = command.params
-            const defUri = labwareId?.split(':')[1]
+            const { labwareId, loadName, namespace, version } = command.params
+            const labwareDefinitionMatch = Object.entries(
+              file.labwareDefinitions
+            ).find(
+              ([definitionUri, labwareDef]) =>
+                labwareDef.parameters.loadName === loadName &&
+                labwareDef.namespace === namespace &&
+                labwareDef.version === version
+            )
+            const labwareDefURI =
+              labwareDefinitionMatch != null ? labwareDefinitionMatch[0] : ''
             const id = labwareId ?? ''
             return {
               ...acc,
               [id]: {
-                labwareDefURI: loadName.includes('/') ? loadName : defUri ?? '',
+                labwareDefURI,
               },
             }
           },


### PR DESCRIPTION
hot fix addressing https://opentrons.atlassian.net/browse/RESC-161

# Overview

I mistakenly defined the `loadLabware`'s loadname as `definitionUri` instead of the true `loadName` and it caused a white screen bug related to duplicating labware and then importing the protocol into PD and then reimporting. (because duplicate labware from <v7 don't have a `definitionURI` as part of the `labwareId`)

# Test Plan

Upload the Created 8 September protocol attached to the ticket. See that it imports correctly. Export it and then reimport that exported protocol. It should work as expected.

# Changelog

- fix the 7.0.0 migration and then remove branching logic from the reducer.

# Review requests

see test plan

# Risk assessment

low but will turn into PD 7.0.1 hot fix