### PR TITLE
refactor(protocol-designer): remove unneeded loadLabware commands fro…

### DIFF
--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -37,13 +37,7 @@ interface LabwareLocationUpdate {
 export const migrateFile = (
   appData: ProtocolFileV7<DesignerApplicationData>
 ): ProtocolFile => {
-  const {
-    designerApplication,
-    commands,
-    robot,
-    labwareDefinitions,
-    liquids,
-  } = appData
+  const { designerApplication, commands, robot, liquids } = appData
 
   if (designerApplication == null || designerApplication.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
@@ -135,31 +129,6 @@ export const migrateFile = (
     filteredSavedStepForms
   )
 
-  const loadLabwareCommands: LoadLabwareCreateCommand[] = commands
-    .filter(
-      (command): command is LoadLabwareCreateCommand =>
-        command.commandType === 'loadLabware'
-    )
-    .map(command => {
-      //  protocols that do multiple migrations through 7.0.0 have a loadName === definitionURI
-      //  this ternary below fixes that
-      const loadName =
-        labwareDefinitions[command.params.loadName] != null
-          ? labwareDefinitions[command.params.loadName].parameters.loadName
-          : command.params.loadName
-      return {
-        ...command,
-        params: {
-          ...command.params,
-          loadName,
-        },
-      }
-    })
-
-  const migratedCommandsV8 = commands.filter(
-    command => command.commandType !== 'loadLabware'
-  )
-
   const flexDeckSpec: OT3RobotMixin = {
     robot: {
       model: FLEX_ROBOT_TYPE,
@@ -216,11 +185,7 @@ export const migrateFile = (
 
   const commandv8Mixin: CommandV8Mixin = {
     commandSchemaId: 'opentronsCommandSchemaV8',
-    commands: [
-      ...migratedCommandsV8,
-      ...loadLabwareCommands,
-      ...trashLoadCommand,
-    ],
+    commands: [...commands, ...trashLoadCommand],
   }
 
   const commandAnnotionaV1Mixin: CommandAnnotationV1Mixin = {


### PR DESCRIPTION
…m 8_0_0 migration

# Overview

Now that the PD 7.0.1 hot fix is in and merged back into edge, this PR removes the unneeded labwareId changes to `8_0_0` migration because those changes are happening in the `7_0_0` migration

# Test Plan

just review the code 😄 you can test importing a protocol too to see if it works correctly but we have tje cypress migration test that does that as well.

# Changelog

remove the labwareId migration

# Review requests

n/a

# Risk assessment

low
