### PR TITLE
fix(app): fix double rendering labware in basedeck component

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/PrepareSpace.tsx
+++ b/app/src/organisms/LabwarePositionCheck/PrepareSpace.tsx
@@ -112,7 +112,9 @@ export const PrepareSpace = (props: PrepareSpaceProps): JSX.Element | null => {
                 labwareLocation: location,
                 definition: labwareDef,
               },
-            ]}
+            ].filter(
+              () => !('moduleModel' in location && location.moduleModel != null)
+            )}
             deckConfig={deckConfig}
           />
         </Flex>


### PR DESCRIPTION
Closes RQA-1899
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds logic to prevent duplicate rendering of labware if it has already been rendered on top of a module. This bug is only noticeable on the thermocycler, since labware is rendered on the TC at an offset.

### Current Behavior

<img width="754" alt="Screenshot 2023-11-16 at 1 34 49 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/f0f00561-a804-4685-b929-5e44d8ed53ad">

### With Fix

<img width="704" alt="Screenshot 2023-11-16 at 2 45 45 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/986197e2-20e3-42ce-867e-4af8affe1679">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- AppUI is set up to test! Here's a protocol. 
[LPC Test (2).json](https://github.com/Opentrons/opentrons/files/13382982/LPC.Test.2.json)
- Launch LPC and proceed to a step with labware. Confirm in devtools there's no double rendering of labware.
- Perform LPC until step 4. Confirm the TC labware does not render directly on slot B1.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix double rendering of labware while performing LPC.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
