### PR TITLE
feat(robot-server): Validate requests to `PUT /deck_configuration`

### DIFF
--- a/robot-server/robot_server/deck_configuration/models.py
+++ b/robot-server/robot_server/deck_configuration/models.py
@@ -3,8 +3,11 @@
 
 from datetime import datetime
 from typing import List, Optional
+from typing_extensions import Literal
 
 import pydantic
+
+from robot_server.errors import ErrorDetails
 
 
 class CutoutFixture(pydantic.BaseModel):
@@ -52,3 +55,10 @@ class DeckConfigurationResponse(pydantic.BaseModel):
             " If that has never happened, this will be `null` or omitted."
         )
     )
+
+
+class InvalidDeckConfigurationResponse(ErrorDetails):
+    """A response for when the client supplies an invalid deck configuration."""
+
+    id: Literal["InvalidDeckConfiguration"] = "InvalidDeckConfiguration"
+    title: str = "Invalid Deck Configuration"

--- a/robot-server/robot_server/deck_configuration/models.py
+++ b/robot-server/robot_server/deck_configuration/models.py
@@ -57,8 +57,8 @@ class DeckConfigurationResponse(pydantic.BaseModel):
     )
 
 
-class InvalidDeckConfigurationResponse(ErrorDetails):
-    """A response for when the client supplies an invalid deck configuration."""
+class InvalidDeckConfiguration(ErrorDetails):
+    """Error details for when a client supplies an invalid deck configuration."""
 
     id: Literal["InvalidDeckConfiguration"] = "InvalidDeckConfiguration"
     title: str = "Invalid Deck Configuration"

--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -45,7 +45,7 @@ router = fastapi.APIRouter()
             "model": SimpleBody[models.DeckConfigurationResponse]
         },
         fastapi.status.HTTP_422_UNPROCESSABLE_ENTITY: {
-            "model": ErrorBody[models.InvalidDeckConfigurationResponse]
+            "model": ErrorBody[models.InvalidDeckConfiguration]
         },
     },
 )
