### PR TITLE
fix(api): refresh motor & encoder positions after fast home failure

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1460,6 +1460,7 @@ class OT3API(
                     self._log.warning(
                         f"Stall on {axis} during fast home, encoder may have missed an overflow"
                     )
+                    await self.refresh_positions()
 
             await self._backend.home([axis], self.gantry_load)
         else:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
After we encounter and ignore a Stall/Collision error during fast home, we need to manually refresh motor positions so we can properly compute the distance/duration for the following moves.
