### PR TITLE
fix(app): fix unaligned fields in ProtocolSetupModulesAndDeck

### DIFF
--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -266,11 +266,7 @@ function RowModule({
           />
         </Flex>
         {isNonConnectingModule ? (
-          <Flex
-            flex="3 0 0"
-            alignItems={ALIGN_CENTER}
-            padding={`${SPACING.spacing8} ${SPACING.spacing16}`}
-          >
+          <Flex flex="3 0 0" alignItems={ALIGN_CENTER}>
             <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
               {t('n_a')}
             </StyledText>


### PR DESCRIPTION
Closes RAUT-852
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

### Before

![33399733-922a-48a2-8049-408f6edc46bd](https://github.com/Opentrons/opentrons/assets/64858653/e2c54eb7-974f-4040-92f1-21414febe98c)

### After

<img width="1019" alt="Screenshot 2023-11-06 at 2 33 46 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/6cde2b6a-405f-479c-8f93-a1e23506698a">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Navigate to ProtocolSetup > Modules and Deck button.
- Confirm that the Magblock (the only N/A module) aligns with other modules.
- Here's a protocol to test. 
[MagBlockWithHS.py.zip](https://github.com/Opentrons/opentrons/files/13272004/MagBlockWithHS.py.zip)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix unaligned modules fields on the ProtocolSetup page.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
