### PR TITLE
fix(app): fix step meter tearing by using no animation

### DIFF
--- a/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
+++ b/app/src/atoms/StepMeter/__tests__/StepMeter.test.tsx
@@ -51,4 +51,21 @@ describe('StepMeter', () => {
     const bar = getByTestId('StepMeter_StepMeterBar')
     expect(bar).toHaveStyle('width: 100%')
   })
+
+  it('should transition with style when progressing forward and no style if progressing backward', () => {
+    props = {
+      ...props,
+      currentStep: 2,
+    }
+    const { getByTestId } = render(props)
+    getByTestId('StepMeter_StepMeterContainer')
+    const bar = getByTestId('StepMeter_StepMeterBar')
+    expect(bar).toHaveStyle('transition: width 0.5s ease-in-out;')
+
+    props = {
+      ...props,
+      currentStep: 1,
+    }
+    expect(bar).not.toHaveStyle('transition: ;')
+  })
 })

--- a/app/src/atoms/StepMeter/index.tsx
+++ b/app/src/atoms/StepMeter/index.tsx
@@ -16,13 +16,13 @@ interface StepMeterProps {
 
 export const StepMeter = (props: StepMeterProps): JSX.Element => {
   const { totalSteps, currentStep } = props
+  const prevPercentComplete = React.useRef(0)
   const progress = currentStep != null ? currentStep : 0
-  const percentComplete = `${
+  const percentComplete =
     //    this logic puts a cap at 100% percentComplete which we should never run into
     currentStep != null && currentStep > totalSteps
       ? 100
       : (progress / totalSteps) * 100
-  }%`
 
   const StepMeterContainer = css`
     position: ${POSITION_RELATIVE};
@@ -45,10 +45,14 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
     top: 0;
     height: 100%;
     background-color: ${COLORS.blueEnabled};
-    width: ${percentComplete};
+    width: ${percentComplete}%;
     transform: translateX(0);
-    transition: width 0.5s ease-in-out;
+    transition: ${prevPercentComplete.current <= percentComplete
+      ? 'width 0.5s ease-in-out'
+      : ''};
   `
+
+  prevPercentComplete.current = percentComplete
 
   return (
     <Box data-testid="StepMeter_StepMeterContainer" css={StepMeterContainer}>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

ODD optimizations do not prevent step meter tearing on the physical ODD when step progress regresses. After talking with Design, we will play no animation solves the problem until we optimize ODD animations.

### No Progress Animation When Pressing "Go Back"

https://github.com/Opentrons/opentrons/assets/64858653/b00926b5-18c8-440b-bd38-2e71de4d59a1
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Launch any flow and confirm the behavior shown in the video.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
