### PR TITLE
fix(app): fix device reset option selector issues

### DIFF
--- a/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
@@ -52,8 +52,6 @@ interface DeviceResetProps {
   setCurrentOption: SetSettingOption
 }
 
-// ToDo (kk:08/30/2023) lines that are related to module calibration will be activated when the be is ready.
-// The tests for that will be added.
 export function DeviceReset({
   robotName,
   setCurrentOption,
@@ -86,20 +84,25 @@ export function DeviceReset({
     ({ id }) => !['authorizedKeys'].includes(id)
   )
 
+  const isEveryOptionSelected = (obj: ResetConfigRequest): boolean => {
+    const requiredTrueKeys = [
+      'pipetteOffsetCalibrations',
+      'gripperOffsetCalibrations',
+      'moduleCalibration',
+      'runsHistory',
+    ]
+    for (const key of requiredTrueKeys) {
+      if (obj != null && !obj[key]) {
+        return false
+      }
+    }
+    return true
+  }
+
   const handleClick = (): void => {
     if (resetOptions != null) {
-      // remove clearAllStoredData since its not a setting on the backend
-      const { clearAllStoredData, ...serverResetOptions } = resetOptions
-      if (Boolean(clearAllStoredData)) {
-        dispatchRequest(
-          resetConfig(robotName, {
-            ...serverResetOptions,
-            onDeviceDisplay: true,
-          })
-        )
-      } else {
-        dispatchRequest(resetConfig(robotName, serverResetOptions))
-      }
+      const { ...serverResetOptions } = resetOptions
+      dispatchRequest(resetConfig(robotName, serverResetOptions))
     }
   }
 
@@ -144,6 +147,33 @@ export function DeviceReset({
   React.useEffect(() => {
     dispatch(fetchResetConfigOptions(robotName))
   }, [dispatch, robotName])
+
+  React.useEffect(() => {
+    if (
+      isEveryOptionSelected(resetOptions) &&
+      (!resetOptions.authorizedKeys || !resetOptions.onDeviceDisplay)
+    ) {
+      setResetOptions({
+        ...resetOptions,
+        authorizedKeys: true,
+        onDeviceDisplay: true,
+      })
+    }
+  }, [resetOptions])
+
+  React.useEffect(() => {
+    if (
+      !isEveryOptionSelected(resetOptions) &&
+      resetOptions.authorizedKeys &&
+      resetOptions.onDeviceDisplay
+    ) {
+      setResetOptions({
+        ...resetOptions,
+        authorizedKeys: false,
+        onDeviceDisplay: false,
+      })
+    }
+  }, [resetOptions])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
@@ -218,7 +248,8 @@ export function DeviceReset({
             value="clearAllStoredData"
             onChange={() => {
               setResetOptions(
-                Boolean(resetOptions.clearAllStoredData)
+                (resetOptions.authorizedKeys ?? false) &&
+                  (resetOptions.onDeviceDisplay ?? false)
                   ? {}
                   : availableOptions.reduce(
                       (acc, val) => {
@@ -227,14 +258,18 @@ export function DeviceReset({
                           [val.id]: true,
                         }
                       },
-                      { clearAllStoredData: true }
+                      { authorizedKeys: true, onDeviceDisplay: true }
                     )
               )
             }}
           />
           <OptionLabel
             htmlFor="clearAllStoredData"
-            isSelected={resetOptions.clearAllStoredData}
+            isSelected={
+              ((resetOptions.authorizedKeys ?? false) &&
+                (resetOptions.onDeviceDisplay ?? false)) ||
+              isEveryOptionSelected(resetOptions)
+            }
           >
             <Flex flexDirection={DIRECTION_COLUMN}>
               <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
@@ -243,7 +278,9 @@ export function DeviceReset({
               <StyledText
                 as="p"
                 color={
-                  resetOptions.clearAllStoredData === true
+                  ((resetOptions.authorizedKeys ?? false) &&
+                    (resetOptions.onDeviceDisplay ?? false)) ||
+                  isEveryOptionSelected(resetOptions)
                     ? COLORS.white
                     : COLORS.darkBlack70
                 }

--- a/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
@@ -85,13 +85,7 @@ export function DeviceReset({
   )
 
   const isEveryOptionSelected = (obj: ResetConfigRequest): boolean => {
-    const requiredTrueKeys = [
-      'pipetteOffsetCalibrations',
-      'gripperOffsetCalibrations',
-      'moduleCalibration',
-      'runsHistory',
-    ]
-    for (const key of requiredTrueKeys) {
+    for (const key of targetOptionsOrder) {
       if (obj != null && !obj[key]) {
         return false
       }

--- a/app/src/organisms/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
@@ -87,6 +87,10 @@ describe('DeviceReset', () => {
     getByText('Clear module calibration')
     getByText('Clear protocol run history')
     getByText('Clears information about past runs of all protocols.')
+    getByText('Clear all stored data')
+    getByText(
+      'Resets all settings. You’ll have to redo initial setup before using the robot again.'
+    )
     expect(queryByText('Clear the ssh authorized keys')).not.toBeInTheDocument()
     expect(getByTestId('DeviceReset_clear_data_button')).toBeDisabled()
   })
@@ -107,6 +111,73 @@ describe('DeviceReset', () => {
     fireEvent.click(getByText('Clear pipette calibration'))
     fireEvent.click(getByText('Clear protocol run history'))
     fireEvent.click(getByText('Clear module calibration'))
+    const clearButton = getByText('Clear data and restart robot')
+    fireEvent.click(clearButton)
+    getByText('Are you sure you want to reset your device?')
+    fireEvent.click(getByText('Confirm'))
+    expect(dispatchApiRequest).toBeCalledWith(
+      mockResetConfig('mockRobot', clearMockResetOptions)
+    )
+  })
+
+  it('when tapping clear all stored data, all options are active', () => {
+    const clearMockResetOptions = {
+      pipetteOffsetCalibrations: true,
+      moduleCalibration: true,
+      runsHistory: true,
+      gripperOffsetCalibrations: true,
+      authorizedKeys: true,
+      onDeviceDisplay: true,
+    }
+
+    const [{ getByText }] = render(props)
+    getByText('Clear all stored data').click()
+    const clearButton = getByText('Clear data and restart robot')
+    fireEvent.click(clearButton)
+    getByText('Are you sure you want to reset your device?')
+    fireEvent.click(getByText('Confirm'))
+    expect(dispatchApiRequest).toBeCalledWith(
+      mockResetConfig('mockRobot', clearMockResetOptions)
+    )
+  })
+
+  it('when tapping all options except clear all stored data, all options are active', () => {
+    const clearMockResetOptions = {
+      pipetteOffsetCalibrations: true,
+      moduleCalibration: true,
+      runsHistory: true,
+      gripperOffsetCalibrations: true,
+      authorizedKeys: true,
+      onDeviceDisplay: true,
+    }
+
+    const [{ getByText }] = render(props)
+    getByText('Clear pipette calibration').click()
+    getByText('Clear gripper calibration').click()
+    getByText('Clear module calibration').click()
+    getByText('Clear protocol run history').click()
+    const clearButton = getByText('Clear data and restart robot')
+    fireEvent.click(clearButton)
+    getByText('Are you sure you want to reset your device?')
+    fireEvent.click(getByText('Confirm'))
+    expect(dispatchApiRequest).toBeCalledWith(
+      mockResetConfig('mockRobot', clearMockResetOptions)
+    )
+  })
+
+  it('when tapping clear all stored data and unselect one options, all options are not active', () => {
+    const clearMockResetOptions = {
+      pipetteOffsetCalibrations: false,
+      moduleCalibration: true,
+      runsHistory: true,
+      gripperOffsetCalibrations: true,
+      authorizedKeys: false,
+      onDeviceDisplay: false,
+    }
+
+    const [{ getByText }] = render(props)
+    getByText('Clear all stored data').click()
+    getByText('Clear pipette calibration').click()
     const clearButton = getByText('Clear data and restart robot')
     fireEvent.click(clearButton)
     getByText('Are you sure you want to reset your device?')


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR aligns selector behavior in ODD with the selector behavior in Desktop app.

[threads for this PR](https://opentrons.slack.com/archives/CSCLVUW3C/p1699986106737179)

close RQA-1891
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
There are a couple of case for this PR.
[UI-1]
1. Go to Robot Settings Dashboard
2. Go to Device Reset
3. Tap Clear all stored data
4. Tap an option except `clear all store data`
Clear all stored data is not highlighted.

[UI-2]
1. Go to Robot Settings Dashboard
2. Go to Device Reset
3. Tap options except `clear all store data`
Clear all stored data is highlighted.

[Function]
For UI1 case, check not clear ssh keys and can using a robot without the unboxing flow.
For UI2 case, check ssh keys are cleared and need to do the unboxing flow to use the robot again.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update DeviceReset component and its tests
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
