### PR TITLE
style(app): reformat TC run profile command text on ODD

### DIFF
--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -742,7 +742,7 @@ describe('CommandText', () => {
     )[0]
     getByText('Setting Target Temperature of Heater-Shaker to 20°C')
   })
-  it('renders correct text for thermocycler/runProfile', () => {
+  it('renders correct text for thermocycler/runProfile on Desktop', () => {
     const mockProfileSteps = [
       { holdSeconds: 10, celsius: 20 },
       { holdSeconds: 30, celsius: 40 },
@@ -772,6 +772,40 @@ describe('CommandText', () => {
     )
     getByText('temperature: 20°C, seconds: 10')
     getByText('temperature: 40°C, seconds: 30')
+  })
+  it('renders correct text for thermocycler/runProfile on ODD', () => {
+    const mockProfileSteps = [
+      { holdSeconds: 10, celsius: 20 },
+      { holdSeconds: 30, celsius: 40 },
+    ]
+    const { getByText, queryByText } = renderWithProviders(
+      <CommandText
+        command={{
+          commandType: 'thermocycler/runProfile',
+          params: { profile: mockProfileSteps, moduleId: 'abc123' },
+          id: 'def456',
+          result: {},
+          status: 'queued',
+          error: null,
+          createdAt: 'fake_timestamp',
+          startedAt: null,
+          completedAt: null,
+        }}
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={FLEX_ROBOT_TYPE}
+        isOnDevice={true}
+      />,
+      {
+        i18nInstance: i18n,
+      }
+    )[0]
+    getByText(
+      'Thermocycler starting 2 repetitions of cycle composed of the following steps:'
+    )
+    getByText('temperature: 20°C, seconds: 10')
+    expect(
+      queryByText('temperature: 40°C, seconds: 30')
+    ).not.toBeInTheDocument()
   })
   it('renders correct text for heaterShaker/setAndWaitForShakeSpeed', () => {
     const { getByText } = renderWithProviders(

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { Flex, DIRECTION_COLUMN, SPACING } from '@opentrons/components'
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  SPACING,
+  ALIGN_CENTER,
+} from '@opentrons/components'
 import { getPipetteNameSpecs, RunTimeCommand } from '@opentrons/shared-data'
 import {
   getAddressableAreaDisplayName,
@@ -48,9 +53,16 @@ interface Props extends StyleProps {
   command: RunTimeCommand
   robotSideAnalysis: CompletedProtocolAnalysis
   robotType: RobotType
+  isOnDevice?: boolean
 }
 export function CommandText(props: Props): JSX.Element | null {
-  const { command, robotSideAnalysis, robotType, ...styleProps } = props
+  const {
+    command,
+    robotSideAnalysis,
+    robotType,
+    isOnDevice = false,
+    ...styleProps
+  } = props
   const { t } = useTranslation('protocol_command_text')
 
   switch (command.commandType) {
@@ -96,10 +108,17 @@ export function CommandText(props: Props): JSX.Element | null {
       const { profile } = command.params
       const steps = profile.map(
         ({ holdSeconds, celsius }: { holdSeconds: number; celsius: number }) =>
-          t('tc_run_profile_steps', { celsius: celsius, seconds: holdSeconds })
+          t('tc_run_profile_steps', {
+            celsius: celsius,
+            seconds: holdSeconds,
+          }).trim()
       )
       return (
-        <Flex flexDirection={DIRECTION_COLUMN} {...styleProps}>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          {...styleProps}
+          alignItems={isOnDevice ? ALIGN_CENTER : undefined}
+        >
           <StyledText as="p" marginBottom={SPACING.spacing4} {...styleProps}>
             {t('tc_starting_profile', {
               repetitions: Object.keys(steps).length,
@@ -107,9 +126,13 @@ export function CommandText(props: Props): JSX.Element | null {
           </StyledText>
           <StyledText as="p" marginLeft={SPACING.spacing16}>
             <ul>
-              {steps.map((step: string, index: number) => (
-                <li key={index}> {step}</li>
-              ))}
+              {isOnDevice ? (
+                <li>{steps[0]}</li>
+              ) : (
+                steps.map((step: string, index: number) => (
+                  <li key={index}> {step}</li>
+                ))
+              )}
             </ul>
           </StyledText>
         </Flex>

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -235,6 +235,7 @@ export function CurrentRunningProtocolCommand({
             command={currentCommand}
             robotSideAnalysis={robotSideAnalysis}
             robotType={robotType}
+            isOnDevice={true}
           />
         ) : null}
       </Flex>

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
@@ -241,6 +241,7 @@ export function RunningProtocolCommandList({
                       robotSideAnalysis={robotSideAnalysis}
                       robotType={robotType}
                       css={COMMAND_ROW_STYLE}
+                      isOnDevice={true}
                     />
                   </Flex>
                 </Flex>


### PR DESCRIPTION
Closes RQA-1937

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR special cases the ODD TC runProfile command text to match designs. We introduce isOnDevice as a prop passed to CommandText, which doesn't feel great, but this feels like the best way to handle it. 

### Current

![Protocol running step copy not truncating and indentation bug](https://github.com/Opentrons/opentrons/assets/64858653/02f76696-542d-46f6-a986-a92cca3cfc1d)

### Restyled

<img width="778" alt="Screenshot 2023-12-05 at 10 45 11 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/e57144d5-8025-47e2-b814-dd45dab87817">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run any protocol that has a TC run profile (here's one: [tc_temp_cycle_test.py.zip](https://github.com/Opentrons/opentrons/files/13562598/tc_temp_cycle_test.py.zip) )
- Confirm ODD matches designs (and nothing on the desktop version of runProfile has changed). 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Truncated ODD thermocycler run profile display text.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
