### PR TITLE
chore: update update-from-usb fake release notes

### DIFF
--- a/app-shell-odd/src/system-update/index.ts
+++ b/app-shell-odd/src/system-update/index.ts
@@ -213,6 +213,8 @@ const fakeReleaseNotesForMassStorage = (version: string): string => `
 # Opentrons Robot Software Version ${version}
 
 This update is from a USB mass storage device connected to your flex, and release notes cannot be shown.
+
+Don't remove the USB mass storage device while the update is in progress.
 `
 
 export const getLatestMassStorageUpdateFiles = (

--- a/app-shell-odd/src/system-update/index.ts
+++ b/app-shell-odd/src/system-update/index.ts
@@ -212,7 +212,7 @@ const getVersionFromZipIfValid = (path: string): Promise<FileDetails> =>
 const fakeReleaseNotesForMassStorage = (version: string): string => `
 # Opentrons Robot Software Version ${version}
 
-This update is from a USB mass storage device connected to your flex, and release notes cannot be shown.
+This update is from a USB mass storage device connected to your Flex, and release notes cannot be shown.
 
 Don't remove the USB mass storage device while the update is in progress.
 `


### PR DESCRIPTION
Add a note to not remove the USB drive while an update from it is in progress.