### PR TITLE
fix(app): Fix desktop app update modals

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -70,6 +70,7 @@
   "problem_during_update": "This update is taking longer than usual.",
   "prompt": "Always show the prompt to choose calibration block or trash bin",
   "receive_alert": "Receive an alert when an Opentrons software update is available.",
+  "release_notes": "Release notes",
   "remind_later": "Remind me later",
   "reset_to_default": "Reset to default",
   "restart_touchscreen": "Restart touchscreen",

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -83,6 +83,7 @@
   "device_reset_description": "Reset labware calibration, boot scripts, and/or robot calibration to factory settings.",
   "device_reset_slideout_description": "Select individual settings to only clear specific data types.",
   "device_resets_cannot_be_undone": "Resets cannot be undone",
+  "release_notes": "Release notes",
   "directly_connected_to_this_computer": "Directly connected to this computer.",
   "disconnect": "Disconnect",
   "disconnect_from_ssid": "Disconnect from {{ssid}}",

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -23,6 +23,7 @@ import {
   UPGRADE,
   REINSTALL,
   DOWNGRADE,
+  getRobotUpdateVersion,
 } from '../../../../redux/robot-update'
 import { ExternalLink } from '../../../../atoms/Link/ExternalLink'
 import { ReleaseNotes } from '../../../../molecules/ReleaseNotes'
@@ -35,8 +36,8 @@ import { useDispatchStartRobotUpdate } from '../../../../redux/robot-update/hook
 import type { State, Dispatch } from '../../../../redux/types'
 import type { RobotSystemType } from '../../../../redux/robot-update/types'
 
-export const RELEASE_NOTES_URL =
-  'https://github.com/Opentrons/opentrons/releases'
+export const RELEASE_NOTES_URL_BASE =
+  'https://github.com/Opentrons/opentrons/releases/tag/v'
 
 const UpdateAppBanner = styled(Banner)`
   border: none;
@@ -78,6 +79,10 @@ export function UpdateRobotModal({
     return getRobotUpdateDisplayInfo(state, robotName)
   })
   const dispatchStartRobotUpdate = useDispatchStartRobotUpdate()
+  const robotUpdateVersion = useSelector((state: State) => {
+    return getRobotUpdateVersion(state, robotName) ?? ''
+  })
+
   const isRobotBusy = useIsRobotBusy()
   const updateDisabled = updateFromFileDisabledReason !== null || isRobotBusy
 
@@ -105,7 +110,7 @@ export function UpdateRobotModal({
   const robotUpdateFooter = (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
       <ExternalLink
-        href={RELEASE_NOTES_URL}
+        href={`${RELEASE_NOTES_URL_BASE}${robotUpdateVersion}`}
         css={css`
           font-size: 0.875rem;
         `}

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -7,7 +7,8 @@ import {
   useHoverTooltip,
   ALIGN_CENTER,
   DIRECTION_COLUMN,
-  JUSTIFY_FLEX_END,
+  JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_SPACE_AROUND,
   SPACING,
   Flex,
   NewPrimaryBtn,
@@ -23,6 +24,7 @@ import {
   REINSTALL,
   DOWNGRADE,
 } from '../../../../redux/robot-update'
+import { ExternalLink } from '../../../../atoms/Link/ExternalLink'
 import { ReleaseNotes } from '../../../../molecules/ReleaseNotes'
 import { useIsRobotBusy } from '../../hooks'
 import { Tooltip } from '../../../../atoms/Tooltip'
@@ -32,6 +34,9 @@ import { useDispatchStartRobotUpdate } from '../../../../redux/robot-update/hook
 
 import type { State, Dispatch } from '../../../../redux/types'
 import type { RobotSystemType } from '../../../../redux/robot-update/types'
+
+export const RELEASE_NOTES_URL =
+  'https://github.com/Opentrons/opentrons/releases'
 
 const UpdateAppBanner = styled(Banner)`
   border: none;
