### PR TITLE
fix(app): do not require probe presence on 96

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
@@ -78,6 +78,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     (instrument): instrument is PipetteData =>
       instrument.ok && instrument.mount === pipetteMount
   )
+  const is96Channel = attachedPipette?.data.channels === 96
 
   React.useEffect(() => {
     // move into correct position for probe attach on mount
@@ -103,7 +104,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     setIsPending(true)
     refetch()
       .then(() => {
-        if (attachedPipette?.state?.tipDetected) {
+        if (is96Channel || attachedPipette?.state?.tipDetected) {
           chainRunCommands(
             [
               { commandType: 'home', params: { axes: [pipetteZMotorAxis] } },

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -81,7 +81,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     setIsPending(true)
     refetch()
       .then(() => {
-        if (attachedPipette?.state?.tipDetected) {
+        if (is96Channel || attachedPipette?.state?.tipDetected) {
           chainRunCommands?.(
             [
               {


### PR DESCRIPTION
The 96 channel pipette is not capable of continuously checking for the presence of a tip (or indeed a calibration probe). It needs to run a special routing, exposed through ot3api.get_tip_presence_status() or ot3api.verify_tip_presence(), to check for a tip. This happens automatically in most of the places we use tips - aka inside other protocol engine commands - but it does not happen automatically and all the time.

This is usually fine, but when we're doing calibration we do it through a protocol engine maintenance run where the way we interact with the robot is dispatching PE commands - and we don't ever dispatch a PE command that implicitly causes a tip check. That means that the 96 can't be relied on to get the presence of a tip.

The long term fix for this is to add a checkTipPresence command to the engine, at least as a maintenance command; in the short term, we can disable the presence check for 96 channel pipettes to unblock testing.

## Testing
- Run the following on a 96 channel and check that it doesn't block you from proceeding because a probe isn't attached:
  - [x] pipette calibration on desktop
  - [x] LPC on desktop
  - [x] pipette calibration on ODD
  - [x] LPC on ODD
- Run the following on a low-throughput pipette and check that it still does block you from proceeding because a probe isn't attached
  - [x] pipette calibration on desktop
  - [x] LPC on desktop
  - [x] pipette calibration on ODD
  - [x] LPC on ODD

Closes RQA-1892
