### PR TITLE
docs(api): make `|apiLevel|` substitution a string constant

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -96,13 +96,10 @@ release = _vers
 # setup the code block substitution extension to auto-update apiLevel
 extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 
-# get the max API level
-from opentrons.protocol_api import MAX_SUPPORTED_VERSION  # noqa
-max_apiLevel = str(MAX_SUPPORTED_VERSION)
-
 # use rst_prolog to hold the subsitution
+# update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: {max_apiLevel}
+.. |apiLevel| replace:: 2.15
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -17,7 +17,7 @@ Protocols and Instruments
 
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:
-   :exclude-members: delay
+   :exclude-members: delay, configure_nozzle_layout, prepare_to_aspirate
 
 .. autoclass:: opentrons.protocol_api.Liquid
 


### PR DESCRIPTION

# Overview

Make the `|apiLevel|` substitution used throughout the Python API docs a string constant, rather than dynamically using `MAX_SUPPORTED_VERSION`. This prevents the situation where a docs deployment after some pre-release features have been merged to `edge` would update code snippets across the docs site, making them unusable (without modification) in the current production release.

Speaking of such features, this PR also hides a couple of them in the API Reference so we don't have to use the docs hotfix procedure to deploy this.

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-apilevel-constant/v2/)
- Check that `|apiLevel|` is properly being substituted with `2.15`.
- Check that nothing pre-release or otherwise unusable is included in the API Reference. 

# Changelog

- set `apiLevel` to a constant value in conf.py
- excluded methods in autoclass

# Review requests

Do we need to add an inline to-do to remove the API Reference exclusions later? Or are we content to track that elsewhere?

# Risk assessment

v low, docs only.