### PR TITLE
docs(api): Versioning page updates for Python API 2.16

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -99,7 +99,7 @@ extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 # use rst_prolog to hold the subsitution
 # update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: 2.15
+.. |apiLevel| replace:: 2.16
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -127,12 +127,12 @@ Changes in API Versions
 Version 2.16
 ------------
 
-This version introduces new features for Flex and adds and improves methods for aspirating and dispensing.
+This version introduces new features for Flex and adds and improves methods for aspirating and dispensing. Note that when updating Flex protocols to version 2.16, you *must* load a trash container before dropping tips.
 
 - New features
 
   - Use :py:meth:`.configure_nozzle_layout` to pick up a single column of tips with the 96-channel pipette. See :ref:`partial-tip-pickup <Partial Tip Pickup>`.
-  - Specify the deck configuration of your Flex with :py:meth:`.load_waste_chute` and :py:meth:`.load_trash_bin`.
+  - Specify the trash containers attached to your Flex with :py:meth:`.load_waste_chute` and :py:meth:`.load_trash_bin`.
   - Dispense, blow out, drop tips, and dispose labware in the waste chute. Disposing labware requires the gripper and calling :py:meth:`.move_labware` with ``use_gripper=True``.
   - Perform actions in staging area slots by referencing slots A4 through D4. See :ref:`deck-slots`.
   - Explicitly command a pipette to :py:meth:`.prepare_to_aspirate`. The API usually prepares pipettes to aspirate automatically, but this is useful for certain applications, like pre-wetting routines.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -140,7 +140,6 @@ This version introduces new features for Flex and adds and improves methods for 
 - Improved features
 
   - :py:meth:`.aspirate`, :py:meth:`.dispense`, and :py:meth:`.mix` will not move any liquid when called with ``volume=0``.
-  - ``opentrons_simulate`` now works for all API versions.
 
 - Other changes
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -131,7 +131,7 @@ This version introduces new features for Flex and adds and improves methods for 
 
 - New features
 
-  - Use :py:meth:`.configure_nozzle_layout` to pick up a single column of tips with the 96-channel pipette. See :ref:`partial-tip-pickup <Partial Tip Pickup>`.
+  - Use :py:meth:`.configure_nozzle_layout` to pick up a single column of tips with the 96-channel pipette. See :ref:`Partial Tip Pickup <partial-tip-pickup>`.
   - Specify the trash containers attached to your Flex with :py:meth:`.load_waste_chute` and :py:meth:`.load_trash_bin`.
   - Dispense, blow out, drop tips, and dispose labware in the waste chute. Disposing labware requires the gripper and calling :py:meth:`.move_labware` with ``use_gripper=True``.
   - Perform actions in staging area slots by referencing slots A4 through D4. See :ref:`deck-slots`.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -131,8 +131,8 @@ This version introduces new features for Flex and adds and improves methods for 
 
 - New features
 
-  - Use :py:meth:`.configure_nozzle_layout` to pick up a single column of tips with the 96-channel pipette. See [ref TK].
-  - Specify the deck configuration of your Flex with :py:meth:`.load_waste_chute` and [TK method name for adding trash bins].
+  - Use :py:meth:`.configure_nozzle_layout` to pick up a single column of tips with the 96-channel pipette. See :ref:`partial-tip-pickup <Partial Tip Pickup>`.
+  - Specify the deck configuration of your Flex with :py:meth:`.load_waste_chute` and :py:meth:`.load_trash_bin`.
   - Dispense, blow out, drop tips, and dispose labware in the waste chute. Disposing labware requires the gripper and calling :py:meth:`.move_labware` with ``use_gripper=True``.
   - Perform actions in staging area slots by referencing slots A4 through D4. See :ref:`deck-slots`.
   - Explicitly command a pipette to :py:meth:`.prepare_to_aspirate`. The API usually prepares pipettes to aspirate automatically, but this is useful for certain applications, like pre-wetting routines.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -82,6 +82,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 | API Version | Introduced in Robot Software |
 +=============+==============================+
+|     2.16    |          7.1.0               |
++-------------+------------------------------+
 |     2.15    |          7.0.0               |
 +-------------+------------------------------+
 |     2.14    |          6.3.0               |
@@ -121,6 +123,24 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 Changes in API Versions
 =======================
