### PR TITLE
docs(api): add comment explaining post-drop slide

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -116,6 +116,12 @@ class MoveLabwareImplementation(
                     f"Cannot move {current_labware.loadName} to addressable area {area_name}"
                 )
             if fixture_validation.is_gripper_waste_chute(area_name):
+                # When dropping off labware in the waste chute, some bigger pieces
+                # of labware (namely tipracks) can get stuck between a gripper
+                # paddle and the bottom of the waste chute, even after the gripper
+                # has homed all the way to the top of its travel. We add a "post-drop
+                # slide" to dropoffs in the waste chute in order to guarantee that the
+                # labware can drop fully through the chute before the gripper jaws close.
                 post_drop_slide_offset = Point(
                     x=(current_labware_definition.dimensions.xDimension / 2.0)
                     + (GRIPPER_PADDLE_WIDTH / 2.0)


### PR DESCRIPTION
# Overview

I got a little hasty with the merge button on #14065 

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
