### PR TITLE
feat(app): Add addressable area command display names

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -36,7 +36,7 @@
   "move_to_coordinates": "Moving to (X: {{x}}, Y: {{y}}, Z: {{z}})",
   "move_to_slot": "Moving to Slot {{slot_name}}",
   "move_to_well": "Moving to well {{well_name}} of {{labware}} in {{labware_location}}",
-  "move_to_addressable_area": "Moving to {{addressable_area}} at {{speed}} mm/s at {{height}} mm high",
+  "move_to_addressable_area": "Moving to {{addressable_area}}",
   "notes": "notes",
   "off_deck": "off deck",
   "offdeck": "offdeck",
@@ -57,6 +57,7 @@
   "tc_awaiting_for_duration": "Waiting for Thermocycler profile to complete",
   "tc_run_profile_steps": "temperature: {{celsius}}°C, seconds: {{seconds}}",
   "tc_starting_profile": "Thermocycler starting {{repetitions}} repetitions of cycle composed of the following steps:",
+  "trash_bin_in_slot": "Trash Bin in {{slot_name}}",
   "touch_tip": "Touching tip",
   "unlatching_hs_latch": "Unlatching labware on Heater-Shaker",
   "wait_for_duration": "Pausing for {{seconds}} seconds. {{message}}",
@@ -64,5 +65,6 @@
   "waiting_for_hs_to_reach": "Waiting for Heater-Shaker to reach target temperature",
   "waiting_for_tc_block_to_reach": "Waiting for Thermocycler block to reach target temperature and holding for specified time",
   "waiting_for_tc_lid_to_reach": "Waiting for Thermocycler lid to reach target temperature",
-  "waiting_to_reach_temp_module": "Waiting for Temperature Module to reach {{temp}}"
+  "waiting_to_reach_temp_module": "Waiting for Temperature Module to reach {{temp}}",
+  "waste_chute": "Waste Chute"
 }

--- a/app/src/organisms/CommandText/__fixtures__/mockRobotSideAnalysis.json
+++ b/app/src/organisms/CommandText/__fixtures__/mockRobotSideAnalysis.json
@@ -6376,6 +6376,21 @@
         "addressableAreaName": "movableTrashD3",
         "offset": { "x": 0, "y": 0, "z": 0 }
       }
+    },
+    {
+      "id": "aca688ed-4916-496d-aae8-ca0e6e56c47e",
+      "key": "e4be36b4-500c-45dd-8405-73115c80aa4x",
+      "commandType": "moveToAddressableArea",
+      "createdAt": "2023-11-29T20:31:00.780650+00:00",
+      "startedAt": "2023-11-29T20:31:29.248207+00:00",
+      "completedAt": "2023-11-29T20:31:33.972466+00:00",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "pipetteId": "c51ddc01-2d21-4e8a-9b10-2cef033488e8",
+        "addressableAreaName": "D3",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
     }
   ],
   "errors": [],

--- a/app/src/organisms/CommandText/__fixtures__/mockRobotSideAnalysis.json
+++ b/app/src/organisms/CommandText/__fixtures__/mockRobotSideAnalysis.json
@@ -6331,6 +6331,51 @@
       "result": {},
       "startedAt": "2023-01-31T21:53:14.615361+00:00",
       "completedAt": "2023-01-31T21:53:14.616757+00:00"
+    },
+    {
+      "id": "aca688ed-4916-496d-aae8-ca0e6e56c47b",
+      "key": "e4be36b4-500c-45dd-8405-73115c80aa4c",
+      "commandType": "moveToAddressableArea",
+      "createdAt": "2023-11-29T20:31:00.780650+00:00",
+      "startedAt": "2023-11-29T20:31:29.248207+00:00",
+      "completedAt": "2023-11-29T20:31:33.972466+00:00",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "pipetteId": "c51ddc01-2d21-4e8a-9b10-2cef033488e8",
+        "addressableAreaName": "1and8ChannelWasteChute",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "id": "aca688ed-4916-496d-aae8-ca0e6e56c47c",
+      "key": "e4be36b4-500c-45dd-8405-73115c80aa44",
+      "commandType": "moveToAddressableArea",
+      "createdAt": "2023-11-29T20:31:00.780650+00:00",
+      "startedAt": "2023-11-29T20:31:29.248207+00:00",
+      "completedAt": "2023-11-29T20:31:33.972466+00:00",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "pipetteId": "c51ddc01-2d21-4e8a-9b10-2cef033488e8",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "id": "aca688ed-4916-496d-aae8-ca0e6e56c47d",
+      "key": "e4be36b4-500c-45dd-8405-73115c80aa4z",
+      "commandType": "moveToAddressableArea",
+      "createdAt": "2023-11-29T20:31:00.780650+00:00",
+      "startedAt": "2023-11-29T20:31:29.248207+00:00",
+      "completedAt": "2023-11-29T20:31:33.972466+00:00",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "pipetteId": "c51ddc01-2d21-4e8a-9b10-2cef033488e8",
+        "addressableAreaName": "movableTrashD3",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
     }
   ],
   "errors": [],

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -283,6 +283,26 @@ describe('CommandText', () => {
     )[0]
     getByText('Moving to Trash Bin in D3')
   })
