### PR TITLE
fix(api): correct logic for simming partial tips

### DIFF
--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -63,6 +63,47 @@ class TipHandler(TypingProtocol):
         """Tell the Hardware API that a tip is attached."""
 
 
+async def _available_for_nozzle_layout(
+    channels: int,
+    style: str,
+    primary_nozzle: Optional[str],
+    front_right_nozzle: Optional[str],
+) -> Dict[str, str]:
+    """Check nozzle layout is compatible with the pipette.
+
+    Returns:
+        A dict of nozzles used to configure the pipette.
+    """
+    if channels == 1:
+        raise CommandPreconditionViolated(
+            message=f"Cannot configure nozzle layout with a {channels} channel pipette."
+        )
+    if style == "EMPTY":
+        return {}
+    if style == "ROW" and channels == 8:
+        raise CommandParameterLimitViolated(
+            command_name="configure_nozzle_layout",
+            parameter_name="RowNozzleLayout",
+            limit_statement="RowNozzleLayout is incompatible with {channels} channel pipettes.",
+            actual_value=str(primary_nozzle),
+        )
+    if not primary_nozzle:
+        return {"primary_nozzle": "A1"}
+    if style == "SINGLE":
+        return {"primary_nozzle": primary_nozzle}
+    if not front_right_nozzle:
+        return {
+            "primary_nozzle": primary_nozzle,
+            "front_right_nozzle": PRIMARY_NOZZLE_TO_ENDING_NOZZLE_MAP[primary_nozzle][
+                style
+            ],
+        }
+    return {
+        "primary_nozzle": primary_nozzle,
+        "front_right_nozzle": front_right_nozzle,
+    }
+
+
 class HardwareTipHandler(TipHandler):
     """Pick up and drop tips, using the Hardware API."""
 
@@ -72,9 +113,9 @@ class HardwareTipHandler(TipHandler):
         hardware_api: HardwareControlAPI,
         labware_data_provider: Optional[LabwareDataProvider] = None,
     ) -> None:
-        self._state_view = state_view
         self._hardware_api = hardware_api
         self._labware_data_provider = labware_data_provider or LabwareDataProvider()
+        self._state_view = state_view
 
     async def available_for_nozzle_layout(
         self,
@@ -83,40 +124,15 @@ class HardwareTipHandler(TipHandler):
         primary_nozzle: Optional[str] = None,
         front_right_nozzle: Optional[str] = None,
     ) -> Dict[str, str]:
-        """Check nozzle layout is compatible with the pipette."""
+        """Returns configuration for nozzle layout to pass to configure_nozzle_layout."""
         if self._state_view.pipettes.get_attached_tip(pipette_id):
             raise CommandPreconditionViolated(
                 message=f"Cannot configure nozzle layout of {str(self)} while it has tips attached."
             )
         channels = self._state_view.pipettes.get_channels(pipette_id)
