### PR TITLE
ci(labware-library): add build timeout of 30 minutes

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -116,6 +116,7 @@ jobs:
   build-ll:
     name: 'build labware library artifact'
     needs: ['js-unit-test']
+    timeout-minutes: 30
     runs-on: 'ubuntu-20.04'
     if: github.event_name != 'pull_request'
     steps:


### PR DESCRIPTION
# Overview

LL builds sometimes hang and cause CI to hold onto runners for hours for no reason. builds should not take longer than 30 mins, and if they do, something bad probably happened and the action would need to be re triggered anyways. 