### PR TITLE
refactor(protocol-designer): deck map renders wasteChuteStagingAreaFi…

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -15,6 +15,7 @@ import {
   TrashCutoutId,
   useOnClickOutside,
   WasteChuteFixture,
+  WasteChuteStagingAreaFixture,
 } from '@opentrons/components'
 import {
   AdditionalEquipmentEntity,
@@ -530,7 +531,11 @@ export const DeckSetup = (): JSX.Element => {
   ]
   const wasteChuteFixtures = Object.values(
     activeDeckSetup.additionalEquipmentOnDeck
-  ).filter(aE => WASTE_CHUTE_CUTOUT.includes(aE.location as CutoutId))
+  ).filter(
+    aE =>
+      WASTE_CHUTE_CUTOUT.includes(aE.location as CutoutId) &&
+      aE.name === 'wasteChute'
+  )
   const stagingAreaFixtures: AdditionalEquipmentEntity[] = Object.values(
     activeDeckSetup.additionalEquipmentOnDeck
   ).filter(
@@ -539,7 +544,17 @@ export const DeckSetup = (): JSX.Element => {
       aE.name === 'stagingArea'
   )
 
-  const hasWasteChute = wasteChuteFixtures.length > 0
+  const wasteChuteStagingAreaFixtures = Object.values(
+    activeDeckSetup.additionalEquipmentOnDeck
+  ).filter(
+    aE =>
+      STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
+      aE.name === 'stagingArea' &&
+      aE.location === WASTE_CHUTE_CUTOUT
+  )
+
+  const hasWasteChute =
+    wasteChuteFixtures.length > 0 || wasteChuteStagingAreaFixtures.length > 0
 
   const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
     aa => isAddressableAreaStandardSlot(aa.id, deckDef)
@@ -613,6 +628,15 @@ export const DeckSetup = (): JSX.Element => {
                     : null}
                   {wasteChuteFixtures.map(fixture => (
                     <WasteChuteFixture
+                      key={fixture.id}
+                      cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+                      deckDefinition={deckDef}
+                      slotClipColor={darkFill}
+                      fixtureBaseColor={lightFill}
+                    />
+                  ))}
+                  {wasteChuteStagingAreaFixtures.map(fixture => (
+                    <WasteChuteStagingAreaFixture
                       key={fixture.id}
                       cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
                       deckDefinition={deckDef}


### PR DESCRIPTION
…xture now

closes RAUT-886

# Overview

the deck map component now renders the waste chute staging area fixture instead of rendering the staging area + waste chute fixtures on top of each other.

# Test Plan

Create a flex protocol and make sure the deck config ff is turned on. Look at the deck map and mess around with adding/deleting staging areas and waste chute and trash bin. see that things render as expected.

# Changelog

- add `wasteChuteStagingAreaFixture` and some extra logic to know when to render the different fixtures
- 
# Review requests

see test plan

# Risk assessment

low