### PR TITLE
fix(api): only send moves to moving axes, unless specified otherwise

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -535,6 +535,7 @@ class OT3Controller:
         origin: Coordinates[Axis, float],
         moves: List[Move[Axis]],
         stop_condition: MoveStopCondition = MoveStopCondition.none,
+        nodes_in_moves_only: bool = True,
     ) -> None:
         """Move to a position.
 
@@ -542,11 +543,22 @@ class OT3Controller:
             origin: The starting point of the move
             moves: List of moves.
             stop_condition: The stop condition.
+            nodes_in_moves_only: Default is True. If False, also send empty moves to
+                                 nodes that are present but not defined in moves.
+
+        .. caution::
+            Setting `nodes_in_moves_only` to False will enable *all* present motors in
+            the system. DO NOT USE when you want to keep one of the axes disabled.
 
         Returns:
             None
         """
-        group = create_move_group(origin, moves, self._motor_nodes(), stop_condition)
+        ordered_nodes = self._motor_nodes()
+        if nodes_in_moves_only:
+            moving_axes = {axis_to_node(ax) for move in moves for ax in move.unit_vector.keys()}
+            ordered_nodes = ordered_nodes.intersection(moving_axes)
+
+        group = create_move_group(origin, moves, ordered_nodes, stop_condition)
         move_group, _ = group
         runner = MoveGroupRunner(
             move_groups=[move_group],

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -555,7 +555,9 @@ class OT3Controller:
         """
         ordered_nodes = self._motor_nodes()
         if nodes_in_moves_only:
-            moving_axes = {axis_to_node(ax) for move in moves for ax in move.unit_vector.keys()}
+            moving_axes = {
+                axis_to_node(ax) for move in moves for ax in move.unit_vector.keys()
+            }
             ordered_nodes = ordered_nodes.intersection(moving_axes)
 
         group = create_move_group(origin, moves, ordered_nodes, stop_condition)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This allows us to keep certain axes disengaged while we command other axes to move.

Instead of sending moves to all present motor nodes all the time, regardless of
whether they actually need to move or not, we are only sending the move requests to 
the axes that are defined in the moves.

Most of the time we're ordering a mount to move (see various move methods in ot3api).
This guarantees that the axes pertaining to that mount (X, Y, and Z) will be receiving the moves
together but the other idle mounts will be left alone.