### PR TITLE
fix(hardware-testing): Allow liquid-probe in Gravimetric so 8ch tests can run overnight

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -465,11 +465,6 @@ def _main(
     volumes: List[float],
 ) -> None:
     union_cfg: Union[PhotometricConfig, GravimetricConfig]
-    if not args.jog:
-        ui.print_warning(
-            "overwriting --jog to True, because liquid-probe "
-            "is not repeatable enough for gravimetric tests"
-        )
     if args.photometric:
         cfg_pm: PhotometricConfig = build_photometric_cfg(
             run_args.ctx,
@@ -480,7 +475,7 @@ def _main(
             args.touch_tip,
             args.refill,
             args.extra,
-            True,  # NOTE: (andy s) always jog
+            args.jog,
             args.same_tip,
             args.ignore_fail,
             args.channels,
@@ -504,7 +499,7 @@ def _main(
             args.isolate_channels if args.isolate_channels else [],
             args.isolate_volumes if args.isolate_volumes else [],
             args.extra,
-            True,  # NOTE: (andy s) always jog
+            args.jog,
             args.same_tip,
             args.ignore_fail,
             args.mode,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR re-enabled liquid-probing tests to speeds up P1000 8ch tests, but should not be used for any other tests (all other tests should use the `--jog` argument)

P1000 8ch gravimetric tests take a very long time, and they do not test low-volumes (aka <5uL). Liquid probing allows these 8ch tests to run overnight, so that an Operator is not needed to re-calibrate (aka "jog") the tip to the liquid in the vial.

Several weeks ago we disabled liquid-probe in gravimetric tests, because its current implementation is not precise enough and can alter our %D at 1uL. However, with it disabled, the P1000 8ch tests take a long time to do.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
