### PR TITLE
fix(protocol-designer): resolve duplicate slot option for waste chute in move labware

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../../../step-forms/selectors'
 import {
   getRobotStateAtActiveItem,
-  getUnocuppiedLabwareLocationOptions,
+  getUnoccupiedLabwareLocationOptions,
 } from '../../../../top-selectors/labware-locations'
 import { getHasWasteChute } from '../../../labware'
 import { StepFormDropdown } from '../StepFormDropdownField'
@@ -36,7 +36,7 @@ export function LabwareLocationField(
     useGripper && hasWasteChute && !isLabwareOffDeck
 
   let unoccupiedLabwareLocationsOptions =
-    useSelector(getUnocuppiedLabwareLocationOptions) ?? []
+    useSelector(getUnoccupiedLabwareLocationOptions) ?? []
 
   if (isLabwareOffDeck && hasWasteChute) {
     unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -36,6 +36,7 @@ import {
 import { getIsAdapter } from '../../utils'
 import type { RobotState } from '@opentrons/step-generation'
 import type { Selector } from '../../types'
+import type { AddressableAreaName } from '@opentrons/shared-data'
 
 interface Option {
   name: string
@@ -114,8 +115,13 @@ export const getUnocuppiedLabwareLocationOptions: Selector<
   ) => {
     const deckDef = getDeckDefFromRobotType(robotType)
     const cutoutFixtures = deckDef.cutoutFixtures
-    const allSlotIds = deckDef.locations.addressableAreas.map(slot => slot.id)
     const hasWasteChute = getHasWasteChute(additionalEquipmentEntities)
+    const allSlotIds = deckDef.locations.addressableAreas.reduce(
+      (acc, slot) => {
+        return hasWasteChute && slot.id === 'D3' ? acc : [...acc, slot.id]
+      },
+      [] as AddressableAreaName[]
+    )
     const stagingAreaCutoutIds = Object.values(additionalEquipmentEntities)
       .filter(aE => aE.name === 'stagingArea')
       //  TODO(jr, 11/13/23): fix AdditionalEquipment['location'] from type string to CutoutId

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -98,7 +98,7 @@ export const getRobotStateAtActiveItem: Selector<RobotState | null> = createSele
 )
 
 //  TODO(jr, 9/20/23): we should test this util since it does a lot.
-export const getUnocuppiedLabwareLocationOptions: Selector<
+export const getUnoccupiedLabwareLocationOptions: Selector<
   Option[] | null
 > = createSelector(
   getRobotStateAtActiveItem,


### PR DESCRIPTION
closes [RAUT-860](https://opentrons.atlassian.net/browse/RAUT-860)

# Overview

Currently, if the protocol is configured with gripper + waste chute and a move labware step utilizes the gripper, the "New Location" dropdown renders options for both D3 and waste chute in D3. We should only show one, contingent upon the presence of the waste chute.

# Test Plan

- waste chute with gripper:

<img width="329" alt="Screen Shot 2023-11-28 at 9 52 24 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/95fe98a6-9b7a-4b01-871c-ca4dcf2483ea">  

- waste chute without gripper:
<img width="334" alt="Screen Shot 2023-11-28 at 9 52 38 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/07614380-c502-4a6b-bb21-4d035c3c5cda">  

- no waste chute with gripper:
<img width="342" alt="Screen Shot 2023-11-28 at 10 39 17 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/c4aec4e8-9013-40fd-b847-39f6a5b2da21">  

- no waste chute without gripper:
<img width="335" alt="Screen Shot 2023-11-28 at 10 39 28 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/6d355ec8-b0d7-4728-b31a-ca1de3a5cc99">

# Changelog

- filter slot D3 in unoccupiedSlotOptions if waste chute is configured
- fix typo in utility `getUnnocupiedLabwareLocationOptions` -> `getUnoccupiedLabwareLocationOptions`

# Review requests

@jerader 

# Risk assessment

low

[RAUT-860]: https://opentrons.atlassian.net/browse/RAUT-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