### PR TITLE
style(app,shared-data): Style deck waste chute submenu

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -142,6 +142,7 @@
   "run_again": "Run again",
   "run_duration": "Run duration",
   "run": "Run",
+  "select_options": "Select options",
   "serial_number": "Serial Number",
   "set_block_temp": "Set temperature",
   "set_block_temperature": "Set block temperature",

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -150,14 +150,14 @@ export function AddFixtureModal({
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
               {displayedFixtureOptions.map(
                 ([cutoutFixtureOption, fixtureDisplayName]) => {
-                  const isGenericWasteChuteOption =
+                  const onClickHandler =
                     cutoutFixtureOption === GENERIC_WASTE_CHUTE_OPTION
-                  const onClickHandler = isGenericWasteChuteOption
-                    ? () => setShowWasteChuteOptions(true)
-                    : () => handleAddODD(cutoutFixtureOption)
-                  const buttonText = isGenericWasteChuteOption
-                    ? t('select_options')
-                    : t('add')
+                      ? () => setShowWasteChuteOptions(true)
+                      : () => handleAddODD(cutoutFixtureOption)
+                  const buttonText =
+                    cutoutFixtureOption === GENERIC_WASTE_CHUTE_OPTION
+                      ? t('select_options')
+                      : t('add')
 
                   return (
                     <React.Fragment key={cutoutFixtureOption}>
@@ -192,14 +192,14 @@ export function AddFixtureModal({
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
               {displayedFixtureOptions.map(
                 ([cutoutFixtureOption, fixtureDisplayName]) => {
-                  const isGenericWasteChuteOption =
+                  const onClickHandler =
                     cutoutFixtureOption === GENERIC_WASTE_CHUTE_OPTION
-                  const onClickHandler = isGenericWasteChuteOption
-                    ? () => setShowWasteChuteOptions(true)
-                    : () => handleAddDesktop(cutoutFixtureOption)
-                  const buttonText = isGenericWasteChuteOption
-                    ? t('select_options')
-                    : t('add')
+                      ? () => setShowWasteChuteOptions(true)
+                      : () => handleAddDesktop(cutoutFixtureOption)
+                  const buttonText =
+                    cutoutFixtureOption === GENERIC_WASTE_CHUTE_OPTION
+                      ? t('select_options')
+                      : t('add')
 
                   return (
                     <React.Fragment key={cutoutFixtureOption}>

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -43,7 +43,7 @@ import type {
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { LegacyModalProps } from '../../molecules/LegacyModal'
 
-const WASTE_CHUTE = 'WASTE_CHUTE'
+const GENERIC_WASTE_CHUTE_OPTION = 'WASTE_CHUTE'
 
 interface AddFixtureModalProps {
   cutoutId: CutoutId
@@ -105,14 +105,16 @@ export function AddFixtureModal({
   }
 
   const fixtureOptions = providedFixtureOptions ?? availableFixtures
-  const fixtureOptionsWithDisplayNames = fixtureOptions.map(fixture => [
-    fixture,
-    getFixtureDisplayName(fixture),
-  ])
+  const fixtureOptionsWithDisplayNames: Array<
+    [CutoutFixtureId | 'WASTE_CHUTE', string]
+  > = fixtureOptions.map(fixture => [fixture, getFixtureDisplayName(fixture)])
 
   const showSelectWasteChuteOptions = cutoutId === WASTE_CHUTE_CUTOUT
   if (showSelectWasteChuteOptions) {
-    fixtureOptionsWithDisplayNames.push([WASTE_CHUTE, t('waste_chute')])
+    fixtureOptionsWithDisplayNames.push([
+      GENERIC_WASTE_CHUTE_OPTION,
+      t('waste_chute'),
+    ])
   }
 
   fixtureOptionsWithDisplayNames.sort((a, b) => a[1].localeCompare(b[1]))
@@ -147,18 +149,18 @@ export function AddFixtureModal({
             <StyledText as="p">{t('add_to_slot_description')}</StyledText>
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
               {displayedFixtureOptions.map(
-                ([cutoutFixtureId, fixtureDisplayName]) => {
+                ([cutoutFixtureOption, fixtureDisplayName]) => {
                   const isGenericWasteChuteOption =
-                    cutoutFixtureId === WASTE_CHUTE
+                    cutoutFixtureOption === GENERIC_WASTE_CHUTE_OPTION
                   const onClickHandler = isGenericWasteChuteOption
                     ? () => setShowWasteChuteOptions(true)
-                    : () => handleAddODD(cutoutFixtureId as CutoutFixtureId)
+                    : () => handleAddODD(cutoutFixtureOption)
                   const buttonText = isGenericWasteChuteOption
                     ? t('select_options')
                     : t('add')
 
                   return (
-                    <React.Fragment key={cutoutFixtureId}>
+                    <React.Fragment key={cutoutFixtureOption}>
                       <Btn
                         onClick={onClickHandler}
                         display="flex"
@@ -189,18 +191,18 @@ export function AddFixtureModal({
             <StyledText as="p">{t('add_fixture_description')}</StyledText>
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
               {displayedFixtureOptions.map(
-                ([cutoutFixtureId, fixtureDisplayName]) => {
+                ([cutoutFixtureOption, fixtureDisplayName]) => {
                   const isGenericWasteChuteOption =
-                    cutoutFixtureId === WASTE_CHUTE
+                    cutoutFixtureOption === GENERIC_WASTE_CHUTE_OPTION
                   const onClickHandler = isGenericWasteChuteOption
                     ? () => setShowWasteChuteOptions(true)
-                    : () => handleAddDesktop(cutoutFixtureId as CutoutFixtureId)
+                    : () => handleAddDesktop(cutoutFixtureOption)
                   const buttonText = isGenericWasteChuteOption
                     ? t('select_options')
                     : t('add')
 
                   return (
-                    <React.Fragment key={cutoutFixtureId}>
+                    <React.Fragment key={cutoutFixtureOption}>
                       <Flex
                         flexDirection={DIRECTION_ROW}
                         alignItems={ALIGN_CENTER}

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -43,6 +43,8 @@ import type {
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { LegacyModalProps } from '../../molecules/LegacyModal'
 
+const WASTE_CHUTE = 'WASTE_CHUTE'
+
 interface AddFixtureModalProps {
   cutoutId: CutoutId
   setShowAddFixtureModal: (showAddFixtureModal: boolean) => void
@@ -58,9 +60,12 @@ export function AddFixtureModal({
   providedFixtureOptions,
   isOnDevice = false,
 }: AddFixtureModalProps): JSX.Element {
-  const { t } = useTranslation('device_details')
+  const { t } = useTranslation(['device_details', 'shared'])
   const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
   const deckConfig = useDeckConfigurationQuery()?.data ?? []
+  const [showWasteChuteOptions, setShowWasteChuteOptions] = React.useState(
+    false
+  )
 
   const modalHeader: ModalHeaderBaseProps = {
     title: t('add_to_slot', {
@@ -77,19 +82,15 @@ export function AddFixtureModal({
     onClose: () => setShowAddFixtureModal(false),
     closeOnOutsideClick: true,
     childrenPadding: SPACING.spacing24,
-    width: '23.125rem',
+    width: '26.75rem',
   }
 
   const availableFixtures: CutoutFixtureId[] = [TRASH_BIN_ADAPTER_FIXTURE]
   if (STAGING_AREA_CUTOUTS.includes(cutoutId)) {
     availableFixtures.push(STAGING_AREA_RIGHT_SLOT_FIXTURE)
   }
-  if (cutoutId === WASTE_CHUTE_CUTOUT) {
-    availableFixtures.push(...WASTE_CHUTE_FIXTURES)
-  }
 
-  // For Touchscreen app
-  const handleTapAdd = (requiredFixtureId: CutoutFixtureId): void => {
+  const handleAddODD = (requiredFixtureId: CutoutFixtureId): void => {
     if (setCurrentDeckConfig != null)
       setCurrentDeckConfig(
         (prevDeckConfig: DeckConfiguration): DeckConfiguration =>
@@ -103,10 +104,28 @@ export function AddFixtureModal({
     setShowAddFixtureModal(false)
   }
 
-  // For Desktop app
   const fixtureOptions = providedFixtureOptions ?? availableFixtures
+  const fixtureOptionsWithDisplayNames = fixtureOptions.map(fixture => [
+    fixture,
+    getFixtureDisplayName(fixture),
+  ])
 
-  const handleClickAdd = (requiredFixtureId: CutoutFixtureId): void => {
+  const showSelectWasteChuteOptions = cutoutId === WASTE_CHUTE_CUTOUT
+  if (showSelectWasteChuteOptions) {
+    fixtureOptionsWithDisplayNames.push([WASTE_CHUTE, t('waste_chute')])
+  }
+
+  fixtureOptionsWithDisplayNames.sort((a, b) => a[1].localeCompare(b[1]))
+
+  const wasteChuteOptionsWithDisplayNames = WASTE_CHUTE_FIXTURES.map(
+    fixture => [fixture, getFixtureDisplayName(fixture)]
+  ).sort((a, b) => a[1].localeCompare(b[1])) as Array<[CutoutFixtureId, string]>
+
+  const displayedFixtureOptions = showWasteChuteOptions
+    ? wasteChuteOptionsWithDisplayNames
+    : fixtureOptionsWithDisplayNames
+
+  const handleAddDesktop = (requiredFixtureId: CutoutFixtureId): void => {
     const newDeckConfig = deckConfig.map(fixture =>
       fixture.cutoutId === cutoutId
         ? { ...fixture, cutoutFixtureId: requiredFixtureId }
@@ -127,14 +146,40 @@ export function AddFixtureModal({
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
             <StyledText as="p">{t('add_to_slot_description')}</StyledText>
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-              {fixtureOptions.map(cutoutFixtureId => (
-                <React.Fragment key={cutoutFixtureId}>
-                  <AddFixtureButton
-                    cutoutFixtureId={cutoutFixtureId}
-                    handleClickAdd={handleTapAdd}
-                  />
-                </React.Fragment>
-              ))}
+              {displayedFixtureOptions.map(
+                ([cutoutFixtureId, fixtureDisplayName]) => {
+                  const isGenericWasteChuteOption =
+                    cutoutFixtureId === WASTE_CHUTE
+                  const onClickHandler = isGenericWasteChuteOption
+                    ? () => setShowWasteChuteOptions(true)
+                    : () => handleAddODD(cutoutFixtureId as CutoutFixtureId)
+                  const buttonText = isGenericWasteChuteOption
+                    ? t('select_options')
+                    : t('add')
+
+                  return (
+                    <React.Fragment key={cutoutFixtureId}>
+                      <Btn
+                        onClick={onClickHandler}
+                        display="flex"
+                        justifyContent={JUSTIFY_SPACE_BETWEEN}
+                        flexDirection={DIRECTION_ROW}
+                        alignItems={ALIGN_CENTER}
+                        padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
+                        css={FIXTURE_BUTTON_STYLE}
+                      >
+                        <StyledText
+                          as="p"
+                          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                        >
+                          {fixtureDisplayName}
+                        </StyledText>
+                        <StyledText as="p">{buttonText}</StyledText>
+                      </Btn>
+                    </React.Fragment>
+                  )
+                }
+              )}
             </Flex>
           </Flex>
         </Modal>
@@ -143,58 +188,56 @@ export function AddFixtureModal({
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
             <StyledText as="p">{t('add_fixture_description')}</StyledText>
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-              {fixtureOptions.map(fixture => (
-                <React.Fragment key={fixture}>
-                  <Flex
-                    flexDirection={DIRECTION_ROW}
-                    alignItems={ALIGN_CENTER}
-                    justifyContent={JUSTIFY_SPACE_BETWEEN}
-                    padding={`${SPACING.spacing8} ${SPACING.spacing16}`}
-                    backgroundColor={COLORS.medGreyEnabled}
-                    borderRadius={BORDERS.borderRadiusSize1}
-                  >
-                    <StyledText css={TYPOGRAPHY.pSemiBold}>
-                      {getFixtureDisplayName(fixture)}
-                    </StyledText>
-                    <TertiaryButton onClick={() => handleClickAdd(fixture)}>
-                      {t('add')}
-                    </TertiaryButton>
-                  </Flex>
-                </React.Fragment>
-              ))}
+              {displayedFixtureOptions.map(
+                ([cutoutFixtureId, fixtureDisplayName]) => {
+                  const isGenericWasteChuteOption =
+                    cutoutFixtureId === WASTE_CHUTE
+                  const onClickHandler = isGenericWasteChuteOption
+                    ? () => setShowWasteChuteOptions(true)
+                    : () => handleAddDesktop(cutoutFixtureId as CutoutFixtureId)
+                  const buttonText = isGenericWasteChuteOption
+                    ? t('select_options')
+                    : t('add')
+
+                  return (
+                    <React.Fragment key={cutoutFixtureId}>
+                      <Flex
+                        flexDirection={DIRECTION_ROW}
+                        alignItems={ALIGN_CENTER}
+                        justifyContent={JUSTIFY_SPACE_BETWEEN}
+                        padding={`${SPACING.spacing8} ${SPACING.spacing16}`}
+                        backgroundColor={COLORS.medGreyEnabled}
+                        borderRadius={BORDERS.borderRadiusSize1}
+                      >
+                        <StyledText css={TYPOGRAPHY.pSemiBold}>
+                          {fixtureDisplayName}
+                        </StyledText>
+                        <TertiaryButton onClick={onClickHandler}>
+                          {buttonText}
+                        </TertiaryButton>
+                      </Flex>
+                    </React.Fragment>
+                  )
+                }
+              )}
             </Flex>
           </Flex>
+          {showWasteChuteOptions ? (
+            <Btn
+              onClick={() => setShowWasteChuteOptions(false)}
+              aria-label="back"
+              paddingX={SPACING.spacing16}
+              marginTop={'1.44rem'}
+              marginBottom={'0.56rem'}
+            >
+              <StyledText css={GO_BACK_BUTTON_STYLE}>
+                {t('shared:go_back')}
+              </StyledText>
+            </Btn>
+          ) : null}
         </LegacyModal>
       )}
     </>
-  )
-}
-
-interface AddFixtureButtonProps {
-  cutoutFixtureId: CutoutFixtureId
-  handleClickAdd: (cutoutFixtureId: CutoutFixtureId) => void
-}
-function AddFixtureButton({
-  cutoutFixtureId,
-  handleClickAdd,
-}: AddFixtureButtonProps): JSX.Element {
-  const { t } = useTranslation('device_details')
-
-  return (
-    <Btn
-      onClick={() => handleClickAdd(cutoutFixtureId)}
-      display="flex"
-      justifyContent={JUSTIFY_SPACE_BETWEEN}
-      flexDirection={DIRECTION_ROW}
-      alignItems={ALIGN_CENTER}
-      padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
-      css={FIXTURE_BUTTON_STYLE}
-    >
-      <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-        {getFixtureDisplayName(cutoutFixtureId)}
-      </StyledText>
-      <StyledText as="p">{t('add')}</StyledText>
-    </Btn>
   )
 }
 
@@ -227,5 +270,13 @@ const FIXTURE_BUTTON_STYLE = css`
   &:disabled {
     background-color: ${COLORS.light1};
     color: ${COLORS.darkBlack60};
+  }
+`
+const GO_BACK_BUTTON_STYLE = css`
+  ${TYPOGRAPHY.pSemiBold};
+  color: ${COLORS.darkGreyEnabled};
+
+  &:hover {
+    opacity: 70%;
   }
 `

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
@@ -5,6 +5,10 @@ import {
   useDeckConfigurationQuery,
   useUpdateDeckConfigurationMutation,
 } from '@opentrons/react-api-client'
+import {
+  getFixtureDisplayName,
+  WASTE_CHUTE_FIXTURES,
+} from '@opentrons/shared-data'
 
 import { i18n } from '../../../i18n'
 import { AddFixtureModal } from '../AddFixtureModal'
@@ -56,8 +60,9 @@ describe('Touchscreen AddFixtureModal', () => {
     )
     getByText('Staging area slot')
     getByText('Trash bin')
-    getByText('Waste chute only')
-    expect(getAllByText('Add').length).toBe(6)
+    getByText('Waste chute')
+    expect(getAllByText('Add').length).toBe(2)
+    expect(getAllByText('Select options').length).toBe(1)
   })
 
   it('should a mock function when tapping app button', () => {
@@ -92,8 +97,9 @@ describe('Desktop AddFixtureModal', () => {
     )
     getByText('Staging area slot')
     getByText('Trash bin')
-    getByText('Waste chute only')
-    expect(getAllByRole('button', { name: 'Add' }).length).toBe(6)
+    getByText('Waste chute')
+    expect(getAllByRole('button', { name: 'Add' }).length).toBe(2)
+    expect(getAllByRole('button', { name: 'Select options' }).length).toBe(1)
   })
 
   it('should render text and buttons slot A1', () => {
@@ -124,5 +130,30 @@ describe('Desktop AddFixtureModal', () => {
     const [{ getByRole }] = render(props)
     getByRole('button', { name: 'Add' }).click()
     expect(mockUpdateDeckConfiguration).toHaveBeenCalled()
+  })
+
+  it('should display appropriate Waste Chute options when the generic Waste Chute button is clicked', () => {
+    const [{ getByText, getByRole, getAllByRole }] = render(props)
+    getByRole('button', { name: 'Select options' }).click()
+    expect(getAllByRole('button', { name: 'Add' }).length).toBe(
+      WASTE_CHUTE_FIXTURES.length
+    )
+
+    WASTE_CHUTE_FIXTURES.forEach(cutoutId => {
+      const displayText = getFixtureDisplayName(cutoutId)
+      getByText(displayText)
+    })
+  })
+
+  it('should allow a user to exit the Waste Chute submenu by clicking "go back"', () => {
+    const [{ getByText, getByRole, getAllByRole }] = render(props)
+    getByRole('button', { name: 'Select options' }).click()
+
+    getByText('Go back').click()
+    getByText('Staging area slot')
+    getByText('Trash bin')
+    getByText('Waste chute')
+    expect(getAllByRole('button', { name: 'Add' }).length).toBe(2)
+    expect(getAllByRole('button', { name: 'Select options' }).length).toBe(1)
   })
 })

--- a/app/src/pages/DeckConfiguration/index.tsx
+++ b/app/src/pages/DeckConfiguration/index.tsx
@@ -8,7 +8,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   JUSTIFY_CENTER,
-  SPACING,
+  JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
 import {
   useDeckConfigurationQuery,
@@ -130,7 +130,10 @@ export function DeckConfigurationEditor(): JSX.Element {
           />
         ) : null}
       </Portal>
-      <Flex flexDirection={DIRECTION_COLUMN}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        justifyContent={JUSTIFY_SPACE_AROUND}
+      >
         <ChildNavigation
           header={t('devices_landing:deck_configuration')}
           onClickBack={handleClickBack}
@@ -138,12 +141,7 @@ export function DeckConfigurationEditor(): JSX.Element {
           onClickButton={handleClickConfirm}
           secondaryButtonProps={secondaryButtonProps}
         />
-        <Flex
-          marginTop="7.75rem"
-          paddingX={SPACING.spacing40}
-          paddingBottom={SPACING.spacing40}
-          justifyContent={JUSTIFY_CENTER}
-        >
+        <Flex marginTop="7.75rem" justifyContent={JUSTIFY_CENTER}>
           <DeckConfigurator
             deckConfig={currentDeckConfig}
             handleClickAdd={handleClickAdd}

--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -86,7 +86,7 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
 
   return (
     <RobotCoordinateSpace
-      height="400px"
+      height="455px"
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${deckDef.cornerOffsetFromOrigin[1]} ${deckDef.dimensions[0]} ${deckDef.dimensions[1]}`}
     >

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -106,7 +106,7 @@ export function getFixtureDisplayName(
   } else if (cutoutFixtureId === WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE) {
     return 'Waste chute only'
   } else if (cutoutFixtureId === WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE) {
-    return 'Waste chute only covered'
+    return 'Waste chute only with cover'
   } else if (
     cutoutFixtureId ===
     STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE
@@ -116,7 +116,7 @@ export function getFixtureDisplayName(
     cutoutFixtureId ===
     STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE
   ) {
-    return 'Waste chute with staging area slot covered'
+    return 'Waste chute with staging area slot and cover'
   } else {
     return 'Slot'
   }


### PR DESCRIPTION
Closes RAUT-832

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Restyles the AddFixtureModal to include a submenu with waste chute options. Also resizes the ODD DeckConfigurator.

### Current Behavior

**AddFixtureModal**

<img width="1186" alt="deck config add to slot D3 list view waste chute" src="https://github.com/Opentrons/opentrons/assets/64858653/05fed667-2094-4d95-aaae-47a1f65d5ea5">

<img width="886" alt="Screenshot 2023-11-29 at 11 59 16 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/bc29f1c5-a0db-442a-b5a0-4827aea0e03d">

**ODD DeckConfigurator**

<img width="1014" alt="Screenshot 2023-11-29 at 11 58 04 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/d4e55ba5-438f-40d8-a959-7e04542f9e79">

### Fixed Behavior

**AddFixtureModal**

<img width="936" alt="deck config add to slot D3 list view waste chute-correct" src="https://github.com/Opentrons/opentrons/assets/64858653/094ded3b-8a4a-4adf-aa0e-4981369596b5">

<img width="881" alt="Screenshot 2023-11-29 at 11 59 58 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/3d62de50-e040-4eb3-927b-981fcc2198da">

**ODD DeckConfigurator**

<img width="826" alt="deck map sizing" src="https://github.com/Opentrons/opentrons/assets/64858653/20b0b574-f276-40f4-8ae7-77afda3f07ea">
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Confirm designs are correct for the following (see ticket for Figma):
1. ODD waste chute submenu
2. Desktop waste chute submenu
3. ODD DeckConfigurator is larger.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added Waste Chute submenu when adding fixtures.
- Resized the ODD Deck Configurator (it's bigger now).
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
