### PR TITLE
chore(api): fix protocol engine tests to test both OT3 API and OT2 API when needed

### DIFF
--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
@@ -6,10 +6,9 @@ import inspect
 import pytest
 from datetime import datetime
 from decoy import Decoy
-from typing import TYPE_CHECKING
+from typing import Any
 
 from opentrons.hardware_control import ot3_calibration
-from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import GripperProbe, OT3Mount
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
@@ -49,7 +48,7 @@ def _mock_ot3_calibration(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None
 )
 async def test_calibrate_gripper(
     decoy: Decoy,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     _mock_ot3_calibration: None,
     params_probe: CalibrateGripperParamsJaw,
     expected_hc_probe: GripperProbe,
@@ -71,7 +70,7 @@ async def test_calibrate_gripper(
 @pytest.mark.ot3_only
 async def test_calibrate_gripper_saves_calibration(
     decoy: Decoy,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     _mock_ot3_calibration: None,
 ) -> None:
     """It should delegate to hardware API to calibrate the gripper & save calibration."""
@@ -103,7 +102,7 @@ async def test_calibrate_gripper_saves_calibration(
 
 @pytest.mark.ot3_only
 async def test_calibrate_gripper_does_not_save_during_error(
-    decoy: Decoy, hardware_api: HardwareControlAPI
+    decoy: Decoy, hardware_api: Any
 ) -> None:
     """Data should not be saved when an error is raised."""
     subject = CalibrateGripperImplementation(hardware_api=hardware_api)
@@ -133,7 +132,7 @@ async def test_calibrate_gripper_does_not_save_during_error(
 @pytest.mark.ot2_only
 async def test_calibrate_gripper_raises_on_ot2(
     decoy: Decoy,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
 ) -> None:
     """It should raise with a descriptive error if run on an OT-2, instead of OT-3."""
     subject = CalibrateGripperImplementation(hardware_api=hardware_api)

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -1,11 +1,10 @@
 """Test calibrate-module command."""
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import Any
 
 import inspect
 import pytest
 from decoy import Decoy
-from opentrons.hardware_control import HardwareControlAPI
 
 from opentrons.protocol_engine.commands.calibration.calibrate_module import (
     CalibrateModuleResult,
@@ -35,7 +34,7 @@ def _mock_ot3_calibration(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None
 
 @pytest.mark.ot3_only
 async def test_calibrate_module_implementation(
-    decoy: Decoy, hardware_api: HardwareControlAPI, state_view: StateView
+    decoy: Decoy, hardware_api: Any, state_view: StateView
 ) -> None:
     """Test Calibration command execution."""
     subject = CalibrateModuleImplementation(state_view, hardware_api)
@@ -94,7 +93,7 @@ async def test_calibrate_module_implementation(
 
 @pytest.mark.ot2_only
 async def test_calibrate_module_implementation_wrong_hardware(
-    decoy: Decoy, hardware_api: HardwareControlAPI, state_view: StateView
+    decoy: Decoy, hardware_api: Any, state_view: StateView
 ) -> None:
     """Should raise an unsupported hardware error."""
     subject = CalibrateModuleImplementation(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import inspect
 import pytest
 from decoy import Decoy
-from opentrons.hardware_control.api import API as OT2API
+from opentrons.hardware_control import HardwareControlAPI
 
 from opentrons.protocol_engine.commands.calibration.calibrate_module import (
     CalibrateModuleResult,
@@ -25,9 +25,6 @@ from opentrons.types import DeckSlotName, MountType, Point
 
 from opentrons.hardware_control import ot3_calibration as calibration
 
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
-
 
 @pytest.mark.ot3_only
 @pytest.fixture(autouse=True)
@@ -38,10 +35,10 @@ def _mock_ot3_calibration(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None
 
 @pytest.mark.ot3_only
 async def test_calibrate_module_implementation(
-    decoy: Decoy, ot3_hardware_api: OT3API, state_view: StateView
+    decoy: Decoy, hardware_api: HardwareControlAPI, state_view: StateView
 ) -> None:
     """Test Calibration command execution."""
-    subject = CalibrateModuleImplementation(state_view, ot3_hardware_api)
+    subject = CalibrateModuleImplementation(state_view, hardware_api)
 
     location = DeckSlotLocation(slotName=DeckSlotName("D3"))
     module_id = "module123"
@@ -75,7 +72,7 @@ async def test_calibrate_module_implementation(
     ).then_return(Point(x=3, y=2, z=1))
     decoy.when(
         await calibration.calibrate_module(
-            hcapi=ot3_hardware_api,
+            hcapi=hardware_api,
             mount=OT3Mount.LEFT,
             slot=location.slotName.id,
             module_id=module_serial,
@@ -95,13 +92,13 @@ async def test_calibrate_module_implementation(
     )
 
 
-@pytest.mark.ot3_only
+@pytest.mark.ot2_only
 async def test_calibrate_module_implementation_wrong_hardware(
-    decoy: Decoy, ot2_hardware_api: OT2API, state_view: StateView
+    decoy: Decoy, hardware_api: HardwareControlAPI, state_view: StateView
 ) -> None:
     """Should raise an unsupported hardware error."""
     subject = CalibrateModuleImplementation(
-        state_view=state_view, hardware_api=ot2_hardware_api
+        state_view=state_view, hardware_api=hardware_api
     )
 
     params = CalibrateModuleParams(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
@@ -1,6 +1,6 @@
 """Test calibrate-pipette command."""
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import Any
 
 import inspect
 import pytest
@@ -14,7 +14,6 @@ from opentrons.protocol_engine.commands.calibration.calibrate_pipette import (
 from opentrons.protocol_engine.errors.exceptions import HardwareNotSupportedError
 from opentrons.protocol_engine.types import InstrumentOffsetVector
 
-from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import OT3Mount
 from opentrons.types import MountType, Point
 
@@ -32,7 +31,7 @@ def _mock_ot3_calibration(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None
 
 @pytest.mark.ot3_only
 async def test_calibrate_pipette_implementation(
-    decoy: Decoy, hardware_api: HardwareControlAPI
+    decoy: Decoy, hardware_api: Any
 ) -> None:
     """Test Calibration command execution."""
     subject = CalibratePipetteImplementation(hardware_api=hardware_api)
@@ -63,7 +62,7 @@ async def test_calibrate_pipette_implementation(
 
 @pytest.mark.ot3_only
 async def test_calibrate_pipette_does_not_save_during_error(
-    decoy: Decoy, hardware_api: HardwareControlAPI
+    decoy: Decoy, hardware_api: Any
 ) -> None:
     """Data should not be saved when an error is raised."""
     subject = CalibratePipetteImplementation(hardware_api=hardware_api)
@@ -91,7 +90,7 @@ async def test_calibrate_pipette_does_not_save_during_error(
 
 @pytest.mark.ot2_only
 async def test_calibrate_pipette_implementation_wrong_hardware(
-    decoy: Decoy, hardware_api: HardwareControlAPI
+    decoy: Decoy, hardware_api: Any
 ) -> None:
     """Should raise an unsupported hardware error."""
     subject = CalibratePipetteImplementation(hardware_api=hardware_api)

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -1,6 +1,6 @@
 """Test for Calibration Set Up Position Implementation."""
 from __future__ import annotations
-from typing import TYPE_CHECKING, Mapping
+from typing import Any, Mapping
 
 import pytest
 from decoy import Decoy
@@ -47,7 +47,7 @@ async def test_calibration_move_to_location_implementation(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,
     state_view: StateView,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     maintenance_position: MaintenancePosition,
     verify_axes: Mapping[Axis, float],
 ) -> None:
@@ -112,7 +112,7 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,
     state_view: StateView,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -14,20 +14,18 @@ from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import MountType, Mount, Point
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import Axis, CriticalPoint
-
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
 
 
 @pytest.mark.ot3_only
 @pytest.fixture
 def subject(
-    ot3_hardware_api: OT3API, state_view: StateView
+    hardware_api: HardwareControlAPI, state_view: StateView
 ) -> MoveToMaintenancePositionImplementation:
     """Returns the subject under test."""
     return MoveToMaintenancePositionImplementation(
-        state_view=state_view, hardware_api=ot3_hardware_api
+        state_view=state_view, hardware_api=hardware_api
     )
 
 
@@ -49,7 +47,7 @@ async def test_calibration_move_to_location_implementation(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,
     state_view: StateView,
-    ot3_hardware_api: OT3API,
+    hardware_api: HardwareControlAPI,
     maintenance_position: MaintenancePosition,
     verify_axes: Mapping[Axis, float],
 ) -> None:
@@ -59,24 +57,24 @@ async def test_calibration_move_to_location_implementation(
     )
 
     decoy.when(
-        await ot3_hardware_api.gantry_position(
+        await hardware_api.gantry_position(
             Mount.LEFT, critical_point=CriticalPoint.MOUNT
         )
     ).then_return(Point(x=1, y=2, z=3))
 
     decoy.when(
-        ot3_hardware_api.get_instrument_max_height(
+        hardware_api.get_instrument_max_height(
             Mount.LEFT, critical_point=CriticalPoint.MOUNT
         )
     ).then_return(250)
 
-    decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
+    decoy.when(hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
     assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
-        await ot3_hardware_api.move_to(
+        await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=1, y=2, z=250),
             critical_point=CriticalPoint.MOUNT,
@@ -85,7 +83,7 @@ async def test_calibration_move_to_location_implementation(
     )
 
     decoy.verify(
-        await ot3_hardware_api.move_to(
+        await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=0, y=110, z=250),
             critical_point=CriticalPoint.MOUNT,
@@ -94,7 +92,7 @@ async def test_calibration_move_to_location_implementation(
     )
 
     decoy.verify(
-        await ot3_hardware_api.move_axes(
+        await hardware_api.move_axes(
             position=verify_axes,
         ),
         times=1,
@@ -102,7 +100,7 @@ async def test_calibration_move_to_location_implementation(
 
     if params.maintenancePosition == MaintenancePosition.ATTACH_INSTRUMENT:
         decoy.verify(
-            await ot3_hardware_api.disengage_axes(
+            await hardware_api.disengage_axes(
                 list(verify_axes.keys()),
             ),
             times=1,
@@ -114,7 +112,7 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,
     state_view: StateView,
-    ot3_hardware_api: OT3API,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(
@@ -122,24 +120,24 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     )
 
     decoy.when(
-        await ot3_hardware_api.gantry_position(
+        await hardware_api.gantry_position(
             Mount.LEFT, critical_point=CriticalPoint.MOUNT
         )
     ).then_return(Point(x=1, y=2, z=3))
 
     decoy.when(
-        ot3_hardware_api.get_instrument_max_height(
+        hardware_api.get_instrument_max_height(
             Mount.LEFT, critical_point=CriticalPoint.MOUNT
         )
     ).then_return(250)
 
-    decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
+    decoy.when(hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
     assert result == MoveToMaintenancePositionResult()
 
     decoy.verify(
-        await ot3_hardware_api.move_to(
+        await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=1, y=2, z=250),
             critical_point=CriticalPoint.MOUNT,
@@ -148,7 +146,7 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     )
 
     decoy.verify(
-        await ot3_hardware_api.move_to(
+        await hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=0, y=110, z=250),
             critical_point=CriticalPoint.MOUNT,
@@ -157,14 +155,14 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     )
 
     decoy.verify(
-        await ot3_hardware_api.move_axes(
+        await hardware_api.move_axes(
             position={Axis.Z_G: 400},
         ),
         times=0,
     )
 
     decoy.verify(
-        await ot3_hardware_api.disengage_axes(
+        await hardware_api.disengage_axes(
             [Axis.Z_G],
         ),
         times=0,

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pytest
-from typing import TYPE_CHECKING, Generator, cast
+from typing import Generator
 from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
@@ -26,6 +26,7 @@ from opentrons.hardware_control.ot3api import OT3API
 def _ot2_hardware_api(decoy: Decoy) -> API:
     return decoy.mock(cls=API)
 
+
 def _ot3_hardware_api(decoy: Decoy) -> OT3API:
     return decoy.mock(cls=OT3API)
 
@@ -34,8 +35,9 @@ def _ot3_hardware_api(decoy: Decoy) -> OT3API:
 def hardware_api(
     request: pytest.FixtureRequest, decoy: Decoy
 ) -> Generator[HardwareControlAPI, None, None]:
+    """Yield a OT2 Hardware Controller API or a OT3 Hardware Controller API."""
     machine = request.param  # type: ignore[attr-defined]
-   
+
     if request.node.get_closest_marker("ot2_only") and machine == "ot3":
         pytest.skip("test requests only ot-2")
     if request.node.get_closest_marker("ot3_only") and machine == "ot2":

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -22,16 +22,18 @@ from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.api import API
 
 
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
-
-
 def _ot2_hardware_api(decoy: Decoy) -> API:
     return decoy.mock(cls=API)
 
 
 def _ot3_hardware_api(decoy: Decoy) -> OT3API:
-    return decoy.mock(cls=OT3API)
+    try:
+        from opentrons.hardware_control.ot3api import OT3API
+
+        return decoy.mock(cls=OT3API)
+    except ImportError:
+        # TODO (tz, 9-23-22) Figure out a better way to use this fixture with OT-3 api only.
+        return None  # type: ignore[return-value]
 
 
 @pytest.fixture(params=["ot2", "ot3"])

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pytest
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator, cast
 from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
@@ -18,36 +18,33 @@ from opentrons.protocols.api_support.deck_type import (
 )
 from opentrons.protocol_engine.types import ModuleDefinition
 
-from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.api import API
-
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
+from opentrons.hardware_control.ot3api import OT3API
 
 
-@pytest.fixture
-def hardware_api(decoy: Decoy) -> HardwareControlAPI:
-    """Get a mocked out HardwareControlAPI of unspecified robot type."""
-    return decoy.mock(cls=OT2HardwareControlAPI)
-
-
-@pytest.fixture
-def ot2_hardware_api(decoy: Decoy) -> API:
-    """Get a mocked out OT-2 hardware API."""
+def _ot2_hardware_api(decoy: Decoy) -> API:
     return decoy.mock(cls=API)
 
+def _ot3_hardware_api(decoy: Decoy) -> OT3API:
+    return decoy.mock(cls=OT3API)
 
-@pytest.mark.ot3_only
-@pytest.fixture
-def ot3_hardware_api(decoy: Decoy) -> OT3API:
-    """Get a mocked out OT3API."""
-    try:
-        from opentrons.hardware_control.ot3api import OT3API
 
-        return decoy.mock(cls=OT3API)
-    except ImportError:
-        # TODO (tz, 9-23-22) Figure out a better way to use this fixture with OT-3 api only.
-        return None  # type: ignore[return-value]
+@pytest.fixture(params=["ot2", "ot3"])
+def hardware_api(
+    request: pytest.FixtureRequest, decoy: Decoy
+) -> Generator[HardwareControlAPI, None, None]:
+    machine = request.param  # type: ignore[attr-defined]
+   
+    if request.node.get_closest_marker("ot2_only") and machine == "ot3":
+        pytest.skip("test requests only ot-2")
+    if request.node.get_closest_marker("ot3_only") and machine == "ot2":
+        pytest.skip("test requests only ot-3")
+
+    if machine == "ot3":
+        yield _ot3_hardware_api(decoy)
+    else:
+        yield _ot2_hardware_api(decoy)
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pytest
-from typing import Generator
+from typing import Generator, TYPE_CHECKING
 from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
@@ -20,7 +20,10 @@ from opentrons.protocol_engine.types import ModuleDefinition
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.api import API
-from opentrons.hardware_control.ot3api import OT3API
+
+
+if TYPE_CHECKING:
+    from opentrons.hardware_control.ot3api import OT3API
 
 
 def _ot2_hardware_api(decoy: Decoy) -> API:

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -45,12 +45,6 @@ from opentrons_shared_data.errors.exceptions import EStopActivatedError, PythonE
 
 
 @pytest.fixture
-def hardware_api(decoy: Decoy) -> HardwareControlAPI:
-    """Get a mocked out StateStore."""
-    return decoy.mock(cls=OT2HardwareControlAPI)
-
-
-@pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mocked out StateStore."""
     return decoy.mock(cls=StateStore)

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -7,7 +7,7 @@ import pytest
 from decoy import Decoy, matchers
 from pydantic import BaseModel
 
-from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI
 
 from opentrons.protocol_engine import errors
 from opentrons.protocol_engine.errors.exceptions import (

--- a/api/tests/opentrons/protocol_engine/execution/test_door_watcher.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_door_watcher.py
@@ -7,7 +7,7 @@ import pytest
 from anyio import to_thread
 from decoy import Decoy, matchers
 
-from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import (
     DoorStateNotification,
     DoorState,
@@ -29,14 +29,6 @@ def state_store(decoy: Decoy) -> StateStore:
 
 
 @pytest.fixture
-def hardware_control_api(
-    decoy: Decoy,
-) -> HardwareControlAPI:
-    """Return a mock in the shape of a HardwareControlAPI."""
-    return decoy.mock(cls=OT2HardwareControlAPI)
-
-
-@pytest.fixture
 def action_dispatcher(decoy: Decoy) -> ActionDispatcher:
     """Return a mock in the shape of an ActionDispatcher."""
     return decoy.mock(cls=ActionDispatcher)
@@ -45,7 +37,7 @@ def action_dispatcher(decoy: Decoy) -> ActionDispatcher:
 @pytest.fixture
 async def subject(
     state_store: StateStore,
-    hardware_control_api: HardwareControlAPI,
+    hardware_api: HardwareControlAPI,
     action_dispatcher: ActionDispatcher,
 ) -> DoorWatcher:
     """Return a DoorWatcher with mocked dependencies.
@@ -54,7 +46,7 @@ async def subject(
     """
     return DoorWatcher(
         state_store=state_store,
-        hardware_api=hardware_control_api,
+        hardware_api=hardware_api,
         action_dispatcher=action_dispatcher,
     )
 
@@ -63,13 +55,13 @@ async def test_event_forwarding(
     decoy: Decoy,
     subject: DoorWatcher,
     state_store: StateStore,
-    hardware_control_api: HardwareControlAPI,
+    hardware_api: HardwareControlAPI,
     action_dispatcher: ActionDispatcher,
 ) -> None:
     """It should forward events that come from a different thread."""
     handler_captor = matchers.Captor()
     unsubscribe_callback = decoy.mock()
-    decoy.when(hardware_control_api.register_callback(handler_captor)).then_return(
+    decoy.when(hardware_api.register_callback(handler_captor)).then_return(
         unsubscribe_callback
     )
 
@@ -84,7 +76,7 @@ async def test_event_forwarding(
 
     await to_thread.run_sync(captured_handler, input_event)
     decoy.verify(
-        hardware_control_api.pause(PauseType.PAUSE),
+        hardware_api.pause(PauseType.PAUSE),
         action_dispatcher.dispatch(expected_action_to_forward),
         times=1,
     )
@@ -93,21 +85,21 @@ async def test_event_forwarding(
     input_event = DoorStateNotification(new_state=DoorState.CLOSED)
     await to_thread.run_sync(captured_handler, input_event)
     decoy.verify(
-        hardware_control_api.pause(PauseType.PAUSE),
+        hardware_api.pause(PauseType.PAUSE),
         times=0,
     )
 
 
 async def test_one_subscribe_one_unsubscribe(
     decoy: Decoy,
-    hardware_control_api: HardwareControlAPI,
+    hardware_api: HardwareControlAPI,
     subject: DoorWatcher,
 ) -> None:
     """Multiple start()s and stop()s should be collapsed."""
     unsubscribe = decoy.mock()
     wrong_unsubscribe = decoy.mock()
 
-    decoy.when(hardware_control_api.register_callback(matchers.Anything())).then_return(
+    decoy.when(hardware_api.register_callback(matchers.Anything())).then_return(
         unsubscribe, wrong_unsubscribe
     )
 

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -6,7 +6,7 @@ from decoy import Decoy
 from typing import TYPE_CHECKING
 
 from opentrons.types import Mount, MountType, Point
-from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import (
     CriticalPoint,
     Axis as HardwareAxis,
@@ -26,15 +26,6 @@ from opentrons.protocol_engine.execution.gantry_mover import (
     VIRTUAL_MAX_OT3_HEIGHT,
 )
 
-if TYPE_CHECKING:
-    from opentrons.hardware_control.ot3api import OT3API
-
-
-@pytest.fixture
-def mock_hardware_api(decoy: Decoy) -> HardwareAPI:
-    """Get a mock in the shape of a HardwareAPI."""
-    return decoy.mock(cls=HardwareAPI)
-
 
 @pytest.fixture
 def mock_state_view(decoy: Decoy) -> StateView:
@@ -44,12 +35,12 @@ def mock_state_view(decoy: Decoy) -> StateView:
 
 @pytest.fixture
 def hardware_subject(
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
 ) -> HardwareGantryMover:
     """Create a GantryMover with its dependencies mocked out."""
     return HardwareGantryMover(
-        hardware_api=mock_hardware_api,
+        hardware_api=hardware_api,
         state_view=mock_state_view,
     )
 
@@ -65,14 +56,14 @@ def virtual_subject(
 async def test_create_gantry_movement_handler(
     decoy: Decoy,
     mock_state_view: StateView,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """It should return virtual or real gantry movement handlers depending on config."""
     decoy.when(mock_state_view.config.use_virtual_pipettes).then_return(False)
     assert isinstance(
         create_gantry_mover(
             state_view=mock_state_view,
-            hardware_api=mock_hardware_api,
+            hardware_api=hardware_api,
         ),
         HardwareGantryMover,
     )
@@ -81,7 +72,7 @@ async def test_create_gantry_movement_handler(
     assert isinstance(
         create_gantry_mover(
             state_view=mock_state_view,
-            hardware_api=mock_hardware_api,
+            hardware_api=hardware_api,
         ),
         VirtualGantryMover,
     )
@@ -89,7 +80,7 @@ async def test_create_gantry_movement_handler(
 
 async def test_get_position(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
     hardware_subject: HardwareGantryMover,
 ) -> None:
@@ -108,7 +99,7 @@ async def test_get_position(
         )
     )
     decoy.when(
-        await mock_hardware_api.gantry_position(
+        await hardware_api.gantry_position(
             mount=Mount.RIGHT,
             critical_point=CriticalPoint.XY_CENTER,
             fail_on_not_homed=True,
@@ -124,7 +115,7 @@ async def test_get_position(
 
 async def test_get_position_raises(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
     hardware_subject: HardwareGantryMover,
 ) -> None:
@@ -138,7 +129,7 @@ async def test_get_position_raises(
         )
     )
     decoy.when(
-        await mock_hardware_api.gantry_position(
+        await hardware_api.gantry_position(
             mount=Mount.LEFT,
             critical_point=CriticalPoint.NOZZLE,
             fail_on_not_homed=False,
@@ -151,7 +142,7 @@ async def test_get_position_raises(
 
 def test_get_max_travel_z(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
     hardware_subject: HardwareGantryMover,
 ) -> None:
@@ -159,16 +150,16 @@ def test_get_max_travel_z(
     decoy.when(mock_state_view.pipettes.get_mount("pipette-id")).then_return(
         MountType.RIGHT
     )
-    decoy.when(
-        mock_hardware_api.get_instrument_max_height(mount=Mount.RIGHT)
-    ).then_return(42.1)
+    decoy.when(hardware_api.get_instrument_max_height(mount=Mount.RIGHT)).then_return(
+        42.1
+    )
 
     assert hardware_subject.get_max_travel_z("pipette-id") == 42.1
 
 
 async def test_move_to(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
     hardware_subject: HardwareGantryMover,
 ) -> None:
@@ -189,13 +180,13 @@ async def test_move_to(
     assert result == Point(4, 5, 6)
 
     decoy.verify(
-        await mock_hardware_api.move_to(
+        await hardware_api.move_to(
             mount=Mount.RIGHT,
             abs_position=Point(1, 2, 3),
             critical_point=CriticalPoint.TIP,
             speed=9001,
         ),
-        await mock_hardware_api.move_to(
+        await hardware_api.move_to(
             mount=Mount.RIGHT,
             abs_position=Point(4, 5, 6),
             critical_point=CriticalPoint.XY_CENTER,
@@ -206,7 +197,7 @@ async def test_move_to(
 
 async def test_move_relative(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
     hardware_subject: HardwareGantryMover,
 ) -> None:
@@ -218,7 +209,7 @@ async def test_move_relative(
         )
     )
     decoy.when(
-        await mock_hardware_api.gantry_position(
+        await hardware_api.gantry_position(
             mount=Mount.RIGHT,
             critical_point=CriticalPoint.XY_CENTER,
             fail_on_not_homed=True,
@@ -236,7 +227,7 @@ async def test_move_relative(
     # TODO(mc, 2022-05-13): the order of these calls is difficult to manage
     # and test for. Ideally, `hardware.move_rel` would return the resulting position
     decoy.verify(
-        await mock_hardware_api.move_rel(
+        await hardware_api.move_rel(
             mount=Mount.RIGHT,
             delta=Point(1, 2, 3),
             fail_on_not_homed=True,
@@ -248,7 +239,7 @@ async def test_move_relative(
 
 async def test_move_relative_must_home(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
     hardware_subject: HardwareGantryMover,
 ) -> None:
@@ -260,7 +251,7 @@ async def test_move_relative_must_home(
         )
     )
     decoy.when(
-        await mock_hardware_api.move_rel(
+        await hardware_api.move_rel(
             mount=Mount.LEFT,
             delta=Point(x=1, y=2, z=3),
             fail_on_not_homed=True,
@@ -278,7 +269,7 @@ async def test_move_relative_must_home(
 
 async def test_home(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     hardware_subject: HardwareGantryMover,
     mock_state_view: StateView,
 ) -> None:
@@ -295,7 +286,7 @@ async def test_home(
         ]
     )
     decoy.verify(
-        await mock_hardware_api.home(
+        await hardware_api.home(
             axes=[
                 HardwareAxis.X,
                 HardwareAxis.Y,
@@ -310,16 +301,16 @@ async def test_home(
     decoy.reset()
 
     await hardware_subject.home(axes=None)
-    decoy.verify(await mock_hardware_api.home(), times=1)
+    decoy.verify(await hardware_api.home(), times=1)
     decoy.reset()
 
     await hardware_subject.home(axes=[])
-    decoy.verify(await mock_hardware_api.home(axes=[]), times=1)
+    decoy.verify(await hardware_api.home(axes=[]), times=1)
 
 
 async def test_ot2_home_fails_with_ot3_axes(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     hardware_subject: HardwareGantryMover,
     mock_state_view: StateView,
 ) -> None:
@@ -339,13 +330,11 @@ async def test_ot2_home_fails_with_ot3_axes(
 @pytest.mark.ot3_only
 async def test_home_on_ot3(
     decoy: Decoy,
-    ot3_hardware_api: OT3API,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
 ) -> None:
     """Test homing all OT3 axes."""
-    subject = HardwareGantryMover(
-        state_view=mock_state_view, hardware_api=ot3_hardware_api
-    )
+    subject = HardwareGantryMover(state_view=mock_state_view, hardware_api=hardware_api)
     decoy.when(mock_state_view.config.robot_type).then_return("OT-3 Standard")
     await subject.home(
         axes=[
@@ -360,7 +349,7 @@ async def test_home_on_ot3(
         ]
     )
     decoy.verify(
-        await ot3_hardware_api.home(
+        await hardware_api.home(
             axes=[
                 HardwareAxis.X,
                 HardwareAxis.Y,
@@ -377,7 +366,7 @@ async def test_home_on_ot3(
 
 async def test_retract_axis(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     hardware_subject: HardwareGantryMover,
     mock_state_view: StateView,
 ) -> None:
@@ -385,14 +374,14 @@ async def test_retract_axis(
     decoy.when(mock_state_view.config.robot_type).then_return("OT-2 Standard")
     await hardware_subject.retract_axis(axis=MotorAxis.RIGHT_Z)
     decoy.verify(
-        await mock_hardware_api.retract_axis(axis=HardwareAxis.A),
+        await hardware_api.retract_axis(axis=HardwareAxis.A),
         times=1,
     )
 
 
 async def test_retract_axis_with_invalid_axis_for_ot2(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     hardware_subject: HardwareGantryMover,
     mock_state_view: StateView,
 ) -> None:
@@ -405,57 +394,55 @@ async def test_retract_axis_with_invalid_axis_for_ot2(
 @pytest.mark.ot3_only
 async def test_retract_axis_on_ot3(
     decoy: Decoy,
-    ot3_hardware_api: OT3API,
+    hardware_api: HardwareControlAPI,
     mock_state_view: StateView,
 ) -> None:
     """It should call OT3 hardware API's retract axis with specified axis."""
-    subject = HardwareGantryMover(
-        state_view=mock_state_view, hardware_api=ot3_hardware_api
-    )
+    subject = HardwareGantryMover(state_view=mock_state_view, hardware_api=hardware_api)
     decoy.when(mock_state_view.config.robot_type).then_return("OT-3 Standard")
     await subject.retract_axis(MotorAxis.EXTENSION_Z)
-    decoy.verify(await ot3_hardware_api.retract_axis(axis=HardwareAxis.Z_G), times=1)
+    decoy.verify(await hardware_api.retract_axis(axis=HardwareAxis.Z_G), times=1)
 
 
 # TODO(mc, 2022-12-01): this is overly complicated
 # https://opentrons.atlassian.net/browse/RET-1287
 async def test_home_z(
     decoy: Decoy,
-    mock_hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     hardware_subject: HardwareGantryMover,
 ) -> None:
     """It should home a single Z axis and plunger."""
     await hardware_subject.home(axes=[MotorAxis.LEFT_Z, MotorAxis.LEFT_PLUNGER])
     decoy.verify(
-        await mock_hardware_api.home_z(Mount.LEFT),
-        await mock_hardware_api.home_plunger(Mount.LEFT),
+        await hardware_api.home_z(Mount.LEFT),
+        await hardware_api.home_plunger(Mount.LEFT),
     )
     decoy.reset()
 
     await hardware_subject.home(axes=[MotorAxis.RIGHT_Z, MotorAxis.RIGHT_PLUNGER])
     decoy.verify(
-        await mock_hardware_api.home_z(Mount.RIGHT),
-        await mock_hardware_api.home_plunger(Mount.RIGHT),
+        await hardware_api.home_z(Mount.RIGHT),
+        await hardware_api.home_plunger(Mount.RIGHT),
     )
     decoy.reset()
 
     await hardware_subject.home(axes=[MotorAxis.LEFT_PLUNGER])
     decoy.verify(
-        await mock_hardware_api.home_plunger(Mount.LEFT),
+        await hardware_api.home_plunger(Mount.LEFT),
         times=1,
     )
     decoy.reset()
 
     await hardware_subject.home(axes=[MotorAxis.RIGHT_PLUNGER])
     decoy.verify(
-        await mock_hardware_api.home_plunger(Mount.RIGHT),
+        await hardware_api.home_plunger(Mount.RIGHT),
         times=1,
     )
     decoy.reset()
 
     await hardware_subject.home(axes=[MotorAxis.RIGHT_Z, MotorAxis.LEFT_PLUNGER])
     decoy.verify(
-        await mock_hardware_api.home([HardwareAxis.A, HardwareAxis.B]),
+        await hardware_api.home([HardwareAxis.A, HardwareAxis.B]),
         times=1,
     )
 

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 from decoy import Decoy
-from typing import TYPE_CHECKING
+from typing import Any
 
 from opentrons.types import Mount, MountType, Point
 from opentrons.hardware_control import HardwareControlAPI
@@ -330,7 +330,7 @@ async def test_ot2_home_fails_with_ot3_axes(
 @pytest.mark.ot3_only
 async def test_home_on_ot3(
     decoy: Decoy,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     mock_state_view: StateView,
 ) -> None:
     """Test homing all OT3 axes."""
@@ -394,7 +394,7 @@ async def test_retract_axis_with_invalid_axis_for_ot2(
 @pytest.mark.ot3_only
 async def test_retract_axis_on_ot3(
     decoy: Decoy,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     mock_state_view: StateView,
 ) -> None:
     """It should call OT3 hardware API's retract axis with specified axis."""

--- a/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 from decoy import Decoy
-from typing import TYPE_CHECKING
+from typing import Any
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import OT3Mount
@@ -197,7 +197,7 @@ async def test_hardware_stopping_sequence_no_pipette(
 async def test_hardware_stopping_sequence_with_gripper(
     decoy: Decoy,
     state_store: StateStore,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     movement: MovementHandler,
     mock_tip_handler: TipHandler,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
@@ -6,7 +6,7 @@ from typing import ContextManager, Any, NamedTuple
 from decoy import Decoy
 
 from opentrons.drivers.types import HeaterShakerLabwareLatchStatus
-from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules.heater_shaker import (
     HeaterShaker as HardwareHeaterShaker,
 )
@@ -36,12 +36,6 @@ from opentrons_shared_data.robot.dev_types import RobotType
 
 
 @pytest.fixture
-def hardware_api(decoy: Decoy) -> HardwareAPI:
-    """Get a mock in the shape of a HardwareAPI."""
-    return decoy.mock(cls=HardwareAPI)
-
-
-@pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mock in the shape of a StateStore."""
     return decoy.mock(cls=StateStore)
@@ -50,7 +44,7 @@ def state_store(decoy: Decoy) -> StateStore:
 @pytest.fixture
 def subject(
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
 ) -> HeaterShakerMovementFlagger:
     """Return a h/s movement flagger initialized with mocked-out dependencies."""
     return HeaterShakerMovementFlagger(
@@ -376,7 +370,7 @@ async def test_raises_depending_on_heater_shaker_latch_status(
     expected_raise_cm: ContextManager[Any],
     subject: HeaterShakerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """When on a H/S, it should raise if the latch isn't open."""
     decoy.when(
@@ -409,7 +403,7 @@ async def test_raises_depending_on_heater_shaker_latch_status(
 async def test_raises_if_hardware_module_has_gone_missing(
     subject: HeaterShakerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """It should raise if the hardware module can't be found by its serial no."""
@@ -461,7 +455,7 @@ async def test_passes_if_virtual_module_latch_open(
 async def test_passes_if_labware_on_non_heater_shaker_module(
     subject: HeaterShakerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """It shouldn't raise if the labware is on a module other than a Heater-Shaker."""
@@ -476,7 +470,7 @@ async def test_passes_if_labware_on_non_heater_shaker_module(
 async def test_passes_if_labware_not_on_any_module(
     subject: HeaterShakerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """It shouldn't raise if the labware isn't on a module."""

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import pytest
 from decoy import Decoy, matchers
-from typing import TYPE_CHECKING, Union, Optional
+from typing import Any, Union, Optional
 
 from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.hardware_control import HardwareControlAPI
@@ -93,7 +93,7 @@ def default_experimental_movement_data() -> LabwareMovementOffsetData:
 @pytest.mark.ot3_only
 @pytest.fixture
 def subject(
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     state_store: StateStore,
     equipment: EquipmentHandler,
     movement: MovementHandler,
@@ -146,7 +146,7 @@ async def test_move_labware_with_gripper(
     decoy: Decoy,
     state_store: StateStore,
     thermocycler_plate_lifter: ThermocyclerPlateLifter,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     subject: LabwareMovementHandler,
     from_location: Union[DeckSlotLocation, ModuleLocation, OnLabwareLocation],
     to_location: Union[DeckSlotLocation, ModuleLocation, OnLabwareLocation],
@@ -335,7 +335,7 @@ async def test_labware_movement_raises_on_ot2(
 async def test_labware_movement_skips_for_virtual_gripper(
     decoy: Decoy,
     state_store: StateStore,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     subject: LabwareMovementHandler,
 ) -> None:
     """It should neither raise error nor move gripper when using virtual gripper."""
@@ -360,7 +360,7 @@ async def test_labware_movement_skips_for_virtual_gripper(
 async def test_labware_movement_raises_without_gripper(
     decoy: Decoy,
     state_store: StateStore,
-    hardware_api: HardwareControlAPI,
+    hardware_api: Any,
     subject: LabwareMovementHandler,
 ) -> None:
     """It should raise an error when attempting a gripper movement without a gripper."""

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -4,8 +4,8 @@ from decoy import Decoy
 from typing import NamedTuple
 
 from opentrons.types import MountType, Point, DeckSlotName, Mount
-from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.motion_planning import Waypoint
 
 from opentrons.protocol_engine.types import (
@@ -35,12 +35,6 @@ from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
 
 @pytest.fixture
-def hardware_api(decoy: Decoy) -> HardwareAPI:
-    """Get a mock in the shape of a HardwareAPI."""
-    return decoy.mock(cls=HardwareAPI)
-
-
-@pytest.fixture
 def state_store(decoy: Decoy) -> StateStore:
     """Get a mock in the shape of a StateStore."""
     return decoy.mock(cls=StateStore)
@@ -67,7 +61,7 @@ def mock_gantry_mover(decoy: Decoy) -> GantryMover:
 @pytest.fixture
 def subject(
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     thermocycler_movement_flagger: ThermocyclerMovementFlagger,
     heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
     mock_gantry_mover: GantryMover,
@@ -424,7 +418,7 @@ async def test_move_relative(
     expected_delta: Point,
     distance: float,
 ) -> None:
-    """Test that move_relative triggers a relative move with the HardwareAPI."""
+    """Test that move_relative triggers a relative move with the HardwareControlAPI."""
     decoy.when(
         await mock_gantry_mover.move_relative(
             pipette_id="pipette-id",
@@ -531,7 +525,7 @@ async def test_retract_axis(
 async def test_check_valid_position(
     decoy: Decoy,
     subject: MovementHandler,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
 ) -> None:
     """It should check for an exception to determine if the position is ok."""
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/execution/test_rail_lights_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_rail_lights_handler.py
@@ -3,7 +3,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.protocol_engine.execution.rail_lights import RailLightsHandler
-from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI
 
 
 @pytest.fixture
@@ -18,7 +18,7 @@ def subject(
 async def test_set_rail_lights(
     decoy: Decoy,
     subject: RailLightsHandler,
-    hardware_api: OT2HardwareControlAPI,
+    hardware_api: HardwareControlAPI,
     binary: bool,
 ) -> None:
     """The hardware controller should be called."""

--- a/api/tests/opentrons/protocol_engine/execution/test_status_bar_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_status_bar_handler.py
@@ -3,7 +3,7 @@ import pytest
 from decoy import Decoy
 
 from opentrons.protocol_engine.execution.status_bar import StatusBarHandler
-from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import StatusBarState
 
 
@@ -19,7 +19,7 @@ def subject(
 async def test_set_status_bar(
     decoy: Decoy,
     subject: StatusBarHandler,
-    hardware_api: OT2HardwareControlAPI,
+    hardware_api: HardwareControlAPI,
     setting: StatusBarState,
 ) -> None:
     """The hardware controller should be called."""
@@ -44,7 +44,7 @@ async def test_set_status_bar(
 async def test_check_status_bar_should_not_be_changed(
     decoy: Decoy,
     subject: StatusBarHandler,
-    hardware_api: OT2HardwareControlAPI,
+    hardware_api: HardwareControlAPI,
     setting: StatusBarState,
     should_be_busy: bool,
 ) -> None:

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -21,19 +21,13 @@ from opentrons.protocol_engine.errors import (
     ThermocyclerNotOpenError,
     WrongModuleTypeError,
 )
-from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import Thermocycler as HardwareThermocycler
 from opentrons.drivers.types import ThermocyclerLidStatus
 
 from opentrons.protocol_engine.execution.thermocycler_movement_flagger import (
     ThermocyclerMovementFlagger,
 )
-
-
-@pytest.fixture
-def hardware_api(decoy: Decoy) -> HardwareAPI:
-    """Get a mock in the shape of a HardwareAPI."""
-    return decoy.mock(cls=HardwareAPI)
 
 
 @pytest.fixture
@@ -45,7 +39,7 @@ def state_store(decoy: Decoy) -> StateStore:
 @pytest.fixture
 def subject(
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
 ) -> ThermocyclerMovementFlagger:
     """Return a movement flagger initialized with mocked-out dependencies."""
     return ThermocyclerMovementFlagger(
@@ -116,7 +110,7 @@ async def test_raises_depending_on_thermocycler_hardware_lid_status(
     expected_raise_cm: ContextManager[Any],
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """When on a Thermocycler, it should raise if the lid isn't open."""
@@ -150,7 +144,7 @@ async def test_raises_depending_on_thermocycler_hardware_lid_status(
 async def test_raises_if_hardware_module_has_gone_missing(
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """It should raise if the hardware module can't be found by its serial no."""
@@ -202,7 +196,7 @@ async def test_passes_if_virtual_module_lid_open(
 async def test_passes_if_labware_on_non_thermocycler_module(
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """It shouldn't raise if the labware is on a module other than a Thermocycler."""
@@ -217,7 +211,7 @@ async def test_passes_if_labware_on_non_thermocycler_module(
 async def test_passes_if_labware_not_on_any_module(
     subject: ThermocyclerMovementFlagger,
     state_store: StateStore,
-    hardware_api: HardwareAPI,
+    hardware_api: HardwareControlAPI,
     decoy: Decoy,
 ) -> None:
     """It shouldn't raise if the labware isn't on a module."""


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
There are some tests in `api/tests/opentrons/protocol_engine` were using only the OT2 API when the same behavior should be observed for the OT3 as well. This PR updates the pytest fixture so it conditionally yield both OT3 and OT2 API. 

So I ended up having to use `Any` as the OT2 or OT3 API type for some tests because mypy didn't like the union type that is HardwareControlAPI. Is there a way to use the handy `@pytest.mark.ot3_only/ot2_only` marker to tell mypy to only check for the proper type so we can keep using the union type? 
