### PR TITLE
fix(app): fix a merge error from 1.0.0

### DIFF
--- a/app/src/organisms/CommandText/PipettingCommandText.tsx
+++ b/app/src/organisms/CommandText/PipettingCommandText.tsx
@@ -14,9 +14,10 @@ import {
   getFinalLabwareLocation,
   getWellRange,
 } from './utils'
-import type { PipetteName } from '@opentrons/shared-data'
-
-import type { PipettingRunTimeCommand } from '@opentrons/shared-data'
+import type {
+  PipetteName,
+  PipettingRunTimeCommand,
+} from '@opentrons/shared-data'
 
 interface PipettingCommandTextProps {
   command: PipettingRunTimeCommand


### PR DESCRIPTION
Looks like the merge for the internal-release didn't have conflicts but did introduce a js lint error. This fixes it.