### PR TITLE
docs(robot-server): Document deck configuration snapshotting

### DIFF
--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -37,6 +37,13 @@ router = fastapi.APIRouter()
         " configuration, such as loading a labware into a staging area slot that this deck"
         " configuration doesn't provide, the run command will fail with an error."
         "\n\n"
+        "**Warning:**"
+        " Currently, you can call this endpoint at any time, even while there is an active run."
+        " However, the robot can't adapt to deck configuration changes in the middle of a run."
+        " The robot will effectively take a snapshot of the deck configuration when the run is"
+        " first played. In the future, this endpoint may error if you try to call it in the middle"
+        " of an active run, so don't rely on being able to do that."
+        "\n\n"
         "After you set the deck configuration, it will persist, even across reboots,"
         " until you set it to something else."
     ),


### PR DESCRIPTION
# Overview

The new `PUT /deck_configuration` endpoint has a special timing relationship with the `/runs` endpoints. The Opentrons App will rely on this heavily, so we need to document it.

# Test Plan

None needed. Docs only.

# Changelog

Edit the public description of `PUT /deck_configuration` to explain how, even though the server will accept a `PUT` request at any time, it only has an effect on the robot's movement if you do it before you play a given run for the first time.

Leave some room for us to add validation in the future, because not having any right now makes me nervous, but we might not get to it before we release v7.1.

# Review requests

Please put any feedback in the form of haiku.

# Risk assessment

None. Docs only.