### PR TITLE
fix(app): render protocol setup labware addressableAreaName location

### DIFF
--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -292,12 +292,12 @@ export function parseAllAddressableAreas(
         ...acc,
         command.params.location.addressableAreaName as AddressableAreaName,
       ]
-    }
-    // TODO(BC, 11/6/23): once moveToAddressableArea command exists add it back here
-    // else if (command.commandType === 'moveToAddressableArea') {
-    // ...
-    // }
-    else {
+    } else if (
+      command.commandType === 'moveToAddressableArea' &&
+      !acc.includes(command.params.addressableAreaName as AddressableAreaName)
+    ) {
+      return [...acc, command.params.addressableAreaName as AddressableAreaName]
+    } else {
       return acc
     }
   }, [])

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -93,10 +93,18 @@ export function LabwareListItem(
   const { createLiveCommand } = useCreateLiveCommandMutation()
   const [isLatchLoading, setIsLatchLoading] = React.useState<boolean>(false)
   const [isLatchClosed, setIsLatchClosed] = React.useState<boolean>(false)
-  let slotInfo: string | null =
-    initialLocation !== 'offDeck' && 'slotName' in initialLocation
-      ? initialLocation.slotName
-      : null
+
+  let slotInfo: string | null = null
+
+  if (initialLocation !== 'offDeck' && 'slotName' in initialLocation) {
+    slotInfo = initialLocation.slotName
+  } else if (
+    initialLocation !== 'offDeck' &&
+    'addressableAreaName' in initialLocation
+  ) {
+    slotInfo = initialLocation.addressableAreaName
+  }
+
   let moduleDisplayName: string | null = null
   let extraAttentionText: JSX.Element | null = null
   let isCorrectHeaterShakerAttached: boolean = false

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -490,6 +490,9 @@ function RowLabware({
   } else if ('slotName' in initialLocation) {
     slotName = initialLocation.slotName
     location = <LocationIcon slotName={initialLocation.slotName} />
+  } else if ('addressableAreaName' in initialLocation) {
+    slotName = initialLocation.addressableAreaName
+    location = <LocationIcon slotName={initialLocation.addressableAreaName} />
   } else if (matchedModuleType != null && matchedModule?.slotName != null) {
     slotName = matchedModule.slotName
     location = (

--- a/app/src/organisms/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ProtocolSetupLabware/index.tsx
@@ -145,6 +145,14 @@ export function ProtocolSetupLabware({
   } else if (
     selectedLabware != null &&
     typeof selectedLabware.location === 'object' &&
+    'addressableAreaName' in selectedLabware?.location
+  ) {
+    location = (
+      <LocationIcon slotName={selectedLabware?.location.addressableAreaName} />
+    )
+  } else if (
+    selectedLabware != null &&
+    typeof selectedLabware.location === 'object' &&
     'moduleId' in selectedLabware?.location
   ) {
     const matchedModule = attachedProtocolModuleMatches.find(


### PR DESCRIPTION
# Overview

in ODD/desktop protocol setup labware lists, renders labware location referenced by addressableAreaName

<img width="1136" alt="Screen Shot 2023-11-16 at 4 58 41 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/5c01ea80-e5bd-4409-a59e-713b14555adf">


# Test Plan

visually verified staging area slot location rendering

# Changelog

 - Renders protocol setup labware addressableAreaName location

# Review requests

# Risk assessment

low
