### PR TITLE
chore(shared-data): Update the waste chute dimensions for the new lowered lid

### DIFF
--- a/api/src/opentrons/protocol_api/_waste_chute_dimensions.py
+++ b/api/src/opentrons/protocol_api/_waste_chute_dimensions.py
@@ -7,7 +7,7 @@ TODO: These should be moved into shared-data and interpreted by Protocol Engine.
 from opentrons.types import Point
 
 
-SLOT_ORIGIN_TO_1_OR_8_TIP_A1 = Point(64, 21.91, 144)
+SLOT_ORIGIN_TO_1_OR_8_TIP_A1 = Point(64, 21.91, 115)
 SLOT_ORIGIN_TO_96_TIP_A1 = Point(14.445, 42.085, 115)
 
 # TODO: This z-coord is misleading. We need to account for the labware height and the paddle height;

--- a/api/src/opentrons/protocol_api/_waste_chute_dimensions.py
+++ b/api/src/opentrons/protocol_api/_waste_chute_dimensions.py
@@ -14,5 +14,5 @@ SLOT_ORIGIN_TO_96_TIP_A1 = Point(14.445, 42.085, 115)
 # we can't define this as a single coordinate.
 SLOT_ORIGIN_TO_GRIPPER_JAW_CENTER = Point(64, 29, 136.5)
 
-# This includes the height of the optional lid.
-ENVELOPE_HEIGHT = 154
+# This is the same with or without the cover attached, since the cover is flush with the rim.
+ENVELOPE_HEIGHT = 125

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
@@ -307,7 +307,7 @@ def test_get_potential_cutout_fixtures_raises(
             AddressableArea(
                 area_name="gripperWasteChute",
                 display_name="Gripper Waste Chute",
-                bounding_box=Dimensions(x=155.0, y=86.0, z=154.0),
+                bounding_box=Dimensions(x=155.0, y=86.0, z=125.0),
                 position=AddressableOffsetVector(x=-12.5, y=2, z=3),
                 compatible_module_types=[],
                 drop_tip_location=None,

--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -364,11 +364,11 @@
         "boundingBox": {
           "xDimension": 155.0,
           "yDimension": 86.0,
-          "zDimension": 154.0
+          "zDimension": 125.0
         },
         "displayName": "1/8 Channel Waste Chute",
         "ableToDropTips": true,
-        "dropTipsOffset": [64.0, 21.91, 144.0]
+        "dropTipsOffset": [64.0, 21.91, 115.0]
       },
       {
         "id": "96ChannelWasteChute",
@@ -377,7 +377,7 @@
         "boundingBox": {
           "xDimension": 155.0,
           "yDimension": 86.0,
-          "zDimension": 154.0
+          "zDimension": 125.0
         },
         "displayName": "96 Channel Waste Chute",
         "ableToDropTips": true,
@@ -390,7 +390,7 @@
         "boundingBox": {
           "xDimension": 155.0,
           "yDimension": 86.0,
-          "zDimension": 154.0
+          "zDimension": 125.0
         },
         "displayName": "Gripper Waste Chute",
         "ableToDropLabware": true,


### PR DESCRIPTION
# Overview

Closes RSS-394.

# Test Plan

* [x] Drop some tips with an 8-channel pipette. It should be ~~10 mm below~~ level with the new, shorter lid.
    * The new lid doesn't physically exist at the time of writing, so you'll have to use your 🌈imagination🌈. The lid would be roughly flush with the top of the lid-less waste chute.

# Changelog

Shorten the waste chute's enclosing bounding boxes. They now enclose just the lid-less part, since the new lid won't extend any higher than that.

Lower the 1- and 8-channel drop offsets to be 10 mm below the new lid instead of 10 mm below the old lid.

# Review requests

~~This is pending [one clarification](https://opentrons.slack.com/archives/C049WNGU22H/p1701121268815999?thread_ts=1698264698.866189&cid=C049WNGU22H) from HW on the "max envelope of chute" numbers.~~

# Risk assessment

Low.