### PR TITLE
fix(app): do not redundantly check labware in LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -48,6 +48,7 @@ describe('CheckItem', () => {
       section: SECTIONS.CHECK_LABWARE,
       pipetteId: mockCompletedAnalysis.pipettes[0].id,
       labwareId: mockCompletedAnalysis.labware[0].id,
+      definitionUri: mockCompletedAnalysis.labware[0].definitionUri,
       location: { slotName: 'D1' },
       protocolData: mockCompletedAnalysis,
       proceed: jest.fn(),

--- a/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/PickUpTip.test.tsx
@@ -51,6 +51,7 @@ describe('PickUpTip', () => {
       section: SECTIONS.PICK_UP_TIP,
       pipetteId: mockCompletedAnalysis.pipettes[0].id,
       labwareId: mockCompletedAnalysis.labware[0].id,
+      definitionUri: mockCompletedAnalysis.labware[0].definitionUri,
       location: { slotName: 'D1' },
       protocolData: mockCompletedAnalysis,
       proceed: jest.fn(),

--- a/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/ReturnTip.test.tsx
@@ -47,6 +47,7 @@ describe('ReturnTip', () => {
       section: SECTIONS.RETURN_TIP,
       pipetteId: mockCompletedAnalysis.pipettes[0].id,
       labwareId: mockCompletedAnalysis.labware[0].id,
+      definitionUri: mockCompletedAnalysis.labware[0].definitionUri,
       location: { slotName: 'D1' },
       protocolData: mockCompletedAnalysis,
       proceed: jest.fn(),

--- a/app/src/organisms/LabwarePositionCheck/types.ts
+++ b/app/src/organisms/LabwarePositionCheck/types.ts
@@ -21,6 +21,7 @@ export interface CheckTipRacksStep {
   pipetteId: string
   labwareId: string
   location: LabwareOffsetLocation
+  definitionUri: string
   adapterId?: string
 }
 export interface AttachProbeStep {
@@ -32,6 +33,7 @@ export interface PickUpTipStep {
   pipetteId: string
   labwareId: string
   location: LabwareOffsetLocation
+  definitionUri: string
   adapterId?: string
 }
 export interface CheckPositionsStep {
@@ -39,6 +41,7 @@ export interface CheckPositionsStep {
   pipetteId: string
   labwareId: string
   location: LabwareOffsetLocation
+  definitionUri: string
   moduleId?: string
 }
 export interface CheckLabwareStep {
@@ -46,6 +49,7 @@ export interface CheckLabwareStep {
   pipetteId: string
   labwareId: string
   location: LabwareOffsetLocation
+  definitionUri: string
   moduleId?: string
   adapterId?: string
 }
@@ -54,6 +58,7 @@ export interface ReturnTipStep {
   pipetteId: string
   labwareId: string
   location: LabwareOffsetLocation
+  definitionUri: string
   adapterId?: string
 }
 export interface DetachProbeStep {

--- a/app/src/organisms/LabwarePositionCheck/utils/getProbeBasedLPCSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getProbeBasedLPCSteps.ts
@@ -75,13 +75,14 @@ function getAllCheckSectionSteps(
   )
 
   return labwareLocations.map(
-    ({ location, labwareId, moduleId, adapterId }) => ({
+    ({ location, labwareId, moduleId, adapterId, definitionUri }) => ({
       section: SECTIONS.CHECK_POSITIONS,
       labwareId: labwareId,
       pipetteId: getPrimaryPipetteId(pipettes),
       location,
       moduleId,
       adapterId,
+      definitionUri: definitionUri
     })
   )
 }

--- a/app/src/organisms/LabwarePositionCheck/utils/getProbeBasedLPCSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getProbeBasedLPCSteps.ts
@@ -82,7 +82,7 @@ function getAllCheckSectionSteps(
       location,
       moduleId,
       adapterId,
-      definitionUri: definitionUri
+      definitionUri: definitionUri,
     })
   )
 }

--- a/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
@@ -169,7 +169,6 @@ function getCheckLabwareSectionSteps(args: LPCArgs): CheckLabwareStep[] {
       modules
     ).reduce<LabwareLocationCombo[]>(
       (labwareLocationAcc, labwareLocationCombo) => {
-        // remove labware that isn't accessed by a pickup tip command
         if (labwareLocationCombo.labwareId !== currentLabware.id) {
           return labwareLocationAcc
         }

--- a/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
+++ b/app/src/organisms/LabwarePositionCheck/utils/getTipBasedLPCSteps.ts
@@ -48,6 +48,7 @@ export const getTipBasedLPCSteps = (
     pipetteId: lastTiprackCheckStep.pipetteId,
     location: lastTiprackCheckStep.location,
     adapterId: lastTiprackCheckStep.adapterId,
+    definitionUri: lastTiprackCheckStep.definitionUri,
   }
   const checkLabwareSectionSteps = getCheckLabwareSectionSteps(args)
 
@@ -57,6 +58,7 @@ export const getTipBasedLPCSteps = (
     pipetteId: lastTiprackCheckStep.pipetteId,
     location: lastTiprackCheckStep.location,
     adapterId: lastTiprackCheckStep.adapterId,
+    definitionUri: lastTiprackCheckStep.definitionUri,
   }
 
   return [
@@ -134,12 +136,13 @@ function getCheckTipRackSectionSteps(args: LPCArgs): CheckTipRacksStep[] {
 
     return [
       ...acc,
-      ...labwareLocations.map(({ location, adapterId }) => ({
+      ...labwareLocations.map(({ location, adapterId, definitionUri }) => ({
         section: SECTIONS.CHECK_TIP_RACKS,
         labwareId: params.labwareId,
         pipetteId: params.pipetteId,
         location,
         adapterId,
+        definitionUri: definitionUri,
       })),
     ]
   }, [])
@@ -148,53 +151,48 @@ function getCheckTipRackSectionSteps(args: LPCArgs): CheckTipRacksStep[] {
 function getCheckLabwareSectionSteps(args: LPCArgs): CheckLabwareStep[] {
   const { labware, modules, commands, primaryPipetteId } = args
   const labwareDefinitions = getLabwareDefinitionsFromCommands(commands)
-  const labwareLocationCombos = getLabwareLocationCombos(
+
+  const deDupedLabwareLocationCombos = getLabwareLocationCombos(
     commands,
     labware,
     modules
-  )
-
-  return labware.reduce<CheckLabwareStep[]>((acc, currentLabware) => {
+  ).reduce<LabwareLocationCombo[]>((acc, labwareLocationCombo) => {
     const labwareDef = labwareDefinitions.find(
-      def => getLabwareDefURI(def) === currentLabware.definitionUri
+      def => getLabwareDefURI(def) === labwareLocationCombo.definitionUri
     )
-    if (currentLabware.id === FIXED_TRASH_ID) return acc
+    if (labwareLocationCombo.labwareId === FIXED_TRASH_ID) return acc
     if (labwareDef == null) {
       throw new Error(
-        `could not find labware definition within protocol with uri: ${currentLabware.definitionUri}`
+        `could not find labware definition within protocol with uri: ${labwareLocationCombo.definitionUri}`
       )
     }
     const isTiprack = getIsTiprack(labwareDef)
     const adapter = (labwareDef?.allowedRoles ?? []).includes('adapter')
     if (isTiprack || adapter) return acc // skip any labware that is a tiprack or adapter
 
-    const labwareLocations = labwareLocationCombos.reduce<
-      LabwareLocationCombo[]
-    >((labwareLocationAcc, labwareLocationCombo) => {
-      if (labwareLocationCombo.labwareId !== currentLabware.id) {
-        return labwareLocationAcc
-      }
-      // remove duplicate definitionUri in same location
-      const comboAlreadyExists = labwareLocationAcc.some(
-        accLocationCombo =>
-          labwareLocationCombo.definitionUri ===
-            accLocationCombo.definitionUri &&
-          isEqual(labwareLocationCombo.location, accLocationCombo.location)
-      )
-      return comboAlreadyExists
-        ? labwareLocationAcc
-        : [...labwareLocationAcc, labwareLocationCombo]
-    }, [])
-
-    return [
-      ...acc,
-      ...labwareLocations.map(({ location, adapterId, labwareId }) => ({
-        section: SECTIONS.CHECK_LABWARE,
-        labwareId: labwareId,
-        pipetteId: primaryPipetteId,
-        location,
-        adapterId,
-      })),
-    ]
+    const comboAlreadyExists = acc.some(
+      accLocationCombo =>
+        labwareLocationCombo.definitionUri === accLocationCombo.definitionUri &&
+        isEqual(labwareLocationCombo.location, accLocationCombo.location)
+    )
+    return comboAlreadyExists ? acc : [...acc, labwareLocationCombo]
   }, [])
+
+  return deDupedLabwareLocationCombos.reduce<CheckLabwareStep[]>(
+    (acc, { labwareId, location, moduleId, adapterId, definitionUri }) => {
+      return [
+        ...acc,
+        {
+          section: SECTIONS.CHECK_LABWARE,
+          labwareId,
+          pipetteId: primaryPipetteId,
+          location,
+          moduleId,
+          adapterId,
+          definitionUri,
+        },
+      ]
+    },
+    []
+  )
 }


### PR DESCRIPTION
# Overview

This PR dedupes labware def uri <> location combos in tip based LPC so we do not redundantly check labware def uri <> location combos.

closes RAUT-889

# Test Plan
Tested on an OT-2 (tip based LPC) just to make sure nothing broke
Tested on a Flex (probe based LPC) just to make sure nothing broke

# Changelog


- Do not redundantly check labware in LPC


# Risk assessment

Low./med
