### PR TITLE
fix(api): Aspirate, dispense, and mix can perform at 0ul

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -165,7 +165,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-aspirate` for more details and examples.
 
-        :param volume: The volume to aspirate, measured in µL. If 0 or unspecified,
+        :param volume: The volume to aspirate, measured in µL. If unspecified,
                     defaults to the maximum volume for the pipette and its currently
                     attached tip.
         :type volume: int or float
@@ -277,7 +277,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-dispense` for more details and examples.
 
-        :param volume: The volume to dispense, measured in µL. If 0 or unspecified,
+        :param volume: The volume to dispense, measured in µL. If unspecified,
                        defaults to :py:attr:`current_volume`. If only a volume is
                        passed, the pipette will dispense from its current position.
         :type volume: int or float
@@ -411,7 +411,7 @@ class InstrumentContext(publisher.CommandPublisher):
         See :ref:`mix` for examples.
 
         :param repetitions: Number of times to mix (default is 1).
-        :param volume: The volume to mix, measured in µL. If 0 or unspecified, defaults
+        :param volume: The volume to mix, measured in µL. If unspecified, defaults
                        to the maximum volume for the pipette and its attached tip.
         :param location: The :py:class:`.Well` or :py:class:`~.types.Location` where the
                         pipette will mix. If unspecified, the pipette will mix at its

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -168,6 +168,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param volume: The volume to aspirate, measured in µL. If unspecified,
                     defaults to the maximum volume for the pipette and its currently
                     attached tip.
+
+                    If ``aspirate`` is called with a volume of precisely 0, its behavior
+                    depends on the API level of the protocol. On API levels below 2.16,
+                    it will behave the same as a volume of ``None``/unspecified: aspirate
+                    until the pipette is full. On API levels at or above 2.16, no liquid
+                    will be aspirated.
         :type volume: int or float
         :param location: Tells the robot where to aspirate from. The location can be
                          a :py:class:`.Well` or a :py:class:`.Location`.
@@ -263,7 +269,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         return self
 
-    @requires_version(2, 0)
+    @requires_version(2, 0)  # noqa: C901
     def dispense(
         self,
         volume: Optional[float] = None,
@@ -279,6 +285,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param volume: The volume to dispense, measured in µL. If unspecified,
                        defaults to :py:attr:`current_volume`. If only a volume is
                        passed, the pipette will dispense from its current position.
+
+                       If ``dispense`` is called with a volume of precisely 0, its behavior
+                       depends on the API level of the protocol. On API levels below 2.16,
+                       it will behave the same as a volume of ``None``/unspecified: dispense
+                       all liquid in the pipette. On API levels at or above 2.16, no liquid
+                       will be dispensed.
         :type volume: int or float
 
         :param location: Tells the robot where to dispense liquid held in the pipette.
@@ -411,6 +423,12 @@ class InstrumentContext(publisher.CommandPublisher):
         :param repetitions: Number of times to mix (default is 1).
         :param volume: The volume to mix, measured in µL. If unspecified, defaults
                        to the maximum volume for the pipette and its attached tip.
+
+                       If ``mix`` is called with a volume of precisely 0, its behavior
+                       depends on the API level of the protocol. On API levels below 2.16,
+                       it will behave the same as a volume of ``None``/unspecified: mix
+                       the full working volume of the pipette. On API levels at or above 2.16,
+                       no liquid will be mixed.
         :param location: The :py:class:`.Well` or :py:class:`~.types.Location` where the
                         pipette will mix. If unspecified, the pipette will mix at its
                         current position.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -236,7 +236,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 reject_adapter=self.api_version >= APIVersion(2, 15),
             )
 
-        c_vol = self._core.get_available_volume() if not volume else volume
+        c_vol = self._core.get_available_volume() if volume is None else volume
         flow_rate = self._core.get_aspirate_flow_rate(rate)
 
         with publisher.publish_context(
@@ -363,7 +363,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 reject_adapter=self.api_version >= APIVersion(2, 15),
             )
 
-        c_vol = self._core.get_current_volume() if not volume else volume
+        c_vol = self._core.get_current_volume() if volume is None else volume
 
         flow_rate = self._core.get_dispense_flow_rate(rate)
 