@@ -98,28 +103,40 @@ export function UpdateRobotModal({
   }
 
   const robotUpdateFooter = (
-    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>
-      <NewSecondaryBtn
-        onClick={closeModal}
-        marginRight={SPACING.spacing8}
-        css={FOOTER_BUTTON_STYLE}
+    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <ExternalLink
+        href={RELEASE_NOTES_URL}
+        css={css`
+          font-size: 0.875rem;
+        `}
+        id="SoftwareUpdateReleaseNotesLink"
+        marginLeft={SPACING.spacing32}
       >
-        {updateType === UPGRADE ? t('remind_me_later') : t('not_now')}
-      </NewSecondaryBtn>
-      <NewPrimaryBtn
-        onClick={() => dispatchStartRobotUpdate(robotName)}
-        marginRight={SPACING.spacing12}
-        css={FOOTER_BUTTON_STYLE}
-        disabled={updateDisabled}
-        {...updateButtonProps}
-      >
-        {t('update_robot_now')}
-      </NewPrimaryBtn>
-      {updateDisabled && (
-        <Tooltip tooltipProps={updateButtonTooltipProps}>
-          {disabledReason}
-        </Tooltip>
-      )}
+        {t('release_notes')}
+      </ExternalLink>
+      <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_AROUND}>
+        <NewSecondaryBtn
+          onClick={closeModal}
+          marginRight={SPACING.spacing8}
+          css={FOOTER_BUTTON_STYLE}
+        >
+          {updateType === UPGRADE ? t('remind_me_later') : t('not_now')}
+        </NewSecondaryBtn>
+        <NewPrimaryBtn
+          onClick={() => dispatchStartRobotUpdate(robotName)}
+          marginRight={SPACING.spacing12}
+          css={FOOTER_BUTTON_STYLE}
+          disabled={updateDisabled}
+          {...updateButtonProps}
+        >
+          {t('update_robot_now')}
+        </NewPrimaryBtn>
+        {updateDisabled && (
+          <Tooltip tooltipProps={updateButtonTooltipProps}>
+            {disabledReason}
+          </Tooltip>
+        )}
+      </Flex>
     </Flex>
   )
 

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/ViewUpdateModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/ViewUpdateModal.tsx
@@ -27,6 +27,7 @@ export function ViewUpdateModal(
   props: ViewUpdateModalProps
 ): JSX.Element | null {
   const { robotName, robot, closeModal } = props
+  const [showAppUpdateModal, setShowAppUpdateModal] = React.useState(true)
 
   const updateInfo = useSelector((state: State) =>
     getRobotUpdateInfo(state, robotName)
@@ -38,7 +39,9 @@ export function ViewUpdateModal(
     getRobotUpdateAvailable(state, robot)
   )
   const robotSystemType = getRobotSystemType(robot)
-  const availableAppUpdateVersion = useSelector(getAvailableShellUpdate)
+  const availableAppUpdateVersion = Boolean(
+    useSelector(getAvailableShellUpdate)
+  )
 
   const [
     showMigrationWarning,
@@ -51,12 +54,12 @@ export function ViewUpdateModal(
   }
 
   let releaseNotes = ''
-  if (updateInfo?.releaseNotes) releaseNotes = updateInfo.releaseNotes
+  if (updateInfo?.releaseNotes != null) releaseNotes = updateInfo.releaseNotes
 
-  if (availableAppUpdateVersion)
+  if (availableAppUpdateVersion && showAppUpdateModal)
     return (
       <Portal>
-        <UpdateAppModal closeModal={close} />
+        <UpdateAppModal closeModal={() => setShowAppUpdateModal(false)} />
       </Portal>
     )
 

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
@@ -8,7 +8,7 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../../../i18n'
 import { getRobotUpdateDisplayInfo } from '../../../../../redux/robot-update'
 import { getDiscoverableRobotByName } from '../../../../../redux/discovery'
-import { UpdateRobotModal } from '../UpdateRobotModal'
+import { UpdateRobotModal, RELEASE_NOTES_URL } from '../UpdateRobotModal'
 import type { Store } from 'redux'
 
 import type { State } from '../../../../../redux/types'
@@ -91,6 +91,13 @@ describe('UpdateRobotModal', () => {
     expect(updateNow).toBeDisabled()
     fireEvent.click(remindMeLater)
     expect(props.closeModal).toHaveBeenCalled()
+  })
+
+  it('renders a release notes link pointing to the Github releases page', () => {
+    const [{ getByText }] = render(props)
+
+    const link = getByText('Release notes')
+    expect(link).toHaveAttribute('href', RELEASE_NOTES_URL)
   })
 
   it('renders proper text when reinstalling', () => {

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/__tests__/UpdateRobotModal.test.tsx
@@ -6,9 +6,12 @@ import { fireEvent } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 
 import { i18n } from '../../../../../i18n'
-import { getRobotUpdateDisplayInfo } from '../../../../../redux/robot-update'
+import {
+  getRobotUpdateDisplayInfo,
+  getRobotUpdateVersion,
+} from '../../../../../redux/robot-update'
 import { getDiscoverableRobotByName } from '../../../../../redux/discovery'
-import { UpdateRobotModal, RELEASE_NOTES_URL } from '../UpdateRobotModal'
+import { UpdateRobotModal, RELEASE_NOTES_URL_BASE } from '../UpdateRobotModal'
 import type { Store } from 'redux'
 
 import type { State } from '../../../../../redux/types'
@@ -24,6 +27,9 @@ const mockGetRobotUpdateDisplayInfo = getRobotUpdateDisplayInfo as jest.MockedFu
 >
 const mockGetDiscoverableRobotByName = getDiscoverableRobotByName as jest.MockedFunction<
   typeof getDiscoverableRobotByName
+>
+const mockGetRobotUpdateVersion = getRobotUpdateVersion as jest.MockedFunction<
+  typeof getRobotUpdateVersion
 >
 
 const render = (props: React.ComponentProps<typeof UpdateRobotModal>) => {
@@ -51,6 +57,7 @@ describe('UpdateRobotModal', () => {
       updateFromFileDisabledReason: 'test',
     })
     when(mockGetDiscoverableRobotByName).mockReturnValue(null)
+    when(mockGetRobotUpdateVersion).mockReturnValue('7.0.0')
   })
 
   afterEach(() => {
@@ -97,7 +104,7 @@ describe('UpdateRobotModal', () => {
     const [{ getByText }] = render(props)
 
     const link = getByText('Release notes')
-    expect(link).toHaveAttribute('href', RELEASE_NOTES_URL)
+    expect(link).toHaveAttribute('href', RELEASE_NOTES_URL_BASE + '7.0.0')
   })
 
   it('renders proper text when reinstalling', () => {

--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -7,7 +7,7 @@ import { renderWithProviders } from '@opentrons/components'
 import { i18n } from '../../../i18n'
 import * as Shell from '../../../redux/shell'
 import { useRemoveActiveAppUpdateToast } from '../../Alerts'
-import { UpdateAppModal, UpdateAppModalProps, RELEASE_NOTES_URL } from '..'
+import { UpdateAppModal, UpdateAppModalProps, RELEASE_NOTES_URL_BASE } from '..'
 
 import type { State } from '../../../redux/types'
 import type { ShellUpdateState } from '../../../redux/shell/types'
@@ -35,6 +35,9 @@ const mockUseRemoveActiveAppUpdateToast = useRemoveActiveAppUpdateToast as jest.
 const render = (props: React.ComponentProps<typeof UpdateAppModal>) => {
   return renderWithProviders(<UpdateAppModal {...props} />, {
     i18nInstance: i18n,
+    initialState: {
+      shell: { update: { info: { version: '7.0.0' }, available: true } },
+    },
   })
 }
 
@@ -83,7 +86,7 @@ describe('UpdateAppModal', () => {
     const [{ getByText }] = render(props)
 
     const link = getByText('Release notes')
-    expect(link).toHaveAttribute('href', RELEASE_NOTES_URL)
+    expect(link).toHaveAttribute('href', RELEASE_NOTES_URL_BASE + '7.0.0')
   })
 
   it('shows error modal on error', () => {

--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import { when } from 'jest-when'
 import { fireEvent } from '@testing-library/react'
+
 import { renderWithProviders } from '@opentrons/components'
+
 import { i18n } from '../../../i18n'
 import * as Shell from '../../../redux/shell'
-import { UpdateAppModal, UpdateAppModalProps } from '..'
 import { useRemoveActiveAppUpdateToast } from '../../Alerts'
+import { UpdateAppModal, UpdateAppModalProps, RELEASE_NOTES_URL } from '..'
 
 import type { State } from '../../../redux/types'
 import type { ShellUpdateState } from '../../../redux/shell/types'
@@ -76,6 +78,14 @@ describe('UpdateAppModal', () => {
     fireEvent.click(getByText('Remind me later'))
     expect(closeModal).toHaveBeenCalled()
   })
+
+  it('renders a release notes link pointing to the Github releases page', () => {
+    const [{ getByText }] = render(props)
+
+    const link = getByText('Release notes')
+    expect(link).toHaveAttribute('href', RELEASE_NOTES_URL)
+  })
+
   it('shows error modal on error', () => {
     getShellUpdateState.mockReturnValue({
       error: {

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -19,6 +19,7 @@ import {
 
 import {
   getShellUpdateState,
+  getAvailableShellUpdate,
   downloadShellUpdate,
   applyShellUpdate,
 } from '../../redux/shell'
@@ -58,8 +59,8 @@ const PlaceholderError = ({
     </>
   )
 }
-export const RELEASE_NOTES_URL =
-  'https://github.com/Opentrons/opentrons/releases'
+export const RELEASE_NOTES_URL_BASE =
+  'https://github.com/Opentrons/opentrons/releases/tag/v'
 const UPDATE_ERROR = 'Update Error'
 const FOOTER_BUTTON_STYLE = css`
   text-transform: lowercase;
@@ -108,6 +109,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   const { t } = useTranslation('app_settings')
   const history = useHistory()
   const { removeActiveAppUpdateToast } = useRemoveActiveAppUpdateToast()
+  const availableAppUpdateVersion = useSelector(getAvailableShellUpdate) ?? ''
 
   if (downloaded)
     setTimeout(() => dispatch(applyShellUpdate()), RESTART_APP_AFTER_TIME)
@@ -122,7 +124,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   const appUpdateFooter = (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
       <ExternalLink
-        href={RELEASE_NOTES_URL}
+        href={`${RELEASE_NOTES_URL_BASE}${availableAppUpdateVersion}`}
         css={css`
           font-size: 0.875rem;
         `}

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -8,12 +8,13 @@ import {
   ALIGN_CENTER,
   COLORS,
   DIRECTION_COLUMN,
-  JUSTIFY_FLEX_END,
   SPACING,
   Flex,
   NewPrimaryBtn,
   NewSecondaryBtn,
   BORDERS,
+  JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
 
 import {
@@ -22,6 +23,7 @@ import {
   applyShellUpdate,
 } from '../../redux/shell'
 
+import { ExternalLink } from '../../atoms/Link/ExternalLink'
 import { ReleaseNotes } from '../../molecules/ReleaseNotes'
 import { LegacyModal } from '../../molecules/LegacyModal'
 import { Banner } from '../../atoms/Banner'
@@ -56,7 +58,8 @@ const PlaceholderError = ({
     </>
   )
 }
-
+export const RELEASE_NOTES_URL =
+  'https://github.com/Opentrons/opentrons/releases'
 const UPDATE_ERROR = 'Update Error'
 const FOOTER_BUTTON_STYLE = css`
   text-transform: lowercase;
@@ -117,21 +120,33 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   removeActiveAppUpdateToast()
 
   const appUpdateFooter = (
-    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_FLEX_END}>
-      <NewSecondaryBtn
-        onClick={handleRemindMeLaterClick}
-        marginRight={SPACING.spacing8}
-        css={FOOTER_BUTTON_STYLE}
+    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <ExternalLink
+        href={RELEASE_NOTES_URL}
+        css={css`
+          font-size: 0.875rem;
+        `}
+        id="SoftwareUpdateReleaseNotesLink"
+        marginLeft={SPACING.spacing32}
       >
-        {t('remind_later')}
-      </NewSecondaryBtn>
-      <NewPrimaryBtn
-        onClick={() => dispatch(downloadShellUpdate())}
-        marginRight={SPACING.spacing12}
-        css={FOOTER_BUTTON_STYLE}
-      >
-        {t('update_app_now')}
-      </NewPrimaryBtn>
+        {t('release_notes')}
+      </ExternalLink>
+      <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_AROUND}>
+        <NewSecondaryBtn
+          onClick={handleRemindMeLaterClick}
+          marginRight={SPACING.spacing8}
+          css={FOOTER_BUTTON_STYLE}
+        >
+          {t('remind_later')}
+        </NewSecondaryBtn>
+        <NewPrimaryBtn
+          onClick={() => dispatch(downloadShellUpdate())}
+          marginRight={SPACING.spacing12}
+          css={FOOTER_BUTTON_STYLE}
+        >
+          {t('update_app_now')}
+        </NewPrimaryBtn>
+      </Flex>
     </Flex>
   )
 


### PR DESCRIPTION
Closes RQA-1877, RQA-1643

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a bug in the desktop robot update flow in which a user downgrades their app then tries to downgrade the robot. Upon clicking the robot update banner, a user first sees an "update your app modal", which is expected. However, if the user clicks X or "Remind me later", the app crashes. 

### Before 

https://github.com/Opentrons/opentrons/assets/64858653/2d96ce7b-b097-47ea-a79b-cffdf065dc52

### After

https://github.com/Opentrons/opentrons/assets/64858653/1b0e5e69-9265-4772-895b-8da9f0f5a5cd


This PR also adds a new link to the GitHub release page.

<img width="1015" alt="Screenshot 2023-11-07 at 1 06 41 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/47479fc7-a824-4043-a927-80baf514cb80">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

Update flows are always a bit fun to test.

### Release Notes button

- Checkout the TEST_BRANCH_RELEASE_NOTES branch.
- Run the app in dev mode and open the software updates modal.

### Robot Updates
- [Download a built version of the app here. ](https://opentrons.slack.com/archives/C81CR4VCZ/p1699301353028729)
- Follow the flow in the video. 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a bug in which the app crashes when attempting to downgrade a robot and declining a desktop app update.
- Add a Release Notes link in desktop update modals.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low - very shallow update flow changes
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
