### PR TITLE
fix(app): module calibration should only use calibrated pipette

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -105,7 +105,8 @@ export function InstrumentsAndModules({
     attachedPipettes?.left ?? null
   )
   const attachPipetteRequired =
-    attachedLeftPipette == null && attachedRightPipette == null
+    attachedLeftPipette?.data?.calibratedOffset?.last_modified == null &&
+    attachedRightPipette?.data?.calibratedOffset?.last_modified == null
   const updatePipetteFWRequired =
     badLeftPipette != null || badRightPipette != null
 

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -60,7 +60,11 @@ export const ModuleWizardFlows = (
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('module_wizard_flows')
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
-  const attachedPipette = attachedPipettes.left ?? attachedPipettes.right
+  const attachedPipette =
+    attachedPipettes.left?.data.calibratedOffset?.last_modified != null
+      ? attachedPipettes.left
+      : attachedPipettes.right
+
   const moduleCalibrationSteps = getModuleCalibrationSteps()
   const availableSlotNames =
     FLEX_SLOT_NAMES_BY_MOD_TYPE[getModuleType(attachedModule.moduleModel)] ?? []
@@ -193,7 +197,11 @@ export const ModuleWizardFlows = (
         continuePastCommandFailure
       )
   }
-  if (currentStep == null || attachedPipette == null) return null
+  if (
+    currentStep == null ||
+    attachedPipette?.data.calibratedOffset?.last_modified == null
+  )
+    return null
 
   const maintenanceRunId =
     maintenanceRunData?.data.id != null &&


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We should not allow users to calibrate modules unless an attached pipette is calibrated. We should ensure a pipette has calibration data before selecting that as the pipette to use for module calibration.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. From both run setup and the module card, ensure the calibrate module CTA is disabled if no attached pipette is calibrated
2. Check that if two pipettes are attached but only the right pipette is calibrated, the right pipette is be used for module calibration.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Check for pipette calibration data before selecting a pipette to use for module calibration
2. Disable module card overflow menu calibrate button if no pipette has calibration data
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Run through the test plan
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
