### PR TITLE
 fix(protocol-designer): adapter/labware combo split migration

### DIFF
--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -50,16 +50,24 @@ export const migrateFile = (
     const loadName =
       labwareDefinitions[labwareEntity.definitionId].parameters.loadName
 
-    return (
-      loadName === 'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep' ||
-      loadName ===
-        'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat' ||
-      loadName ===
-        'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt' ||
-      loadName ===
-        'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat' ||
-      loadName === 'opentrons_96_aluminumblock_biorad_wellplate_200ul' ||
-      loadName === 'opentrons_96_aluminumblock_nest_wellplate_100ul'
+    const adapterLoadNames = [
+      'opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep',
+      'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat',
+      'opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt',
+      'opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat',
+      'opentrons_96_aluminumblock_biorad_wellplate_200ul',
+      'opentrons_96_aluminumblock_nest_wellplate_100ul',
+    ]
+    console.log(
+      loadName === 'opentrons_96_aluminumblock_biorad_wellplate_200ul'
+        ? 'loadname in adapter loadname'
+        : null,
+      loadName,
+      adapterLoadNames.includes(loadName)
+    )
+
+    return labwareId.includes(
+      'opentrons_96_aluminumblock_biorad_wellplate_200ul'
     )
   }
 
@@ -152,6 +160,7 @@ export const migrateFile = (
   const newLabwareDefinitions: LabwareDefinitionsByUri = Object.keys(
     labwareDefinitions
   ).reduce((acc: LabwareDefinitionsByUri, defId: string) => {
+    //  !defId.includes('opentrons_96_aluminumblock_biorad_wellplate_200ul')
     if (!getIsAdapter(defId)) {
       acc[defId] = labwareDefinitions[defId]
     } else {

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -196,6 +196,8 @@ export const migrateFile = (
       const labwareDef = allLatestDefs[labwareUri]
       acc[adapterUri] = adapterLabwareDef
       acc[labwareUri] = labwareDef
+    } else {
+      acc[defId] = labwareDefinitions[defId]
     }
     return acc
   }, {})
@@ -339,7 +341,7 @@ export const migrateFile = (
         }
         if (newDispenseLabwareDefinition == null) {
           console.error(
-            `expected to find aspirate labware definition with labwareId ${dispenseLabware} but could not`
+            `expected to find dispense labware definition with labwareId ${dispenseLabware} but could not`
           )
         }
         const dispenseTouchTipIncompatible = newDispenseLabwareDefinition?.parameters.quirks?.includes(
@@ -380,7 +382,7 @@ export const migrateFile = (
 
         if (newMixLabwareDefinition == null) {
           console.error(
-            `expected to find aspirate labware definition with labwareId ${mixLabware} but could not`
+            `expected to find mix labware definition with labwareId ${mixLabware} but could not`
           )
         }
 

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -344,7 +344,7 @@ export const migrateFile = (
           mixLabwareDefinition = newLabwareDefinitions[labwareUri]
           mixLabware = labwaresMapped[stepForm.labware][0]
         }
-        const mixTouchTipIncompatible = mixLabware?.parameters.quirks?.includes(
+        const mixTouchTipIncompatible = mixLabwareDefinition?.parameters.quirks?.includes(
           'touchTipDisabled'
         )
         return {

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -66,9 +66,7 @@ export const migrateFile = (
       adapterLoadNames.includes(loadName)
     )
 
-    return labwareId.includes(
-      'opentrons_96_aluminumblock_biorad_wellplate_200ul'
-    )
+    return adapterLoadNames.includes(loadName)
   }
 
   const loadPipetteCommands: LoadPipetteCreateCommand[] = commands

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -3,8 +3,7 @@ import { uuid } from '../../utils'
 import { getOnlyLatestDefs } from '../../labware-defs'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../constants'
 import { getAdapterAndLabwareSplitInfo } from './utils/getAdapterAndLabwareSplitInfo'
-import {
-  getLabwareDefURI,
+import type {
   LabwareDefinition2,
   LabwareDefinitionsByUri,
   ProtocolFileV6,
@@ -197,8 +196,6 @@ export const migrateFile = (
       const labwareDef = allLatestDefs[labwareUri]
       acc[adapterUri] = adapterLabwareDef
       acc[labwareUri] = labwareDef
-    } else {
-      acc[defId] = labwareDefinitions[defId]
     }
     return acc
   }, {})

--- a/protocol-designer/src/load-file/migration/utils/getAdapterAndLabwareSplitInfo.ts
+++ b/protocol-designer/src/load-file/migration/utils/getAdapterAndLabwareSplitInfo.ts
@@ -54,8 +54,8 @@ export const getAdapterAndLabwareSplitInfo = (
     labwareId.includes('opentrons_96_aluminumblock_biorad_wellplate_200ul')
   ) {
     return {
-      labwareUri: 'opentrons/opentrons_96_well_aluminum_block/1',
-      adapterUri: 'opentrons/biorad_96_wellplate_200ul_pcr/2',
+      adapterUri: 'opentrons/opentrons_96_well_aluminum_block/1',
+      labwareUri: 'opentrons/biorad_96_wellplate_200ul_pcr/2',
       labwareDisplayName: 'Bio-Rad 96 Well Plate 200 µL PCR',
       adapterDisplayName: 'Opentrons 96 Well Aluminum Block',
     }


### PR DESCRIPTION
closes RESC-169

# Overview

This PR fixes the adapter/labware combo split white screening where the migrations into the split labware was not happening correctly. 

# Test Plan

Check the 3 protocols mentioned in the ticket. See that they import properly and that the pipetting steps and liquids get populated correctly.

# Changelog

- map the labware ids to a new id and then follow that map for the liquids and step forms. 
- fix labware defintiion migration and `getIsAdapter` clean up

# Review requests

see test plan

# Risk assessment

low-ish, this will turn into another PD hot fix but QA will test the release candidate