### PR TITLE
fix(app): render compatible fixture in protocol setup fixture list when conflicted

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupFixtureList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupFixtureList.tsx
@@ -168,7 +168,11 @@ export function FixtureListItem({
               <img
                 width="60px"
                 height="54px"
-                src={getFixtureImage(cutoutFixtureId)}
+                src={
+                  isCurrentFixtureCompatible
+                    ? getFixtureImage(cutoutFixtureId)
+                    : getFixtureImage(compatibleCutoutFixtureIds?.[0])
+                }
               />
             ) : null}
             <Flex flexDirection={DIRECTION_COLUMN}>
@@ -176,7 +180,9 @@ export function FixtureListItem({
                 css={TYPOGRAPHY.pSemiBold}
                 marginLeft={SPACING.spacing20}
               >
-                {getFixtureDisplayName(cutoutFixtureId)}
+                {isCurrentFixtureCompatible
+                  ? getFixtureDisplayName(cutoutFixtureId)
+                  : getFixtureDisplayName(compatibleCutoutFixtureIds?.[0])}
               </StyledText>
               <Btn
                 marginLeft={SPACING.spacing16}

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -161,9 +161,9 @@ export function FixtureTable({
               >
                 <Flex flex="4 0 0" alignItems={ALIGN_CENTER}>
                   <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-                    {cutoutFixtureId != null
+                    {cutoutFixtureId != null && isCurrentFixtureCompatible
                       ? getFixtureDisplayName(cutoutFixtureId)
-                      : null}
+                      : getFixtureDisplayName(compatibleCutoutFixtureIds?.[0])}
                   </StyledText>
                 </Flex>
                 <Flex flex="2 0 0" alignItems={ALIGN_CENTER}>

--- a/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
@@ -48,7 +48,6 @@ export function WasteChuteStagingAreaFixture(
   }
 
   return (
-    // TODO: render a "Waste chute" foreign object similar to FlexTrash
     <g {...restProps}>
       <SlotBase
         d="M314.8,96.1h329.9c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,94.2,312.4,96.1,314.8,96.1z"

--- a/components/src/hardware-sim/Deck/FlexTrash.tsx
+++ b/components/src/hardware-sim/Deck/FlexTrash.tsx
@@ -8,7 +8,7 @@ import {
 import { Icon } from '../../icons'
 import { Flex, Text } from '../../primitives'
 import { ALIGN_CENTER, JUSTIFY_CENTER } from '../../styles'
-import { BORDERS, SPACING, TYPOGRAPHY } from '../../ui-style-constants'
+import { BORDERS, COLORS, SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 import { RobotCoordsForeignObject } from './RobotCoordsForeignObject'
 
 import trashDef from '@opentrons/shared-data/labware/definitions/2/opentrons_1_trash_3200ml_fixed/1.json'
@@ -98,7 +98,7 @@ export const FlexTrash = ({
         >
           {rotateDegrees === '180' ? (
             <Text
-              color={trashIconColor}
+              color={COLORS.white}
               // rotate text back 180 degrees
               transform={`rotate(${rotateDegrees}deg)`}
               transformOrigin="center"
@@ -116,7 +116,7 @@ export const FlexTrash = ({
             transformOrigin="center"
           />
           {rotateDegrees === '0' ? (
-            <Text color={trashIconColor} css={TYPOGRAPHY.bodyTextSemiBold}>
+            <Text color={COLORS.white} css={TYPOGRAPHY.bodyTextSemiBold}>
               Trash bin
             </Text>
           ) : null}


### PR DESCRIPTION
# Overview

picks the fist compatible fixture to render name/image when existing configured fixture is not compatible with what is required by the protocol. tweaks trash bin text color because design mismatch was noticed.

closes RAUT-863

# Test Plan

 - manually verified correct fixture rendering in list

# Changelog

 - Renders compatible fixture in protocol setup fixture list when conflicted

# Review requests

# Risk assessment

low