### PR TITLE
refactor(components): update deck map and deck configurator styling

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/EmptyConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/EmptyConfigFixture.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 
 import {
   getDeckDefFromRobotType,
@@ -71,14 +72,7 @@ export function EmptyConfigFixture(
       flexProps={{ flex: '1' }}
       foreignObjectProps={{ flex: '1' }}
     >
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={COLORS.mediumBlueEnabled}
-        border={`5px dashed ${COLORS.blueEnabled}`}
-        borderRadius={BORDERS.radiusSoftCorners}
-        justifyContent={JUSTIFY_CENTER}
-        width="100%"
-      >
+      <Flex css={EMPTY_CONFIG_STYLE}>
         <Btn
           display={DISPLAY_FLEX}
           justifyContent={JUSTIFY_CENTER}
@@ -90,3 +84,30 @@ export function EmptyConfigFixture(
     </RobotCoordsForeignObject>
   )
 }
+
+const EMPTY_CONFIG_STYLE = css`
+  align-items: ${ALIGN_CENTER};
+  justify-content: ${JUSTIFY_CENTER};
+  background-color: ${COLORS.mediumBlueEnabled};
+  border: 3px dashed ${COLORS.blueEnabled};
+  border-radius: ${BORDERS.radiusSoftCorners};
+  width: 100%;
+
+  &:active {
+    border: 3px solid ${COLORS.blueEnabled};
+    background-color: ${COLORS.mediumBluePressed};
+  }
+
+  &:focus {
+    border: 3px solid ${COLORS.blueEnabled};
+    background-color: ${COLORS.mediumBluePressed};
+  }
+
+  &:hover {
+    background-color: ${COLORS.mediumBluePressed};
+  }
+
+  &:focus-visible {
+    border: 3px solid ${COLORS.fundamentalsFocus};
+  }
+`

--- a/components/src/hardware-sim/DeckConfigurator/StagingAreaConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/StagingAreaConfigFixture.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 
 import {
   getDeckDefFromRobotType,
@@ -64,15 +65,7 @@ export function StagingAreaConfigFixture(
       flexProps={{ flex: '1' }}
       foreignObjectProps={{ flex: '1' }}
     >
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={COLORS.grey2}
-        borderRadius={BORDERS.radiusSoftCorners}
-        color={COLORS.white}
-        gridGap={SPACING.spacing8}
-        justifyContent={JUSTIFY_CENTER}
-        width="100%"
-      >
+      <Flex css={STAGING_AREA_CONFIG_STYLE}>
         <Text css={TYPOGRAPHY.bodyTextSemiBold}>
           {stagingAreaDef.metadata.displayName}
         </Text>
@@ -89,3 +82,25 @@ export function StagingAreaConfigFixture(
     </RobotCoordsForeignObject>
   )
 }
+
+const STAGING_AREA_CONFIG_STYLE = css`
+  align-items: ${ALIGN_CENTER};
+  background-color: ${COLORS.grey2};
+  border-radius: ${BORDERS.borderRadiusSize1};
+  color: ${COLORS.white};
+  grid-gap: ${SPACING.spacing8};
+  justify-content: ${JUSTIFY_CENTER};
+  width: 100%;
+
+  &:active {
+    background-color: ${COLORS.darkBlack90};
+  }
+
+  &:hover {
+    background-color: ${COLORS.grey1};
+  }
+
+  &:focus-visible {
+    border: 3px solid ${COLORS.fundamentalsFocus};
+  }
+`

--- a/components/src/hardware-sim/DeckConfigurator/TrashBinConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/TrashBinConfigFixture.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 
 import {
   getDeckDefFromRobotType,
@@ -70,15 +71,7 @@ export function TrashBinConfigFixture(
       flexProps={{ flex: '1' }}
       foreignObjectProps={{ flex: '1' }}
     >
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={COLORS.grey2}
-        borderRadius={BORDERS.radiusSoftCorners}
-        color={COLORS.white}
-        gridGap={SPACING.spacing8}
-        justifyContent={JUSTIFY_CENTER}
-        width="100%"
-      >
+      <Flex css={TRASH_BIN_CONFIG_STYLE}>
         <Text css={TYPOGRAPHY.bodyTextSemiBold}>
           {trashBinDef.metadata.displayName}
         </Text>
@@ -95,3 +88,24 @@ export function TrashBinConfigFixture(
     </RobotCoordsForeignObject>
   )
 }
+
+const TRASH_BIN_CONFIG_STYLE = css`
+  align-items: ${ALIGN_CENTER};
+  background-color: ${COLORS.grey2};
+  border-radius: ${BORDERS.borderRadiusSize1};
+  color: ${COLORS.white};
+  justify-content: ${JUSTIFY_CENTER};
+  grid-gap: ${SPACING.spacing8};
+  width: 100%;
+
+  &:active {
+    background-color: ${COLORS.darkBlack90};
+  }
+
+  &:hover {
+    background-color: ${COLORS.grey1};
+  }
+
+  &:focus-visible {
+  }
+`

--- a/components/src/hardware-sim/DeckConfigurator/WasteChuteConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/WasteChuteConfigFixture.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 
 import {
   getDeckDefFromRobotType,
@@ -64,15 +65,7 @@ export function WasteChuteConfigFixture(
       flexProps={{ flex: '1' }}
       foreignObjectProps={{ flex: '1' }}
     >
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={COLORS.grey2}
-        borderRadius={BORDERS.radiusSoftCorners}
-        color={COLORS.white}
-        gridGap={SPACING.spacing8}
-        justifyContent={JUSTIFY_CENTER}
-        width="100%"
-      >
+      <Flex css={WASTE_CHUTE_CONFIG_STYLE}>
         <Text css={TYPOGRAPHY.bodyTextSemiBold}>
           {wasteChuteDef.metadata.displayName}
         </Text>
@@ -89,3 +82,25 @@ export function WasteChuteConfigFixture(
     </RobotCoordsForeignObject>
   )
 }
+
+const WASTE_CHUTE_CONFIG_STYLE = css`
+  align-items: ${ALIGN_CENTER};
+  background-color: ${COLORS.grey2};
+  border-radius: ${BORDERS.borderRadiusSize1};
+  color: ${COLORS.white};
+  justify-content: ${JUSTIFY_CENTER};
+  grid-gap: ${SPACING.spacing8};
+  width: 100%;
+
+  &:active {
+    background-color: ${COLORS.darkBlack90};
+  }
+
+  &:hover {
+    background-color: ${COLORS.grey1};
+  }
+
+  &:focus-visible {
+    border: 3px solid ${COLORS.fundamentalsFocus};
+  }
+`


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update deck map and deck configurator styling
Deck map part will be followed by another pr.

design
https://www.figma.com/file/1ot18My22DALIcjdLl5LJh/Helix-Design-System?node-id=358%3A76193&mode=dev
~~I'm asking about the border-radius size to Mel since the size in the design is 3.46px but we don't have it as a radius size const.~~

There are some same styles in waste chute, trash bin, and staging area. I think we can create a common style and share it with them, but we can do it after 7.1.0 and we can have a rule for this kind of case.

close RAUT-773 partially 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Go to Device Details page in Desktop app
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add css to each config fixture component 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
