### PR TITLE
feat(app): Add warning for 96-channel calibration with waste chute

### DIFF
--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -1,6 +1,6 @@
 {
   "attach_probe": "Attach probe to pipette",
-  "begin_calibration": "Begin automated calibration",
+  "begin_calibration": "Begin calibration",
   "calibrate_pipette": "Calibrate pipettes before proceeding to module calibration",
   "calibrate": "Calibrate",
   "calibration_adapter_heatershaker": "Calibration Adapter",
@@ -22,9 +22,6 @@
   "firmware_updated": "{{module}} firmware updated!",
   "firmware_up_to_date": "{{module}} firmware up to date.",
   "get_started": "<block>To get started, remove labware from the deck and clean up the working area to make the calibration easier. Also gather the needed equipment shown to the right.</block><block>The calibration adapter came with your module. The pipette probe came with your Flex pipette.</block>",
-  "install_probe_8_channel": "<block>Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the <strong>backmost</strong> pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.</block>",
-  "install_probe_96_channel": "<block>Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the <strong>A1 (back left corner)</strong> pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.</block>",
-  "install_probe": "Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.",
   "module_calibrating": "Stand back, {{moduleName}} is calibrating",
   "module_calibration_failed": "The module calibration could not be completed. Contact customer support for assistance.",
   "module_calibration": "Module calibration",

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -46,7 +46,7 @@
   "hold_and_loosen": "Hold the pipette in place and loosen the pipette screws. (The screws are captive and will not come apart from the pipette.) Then carefully remove the pipette.",
   "hold_pipette_carefully": "Hold onto the pipette so it does not fall. Connect the pipette by aligning the two protruding rods on the mounting plate. Ensure a secure attachment by screwing in the four front screws with the provided screwdriver.",
   "how_to_reattach": "<block>Push the right pipette mount up to the top of the z-axis. Then tighten the captive screw at the top right of the gantry carriage.</block><block>When reattached, the right mount should no longer freely move up and down.</block>",
-  "install_probe": "Take the calibration probe from its storage location. Ensure its collar is fully unlocked. Push the pipette ejector up and press the probe firmly onto the <bold>{{location}}</bold> pipette nozzle as far as it can go. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.",
+  "install_probe": "Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the <bold>{{location}}</bold> pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.",
   "loose_detach": "Loosen screws and detach ",
   "move_gantry_to_front": "Move gantry to front",
   "must_detach_mounting_plate": "You must detach the mounting plate and reattach the z-axis carraige before using other pipettes. We do not recommend exiting this process before completion.",
@@ -84,6 +84,8 @@
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",
+  "waste_chute_error": "Remove the Waste Chute from the Deck Plate Adaptor before proceeding.",
+  "waste_chute_warning": "If the Waste Chute is installed, remove it from the Deck Plate Adaptor before proceeding.",
   "wrong_pip": "wrong instrument installed",
   "z_axis_still_attached": "z-axis screw still secure"
 }

--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -84,8 +84,8 @@
   "unscrew_and_detach": "Loosen Screws and Detach Mounting Plate",
   "unscrew_at_top": "<block>Loosen the captive screw on the top right of the  carriage. This releases the right pipette mount, which should then freely move up and down.</block>",
   "unscrew_carriage": "unscrew z-axis carriage",
-  "waste_chute_error": "Remove the Waste Chute from the Deck Plate Adaptor before proceeding.",
-  "waste_chute_warning": "If the Waste Chute is installed, remove it from the Deck Plate Adaptor before proceeding.",
+  "waste_chute_error": "Remove the waste chute from the deck plate adapter before proceeding.",
+  "waste_chute_warning": "If the waste chute is installed, remove it from the deck plate adapter before proceeding.",
   "wrong_pip": "wrong instrument installed",
   "z_axis_still_attached": "z-axis screw still secure"
 }

