### PR TITLE
feat(robot-server): Add robotType to analysis results

### DIFF
--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -145,10 +145,16 @@ class AnalyzeResults(BaseModel):
     See robot-server's analysis models for field documentation.
     """
 
+    # We want to unify this local analysis model with the one that robot-server returns.
+    # Until that happens, we need to keep these fields in sync manually.
+
+    # Fields that are currently unique to this local analysis module, missing from robot-server:
     createdAt: datetime
     files: List[ProtocolFile]
     config: Union[JsonConfig, PythonConfig]
     metadata: Dict[str, Any]
+
+    # Fields that should match robot-server:
     robotType: RobotType
     commands: List[Command]
     labware: List[LoadedLabware]

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -1,8 +1,9 @@
 """Response models for protocol analysis."""
 # TODO(mc, 2021-08-25): add modules to simulation result
 from enum import Enum
+from opentrons_shared_data.robot.dev_types import RobotType
 from pydantic import BaseModel, Field
-from typing import List, Union
+from typing import List, Optional, Union
 from typing_extensions import Literal
 
 from opentrons.protocol_engine import (
@@ -90,6 +91,17 @@ class CompletedAnalysis(BaseModel):
     )
 
     # Fields that should match local analysis:
+    robotType: Optional[RobotType] = Field(
+        # robotType is deliberately typed as a Literal instead of an Enum.
+        # It's a bad idea at the moment to store enums in robot-server's database.
+        # https://opentrons.atlassian.net/browse/RSS-98
+        default=None,  # default=None to fit objects that were stored before this field existed.
+        description=(
+            "The type of robot that this protocol can run on."
+            " This field was added in v7.1.0. It will be `null` or omitted"
+            " in analyses that were originally created on older versions."
+        ),
+    )
     commands: List[Command] = Field(
         ...,
         description="The protocol commands the run is expected to produce",

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -75,6 +75,10 @@ class CompletedAnalysis(BaseModel):
         JSON protocols are currently deterministic by design.
     """
 
+    # We want to unify this HTTP-facing analysis model with the one that local analysis returns.
+    # Until that happens, we need to keep these fields in sync manually.
+
+    # Fields that are currently unique to robot-server, missing from local analysis:
     id: str = Field(..., description="Unique identifier of this analysis resource")
     status: Literal[AnalysisStatus.COMPLETED] = Field(
         AnalysisStatus.COMPLETED,
@@ -84,9 +88,11 @@ class CompletedAnalysis(BaseModel):
         ...,
         description="Whether the protocol is expected to run successfully",
     )
-    pipettes: List[LoadedPipette] = Field(
+
+    # Fields that should match local analysis:
+    commands: List[Command] = Field(
         ...,
-        description="Pipettes used by the protocol",
+        description="The protocol commands the run is expected to produce",
     )
     labware: List[LoadedLabware] = Field(
         ...,
@@ -98,13 +104,17 @@ class CompletedAnalysis(BaseModel):
             " not its *initial* location."
         ),
     )
+    pipettes: List[LoadedPipette] = Field(
+        ...,
+        description="Pipettes used by the protocol",
+    )
     modules: List[LoadedModule] = Field(
         default_factory=list,
         description="Modules that have been loaded into the run.",
     )
-    commands: List[Command] = Field(
-        ...,
-        description="The protocol commands the run is expected to produce",
+    liquids: List[Liquid] = Field(
+        default_factory=list,
+        description="Liquids used by the protocol",
     )
     errors: List[ErrorOccurrence] = Field(
         ...,
@@ -113,10 +123,6 @@ class CompletedAnalysis(BaseModel):
             " For historical reasons, this is an array,"
             " but it won't have more than one element."
         ),
-    )
-    liquids: List[Liquid] = Field(
-        default_factory=list,
-        description="Liquids used by the protocol",
     )
 
 

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from logging import getLogger
 from typing import Dict, List, Optional
 from typing_extensions import Final
