### PR TITLE
refactor(protocol-designer): reimporting protocol with deck config fixes

### DIFF
--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedStagingAreas.test.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedStagingAreas.test.ts
@@ -12,8 +12,18 @@ describe('getUnusedStagingAreas', () => {
         location: 'cutoutA3',
       },
     } as AdditionalEquipment
+    const mockCommand = ([
+      {
+        stagingArea: {
+          commandType: 'loadLabware',
+          params: { location: { slotName: 'A1' } },
+        },
+      },
+    ] as unknown) as CreateCommand[]
 
-    expect(getUnusedStagingAreas(mockAdditionalEquipment, [])).toEqual(['A4'])
+    expect(
+      getUnusedStagingAreas(mockAdditionalEquipment, mockCommand)
+    ).toEqual(['A4'])
   })
   it('returns true for multi unused staging areas', () => {
     const stagingArea = 'stagingAreaId'
@@ -45,17 +55,15 @@ describe('getUnusedStagingAreas', () => {
         location: 'cutoutA3',
       },
     } as AdditionalEquipment
-    const mockCommand = ([
+    const mockCommand = [
       {
-        stagingArea: {
-          commandType: 'loadLabware',
-          params: { location: { slotName: 'A4' } },
-        },
+        commandType: 'loadLabware',
+        params: { location: { addressableAreaName: 'A4' } },
       },
-    ] as unknown) as CreateCommand[]
+    ] as CreateCommand[]
 
-    expect(
-      getUnusedStagingAreas(mockAdditionalEquipment, mockCommand)
-    ).toEqual(['A4'])
+    expect(getUnusedStagingAreas(mockAdditionalEquipment, mockCommand)).toEqual(
+      []
+    )
   })
 })

--- a/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedStagingAreas.test.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/__tests__/getUnusedStagingAreas.test.ts
@@ -12,18 +12,8 @@ describe('getUnusedStagingAreas', () => {
         location: 'cutoutA3',
       },
     } as AdditionalEquipment
-    const mockCommand = ([
-      {
-        stagingArea: {
-          commandType: 'loadLabware',
-          params: { location: { slotName: 'A1' } },
-        },
-      },
-    ] as unknown) as CreateCommand[]
 
-    expect(
-      getUnusedStagingAreas(mockAdditionalEquipment, mockCommand)
-    ).toEqual(['A4'])
+    expect(getUnusedStagingAreas(mockAdditionalEquipment, [])).toEqual(['A4'])
   })
   it('returns true for multi unused staging areas', () => {
     const stagingArea = 'stagingAreaId'

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedStagingAreas.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedStagingAreas.ts
@@ -24,20 +24,19 @@ export const getUnusedStagingAreas = (
 
   const stagingAreaCommandSlots: string[] = stagingAreaAddressableAreaNames.filter(
     location =>
-      commands?.filter(
+      (commands ?? [])?.some(
         command =>
           (command.commandType === 'loadLabware' &&
             command.params.location !== 'offDeck' &&
-            'slotName' in command.params.location &&
-            command.params.location.slotName === location) ||
+            'addressableAreaName' in command.params.location &&
+            command.params.location.addressableAreaName === location) ||
           (command.commandType === 'moveLabware' &&
             command.params.newLocation !== 'offDeck' &&
-            'slotName' in command.params.newLocation &&
-            command.params.newLocation.slotName === location)
+            'addressableAreaName' in command.params.newLocation &&
+            command.params.newLocation.addressableAreaName === location)
       )
-        ? location
-        : null
+        ? null
+        : location
   )
-
   return stagingAreaCommandSlots
 }

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1350,16 +1350,6 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
               command.params.addressableAreaName
             ))
       )
-      const wasteChuteId = `${uuid()}:wasteChute`
-      const wasteChute = hasWasteChuteCommands
-        ? {
-            [wasteChuteId]: {
-              name: 'wasteChute' as const,
-              id: wasteChuteId,
-              location: 'cutoutD3',
-            },
-          }
-        : {}
 
       const getStagingAreaSlotNames = (
         commandType: 'moveLabware' | 'loadLabware',
@@ -1370,7 +1360,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
             command =>
               command.commandType === commandType &&
               command.params[locationKey] !== 'offDeck' &&
-              'slotName' in command.params[locationKey] &&
+              'addressableAreaName' in command.params[locationKey] &&
               COLUMN_4_SLOTS.includes(
                 command.params[locationKey].addressableAreaName
               )
@@ -1413,7 +1403,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       const trashAddressableAreaName =
         trashBinCommand?.params.addressableAreaName
       const savedStepForms = file.designerApplication?.data?.savedStepForms
-      const moveLiquidStep =
+      const moveLiquidStepTrashBin =
         savedStepForms != null
           ? Object.values(savedStepForms).find(
               stepForm =>
@@ -1421,28 +1411,37 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
                 (stepForm.aspirate_labware.includes('trashBin') ||
                   stepForm.dispense_labware.includes('trashBin') ||
                   stepForm.dropTip_location.includes('trashBin') ||
-                  stepForm.blowout_location.includes('trashBin'))
+                  stepForm.blowout_location?.includes('trashBin'))
             )
           : null
 
       let trashBinId: string | null = null
