### PR TITLE
fix(shared-data): add pickUpOffset, dropOffset params to schema v8 models

### DIFF
--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v7.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v7.py
@@ -51,9 +51,11 @@ class Params(BaseModel):
     offset: Optional[OffsetVector]
     profile: Optional[List[ProfileStep]]
     radius: Optional[float]
+    # schema v7 add-ons
     newLocation: Optional[Union[Location, Literal["offDeck"]]]
     strategy: Optional[str]
-    # schema v7 add-ons
+    pickUpOffset: Optional[OffsetVector]
+    dropOffset: Optional[OffsetVector]
     homeAfter: Optional[bool]
     alternateDropLocation: Optional[bool]
     holdTimeSeconds: Optional[float]

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -65,6 +65,8 @@ class Params(BaseModel):
     pushOut: Optional[float]
     # schema v8 add-ons
     addressableAreaName: Optional[str]
+    pickUpOffset: Optional[OffsetVector]
+    dropOffset: Optional[OffsetVector]
 
 
 class Command(BaseModel):

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -63,10 +63,10 @@ class Params(BaseModel):
     namespace: Optional[str]
     version: Optional[int]
     pushOut: Optional[float]
-    # schema v8 add-ons
-    addressableAreaName: Optional[str]
     pickUpOffset: Optional[OffsetVector]
     dropOffset: Optional[OffsetVector]
+    # schema v8 add-ons
+    addressableAreaName: Optional[str]
 
 
 class Command(BaseModel):


### PR DESCRIPTION
# Overview

JSON Schema v8 includes the `pickUpOffset` and `dropOffset` params to `moveLabware` command. But probably since PD doesn't use these params, we never added them to the json protocol pydantic models. This was blocking ABR testing since we need to use JSON protocols to test using engine commands without the python API.

# Changelog

- just addition of the two params

# Review requests

- Do we need to add these to the v7 the model too? I don't think it'd cause any harm but I don't think it'll be useful either.

# Risk assessment

- This is mainly being added for internal testing but what happens if I hand-edit a PD protocol to add these params to a `moveLabware` command and reupload in PD? Does PD know to ignore it or will it raise errors?