+
+Version 2.16
+------------
+
+This version introduces new features for Flex and adds and improves methods for aspirating and dispensing.
+
+- New features
+
+  - Use :py:meth:`.configure_nozzle_layout` to pick up a single column of tips with the 96-channel pipette. See [ref TK].
+  - Specify the deck configuration of your Flex with :py:meth:`.load_waste_chute` and [TK method name for adding trash bins].
+  - Dispense, blow out, drop tips, and dispose labware in the waste chute. Disposing labware requires the gripper and calling :py:meth:`.move_labware` with ``use_gripper=True``.
+  - Perform actions in staging area slots by referencing slots A4 through D4. See :ref:`deck-slots`.
+  - Explicitly command a pipette to :py:meth:`.prepare_to_aspirate`. The API usually prepares pipettes to aspirate automatically, but this is useful for certain applications, like pre-wetting routines.
+
+- Improved features
+
+  - :py:meth:`.aspirate`, :py:meth:`.dispense`, and :py:meth:`.mix` will not move any liquid when called with ``volume=0``.
+  - ``opentrons_simulate`` now works for all API versions.
 
 Version 2.15
 ------------

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -148,7 +148,7 @@ This version introduces new features for Flex and adds and improves methods for 
   
 - Known issues
 
-  - It's possible to load a Thermocycler and then load another item in slot A1. Don't do this, as it could lead to unexpected pipetting behavior and crashes.
+  - It's possible to load a Thermocycler and then load another item in slot A1. It's also possible to load any labware or adapter on in the same slot as a trash bin. Don't do either of these things, as it could lead to unexpected pipetting behavior and crashes.
 
 Version 2.15
 ------------

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -142,6 +142,10 @@ This version introduces new features for Flex and adds and improves methods for 
   - :py:meth:`.aspirate`, :py:meth:`.dispense`, and :py:meth:`.mix` will not move any liquid when called with ``volume=0``.
   - ``opentrons_simulate`` now works for all API versions.
 
+- Other changes
+
+  - :py:obj:`.ProtocolContext.fixed_trash` and :py:obj:`.InstrumentContext.trash_container` now return :py:class:`.TrashBin` objects instead of :py:class:`.Labware` objects.
+
 Version 2.15
 ------------
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -145,6 +145,10 @@ This version introduces new features for Flex and adds and improves methods for 
 - Other changes
 
   - :py:obj:`.ProtocolContext.fixed_trash` and :py:obj:`.InstrumentContext.trash_container` now return :py:class:`.TrashBin` objects instead of :py:class:`.Labware` objects.
+  
+- Known issues
+
+  - It's possible to load a Thermocycler and then load another item in slot A1. Don't do this, as it could lead to unexpected pipetting behavior and crashes.
 
 Version 2.15
 ------------

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -144,6 +144,7 @@ This version introduces new features for Flex and adds and improves methods for 
 - Other changes
 
   - :py:obj:`.ProtocolContext.fixed_trash` and :py:obj:`.InstrumentContext.trash_container` now return :py:class:`.TrashBin` objects instead of :py:class:`.Labware` objects.
+  - Flex will no longer automatically drop tips in the trash at the end of a protocol. You can add a :py:meth:`.drop_tip()` command to your protocol or use the Opentrons App to drop the tips.
   
 - Known issues
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -68,7 +68,7 @@ If you upload a protocol that specifies a higher API level than the maximum supp
 
 Opentrons robots running the latest software (7.0.0) support the following version ranges: 
 
-    * **Flex:** version 2.15.
+    * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.
 
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -66,7 +66,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software (7.0.0) support the following version ranges: 
+Opentrons robots running the latest software (7.1.0) support the following version ranges: 
 
     * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -147,7 +147,7 @@ This version introduces new features for Flex and adds and improves methods for 
   
 - Known issues
 
-  - It's possible to load a Thermocycler and then load another item in slot A1. It's also possible to load any labware or adapter on in the same slot as a trash bin. Don't do either of these things, as it could lead to unexpected pipetting behavior and crashes.
+  - It's possible to load a Thermocycler and then load another item in slot A1. Don't do this, as it could lead to unexpected pipetting behavior and crashes.
 
 Version 2.15
 ------------


### PR DESCRIPTION
# Overview

Updates the Versioning page for new and improved features in Python API version 2.16.

# Test Plan

Review [sandbox](http://sandbox.docs.opentrons.com/docs-versioning-2.16/v2/versioning.html)

# Changelog

- updated version table
- list of new features in 2.16, with cross-references
- `|apiLevel|` substitution -> `2.16`

# Review requests

Any important features missing? Anything included that was actually in 2.15?

Note that the cross-reference to "Partial Tip Pickup" depends on #14189 and will only display as plain text here.

# Risk assessment

nil, docs only.