### PR TITLE
fix(app): fix calibration copy, 96 wizard attach title

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -12,6 +12,7 @@
   "are_you_sure_you_want_to_disconnect": "Are you sure you want to disconnect from {{ssid}}?",
   "attach_a_pipette_before_calibrating": "Attach a pipette in order to perform calibration",
   "boot_scripts": "Boot scripts",
+  "both": "Both",
   "browse_file_system": "Browse file system",
   "bug_fixes": "Bug Fixes",
   "calibrate_deck": "Calibrate deck",

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -65,8 +65,11 @@ export const PipetteWizardFlows = (
 
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
   const memoizedPipetteInfo = React.useMemo(() => props.pipetteInfo ?? null, [])
-  const isGantryEmpty =
-    attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null
+  const isGantryEmpty = React.useMemo(
+    () => attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null,
+    []
+  )
+
   const pipetteWizardSteps = React.useMemo(
     () =>
       memoizedPipetteInfo == null

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -24,6 +24,7 @@ import {
 
 import type { State } from '../../../redux/types'
 import type { FormattedPipetteOffsetCalibration } from '..'
+import type { LEFT } from '../../../redux/pipettes'
 
 const StyledTable = styled.table`
   width: 100%;
@@ -66,10 +67,13 @@ export function PipetteOffsetCalibrationItems({
   const attachedPipettesFromPipetteQuery = useAttachedPipettes()
   const attachedPipetteFromInstrumentQuery = useAttachedPipettesFromInstrumentsQuery()
   const isFlex = useIsFlex(robotName)
-  const attachedPipettes = Boolean(isFlex)
+  const attachedPipettes = isFlex
     ? attachedPipetteFromInstrumentQuery
     : attachedPipettesFromPipetteQuery
 
+  const is96Attached =
+    // @ts-expect-error isFlex is a type narrower but not recognized as one
+    isFlex && attachedPipettes?.[LEFT]?.instrumentName === 'p1000_96'
   return (
     <StyledTable>
       <thead>
@@ -97,7 +101,7 @@ export function PipetteOffsetCalibrationItems({
                     as="p"
                     textTransform={TYPOGRAPHY.textTransformCapitalize}
                   >
-                    {calibration.mount}
+                    {is96Attached ? t('both') : calibration.mount}
                   </StyledText>
                 </StyledTableCell>
                 {isFlex ? null : (

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -16,6 +16,7 @@ import { StyledText } from '../../../atoms/text'
 import { OverflowMenu } from './OverflowMenu'
 import { formatLastCalibrated, getDisplayNameForTipRack } from './utils'
 import { getCustomLabwareDefinitions } from '../../../redux/custom-labware'
+import { LEFT } from '../../../redux/pipettes'
 import {
   useAttachedPipettes,
   useIsFlex,
@@ -24,7 +25,6 @@ import {
 
 import type { State } from '../../../redux/types'
 import type { FormattedPipetteOffsetCalibration } from '..'
-import type { LEFT } from '../../../redux/pipettes'
 
 const StyledTable = styled.table`
   width: 100%;


### PR DESCRIPTION
fix RQA-1866, RQA-1767

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Fix two 96-channel bugs:
1. Title of 96-channel attach wizard changes to "Detach and attach 96-channel" after attachment
2. Robot settings calibration item mount listed as "left" instead of "both"

# Test Plan

1. Attach a 96-channel pipette with an empty gantry, see that for the duration of the wizard flow the title remains "Attach 96-Channel Pipette"
2. Once the pipette is attached and calibrated, go to robot settings/calibration on desktop and see that under "Mount" you now see "Both"
<!--

Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Memoize "isGantryEmpty" variable so it doesn't become `false` after 96-pipette is attached and update mount to say "both" when 96 channel is attached
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over code and test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
