### PR TITLE
docs(api): better H2 structure for API Reference page

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -2,13 +2,14 @@
 
 .. _protocol-api-reference:
 
+***********************
 API Version 2 Reference
-=======================
+***********************
 
 .. _protocol_api-protocols-and-instruments:
 
 Protocols
----------
+=========
 .. module:: opentrons.protocol_api
 
 .. autoclass:: opentrons.protocol_api.ProtocolContext
@@ -16,7 +17,7 @@ Protocols
    :exclude-members: location_cache, cleanup, clear_commands
 
 Instruments
------------
+===========
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:
    :exclude-members: delay
@@ -24,13 +25,13 @@ Instruments
 .. _protocol-api-labware:
 
 Labware
--------
+=======
 .. autoclass:: opentrons.protocol_api.Labware
    :members:
    :exclude-members: next_tip, use_tips, previous_tip, return_tips
 
 Wells and Liquids
------------------
+=================
 .. autoclass:: opentrons.protocol_api.Well
    :members:
    :exclude-members: geometry
@@ -40,7 +41,7 @@ Wells and Liquids
 .. _protocol-api-modules:
 
 Modules
--------
+=======
 
 .. autoclass:: opentrons.protocol_api.HeaterShakerContext
    :members:
@@ -71,7 +72,7 @@ Modules
 .. _protocol-api-types:
 
 Useful Types
-------------
+============
 
 ..
    The opentrons.types module contains a mixture of public Protocol API things and private internal things.
@@ -84,7 +85,7 @@ Useful Types
    :no-value:
 
 Executing and Simulating Protocols
-----------------------------------
+==================================
 
 .. automodule:: opentrons.execute
    :members:

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -7,31 +7,35 @@ API Version 2 Reference
 
 .. _protocol_api-protocols-and-instruments:
 
-Protocols and Instruments
--------------------------
+Protocols
+---------
 .. module:: opentrons.protocol_api
 
 .. autoclass:: opentrons.protocol_api.ProtocolContext
    :members:
-   :exclude-members: location_cache, cleanup, clear_commands, load_waste_chute
+   :exclude-members: location_cache, cleanup, clear_commands
 
+Instruments
+-----------
 .. autoclass:: opentrons.protocol_api.InstrumentContext
    :members:
-   :exclude-members: delay, configure_nozzle_layout, prepare_to_aspirate
-
-.. autoclass:: opentrons.protocol_api.Liquid
+   :exclude-members: delay
 
 .. _protocol-api-labware:
 
-Labware and Wells
------------------
+Labware
+-------
 .. autoclass:: opentrons.protocol_api.Labware
    :members:
    :exclude-members: next_tip, use_tips, previous_tip, return_tips
 
+Wells and Liquids
+-----------------
 .. autoclass:: opentrons.protocol_api.Well
    :members:
    :exclude-members: geometry
+
+.. autoclass:: opentrons.protocol_api.Liquid
 
 .. _protocol-api-modules:
 
@@ -66,8 +70,8 @@ Modules
 
 .. _protocol-api-types:
 
-Useful Types and Definitions
-----------------------------
+Useful Types
+------------
 
 ..
    The opentrons.types module contains a mixture of public Protocol API things and private internal things.


### PR DESCRIPTION
# Overview

Improve the navigability of the API Reference page by giving each large class its own H2. It used to require a bunch of scrolling to get to `InstrumentContext` and `Well`, which was annoying.

Will hold off deploying this until `docs@2.16`.

Addresses [RTC-366](https://opentrons.atlassian.net/browse/RTC-366), RTC-362

# Test Plan

Checked new formatting [in the sandbox](http://sandbox.docs.opentrons.com/api-reference-restructure/v2/new_protocol_api.html).

# Changelog

- New H2 for Instruments, Wells
- Moved Liquids class under Wells (it's small and thematically related)
- Standardized RST header styles
- Unhid 2.16 methods, since I was already editing the reference page.

# Risk assessment

v low. there could be some external links to the old H2s, but it would make way more sense for external links to go to particular entries, each of which has its own permalink which isn't changed by this PR.

[RTC-366]: https://opentrons.atlassian.net/browse/RTC-366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