-      if (moveLiquidStep != null) {
-        if (moveLiquidStep.aspirate_labware.includes('trashBin')) {
-          trashBinId = moveLiquidStep.aspirate_labware
-        } else if (moveLiquidStep.dispense_labware.includes('trashBin')) {
-          trashBinId = moveLiquidStep.dispense_labware
-        } else if (moveLiquidStep.dropTip_location.includes('trashBin')) {
-          trashBinId = moveLiquidStep.dropTip_location
-        } else if (moveLiquidStep.blowOut_location.includes('trashBin')) {
-          trashBinId = moveLiquidStep.blowOut_location
+      if (moveLiquidStepTrashBin != null) {
+        if (moveLiquidStepTrashBin.aspirate_labware.includes('trashBin')) {
+          trashBinId = moveLiquidStepTrashBin.aspirate_labware
+        } else if (
+          moveLiquidStepTrashBin.dispense_labware.includes('trashBin')
+        ) {
+          trashBinId = moveLiquidStepTrashBin.dispense_labware
+        } else if (
+          moveLiquidStepTrashBin.dropTip_location.includes('trashBin')
+        ) {
+          trashBinId = moveLiquidStepTrashBin.dropTip_location
+        } else if (
+          moveLiquidStepTrashBin.blowOut_location?.includes('trashBin')
+        ) {
+          trashBinId = moveLiquidStepTrashBin.blowOut_location
         }
       }
 
-      const trashCutoutId = getCutoutIdByAddressableArea(
-        trashAddressableAreaName as AddressableAreaName,
-        isFlex ? 'trashBinAdapter' : 'fixedTrashSlot',
-        isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
-      )
+      const trashCutoutId =
+        trashAddressableAreaName != null
+          ? getCutoutIdByAddressableArea(
+              trashAddressableAreaName as AddressableAreaName,
+              isFlex ? 'trashBinAdapter' : 'fixedTrashSlot',
+              isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
+            )
+          : null
       const trashBin =
         trashAddressableAreaName != null && trashBinId != null
           ? {
@@ -1460,6 +1459,48 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           'expected to find a fixedTrash command for the OT-2 but could not'
         )
       }
+
+      const moveLiquidStepWasteChute =
+        savedStepForms != null
+          ? Object.values(savedStepForms).find(
+              stepForm =>
+                stepForm.stepType === 'moveLiquid' &&
+                (stepForm.aspirate_labware.includes('wasteChute') ||
+                  stepForm.dispense_labware.includes('wasteChute') ||
+                  stepForm.dropTip_location.includes('wasteChute') ||
+                  stepForm.blowout_location?.includes('wasteChute'))
+            )
+          : null
+
+      let wasteChuteId: string | null = null
+      if (hasWasteChuteCommands && moveLiquidStepWasteChute != null) {
+        if (moveLiquidStepWasteChute.aspirate_labware.includes('wasteChute')) {
+          wasteChuteId = moveLiquidStepWasteChute.aspirate_labware
+        } else if (
+          moveLiquidStepWasteChute.dispense_labware.includes('wasteChute')
+        ) {
+          wasteChuteId = moveLiquidStepWasteChute.dispense_labware
+        } else if (
+          moveLiquidStepWasteChute.dropTip_location.includes('wasteChute')
+        ) {
+          wasteChuteId = moveLiquidStepWasteChute.dropTip_location
+        } else if (
+          moveLiquidStepWasteChute.blowOut_location?.includes('wasteChute')
+        ) {
+          wasteChuteId = moveLiquidStepWasteChute.blowOut_location
+        }
+      }
+
+      const wasteChute =
+        hasWasteChuteCommands && wasteChuteId != null
+          ? {
+              [wasteChuteId]: {
+                name: 'wasteChute' as const,
+                id: wasteChuteId,
+                location: 'cutoutD3',
+              },
+            }
+          : {}
 
       const gripperId = `${uuid()}:gripper`
       const gripper = hasGripperCommands


### PR DESCRIPTION
closes RAUT-890

# Overview

When you reimport a protocol with staging area slots and waste chute, they don't populate correctly. But this PR fixes that. 

# Test Plan

Create a flex protocol and add a staging area and waste chute. Delete the trash bin. Add a labware and then add a transfer step! Also add a misc labware to be on top of the staging areas. (otherwise the staging areas aren't needed and won't repopulate during reimport)

Export the protocol. Open it up and change the version from `7.0.2` to `8.0.0` (this version change happens during the release process so we have to manually change it whenever we want to reimport a protocol)

Reimport the protocol. See that the staging area slots and waste chute are added as expected. Then go to the deck view and see that none of the timeline steps have an error.

I also attached this protocol you can use! It has 2 staging area slots in A4 and B4 and a waste chute (plus some modules):
[doItAllV8.json](https://github.com/Opentrons/opentrons/files/13546687/doItAllV8.json)

# Changelog

- fix the reducer logic for staging areas to look for `addressableAreaName` instead of `slotName`
- fix the reducer logic for waste chute by not generating a new Id and instead, grabbing the Id from the step form steps (autogenerating was causing 2 different waste chute Ids to appear in the protocol!)
- fix the `getUnusedStagingArea` logic by making it opposite and cleaning it up and also looking for `addressableAreaName`. Then fix the test

# Review requests

see test plan

# Risk assessment

low