### PR TITLE
fix(shared-data): remove requirement for current entry to TipHandlingConfigurations

### DIFF
--- a/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
+++ b/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
@@ -61,7 +61,7 @@
     "tipConfigurations": {
       "type": "object",
       "description": "Object containing configurations specific to tip handling",
-      "required": ["current", "speed"],
+      "required": ["speed"],
       "properties": {
         "presses": {},
         "speed": { "$ref": "#/definitions/editConfigurations" },

--- a/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
+++ b/shared-data/pipette/schemas/2/pipettePropertiesSchema.json
@@ -63,7 +63,6 @@
       "description": "Object containing configurations specific to tip handling",
       "required": ["current", "speed"],
       "properties": {
-        "current": { "$ref": "#/definitions/currentRange" },
         "presses": {},
         "speed": { "$ref": "#/definitions/editConfigurations" },
         "increment": {},

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -146,13 +146,17 @@ class PlungerHomingConfigurations(BaseModel):
     )
     speed: float = Field(
         ...,
-        description="The speed to move the z or plunger axis for tip pickup or drop off.",
+        description="The speed to move the plunger axis for homing.",
     )
 
 
-class TipHandlingConfigurations(PlungerHomingConfigurations):
+class TipHandlingConfigurations(BaseModel):
     presses: int = Field(
         default=0.0, description="The number of tries required to force pick up a tip."
+    )
+    speed: float = Field(
+        ...,
+        description="The speed to move the z or plunger axis for tip pickup or drop off.",
     )
     increment: float = Field(
         default=0.0,

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -142,7 +142,7 @@ class PlungerPositions(BaseModel):
 class PlungerHomingConfigurations(BaseModel):
     current: float = Field(
         default=0.0,
-        description="Either the z motor current needed for picking up tip or the plunger motor current for dropping tip off the nozzle.",
+        description="The current to move the plunger axis for homing.",
     )
     speed: float = Field(
         ...,
@@ -153,6 +153,10 @@ class PlungerHomingConfigurations(BaseModel):
 class TipHandlingConfigurations(BaseModel):
     presses: int = Field(
         default=0.0, description="The number of tries required to force pick up a tip."
+    )
+    current: float = Field(
+        default=0.0,
+        description="The current to use for tip drop-off.",
     )
     speed: float = Field(
         ...,

--- a/shared-data/python/opentrons_shared_data/pipette/scripts/build_json_script.py
+++ b/shared-data/python/opentrons_shared_data/pipette/scripts/build_json_script.py
@@ -40,14 +40,12 @@ def _build_tip_handling_configurations(
     increment = 0
     distance = 0.0
     if tip_handling_type == "pickup" and model_configurations:
-        current = model_configurations["pickUpCurrent"]["value"]
         speed = model_configurations["pickUpSpeed"]["value"]
         presses = model_configurations["pickUpPresses"]["value"]
         increment = int(model_configurations["pickUpIncrement"]["value"])
         distance = model_configurations["pickUpDistance"]["value"]
     elif tip_handling_type == "pickup":
         print("Handling pick up tip configurations\n")
-        current = float(input("please provide the current\n"))
         speed = float(input("please provide the speed\n"))
         presses = int(input("please provide the number of presses for force pick up\n"))
         increment = int(
@@ -59,14 +57,11 @@ def _build_tip_handling_configurations(
             input("please provide the starting distance for pick up tip\n")
         )
     elif tip_handling_type == "drop" and model_configurations:
-        current = model_configurations["dropTipCurrent"]["value"]
         speed = model_configurations["dropTipSpeed"]["value"]
     elif tip_handling_type == "drop":
         print("Handling drop tip configurations\n")
-        current = float(input("please provide the current\n"))
         speed = float(input("please provide the speed\n"))
     return TipHandlingConfigurations(
-        current=current,
         speed=speed,
         presses=presses,
         increment=increment,


### PR DESCRIPTION
The schema has been updated to no longer need a `current` from shared data's `TipHandlingConfigurations`, but the schema and `pipette_definitions` needed a couple of small changes to also allow for that.

I'm working on updating the tests for the schema, but I figure we should get the fix in as soon as possible. 