### PR TITLE
chore(app-shell): Fix internal release updates

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -230,7 +230,7 @@ jobs:
              echo "Configuring project, bucket, and folder for ot3"
              echo "project=ot3" >> $GITHUB_OUTPUT
              echo "bucket=${{env._APP_DEPLOY_BUCKET_OT3}}" >> $GITHUB_OUTPUT
-             echo "folder=${{env._APP_DEPLOY_BUCKET_OT3}}" >> $GITHUB_OUTPUT
+             echo "folder=${{env._APP_DEPLOY_FOLDER_OT3}}" >> $GITHUB_OUTPUT
           fi
       - uses: 'actions/checkout@v3'
         with:


### PR DESCRIPTION
Since ac0304a5c61462c2c31174308f88eed5404cfda8 we were not properly setting the folder-part of the app update flow in internal-releases which meant the app couldn't update.

## Testing
- Download the built app and see if the logs say it's looking at the right place

Closes RQA-1882
