### PR TITLE
feat(shared-data, app): FE support for aspirateInPlace

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -2,6 +2,7 @@
   "adapter_in_mod_in_slot": "{{adapter}} on {{module}} in {{slot}}",
   "adapter_in_slot": "{{adapter}} in {{slot}}",
   "aspirate": "Aspirating {{volume}} µL from well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
+  "aspirate_in_place": "Aspirating {{volume}} µL in place at {{flow_rate}} µL/sec ",
   "blowout": "Blowing out at well {{well_name}} of {{labware}} in {{labware_location}} at {{flow_rate}} µL/sec",
   "blowout_in_place": "Blowing out in place at {{flow_rate}} µL/sec",
   "closing_tc_lid": "Closing Thermocycler lid",

--- a/app/src/organisms/CommandText/PipettingCommandText.tsx
+++ b/app/src/organisms/CommandText/PipettingCommandText.tsx
@@ -126,6 +126,10 @@ export const PipettingCommandText = ({
       const { flowRate } = command.params
       return t('blowout_in_place', { flow_rate: flowRate })
     }
+    case 'aspirateInPlace': {
+      const { flowRate, volume } = command.params
+      return t('aspirate_in_place', { volume, flow_rate: flowRate })
+    }
     default: {
       console.warn(
         'PipettingCommandText encountered a command with an unrecognized commandType: ',

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import {
+  AspirateInPlaceRunTimeCommand,
   BlowoutInPlaceRunTimeCommand,
   DispenseInPlaceRunTimeCommand,
   DropTipInPlaceRunTimeCommand,
@@ -150,6 +151,26 @@ describe('CommandText', () => {
       { i18nInstance: i18n }
     )[0]
     getByText('Blowing out in place at 300 µL/sec')
+  })
+  it('renders correct text for aspirateInPlace', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={FLEX_ROBOT_TYPE}
+        command={
+          {
+            commandType: 'aspirateInPlace',
+            params: {
+              pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
+              flowRate: 300,
+              volume: 10,
+            },
+          } as AspirateInPlaceRunTimeCommand
+        }
+      />,
+      { i18nInstance: i18n }
+    )[0]
+    getByText('Aspirating 10 µL in place at 300 µL/sec')
   })
   it('renders correct text for moveToWell', () => {
     const dispenseCommand = mockRobotSideAnalysis.commands.find(

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -54,6 +54,7 @@ export function CommandText(props: Props): JSX.Element | null {
 
   switch (command.commandType) {
     case 'aspirate':
+    case 'aspirateInPlace':
     case 'dispense':
     case 'dispenseInPlace':
     case 'blowout':

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -1,6 +1,7 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
 export type PipettingRunTimeCommand =
   | AspirateRunTimeCommand
+  | AspirateInPlaceRunTimeCommand
   | BlowoutInPlaceRunTimeCommand
   | BlowoutRunTimeCommand
   | ConfigureForVolumeRunTimeCommand
@@ -14,6 +15,7 @@ export type PipettingRunTimeCommand =
 
 export type PipettingCreateCommand =
   | AspirateCreateCommand
+  | AspirateInPlaceCreateCommand
   | BlowoutCreateCommand
   | BlowoutInPlaceCreateCommand
   | ConfigureForVolumeCreateCommand
@@ -47,6 +49,16 @@ export interface AspirateCreateCommand extends CommonCommandCreateInfo {
 export interface AspirateRunTimeCommand
   extends CommonCommandRunTimeInfo,
     AspirateCreateCommand {
+  result?: BasicLiquidHandlingResult
+}
+
+export interface AspirateInPlaceCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'aspirateInPlace'
+  params: AspirateInPlaceParams
+}
+export interface AspirateInPlaceRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    AspirateInPlaceCreateCommand {
   result?: BasicLiquidHandlingResult
 }
 
@@ -174,6 +186,11 @@ export interface DispenseInPlaceParams {
   pushOut?: number
 }
 
+export interface AspirateInPlaceParams {
+  pipetteId: string
+  volume: number
+  flowRate: number // µL/s
+}
 interface FlowRateParams {
   flowRate: number // µL/s
 }


### PR DESCRIPTION
# Overview

This command is used for wasteChute and movableTrash

# Test Plan

There isn't really a way to test this so just review the code. The test case checks that the command text renders properly

# Changelog

- add `aspirateInPlace` types 
- add support in command text

# Review requests

see test plan

# Risk assessment

low