### PR TITLE
refactor(robot-server,api-client): Rename `GET /deck_configuration` field `lastUpdatedAt` to `lastModifiedAt`

### DIFF
--- a/api-client/src/deck_configuration/types.ts
+++ b/api-client/src/deck_configuration/types.ts
@@ -9,6 +9,6 @@ export interface UpdateDeckConfigurationRequest {
 export interface DeckConfigurationResponse {
   data: {
     cutoutFixtures: DeckConfiguration
-    lastUpdatedAt: string
+    lastModifiedAt: string
   }
 }

--- a/robot-server/robot_server/deck_configuration/models.py
+++ b/robot-server/robot_server/deck_configuration/models.py
@@ -49,7 +49,7 @@ class DeckConfigurationResponse(pydantic.BaseModel):
     cutoutFixtures: List[CutoutFixture] = pydantic.Field(
         description="A full list of all the cutout fixtures that are mounted onto the deck."
     )
-    lastUpdatedAt: Optional[datetime] = pydantic.Field(
+    lastModifiedAt: Optional[datetime] = pydantic.Field(
         description=(
             "When the deck configuration was last set over HTTP."
             " If that has never happened, this will be `null` or omitted."

--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -59,7 +59,7 @@ router = fastapi.APIRouter()
 async def put_deck_configuration(  # noqa: D103
     request_body: RequestModel[models.DeckConfigurationRequest],
     store: DeckConfigurationStore = fastapi.Depends(get_deck_configuration_store),
-    last_updated_at: datetime = fastapi.Depends(get_current_time),
+    now: datetime = fastapi.Depends(get_current_time),
     deck_definition: DeckDefinitionV4 = fastapi.Depends(get_deck_definition),
 ) -> PydanticResponse[
     Union[
@@ -70,7 +70,7 @@ async def put_deck_configuration(  # noqa: D103
     placements = validation_mapping.map_in(request_body.data)
     validation_errors = validation.get_configuration_errors(deck_definition, placements)
     if len(validation_errors) == 0:
-        success_data = await store.set(request_body.data, last_updated_at)
+        success_data = await store.set(request=request_body.data, last_modified_at=now)
         return await PydanticResponse.create(
             content=SimpleBody.construct(data=success_data)
         )

--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -20,11 +20,11 @@ class DeckConfigurationStore:
         self._last_update: Optional[_LastUpdate] = None
 
     async def set(
-        self, request: models.DeckConfigurationRequest, last_updated_at: datetime
+        self, request: models.DeckConfigurationRequest, last_modified_at: datetime
     ) -> models.DeckConfigurationResponse:
         """Set the robot's current deck configuration."""
         self._last_update = _LastUpdate(
-            cutout_fixtures=request.cutoutFixtures, timestamp=last_updated_at
+            cutout_fixtures=request.cutoutFixtures, timestamp=last_modified_at
         )
         return await self.get()
 
@@ -35,12 +35,12 @@ class DeckConfigurationStore:
                 cutoutFixtures=defaults.for_deck_definition(
                     self._deck_type.value
                 ).cutoutFixtures,
-                lastUpdatedAt=None,
+                lastModifiedAt=None,
             )
         else:
             return models.DeckConfigurationResponse.construct(
                 cutoutFixtures=self._last_update.cutout_fixtures,
-                lastUpdatedAt=self._last_update.timestamp,
+                lastModifiedAt=self._last_update.timestamp,
             )
 
     async def get_deck_configuration(self) -> DeckConfigurationType:

--- a/robot-server/tests/integration/http_api/test_deck_configuration.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_deck_configuration.tavern.yaml
@@ -12,14 +12,14 @@ stages:
     response:
       json:
         data:
-          # lastUpdatedAt is deliberately omitted from this expected object.
-          # A lastUpdatedAt that's omitted or null means the deck configuration has never been set.
+          # lastModifiedAt is deliberately omitted from this expected object.
+          # A lastModifiedAt that's omitted or null means the deck configuration has never been set.
           #
           # Unfortunately, this makes this test order-dependent with any other tests
           # that modify the deck configuration, even if they try to restore the original value
           # after they're done. We probably need some kind of deck configuration factory-reset.
           #
-          # lastUpdatedAt: null
+          # lastModifiedAt: null
           cutoutFixtures:
             - cutoutFixtureId: singleLeftSlot
               cutoutId: cutoutA1
@@ -86,11 +86,11 @@ stages:
     response:
       json:
         data:
-          lastUpdatedAt: !anystr
+          lastModifiedAt: !anystr
           cutoutFixtures: *expectedCutoutFixtures
       save:
         json:
-          last_updated_at: data.lastUpdatedAt
+          last_modified_at: data.lastModifiedAt
 
   - name: Set an invalid deck configuration
     request:
@@ -142,5 +142,5 @@ stages:
     response:
       json:
         data:
-          lastUpdatedAt: '{last_updated_at}'
+          lastModifiedAt: '{last_modified_at}'
           cutoutFixtures: *expectedCutoutFixtures


### PR DESCRIPTION
# Overview

When I added the `GET /deck_configuration` endpoint, I gave it a `lastUpdatedAt` field.

That name is accidentally inconsistent with our calibration endpoints (deck, pipette, etc.), which instead use `lastModified`.

This PR changes `lastUpdatedAt` to `lastModifiedAt`.

I'm deliberately keeping the `At` suffix because that has been an intentional naming convention of our HTTP API going forward. (Protocol Engine has `createdAt`, `completedAt`, etc.) So that's an intentional inconsistency.

# Test Plan

None applicable. As far as I can tell, there's not yet any app code that reads this field.

# Changelog

* Rename the `lastUpdatedAt` field in `GET /deck_configuration` to `lastModifiedAt`.
* Update the TypeScript bindings. 

# Review requests

None in particular.

# Risk assessment

Low for now, since nothing uses this yet.