-        if channels == 1:
-            raise CommandPreconditionViolated(
-                message=f"Cannot configure nozzle layout with a {channels} channel pipette."
-            )
-        if style == "EMPTY":
-            return {}
-        if style == "ROW" and channels == 8:
-            raise CommandParameterLimitViolated(
-                command_name="configure_nozzle_layout",
-                parameter_name="RowNozzleLayout",
-                limit_statement="RowNozzleLayout is incompatible with {channels} channel pipettes.",
-                actual_value=str(primary_nozzle),
-            )
-        if not primary_nozzle:
-            return {"primary_nozzle": "A1"}
-        if style == "SINGLE":
-            return {"primary_nozzle": primary_nozzle}
-        if not front_right_nozzle:
-            return {
-                "primary_nozzle": primary_nozzle,
-                "front_right_nozzle": PRIMARY_NOZZLE_TO_ENDING_NOZZLE_MAP[
-                    primary_nozzle
-                ][style],
-            }
-        return {
-            "primary_nozzle": primary_nozzle,
-            "front_right_nozzle": front_right_nozzle,
-        }
+        return await _available_for_nozzle_layout(
+            channels, style, primary_nozzle, front_right_nozzle
+        )
 
     async def pick_up_tip(
         self,
@@ -196,48 +212,6 @@ class VirtualTipHandler(TipHandler):
     def __init__(self, state_view: StateView) -> None:
         self._state_view = state_view
 
-    async def available_for_nozzle_layout(
-        self,
-        pipette_id: str,
-        style: str,
-        primary_nozzle: Optional[str] = None,
-        front_right_nozzle: Optional[str] = None,
-    ) -> Dict[str, str]:
-        """Check nozzle layout is compatible with the pipette."""
-        if self._state_view.pipettes.get_attached_tip(pipette_id):
-            raise CommandPreconditionViolated(
-                message=f"Cannot configure nozzle layout of {str(self)} while it has tips attached."
-            )
-        channels = self._state_view.pipettes.get_channels(pipette_id)
-        if channels == 1:
-            raise CommandPreconditionViolated(
-                message=f"Cannot configure nozzle layout with a {channels} channel pipette."
-            )
-        if style == "EMPTY":
-            return {}
-        if style == "ROW" and channels == 8:
-            raise CommandParameterLimitViolated(
-                command_name="configure_nozzle_layout",
-                parameter_name="RowNozzleLayout",
-                limit_statement="RowNozzleLayout is incompatible with {channels} channel pipettes.",
-                actual_value=str(primary_nozzle),
-            )
-        if not primary_nozzle:
-            return {"primary_nozzle": "A1"}
-        if style == "SINGLE":
-            return {"primary_nozzle": primary_nozzle}
-        if not front_right_nozzle:
-            return {
-                "primary_nozzle": primary_nozzle,
-                "front_right_nozzle": PRIMARY_NOZZLE_TO_ENDING_NOZZLE_MAP[
-                    primary_nozzle
-                ][style],
-            }
-        return {
-            "primary_nozzle": primary_nozzle,
-            "front_right_nozzle": front_right_nozzle,
-        }
-
     async def pick_up_tip(
         self,
         pipette_id: str,
@@ -261,6 +235,23 @@ class VirtualTipHandler(TipHandler):
         )
 
         return nominal_tip_geometry
+
+    async def available_for_nozzle_layout(
+        self,
+        pipette_id: str,
+        style: str,
+        primary_nozzle: Optional[str] = None,
+        front_right_nozzle: Optional[str] = None,
+    ) -> Dict[str, str]:
+        """Returns configuration for nozzle layout to pass to configure_nozzle_layout."""
+        if self._state_view.pipettes.get_attached_tip(pipette_id):
+            raise CommandPreconditionViolated(
+                message=f"Cannot configure nozzle layout of {str(self)} while it has tips attached."
+            )
+        channels = self._state_view.pipettes.get_channels(pipette_id)
+        return await _available_for_nozzle_layout(
+            channels, style, primary_nozzle, front_right_nozzle
+        )
 
     async def drop_tip(
         self,

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -60,12 +60,12 @@ class VirtualPipetteDataProvider:
                 pipette_model_string
             )
             new_nozzle_manager = NozzleConfigurationManager.build_from_config(config)
-            if back_left_nozzle and front_right_nozzle and starting_nozzle:
+            if back_left_nozzle and front_right_nozzle:
                 new_nozzle_manager.update_nozzle_configuration(
                     back_left_nozzle, front_right_nozzle, starting_nozzle
                 )
             self._nozzle_manager_layout_by_id[pipette_id] = new_nozzle_manager
-        elif back_left_nozzle and front_right_nozzle and starting_nozzle:
+        elif back_left_nozzle and front_right_nozzle:
             # Need to make sure that we pass all the right nozzles here.
             self._nozzle_manager_layout_by_id[pipette_id].update_nozzle_configuration(
                 back_left_nozzle, front_right_nozzle, starting_nozzle

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -138,6 +138,29 @@ def test_load_virtual_pipette_nozzle_layout(
     assert result.front_right == "E1"
     assert result.back_left == "A1"
 
+    subject_instance.configure_virtual_pipette_nozzle_layout(
+        "my-pipette", "p300_multi_v2.1"
+    )
+    result = subject_instance.get_nozzle_layout_for_pipette("my-pipette")
+    assert result.configuration.value == "FULL"
+
+    subject_instance.configure_virtual_pipette_nozzle_layout(
+        "my-96-pipette", "p1000_96_v3.5", "A1", "A12", "A1"
+    )
+    result = subject_instance.get_nozzle_layout_for_pipette("my-96-pipette")
+    assert result.configuration.value == "ROW"
+    subject_instance.configure_virtual_pipette_nozzle_layout(
+        "my-96-pipette", "p1000_96_v3.5", "A1", "A1"
+    )
+    result = subject_instance.get_nozzle_layout_for_pipette("my-96-pipette")
+    assert result.configuration.value == "SINGLE"
+
+    subject_instance.configure_virtual_pipette_nozzle_layout(
+        "my-96-pipette", "p1000_96_v3.5", "A1", "H1"
+    )
+    result = subject_instance.get_nozzle_layout_for_pipette("my-96-pipette")
+    assert result.configuration.value == "COLUMN"
+
 
 def test_get_pipette_static_config(
     supported_tip_fixture: pipette_definition.SupportedTipsDefinition,


### PR DESCRIPTION
When we simulate partial tip pickup we do it by emulating the hardware control logic in the virtual pipette data provider and then passing the result to a nozzle manager the way the hardware controller does. Unfortunately, the logic in the pipette virtual data handler did not match the hardware controller.

Until we get to a place where we can have an actual simualting hardware controller or something, we just have to keep these in sync.

## Testing
This is an analysis-only change, and has no effect on execution. The best way to test it is to test https://github.com/Opentrons/opentrons/pull/13972 since that's where I noticed the issue (we'll rebase that PR on this).