### PR TITLE
feat(api): load and move labware to and from staging slots

### DIFF
--- a/api/src/opentrons/protocol_api/_types.py
+++ b/api/src/opentrons/protocol_api/_types.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing_extensions import Final
 import enum
 
@@ -16,3 +17,34 @@ A special location value, indicating that a labware is not currently on the robo
 
 See :ref:`off-deck-location` for details on using ``OFF_DECK`` with :py:obj:`ProtocolContext.move_labware()`.
 """
+
+
+class StagingSlotName(enum.Enum):
+    """Staging slot identifiers."""
+
+    SLOT_A4 = "A4"
+    SLOT_B4 = "B4"
+    SLOT_C4 = "C4"
+    SLOT_D4 = "D4"
+
+    @classmethod
+    def from_primitive(cls, value: str) -> StagingSlotName:
+        str_val = str(value).upper()
+        return cls(str_val)
+
+    @property
+    def id(self) -> str:
+        """This slot's unique ID, as it appears in the deck definition.
+
+        This can be used to look up slot details in the deck definition.
+
+        This is preferred over `.value` or `.__str__()` for explicitness.
+        """
+        return self.value
+
+    def __str__(self) -> str:
+        """Stringify to the unique ID.
+
+        For explicitness, prefer using `.id` instead.
+        """
+        return self.id

--- a/api/src/opentrons/protocol_api/_types.py
+++ b/api/src/opentrons/protocol_api/_types.py
@@ -19,6 +19,7 @@ See :ref:`off-deck-location` for details on using ``OFF_DECK`` with :py:obj:`Pro
 """
 
 
+# TODO(jbl 11-17-2023) move this away from being an Enum and make this a NewType or something similar
 class StagingSlotName(enum.Enum):
     """Staging slot identifiers."""
 
@@ -29,7 +30,7 @@ class StagingSlotName(enum.Enum):
 
     @classmethod
     def from_primitive(cls, value: str) -> StagingSlotName:
