### PR TITLE
app(fix): Connect to Wifi Network via USB

### DIFF
--- a/app/src/molecules/modals/ErrorModal.tsx
+++ b/app/src/molecules/modals/ErrorModal.tsx
@@ -11,7 +11,7 @@ interface Props {
   description: string
   close?: () => unknown
   closeUrl?: string
-  error: { message?: string; [key: string]: unknown }
+  error: { message?: string; [key: string]: unknown } | null
 }
 
 const DEFAULT_HEADING = 'Unexpected Error'
@@ -37,7 +37,7 @@ export function ErrorModal(props: Props): JSX.Element {
     <Portal>
       <AlertModal heading={heading} buttons={[closeButtonProps]} alertOverlay>
         <p className={styles.error_modal_message}>
-          {error.message ?? AN_UNKNOWN_ERROR_OCCURRED}
+          {error?.message ?? AN_UNKNOWN_ERROR_OCCURRED}
         </p>
         <p>{description}</p>
         <p>

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ResultModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ResultModal.tsx
@@ -1,25 +1,28 @@
 import * as React from 'react'
 
 import { AlertModal, SpinnerModal } from '@opentrons/components'
+
+import * as Copy from './i18n'
 import { ErrorModal } from '../../../../molecules/modals'
 import { DISCONNECT } from './constants'
-import * as Copy from './i18n'
+import { PENDING, SUCCESS, FAILURE } from '../../../../redux/robot-api'
 
 import type { NetworkChangeType } from './types'
+import type { RequestStatus } from '../../../../redux/robot-api/types'
 
 export interface ResultModalProps {
   type: NetworkChangeType
   ssid: string | null
-  isPending: boolean
+  requestStatus: RequestStatus
   error: { message?: string; [key: string]: unknown } | null
   onClose: () => unknown
 }
 
 export const ResultModal = (props: ResultModalProps): JSX.Element => {
-  const { type, ssid, isPending, error, onClose } = props
+  const { type, ssid, requestStatus, error, onClose } = props
   const isDisconnect = type === DISCONNECT
 
-  if (isPending) {
+  if (requestStatus === PENDING) {
     const message = isDisconnect
       ? Copy.DISCONNECTING_FROM_NETWORK(ssid)
       : Copy.CONNECTING_TO_NETWORK(ssid)
@@ -27,7 +30,7 @@ export const ResultModal = (props: ResultModalProps): JSX.Element => {
     return <SpinnerModal alertOverlay message={message} />
   }
 
-  if (error) {
+  if (error || requestStatus === FAILURE) {
     const heading = isDisconnect
       ? Copy.UNABLE_TO_DISCONNECT
       : Copy.UNABLE_TO_CONNECT

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ResultModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/ResultModal.tsx
@@ -5,7 +5,7 @@ import { AlertModal, SpinnerModal } from '@opentrons/components'
 import * as Copy from './i18n'
 import { ErrorModal } from '../../../../molecules/modals'
 import { DISCONNECT } from './constants'
-import { PENDING, SUCCESS, FAILURE } from '../../../../redux/robot-api'
+import { PENDING, FAILURE } from '../../../../redux/robot-api'
 
 import type { NetworkChangeType } from './types'
 import type { RequestStatus } from '../../../../redux/robot-api/types'
@@ -41,11 +41,15 @@ export const ResultModal = (props: ResultModalProps): JSX.Element => {
 
     const retryMessage = !isDisconnect ? ` ${Copy.CHECK_YOUR_CREDENTIALS}.` : ''
 
+    const placeholderError = {
+      message: `Likely incorrect network password. ${Copy.CHECK_YOUR_CREDENTIALS}.`,
+    }
+
     return (
       <ErrorModal
         heading={heading}
         description={`${message}.${retryMessage}`}
-        error={error}
+        error={error ?? placeholderError}
         close={onClose}
       />
     )

--- a/app/src/organisms/Devices/RobotSettings/ConnectNetwork/__tests__/ResultModal.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/ConnectNetwork/__tests__/ResultModal.test.tsx
@@ -5,6 +5,7 @@ import { AlertModal, SpinnerModal } from '@opentrons/components'
 import { ErrorModal } from '../../../../../molecules/modals'
 import { ResultModal } from '../ResultModal'
 import { DISCONNECT, CONNECT, JOIN_OTHER } from '../constants'
+import { PENDING, FAILURE, SUCCESS } from '../../../../../redux/robot-api'
 
 import type { ShallowWrapper } from 'enzyme'
 import type { ResultModalProps } from '../ResultModal'
@@ -31,7 +32,7 @@ describe("SelectNetwork's ResultModal", () => {
             type,
             ssid,
             error: null,
-            isPending: true,
+            requestStatus: PENDING,
             onClose: handleClose,
           }}
         />
@@ -99,7 +100,7 @@ describe("SelectNetwork's ResultModal", () => {
             type,
             ssid,
             error: null,
-            isPending: false,
+            requestStatus: SUCCESS,
             onClose: handleClose,
           }}
         />
@@ -188,7 +189,7 @@ describe("SelectNetwork's ResultModal", () => {
             type,
             ssid,
             error,
-            isPending: false,
+            requestStatus: FAILURE,
             onClose: handleClose,
           }}
         />
@@ -248,6 +249,42 @@ describe("SelectNetwork's ResultModal", () => {
       )
       expect(alert.prop('close')).toEqual(handleClose)
       expect(alert.prop('error')).toEqual(error)
+    })
+
+    it('displays an ErrorModal with appropriate failure message if the status is failure and no error message is given', () => {
+      const render: (
+        type: ResultModalProps['type'],
+        ssid?: ResultModalProps['ssid']
+      ) => ShallowWrapper<React.ComponentProps<typeof ResultModal>> = (
+        type,
+        ssid = mockSsid
+      ) => {
+        return shallow(
+          <ResultModal
+            {...{
+              type,
+              ssid,
+              error: null,
+              requestStatus: FAILURE,
+              onClose: handleClose,
+            }}
+          />
+        )
+      }
+
+      const wrapper = render(JOIN_OTHER, null)
+      const alert = wrapper.find(ErrorModal)
+
+      expect(alert).toHaveLength(1)
+      expect(alert.prop('heading')).toEqual('Unable to connect to Wi-Fi')
+      expect(alert.prop('description')).toEqual(
+        expect.stringContaining('unable to connect to Wi-Fi')
+      )
+      expect(alert.prop('close')).toEqual(handleClose)
+      expect(alert.prop('error')).toEqual({
+        message:
+          'Likely incorrect network password. Please double-check your network credentials.',
+      })
     })
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/SelectNetwork.tsx
+++ b/app/src/organisms/Devices/RobotSettings/SelectNetwork.tsx
@@ -104,7 +104,7 @@ export const SelectNetwork = ({
             <ResultModal
               type={changeState.type}
               ssid={changeState.ssid}
-              isPending={requestState.status === RobotApi.PENDING}
+              requestStatus={requestState.status}
               error={
                 'error' in requestState &&
                 requestState.error != null &&

--- a/app/src/organisms/Devices/RobotSettings/__tests__/SelectNetwork.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/SelectNetwork.test.tsx
@@ -17,9 +17,10 @@ import { ConnectModal } from '../ConnectNetwork/ConnectModal'
 import { ResultModal } from '../ConnectNetwork/ResultModal'
 
 import { SelectNetwork } from '../SelectNetwork'
+import { RequestState } from '../../../../redux/robot-api/types'
+import { PENDING, SUCCESS, FAILURE } from '../../../../redux/robot-api'
 
 import type { ReactWrapper } from 'enzyme'
-import { RequestState } from '../../../../redux/robot-api/types'
 
 jest.mock('../../../../resources/networking/hooks')
 jest.mock('../../../../redux/networking/selectors')
@@ -260,7 +261,7 @@ describe('<TemporarySelectNetwork />', () => {
         expect(resultModal.props()).toEqual({
           type: Constants.CONNECT,
           ssid: mockConfigure.ssid,
-          isPending: true,
+          requestStatus: PENDING,
           error: null,
           onClose: expect.any(Function),
         })
@@ -278,7 +279,7 @@ describe('<TemporarySelectNetwork />', () => {
         expect(resultModal.props()).toEqual({
           type: Constants.CONNECT,
           ssid: mockConfigure.ssid,
-          isPending: false,
+          requestStatus: SUCCESS,
           error: null,
           onClose: expect.any(Function),
         })
@@ -307,7 +308,7 @@ describe('<TemporarySelectNetwork />', () => {
         expect(resultModal.props()).toEqual({
           type: Constants.CONNECT,
           ssid: mockConfigure.ssid,
-          isPending: false,
+          requestStatus: FAILURE,
           error: { message: 'oh no!' },
           onClose: expect.any(Function),
         })

--- a/app/src/redux/robot-api/http.ts
+++ b/app/src/redux/robot-api/http.ts
@@ -60,6 +60,7 @@ export function fetchRobotApi(
           headers: options.headers,
           method,
           url,
+          data: options.body,
         })
       ).pipe(
         map(response => ({


### PR DESCRIPTION
Closes RQA-1777, RQA-1781

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a bug when attempting to connect to a wifi network via USB connection only - a success modal would immediately appear upon entering any password. Wifi form data was not properly passed to the appshellrequestor, yielding a POST request with a null body. This fix solves a few minor undocumented USB bugs as well concerning system time syncing and deck configuration sessions. 

Additionally, the Wifi error modal error handling did not accurately account for all instances that could throw an error (such as this bug). In addition to checking if the response contains an error object, let's also check the error response yielding "failure." This PR also adds more meaningful default error handling text for Wifi connectivity issues.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/99505e41-e045-4015-9439-3d5f9059fe12


### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/60414a54-ba73-4d35-8fae-325986e01794

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Connect to a robot that is only connected to a network via USB.
- Connect to a wifi network.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix connecting to a Wifi network via USB.
- Add more robust error handling for Wifi network connectivity. 

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low - there are only a few minor places that make use of fetchRobotApi and send data along with the request. These should be the only places affected. 

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
