### PR TITLE
refactor(protocol-engine): Delete duplicate DeckConfiguration type

### DIFF
--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -1,6 +1,6 @@
 """Basic addressable area data state and store."""
 from dataclasses import dataclass
-from typing import Dict, Set, Union, List, Tuple
+from typing import Dict, Set, Union, List
 
 from opentrons_shared_data.deck.dev_types import DeckDefinitionV4, SlotDefV3
 

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -59,10 +59,6 @@ def _get_conflicting_addressable_areas(
     return loaded_areas_on_cutout
 
 
-# TODO make the below some sort of better type
-DeckConfiguration = List[Tuple[str, str]]  # cutout_id, cutout_fixture_id
-
-
 class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
     """Addressable area state container."""
 
@@ -126,7 +122,7 @@ class AddressableAreaStore(HasState[AddressableAreaState], HandlesActions):
 
     @staticmethod
     def _get_addressable_areas_from_deck_configuration(
-        deck_config: DeckConfiguration, deck_definition: DeckDefinitionV4
+        deck_config: DeckConfigurationType, deck_definition: DeckDefinitionV4
     ) -> Dict[str, AddressableArea]:
         """Load all provided addressable areas with a valid deck configuration."""
         # TODO uncomment once execute is hooked up with this properly

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -776,4 +776,4 @@ NozzleLayoutConfigurationType = Union[
 ]
 
 # TODO make the below some sort of better type
-DeckConfigurationType = List[Tuple[str, str]]
+DeckConfigurationType = List[Tuple[str, str]]  # cutout_id, cutout_fixture_id

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store.py
@@ -16,9 +16,9 @@ from opentrons.protocol_engine.state import Config
 from opentrons.protocol_engine.state.addressable_areas import (
     AddressableAreaStore,
     AddressableAreaState,
-    DeckConfiguration,
 )
 from opentrons.protocol_engine.types import (
+    DeckConfigurationType,
     DeckType,
     ModuleModel,
     LabwareMovementStrategy,
@@ -33,7 +33,7 @@ from .command_fixtures import (
 )
 
 
-def _make_deck_config() -> DeckConfiguration:
+def _make_deck_config() -> DeckConfigurationType:
     return [
         ("cutoutA1", "singleLeftSlot"),
         ("cutoutB1", "singleLeftSlot"),


### PR DESCRIPTION
# Overview

`opentrons.protocol_engine` had two identical type aliases, `DeckConfiguration` and `DeckConfigurationType`. I think this was just an accidental thing left over from #13971.

This PR deletes the older `addressable_areas.DeckConfiguration` in favor of the newer `types.DeckConfigurationType`.

The `# todo` to make this type more semantic (not a `Tuple` alias) still stands. We also still intend to deduplicate this further with other deck configuration types outside of `opentrons.protocol_engine`.

# Test Plan

None needed.

# Review requests

Did I resolve this duplication in the correct direction?

# Risk assessment

Low.