### PR TITLE
fix(hardware): let can messenger known what nodes are present

### DIFF
--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -200,6 +200,7 @@ class CanMessenger:
         self._known_nodes: Set[NodeId] = set(_Basic_Nodes.copy())
 
     def update_known_nodes(self, nodes: Set[NodeId]) -> None:
+        """Update present nodes."""
         self._known_nodes = nodes
         log.debug(f"Known nodes have been updated: {self._known_nodes}")
 

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -198,7 +198,7 @@ class CanMessenger:
         self._nonexclusive_access_count = 0
         self._exclusive_lock = asyncio.Lock()
         self._known_nodes: Set[NodeId] = set(_Basic_Nodes.copy())
-    
+
     def update_known_nodes(self, nodes: Set[NodeId]) -> None:
         self._known_nodes = nodes
         log.debug(f"Known nodes have been updated: {self._known_nodes}")

--- a/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
+++ b/hardware/opentrons_hardware/drivers/can_bus/can_messenger.py
@@ -12,6 +12,7 @@ from typing import (
     cast,
     TypeVar,
     Type,
+    Set,
 )
 
 import logging
@@ -83,8 +84,8 @@ class AcknowledgeListener:
         self._timeout = timeout
         self._event = asyncio.Event()
         self._exclusive = exclusive
-        # todo add ability to know how many nodes will ack to a broadcast
-        # we can assume at least 3 for the gantry and head boards
+        # NOTE: 96-channel replies with the same nodes 3 times to broadcast,
+        # right now we consider the responded with the first reply we receive
         self._expected_nodes = expected_nodes
         self._expected_gripper_subnodes = (
             _Gripper_SubNodes.copy() if NodeId.gripper in expected_nodes else []
@@ -196,6 +197,11 @@ class CanMessenger:
         self._held_exclusive = False
         self._nonexclusive_access_count = 0
         self._exclusive_lock = asyncio.Lock()
+        self._known_nodes: Set[NodeId] = set(_Basic_Nodes.copy())
+    
+    def update_known_nodes(self, nodes: Set[NodeId]) -> None:
+        self._known_nodes = nodes
+        log.debug(f"Known nodes have been updated: {self._known_nodes}")
 
     async def send(self, node_id: NodeId, message: MessageDefinition) -> None:
         """Send a message."""
@@ -273,7 +279,8 @@ class CanMessenger:
         if len(expected_nodes) == 0:
             log.warning("Expected Nodes should have been specified")
             if node_id == NodeId.broadcast:
-                expected_nodes = _Basic_Nodes.copy()
+                if not expected_nodes:
+                    expected_nodes = list(self._known_nodes)
             else:
                 expected_nodes = [node_id]
 

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -386,6 +386,7 @@ class CanNetworkInfo:
         finally:
             self._can_messenger.remove_listener(listener)
             self._device_info_cache = nodes
+            self._can_messenger.update_known_nodes(self.nodes)
         return nodes
 
     async def probe_specific(
@@ -440,6 +441,7 @@ class CanNetworkInfo:
                     self._device_info_cache[target] = nodes[target]
                 else:
                     self._device_info_cache.pop(target, None)
+            self._can_messenger.update_known_nodes(self.nodes)
         return nodes
 
     def mark_absent(self, devices: Set[NodeId]) -> Dict[NodeId, DeviceInfoCache]:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When we broadcast a CAN message to all the nodes, we are only expecting the basic nodes (X,Y and head) to respond. But now with network info, we do know what devices are present. So we can send over the known (found) nodes to the can messenger whenever we probe the network so our AckListener can actually wait for all present nodes to respond.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
