### PR TITLE
refactor(api, shared-data, app): camelCase ConfigurationParams and add to pydantic model

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -614,22 +614,22 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         if style == NozzleLayout.COLUMN:
             configuration_model: NozzleLayoutConfigurationType = (
                 ColumnNozzleLayoutConfiguration(
-                    primary_nozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
+                    primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
                 )
             )
         elif style == NozzleLayout.ROW:
             configuration_model = RowNozzleLayoutConfiguration(
-                primary_nozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
+                primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
             )
         elif style == NozzleLayout.QUADRANT:
             assert front_right_nozzle is not None
             configuration_model = QuadrantNozzleLayoutConfiguration(
-                primary_nozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle),
-                front_right_nozzle=front_right_nozzle,
+                primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle),
+                frontRightNozzle=front_right_nozzle,
             )
         elif style == NozzleLayout.SINGLE:
             configuration_model = SingleNozzleLayoutConfiguration(
-                primary_nozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
+                primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle)
             )
         else:
             configuration_model = AllNozzleLayoutConfiguration()

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -326,7 +326,7 @@ class SyncClient:
         """Execute a ConfigureForVolume command."""
         request = commands.ConfigureNozzleLayoutCreate(
             params=commands.ConfigureNozzleLayoutParams(
-                pipetteId=pipette_id, configuration_params=configuration_params
+                pipetteId=pipette_id, configurationParams=configuration_params
             )
         )
         result = self._transport.execute_command(request=request)

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -33,7 +33,7 @@ ConfigureNozzleLayoutCommandType = Literal["configureNozzleLayout"]
 class ConfigureNozzleLayoutParams(PipetteIdMixin):
     """Parameters required to configure the nozzle layout for a specific pipette."""
 
