### PR TITLE
feat(protocol-designer): no longer put off-deck button behind ff

### DIFF
--- a/protocol-designer/src/components/DeckSetupManager.tsx
+++ b/protocol-designer/src/components/DeckSetupManager.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
-import { getEnableOffDeckVisAndMultiTip } from '../feature-flags/selectors'
 import {
   getBatchEditSelectedStepTypes,
   getHoveredItem,
@@ -12,15 +11,12 @@ import { OffDeckLabwareButton } from './OffDeckLabwareButton'
 export const DeckSetupManager = (): JSX.Element => {
   const batchEditSelectedStepTypes = useSelector(getBatchEditSelectedStepTypes)
   const hoveredItem = useSelector(getHoveredItem)
-  const enableOffDeckVisAndMultiTipFF = useSelector(
-    getEnableOffDeckVisAndMultiTip
-  )
 
   if (batchEditSelectedStepTypes.length === 0 || hoveredItem !== null) {
     // not batch edit mode, or batch edit while item is hovered: show the deck
     return (
       <>
-        {enableOffDeckVisAndMultiTipFF ? <OffDeckLabwareButton /> : null}
+        <OffDeckLabwareButton />
         <DeckSetup />
       </>
     )

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -24,8 +24,7 @@ const initialFlags: Flags = {
   OT_PD_ALLOW_96_CHANNEL: process.env.OT_PD_ALLOW_96_CHANNEL === '1' || false,
   OT_PD_ENABLE_FLEX_DECK_MODIFICATION:
     process.env.OT_PD_ENABLE_FLEX_DECK_MODIFICATION === '1' || false,
-  OT_PD_ENABLE_OFF_DECK_VIS_AND_MULTI_TIP:
-    process.env.OT_PD_ENABLE_OFF_DECK_VIS_AND_MULTI_TIP === '1' || false,
+  OT_PD_ENABLE_MULTI_TIP: process.env.OT_PD_ENABLE_MULTI_TIP === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -27,7 +27,7 @@ export const getEnableDeckModification: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_FLEX_DECK_MODIFICATION ?? false
 )
-export const getEnableOffDeckVisAndMultiTip: Selector<boolean> = createSelector(
+export const getEnableMultiTip: Selector<boolean> = createSelector(
   getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_OFF_DECK_VIS_AND_MULTI_TIP ?? false
+  flags => flags.OT_PD_ENABLE_MULTI_TIP ?? false
 )

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -28,7 +28,7 @@ export type FlagTypes =
   | 'OT_PD_ALLOW_ALL_TIPRACKS'
   | 'OT_PD_ALLOW_96_CHANNEL'
   | 'OT_PD_ENABLE_FLEX_DECK_MODIFICATION'
-  | 'OT_PD_ENABLE_OFF_DECK_VIS_AND_MULTI_TIP'
+  | 'OT_PD_ENABLE_MULTI_TIP'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -22,6 +22,6 @@
   },
   "OT_PD_ENABLE_MULTI_TIP": {
     "title": "Enable multi tiprack support",
-    "description": "Allow users to use multi tiprack support"
+    "description": "Allow users to select multiple tipracks per pipette"
   }
 }

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -20,8 +20,8 @@
     "title": "Enable Flex deck modification",
     "description": "Allow users to select waste chute, Flex staging, and modify trash slot"
   },
-  "OT_PD_ENABLE_OFF_DECK_VIS_AND_MULTI_TIP": {
-    "title": "Enable off-deck visuals and multi tiprack support",
-    "description": "Allow users to see off-deck labware visualizations and multi tiprack support"
+  "OT_PD_ENABLE_MULTI_TIP": {
+    "title": "Enable multi tiprack support",
+    "description": "Allow users to use multi tiprack support"
   }
 }


### PR DESCRIPTION
closes RAUT-887

# Overview

To prepare for the 1st 8.0 release candidate, this is to no longer put the off-deck button behind the ff and then rename the ff to only encompass multi-tip support

# Test Plan

Create a flex protocol and go to deck setup and see that the off deck button is visible and works correctly!

Create a protocol for the ot-2 and notice the off-deck button there as well.

# Changelog

- remove off-deck button from being behind a feature flag and rename the ff to something that doesn't include the off-deck button

# Review requests

see test plan

# Risk assessment

low
