### PR TITLE
refactor(robot-server): Fix log.warn() deprecation warning

### DIFF
--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -266,7 +266,7 @@ class RunStore:
                 else None
             )
         except ValidationError as e:
-            log.warn(f"Error retrieving state summary for {run_id}: {e}")
+            log.warning(f"Error retrieving state summary for {run_id}: {e}")
             return None
 
     @lru_cache(maxsize=_CACHE_ENTRIES)


### PR DESCRIPTION
# Changelog

Change `log.warn()` to `log.warning()` to fix this deprecation warning in robot-server's test suite:

```
tests/runs/test_run_store.py::test_get_state_summary_failure
  /Users/maxmarrone/Code/Opentrons/opentrons/robot-server/robot_server/runs/run_store.py:269: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn(f"Error retrieving state summary for {run_id}: {e}")
```

# Risk assessment

No risk.