### PR TITLE
fix(app): search for correct subsystem update for strung together flows

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -347,7 +347,9 @@ export const PipetteWizardFlows = (
     modalContent = (
       <FirmwareUpdateModal
         proceed={proceed}
-        subsystem={mount === LEFT ? 'pipette_left' : 'pipette_right'}
+        subsystem={
+          currentStep.mount === LEFT ? 'pipette_left' : 'pipette_right'
+        }
         description={t('firmware_updating')}
         proceedDescription={t('firmware_up_to_date')}
         isOnDevice={isOnDevice}


### PR DESCRIPTION
Fix RQA-1925

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
If you launch a 96-channel attachment flow via the right pipette card, the `mount` value in the `PipetteWizardFlows` component will be `right`. In `getPipetteWizardSteps` we handle the logic of determining which mount each step in a flow corresponds to, so in the child components of these flows we should always use `currentStep.mount` to determine what pipette we're referring to. We missed this in one instance where we use `mount` to determine which `subsystem` we should check for a firmware update. Because of this, 96-channel pipette attachments initiated via the right pipette card were skipping firmware updates.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Initiate a 96-channel attachment from the right pipette card and attach a pipette that needs a firmware update. See that the firmware update is initiated after attachment.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Use `currentStep.mount` to determine which subsystem we need to check for a firmware update
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Sanity check
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
