### PR TITLE
fix(app): protect against null access of gripper data when fw update is ongoing

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupInstrumentCalibration.tsx
@@ -53,7 +53,7 @@ export function SetupInstrumentCalibration({
   )
   const attachedGripperMatch = usesGripper
     ? (instrumentsQueryData?.data ?? []).find(
-        (i): i is GripperData => i.instrumentType === 'gripper'
+        (i): i is GripperData => i.instrumentType === 'gripper' && i.ok
       ) ?? null
     : null
 

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -41,7 +41,7 @@ export function ProtocolSetupInstruments({
       : false
   const attachedGripperMatch = usesGripper
     ? (attachedInstruments?.data ?? []).find(
-        (i): i is GripperData => i.instrumentType === 'gripper'
+        (i): i is GripperData => i.instrumentType === 'gripper' && i.ok
       ) ?? null
     : null
 


### PR DESCRIPTION
# Overview

Prevent attempted access to gripper instrument data in cases where the gripper may be undergoing a fw update

Closes RAUT-882

# Risk assessment
low