-    configuration_params: Union[
+    configurationParams: Union[
         AllNozzleLayoutConfiguration,
         SingleNozzleLayoutConfiguration,
         RowNozzleLayoutConfiguration,
@@ -73,8 +73,13 @@ class ConfigureNozzleLayoutImplementation(
         self, params: ConfigureNozzleLayoutParams
     ) -> Tuple[ConfigureNozzleLayoutResult, ConfigureNozzleLayoutPrivateResult]:
         """Check that requested pipette can support the requested nozzle layout."""
+        primary_nozzle = params.configurationParams.dict().get("primaryNozzle")
+        front_right_nozzle = params.configurationParams.dict().get("frontRightNozzle")
         nozzle_params = await self._tip_handler.available_for_nozzle_layout(
-            pipette_id=params.pipetteId, **params.configuration_params.dict()
+            pipette_id=params.pipetteId,
+            style=params.configurationParams.style,
+            primary_nozzle=primary_nozzle,
+            front_right_nozzle=front_right_nozzle,
         )
 
         nozzle_map = await self._equipment.configure_nozzle_layout(

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -748,7 +748,7 @@ class SingleNozzleLayoutConfiguration(BaseModel):
     """Minimum information required for a new nozzle configuration."""
 
     style: Literal["SINGLE"] = "SINGLE"
-    primary_nozzle: PRIMARY_NOZZLE_LITERAL = Field(
+    primaryNozzle: PRIMARY_NOZZLE_LITERAL = Field(
         ...,
         description="The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
     )
@@ -758,7 +758,7 @@ class RowNozzleLayoutConfiguration(BaseModel):
     """Minimum information required for a new nozzle configuration."""
 
     style: Literal["ROW"] = "ROW"
-    primary_nozzle: PRIMARY_NOZZLE_LITERAL = Field(
+    primaryNozzle: PRIMARY_NOZZLE_LITERAL = Field(
         ...,
         description="The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
     )
@@ -768,7 +768,7 @@ class ColumnNozzleLayoutConfiguration(BaseModel):
     """Information required for nozzle configurations of type ROW and COLUMN."""
 
     style: Literal["COLUMN"] = "COLUMN"
-    primary_nozzle: PRIMARY_NOZZLE_LITERAL = Field(
+    primaryNozzle: PRIMARY_NOZZLE_LITERAL = Field(
         ...,
         description="The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
     )
@@ -778,11 +778,11 @@ class QuadrantNozzleLayoutConfiguration(BaseModel):
     """Information required for nozzle configurations of type QUADRANT."""
 
     style: Literal["QUADRANT"] = "QUADRANT"
-    primary_nozzle: PRIMARY_NOZZLE_LITERAL = Field(
+    primaryNozzle: PRIMARY_NOZZLE_LITERAL = Field(
         ...,
         description="The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
     )
-    front_right_nozzle: str = Field(
+    frontRightNozzle: str = Field(
         ...,
         regex=NOZZLE_NAME_REGEX,
         description="The front right nozzle in your configuration.",

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -891,19 +891,19 @@ def test_has_tip(
             NozzleLayout.COLUMN,
             "A1",
             "H1",
-            ColumnNozzleLayoutConfiguration(primary_nozzle="A1"),
+            ColumnNozzleLayoutConfiguration(primaryNozzle="A1"),
         ],
         [
             NozzleLayout.SINGLE,
             "H12",
             None,
-            SingleNozzleLayoutConfiguration(primary_nozzle="H12"),
+            SingleNozzleLayoutConfiguration(primaryNozzle="H12"),
         ],
         [
             NozzleLayout.ROW,
             "A12",
             None,
-            RowNozzleLayoutConfiguration(primary_nozzle="A12"),
+            RowNozzleLayoutConfiguration(primaryNozzle="A12"),
         ],
     ],
 )

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
@@ -291,7 +291,7 @@ NINETY_SIX_MAP = OrderedDict(
     argnames=["request_model", "expected_nozzlemap", "nozzle_params"],
     argvalues=[
         [
-            SingleNozzleLayoutConfiguration(primary_nozzle="A1"),
+            SingleNozzleLayoutConfiguration(primaryNozzle="A1"),
             NozzleMap.build(
                 physical_nozzles=OrderedDict({"A1": Point(0, 0, 0)}),
                 physical_rows=OrderedDict({"A": ["A1"]}),
@@ -303,7 +303,7 @@ NINETY_SIX_MAP = OrderedDict(
             {"primary_nozzle": "A1"},
         ],
         [
-            ColumnNozzleLayoutConfiguration(primary_nozzle="A1"),
+            ColumnNozzleLayoutConfiguration(primaryNozzle="A1"),
             NozzleMap.build(
                 physical_nozzles=NINETY_SIX_MAP,
                 physical_rows=NINETY_SIX_ROWS,
@@ -316,7 +316,7 @@ NINETY_SIX_MAP = OrderedDict(
         ],
         [
             QuadrantNozzleLayoutConfiguration(
-                primary_nozzle="A1", front_right_nozzle="E1"
+                primaryNozzle="A1", frontRightNozzle="E1"
             ),
             NozzleMap.build(
                 physical_nozzles=NINETY_SIX_MAP,
@@ -355,12 +355,25 @@ async def test_configure_nozzle_layout_implementation(
 
     requested_nozzle_layout = ConfigureNozzleLayoutParams(
         pipetteId="pipette-id",
-        configuration_params=request_model,
+        configurationParams=request_model,
+    )
+    primary_nozzle = (
+        None
+        if isinstance(request_model, AllNozzleLayoutConfiguration)
+        else request_model.primaryNozzle
+    )
+    front_right_nozzle = (
+        request_model.frontRightNozzle
+        if isinstance(request_model, QuadrantNozzleLayoutConfiguration)
+        else None
     )
 
     decoy.when(
         await tip_handler.available_for_nozzle_layout(
-            "pipette-id", **request_model.dict()
+            pipette_id="pipette-id",
+            style=request_model.style,
+            primary_nozzle=primary_nozzle,
+            front_right_nozzle=front_right_nozzle,
         )
     ).then_return(nozzle_params)
 

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -199,7 +199,7 @@ export function CommandText(props: Props): JSX.Element | null {
       )
     }
     case 'configureNozzleLayout': {
-      const { configuration_params, pipetteId } = command.params
+      const { configurationParams, pipetteId } = command.params
       const pipetteName = robotSideAnalysis.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
@@ -208,7 +208,7 @@ export function CommandText(props: Props): JSX.Element | null {
       return (
         <StyledText as="p" {...styleProps}>
           {t('configure_nozzle_layout', {
-            amount: configuration_params.style === 'COLUMN' ? '8' : 'all',
+            amount: configurationParams.style === 'COLUMN' ? '8' : 'all',
             pipette:
               pipetteName != null
                 ? getPipetteNameSpecs(pipetteName)?.displayName

--- a/app/src/organisms/CommandText/utils/getWellRange.ts
+++ b/app/src/organisms/CommandText/utils/getWellRange.ts
@@ -27,9 +27,9 @@ export function getWellRange(
         c.params?.pipetteId === pipetteId
       ) {
         // TODO(sb, 11/9/23): add support for quadrant and row configurations when needed
-        if (c.params.configuration_params.style === 'SINGLE') {
+        if (c.params.configurationParams.style === 'SINGLE') {
           usedChannels = 1
-        } else if (c.params.configuration_params.style === 'COLUMN') {
+        } else if (c.params.configurationParams.style === 'COLUMN') {
           usedChannels = 8
         }
         break

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -469,14 +469,14 @@
           "enum": ["SINGLE"],
           "type": "string"
         },
-        "primary_nozzle": {
-          "title": "Primary Nozzle",
+        "primaryNozzle": {
+          "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
           "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": ["primary_nozzle"]
+      "required": ["primaryNozzle"]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -489,14 +489,14 @@
           "enum": ["ROW"],
           "type": "string"
         },
-        "primary_nozzle": {
-          "title": "Primary Nozzle",
+        "primaryNozzle": {
+          "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
           "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": ["primary_nozzle"]
+      "required": ["primaryNozzle"]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -509,14 +509,14 @@
           "enum": ["COLUMN"],
           "type": "string"
         },
-        "primary_nozzle": {
-          "title": "Primary Nozzle",
+        "primaryNozzle": {
+          "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
           "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": ["primary_nozzle"]
+      "required": ["primaryNozzle"]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -529,20 +529,20 @@
           "enum": ["QUADRANT"],
           "type": "string"
         },
-        "primary_nozzle": {
-          "title": "Primary Nozzle",
+        "primaryNozzle": {
+          "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
           "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         },
-        "front_right_nozzle": {
-          "title": "Front Right Nozzle",
+        "frontRightNozzle": {
+          "title": "Frontrightnozzle",
           "description": "The front right nozzle in your configuration.",
           "pattern": "[A-Z][0-100]",
           "type": "string"
         }
       },
-      "required": ["primary_nozzle", "front_right_nozzle"]
+      "required": ["primaryNozzle", "frontRightNozzle"]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -554,8 +554,8 @@
           "description": "Identifier of pipette to use for liquid handling.",
           "type": "string"
         },
-        "configuration_params": {
-          "title": "Configuration Params",
+        "configurationParams": {
+          "title": "Configurationparams",
           "anyOf": [
             {
               "$ref": "#/definitions/AllNozzleLayoutConfiguration"
@@ -575,7 +575,7 @@
           ]
         }
       },
-      "required": ["pipetteId", "configuration_params"]
+      "required": ["pipetteId", "configurationParams"]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -179,21 +179,21 @@ const COLUMN = 'COLUMN'
 const SINGLE = 'SINGLE'
 const ROW = 'ROW'
 const QUADRANT = 'QUADRANT'
-const EMPTY = 'EMPTY'
+const ALL = 'ALL'
 
 export type NozzleConfigurationStyle =
   | typeof COLUMN
   | typeof SINGLE
   | typeof ROW
   | typeof QUADRANT
-  | typeof EMPTY
+  | typeof ALL
 
 interface NozzleConfigurationParams {
-  primary_nozzle: string
+  primaryNozzle: string
   style: NozzleConfigurationStyle
 }
 
 interface ConfigureNozzleLayoutParams {
   pipetteId: string
-  configuration_params: NozzleConfigurationParams
+  configurationParams: NozzleConfigurationParams
 }

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -13,7 +13,7 @@ from .shared_models import (
     Metadata,
     DesignerApplication,
     Robot,
-    ConfigurationParams
+    NozzleConfigurationParams,
 )
 
 
@@ -68,7 +68,7 @@ class Params(BaseModel):
     dropOffset: Optional[OffsetVector]
     # schema v8 add-ons
     addressableAreaName: Optional[str]
-    configurationParams: Optional[ConfigurationParams]
+    configurationParams: Optional[NozzleConfigurationParams]
 
 
 class Command(BaseModel):

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -13,6 +13,7 @@ from .shared_models import (
     Metadata,
     DesignerApplication,
     Robot,
+    ConfigurationParams
 )
 
 
@@ -67,6 +68,7 @@ class Params(BaseModel):
     dropOffset: Optional[OffsetVector]
     # schema v8 add-ons
     addressableAreaName: Optional[str]
+    configurationParams: Optional[ConfigurationParams]
 
 
 class Command(BaseModel):

--- a/shared-data/python/opentrons_shared_data/protocol/models/shared_models.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/shared_models.py
@@ -104,6 +104,8 @@ class Labware(BaseModel):
     displayName: Optional[str]
     definitionId: str
 
-class ConfigurationParams(BaseModel): 
-    primaryNozzle: Optional[str]
+
+class NozzleConfigurationParams(BaseModel):
     style: str
+    primaryNozzle: Optional[str]
+    frontRightNozzle: Optional[str]

--- a/shared-data/python/opentrons_shared_data/protocol/models/shared_models.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/shared_models.py
@@ -103,3 +103,7 @@ class Liquid(BaseModel):
 class Labware(BaseModel):
     displayName: Optional[str]
     definitionId: str
+
+class ConfigurationParams(BaseModel): 
+    primaryNozzle: Optional[str]
+    style: str


### PR DESCRIPTION
# Overview

These changes enables JSON protocols to pass analysis with the `configureNozzleLayout` command. Co-authored with @sanni-t 

# Test Plan

Create a JSON protocol with a `configureNozzleLayout` command and make sure that is passes protocol analysis. Probably good to test a python protocol too.

# Changelog

- camelCase `configurationParams` and `primaryNozzle` throughout PE and TS types
- add `configurationParams` to V8 Pydantic model
- camelCase in TS type and change `EMPTY` to `ALL`
- fix affected TS components

# Review requests

see test plan

# Risk assessment

low