### PR TITLE
fix(api, shared-data, robot-server): stringify all error info in run log

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -618,7 +618,7 @@ class API(
             if any(unsupported):
                 raise UnsupportedHardwareCommand(
                     message=f"At least one axis in {axes} is not supported on the OT2.",
-                    detail={"unsupported_axes": unsupported},
+                    detail={"unsupported_axes": str(unsupported)},
                 )
         self._reset_last_mount()
         # Initialize/update current_position
@@ -661,14 +661,14 @@ class API(
                 raise PositionUnknownError(
                     message=f"Current position of {str(mount)} pipette is unknown,"
                     " please home.",
-                    detail={"mount": str(mount), "missing_axes": position_axes},
+                    detail={"mount": str(mount), "missing_axes": str(position_axes)},
                 )
             axes_str = [ot2_axis_to_string(a) for a in position_axes]
             if not self._backend.is_homed(axes_str):
                 unhomed = self._backend._unhomed_axes(axes_str)
                 raise PositionUnknownError(
                     message=f"{str(mount)} pipette axes ({unhomed}) must be homed.",
-                    detail={"mount": str(mount), "unhomed_axes": unhomed},
+                    detail={"mount": str(mount), "unhomed_axes": str(unhomed)},
                 )
         elif not self._current_position and not refresh:
             raise PositionUnknownError(
@@ -755,7 +755,7 @@ class API(
         """
         raise UnsupportedHardwareCommand(
             message="move_axes is not supported on the OT-2.",
-            detail={"axes_commanded": list(position.keys())},
+            detail={"axes_commanded": str(list(position.keys()))},
         )
 
     async def move_rel(
@@ -781,7 +781,7 @@ class API(
                     " is unknown.",
                     detail={
                         "mount": str(mount),
-                        "fail_on_not_homed": fail_on_not_homed,
+                        "fail_on_not_homed": str(fail_on_not_homed),
                     },
                 )
             else:
@@ -797,7 +797,7 @@ class API(
             unhomed = self._backend._unhomed_axes(axes_str)
             raise PositionUnknownError(
                 message=f"{str(mount)} pipette axes ({unhomed}) must be homed.",
-                detail={"mount": str(mount), "unhomed_axes": unhomed},
+                detail={"mount": str(mount), "unhomed_axes": str(unhomed)},
             )
 
         await self._cache_and_maybe_retract_mount(mount)

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1166,7 +1166,7 @@ class OT3Controller:
                         mount = Axis.to_ot3_mount(node_to_axis(q_msg[0]))
                         raise PipetteOverpressureError(
                             message=msg.format(str(mount)),
-                            detail={"mount": mount},
+                            detail={"mount": str(mount)},
                         )
         else:
             yield

--- a/api/src/opentrons/hardware_control/errors.py
+++ b/api/src/opentrons/hardware_control/errors.py
@@ -25,7 +25,7 @@ class InvalidPipetteName(InvalidInstrumentData):
     def __init__(self, name: int, mount: str) -> None:
         super().__init__(
             message=f"Invalid pipette name key {name} on mount {mount}",
-            detail={"mount": mount, "name": name},
+            detail={"mount": mount, "name": str(name)},
         )
 
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -638,7 +638,7 @@ class PipetteHandlerProvider(Generic[MountType]):
                     message="Cannot push_out on a dispense that does not leave the pipette empty",
                     detail={
                         "command": "dispense",
-                        "remaining-volume": instrument.current_volume - disp_vol,
+                        "remaining-volume": str(instrument.current_volume - disp_vol),
                     },
                 )
             push_out_ul = 0

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -183,16 +183,16 @@ class Gripper(AbstractInstrument[GripperDefinition]):
             raise CommandPreconditionViolated(
                 "Cannot calibrate gripper without attaching a calibration probe",
                 detail={
-                    "probe": self._attached_probe,
-                    "jaw_state": self.state,
+                    "probe": str(self._attached_probe),
+                    "jaw_state": str(self.state),
                 },
             )
         if self.state != GripperJawState.GRIPPING:
             raise CommandPreconditionViolated(
                 "Cannot calibrate gripper if jaw is not in gripping state",
                 detail={
-                    "probe": self._attached_probe,
-                    "jaw_state": self.state,
+                    "probe": str(self._attached_probe),
+                    "jaw_state": str(self.state),
                 },
             )
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -133,7 +133,7 @@ class GripperHandler:
                 message=f"Cannot {command} gripper jaw before homing",
                 detail={
                     "command": command,
-                    "jaw_state": gripper.state,
+                    "jaw_state": str(gripper.state),
                 },
             )
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -597,7 +597,7 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
                 message=f"Liquid class {class_name} is not valid for {self._config.display_name}",
                 detail={
                     "requested-class-name": class_name,
-                    "pipette-model": self._pipette_model,
+                    "pipette-model": str(self._pipette_model),
                 },
             )
         if (

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -613,7 +613,7 @@ class OT3PipetteHandler:
                     message="Cannot push_out on a dispense that does not leave the pipette empty",
                     detail={
                         "command": "dispense",
-                        "remaining-volume": instrument.current_volume - disp_vol,
+                        "remaining-volume": str(instrument.current_volume - disp_vol),
                     },
                 )
             push_out_ul = 0

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -945,7 +945,7 @@ class OT3API(
             raise PositionUnknownError(
                 message=f"Motor positions for {str(mount)} mount are missing ("
                 f"{mount_axes}); must first home motors.",
-                detail={"mount": str(mount), "missing_axes": mount_axes},
+                detail={"mount": str(mount), "missing_axes": str(mount_axes)},
             )
         self._assert_motor_ok(mount_axes)
 

--- a/api/src/opentrons/protocol_runner/json_file_reader.py
+++ b/api/src/opentrons/protocol_runner/json_file_reader.py
@@ -25,7 +25,7 @@ class JsonFileReader:
                 message=f"Cannot execute {name} as a JSON protocol",
                 detail={
                     "kind": "non-json-file-in-json-file-reader",
-                    "metadata-name": protocol_source.metadata.get("name"),
+                    "metadata-name": str(protocol_source.metadata.get("name")),
                     "file-name": protocol_source.main_file.name,
                 },
             )
@@ -40,7 +40,9 @@ class JsonFileReader:
                 message=f"{name} is a JSON protocol v{protocol_source.config.schema_version} which this robot cannot execute",
                 detail={
                     "kind": "schema-version-unknown",
-                    "requested-schema-version": protocol_source.config.schema_version,
+                    "requested-schema-version": str(
+                        protocol_source.config.schema_version
+                    ),
                     "minimum-handled-schema-version": "6",
                     "maximum-handled-shcema-version": "8",
                 },

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -1,4 +1,5 @@
 """Runs' on-db store."""
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
@@ -17,6 +18,8 @@ from robot_server.protocols import ProtocolNotFoundError
 
 from .action_models import RunAction, RunActionType
 from .run_models import RunNotFoundError
+
+log = logging.getLogger(__name__)
 
 _CACHE_ENTRIES = 32
 
@@ -263,6 +266,7 @@ class RunStore:
                 else None
             )
         except ValidationError:
+            log.warn(f"invalid state summary for run ID: {run_id}")
             return None
 
     @lru_cache(maxsize=_CACHE_ENTRIES)

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -265,8 +265,8 @@ class RunStore:
                 if row.state_summary is not None
                 else None
             )
-        except ValidationError:
-            log.warn(f"invalid state summary for run ID: {run_id}")
+        except ValidationError as e:
+            log.warn(f"Error retrieving state summary for {run_id}: {e}")
             return None
 
     @lru_cache(maxsize=_CACHE_ENTRIES)

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -110,7 +110,7 @@ def invalid_state_summary() -> StateSummary:
     analysis_error = pe_errors.ErrorOccurrence.construct(
         id="error-id",
         # Invalid value here should fail analysis
-        createdAt=MountType.LEFT,
+        createdAt=MountType.LEFT,  # type: ignore
         errorType="BadError",
         detail="oh no",
     )
@@ -410,7 +410,7 @@ def test_get_state_summary(subject: RunStore, state_summary: StateSummary) -> No
 def test_get_state_summary_failure(
     subject: RunStore, invalid_state_summary: StateSummary
 ) -> None:
-    """It should return None"""
+    """It should return None."""
     subject.insert(
         run_id="run-id",
         protocol_id=None,

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -104,6 +104,46 @@ def state_summary() -> StateSummary:
     )
 
 
+@pytest.fixture
+def invalid_state_summary() -> StateSummary:
+    """Should fail pydantic validation."""
+    analysis_error = pe_errors.ErrorOccurrence.construct(
+        id="error-id",
+        # Invalid value here should fail analysis
+        createdAt=MountType.LEFT,
+        errorType="BadError",
+        detail="oh no",
+    )
+
+    analysis_labware = pe_types.LoadedLabware(
+        id="labware-id",
+        loadName="load-name",
+        definitionUri="namespace/load-name/42",
+        location=pe_types.DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        offsetId=None,
+    )
+
+    analysis_pipette = pe_types.LoadedPipette(
+        id="pipette-id",
+        pipetteName=PipetteNameType.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+
+    liquids = [Liquid(id="some-id", displayName="water", description="water desc")]
+
+    return StateSummary(
+        errors=[analysis_error],
+        labware=[analysis_labware],
+        pipettes=[analysis_pipette],
+        # TODO(mc, 2022-02-14): evaluate usage of modules in the analysis resp.
+        modules=[],
+        # TODO (tz 22-4-19): added the field to class. make sure what to initialize
+        labwareOffsets=[],
+        status=EngineStatus.IDLE,
+        liquids=liquids,
+    )
+
+
 def test_update_run_state(
     subject: RunStore,
     state_summary: StateSummary,
@@ -365,6 +405,22 @@ def test_get_state_summary(subject: RunStore, state_summary: StateSummary) -> No
     subject.update_run_state(run_id="run-id", summary=state_summary, commands=[])
     result = subject.get_state_summary(run_id="run-id")
     assert result == state_summary
+
+
+def test_get_state_summary_failure(
+    subject: RunStore, invalid_state_summary: StateSummary
+) -> None:
+    """It should return None"""
+    subject.insert(
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+    subject.update_run_state(
+        run_id="run-id", summary=invalid_state_summary, commands=[]
+    )
+    result = subject.get_state_summary(run_id="run-id")
+    assert result is None
 
 
 def test_get_state_summary_none(subject: RunStore) -> None:

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -19,7 +19,7 @@ class EnumeratedError(Exception):
         self,
         code: ErrorCodes,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence["EnumeratedError"]] = None,
     ) -> None:
         """Build an EnumeratedError."""
@@ -61,7 +61,7 @@ class CommunicationError(EnumeratedError):
         self,
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CommunicationError."""
@@ -88,7 +88,7 @@ class RoboticsControlError(EnumeratedError):
         self,
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a RoboticsControlError."""
@@ -116,7 +116,7 @@ class RoboticsInteractionError(EnumeratedError):
         self,
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a RoboticsInteractionError."""
@@ -144,7 +144,7 @@ class GeneralError(EnumeratedError):
         self,
         code: Optional[ErrorCodes] = None,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[Union[EnumeratedError, BaseException]]] = None,
     ) -> None:
         """Build a GeneralError."""
@@ -220,7 +220,7 @@ class RobotInUseError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CanbusCommunicationError."""
@@ -233,7 +233,7 @@ class CanbusCommunicationError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CanbusCommunicationError."""
@@ -248,7 +248,7 @@ class InternalUSBCommunicationError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InternalUSBCommunicationError."""
@@ -263,7 +263,7 @@ class ModuleCommunicationError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CanbusCommunicationError."""
@@ -278,7 +278,7 @@ class CommandTimedOutError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CommandTimedOutError."""
@@ -291,7 +291,7 @@ class FirmwareUpdateFailedError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FirmwareUpdateFailedError."""
@@ -304,7 +304,7 @@ class InternalMessageFormatError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InternalMesasgeFormatError."""
@@ -319,7 +319,7 @@ class CANBusConfigurationError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CANBus Configuration Error."""
@@ -334,7 +334,7 @@ class CANBusBusError(CommunicationError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CANBus Bus Error."""
@@ -347,7 +347,7 @@ class MotionFailedError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a MotionFailedError."""
@@ -360,7 +360,7 @@ class HomingFailedError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a HomingFailedError."""
@@ -373,7 +373,7 @@ class StallOrCollisionDetectedError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a StallOrCollisionDetectedError."""
@@ -388,7 +388,7 @@ class MotionPlanningFailureError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a MotionPlanningFailureError."""
@@ -401,7 +401,7 @@ class PositionEstimationInvalidError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a PositionEstimationFailedError."""
@@ -416,7 +416,7 @@ class MoveConditionNotMetError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a MoveConditionNotMetError."""
@@ -435,7 +435,7 @@ class CalibrationStructureNotFoundError(RoboticsControlError):
         self,
         structure_height: float,
         lower_limit: float,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CalibrationStructureNotFoundError."""
@@ -454,7 +454,7 @@ class EdgeNotFoundError(RoboticsControlError):
         self,
         edge_name: str,
         stride: float,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a EdgeNotFoundError."""
@@ -473,7 +473,7 @@ class EarlyCapacitiveSenseTrigger(RoboticsControlError):
         self,
         found: float,
         nominal: float,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a EarlyCapacitiveSenseTrigger."""
@@ -492,7 +492,7 @@ class InaccurateNonContactSweepError(RoboticsControlError):
         self,
         found: float,
         nominal: float,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a InaccurateNonContactSweepError."""
@@ -513,7 +513,7 @@ class MisalignedGantryError(RoboticsControlError):
 
     def __init__(
         self,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a MisalignedGantryError."""
@@ -534,7 +534,7 @@ class UnmatchedTipPresenceStates(RoboticsControlError):
     def __init__(
         self,
         states: Dict[int, int],
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnmatchedTipPresenceStatesError."""
@@ -562,7 +562,7 @@ class PositionUnknownError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a PositionUnknownError."""
@@ -575,7 +575,7 @@ class ExecutionCancelledError(RoboticsControlError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a ExecutionCancelledError."""
@@ -588,7 +588,7 @@ class LabwareDroppedError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a LabwareDroppedError."""
@@ -601,7 +601,7 @@ class TipPickupFailedError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a TipPickupFailedError."""
@@ -614,7 +614,7 @@ class TipDropFailedError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a TipPickupFailedError."""
@@ -629,7 +629,7 @@ class UnexpectedTipRemovalError(RoboticsInteractionError):
         action: str,
         pipette_name: str,
         mount: str,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnexpectedTipRemovalError."""
@@ -651,7 +651,7 @@ class UnexpectedTipAttachError(RoboticsInteractionError):
         pipette_name: str,
         mount: str,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnexpectedTipAttachError."""
@@ -670,7 +670,7 @@ class FirmwareUpdateRequiredError(RoboticsInteractionError):
         action: str,
         subsystems_to_update: List[Any],
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a FirmwareUpdateRequiredError."""
@@ -687,7 +687,7 @@ class PipetteOverpressureError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an PipetteOverpressureError."""
@@ -700,7 +700,7 @@ class EStopActivatedError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an EStopActivatedError."""
@@ -713,7 +713,7 @@ class EStopNotPresentError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an EStopNotPresentError."""
@@ -726,7 +726,7 @@ class PipetteNotPresentError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an PipetteNotPresentError."""
@@ -739,7 +739,7 @@ class GripperNotPresentError(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a GripperNotPresentError."""
@@ -752,7 +752,7 @@ class InvalidActuator(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InvalidActuator."""
@@ -766,7 +766,7 @@ class ModuleNotPresent(RoboticsInteractionError):
         self,
         identifier: str,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a ModuleNotPresentError."""
@@ -784,7 +784,7 @@ class InvalidInstrumentData(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InvalidInstrumentData."""
@@ -797,7 +797,7 @@ class InvalidLiquidClassName(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InvalidLiquidClassName."""
@@ -812,7 +812,7 @@ class TipDetectorNotFound(RoboticsInteractionError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a TipDetectorNotFound."""
@@ -827,7 +827,7 @@ class APIRemoved(GeneralError):
         api_element: str,
         since_version: str,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an APIRemoved error."""
@@ -849,7 +849,7 @@ class CommandPreconditionViolated(GeneralError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build a CommandPreconditionViolated instance."""
@@ -893,7 +893,7 @@ class UnsupportedHardwareCommand(GeneralError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an UnsupportedHardwareCommand."""
@@ -908,7 +908,7 @@ class InvalidProtocolData(GeneralError):
     def __init__(
         self,
         message: Optional[str] = None,
-        detail: Optional[Dict[str, Any]] = None,
+        detail: Optional[Dict[str, str]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InvalidProtocolData."""


### PR DESCRIPTION


# Overview

The `GET /runs` endpoint was returning a 500 error in some cases as a result of invalid entries in the robot run log. In the specific case of RQA-1872, the cause is a non-string entry in the `errorInfo` dictionary for an error that failed a run. To get _more_ specific, the issue was that the PipetteOverpressureError exception was being created with an info field with a value field that was an instance of `OT3Mount`.

Before this PR, our enumerated errors would accept a dictionary with string keys and _any_ value type. This PR changes the classes to force the dictionary values to be strings. The `ErrorOccurrence` constructor was not performing any validation on its inputs because it was using the `construct` method, and now it doesn't have to worry about that because any exceptions _have_ to use strings.

In addition, this PR adds a catch for `ValidationErrors` when getting the State Summary from the Run Store. It will return None, which is already tolerated by the higher calling functions in the `GET /runs` chain.

# Test Plan

Fail a run with an overpressure error on a robot with current `edge`, then push this branch, and then make sure `GET /runs` doesn't return a 500 error (there should be an empty state summary for the run that failed). 

# Changelog



# Review requests



# Risk assessment

Pretty low, touches error handling that was already broken and stringifies a bunch of error messages.
