### PR TITLE
fix(app): only show 96 channel weight warning for 96 detach

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -254,25 +254,25 @@ export const BeforeBeginning = (
               )}
           </Flex>
           {selectedPipette === NINETY_SIX_CHANNEL &&
-          (flowType === FLOWS.CALIBRATE || flowType === FLOWS.ATTACH) ? (
-            <Banner
-              type={isWasteChuteOnDeck ? 'error' : 'warning'}
-              size={isOnDevice ? '1.5rem' : '1rem'}
-              marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
-            >
-              {isWasteChuteOnDeck
-                ? t('waste_chute_error')
-                : t('waste_chute_warning')}
-            </Banner>
-          ) : (
-            <Banner
-              type="warning"
-              size={isOnDevice ? '1.5rem' : '1rem'}
-              marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
-            >
-              {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
-            </Banner>
-          )}
+            (flowType === FLOWS.CALIBRATE || flowType === FLOWS.ATTACH ? (
+              <Banner
+                type={isWasteChuteOnDeck ? 'error' : 'warning'}
+                size={isOnDevice ? '1.5rem' : '1rem'}
+                marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
+              >
+                {isWasteChuteOnDeck
+                  ? t('waste_chute_error')
+                  : t('waste_chute_warning')}
+              </Banner>
+            ) : (
+              <Banner
+                type="warning"
+                size={isOnDevice ? '1.5rem' : '1rem'}
+                marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
+              >
+                {t('pipette_heavy', { weight: WEIGHT_OF_96_CHANNEL })}
+              </Banner>
+            ))}
         </>
       }
       proceedButtonText={proceedButtonText}


### PR DESCRIPTION
fix RQA-1960, RQA-1962

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fix ternary to show warnings on the Before you Begin screen _only_ for 96 channel pipettes. For the detach flow we should show the heavy pipette warning and for the attach and calibrate flows we should show the waste chute warning.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Launch a single or 8 channel attach and/or calibrate flow and see that the 96-channel warning is no longer present
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Fix parentheses location in ternary
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Sanity check
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
