### PR TITLE
docs(api): docstring for `load_waste_chute()`

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -467,7 +467,9 @@ class ProtocolContext(CommandPublisher):
     ) -> WasteChute:
         """Load the waste chute on the deck.
 
-        The waste chute always occupies slot D3.
+        The deck plate adapter for the waste chute can only go in slot D3. If you try to
+        load another item in slot D3 after loading the waste chute, or vice versa, the
+        API will raise an error.
 
         :param bool cover: Set to ``True`` when the cover is attached to the top of
             the waste chute. The hole in the cover can fit up to eight tips in a

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -463,9 +463,19 @@ class ProtocolContext(CommandPublisher):
     def load_waste_chute(
         self,
         *,
-        # TODO: Confirm official naming of "staging area slot".
         with_staging_area_slot_d4: bool = False,
     ) -> WasteChute:
+        """Load the waste chute on the deck.
+
+        The waste chute always occupies slot D3.
+
+        :param bool cover: Set to ``True`` when the cover is attached to the top of
+            the waste chute. The hole in the cover can fit up to eight tips in a
+            column configuration. Pipettes can dispense, blow out, or drop tips
+            through the hole in the cover. When the cover is attached, the gripper
+            can't drop labware down the chute. If you try to move labware to the
+            waste chute when ``cover=True``, the API will raise an error.
+        """
         if with_staging_area_slot_d4:
             raise NotImplementedError(
                 "The waste chute staging area slot is not currently implemented."

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -470,13 +470,6 @@ class ProtocolContext(CommandPublisher):
         The deck plate adapter for the waste chute can only go in slot D3. If you try to
         load another item in slot D3 after loading the waste chute, or vice versa, the
         API will raise an error.
-
-        :param bool cover: Set to ``True`` when the cover is attached to the top of
-            the waste chute. The hole in the cover can fit up to eight tips in a
-            column configuration. Pipettes can dispense, blow out, or drop tips
-            through the hole in the cover. When the cover is attached, the gripper
-            can't drop labware down the chute. If you try to move labware to the
-            waste chute when ``cover=True``, the API will raise an error.
         """
         if with_staging_area_slot_d4:
             raise NotImplementedError(


### PR DESCRIPTION

# Overview

API Reference entry for `load_waste_chute()`.

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docstring-load_waste_chute/v2/new_protocol_api.html#opentrons.protocol_api.ProtocolContext.load_waste_chute)

# Changelog

- draft docstring for `load_waste_chute()` behavior
- removed TODOs to confirm product names (they are accurate)

# Review requests

- [ ] final confirmation on `cover` parameter
- [ ] final confirmation on any other parameters

# Risk assessment

v low, docs only