### PR TITLE
refactor(app): remove console log on release notes component

### DIFF
--- a/app/src/molecules/ReleaseNotes/index.tsx
+++ b/app/src/molecules/ReleaseNotes/index.tsx
@@ -26,7 +26,6 @@ const DEFAULT_RELEASE_NOTES = 'We recommend upgrading to the latest version.'
 export function ReleaseNotes(props: ReleaseNotesProps): JSX.Element {
   const { source } = props
 
-  console.log(DEFAULT_RELEASE_NOTES)
   return (
     <div className={styles.release_notes}>
       {source != null ? (


### PR DESCRIPTION
# Overview

I noticed a bunch of console logs when viewing app + robot release notes in the app. This PR just removes a leftover console log.