--- a/app/src/molecules/GenericWizardTile/index.tsx
+++ b/app/src/molecules/GenericWizardTile/index.tsx
@@ -130,7 +130,7 @@ export function GenericWizardTile(props: GenericWizardTileProps): JSX.Element {
         <Flex
           flexDirection={DIRECTION_COLUMN}
           flex="1"
-          gridGap={SPACING.spacing24}
+          gridGap={isOnDevice ? SPACING.spacing8 : SPACING.spacing16}
         >
           <Flex display={DISPLAY_INLINE_BLOCK}>
             {typeof header === 'string' ? <Title>{header}</Title> : header}

--- a/app/src/organisms/LabwarePositionCheck/ExitConfirmation.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ExitConfirmation.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   Icon,
   ALIGN_CENTER,
-  JUSTIFY_SPACE_BETWEEN,
   DIRECTION_COLUMN,
   SPACING,
   SIZE_3,
@@ -99,7 +98,7 @@ export const ExitConfirmation = (props: ExitConfirmationProps): JSX.Element => {
         <Flex
           width="100%"
           marginTop={SPACING.spacing32}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          justifyContent={JUSTIFY_FLEX_END}
           alignItems={ALIGN_CENTER}
         >
           <Flex gridGap={SPACING.spacing8}>
@@ -123,7 +122,7 @@ export const ExitConfirmation = (props: ExitConfirmationProps): JSX.Element => {
 
 const ConfirmationHeader = styled.h1`
   margin-top: ${SPACING.spacing24};
-  ${TYPOGRAPHY.level3HeaderSemiBold}
+  ${TYPOGRAPHY.h1Default}
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     ${TYPOGRAPHY.level4HeaderSemiBold}
   }

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -161,7 +161,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         <Banner
           type={isWasteChuteOnDeck ? 'error' : 'warning'}
           size={isOnDevice ? '1.5rem' : SIZE_1}
-          marginY={SPACING.spacing4}
+          marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
         >
           {isWasteChuteOnDeck
             ? t('pipette_wizard_flows:waste_chute_error')

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -4,6 +4,7 @@ import attachProbe1 from '../../assets/videos/pipette-wizard-flows/Pipette_Attac
 import attachProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_8.webm'
 import attachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_96.webm'
 import { Trans, useTranslation } from 'react-i18next'
+import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
 import {
   LEFT,
   THERMOCYCLER_MODULE_MODELS,
@@ -15,8 +16,10 @@ import {
   RESPONSIVENESS,
   SPACING,
   TYPOGRAPHY,
+  SIZE_1,
 } from '@opentrons/components'
 
+import { Banner } from '../../atoms/Banner'
 import { StyledText } from '../../atoms/text'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 
@@ -59,26 +62,34 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     isOnDevice,
     slotName,
   } = props
-  const { t, i18n } = useTranslation('module_wizard_flows')
+  const { t, i18n } = useTranslation([
+    'module_wizard_flows',
+    'pipette_wizard_flows',
+  ])
 
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
 
   const attachedPipetteChannels = attachedPipette.data.channels
-  let pipetteAttachProbeVideoSource, i18nKey
+  let pipetteAttachProbeVideoSource, probeLocation
   switch (attachedPipetteChannels) {
     case 1:
       pipetteAttachProbeVideoSource = attachProbe1
-      i18nKey = 'install_probe'
+      probeLocation = ''
       break
     case 8:
       pipetteAttachProbeVideoSource = attachProbe8
-      i18nKey = 'install_probe_8_channel'
+      probeLocation = t('pipette_wizard_flows:backmost')
       break
     case 96:
       pipetteAttachProbeVideoSource = attachProbe96
-      i18nKey = 'install_probe_96_channel'
+      probeLocation = t('pipette_wizard_flows:ninety_six_probe_location')
       break
   }
+  const wasteChuteConflict =
+    slotName === 'C3' && attachedPipette.data.channels === 96
+  const deckConfig = useDeckConfigurationQuery().data
+  const isWasteChuteOnDeck =
+    deckConfig?.find(fixture => fixture.loadName === 'wasteChute') ?? false
 
   const pipetteAttachProbeVid = (
     <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
@@ -135,19 +146,30 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       </InProgressModal>
     )
 
-  const bodyText =
-    attachedPipetteChannels === 8 || attachedPipetteChannels === 96 ? (
+  const bodyText = (
+    <>
       <Trans
         t={t}
-        i18nKey={i18nKey}
+        i18nKey={'pipette_wizard_flows:install_probe'}
+        values={{ location: probeLocation }}
         components={{
           strong: <strong />,
           block: <StyledText css={BODY_STYLE} />,
         }}
       />
-    ) : (
-      <StyledText css={BODY_STYLE}>{t('install_probe')}</StyledText>
-    )
+      {wasteChuteConflict && (
+        <Banner
+          type={isWasteChuteOnDeck ? 'error' : 'warning'}
+          size={isOnDevice ? '1.5rem' : SIZE_1}
+          marginY={SPACING.spacing4}
+        >
+          {isWasteChuteOnDeck
+            ? t('pipette_wizard_flows:waste_chute_error')
+            : t('pipette_wizard_flows:waste_chute_warning')}
+        </Banner>
+      )}
+    </>
+  )
 
   const handleBeginCalibration = (): void => {
     if (adapterId == null) {

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -5,6 +5,7 @@ import attachProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Attac
 import attachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_96.webm'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
+import { WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import {
   LEFT,
   THERMOCYCLER_MODULE_MODELS,
@@ -16,7 +17,6 @@ import {
   RESPONSIVENESS,
   SPACING,
   TYPOGRAPHY,
-  SIZE_1,
 } from '@opentrons/components'
 
 import { Banner } from '../../atoms/Banner'
@@ -89,7 +89,8 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     slotName === 'C3' && attachedPipette.data.channels === 96
   const deckConfig = useDeckConfigurationQuery().data
   const isWasteChuteOnDeck =
-    deckConfig?.find(fixture => fixture.loadName === 'wasteChute') ?? false
+    deckConfig?.find(fixture => fixture.cutoutId === WASTE_CHUTE_CUTOUT) ??
+    false
 
   const pipetteAttachProbeVid = (
     <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
@@ -160,7 +161,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       {wasteChuteConflict && (
         <Banner
           type={isWasteChuteOnDeck ? 'error' : 'warning'}
-          size={isOnDevice ? '1.5rem' : SIZE_1}
+          size={isOnDevice ? '1.5rem' : '1rem'}
           marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
         >
           {isWasteChuteOnDeck

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -7,9 +7,8 @@ import {
   COLORS,
   SPACING,
   RESPONSIVENESS,
-  SIZE_1,
 } from '@opentrons/components'
-import { LEFT, MotorAxes } from '@opentrons/shared-data'
+import { LEFT, MotorAxes, WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import {
   useDeckConfigurationQuery,
   useInstrumentsQuery,
@@ -82,7 +81,8 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   )
   const deckConfig = useDeckConfigurationQuery().data
   const isWasteChuteOnDeck =
-    deckConfig?.find(fixture => fixture.loadName === 'wasteChute') ?? false
+    deckConfig?.find(fixture => fixture.cutoutId === WASTE_CHUTE_CUTOUT) ??
+    false
 
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
@@ -236,7 +236,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
           {is96Channel && (
             <Banner
               type={isWasteChuteOnDeck ? 'error' : 'warning'}
-              size={isOnDevice ? '1.5rem' : SIZE_1}
+              size={isOnDevice ? '1.5rem' : '1rem'}
               marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
             >
               {isWasteChuteOnDeck

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -237,7 +237,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
             <Banner
               type={isWasteChuteOnDeck ? 'error' : 'warning'}
               size={isOnDevice ? '1.5rem' : SIZE_1}
-              // marginY={SPACING.}
+              marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
             >
               {isWasteChuteOnDeck
                 ? t('waste_chute_error')

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -7,10 +7,15 @@ import {
   COLORS,
   SPACING,
   RESPONSIVENESS,
+  SIZE_1,
 } from '@opentrons/components'
 import { LEFT, MotorAxes } from '@opentrons/shared-data'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import {
+  useDeckConfigurationQuery,
+  useInstrumentsQuery,
+} from '@opentrons/react-api-client'
 import { StyledText } from '../../atoms/text'
+import { Banner } from '../../atoms/Banner'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
@@ -75,6 +80,9 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     (instrument): instrument is PipetteData =>
       instrument.ok && instrument.mount === mount
   )
+  const deckConfig = useDeckConfigurationQuery().data
+  const isWasteChuteOnDeck =
+    deckConfig?.find(fixture => fixture.loadName === 'wasteChute') ?? false
 
   if (pipetteId == null) return null
   const handleOnClick = (): void => {
@@ -214,16 +222,29 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         channel: attachedPipettes[mount]?.data.channels,
       })}
       bodyText={
-        <StyledText css={BODY_STYLE}>
-          <Trans
-            t={t}
-            i18nKey={'install_probe'}
-            values={{ location: probeLocation }}
-            components={{
-              bold: <strong />,
-            }}
-          />
-        </StyledText>
+        <>
+          <StyledText css={BODY_STYLE}>
+            <Trans
+              t={t}
+              i18nKey={'install_probe'}
+              values={{ location: probeLocation }}
+              components={{
+                bold: <strong />,
+              }}
+            />
+          </StyledText>
+          {is96Channel && (
+            <Banner
+              type={isWasteChuteOnDeck ? 'error' : 'warning'}
+              size={isOnDevice ? '1.5rem' : SIZE_1}
+              // marginY={SPACING.}
+            >
+              {isWasteChuteOnDeck
+                ? t('waste_chute_error')
+                : t('waste_chute_warning')}
+            </Banner>
+          )}
+        </>
       }
       proceedButtonText={t('begin_calibration')}
       proceed={handleOnClick}

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
 import { UseMutateFunction } from 'react-query'
 import { COLORS, DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
 import {
@@ -11,7 +12,6 @@ import {
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
-import { Trans, useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react'
 import { UseMutateFunction } from 'react-query'
-import {
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  SIZE_1,
-  SPACING,
-} from '@opentrons/components'
+import { COLORS, DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
 import {
   NINETY_SIX_CHANNEL,
   RIGHT,
@@ -14,6 +8,7 @@ import {
   WEIGHT_OF_96_CHANNEL,
   LoadedPipette,
   getPipetteNameSpecs,
+  WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
 import { Trans, useTranslation } from 'react-i18next'
@@ -86,7 +81,8 @@ export const BeforeBeginning = (
     flowType === FLOWS.ATTACH
   const deckConfig = useDeckConfigurationQuery().data
   const isWasteChuteOnDeck =
-    deckConfig?.find(fixture => fixture.loadName === 'wasteChute') ?? false
+    deckConfig?.find(fixture => fixture.cutoutId === WASTE_CHUTE_CUTOUT) ??
+    false
 
   if (
     pipetteId == null &&
@@ -261,7 +257,7 @@ export const BeforeBeginning = (
           (flowType === FLOWS.CALIBRATE || flowType === FLOWS.ATTACH) ? (
             <Banner
               type={isWasteChuteOnDeck ? 'error' : 'warning'}
-              size={isOnDevice ? '1.5rem' : SIZE_1}
+              size={isOnDevice ? '1.5rem' : '1rem'}
               marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
             >
               {isWasteChuteOnDeck
@@ -271,7 +267,7 @@ export const BeforeBeginning = (
           ) : (
             <Banner
               type="warning"
-              size={isOnDevice ? '1.5rem' : SIZE_1}
+              size={isOnDevice ? '1.5rem' : '1rem'}
               marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
             >
               {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -15,6 +15,7 @@ import {
   LoadedPipette,
   getPipetteNameSpecs,
 } from '@opentrons/shared-data'
+import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
 import { Trans, useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
@@ -83,6 +84,9 @@ export const BeforeBeginning = (
     isGantryEmpty &&
     selectedPipette === NINETY_SIX_CHANNEL &&
     flowType === FLOWS.ATTACH
+  const deckConfig = useDeckConfigurationQuery().data
+  const isWasteChuteOnDeck =
+    deckConfig?.find(fixture => fixture.loadName === 'wasteChute') ?? false
 
   if (
     pipetteId == null &&
@@ -234,21 +238,9 @@ export const BeforeBeginning = (
   ) : (
     <GenericWizardTile
       header={t('before_you_begin')}
-      //  TODO(jr, 11/3/22): wire up this URL and unhide the link!
-      // getHelp={BEFORE_YOU_BEGIN_URL}
       rightHandBody={rightHandBody}
       bodyText={
         <>
-          {selectedPipette === NINETY_SIX_CHANNEL &&
-          (flowType === FLOWS.DETACH || flowType === FLOWS.ATTACH) ? (
-            <Banner
-              type="warning"
-              size={isOnDevice ? '1.5rem' : SIZE_1}
-              marginY={SPACING.spacing4}
-            >
-              {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
-            </Banner>
-          ) : null}
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing6}>
             <Trans
               t={t}
@@ -257,7 +249,34 @@ export const BeforeBeginning = (
                 block: <StyledText css={BODY_STYLE} />,
               }}
             />
+            {selectedPipette === NINETY_SIX_CHANNEL &&
+              flowType === FLOWS.ATTACH &&
+              !isOnDevice && (
+                <StyledText css={BODY_STYLE}>
+                  {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
+                </StyledText>
+              )}
           </Flex>
+          {selectedPipette === NINETY_SIX_CHANNEL &&
+          (flowType === FLOWS.CALIBRATE || flowType === FLOWS.ATTACH) ? (
+            <Banner
+              type={isWasteChuteOnDeck ? 'error' : 'warning'}
+              size={isOnDevice ? '1.5rem' : SIZE_1}
+              marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
+            >
+              {isWasteChuteOnDeck
+                ? t('waste_chute_error')
+                : t('waste_chute_warning')}
+            </Banner>
+          ) : (
+            <Banner
+              type="warning"
+              size={isOnDevice ? '1.5rem' : SIZE_1}
+              marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
+            >
+              {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
+            </Banner>
+          )}
         </>
       }
       proceedButtonText={proceedButtonText}

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
-import { RIGHT } from '@opentrons/shared-data'
+import { RIGHT, WEIGHT_OF_96_CHANNEL } from '@opentrons/shared-data'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import {
   Btn,
@@ -13,9 +13,11 @@ import {
   ALIGN_FLEX_END,
   ALIGN_CENTER,
   SPACING,
+  SIZE_1,
   RESPONSIVENESS,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
+import { Banner } from '../../atoms/Banner'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { Skeleton } from '../../atoms/Skeleton'
@@ -153,7 +155,20 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
       </>
     )
   } else {
-    bodyText = <StyledText css={BODY_STYLE}>{t('hold_and_loosen')}</StyledText>
+    bodyText = (
+      <>
+        <StyledText css={BODY_STYLE}>{t('hold_and_loosen')}</StyledText>
+        {is96ChannelPipette && (
+          <Banner
+            type="warning"
+            size={isOnDevice ? '1.5rem' : SIZE_1}
+            marginY={SPACING.spacing4}
+          >
+            {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
+          </Banner>
+        )}
+      </>
+    )
   }
 
   if (isRobotMoving) return <InProgressModal description={t('stand_back')} />

--- a/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountPipette.tsx
@@ -55,6 +55,11 @@ export const MountPipette = (props: MountPipetteProps): JSX.Element => {
   } else {
     bodyText = (
       <>
+        <StyledText css={BODY_STYLE}>
+          {isSingleMountPipette
+            ? t('align_the_connector')
+            : t('hold_pipette_carefully')}
+        </StyledText>
         {!isSingleMountPipette ? (
           <Banner
             type="warning"
@@ -64,11 +69,6 @@ export const MountPipette = (props: MountPipetteProps): JSX.Element => {
             {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
           </Banner>
         ) : null}
-        <StyledText css={BODY_STYLE}>
-          {isSingleMountPipette
-            ? t('align_the_connector')
-            : t('hold_pipette_carefully')}
-        </StyledText>
       </>
     )
   }

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -245,7 +245,7 @@ describe('AttachProbe', () => {
     }
     const { getByText } = render(props)
     getByText(
-      'Remove the Waste Chute from the Deck Plate Adaptor before proceeding.'
+      'Remove the waste chute from the deck plate adapter before proceeding.'
     )
   })
 })

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -68,7 +68,7 @@ describe('AttachProbe', () => {
     mockUseDeckConfigurationQuery.mockReturnValue({
       data: [
         {
-          loadName: 'wasteChute',
+          cutoutId: 'cutoutD3',
         } as any,
       ],
     } as any)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { nestedTextMatcher, renderWithProviders } from '@opentrons/components'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import {
+  useInstrumentsQuery,
+  useDeckConfigurationQuery,
+} from '@opentrons/react-api-client'
 import { LEFT, SINGLE_MOUNT_PIPETTES } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import {
@@ -22,6 +25,9 @@ jest.mock('@opentrons/react-api-client')
 
 const mockUseInstrumentsQuery = useInstrumentsQuery as jest.MockedFunction<
   typeof useInstrumentsQuery
+>
+const mockUseDeckConfigurationQuery = useDeckConfigurationQuery as jest.MockedFunction<
+  typeof useDeckConfigurationQuery
 >
 
 describe('AttachProbe', () => {
@@ -59,12 +65,19 @@ describe('AttachProbe', () => {
       } as any,
       refetch,
     } as any)
+    mockUseDeckConfigurationQuery.mockReturnValue({
+      data: [
+        {
+          loadName: 'wasteChute',
+        } as any,
+      ],
+    } as any)
   })
   it('returns the correct information, buttons work as expected', async () => {
     const { getByText, getByTestId, getByRole, getByLabelText } = render(props)
     getByText('Attach calibration probe')
     getByText(
-      'Take the calibration probe from its storage location. Ensure its collar is fully unlocked. Push the pipette ejector up and press the probe firmly onto the pipette nozzle as far as it can go. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.'
+      'Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.'
     )
     getByTestId('Pipette_Attach_Probe_1.webm')
     const proceedBtn = getByRole('button', { name: 'Begin calibration' })
@@ -111,7 +124,7 @@ describe('AttachProbe', () => {
     const { getByText } = render(props)
     getByText(
       nestedTextMatcher(
-        'Take the calibration probe from its storage location. Ensure its collar is fully unlocked. Push the pipette ejector up and press the probe firmly onto the backmost pipette nozzle as far as it can go. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.'
+        'Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the backmost pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.'
       )
     )
   })
@@ -181,7 +194,7 @@ describe('AttachProbe', () => {
     const { getByText, getByTestId, getByRole, getByLabelText } = render(props)
     getByText('Attach calibration probe')
     getByText(
-      'Take the calibration probe from its storage location. Ensure its collar is fully unlocked. Push the pipette ejector up and press the probe firmly onto the pipette nozzle as far as it can go. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.'
+      'Take the calibration probe from its storage location. Ensure its collar is unlocked. Push the pipette ejector up and press the probe firmly onto the pipette nozzle. Twist the collar to lock the probe. Test that the probe is secure by gently pulling it back and forth.'
     )
     getByTestId('Pipette_Attach_Probe_1.webm')
     getByRole('button', { name: 'Begin calibration' }).click()
@@ -220,5 +233,19 @@ describe('AttachProbe', () => {
       flowType: FLOWS.ATTACH,
     }
     expect(screen.queryByLabelText('back')).not.toBeInTheDocument()
+  })
+
+  it('renders a waste chute warning when 96 channel and waste chute are attached', () => {
+    props = {
+      ...props,
+      attachedPipettes: {
+        left: mock96ChannelAttachedPipetteInformation,
+        right: null,
+      },
+    }
+    const { getByText } = render(props)
+    getByText(
+      'Remove the Waste Chute from the Deck Plate Adaptor before proceeding.'
+    )
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
fix RQA-1883, RQA-1897, RAUT-848
# Overview
This PR adds a warning to calibration flows that use a 96 channel telling users to detach the waste chute before calibrating. It also updates some styling and copy of banners in these flows to match designs.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
With a 96-channel attached, initiate both calibration and module calibration flows. Ensure the following is true:
1. For pipette cal, if no waste chute is in the deck config you should see a yellow warning on both the before beginning and attach probe screens
2. If the waste chute is in the deck config, this should be a red banner instead of yellow
3. For module calibration, the same logic should apply to the attach probe screen only if there is a module in slot C3 being calibrated

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Add banner for waste chute collision to pipette cal before beginning and attach probe and module cal attach probe screen
2. Move all banners in pipette flows to below the body text instead of above it
3. Update copy and padding to match designs
4. Fix styling bug on LPC early exit screen

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test this out if you can! Should be doable with a simulator
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
