### PR TITLE
feat(app): add recalibrate button in ProtocolSetupInstruments

### DIFF
--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -14,7 +14,6 @@ import {
   JUSTIFY_FLEX_START,
 } from '@opentrons/components'
 import {
-  CompletedProtocolAnalysis,
   getGripperDisplayName,
   getPipetteNameSpecs,
   NINETY_SIX_CHANNEL,
@@ -47,7 +46,6 @@ export const MountItem = styled.div<{ isReady: boolean }>`
 `
 interface ProtocolInstrumentMountItemProps {
   mount: Mount | 'extension'
-  mostRecentAnalysis?: CompletedProtocolAnalysis | null
   attachedInstrument: InstrumentData | null
   speccedName: PipetteName | GripperModel
   instrumentsRefetch?: () => void
@@ -56,7 +54,7 @@ export function ProtocolInstrumentMountItem(
   props: ProtocolInstrumentMountItemProps
 ): JSX.Element {
   const { i18n, t } = useTranslation('protocol_setup')
-  const { mount, attachedInstrument, speccedName, mostRecentAnalysis } = props
+  const { mount, attachedInstrument, speccedName } = props
   const [
     showPipetteWizardFlow,
     setShowPipetteWizardFlow,
@@ -106,7 +104,7 @@ export function ProtocolInstrumentMountItem(
           gridGap={SPACING.spacing24}
         >
           <Flex
-            flex={isAttachedWithCal ? 1 : 2}
+            flex="2"
             flexDirection={DIRECTION_COLUMN}
             gridGap={SPACING.spacing4}
           >
@@ -157,6 +155,15 @@ export function ProtocolInstrumentMountItem(
               />
             </Flex>
           )}
+          {isAttachedWithCal && (
+            <Flex flex="1">
+              <SmallButton
+                onClick={handleCalibrate}
+                buttonText={i18n.format(t('recalibrate'), 'capitalize')}
+                buttonCategory="rounded"
+              />
+            </Flex>
+          )}
         </Flex>
       </MountItem>
       {showPipetteWizardFlow ? (
@@ -165,7 +172,6 @@ export function ProtocolInstrumentMountItem(
           closeFlow={() => setShowPipetteWizardFlow(false)}
           selectedPipette={selectedPipette}
           mount={mount as Mount}
-          pipetteInfo={mostRecentAnalysis?.pipettes}
           onComplete={props.instrumentsRefetch}
         />
       ) : null}

--- a/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
+++ b/app/src/organisms/InstrumentMountItem/__tests__/ProtocolInstrumentMountItem.test.tsx
@@ -139,7 +139,7 @@ describe('ProtocolInstrumentMountItem', () => {
     fireEvent.click(button)
     getByText('pipette wizard flow')
   })
-  it('renders the correct information when gripper needs to be atached', () => {
+  it('renders the correct information when gripper needs to be attached', () => {
     props = {
       ...props,
       mount: 'extension',
@@ -166,5 +166,20 @@ describe('ProtocolInstrumentMountItem', () => {
     const button = getByText('Calibrate')
     fireEvent.click(button)
     getByText('gripper wizard flow')
+  })
+  it('renders the correct information when an instrument is attached and calibrated', () => {
+    props = {
+      ...props,
+      mount: LEFT,
+      attachedInstrument: {
+        ...mockLeftPipetteData,
+      } as any,
+    }
+    const { getByText } = render(props)
+    getByText('Left Mount')
+    getByText('Calibrated')
+    const button = getByText('Recalibrate')
+    fireEvent.click(button)
+    getByText('pipette wizard flow')
   })
 })

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -85,7 +85,6 @@ export function ProtocolSetupInstruments({
             mount={loadedPipette.mount}
             speccedName={loadedPipette.pipetteName}
             attachedInstrument={attachedPipetteMatch}
-            mostRecentAnalysis={mostRecentAnalysis}
             instrumentsRefetch={refetch}
           />
         )


### PR DESCRIPTION
Closes RQA-1949

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds a recalibrate button for instruments within the ProtocolSetup > Instruments page. 

### Current Behavior
<img width="1176" alt="Screenshot 2023-12-05 at 8 50 46 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/0c1f386e-3ae6-48d9-ab5c-d1068cb332bf">

### New Behavior

<img width="600" alt="Screenshot 2023-11-29 at 9 56 24 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/8a4cfcec-72d3-49d0-8a42-e0af6704884d">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Navigate to ProtocolSetup for any protocol that has an instrument (already calibrated). The recalibrate button should now be visible, and it should properly launch the recalibration flows.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added new recalibrate button in ProtocolSetupInstruments.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
