### PR TITLE
fix(app, shared-data): fix white screen during OT-2 calibration flows

### DIFF
--- a/app/src/organisms/CalibrationPanels/CalibrationLabwareRender.tsx
+++ b/app/src/organisms/CalibrationPanels/CalibrationLabwareRender.tsx
@@ -14,28 +14,32 @@ import {
 import { getLabwareDisplayName, getIsTiprack } from '@opentrons/shared-data'
 import styles from './styles.css'
 
-import type { LabwareDefinition2, DeckSlot } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition2,
+  CoordinateTuple,
+} from '@opentrons/shared-data'
 
 const SHORT = 'SHORT'
 const TALL = 'TALL'
 
 interface CalibrationLabwareRenderProps {
   labwareDef: LabwareDefinition2
-  slotDef: DeckSlot
+  slotDefPosition: CoordinateTuple | null
 }
 
 export function CalibrationLabwareRender(
   props: CalibrationLabwareRenderProps
 ): JSX.Element {
-  const { labwareDef, slotDef } = props
+  const { labwareDef, slotDefPosition } = props
+
   const title = getLabwareDisplayName(labwareDef)
   const isTiprack = getIsTiprack(labwareDef)
 
   // TODO: we can change this boolean to check to isCalibrationBlock instead of isTiprack to render any labware
   return isTiprack ? (
     <g
-      transform={`translate(${String(slotDef.position[0])}, ${String(
-        slotDef.position[1]
+      transform={`translate(${String(slotDefPosition?.[0])}, ${String(
+        slotDefPosition?.[1]
       )})`}
     >
       <LabwareRender definition={labwareDef} />
@@ -52,21 +56,24 @@ export function CalibrationLabwareRender(
       </RobotCoordsForeignDiv>
     </g>
   ) : (
-    <CalibrationBlockRender labwareDef={labwareDef} slotDef={slotDef} />
+    <CalibrationBlockRender
+      labwareDef={labwareDef}
+      slotDefPosition={slotDefPosition}
+    />
   )
 }
 
 export function CalibrationBlockRender(
   props: CalibrationLabwareRenderProps
 ): JSX.Element | null {
-  const { labwareDef, slotDef } = props
+  const { labwareDef, slotDefPosition } = props
 
   switch (labwareDef.parameters.loadName) {
     case 'opentrons_calibrationblock_short_side_right': {
       return (
         <g
-          transform={`translate(${String(slotDef.position[0])}, ${String(
-            slotDef.position[1]
+          transform={`translate(${String(slotDefPosition?.[0])}, ${String(
+            slotDefPosition?.[1]
           )})`}
         >
           <rect
@@ -115,8 +122,8 @@ export function CalibrationBlockRender(
     case 'opentrons_calibrationblock_short_side_left': {
       return (
         <g
-          transform={`translate(${String(slotDef.position[0])}, ${String(
-            slotDef.position[1]
+          transform={`translate(${String(slotDefPosition?.[0])}, ${String(
+            slotDefPosition?.[1]
           )})`}
         >
           <rect

--- a/app/src/organisms/CalibrationPanels/DeckSetup.tsx
+++ b/app/src/organisms/CalibrationPanels/DeckSetup.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
+
 import {
   RobotWorkSpace,
   Flex,
@@ -11,14 +12,18 @@ import {
   SPACING,
   PrimaryButton,
 } from '@opentrons/components'
+import {
+  getLabwareDisplayName,
+  getPositionFromSlotId,
+} from '@opentrons/shared-data'
 import { getDeckDefinitions } from '@opentrons/components/src/hardware-sim/Deck/getDeckDefinitions'
-import { getLabwareDisplayName } from '@opentrons/shared-data'
 
 import * as Sessions from '../../redux/sessions'
 import { StyledText } from '../../atoms/text'
 import { NeedHelpLink } from './NeedHelpLink'
 import { CalibrationLabwareRender } from './CalibrationLabwareRender'
 
+import type { AddressableArea } from '@opentrons/shared-data'
 import type { CalibrationPanelProps } from './types'
 
 const TIPRACK = 'tip rack'
@@ -102,32 +107,28 @@ export function DeckSetup(props: CalibrationPanelProps): JSX.Element {
             viewBox={`-46 -10 ${488} ${390}`} // TODO: put these in variables
           >
             {({ deckSlotsById }) =>
-              map(
-                deckSlotsById,
-                (
-                  slot: typeof deckSlotsById[keyof typeof deckSlotsById],
-                  slotId
-                ) => {
-                  if (!slot.matingSurfaceUnitVector) return null // if slot has no mating surface, don't render anything in it
-                  let labwareDef = null
-                  if (String(tipRack?.slot) === slotId) {
-                    labwareDef = tipRack?.definition
-                  } else if (
-                    calBlock != null &&
-                    String(calBlock?.slot) === slotId
-                  ) {
-                    labwareDef = calBlock?.definition
-                  }
-
-                  return labwareDef != null ? (
-                    <CalibrationLabwareRender
-                      key={slotId}
-                      slotDef={slot}
-                      labwareDef={labwareDef}
-                    />
-                  ) : null
+              map(deckSlotsById, (slot: AddressableArea, slotId) => {
+                if (!slot.matingSurfaceUnitVector) return null // if slot has no mating surface, don't render anything in it
+                let labwareDef = null
+                if (String(tipRack?.slot) === slotId) {
+                  labwareDef = tipRack?.definition
+                } else if (
+                  calBlock != null &&
+                  String(calBlock?.slot) === slotId
+                ) {
+                  labwareDef = calBlock?.definition
                 }
-              )
+
+                const slotDefPosition = getPositionFromSlotId(slot.id, deckDef)
+
+                return labwareDef != null ? (
+                  <CalibrationLabwareRender
+                    key={slotId}
+                    slotDefPosition={slotDefPosition}
+                    labwareDef={labwareDef}
+                  />
+                ) : null
+              })
             }
           </RobotWorkSpace>
         </Flex>


### PR DESCRIPTION
Closes RQA-1944

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Refactors calibration flows within the CalibrationDashboard with the most recent deck definition. Also fixes some typing and naming around the deck definition.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/55b1f016-a398-42c8-9379-1a1f9d32c65b

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/e5efcb52-cf46-4960-b426-30d8ab7c1d05

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Launch calibration dashboard, launch any calibration flow, click through the wizard to a step that displays the deck. 
- Note the lack of white screening.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fix white screen during OT-2 calibration flows. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
