### PR TITLE
fix(hardware): error details should always be strings

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -319,13 +319,13 @@ class FirmwareUpdateData(FirmwareUpdateWithAddress):
             raise InternalMessageFormatError(
                 f"FirmwareUpdateData: Data address needs to be doubleword aligned."
                 f" {address} mod 8 equals {address % 8} and should be 0",
-                detail={"address": address},
+                detail={"address": str(address)},
             )
         if data_length > FirmwareUpdateDataField.NUM_BYTES:
             raise InternalMessageFormatError(
                 f"FirmwareUpdateData: Data cannot be more than"
                 f" {FirmwareUpdateDataField.NUM_BYTES} bytes got {data_length}.",
-                detail={"size": data_length},
+                detail={"size": str(data_length)},
             )
 
     @classmethod

--- a/hardware/opentrons_hardware/hardware_control/move_group_runner.py
+++ b/hardware/opentrons_hardware/hardware_control/move_group_runner.py
@@ -617,7 +617,7 @@ class MoveScheduler:
                 detail={
                     "missing-nodes": missing_node_msg,
                     "full-timeout": str(full_timeout),
-                    "expected-time": expected_time,
+                    "expected-time": str(expected_time),
                     "elapsed": str(time.time() - start_time),
                 },
             )

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -186,7 +186,7 @@ async def capacitive_probe(
             detail={
                 "tool": tool.name,
                 "sensor": sensor_id.name,
-                "threshold": relative_threshold_pf,
+                "threshold": str(relative_threshold_pf),
             },
         )
     LOG.info(f"starting capacitive probe with threshold {threshold.to_float()}")

--- a/hardware/opentrons_hardware/instruments/gripper/serials.py
+++ b/hardware/opentrons_hardware/instruments/gripper/serials.py
@@ -70,6 +70,6 @@ def gripper_serial_val_from_parts(model: int, serialval: bytes) -> bytes:
     except struct.error as e:
         raise InvalidInstrumentData(
             message="Invalid serial data",
-            detail={"model": model, "serial": serialval},
+            detail={"model": str(model), "serial": str(serialval)},
             wrapping=[PythonException(e)],
         )

--- a/hardware/opentrons_hardware/instruments/pipettes/serials.py
+++ b/hardware/opentrons_hardware/instruments/pipettes/serials.py
@@ -93,6 +93,6 @@ def serial_val_from_parts(name: PipetteName, model: int, serialval: bytes) -> by
     except struct.error as e:
         raise InvalidInstrumentData(
             message="Invalid pipette serial",
-            detail={"name": name, "model": model, "serial": str(serialval)},
+            detail={"name": str(name), "model": str(model), "serial": str(serialval)},
             wrapping=[PythonException(e)],
         )


### PR DESCRIPTION


# Overview

For reasons explained in #13942, python enumerated error details always need to be strings. I forgot to lint through the `hardware` project and missed some, which the linter is (rightfully) failing over.

# Test Plan

n/a 

# Changelog


# Review requests


# Risk assessment

