### PR TITLE
fix(protocol-designer): separate well order field tooltip and modal

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
@@ -89,16 +89,7 @@ export const WellOrderField = (props: WellOrderFieldProps): JSX.Element => {
       </Tooltip>
       <div {...targetProps}>
         <FormGroup label={props.label} className={className}>
-          <WellOrderModal
-            prefix={props.prefix}
-            closeModal={handleClose}
-            isOpen={isModalOpen}
-            updateValues={updateValues}
-            firstValue={firstValue}
-            secondValue={secondValue}
-            firstName={firstName}
-            secondName={secondName}
-          />
+
           {firstValue != null && secondValue != null ? (
             <img
               onClick={handleOpen}
@@ -128,6 +119,16 @@ export const WellOrderField = (props: WellOrderFieldProps): JSX.Element => {
           )}
         </FormGroup>
       </div>
+      <WellOrderModal
+        prefix={props.prefix}
+        closeModal={handleClose}
+        isOpen={isModalOpen}
+        updateValues={updateValues}
+        firstValue={firstValue}
+        secondValue={secondValue}
+        firstName={firstName}
+        secondName={secondName}
+      />
     </>
   )
 }

--- a/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellOrderField/index.tsx
@@ -89,7 +89,6 @@ export const WellOrderField = (props: WellOrderFieldProps): JSX.Element => {
       </Tooltip>
       <div {...targetProps}>
         <FormGroup label={props.label} className={className}>
-
           {firstValue != null && secondValue != null ? (
             <img
               onClick={handleOpen}


### PR DESCRIPTION
# Overview

Prevent ghost tooltip from appearing after well order modal is opened

Closes RAUT-266

# Risk assessment

low
