### PR TITLE
fix(app): fix protocol card display issue for a failed analysis case

### DIFF
--- a/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
@@ -70,10 +70,11 @@ export function ProtocolCard(props: {
   )
 
   const isFailedAnalysis =
-    (mostRecentAnalysis != null &&
-      'result' in mostRecentAnalysis &&
-      (mostRecentAnalysis.result === 'error' ||
-        mostRecentAnalysis.result === 'not-ok')) ??
+    (mostRecentAnalysis == null ||
+      (mostRecentAnalysis != null &&
+        'result' in mostRecentAnalysis &&
+        (mostRecentAnalysis.result === 'error' ||
+          mostRecentAnalysis.result === 'not-ok'))) ??
     false
 
   const handleProtocolClick = (

--- a/app/src/pages/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -125,4 +125,23 @@ describe('ProtocolCard', () => {
     )
     getByText('Delete protocol')
   })
+
+  it('should display the analysis failed error modal when clicking on the protocol when doing a long pressing - undefined case', async () => {
+    mockUseProtocolAnalysisAsDocumentQuery.mockReturnValue({
+      data: undefined as any,
+    } as UseQueryResult<CompletedProtocolAnalysis>)
+    const [{ getByText, getByLabelText }] = render()
+    const name = getByText('yay mock protocol')
+    fireEvent.mouseDown(name)
+    jest.advanceTimersByTime(1005)
+    expect(props.longPress).toHaveBeenCalled()
+    getByLabelText('failedAnalysis_icon')
+    getByText('Failed analysis')
+    getByText('yay mock protocol').click()
+    getByText('Protocol analysis failed')
+    getByText(
+      'Delete the protocol, make changes to address the error, and resend the protocol to this robot from the Opentrons App.'
+    )
+    getByText('Delete protocol')
+  })
 })


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The error boundary is displayed because `mostRecentAnalysis` was undefined (since `Liquids` tab checks that to display liquids' information) and `isFailedAnalysis` missed the undefined case.

![Screenshot 2023-11-20 at 1 39 24 PM](https://github.com/Opentrons/opentrons/assets/474225/e1507053-a61f-4b76-b14a-ec9a8098c244)

close RQA-1916

[AllMovableTrashBins.json.zip](https://github.com/Opentrons/opentrons/files/13418378/AllMovableTrashBins.json.zip)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. send a failed analysis protocol to Flex
2. go to All Protocols and the protocol you sent is showing `Failed analysis`

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- modify the condition for `isFailedAnalysis`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