@@ -433,7 +433,7 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("mix", self.name, self.mount)
 
-        c_vol = self._core.get_available_volume() if not volume else volume
+        c_vol = self._core.get_available_volume() if volume is None else volume
 
         with publisher.publish_context(
             broker=self.broker,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -236,7 +236,11 @@ class InstrumentContext(publisher.CommandPublisher):
                 reject_adapter=self.api_version >= APIVersion(2, 15),
             )
 
-        c_vol = self._core.get_available_volume() if volume is None else volume
+        if self.api_version >= APIVersion(2, 16):
+            assume_volume = bool(volume is None)
+        else:
+            assume_volume = bool(not volume)
+        c_vol = self._core.get_available_volume() if assume_volume else volume
         flow_rate = self._core.get_aspirate_flow_rate(rate)
 
         with publisher.publish_context(
@@ -363,7 +367,11 @@ class InstrumentContext(publisher.CommandPublisher):
                 reject_adapter=self.api_version >= APIVersion(2, 15),
             )
 
-        c_vol = self._core.get_current_volume() if volume is None else volume
+        if self.api_version >= APIVersion(2, 16):
+            assume_volume = bool(volume is None)
+        else:
+            assume_volume = bool(not volume)
+        c_vol = self._core.get_current_volume() if assume_volume else volume
 
         flow_rate = self._core.get_dispense_flow_rate(rate)
 
@@ -433,7 +441,11 @@ class InstrumentContext(publisher.CommandPublisher):
         if not self._core.has_tip():
             raise UnexpectedTipRemovalError("mix", self.name, self.mount)
 
-        c_vol = self._core.get_available_volume() if volume is None else volume
+        if self.api_version >= APIVersion(2, 16):
+            assume_volume = bool(volume is None)
+        else:
+            assume_volume = bool(not volume)
+        c_vol = self._core.get_available_volume() if assume_volume else volume
 
         with publisher.publish_context(
             broker=self.broker,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -237,10 +237,9 @@ class InstrumentContext(publisher.CommandPublisher):
             )
 
         if self.api_version >= APIVersion(2, 16):
-            assume_volume = bool(volume is None)
+            c_vol = self._core.get_available_volume() if volume is None else volume
         else:
-            assume_volume = bool(not volume)
-        c_vol = self._core.get_available_volume() if assume_volume else volume
+            c_vol = self._core.get_available_volume() if not volume else volume
         flow_rate = self._core.get_aspirate_flow_rate(rate)
 
         with publisher.publish_context(
@@ -368,10 +367,9 @@ class InstrumentContext(publisher.CommandPublisher):
             )
 
         if self.api_version >= APIVersion(2, 16):
-            assume_volume = bool(volume is None)
+            c_vol = self._core.get_current_volume() if volume is None else volume
         else:
-            assume_volume = bool(not volume)
-        c_vol = self._core.get_current_volume() if assume_volume else volume
+            c_vol = self._core.get_current_volume() if not volume else volume
 
         flow_rate = self._core.get_dispense_flow_rate(rate)
 
@@ -442,10 +440,9 @@ class InstrumentContext(publisher.CommandPublisher):
             raise UnexpectedTipRemovalError("mix", self.name, self.mount)
 
         if self.api_version >= APIVersion(2, 16):
-            assume_volume = bool(volume is None)
+            c_vol = self._core.get_available_volume() if volume is None else volume
         else:
-            assume_volume = bool(not volume)
-        c_vol = self._core.get_available_volume() if assume_volume else volume
+            c_vol = self._core.get_available_volume() if not volume else volume
 
         with publisher.publish_context(
             broker=self.broker,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

I would expect `.aspirate(0)` and `.dispense(0)` to aspirate/dispense 0 ul.

Currently `.aspirate(0)` will aspirate the tip's max-volume, and `.dispense(0)` will dispense all volume currently in the tip.

Looking in git history and this line was added in instrument_context.py in 2020, where the `if not volume` is used to determine if the volume should be defaulted:

```python
c_vol = self._core.get_available_volume() if not volume else volume
```

I'm assuming this behavior wasn't intentional.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
