### PR TITLE
fix(engine, api): check correctly against new cutout IDs in get_slot_definition

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -317,7 +317,7 @@ class LabwareView(HasState[LabwareState]):
         #   things TM TM TM
 
         for cutout in deck_def["locations"]["cutouts"]:
-            if cutout["id"] == slot.id:
+            if cutout["id"].endswith(slot.id):
                 base_position = cutout["position"]
                 break
         else:


### PR DESCRIPTION
# Overview

In the process of working on deck configuration, some shim code was added to convert the data in Deck Definition V4 to the old SlotDefV3 (which was the entirety of data stored in `orderedSlots` in the v3 deck). PR #13872 changed the cutout IDs in the new deck definition to be unique from the addressable area names. This caused an issue with the shim code which was comparing the two `id` names.

The temporary code has been updated to now correctly compare against the end of the cutout ID string, rather than the whole string.

# Test Plan

Just CI.

# Changelog

- Fixed shim code in `LabwareView.get_slot_definition `

# Review requests

# Risk assessment

Low, bug fix.