+  it('renders correct text for moveToAddressableArea for slots', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={OT2_ROBOT_TYPE}
+        command={
+          {
+            id: 'aca688ed-4916-496d-aae8-ca0e6e56c47e',
+            commandType: 'moveToAddressableArea',
+            params: {
+              pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
+              addressableAreaName: 'D3',
+            },
+          } as MoveToAddressableAreaRunTimeCommand
+        }
+      />,
+      { i18nInstance: i18n }
+    )[0]
+    getByText('Moving to D3')
+  })
   it('renders correct text for configureForVolume', () => {
     const command = {
       commandType: 'configureForVolume',

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -7,6 +7,7 @@ import {
   DropTipInPlaceRunTimeCommand,
   FLEX_ROBOT_TYPE,
   MoveToAddressableAreaRunTimeCommand,
+  OT2_ROBOT_TYPE,
   PrepareToAspirateRunTimeCommand,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
@@ -193,26 +194,94 @@ describe('CommandText', () => {
       getByText('Moving to well A1 of NEST 1 Well Reservoir 195 mL in Slot 5')
     }
   })
-  it('renders correct text for moveToAddressableArea', () => {
+  it('renders correct text for labware involving an addressable area slot', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        command={{
+          commandType: 'moveLabware',
+          params: {
+            strategy: 'usingGripper',
+            labwareId: mockRobotSideAnalysis.labware[2].id,
+            newLocation: { addressableAreaName: '5' },
+          },
+          id: 'def456',
+          result: { offsetId: 'fake_offset_id' },
+          status: 'queued',
+          error: null,
+          createdAt: 'fake_timestamp',
+          startedAt: null,
+          completedAt: null,
+        }}
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={FLEX_ROBOT_TYPE}
+      />,
+      {
+        i18nInstance: i18n,
+      }
+    )[0]
+    getByText(
+      'Moving Opentrons 96 Tip Rack 300 µL using gripper from Slot 9 to Slot 5'
+    )
+  })
+  it('renders correct text for moveToAddressableArea for Waste Chutes', () => {
     const { getByText } = renderWithProviders(
       <CommandText
         robotSideAnalysis={mockRobotSideAnalysis}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
+            id: 'aca688ed-4916-496d-aae8-ca0e6e56c47b',
             commandType: 'moveToAddressableArea',
             params: {
               pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
-              addressableAreaName: 'D3',
-              speed: 200,
-              minimumZHeight: 100,
+              addressableAreaName: '1and8ChannelWasteChute',
             },
           } as MoveToAddressableAreaRunTimeCommand
         }
       />,
       { i18nInstance: i18n }
     )[0]
-    getByText('Moving to D3 at 200 mm/s at 100 mm high')
+    getByText('Moving to Waste Chute')
+  })
+  it('renders correct text for moveToAddressableArea for Fixed Trash', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={OT2_ROBOT_TYPE}
+        command={
+          {
+            id: 'aca688ed-4916-496d-aae8-ca0e6e56c47c',
+            commandType: 'moveToAddressableArea',
+            params: {
+              pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
+              addressableAreaName: 'fixedTrash',
+            },
+          } as MoveToAddressableAreaRunTimeCommand
+        }
+      />,
+      { i18nInstance: i18n }
+    )[0]
+    getByText('Moving to Fixed Trash')
+  })
+  it('renders correct text for moveToAddressableArea for Trash Bins', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={OT2_ROBOT_TYPE}
+        command={
+          {
+            id: 'aca688ed-4916-496d-aae8-ca0e6e56c47d',
+            commandType: 'moveToAddressableArea',
+            params: {
+              pipetteId: 'f6d1c83c-9d1b-4d0d-9de3-e6d649739cfb',
+              addressableAreaName: 'movableTrashD3',
+            },
+          } as MoveToAddressableAreaRunTimeCommand
+        }
+      />,
+      { i18nInstance: i18n }
+    )[0]
+    getByText('Moving to Trash Bin in D3')
   })
   it('renders correct text for configureForVolume', () => {
     const command = {

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Flex, DIRECTION_COLUMN, SPACING } from '@opentrons/components'
 import { getPipetteNameSpecs, RunTimeCommand } from '@opentrons/shared-data'
 import {
+  getAddressableAreaDisplayName,
   getLabwareName,
   getLabwareDisplayLocation,
   getFinalLabwareLocation,
@@ -235,13 +236,16 @@ export function CommandText(props: Props): JSX.Element | null {
       )
     }
     case 'moveToAddressableArea': {
-      const { addressableAreaName, speed, minimumZHeight } = command.params
+      const addressableAreaDisplayName = getAddressableAreaDisplayName(
+        robotSideAnalysis,
+        command.id,
+        t
+      )
+
       return (
         <StyledText as="p" {...styleProps}>
           {t('move_to_addressable_area', {
-            addressable_area: addressableAreaName,
-            speed: speed,
-            height: minimumZHeight,
+            addressable_area: addressableAreaDisplayName,
           })}
         </StyledText>
       )

--- a/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
+++ b/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
@@ -22,13 +22,35 @@ export function getAddressableAreaDisplayName(
 
   const addressableAreaName: MoveToAddressableAreaParams['addressableAreaName'] =
     addressableAreaCommand.params.addressableAreaName
-  const movableTrashSubstr = 'movableTrash'
 
-  if (addressableAreaName.includes(movableTrashSubstr)) {
-    const slotName = addressableAreaName.split(movableTrashSubstr)[1]
+  if (addressableAreaName.includes('movableTrash')) {
+    const slotName = getMovableTrashSlot(addressableAreaName)
     return t('trash_bin_in_slot', { slot_name: slotName })
   } else if (addressableAreaName.includes('WasteChute')) {
     return t('waste_chute')
   } else if (addressableAreaName === 'fixedTrash') return t('fixed_trash')
   else return addressableAreaName
+}
+
+const getMovableTrashSlot = (addressableAreaName: string): string => {
+  switch (addressableAreaName) {
+    case 'movableTrashA1':
+      return 'A1'
+    case 'movableTrashA3':
+      return 'A3'
+    case 'movableTrashB1':
+      return 'B1'
+    case 'movableTrashB3':
+      return 'B3'
+    case 'movableTrashC1':
+      return 'C1'
+    case 'movableTrashC3':
+      return 'C3'
+    case 'movableTrashD1':
+      return 'D1'
+    case 'movableTrashD3':
+      return 'D3'
+    default:
+      return ''
+  }
 }

--- a/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
+++ b/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
@@ -1,0 +1,34 @@
+import type {
+  CompletedProtocolAnalysis,
+  MoveToAddressableAreaParams,
+} from '@opentrons/shared-data'
+import type { TFunction } from 'react-i18next'
+
+export function getAddressableAreaDisplayName(
+  analysis: CompletedProtocolAnalysis,
+  commandId: string,
+  t: TFunction<'protocol_command_text'>
+): string {
+  const addressableAreaCommand = (analysis?.commands ?? []).find(
+    command => command.id === commandId
+  )
+
+  if (
+    addressableAreaCommand == null ||
+    !('addressableAreaName' in addressableAreaCommand.params)
+  ) {
+    return ''
+  }
+
+  const addressableAreaName: MoveToAddressableAreaParams['addressableAreaName'] =
+    addressableAreaCommand.params.addressableAreaName
+  const movableTrashSubstr = 'movableTrash'
+
+  if (addressableAreaName.includes(movableTrashSubstr)) {
+    const slotName = addressableAreaName.split(movableTrashSubstr)[1]
+    return t('trash_bin_in_slot', { slot_name: slotName })
+  } else if (addressableAreaName.includes('WasteChute')) {
+    return t('waste_chute')
+  } else if (addressableAreaName === 'fixedTrash') return t('fixed_trash')
+  else return addressableAreaName
+}

--- a/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
@@ -28,6 +28,10 @@ export function getLabwareDisplayLocation(
     return isOnDevice
       ? location.slotName
       : t('slot', { slot_name: location.slotName })
+  } else if ('addressableAreaName' in location) {
+    return isOnDevice
+      ? location.addressableAreaName
+      : t('slot', { slot_name: location.addressableAreaName })
   } else if ('moduleId' in location) {
     const moduleModel = getModuleModel(robotSideAnalysis, location.moduleId)
     if (moduleModel == null) {

--- a/app/src/organisms/CommandText/utils/index.ts
+++ b/app/src/organisms/CommandText/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './getAddressableAreaDisplayName'
 export * from './getLabwareName'
 export * from './getPipetteNameOnMount'
 export * from './getModuleModel'


### PR DESCRIPTION
Closes RAUT-878

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds command text support for addressable areas (via a utility function). When moving to labware within an addressable area, the slot name is properly displayed. Additionally, appropriate, translated text is shown when moving to a waste chute or fixed trash. 

### Current Behavior (Step 8)

![Screenshot 2023-11-30 at 9 20 21 AM](https://github.com/Opentrons/opentrons/assets/64858653/f6f5155a-e1c1-4a88-bcb2-6d5239ea4c2d)

### Fixed Behavior (Step 8)

<img width="903" alt="Screenshot 2023-11-30 at 1 58 06 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/ce61c8c2-4d27-412a-b7ab-cedf86185462">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Run a protocol that makes use of a trash bin, a waste chute, and contains labware on an addressable area.
- Confirm on the desktop app & ODD that appropriate text is now displayed. 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added appropriate command display text during protocol runs for addressable areas. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
