### PR TITLE
refactor(app): make deck config section responsive

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -11,10 +11,8 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
-  JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   Link,
-  SIZE_5,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -235,5 +235,6 @@ const DECK_CONFIG_SECTION_STYLE = css`
   @media screen and (max-width: 1024px) {
     flex-direction: ${DIRECTION_COLUMN};
     align-items: ${ALIGN_CENTER};
+    grid-gap: ${SPACING.spacing32};
   }
 `

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 
 import {
   ALIGN_CENTER,
@@ -10,6 +11,7 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
+  JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   Link,
   SIZE_5,
@@ -162,7 +164,7 @@ export function DeviceDetailsDeckConfiguration({
               {t('deck_configuration_is_not_available_when_robot_is_busy')}
             </Banner>
           ) : null}
-          <Flex gridGap={SPACING.spacing40}>
+          <Flex css={DECK_CONFIG_SECTION_STYLE}>
             <Flex
               // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
               marginLeft={`-${SPACING.spacing32}`}
@@ -197,7 +199,7 @@ export function DeviceDetailsDeckConfiguration({
                     backgroundColor={COLORS.fundamentalsBackground}
                     gridGap={SPACING.spacing60}
                     padding={SPACING.spacing8}
-                    width={SIZE_5}
+                    width="100%"
                     css={TYPOGRAPHY.labelRegular}
                   >
                     <StyledText>
@@ -213,7 +215,7 @@ export function DeviceDetailsDeckConfiguration({
                   backgroundColor={COLORS.fundamentalsBackground}
                   gridGap={SPACING.spacing60}
                   padding={SPACING.spacing8}
-                  width={SIZE_5}
+                  width="100%"
                   css={TYPOGRAPHY.labelRegular}
                 >
                   <StyledText>{t('no_deck_fixtures')}</StyledText>
@@ -226,3 +228,12 @@ export function DeviceDetailsDeckConfiguration({
     </>
   )
 }
+
+const DECK_CONFIG_SECTION_STYLE = css`
+  flex-direction: ${DIRECTION_ROW};
+  grid-gap: ${SPACING.spacing40};
+  @media screen and (max-width: 1024px) {
+    flex-direction: ${DIRECTION_COLUMN};
+    align-items: ${ALIGN_CENTER};
+  }
+`


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add media query to make deck config section responsive.
This PR does not align with the design completely responsive since deck configurator(svg) has own paddings.
Brian and Brent talked about making cartoon version of deck view for this in the future.

The key for this pr is to avoid cutting off the table when the windows width is less than 1024px.

I think we can make the entire device detail page responsive after 7.1.0.
 
design
https://www.figma.com/file/nJBVk8a26wdls3ZnkgRmns/OCT-Release%3A-Desktop-%5BDeck-configuration-%26-Drop-tips%5D?node-id=1620%3A14486&mode=dev

![Screenshot 2023-11-20 at 12 05 30 PM](https://github.com/Opentrons/opentrons/assets/474225/f970de1d-e4b2-4a82-831e-ef2f5bf998ec)

![Screenshot 2023-11-20 at 12 07 42 PM](https://github.com/Opentrons/opentrons/assets/474225/c79caae5-44fe-4eeb-9328-ad65871eabf6)

close RAUT-872
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
