### PR TITLE
test(app): update remaining app tests to deck definition v4

### DIFF
--- a/app/src/molecules/DeckThumbnail/__tests__/DeckThumbnail.test.tsx
+++ b/app/src/molecules/DeckThumbnail/__tests__/DeckThumbnail.test.tsx
@@ -5,8 +5,8 @@ import {
   getDeckDefFromRobotType,
   OT2_ROBOT_TYPE,
 } from '@opentrons/shared-data'
-import ot2StandardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
-import ot3StandardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot3_standard.json'
+import ot2StandardDeckDef from '@opentrons/shared-data/deck/definitions/4/ot2_standard.json'
+import ot3StandardDeckDef from '@opentrons/shared-data/deck/definitions/4/ot3_standard.json'
 import fixture_tiprack_300_ul from '@opentrons/shared-data/labware/fixtures/2/fixture_tiprack_300_ul.json'
 import {
   BaseDeck,

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsMap.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsMap.test.tsx
@@ -20,8 +20,8 @@ import {
   parseLiquidsInLoadOrder,
   simpleAnalysisFileFixture,
 } from '@opentrons/api-client'
-import ot2StandardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot2_standard.json'
-import ot3StandardDeckDef from '@opentrons/shared-data/deck/definitions/3/ot3_standard.json'
+import ot2StandardDeckDef from '@opentrons/shared-data/deck/definitions/4/ot2_standard.json'
+import ot3StandardDeckDef from '@opentrons/shared-data/deck/definitions/4/ot3_standard.json'
 
 import { useAttachedModules } from '../../../hooks'
 import { LabwareInfoOverlay } from '../../LabwareInfoOverlay'


### PR DESCRIPTION
# Overview

updates two tests that were still relying on deck definition v3

as in https://github.com/Opentrons/opentrons/pull/14042/commits/0e1834165d28ecced9a8138946f05d3f94a220ba

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

 - Updates remaining app tests to deck definition v4

# Review requests

# Risk assessment

low
