### PR TITLE
refactor(protocol-designer): change tiprack default slot and copy upd…

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/PipetteTypeTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/PipetteTypeTile.tsx
@@ -46,7 +46,7 @@ export function FirstPipetteTypeTile(
       mount={mount}
       allowNoPipette={false}
       display96Channel={allow96Channel}
-      tileHeader={i18n.t('modal.create_file_wizard.choose_first_pipette')}
+      tileHeader={i18n.t('modal.create_file_wizard.choose_left_pipette')}
     />
   )
 }
@@ -66,7 +66,7 @@ export function SecondPipetteTypeTile(
         mount={RIGHT}
         allowNoPipette
         display96Channel={false}
-        tileHeader={i18n.t('modal.create_file_wizard.choose_second_pipette')}
+        tileHeader={i18n.t('modal.create_file_wizard.choose_right_pipette')}
       />
     )
   }

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -263,9 +263,15 @@ export function CreateFileWizard(): JSX.Element | null {
       const newTiprackModels: string[] = uniq(
         pipettes.map(pipette => pipette.tiprackDefURI)
       )
-      newTiprackModels.forEach(tiprackDefURI => {
+      newTiprackModels.forEach((tiprackDefURI, index) => {
+        const ot2Slots = index === 0 ? '2' : '5'
+        const flexSlots = index === 0 ? 'C2' : 'B2'
         dispatch(
           labwareIngredActions.createContainer({
+            slot:
+              values.fields.robotType === FLEX_ROBOT_TYPE
+                ? flexSlots
+                : ot2Slots,
             labwareDefURI: tiprackDefURI,
             adapterUnderLabwareDefURI:
               values.pipettesByMount.left.pipetteName === 'p1000_96'

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
@@ -162,7 +162,7 @@ describe('Edit Modules Modal', () => {
       getLabwareIsCompatibleMock.mockReturnValue(false)
       const wrapper = render(props)
       expect(wrapper.find(SlotDropdown).childAt(0).prop('error')).toMatch(
-        'Slot 1 is occupied. Clear the slot to continue.'
+        'Slot 1 is occupied. Navigate to the design tab and remove the labware or remove the additional item to continue.'
       )
     })
 
@@ -171,7 +171,7 @@ describe('Edit Modules Modal', () => {
       getSlotIdsBlockedBySpanningMock.mockReturnValue(['1']) // 1 is default slot
       const wrapper = render(props)
       expect(wrapper.find(SlotDropdown).childAt(0).prop('error')).toMatch(
-        'Slot 1 is occupied. Clear the slot to continue.'
+        'Slot 1 is occupied. Navigate to the design tab and remove the labware or remove the additional item to continue.'
       )
     })
 

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -197,7 +197,7 @@
   "module_placement": {
     "SLOT_OCCUPIED": {
       "title": "Cannot place module",
-      "body": "Slot {{selectedSlot}} is occupied. Clear the slot to continue."
+      "body": "Slot {{selectedSlot}} is occupied. Navigate to the design tab and remove the labware or remove the additional item to continue."
     },
     "HEATER_SHAKER_ADJACENT_LABWARE_TOO_TALL": {
       "title": "Cannot place module",

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -70,26 +70,26 @@
     }
   },
   "create_file_wizard": {
-    "choose_additional_items": "Choose additional items",
     "add_optional_info": "Add more information, if you like (you can change this later).",
+    "choose_additional_items": "Choose additional items",
     "choose_at_least_one_tip_rack": "Choose at least one tiprack for this pipette",
-    "choose_first_pipette": "Choose first pipette",
-    "choose_second_pipette": "Choose second pipette",
+    "choose_left_pipette": "Choose left pipette",
+    "choose_right_pipette": "Choose right pipette",
     "choose_robot_type": "Choose robot type",
     "choose_tips_for_pipette": "Choose tips for {{pipetteName}}",
     "create_new_protocol": "Create New Protocol",
     "custom_tiprack": "Custom tips",
-    "name_your_protocol": "Name your protocol.",
     "description": "Description",
+    "name_your_protocol": "Name your protocol.",
     "organization_or_author": "Organization/Author",
     "pipette_type": "Pipette Type",
-    "protocol_name": "Protocol Name",
     "protocol_name_and_description": "Protocol name and description",
+    "protocol_name": "Protocol Name",
     "review_file_details": "Review file details",
     "robot_type": "Robot Type",
+    "staging_areas": "Staging area slots",
     "upload_tiprack": "Upload a custom tiprack to select its definition",
-    "upload": "Upload",
-    "staging_areas": "Staging area slots"
+    "upload": "Upload"
   },
   "well_order": {
     "title": "Well Order",


### PR DESCRIPTION
…ates

closes RAUT-875

# Overview

This PR does a few things as discussed in a slack thread. They are all quality of life improvements from Anurag:
1. updates the copy in the pipette type tiles to specify "left" and "right" instead of "first" and "second"
2. adds a default slot for the generated pipettes. instead of being generated in the next available slot, they are generated in the center column for both the Ot-2 and Flex. This means that you can modify the modules without having to worry about the slot being occupied by the default tiprack
3. updates the copy for an occupied slot warning when editing the modules to something more descriptive

# Test Plan

Create a Flex protocol and notice that the pipette type tiles include which mount you are selecting a pipetting for. Make sure you add a pipette to both mounts. Once you've created the protocol, navigate to the design tab and see that the tipracks are generated in slots B2 and C2. Move one of the tipracks into slot A2. Then add a magnetic block from the file tab and see that the error says that the slot is occupied.

Now create a new protocol for the OT-2. Add both pipettes. Go to the design tab and see that the tipracks are generated in slots 2 and 5. 

# Changelog

- add a slot for the generated tips
- change the copy for the alert text and the modal tile headers

# Review requests

see test plan

# Risk assessment

low