### PR TITLE
refactor(app): only show ODD runs loading screen when server returns 503

### DIFF
--- a/app/src/organisms/Devices/__tests__/RecentProtocolRuns.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RecentProtocolRuns.test.tsx
@@ -8,6 +8,7 @@ import { RecentProtocolRuns } from '../RecentProtocolRuns'
 import { HistoricalProtocolRun } from '../HistoricalProtocolRun'
 
 import type { Runs } from '@opentrons/api-client'
+import type { AxiosError } from 'axios'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../hooks')
@@ -57,7 +58,7 @@ describe('RecentProtocolRuns', () => {
     mockUseIsRobotViewable.mockReturnValue(true)
     mockUseAllRunsQuery.mockReturnValue({
       data: {},
-    } as UseQueryResult<Runs, Error>)
+    } as UseQueryResult<Runs, AxiosError>)
     const [{ getByText }] = render()
 
     getByText('No protocol runs yet!')
@@ -76,7 +77,7 @@ describe('RecentProtocolRuns', () => {
           },
         ],
       },
-    } as UseQueryResult<Runs, Error>)
+    } as UseQueryResult<Runs, AxiosError>)
     const [{ getByText }] = render()
     getByText('Recent Protocol Runs')
     getByText('Run')

--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -14,6 +14,7 @@ import { useIsRobotBusy } from '../useIsRobotBusy'
 import { useIsFlex } from '../useIsFlex'
 
 import type { Sessions, Runs } from '@opentrons/api-client'
+import type { AxiosError } from 'axios'
 
 jest.mock('@opentrons/react-api-client')
 jest.mock('../../../ProtocolUpload/hooks')
@@ -49,7 +50,7 @@ describe('useIsRobotBusy', () => {
           current: {},
         },
       },
-    } as UseQueryResult<Runs, Error>)
+    } as UseQueryResult<Runs, AxiosError>)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
     mockUseIsFlex.mockReturnValue(false)
   })

--- a/app/src/pages/OnDeviceDisplay/RobotDashboard/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/RobotDashboard/index.tsx
@@ -58,7 +58,7 @@ export function RobotDashboard(): JSX.Element {
   // GET runs query will error with 503 if database is initializing
   // this should be momentary, and the type of error to come from this endpoint
   // so, all errors will be mapped to an initializing spinner
-  if (allRunsQueryError != null) {
+  if (allRunsQueryError?.code === '503') {
     contents = <ServerInitializing />
   } else if (recentRunsOfUniqueProtocols.length > 0) {
     contents = (

--- a/react-api-client/src/runs/useAllRunsQuery.ts
+++ b/react-api-client/src/runs/useAllRunsQuery.ts
@@ -3,10 +3,11 @@ import { useQuery } from 'react-query'
 import { useHost } from '../api'
 
 import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type { AxiosError } from 'axios'
 
 export type UseAllRunsQueryOptions = UseQueryOptions<
   Runs,
-  Error,
+  AxiosError,
   Runs,
   Array<string | HostConfig>
 >
@@ -15,7 +16,7 @@ export function useAllRunsQuery(
   params: GetRunsParams = {},
   options: UseAllRunsQueryOptions = {},
   hostOverride?: HostConfig | null
-): UseQueryResult<Runs> {
+): UseQueryResult<Runs, AxiosError> {
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
@@ -25,7 +26,12 @@ export function useAllRunsQuery(
   }
   const query = useQuery(
     queryKey,
-    () => getRuns(host as HostConfig, params).then(response => response.data),
+    () =>
+      getRuns(host as HostConfig, params)
+        .then(response => response.data)
+        .catch((e: AxiosError) => {
+          throw e
+        }),
     { enabled: host !== null, ...options }
   )
 


### PR DESCRIPTION
# Overview

We currently show a loading screen on the ODD when the runs endpoint returns any error. We specifically want to only show the loading screen when the endpoint returns a 503.

Partially addresses https://opentrons.atlassian.net/browse/RQA-1872

# Risk assessment

Low