-        str_val = str(value).upper()
+        str_val = value.upper()
         return cls(str_val)
 
     @property

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -20,6 +20,7 @@ from opentrons.protocols.api_support.types import APIVersion
 
 from opentrons.protocol_engine import (
     DeckSlotLocation,
+    AddressableAreaLocation,
     ModuleLocation,
     OnLabwareLocation,
     ModuleModel as EngineModuleModel,
@@ -41,7 +42,7 @@ from opentrons.protocol_engine.errors import (
 )
 
 from ... import validation
-from ..._types import OffDeckType, OFF_DECK
+from ..._types import OffDeckType, OFF_DECK, StagingSlotName
 from ..._liquid import Liquid
 from ..._waste_chute import WasteChute
 from ..protocol import AbstractProtocol
@@ -143,7 +144,12 @@ class ProtocolCore(
         self,
         load_name: str,
         location: Union[
-            DeckSlotName, LabwareCore, ModuleCore, NonConnectedModuleCore, OffDeckType
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCore,
+            ModuleCore,
+            NonConnectedModuleCore,
+            OffDeckType,
         ],
         label: Optional[str],
         namespace: Optional[str],
@@ -204,7 +210,13 @@ class ProtocolCore(
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckSlotName, ModuleCore, NonConnectedModuleCore, OffDeckType],
+        location: Union[
+            DeckSlotName,
+            StagingSlotName,
+            ModuleCore,
+            NonConnectedModuleCore,
+            OffDeckType,
+        ],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LabwareCore:
@@ -255,6 +267,7 @@ class ProtocolCore(
         labware_core: LabwareCore,
         new_location: Union[
             DeckSlotName,
+            StagingSlotName,
             LabwareCore,
             ModuleCore,
             NonConnectedModuleCore,
@@ -652,7 +665,12 @@ class ProtocolCore(
     def _convert_labware_location(
         self,
         location: Union[
-            DeckSlotName, LabwareCore, ModuleCore, NonConnectedModuleCore, OffDeckType
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCore,
+            ModuleCore,
+            NonConnectedModuleCore,
+            OffDeckType,
         ],
     ) -> LabwareLocation:
         if isinstance(location, LabwareCore):
@@ -662,7 +680,13 @@ class ProtocolCore(
 
     @staticmethod
     def _get_non_stacked_location(
-        location: Union[DeckSlotName, ModuleCore, NonConnectedModuleCore, OffDeckType]
+        location: Union[
+            DeckSlotName,
+            StagingSlotName,
+            ModuleCore,
+            NonConnectedModuleCore,
+            OffDeckType,
+        ]
     ) -> NonStackedLocation:
         if isinstance(location, (ModuleCore, NonConnectedModuleCore)):
             return ModuleLocation(moduleId=location.module_id)
@@ -670,3 +694,5 @@ class ProtocolCore(
             return OFF_DECK_LOCATION
         elif isinstance(location, DeckSlotName):
             return DeckSlotLocation(slotName=location)
+        elif isinstance(location, StagingSlotName):
+            return AddressableAreaLocation(addressableAreaName=location.id)

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -17,7 +17,7 @@ from opentrons.protocols import labware as labware_definition
 
 from ...labware import Labware
 from ..._liquid import Liquid
-from ..._types import OffDeckType
+from ..._types import OffDeckType, StagingSlotName
 from ..._waste_chute import WasteChute
 from ..protocol import AbstractProtocol
 from ..labware import LabwareLoadParams
@@ -152,6 +152,7 @@ class LegacyProtocolCore(
             DeckSlotName,
             LegacyLabwareCore,
             legacy_module_core.LegacyModuleCore,
+            StagingSlotName,
             OffDeckType,
         ],
         label: Optional[str],
@@ -167,6 +168,8 @@ class LegacyProtocolCore(
             raise APIVersionError(
                 "Loading a labware onto another labware or adapter is only supported with api version 2.15 and above"
             )
+        elif isinstance(location, StagingSlotName):
+            raise APIVersionError("Using a staging deck slot requires apiLevel 2.16.")
 
         deck_slot = (
             location if isinstance(location, DeckSlotName) else location.get_deck_slot()
@@ -237,7 +240,12 @@ class LegacyProtocolCore(
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckSlotName, legacy_module_core.LegacyModuleCore, OffDeckType],
+        location: Union[
+            DeckSlotName,
+            StagingSlotName,
+            legacy_module_core.LegacyModuleCore,
+            OffDeckType,
+        ],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LegacyLabwareCore:
@@ -250,6 +258,7 @@ class LegacyProtocolCore(
         labware_core: LegacyLabwareCore,
         new_location: Union[
             DeckSlotName,
+            StagingSlotName,
             LegacyLabwareCore,
             legacy_module_core.LegacyModuleCore,
             OffDeckType,

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -20,7 +20,7 @@ from .labware import LabwareCoreType, LabwareLoadParams
 from .module import ModuleCoreType
 from .._liquid import Liquid
 from .._waste_chute import WasteChute
-from .._types import OffDeckType
+from .._types import OffDeckType, StagingSlotName
 
 
 class AbstractProtocol(
@@ -61,7 +61,9 @@ class AbstractProtocol(
     def load_labware(
         self,
         load_name: str,
-        location: Union[DeckSlotName, LabwareCoreType, ModuleCoreType, OffDeckType],
+        location: Union[
+            DeckSlotName, StagingSlotName, LabwareCoreType, ModuleCoreType, OffDeckType
+        ],
         label: Optional[str],
         namespace: Optional[str],
         version: Optional[int],
@@ -73,7 +75,7 @@ class AbstractProtocol(
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckSlotName, ModuleCoreType, OffDeckType],
+        location: Union[DeckSlotName, StagingSlotName, ModuleCoreType, OffDeckType],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LabwareCoreType:
@@ -86,7 +88,12 @@ class AbstractProtocol(
         self,
         labware_core: LabwareCoreType,
         new_location: Union[
-            DeckSlotName, LabwareCoreType, ModuleCoreType, OffDeckType, WasteChute
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCoreType,
+            ModuleCoreType,
+            OffDeckType,
+            WasteChute,
         ],
         use_gripper: bool,
         pause_for_manual_move: bool,

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -42,9 +42,12 @@ def _get_slot_name(
     slot_key: DeckLocation, api_version: APIVersion, robot_type: RobotType
 ) -> DeckSlotName:
     try:
-        return validation.ensure_and_convert_deck_slot(
+        slot = validation.ensure_and_convert_deck_slot(
             slot_key, api_version, robot_type
         )
+        if not isinstance(slot, DeckSlotName):
+            raise ValueError("Cannot currently load staging slots from Deck.")
+        return slot
     except (TypeError, ValueError) as error:
         raise KeyError(slot_key) from error
 

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -158,10 +158,8 @@ def ensure_and_convert_deck_slot(
             raise APIVersionError(
                 f"Using a staging deck slot requires apiLevel {_STAGING_DECK_SLOT_VERSION_GATE}."
             )
-        try:
-            parsed_staging_slot = StagingSlotName.from_primitive(str(deck_slot))
-        except ValueError as e:
-            raise ValueError(f"'{deck_slot}' is not a valid staging slot") from e
+        # Don't need a try/except since we're already pre-validating this
+        parsed_staging_slot = StagingSlotName.from_primitive(str(deck_slot))
         return parsed_staging_slot
     else:
         try:

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -31,6 +31,7 @@ from opentrons.hardware_control.modules.types import (
     MagneticBlockModel,
     ThermocyclerStep,
 )
+from ._types import StagingSlotName
 
 if TYPE_CHECKING:
     from .labware import Well
@@ -38,6 +39,9 @@ if TYPE_CHECKING:
 
 # The first APIVersion where Python protocols can specify deck labels like "D1" instead of "1".
 _COORDINATE_DECK_LABEL_VERSION_GATE = APIVersion(2, 15)
+
+# The first APIVersion where Python protocols can specify staging deck slots (e.g. "D4")
+_STAGING_DECK_SLOT_VERSION_GATE = APIVersion(2, 16)
 
 # Mapping of public Python Protocol API pipette load names
 # to names used by the internal Opentrons system
@@ -127,7 +131,7 @@ def ensure_pipette_name(pipette_name: str) -> PipetteNameType:
 
 def ensure_and_convert_deck_slot(
     deck_slot: Union[int, str], api_version: APIVersion, robot_type: RobotType
-) -> DeckSlotName:
+) -> Union[DeckSlotName, StagingSlotName]:
     """Ensure that a primitive value matches a named deck slot.
 
     Also, convert the deck slot to match the given `robot_type`.
@@ -149,21 +153,31 @@ def ensure_and_convert_deck_slot(
     if not isinstance(deck_slot, (int, str)):
         raise TypeError(f"Deck slot must be a string or integer, but got {deck_slot}")
 
-    try:
-        parsed_slot = DeckSlotName.from_primitive(deck_slot)
-    except ValueError as e:
-        raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e
+    if deck_slot in {"A4", "B4", "C4", "D4"}:
+        if api_version < APIVersion(2, 16):
+            raise APIVersionError(
+                f"Using a staging deck slot requires apiLevel {_STAGING_DECK_SLOT_VERSION_GATE}."
+            )
+        try:
+            parsed_staging_slot = StagingSlotName.from_primitive(str(deck_slot))
+        except ValueError as e:
+            raise ValueError(f"'{deck_slot}' is not a valid staging slot") from e
+        return parsed_staging_slot
+    else:
+        try:
+            parsed_slot = DeckSlotName.from_primitive(deck_slot)
+        except ValueError as e:
+            raise ValueError(f"'{deck_slot}' is not a valid deck slot") from e
+        is_ot2_style = parsed_slot.to_ot2_equivalent() == parsed_slot
+        if not is_ot2_style and api_version < _COORDINATE_DECK_LABEL_VERSION_GATE:
+            alternative = parsed_slot.to_ot2_equivalent().id
+            raise APIVersionError(
+                f'Specifying a deck slot like "{deck_slot}" requires apiLevel'
+                f" {_COORDINATE_DECK_LABEL_VERSION_GATE}."
+                f' Increase your protocol\'s apiLevel, or use slot "{alternative}" instead.'
+            )
 
-    is_ot2_style = parsed_slot.to_ot2_equivalent() == parsed_slot
-    if not is_ot2_style and api_version < _COORDINATE_DECK_LABEL_VERSION_GATE:
-        alternative = parsed_slot.to_ot2_equivalent().id
-        raise APIVersionError(
-            f'Specifying a deck slot like "{deck_slot}" requires apiLevel'
-            f" {_COORDINATE_DECK_LABEL_VERSION_GATE}."
-            f' Increase your protocol\'s apiLevel, or use slot "{alternative}" instead.'
-        )
-
-    return parsed_slot.to_equivalent_for_robot_type(robot_type)
+        return parsed_slot.to_equivalent_for_robot_type(robot_type)
 
 
 def internal_slot_to_public_string(

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -129,6 +129,9 @@ def ensure_pipette_name(pipette_name: str) -> PipetteNameType:
         ) from None
 
 
+# TODO(jbl 11-17-2023) this function's original purpose was ensure a valid deck slot for a given robot type
+#   With deck configuration, the shape of this should change to better represent it checking if a deck slot
+#   (and maybe any addressable area) being valid for that deck configuration
 def ensure_and_convert_deck_slot(
     deck_slot: Union[int, str], api_version: APIVersion, robot_type: RobotType
 ) -> Union[DeckSlotName, StagingSlotName]:
@@ -153,7 +156,7 @@ def ensure_and_convert_deck_slot(
     if not isinstance(deck_slot, (int, str)):
         raise TypeError(f"Deck slot must be a string or integer, but got {deck_slot}")
 
-    if deck_slot in {"A4", "B4", "C4", "D4"}:
+    if str(deck_slot).upper() in {"A4", "B4", "C4", "D4"}:
         if api_version < APIVersion(2, 16):
             raise APIVersionError(
                 f"Using a staging deck slot requires apiLevel {_STAGING_DECK_SLOT_VERSION_GATE}."

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -19,6 +19,7 @@ from opentrons.hardware_control.modules.types import ModuleType, TemperatureModu
 
 from opentrons.protocols import labware as mock_labware
 from opentrons.protocols.api_support.util import APIVersionError
+from opentrons.protocol_api._types import StagingSlotName
 from opentrons.protocol_api.core.legacy.module_geometry import ModuleGeometry
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION, OFF_DECK
 from opentrons.protocol_api.core.labware import LabwareLoadParams
@@ -173,6 +174,20 @@ def test_load_labware_off_deck_raises(
         subject.load_labware(
             load_name="cool load name",
             location=OFF_DECK,
+            label="cool label",
+            namespace="cool namespace",
+            version=1337,
+        )
+
+
+def test_load_labware_on_staging_slot_raises(
+    subject: LegacyProtocolCore,
+) -> None:
+    """It should raise an api error when loading onto a staging slot."""
+    with pytest.raises(APIVersionError):
+        subject.load_labware(
+            load_name="cool load name",
+            location=StagingSlotName.SLOT_B4,
             label="cool label",
             namespace="cool namespace",
             version=1337,

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -28,6 +28,7 @@ from opentrons.protocol_api import (
     validation as mock_validation,
     Liquid,
 )
+from opentrons.protocol_api._types import StagingSlotName
 from opentrons.protocol_api.core.core_map import LoadedCoreMap
 from opentrons.protocol_api.core.labware import LabwareLoadParams
 from opentrons.protocol_api.core.common import (
@@ -383,6 +384,52 @@ def test_load_labware_off_deck_raises(
         )
 
 
+def test_load_labware_on_staging_slot(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    api_version: APIVersion,
+    subject: ProtocolContext,
+) -> None:
+    """It should create a labware on a staging slot using its execution core."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_LABWARE")).then_return(
+        "lowercase_labware"
+    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(StagingSlotName.SLOT_B4)
+
+    decoy.when(
+        mock_core.load_labware(
+            load_name="lowercase_labware",
+            location=StagingSlotName.SLOT_B4,
+            label="some_display_name",
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.get_name()).then_return("Full Name")
+    decoy.when(mock_labware_core.get_display_name()).then_return("Display Name")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    result = subject.load_labware(
+        load_name="UPPERCASE_LABWARE",
+        location=42,
+        label="some_display_name",
+        namespace="some_namespace",
+        version=1337,
+    )
+
+    assert isinstance(result, Labware)
+    assert result.name == "Full Name"
+
+    decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
+
+
 def test_load_labware_from_definition(
     decoy: Decoy,
     mock_core: ProtocolCore,
@@ -449,6 +496,47 @@ def test_load_adapter(
         mock_core.load_adapter(
             load_name="lowercase_adapter",
             location=DeckSlotName.SLOT_5,
+            namespace="some_namespace",
+            version=1337,
+        )
+    ).then_return(mock_labware_core)
+
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    result = subject.load_adapter(
+        load_name="UPPERCASE_ADAPTER",
+        location=42,
+        namespace="some_namespace",
+        version=1337,
+    )
+
+    assert isinstance(result, Labware)
+
+    decoy.verify(mock_core_map.add(mock_labware_core, result), times=1)
+
+
+def test_load_adapter_on_staging_slot(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    api_version: APIVersion,
+    subject: ProtocolContext,
+) -> None:
+    """It should create an adapter on a staging slot using its execution core."""
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(mock_validation.ensure_lowercase_name("UPPERCASE_ADAPTER")).then_return(
+        "lowercase_adapter"
+    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(StagingSlotName.SLOT_B4)
+
+    decoy.when(
+        mock_core.load_adapter(
+            load_name="lowercase_adapter",
+            location=StagingSlotName.SLOT_B4,
             namespace="some_namespace",
             version=1337,
         )
@@ -591,6 +679,50 @@ def test_move_labware_to_slot(
         mock_core.move_labware(
             labware_core=mock_labware_core,
             new_location=DeckSlotName.SLOT_1,
+            use_gripper=False,
+            pause_for_manual_move=True,
+            pick_up_offset=None,
+            drop_offset=(1, 2, 3),
+        )
+    )
+
+
+def test_move_labware_to_staging_slot(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    api_version: APIVersion,
+    subject: ProtocolContext,
+) -> None:
+    """It should move labware to new slot location."""
+    drop_offset = {"x": 4, "y": 5, "z": 6}
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(StagingSlotName.SLOT_B4)
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    movable_labware = Labware(
+        core=mock_labware_core,
+        api_version=MAX_SUPPORTED_VERSION,
+        protocol_core=mock_core,
+        core_map=mock_core_map,
+    )
+    decoy.when(
+        mock_validation.ensure_valid_labware_offset_vector(drop_offset)
+    ).then_return((1, 2, 3))
+    subject.move_labware(
+        labware=movable_labware,
+        new_location=42,
+        drop_offset=drop_offset,
+    )
+
+    decoy.verify(
+        mock_core.move_labware(
+            labware_core=mock_labware_core,
+            new_location=StagingSlotName.SLOT_B4,
             use_gripper=False,
             pause_for_manual_move=True,
             pick_up_offset=None,
@@ -783,6 +915,26 @@ def test_load_module_with_mag_block_raises(subject: ProtocolContext) -> None:
             location=42,
             configuration="semi",
         )
+
+
+def test_load_module_on_staging_slot_raises(
+    decoy: Decoy,
+    mock_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    api_version: APIVersion,
+    subject: ProtocolContext,
+) -> None:
+    """It should raise when attempting to load a module onto a staging slot."""
+    decoy.when(mock_validation.ensure_module_model("spline reticulator")).then_return(
+        TemperatureModuleModel.TEMPERATURE_V1
+    )
+    decoy.when(mock_core.robot_type).then_return("OT-3 Standard")
+    decoy.when(
+        mock_validation.ensure_and_convert_deck_slot(42, api_version, "OT-3 Standard")
+    ).then_return(StagingSlotName.SLOT_B4)
+
+    with pytest.raises(ValueError, match="Cannot load a module onto a staging slot."):
+        subject.load_module(module_name="spline reticulator", location=42)
 
 
 def test_loaded_modules(

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -25,6 +25,7 @@ from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.protocol_api import validation as subject, Well, Labware
+from opentrons.protocol_api._types import StagingSlotName
 
 
 @pytest.mark.parametrize(
@@ -131,6 +132,11 @@ def test_ensure_pipette_input_invalid(input_value: str) -> None:
         ("a3", APIVersion(2, 15), "OT-3 Standard", DeckSlotName.SLOT_A3),
         ("A3", APIVersion(2, 15), "OT-2 Standard", DeckSlotName.FIXED_TRASH),
         ("A3", APIVersion(2, 15), "OT-3 Standard", DeckSlotName.SLOT_A3),
+        # Staging slots:
+        ("A4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_A4),
+        ("B4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_B4),
+        ("C4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_C4),
+        ("D4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_D4),
     ],
 )
 def test_ensure_and_convert_deck_slot(
@@ -162,6 +168,7 @@ def test_ensure_and_convert_deck_slot(
             APIVersionError,
             '"A1" requires apiLevel 2.15. Increase your protocol\'s apiLevel, or use slot "10" instead.',
         ),
+        ("A4", APIVersion(2, 15), APIVersionError, "Using a staging deck slot"),
     ],
 )
 @pytest.mark.parametrize("input_robot_type", ["OT-2 Standard", "OT-3 Standard"])

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -134,9 +134,9 @@ def test_ensure_pipette_input_invalid(input_value: str) -> None:
         ("A3", APIVersion(2, 15), "OT-3 Standard", DeckSlotName.SLOT_A3),
         # Staging slots:
         ("A4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_A4),
-        ("B4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_B4),
+        ("b4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_B4),
         ("C4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_C4),
-        ("D4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_D4),
+        ("d4", APIVersion(2, 16), "OT-3 Standard", StagingSlotName.SLOT_D4),
     ],
 )
 def test_ensure_and_convert_deck_slot(


### PR DESCRIPTION
# Overview

This PR hooks up the public Python API to allow `load_labware`, `load_adapter` and `move_labware` to use the A4, B4, C4, and D4 staging slots.

This was accomplished via adding a new `StagingSlotName` enum type that can be returned from the validation function `ensure_and_convert_deck_slot`. The new type is then allowed to be passed to the three methods mentioned above. For trying to load a module into a staging slot, an error will be raised. For now, attempting to access a staging slot via the `Deck` class will also raise an error.

# Test Plan

Unit test coverage and analyzed and ran the following protocol on hardware.

```
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.16",
}


def run(protocol_context):

    tiprack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_1000ul", "B4")
    
    pipette = protocol_context.load_instrument(
        "flex_1channel_1000", mount="left", tip_racks=[tiprack1]
    )

    protocol_context.move_labware(tiprack1, "B2", use_gripper=True)
```

# Changelog

- Added `StagingSlotName` type
- Modified `ensure_and_convert_deck_slot` to return `StagingSlotName` in addition to `DeckSlotName`
- Allow engine based protocol core to use `StagingSlotName` for `load_labware`, `load_adapter` and `move_labware`

# Review requests

The general location and shape of `StagingSlotName` and if this is a good direction to move forward with this.

# Risk assessment

Low, it's mostly hooking up PAPI to send the correct PE type when making the engine client call, some simple error checking and no other unnecessary changes.