### PR TITLE
docs(robot-server): Update GET /health response examples

### DIFF
--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -21,10 +21,15 @@ class HealthLinks(BaseModel):
     serverLog: str = Field(
         ...,
         description="The path to the HTTP server logs endpoint",
+        examples=["/logs/server.log"],
     )
     oddLog: typing.Optional[str] = Field(
         None,
-        description="The path to the ODD app logs endpoint",
+        description=(
+            "The path to the on-device display app logs endpoint"
+            " (only present on the Opentrons Flex)"
+        ),
+        examples=["/logs/touchscreen.log"],
     )
     apiSpec: str = Field(
         ...,

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -11,10 +11,12 @@ class HealthLinks(BaseModel):
     apiLog: str = Field(
         ...,
         description="The path to the API logs endpoint",
+        examples=["/logs/api.log"],
     )
     serialLog: str = Field(
         ...,
         description="The path to the motor control serial communication logs endpoint",
+        examples=["/logs/serial.log"],
     )
     serverLog: str = Field(
         ...,
@@ -27,10 +29,12 @@ class HealthLinks(BaseModel):
     apiSpec: str = Field(
         ...,
         description="The path to the OpenAPI specification of the server",
+        examples=["/openapi.json"],
     )
     systemTime: str = Field(
         ...,
         description="The path to the system time endpoints",
+        examples=["/system/time"],
     )
 
 
@@ -42,6 +46,7 @@ class Health(BaseResponseBody):
         description="The robot's name. In most cases the same as its "
         "mDNS advertisement domain name, but this can get out "
         "of sync. Mostly useful for user-facing titles.",
+        examples=["Otie"],
     )
     robot_model: RobotModel = Field(
         ...,
@@ -50,23 +55,26 @@ class Health(BaseResponseBody):
     api_version: str = Field(
         ...,
         description="The API server's software version",
+        examples=["3.15.2"],
     )
     fw_version: str = Field(
         ...,
         description="The motor controller's firmware version. Doesn't "
         "follow a pattern; suitable only for display or exact matching.",
+        examples=["v2.15.0"],
     )
     board_revision: str = Field(
         ...,
         description="The hardware revision of the OT-2's central routing board.",
+        examples=["2.1"],
     )
     logs: typing.List[str] = Field(
         ...,
         description="List of paths at which to find log endpoints",
+        examples=[["/logs/serial.log", "/logs/api.log"]],
     )
     system_version: str = Field(
-        ...,
-        description="The robot's operating system version.",
+        ..., description="The robot's operating system version.", examples=["1.2.1"]
     )
     maximum_protocol_api_version: typing.List[int] = Field(
         ...,
@@ -74,6 +82,7 @@ class Health(BaseResponseBody):
         "in the format `[major_version, minor_version]`",
         min_items=2,
         max_items=2,
+        examples=[[2, 8]],
     )
     minimum_protocol_api_version: typing.List[int] = Field(
         ...,
@@ -81,32 +90,11 @@ class Health(BaseResponseBody):
         "in the format `[major_version, minor_version]`",
         min_items=2,
         max_items=2,
+        examples=[[2, 0]],
     )
     robot_serial: typing.Optional[str] = Field(
         default=None,
         description="The robot serial number. Should be used if present; if not present, use result of /server/update/health.",
+        examples=["OT2CEP20190604A02"],
     )
     links: HealthLinks
-
-    class Config:
-        """Health response model schema configuration."""
-
-        schema_extra = {
-            "example": {
-                "name": "OT2CEP20190604A02",
-                "api_version": "3.15.2",
-                "fw_version": "v2.15.0",
-                "board_revision": "2.1",
-                "logs": ["/logs/serial.log", "/logs/api.log"],
-                "system_version": "1.2.1",
-                "maximum_protocol_api_version": [2, 8],
-                "minimum_protocol_api_version": [2, 0],
-                "links": {
-                    "apiLog": "/logs/api.log",
-                    "serialLog": "/logs/serial.log",
-                    "apiSpec": "/openapi.json",
-                    "systemTime": "/system/time",
-                },
-                "robot_serial": None,
-            }
-        }


### PR DESCRIPTION
# Overview

The HTTP API docs were showing an incomplete example for `GET /health`. (@y3rsh thanks for catching this.)

# Test Plan

Run `make -C robot-server dev` and view http://localhost:31950/redoc#tag/Health/operation/get_health_health_get.

# Changelog

* Fix some fields, especially `robot_type`, not being shown in our `GET /health` example response on ReDoc. [Before](https://github.com/Opentrons/opentrons/assets/3236864/1fd1501f-5a33-4123-a620-9c690e65e36f), [after](https://github.com/Opentrons/opentrons/assets/3236864/2136ebe8-2312-4be9-8c39-8b7fced7fec6).
    * ReDoc normally keeps this stuff up to date automatically. The problem was that our Python code overrode the examples for *the whole model* instead of just for specific fields. This changes it to only override the examples for specific fields, so unmentioned fields will have their examples autogenerated, like we want.
* Update the example values for `name` and `robot_serial` to show how they can be different. Otherwise, leave the existing example values in place.

# Review requests

* Are there any apparent downsides to defining the examples field-by-field like this?
* There are a lot of other old endpoints that theoretically have this same problem. Searching `robot-server` for `schema_extra` is a good starting point. Do we want to ticket that, or just let it lie?

# Risk assessment

Low.