### PR TITLE
fix(app): fix last run protocol sorting on protocol dashboard

### DIFF
--- a/app/src/pages/ProtocolDashboard/index.tsx
+++ b/app/src/pages/ProtocolDashboard/index.tsx
@@ -96,7 +96,14 @@ export function ProtocolDashboard(): JSX.Element {
   }
 
   const runData = runs.data?.data != null ? runs.data?.data : []
-  const sortedProtocols = sortProtocols(sortBy, unpinnedProtocols, runData)
+  const allRunsNewestFirst = runData.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  )
+  const sortedProtocols = sortProtocols(
+    sortBy,
+    unpinnedProtocols,
+    allRunsNewestFirst
+  )
   const handleProtocolsBySortKey = (
     sortKey: ProtocolsOnDeviceSortKey
   ): void => {

--- a/app/src/pages/ProtocolDashboard/utils.ts
+++ b/app/src/pages/ProtocolDashboard/utils.ts
@@ -7,17 +7,17 @@ const DUMMY_FOR_NO_DATE_CASE = -8640000000000000
 export function sortProtocols(
   sortBy: ProtocolsOnDeviceSortKey,
   protocols: ProtocolResource[],
-  runs: RunData[]
+  allRunsNewestFirst: RunData[]
 ): ProtocolResource[] {
   protocols.sort((a, b) => {
     const aName = a.metadata.protocolName ?? a.files[0].name
     const bName = b.metadata.protocolName ?? b.files[0].name
     const aLastRun = new Date(
-      runs.find(run => run.protocolId === a.id)?.completedAt ??
+      allRunsNewestFirst.find(run => run.protocolId === a.id)?.completedAt ??
         new Date(DUMMY_FOR_NO_DATE_CASE)
     )
     const bLastRun = new Date(
-      runs.find(run => run.protocolId === b.id)?.completedAt ??
+      allRunsNewestFirst.find(run => run.protocolId === b.id)?.completedAt ??
         new Date(DUMMY_FOR_NO_DATE_CASE)
     )
     const aDate = new Date(a.createdAt)


### PR DESCRIPTION
# Overview

We were incorrectly calculating the last run timestamp of a given protocol, this fixes the logic to report the correct value

Closes RAUT-843

# Review Requests

- re-run a protocol on a Flex.  From the Protocol Dashboard the timestamp of the newest run of that protocol should be visible in the table. 

# Risk assessment
low
