### PR TITLE
fix(protocol-designer): moving labware onto an adapter on the deck

### DIFF
--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -119,6 +119,7 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
         const labwareOnAdapter = Object.values(labware).find(
           temporalProperties => temporalProperties.slot === labwareId
         )
+        const adapterSlot = labwareOnDeck.slot
         const modIdWithAdapter = Object.keys(modules).find(
           modId => modId === labwareOnDeck.slot
         )
@@ -127,18 +128,21 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
         const modSlot =
           modIdWithAdapter != null ? modules[modIdWithAdapter].slot : null
         const isAdapter = getIsAdapter(labwareId, labwareEntities)
+        const moduleUnderAdapter =
+          modIdWithAdapter != null
+            ? getModuleDisplayName(moduleEntities[modIdWithAdapter].model)
+            : 'unknown module'
+        const moduleSlotInfo = modSlot ?? 'unknown slot'
+        const adapterSlotInfo = adapterSlot ?? 'unknown adapter'
 
         return labwareOnAdapter == null && isAdapter
           ? [
               ...acc,
               {
-                name: `${adapterDisplayName} on top of ${
+                name:
                   modIdWithAdapter != null
-                    ? getModuleDisplayName(
-                        moduleEntities[modIdWithAdapter].model
-                      )
-                    : 'unknown module'
-                } in slot ${modSlot ?? 'unknown slot'}`,
+                    ? `${adapterDisplayName} on top of ${moduleUnderAdapter} in slot ${moduleSlotInfo}`
+                    : `${adapterDisplayName} on slot ${adapterSlotInfo}`,
                 value: labwareId,
               },
             ]

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -62,17 +62,24 @@ export const moveLabware: CommandCreator<MoveLabwareArgs> = (
     newLocation !== 'offDeck' && 'labwareId' in newLocation
       ? newLocation.labwareId
       : null
-  const destModuleIdUnderAdapter =
+
+  const destModuleOrSlotUnderAdapterId =
     destAdapterId != null ? prevRobotState.labware[destAdapterId].slot : null
-  const destinationModuleId =
-    destModuleIdUnderAdapter != null ? destModuleIdUnderAdapter : destModuleId
+  const destinationModuleIdOrSlot =
+    destModuleOrSlotUnderAdapterId != null
+      ? destModuleOrSlotUnderAdapterId
+      : destModuleId
 
   if (newLocation === 'offDeck' && useGripper) {
     errors.push(errorCreators.labwareOffDeck())
   }
-  if (destinationModuleId != null) {
+  if (
+    destinationModuleIdOrSlot != null &&
+    prevRobotState.modules[destinationModuleIdOrSlot] != null
+  ) {
     const destModuleState =
-      prevRobotState.modules[destinationModuleId].moduleState
+      prevRobotState.modules[destinationModuleIdOrSlot].moduleState
+
     if (
       destModuleState.type === THERMOCYCLER_MODULE_TYPE &&
       destModuleState.lidOpen !== true


### PR DESCRIPTION
closes RAUT-847

# Overview

I sort of fixed these bugs on `edge` awhile ago with the 96-channel pr, but didn't realize it wasn't fixed for 7.0

# Test Plan

- created a Flex or ot-2 protocol. Add a H-S or Temperature module and add an adapter on top of the module and add an adapter directly to the deck
- move labware onto both the module's adapter and the adapter on the deck. see that nothing errors and the location strings in the dropdown look correct
- move the labware a few more times and see that nothing errors and everything works as expected

# Changelog

- account for adapters directly on the deck in the util for labware location dropdown and in the `moveLabware` atomic command

# Review requests

see test plan

# Risk assessment

low