### PR TITLE
refactor(shared-data): update movable trash offset from cutout fixture

### DIFF
--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -252,7 +252,7 @@
       {
         "id": "movableTrashD1",
         "areaType": "movableTrash",
-        "offsetFromCutoutFixture": [-17.0, -2.75, 0.0],
+        "offsetFromCutoutFixture": [-101.5, -2.75, 0.0],
         "boundingBox": {
           "xDimension": 246.5,
           "yDimension": 91.5,
@@ -265,7 +265,7 @@
       {
         "id": "movableTrashC1",
         "areaType": "movableTrash",
-        "offsetFromCutoutFixture": [-17.0, -2.75, 0.0],
+        "offsetFromCutoutFixture": [-101.5, -2.75, 0.0],
         "boundingBox": {
           "xDimension": 246.5,
           "yDimension": 91.5,
@@ -278,7 +278,7 @@
       {
         "id": "movableTrashB1",
         "areaType": "movableTrash",
-        "offsetFromCutoutFixture": [-17.0, -2.75, 0.0],
+        "offsetFromCutoutFixture": [-101.5, -2.75, 0.0],
         "boundingBox": {
           "xDimension": 246.5,
           "yDimension": 91.5,
@@ -291,7 +291,7 @@
       {
         "id": "movableTrashA1",
         "areaType": "movableTrash",
-        "offsetFromCutoutFixture": [-17.0, -2.75, 0.0],
+        "offsetFromCutoutFixture": [-101.5, -2.75, 0.0],
         "boundingBox": {
           "xDimension": 246.5,
           "yDimension": 91.5,


### PR DESCRIPTION
# Overview

Fixes the offset from cutout fixture for movable trash addressable areas in the left most slots

Changes to the deck schema will follow soon which will necessitate updating these offset vectors again
