### PR TITLE
chore(api): Update overpressure text

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -232,8 +232,8 @@ settings = [
     ),
     SettingDefinition(
         _id="disableOverpressureDetection",
-        title="Disable overpressure detection on pipettes.",
-        description="This setting disables overpressure detection on pipettes, do not turn this feature off unless recommended.",
+        title="Disable pipette pressure sensing.",
+        description="This setting disables pressure sensing capability on pipettes. This will prevent errors when overpressuring the pipette. Do not set this setting unless you are intentionally causing >8kPa inside the pipette air channel.",
         robot_type=[RobotTypeEnum.FLEX],
     ),
     SettingDefinition(

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -129,10 +129,21 @@ lint:
 format:
 	$(python) -m black .
 
-.PHONY: dev
-dev: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= dev.env
-dev:
+.PHONY: _dev
+_dev:
 	$(pipenv) run $(run_dev)
+
+.PHONY: dev
+dev: dev-ot2
+
+.PHONY: dev-flex
+dev-flex: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= dev-flex.env
+dev-flex: _dev
+
+.PHONY: dev-ot2
+dev-ot2: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= dev.env
+dev-ot2: _dev
+
 
 .PHONY: dev-with-emulator
 dev-with-emulator: export OT_ROBOT_SERVER_DOT_ENV_PATH ?= emulator.env


### PR DESCRIPTION
The overpressure disable button is going to be useful for when people want to purposefully put high pressures inside the pipette air columns. Let's make the name and description a bit more explicit.

Here's what it looks like now:
<img width="915" alt="Screenshot 2023-11-27 at 4 06 01 PM" src="https://github.com/Opentrons/opentrons/assets/3091648/c54c80d9-0c04-4c88-bb31-95c1951a9546">
