### PR TITLE
feat(step-generation): create aspirateInPlace command creator

### DIFF
--- a/step-generation/src/__tests__/aspirateInPlace.test.ts
+++ b/step-generation/src/__tests__/aspirateInPlace.test.ts
@@ -1,0 +1,41 @@
+import {
+  makeContext,
+  getRobotStateWithTipStandard,
+  getSuccessResult,
+} from '../fixtures'
+import { aspirateInPlace } from '../commandCreators/atomic'
+import type { RobotState, InvariantContext } from '../types'
+import type { AspirateInPlaceArgs } from '../commandCreators/atomic/aspirateInPlace'
+
+describe('aspirateInPlace', () => {
+  let invariantContext: InvariantContext
+  let robotStateWithTip: RobotState
+
+  const mockId = 'mockId'
+  const mockFlowRate = 10
+  const mockVolume = 10
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotStateWithTip = getRobotStateWithTipStandard(invariantContext)
+  })
+  it('aspirate in place', () => {
+    const params: AspirateInPlaceArgs = {
+      pipetteId: mockId,
+      flowRate: mockFlowRate,
+      volume: mockVolume,
+    }
+    const result = aspirateInPlace(params, invariantContext, robotStateWithTip)
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        commandType: 'aspirateInPlace',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockId,
+          volume: mockVolume,
+          flowRate: mockFlowRate,
+        },
+      },
+    ])
+  })
+})

--- a/step-generation/src/commandCreators/atomic/aspirateInPlace.ts
+++ b/step-generation/src/commandCreators/atomic/aspirateInPlace.ts
@@ -1,0 +1,30 @@
+import { uuid } from '../../utils'
+import type { CommandCreator } from '../../types'
+export interface AspirateInPlaceArgs {
+  pipetteId: string
+  volume: number
+  flowRate: number
+}
+
+export const aspirateInPlace: CommandCreator<AspirateInPlaceArgs> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { pipetteId, volume, flowRate } = args
+
+  const commands = [
+    {
+      commandType: 'aspirateInPlace' as const,
+      key: uuid(),
+      params: {
+        pipetteId,
+        volume,
+        flowRate,
+      },
+    },
+  ]
+  return {
+    commands,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/index.ts
+++ b/step-generation/src/commandCreators/atomic/index.ts
@@ -1,4 +1,5 @@
 import { aspirate } from './aspirate'
+import { aspirateInPlace } from './aspirateInPlace'
 import { blowout } from './blowout'
 import { blowOutInPlace } from './blowOutInPlace'
 import { deactivateTemperature } from './deactivateTemperature'
@@ -19,6 +20,7 @@ import { touchTip } from './touchTip'
 import { waitForTemperature } from './waitForTemperature'
 export {
   aspirate,
+  aspirateInPlace,
   blowout,
   blowOutInPlace,
   deactivateTemperature,

--- a/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
@@ -1,7 +1,16 @@
+import type { AspirateInPlaceArgs } from '../commandCreators/atomic/aspirateInPlace'
 import type { BlowOutInPlaceArgs } from '../commandCreators/atomic/blowOutInPlace'
 import type { DispenseInPlaceArgs } from '../commandCreators/atomic/dispenseInPlace'
 import type { DropTipInPlaceArgs } from '../commandCreators/atomic/dropTipInPlace'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
+
+export const forAspirateInPlace = (
+  params: AspirateInPlaceArgs,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void => {
+  //   TODO(jr, 11/6/23): update state
+}
 
 export const forDispenseInPlace = (
   params: DispenseInPlaceArgs,

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -34,6 +34,7 @@ import {
 } from './heaterShakerUpdates'
 import { forMoveLabware } from './forMoveLabware'
 import {
+  forAspirateInPlace,
   forBlowOutInPlace,
   forDispenseInPlace,
   forDropTipInPlace,
@@ -95,6 +96,14 @@ function _getNextRobotStateAndWarningsSingleCommand(
 
     case 'moveLabware':
       forMoveLabware(command.params, invariantContext, robotStateAndWarnings)
+      break
+
+    case 'aspirateInPlace':
+      forAspirateInPlace(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
       break
 
     case 'dropTipInPlace':


### PR DESCRIPTION
closes [RAUT-874](https://opentrons.atlassian.net/browse/RAUT-874)

# Overview

Create aspirateInPlace atomic command creator with necessary params. Write test for new command and wireup

# Changelog

- create commandCreator for aspirateInPlace (referenced dispenseInPlace)
- write test for command
- add command inPlaceCommandUpdates with todo to update state

# Risk assessment

low

[RAUT-874]: https://opentrons.atlassian.net/browse/RAUT-874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