+from opentrons_shared_data.robot.dev_types import RobotType
 
 import sqlalchemy
 
@@ -120,6 +121,7 @@ class AnalysisStore:
     async def update(
         self,
         analysis_id: str,
+        robot_type: RobotType,
         commands: List[Command],
         labware: List[LoadedLabware],
         modules: List[LoadedModule],
@@ -132,6 +134,7 @@ class AnalysisStore:
         Args:
             analysis_id: The ID of the analysis to promote.
                 Must point to a valid pending analysis.
+            robot_type: See `CompletedAnalysis.robotType`.
             commands: See `CompletedAnalysis.commands`.
             labware: See `CompletedAnalysis.labware`.
             modules: See `CompletedAnalysis.modules`.
@@ -156,6 +159,7 @@ class AnalysisStore:
         completed_analysis = CompletedAnalysis.construct(
             id=analysis_id,
             result=result,
+            robotType=robot_type,
             commands=commands,
             labware=labware,
             modules=modules,

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -36,6 +36,7 @@ class ProtocolAnalyzer:
 
         await self._analysis_store.update(
             analysis_id=analysis_id,
+            robot_type=protocol_resource.source.robot_type,
             commands=result.commands,
             labware=result.state_summary.labware,
             modules=result.state_summary.modules,

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -68,7 +68,7 @@ stages:
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
-        links: 
+        links:
           referencingRuns: []
   - name: Get protocol analysis by ID
     request:
@@ -84,6 +84,7 @@ stages:
           - id: '{analysis_id}'
             status: completed
             result: ok
+            robotType: OT-2 Standard
             pipettes:
               - id: pipetteId
                 pipetteName: p10_single
@@ -131,8 +132,8 @@ stages:
                 commandType: home
                 key: !anystr
                 status: succeeded
-                params: { }
-                result: { }
+                params: {}
+                result: {}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -68,7 +68,7 @@ stages:
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
-        links:
+        links: 
           referencingRuns: []
   - name: Get protocol analysis by ID
     request:
@@ -132,8 +132,8 @@ stages:
                 commandType: home
                 key: !anystr
                 status: succeeded
-                params: {}
-                result: {}
+                params: { }
+                result: { }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
@@ -69,7 +69,7 @@ stages:
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
-        links:
+        links: 
           referencingRuns: []
   - name: Get protocol analysis by ID
     request:
@@ -133,8 +133,8 @@ stages:
                 commandType: home
                 key: !anystr
                 status: succeeded
-                params: {}
-                result: {}
+                params: { }
+                result: { }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -430,7 +430,8 @@ stages:
                   forceDirect: false
                   speed: 12.3
                 result:
-                  position: { 'x': 350.205, 'y': 65.115, 'z': 98.25 }
+                  position:
+                    { 'x': 350.205, 'y': 65.115, 'z': 98.25 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -451,7 +452,8 @@ stages:
                   minimumZHeight: 35.0
                   forceDirect: true
                 result:
-                  position: { 'x': 352.205, 'y': 68.115, 'z': 93.3 }
+                  position:
+                    { 'x': 352.205, 'y': 68.115, 'z': 93.3 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
@@ -69,7 +69,7 @@ stages:
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
-        links: 
+        links:
           referencingRuns: []
   - name: Get protocol analysis by ID
     request:
@@ -85,6 +85,7 @@ stages:
           - id: '{analysis_id}'
             status: completed
             result: ok
+            robotType: OT-3 Standard
             pipettes:
               - id: pipetteId
                 pipetteName: p1000_96
@@ -132,8 +133,8 @@ stages:
                 commandType: home
                 key: !anystr
                 status: succeeded
-                params: { }
-                result: { }
+                params: {}
+                result: {}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -429,8 +430,7 @@ stages:
                   forceDirect: false
                   speed: 12.3
                 result:
-                  position:
-                    { 'x': 350.205, 'y': 65.115, 'z': 98.25 }
+                  position: { 'x': 350.205, 'y': 65.115, 'z': 98.25 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -451,8 +451,7 @@ stages:
                   minimumZHeight: 35.0
                   forceDirect: true
                 result:
-                  position:
-                    { 'x': 352.205, 'y': 68.115, 'z': 93.3 }
+                  position: { 'x': 352.205, 'y': 68.115, 'z': 93.3 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
@@ -68,7 +68,7 @@ stages:
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
-        links:
+        links: 
           referencingRuns: []
   - name: Get protocol analysis by ID
     request:
@@ -132,8 +132,8 @@ stages:
                 commandType: home
                 key: !anystr
                 status: succeeded
-                params: {}
-                result: {}
+                params: { }
+                result: { }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -318,12 +318,7 @@ stages:
                   volume: 5.0
                   flowRate: 3.0
                 result:
-                  position:
-                    {
-                      'x': 12.930000000000001,
-                      'y': 74.08999999999999,
-                      'z': 83.14,
-                    }
+                  position: { 'x': 12.930000000000001, 'y': 74.08999999999999, 'z': 83.14 }
                   volume: 5.0
                 startedAt: !anystr
                 completedAt: !anystr
@@ -412,7 +407,7 @@ stages:
                     z: 100.0
                   forceDirect: false
                 result:
-                  position: { 'x': 100.0, 'y': 100.0, 'z': 100.0 }
+                  position: {'x': 100.0, 'y': 100.0, 'z': 100.0}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -432,7 +427,8 @@ stages:
                       z: 0
                   forceDirect: false
                 result:
-                  position: { 'x': 289.805, 'y': 65.115, 'z': 98.25 }
+                  position:
+                    { 'x': 289.805, 'y': 65.115, 'z': 98.25 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -453,7 +449,8 @@ stages:
                   minimumZHeight: 35.0
                   forceDirect: true
                 result:
-                  position: { 'x': 291.805, 'y': 68.115, 'z': 93.3 }
+                  position:
+                    { 'x': 291.805, 'y': 68.115, 'z': 93.3 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
@@ -68,7 +68,7 @@ stages:
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
-        links: 
+        links:
           referencingRuns: []
   - name: Get protocol analysis by ID
     request:
@@ -84,6 +84,7 @@ stages:
           - id: '{analysis_id}'
             status: completed
             result: ok
+            robotType: OT-2 Standard
             pipettes:
               - id: pipetteId
                 pipetteName: p10_single
@@ -131,8 +132,8 @@ stages:
                 commandType: home
                 key: !anystr
                 status: succeeded
-                params: { }
-                result: { }
+                params: {}
+                result: {}
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -317,7 +318,12 @@ stages:
                   volume: 5.0
                   flowRate: 3.0
                 result:
-                  position: { 'x': 12.930000000000001, 'y': 74.08999999999999, 'z': 83.14 }
+                  position:
+                    {
+                      'x': 12.930000000000001,
+                      'y': 74.08999999999999,
+                      'z': 83.14,
+                    }
                   volume: 5.0
                 startedAt: !anystr
                 completedAt: !anystr
@@ -406,7 +412,7 @@ stages:
                     z: 100.0
                   forceDirect: false
                 result:
-                  position: {'x': 100.0, 'y': 100.0, 'z': 100.0}
+                  position: { 'x': 100.0, 'y': 100.0, 'z': 100.0 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -426,8 +432,7 @@ stages:
                       z: 0
                   forceDirect: false
                 result:
-                  position:
-                    { 'x': 289.805, 'y': 65.115, 'z': 98.25 }
+                  position: { 'x': 289.805, 'y': 65.115, 'z': 98.25 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr
@@ -448,8 +453,7 @@ stages:
                   minimumZHeight: 35.0
                   forceDirect: true
                 result:
-                  position:
-                    { 'x': 291.805, 'y': 68.115, 'z': 93.3 }
+                  position: { 'x': 291.805, 'y': 68.115, 'z': 93.3 }
                 startedAt: !anystr
                 completedAt: !anystr
               - id: !anystr

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -126,6 +126,7 @@ async def test_returned_in_order_added(
         subject.add_pending(protocol_id="protocol-id", analysis_id=analysis_id)
         await subject.update(
             analysis_id=analysis_id,
+            robot_type="OT-2 Standard",
             labware=[],
             modules=[],
             pipettes=[],
@@ -173,6 +174,7 @@ async def test_update_adds_details_and_completes_analysis(
     subject.add_pending(protocol_id="protocol-id", analysis_id="analysis-id")
     await subject.update(
         analysis_id="analysis-id",
+        robot_type="OT-2 Standard",
         labware=[labware],
         pipettes=[pipette],
         # TODO(mm, 2022-10-21): Give the subject some commands, errors, and liquids here
@@ -189,6 +191,7 @@ async def test_update_adds_details_and_completes_analysis(
     assert result == CompletedAnalysis(
         id="analysis-id",
         result=AnalysisResult.OK,
+        robotType="OT-2 Standard",
         labware=[labware],
         pipettes=[pipette],
         modules=[],
@@ -201,6 +204,7 @@ async def test_update_adds_details_and_completes_analysis(
         "id": "analysis-id",
         "result": "ok",
         "status": "completed",
+        "robotType": "OT-2 Standard",
         "labware": [
             {
                 "id": "labware-id",
@@ -270,6 +274,7 @@ async def test_update_infers_status_from_errors(
     subject.add_pending(protocol_id="protocol-id", analysis_id="analysis-id")
     await subject.update(
         analysis_id="analysis-id",
+        robot_type="OT-2 Standard",
         commands=commands,
         errors=errors,
         labware=[],

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -53,6 +53,8 @@ async def test_analyze(
     subject: ProtocolAnalyzer,
 ) -> None:
     """It should be able to analyze a protocol."""
+    robot_type = "OT-3 Standard"
+
     protocol_resource = ProtocolResource(
         protocol_id="protocol-id",
         created_at=datetime(year=2021, month=1, day=1),
@@ -62,7 +64,7 @@ async def test_analyze(
             config=JsonProtocolConfig(schema_version=123),
             files=[],
             metadata={},
-            robot_type="OT-3 Standard",
+            robot_type=robot_type,
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
@@ -101,7 +103,7 @@ async def test_analyze(
 
     decoy.when(
         await protocol_runner.create_simulating_runner(
-            robot_type="OT-3 Standard",
+            robot_type=robot_type,
             protocol_config=JsonProtocolConfig(schema_version=123),
         )
     ).then_return(json_runner)
@@ -130,6 +132,7 @@ async def test_analyze(
     decoy.verify(
         await analysis_store.update(
             analysis_id="analysis-id",
+            robot_type=robot_type,
             commands=[analysis_command],
             labware=[analysis_labware],
             modules=[],

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -4,6 +4,7 @@ from decoy import Decoy
 from datetime import datetime
 from pathlib import Path
 
+from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
 from opentrons.types import MountType, DeckSlotName
@@ -53,7 +54,7 @@ async def test_analyze(
     subject: ProtocolAnalyzer,
 ) -> None:
     """It should be able to analyze a protocol."""
-    robot_type = "OT-3 Standard"
+    robot_type: RobotType = "OT-3 Standard"
 
     protocol_resource = ProtocolResource(
         protocol_id="protocol-id",


### PR DESCRIPTION
# Overview

Closes RSS-401.

# Test Plan

I reckon our automated integration tests are sufficient for this.

# Changelog

* Make robot-server return a protocol's `robotType` from `GET /protocols/{id}/{analyses}` and `GET /protocols/{id}/analyses/{id}`.
* Add some comments to mitigate further drift between local analysis and robot-server analysis.

# Review requests

* Is this the expected API?

# Risk assessment

Low.