### PR TITLE
refactor(protocol-designer): do not render staging area fixture under trash bin

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -536,7 +536,7 @@ export const DeckSetup = (): JSX.Element => {
   ).filter(
     aE =>
       STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
-      aE.location === 'stagingArea'
+      aE.name === 'stagingArea'
   )
 
   const hasWasteChute = wasteChuteFixtures.length > 0

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -533,7 +533,11 @@ export const DeckSetup = (): JSX.Element => {
   ).filter(aE => WASTE_CHUTE_CUTOUT.includes(aE.location as CutoutId))
   const stagingAreaFixtures: AdditionalEquipmentEntity[] = Object.values(
     activeDeckSetup.additionalEquipmentOnDeck
-  ).filter(aE => STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId))
+  ).filter(
+    aE =>
+      STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
+      aE.location === 'stagingArea'
+  )
 
   const hasWasteChute = wasteChuteFixtures.length > 0
 


### PR DESCRIPTION
# Overview

Just adding some more logic to when the staging area fixtures are rendered

# Test Plan

Make sure your deck config ff is turned on and create a flex protocol. Add a waste chute and trash bin. Go to the deck map and see that the staging areas are not rendered.

# Changelog

- only create staging area fixture if the additional equipment name is staging area

# Review requests

see test plan

# Risk assessment

low