@@ -57,7 +57,7 @@ async def put_deck_configuration(  # noqa: D103
 ) -> PydanticResponse[
     Union[
         SimpleBody[models.DeckConfigurationResponse],
-        ErrorBody[models.InvalidDeckConfigurationResponse],
+        ErrorBody[models.InvalidDeckConfiguration],
     ]
 ]:
     placements = validation_mapping.map_in(request_body.data)

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -65,7 +65,7 @@ def get_configuration_errors(
             errors.add(OvercrowdedCutoutError(cutout, tuple(fixtures)))
 
     for placement in placements:
-        found_cutout_fixture = find_cutout_fixture(
+        found_cutout_fixture = _find_cutout_fixture(
             deck_definition, placement.cutout_fixture_id
         )
         if isinstance(found_cutout_fixture, UnrecognizedCutoutFixtureError):
@@ -84,7 +84,7 @@ def get_configuration_errors(
     return errors
 
 
-def find_cutout_fixture(
+def _find_cutout_fixture(
     deck_definition: deck_types.DeckDefinitionV4, cutout_fixture_id: str
 ) -> Union[deck_types.CutoutFixture, UnrecognizedCutoutFixtureError]:
     try:

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -1,38 +1,40 @@
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import List, Union
+from typing import DefaultDict, List, Set, Tuple, Union
 
 from opentrons_shared_data.deck import dev_types as deck_types
 
 
-@dataclass
+@dataclass(frozen=True)
 class MountedCutoutFixture:
     cutout_id: str
     cutout_fixture_id: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnoccupiedCutoutError:
     cutout_id: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class OvercrowdedCutoutError:
     cutout_id: str
-    cutout_fixture_ids: List[str]
+    cutout_fixture_ids: Tuple[str, ...]
+    """All the conflicting cutout fixtures, in input order."""
 
 
-@dataclass
+@dataclass(frozen=True)
 class InvalidLocationError:
     cutout_id: str
     cutout_fixture_id: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnrecognizedCutoutError:
     cutout_id: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class UnrecognizedCutoutFixtureError:
     cutout_fixture_id: str
 
@@ -49,5 +51,24 @@ ConfigurationError = Union[
 def get_configuration_errors(
     deck_definition: deck_types.DeckDefinitionV4,
     cutout_fixtures: List[MountedCutoutFixture],
-) -> List[ConfigurationError]:
-    return []
+) -> Set[ConfigurationError]:
+    errors: Set[ConfigurationError] = set()
+    fixtures_by_cutout: DefaultDict[str, List[str]] = defaultdict(list)
+
+    for cutout_fixture in cutout_fixtures:
+        fixtures_by_cutout[cutout_fixture.cutout_id].append(
+            cutout_fixture.cutout_fixture_id
+        )
+
+    expected_cutouts = set(c["id"] for c in deck_definition["locations"]["cutouts"])
+    occupied_cutouts = set(fixtures_by_cutout.keys())
+    errors.update(
+        UnoccupiedCutoutError(cutout_id)
+        for cutout_id in expected_cutouts - occupied_cutouts
+    )
+
+    for cutout, fixtures in fixtures_by_cutout.items():
+        if len(fixtures) > 1:
+            errors.add(OvercrowdedCutoutError(cutout, tuple(fixtures)))
+
+    return errors

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -1,3 +1,6 @@
+"""Validate a deck configuration."""
+
+
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import DefaultDict, FrozenSet, List, Set, Tuple, Union
@@ -7,17 +10,23 @@ from opentrons_shared_data.deck import dev_types as deck_types
 
 @dataclass(frozen=True)
 class Placement:
+    """A placement of a cutout fixture in a cutout."""
+
     cutout_id: str
     cutout_fixture_id: str
 
 
 @dataclass(frozen=True)
 class UnoccupiedCutoutError:
+    """When a cutout has been left empty--no cutout fixtures mounted to it."""
+
     cutout_id: str
 
 
 @dataclass(frozen=True)
 class OvercrowdedCutoutError:
+    """When a cutout has had more than one cutout fixture mounted to it."""
+
     cutout_id: str
     cutout_fixture_ids: Tuple[str, ...]
     """All the conflicting cutout fixtures, in input order."""
@@ -25,6 +34,8 @@ class OvercrowdedCutoutError:
 
 @dataclass(frozen=True)
 class InvalidLocationError:
+    """When a cutout fixture has been mounted somewhere it cannot be mounted."""
+
     cutout_id: str
     cutout_fixture_id: str
     allowed_cutout_ids: FrozenSet[str]
@@ -32,6 +43,8 @@ class InvalidLocationError:
 
 @dataclass(frozen=True)
 class UnrecognizedCutoutFixtureError:
+    """When an cutout has been mounted that's not defined by the deck definition."""
+
     cutout_fixture_id: str
 
 
@@ -47,6 +60,10 @@ def get_configuration_errors(
     deck_definition: deck_types.DeckDefinitionV4,
     placements: List[Placement],
 ) -> Set[ConfigurationError]:
+    """Return all the problems with the given deck configration.
+
+    If there are no problems, return ``{}``.
+    """
     errors: Set[ConfigurationError] = set()
     fixtures_by_cutout: DefaultDict[str, List[str]] = defaultdict(list)
 

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -31,11 +31,6 @@ class InvalidLocationError:
 
 
 @dataclass(frozen=True)
-class UnrecognizedCutoutError:
-    cutout_id: str
-
-
-@dataclass(frozen=True)
 class UnrecognizedCutoutFixtureError:
     cutout_fixture_id: str
 
@@ -44,7 +39,6 @@ ConfigurationError = Union[
     UnoccupiedCutoutError,
     OvercrowdedCutoutError,
     InvalidLocationError,
-    UnrecognizedCutoutError,
     UnrecognizedCutoutFixtureError,
 ]
 

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+from typing import List, Union
+
+from opentrons_shared_data.deck import dev_types as deck_types
+
+
+@dataclass
+class MountedCutoutFixture:
+    cutout_id: str
+    cutout_fixture_id: str
+
+
+@dataclass
+class UnoccupiedCutoutError:
+    cutout_id: str
+
+
+@dataclass
+class OvercrowdedCutoutError:
+    cutout_id: str
+    cutout_fixture_ids: List[str]
+
+
+@dataclass
+class InvalidLocationError:
+    cutout_id: str
+    cutout_fixture_id: str
+
+
+@dataclass
+class UnrecognizedCutoutError:
+    cutout_id: str
+
+
+@dataclass
+class UnrecognizedCutoutFixtureError:
+    cutout_fixture_id: str
+
+
+ConfigurationError = Union[
+    UnoccupiedCutoutError,
+    OvercrowdedCutoutError,
+    InvalidLocationError,
+    UnrecognizedCutoutError,
+    UnrecognizedCutoutFixtureError,
+]
+
+
+def get_configuration_errors(
+    deck_definition: deck_types.DeckDefinitionV4,
+    cutout_fixtures: List[MountedCutoutFixture],
+) -> List[ConfigurationError]:
+    return []

--- a/robot-server/robot_server/deck_configuration/validation_mapping.py
+++ b/robot-server/robot_server/deck_configuration/validation_mapping.py
@@ -16,17 +16,17 @@ def map_in(request: models.DeckConfigurationRequest) -> List[validation.Placemen
 
 def map_out(
     validation_errors: Iterable[validation.ConfigurationError],
-) -> List[models.InvalidDeckConfigurationResponse]:
+) -> List[models.InvalidDeckConfiguration]:
     return [_map_out_single_error(e) for e in validation_errors]
 
 
 def _map_out_single_error(
     error: validation.ConfigurationError,
-) -> models.InvalidDeckConfigurationResponse:
+) -> models.InvalidDeckConfiguration:
     meta = {
         "deckConfigurationProblem": error.__class__.__name__,
         **dataclasses.asdict(error),
     }
-    return models.InvalidDeckConfigurationResponse(
+    return models.InvalidDeckConfiguration(
         detail="Invalid deck configuration.", meta=meta
     )

--- a/robot-server/robot_server/deck_configuration/validation_mapping.py
+++ b/robot-server/robot_server/deck_configuration/validation_mapping.py
@@ -1,0 +1,20 @@
+"""Convert between internal types for validation and HTTP-exposed response models."""
+
+from typing import Iterable, List
+
+from . import models
+from . import validation
+
+
+def map_in(request: models.DeckConfigurationRequest) -> List[validation.Placement]:
+    return [
+        validation.Placement(cutout_id=p.cutoutId, cutout_fixture_id=p.cutoutFixtureId)
+        for p in request.cutoutFixtures
+    ]
+
+
+def map_out(
+    validation_errors: Iterable[validation.ConfigurationError],
+) -> List[models.InvalidDeckConfigurationResponse]:
+    # TODO
+    return [models.InvalidDeckConfigurationResponse.construct(detail="oh god")]

--- a/robot-server/robot_server/deck_configuration/validation_mapping.py
+++ b/robot-server/robot_server/deck_configuration/validation_mapping.py
@@ -8,6 +8,7 @@ from . import validation
 
 
 def map_in(request: models.DeckConfigurationRequest) -> List[validation.Placement]:
+    """Map a request from HTTP to internal types that can be validated."""
     return [
         validation.Placement(cutout_id=p.cutoutId, cutout_fixture_id=p.cutoutFixtureId)
         for p in request.cutoutFixtures
@@ -17,6 +18,7 @@ def map_in(request: models.DeckConfigurationRequest) -> List[validation.Placemen
 def map_out(
     validation_errors: Iterable[validation.ConfigurationError],
 ) -> List[models.InvalidDeckConfiguration]:
+    """Map internal results from validation to HTTP-exposed types."""
     return [_map_out_single_error(e) for e in validation_errors]
 
 

--- a/robot-server/robot_server/deck_configuration/validation_mapping.py
+++ b/robot-server/robot_server/deck_configuration/validation_mapping.py
@@ -25,8 +25,13 @@ def map_out(
 def _map_out_single_error(
     error: validation.ConfigurationError,
 ) -> models.InvalidDeckConfiguration:
+    # Expose the error details in a developer-facing, kind of lazy way.
+    # This format isn't guaranteed by robot-server's HTTP API;
+    # it's just meant to help app developers debug their deck config requests.
     meta = {
         "deckConfigurationProblem": error.__class__.__name__,
+        # Note that this dataclasses.asdict() will break if the internal error
+        # that we're mapping from is ever not a dataclass.
         **dataclasses.asdict(error),
     }
     return models.InvalidDeckConfiguration(

--- a/robot-server/robot_server/deck_configuration/validation_mapping.py
+++ b/robot-server/robot_server/deck_configuration/validation_mapping.py
@@ -1,5 +1,6 @@
 """Convert between internal types for validation and HTTP-exposed response models."""
 
+import dataclasses
 from typing import Iterable, List
 
 from . import models
@@ -16,5 +17,16 @@ def map_in(request: models.DeckConfigurationRequest) -> List[validation.Placemen
 def map_out(
     validation_errors: Iterable[validation.ConfigurationError],
 ) -> List[models.InvalidDeckConfigurationResponse]:
-    # TODO
-    return [models.InvalidDeckConfigurationResponse.construct(detail="oh god")]
+    return [_map_out_single_error(e) for e in validation_errors]
+
+
+def _map_out_single_error(
+    error: validation.ConfigurationError,
+) -> models.InvalidDeckConfigurationResponse:
+    meta = {
+        "deckConfigurationProblem": error.__class__.__name__,
+        **dataclasses.asdict(error),
+    }
+    return models.InvalidDeckConfigurationResponse(
+        detail="Invalid deck configuration.", meta=meta
+    )

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -289,6 +289,7 @@ async def get_deck_type() -> DeckType:
 async def get_deck_definition(
     deck_type: DeckType = Depends(get_deck_type),
 ) -> deck.dev_types.DeckDefinitionV4:
+    """Return this robot's deck definition."""
     return deck.load(deck_type, version=4)
 
 

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -16,6 +16,8 @@ from typing import (
 from uuid import uuid4  # direct to avoid import cycles in service.dependencies
 from traceback import format_exception_only, TracebackException
 from contextlib import contextmanager
+
+from opentrons_shared_data import deck
 from opentrons_shared_data.robot.dev_types import RobotType, RobotTypeEnum
 
 from opentrons import initialize as initialize_api, should_use_ot3
@@ -282,6 +284,12 @@ async def get_robot_type_enum() -> RobotTypeEnum:
 async def get_deck_type() -> DeckType:
     """Return what kind of deck the robot that this server is running on has."""
     return DeckType(guess_deck_type_from_global_config())
+
+
+async def get_deck_definition(
+    deck_type: DeckType = Depends(get_deck_type),
+) -> deck.dev_types.DeckDefinitionV4:
+    return deck.load(deck_type, version=4)
 
 
 async def _postinit_ot2_tasks(

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -105,9 +105,10 @@ def test_invalid_cutout_for_fixture() -> None:
             ("singleLeftSlot", "cutoutD1"),
             ("singleCenterSlot", "cutoutA2"),
             ("singleCenterSlot", "cutoutB2"),
-            # Invalid because wasteChuteRightAdapterNoCover can't be placed in cutout C2.
+            # Invalid because wasteChuteRightAdapterNoCover can't be placed in cutout C2...
             ("wasteChuteRightAdapterNoCover", "cutoutC2"),
-            ("singleCenterSlot", "cutoutD2"),
+            # ...nor can singleLeftSlot be placed in cutout D2.
+            ("singleLeftSlot", "cutoutD2"),
             ("stagingAreaRightSlot", "cutoutA3"),
             ("singleRightSlot", "cutoutB3"),
             ("stagingAreaRightSlot", "cutoutC3"),
@@ -116,8 +117,17 @@ def test_invalid_cutout_for_fixture() -> None:
     ]
     assert subject.get_configuration_errors(deck_definition, cutout_fixtures) == {
         subject.InvalidLocationError(
-            cutout_id="cutoutC2", cutout_fixture_id="wasteChuteRightAdapterNoCover"
-        )
+            cutout_id="cutoutC2",
+            cutout_fixture_id="wasteChuteRightAdapterNoCover",
+            allowed_cutout_ids=frozenset(["cutoutD3"]),
+        ),
+        subject.InvalidLocationError(
+            cutout_id="cutoutD2",
+            cutout_fixture_id="singleLeftSlot",
+            allowed_cutout_ids=frozenset(
+                ["cutoutA1", "cutoutB1", "cutoutC1", "cutoutD1"]
+            ),
+        ),
     }
 
 

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -149,8 +149,9 @@ def test_unrecognized_cutout() -> None:
             ("singleRightSlot", "cutoutA3"),
             ("singleRightSlot", "cutoutB3"),
             ("singleRightSlot", "cutoutC3"),
+            ("singleRightSlot", "cutoutD3"),
             # Invalid because "someUnrecognizedCutout" is not defined by the deck definition.
-            ("someUnrecognizedCutout", "cutoutD3"),
+            ("singleRightSlot", "someUnrecognizedCutout"),
         ]
     ]
     assert subject.get_configuration_errors(deck_definition, cutout_fixtures) == [

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -1,9 +1,12 @@
+"""Unit tests for robot_server.deck_configuration.validation."""
+
 from opentrons_shared_data.deck import load as load_deck_definition
 
 from robot_server.deck_configuration import validation as subject
 
 
 def test_valid() -> None:
+    """It should return an empty error list if the input is valid."""
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
         subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
@@ -26,6 +29,7 @@ def test_valid() -> None:
 
 
 def test_invalid_empty_cutouts() -> None:
+    """It should enforce that every cutout is occupied."""
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
         subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
@@ -52,6 +56,7 @@ def test_invalid_empty_cutouts() -> None:
 
 
 def test_invalid_overcrowded_cutouts() -> None:
+    """It should prevent you from putting multiple things into a single cutout."""
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
         subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
@@ -87,6 +92,7 @@ def test_invalid_overcrowded_cutouts() -> None:
 
 
 def test_invalid_cutout_for_fixture() -> None:
+    """Each fixture must be placed in a location that's valid for that particular fixture."""
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
         subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
@@ -124,6 +130,7 @@ def test_invalid_cutout_for_fixture() -> None:
 
 
 def test_unrecognized_cutout() -> None:
+    """It should raise a sensible error if you pass a totally nonexistent cutout."""
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
         subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
@@ -156,6 +163,7 @@ def test_unrecognized_cutout() -> None:
 
 
 def test_unrecognized_cutout_fixture() -> None:
+    """It should raise a sensible error if you pass a totally nonexistent cutout fixture."""
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
         subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -154,9 +154,15 @@ def test_unrecognized_cutout() -> None:
             ("singleRightSlot", "someUnrecognizedCutout"),
         ]
     ]
-    assert subject.get_configuration_errors(deck_definition, cutout_fixtures) == [
-        subject.UnrecognizedCutoutError(cutout_id="someUnrecognizedCutout")
-    ]
+    assert subject.get_configuration_errors(deck_definition, cutout_fixtures) == {
+        subject.InvalidLocationError(
+            cutout_fixture_id="singleRightSlot",
+            cutout_id="someUnrecognizedCutout",
+            allowed_cutout_ids=frozenset(
+                ["cutoutA3", "cutoutB3", "cutoutC3", "cutoutD3"]
+            ),
+        )
+    }
 
 
 def test_unrecognized_cutout_fixture() -> None:

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -6,9 +6,7 @@ from robot_server.deck_configuration import validation as subject
 def test_valid() -> None:
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
-        subject.MountedCutoutFixture(
-            cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id
-        )
+        subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
         for cutout_fixture_id, cutout_id in [
             ("singleLeftSlot", "cutoutA1"),
             ("singleLeftSlot", "cutoutB1"),
@@ -30,9 +28,7 @@ def test_valid() -> None:
 def test_invalid_empty_cutouts() -> None:
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
-        subject.MountedCutoutFixture(
-            cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id
-        )
+        subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
         for cutout_fixture_id, cutout_id in [
             ("singleLeftSlot", "cutoutA1"),
             ("singleLeftSlot", "cutoutB1"),
@@ -58,9 +54,7 @@ def test_invalid_empty_cutouts() -> None:
 def test_invalid_overcrowded_cutouts() -> None:
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
-        subject.MountedCutoutFixture(
-            cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id
-        )
+        subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
         for cutout_fixture_id, cutout_id in [
             ("singleLeftSlot", "cutoutA1"),
             ("singleLeftSlot", "cutoutB1"),
@@ -95,9 +89,7 @@ def test_invalid_overcrowded_cutouts() -> None:
 def test_invalid_cutout_for_fixture() -> None:
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
-        subject.MountedCutoutFixture(
-            cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id
-        )
+        subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
         for cutout_fixture_id, cutout_id in [
             ("singleLeftSlot", "cutoutA1"),
             ("singleLeftSlot", "cutoutB1"),
@@ -134,9 +126,7 @@ def test_invalid_cutout_for_fixture() -> None:
 def test_unrecognized_cutout() -> None:
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
-        subject.MountedCutoutFixture(
-            cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id
-        )
+        subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
         for cutout_fixture_id, cutout_id in [
             ("singleLeftSlot", "cutoutA1"),
             ("singleLeftSlot", "cutoutB1"),
@@ -168,9 +158,7 @@ def test_unrecognized_cutout() -> None:
 def test_unrecognized_cutout_fixture() -> None:
     deck_definition = load_deck_definition("ot3_standard", version=4)
     cutout_fixtures = [
-        subject.MountedCutoutFixture(
-            cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id
-        )
+        subject.Placement(cutout_fixture_id=cutout_fixture_id, cutout_id=cutout_id)
         for cutout_fixture_id, cutout_id in [
             ("singleLeftSlot", "cutoutA1"),
             ("singleLeftSlot", "cutoutB1"),

--- a/robot-server/tests/integration/http_api/test_deck_configuration.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_deck_configuration.tavern.yaml
@@ -6,7 +6,7 @@ marks:
       - ot3_server_base_url
 
 stages:
-  - name: Set the deck configuration
+  - name: Set a valid deck configuration
     request:
       url: '{ot3_server_base_url}/deck_configuration'
       method: PUT
@@ -48,9 +48,60 @@ stages:
         data:
           lastUpdatedAt: !anystr
           cutoutFixtures: *expectedCutoutFixtures
+      save:
+        json:
+          last_updated_at: data.lastUpdatedAt
+
+  - name: Set an invalid deck configuration
+    request:
+      url: '{ot3_server_base_url}/deck_configuration'
+      method: PUT
+      json:
+        data:
+          cutoutFixtures:
+            # Invalid deck configuration: cutoutA1 is left unoccupied.
+            # - cutoutFixtureId: singleLeftSlot
+            #   cutoutId: cutoutA1
+            - cutoutFixtureId: singleLeftSlot
+              cutoutId: cutoutB1
+            - cutoutFixtureId: singleLeftSlot
+              cutoutId: cutoutC1
+            - cutoutFixtureId: singleLeftSlot
+              cutoutId: cutoutD1
+            - cutoutFixtureId: singleCenterSlot
+              cutoutId: cutoutA2
+            - cutoutFixtureId: singleCenterSlot
+              cutoutId: cutoutB2
+            - cutoutFixtureId: singleCenterSlot
+              cutoutId: cutoutC2
+            - cutoutFixtureId: singleCenterSlot
+              cutoutId: cutoutD2
+            - cutoutFixtureId: singleRightSlot
+              cutoutId: cutoutA3
+            - cutoutFixtureId: singleRightSlot
+              cutoutId: cutoutB3
+            - cutoutFixtureId: singleRightSlot
+              cutoutId: cutoutC3
+            - cutoutFixtureId: singleRightSlot
+              cutoutId: cutoutD3
+    response:
+      status_code: 422
+      json:
+        errors:
+          - id: InvalidDeckConfiguration
+            title: Invalid Deck Configuration
+            errorCode: '4000'
+            detail: !anystr
+
+  - name: Get the deck configuration and make sure it's not the invalid one
+    request:
+      url: '{ot3_server_base_url}/deck_configuration'
+    response:
+      json:
+        data:
+          lastUpdatedAt: '{last_updated_at}'
+          cutoutFixtures: *expectedCutoutFixtures
 # TODO(mm, 2023-11-02):
 #
 # - Test that the server has a default deck configuration.
 #   The default configuration will be different between OT-2 and Flex.
-#
-# - Test that the server rejects invalid deck configurations.

--- a/robot-server/tests/integration/http_api/test_deck_configuration.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_deck_configuration.tavern.yaml
@@ -91,7 +91,10 @@ stages:
           - id: InvalidDeckConfiguration
             title: Invalid Deck Configuration
             errorCode: '4000'
-            detail: !anystr
+            detail: Invalid deck configuration.
+            meta:
+              deckConfigurationProblem: UnoccupiedCutoutError
+              cutout_id: cutoutA1
 
   - name: Get the deck configuration and make sure it's not the invalid one
     request:


### PR DESCRIPTION
# Overview

When a client sends an HTTP request to set the robot's deck configuration, this PR makes the server check that the new configuration is valid. Stuff like, you can't put two things into the same cutout.

Closes RSS-399.

# Test Plan

The automated tests added in this PR should be sufficient.

# Changelog

* Add a new module, `robot_server.deck_configuration.validation`.
* Wire it up to the `PUT /deck_configuration` endpoint.

# Review requests

* See inline notes.
* Did I miss any validation rules when I was speccing out RSS-399?

# Risk assessment

Low.