### PR TITLE
fix(app): fix protocol slideout whitescreen 

### DIFF
--- a/app/src/molecules/DeckThumbnail/__tests__/DeckThumbnail.test.tsx
+++ b/app/src/molecules/DeckThumbnail/__tests__/DeckThumbnail.test.tsx
@@ -188,6 +188,21 @@ describe('DeckThumbnail', () => {
     getByText('mock BaseDeck')
   })
 
+  it('returns null when there is no protocolAnalysis or the protocolAnalysis contains an error', () => {
+    const { queryByText } = render({
+      protocolAnalysis: null,
+    })
+    expect(queryByText('mock BaseDeck')).not.toBeInTheDocument()
+
+    render({
+      protocolAnalysis: {
+        ...protocolAnalysis,
+        errors: 'test error',
+      },
+    })
+    expect(queryByText('mock BaseDeck')).not.toBeInTheDocument()
+  })
+
   it('renders an OT-3 deck view when the protocol is an OT-3 protocol', () => {
     // ToDo (kk:11/06/2023) update this test later
     // const mockLabwareLocations = [

--- a/app/src/molecules/DeckThumbnail/index.tsx
+++ b/app/src/molecules/DeckThumbnail/index.tsx
@@ -35,7 +35,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element | null {
   const { protocolAnalysis, showSlotLabels = false, ...styleProps } = props
   const attachedModules = useAttachedModules()
 
-  if (protocolAnalysis == null) return null
+  if (protocolAnalysis == null || protocolAnalysis.errors.length) return null
 
   const robotType = getRobotTypeFromLoadedLabware(protocolAnalysis.labware)
   const deckDef = getDeckDefFromRobotType(robotType)

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -163,7 +163,6 @@ export function ChooseProtocolSlideoutComponent(
           }}
           robotName={robot.name}
           {...{ selectedProtocol, runCreationError, runCreationErrorCode }}
-          protocolAnalysis={selectedProtocol?.mostRecentAnalysis}
         />
       ) : null}
     </Slideout>
@@ -192,7 +191,6 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
     runCreationError,
     runCreationErrorCode,
     robotName,
-    protocolAnalysis,
   } = props
   const { t } = useTranslation(['device_details', 'shared'])
   const storedProtocols = useSelector((state: State) =>
@@ -227,8 +225,10 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                     height="4.25rem"
                     width="4.75rem"
                   >
-                    {protocolAnalysis != null ? (
-                      <DeckThumbnail protocolAnalysis={protocolAnalysis} />
+                    {storedProtocol.mostRecentAnalysis != null ? (
+                      <DeckThumbnail
+                        protocolAnalysis={storedProtocol.mostRecentAnalysis}
+                      />
                     ) : null}
                   </Box>
                   <StyledText

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -36,7 +36,6 @@ import { useCreateRunFromProtocol } from '../ChooseRobotToRunProtocolSlideout/us
 import { ApplyHistoricOffsets } from '../ApplyHistoricOffsets'
 import { useOffsetCandidatesForAnalysis } from '../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 
-import { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { Robot } from '../../redux/discovery/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
@@ -181,7 +180,6 @@ interface StoredProtocolListProps {
   runCreationError: string | null
   runCreationErrorCode: number | null
   robotName: string
-  protocolAnalysis?: ProtocolAnalysisOutput | null
 }
 
 function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {


### PR DESCRIPTION
Closes RQA-1887, RQA-1888

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes two issues related to ProtocolSlideout. 

First, the deck map of the currently selected protocol was accidentally passed to every protocol card, causing all the deck maps to render the currently selected card. 

Second, after the large refactor of the DeckThumbnail and related components, we did not update the error handling logic for protocols that failed protocol analysis. Selecting a protocol that fails analysis will cause an attempt to render the protocol's  deck map, causing the whitescreen - this PR adds updated error handling.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/626a5a91-352d-4a7f-b470-cac8f2eb4a6c

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/05c93b21-15ca-4838-a06b-5b5ee258aa43


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Check expected behavior by following the video!
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed bugs related to protocol slideout.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
