### PR TITLE
fix(app): fix device reset selector behavior in ODD

### DIFF
--- a/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
@@ -158,6 +158,8 @@ export function DeviceReset({
     dispatch(fetchResetConfigOptions(robotName))
   }, [dispatch, robotName])
 
+  console.log('resetOptions', resetOptions)
+
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       {showConfirmationModal && (
@@ -193,6 +195,7 @@ export function DeviceReset({
                     setResetOptions({
                       ...resetOptions,
                       [option.id]: !(resetOptions[option.id] ?? false),
+                      clearAllStoredData: isEveryOptionSelected,
                     })
                   }
                 />
@@ -231,7 +234,7 @@ export function DeviceReset({
             value="clearAllStoredData"
             onChange={() => {
               setResetOptions(
-                Boolean(resetOptions.clearAllStoredData)
+                isEveryOptionSelected
                   ? {}
                   : availableOptions.reduce(
                       (acc, val) => {

--- a/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
@@ -29,6 +29,7 @@ import type { Dispatch, State } from '../../redux/types'
 import type { ResetConfigRequest } from '../../redux/robot-admin/types'
 import type { SetSettingOption } from '../../pages/OnDeviceDisplay/RobotSettingsDashboard'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
+import e from 'express'
 
 interface LabelProps {
   isSelected?: boolean
@@ -141,6 +142,18 @@ export function DeviceReset({
       subText,
     }
   }
+
+  const totalOptionsSelected = Object.values(resetOptions).filter(
+    selected => selected === true
+  ).length
+
+  const allOptionsWithoutODD =
+    options != null ? options.filter(o => o.id !== 'onDeviceDisplay') : []
+
+  const isEveryOptionSelected =
+    totalOptionsSelected > 0 &&
+    totalOptionsSelected === allOptionsWithoutODD.length
+
   React.useEffect(() => {
     dispatch(fetchResetConfigOptions(robotName))
   }, [dispatch, robotName])
@@ -234,7 +247,7 @@ export function DeviceReset({
           />
           <OptionLabel
             htmlFor="clearAllStoredData"
-            isSelected={resetOptions.clearAllStoredData}
+            isSelected={isEveryOptionSelected}
           >
             <Flex flexDirection={DIRECTION_COLUMN}>
               <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
@@ -243,9 +256,7 @@ export function DeviceReset({
               <StyledText
                 as="p"
                 color={
-                  resetOptions.clearAllStoredData === true
-                    ? COLORS.white
-                    : COLORS.darkBlack70
+                  isEveryOptionSelected ? COLORS.white : COLORS.darkBlack70
                 }
               >
                 {t('clear_all_stored_data_description')}

--- a/app/src/organisms/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
@@ -115,4 +115,6 @@ describe('DeviceReset', () => {
       mockResetConfig('mockRobot', clearMockResetOptions)
     )
   })
+
+  it('when removing an option after tapping clear all stored data, clearAllStoredData and authorizedKeys are false', () => {})
 })


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR aligns selector behavior in ODD with the selector behavior in Desktop app.

close RQA-1891
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Go to Robot Settings Dashboard
2. Go to Device Reset
3. Tap Clear all stored data
4. Tap an option except (clear all store data)
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
