### PR TITLE
fix(hardware-testing): remove partial for gravi

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -376,7 +376,10 @@ def _load_pipette(
     if pipette.channels == 8 and not increment and not photometric:
         hwapi = get_sync_hw_api(ctx)
         mnt = OT3Mount.LEFT if pipette_mount == "left" else OT3Mount.RIGHT
-        hwapi.update_nozzle_configuration_for_mount(mnt, "H1", "H1", "H1")
+        hwpipette: Pipette = hwapi.hardware_pipettes[mnt.to_mount()]
+        hwpipette._config.pick_up_tip_configurations.press_fit.current_by_tip_count[
+            8
+        ] = 0.2
     return pipette
 
 


### PR DESCRIPTION
If we want to use the nozzle configurations in the gravimetric testing, in addition to setting the configuration we need to change the protocols to specify
- pick_up_tip in the right well rather than A1 for alignment
- liquid handling in the right well rather than A1 for alignment
- which nozzle should be active every time we change which tip we're testing

