### PR TITLE
feat(api): add get tip presence command in protocol engine

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1995,25 +1995,27 @@ class OT3API(
 
     async def get_tip_presence_status(
         self,
-        mount: OT3Mount,
+        mount: Union[top_types.Mount, OT3Mount],
     ) -> TipStateType:
         """
         Check tip presence status. If a high throughput pipette is present,
         move the tip motors down before checking the sensor status.
         """
+        real_mount = OT3Mount.from_mount(mount)
         async with contextlib.AsyncExitStack() as stack:
             if (
-                mount == OT3Mount.LEFT
+                real_mount == OT3Mount.LEFT
                 and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
             ):
                 await stack.enter_async_context(self._high_throughput_check_tip())
-            result = await self._backend.get_tip_status(mount)
+            result = await self._backend.get_tip_status(real_mount)
         return result
 
     async def verify_tip_presence(
-        self, mount: OT3Mount, expected: TipStateType
+        self, mount: Union[top_types.Mount, OT3Mount], expected: TipStateType
     ) -> None:
-        status = await self.get_tip_presence_status(mount)
+        real_mount = OT3Mount.from_mount(mount)
+        status = await self.get_tip_presence_status(real_mount)
         if status != expected:
             raise FailedTipStateCheck(expected, status.value)
 

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -290,6 +290,22 @@ from .configure_nozzle_layout import (
     ConfigureNozzleLayoutCommandType,
 )
 
+from .get_tip_presence import (
+    GetTipPresence,
+    GetTipPresenceCreate,
+    GetTipPresenceParams,
+    GetTipPresenceResult,
+    GetTipPresenceCommandType,
+)
+
+from .verify_tip_presence import (
+    VerifyTipPresence,
+    VerifyTipPresenceCreate,
+    VerifyTipPresenceParams,
+    VerifyTipPresenceResult,
+    VerifyTipPresenceCommandType,
+)
+
 __all__ = [
     # command type unions
     "Command",
@@ -505,4 +521,16 @@ __all__ = [
     "ConfigureNozzleLayoutParams",
     "ConfigureNozzleLayoutResult",
     "ConfigureNozzleLayoutCommandType",
+    # get pipette tip presence bundle
+    "GetTipPresence",
+    "GetTipPresenceCreate",
+    "GetTipPresenceParams",
+    "GetTipPresenceResult",
+    "GetTipPresenceCommandType",
+    # verify pipette tip presence bundle
+    "VerifyTipPresence",
+    "VerifyTipPresenceCreate",
+    "VerifyTipPresenceParams",
+    "VerifyTipPresenceResult",
+    "VerifyTipPresenceCommandType",
 ]

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -260,6 +260,22 @@ from .configure_nozzle_layout import (
     ConfigureNozzleLayoutPrivateResult,
 )
 
+from .verify_tip_presence import (
+    VerifyTipPresence,
+    VerifyTipPresenceCreate,
+    VerifyTipPresenceParams,
+    VerifyTipPresenceResult,
+    VerifyTipPresenceCommandType,
+)
+
+from .get_tip_presence import (
+    GetTipPresence,
+    GetTipPresenceCreate,
+    GetTipPresenceParams,
+    GetTipPresenceResult,
+    GetTipPresenceCommandType,
+)
+
 Command = Union[
     Aspirate,
     AspirateInPlace,
@@ -292,6 +308,8 @@ Command = Union[
     SetRailLights,
     TouchTip,
     SetStatusBar,
+    VerifyTipPresence,
+    GetTipPresence,
     heater_shaker.WaitForTemperature,
     heater_shaker.SetTargetTemperature,
     heater_shaker.DeactivateHeater,
@@ -351,6 +369,8 @@ CommandParams = Union[
     SetRailLightsParams,
     TouchTipParams,
     SetStatusBarParams,
+    VerifyTipPresenceParams,
+    GetTipPresenceParams,
     heater_shaker.WaitForTemperatureParams,
     heater_shaker.SetTargetTemperatureParams,
     heater_shaker.DeactivateHeaterParams,
@@ -411,6 +431,8 @@ CommandType = Union[
     SetRailLightsCommandType,
     TouchTipCommandType,
     SetStatusBarCommandType,
+    VerifyTipPresenceCommandType,
+    GetTipPresenceCommandType,
     heater_shaker.WaitForTemperatureCommandType,
     heater_shaker.SetTargetTemperatureCommandType,
     heater_shaker.DeactivateHeaterCommandType,
@@ -470,6 +492,8 @@ CommandCreate = Union[
     SetRailLightsCreate,
     TouchTipCreate,
     SetStatusBarCreate,
+    VerifyTipPresenceCreate,
+    GetTipPresenceCreate,
     heater_shaker.WaitForTemperatureCreate,
     heater_shaker.SetTargetTemperatureCreate,
     heater_shaker.DeactivateHeaterCreate,
@@ -529,6 +553,8 @@ CommandResult = Union[
     SetRailLightsResult,
     TouchTipResult,
     SetStatusBarResult,
+    VerifyTipPresenceResult,
+    GetTipPresenceResult,
     heater_shaker.WaitForTemperatureResult,
     heater_shaker.SetTargetTemperatureResult,
     heater_shaker.DeactivateHeaterResult,

--- a/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
@@ -1,0 +1,80 @@
+"""Get tip presence command request, result and implementation models."""
+from __future__ import annotations
+
+from pydantic import Field, BaseModel
+from typing import TYPE_CHECKING, Optional, Type
+from typing_extensions import Literal
+
+from .pipetting_common import PipetteIdMixin
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+from ..types import TipPresenceStatus
+
+if TYPE_CHECKING:
+    from ..execution import TipHandler
+
+
+GetTipPresenceCommandType = Literal["getTipPresence"]
+
+
+class GetTipPresenceParams(PipetteIdMixin):
+    """Payload required for a GetTipPresence command."""
+
+    pass
+
+
+class GetTipPresenceResult(BaseModel):
+    """Result data from the execution of a GetTipPresence command."""
+
+    status: TipPresenceStatus = Field(
+        ...,
+        description=(
+            "Whether or not a tip is attached on the pipette. This only works on"
+            " on FLEX because OT-2 pipettes do not possess tip presence sensors,"
+            " hence, will always return TipPresenceStatus.UNKNOWN."
+        ),
+    )
+
+
+class GetTipPresenceImplementation(
+    AbstractCommandImpl[GetTipPresenceParams, GetTipPresenceResult]
+):
+    """GetTipPresence command implementation."""
+
+    def __init__(
+        self,
+        tip_handler: TipHandler,
+        **kwargs: object,
+    ) -> None:
+        self._tip_handler = tip_handler
+
+    async def execute(self, params: GetTipPresenceParams) -> GetTipPresenceResult:
+        """Verify if tip presence is as expected for the requested pipette."""
+        pipette_id = params.pipetteId
+
+        result = await self._tip_handler.get_tip_presence(
+            pipette_id=pipette_id,
+        )
+
+        return GetTipPresenceResult(status=result)
+
+
+class GetTipPresence(BaseCommand[GetTipPresenceParams, GetTipPresenceResult]):
+    """GetTipPresence command model."""
+
+    commandType: GetTipPresenceCommandType = "getTipPresence"
+    params: GetTipPresenceParams
+    result: Optional[GetTipPresenceResult]
+
+    _ImplementationCls: Type[
+        GetTipPresenceImplementation
+    ] = GetTipPresenceImplementation
+
+
+class GetTipPresenceCreate(BaseCommandCreate[GetTipPresenceParams]):
+    """GetTipPresence command creation request model."""
+
+    commandType: GetTipPresenceCommandType = "getTipPresence"
+    params: GetTipPresenceParams
+
+    _CommandCls: Type[GetTipPresence] = GetTipPresence

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -1,0 +1,77 @@
+"""Verify tip presence command request, result and implementation models."""
+from __future__ import annotations
+
+from pydantic import Field, BaseModel
+from typing import TYPE_CHECKING, Optional, Type
+from typing_extensions import Literal
+
+from .pipetting_common import PipetteIdMixin
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+
+from ..types import TipPresenceStatus
+
+if TYPE_CHECKING:
+    from ..execution import TipHandler
+
+
+VerifyTipPresenceCommandType = Literal["verifyTipPresence"]
+
+
+class VerifyTipPresenceParams(PipetteIdMixin):
+    """Payload required for a VerifyTipPresence command."""
+
+    expectedState: TipPresenceStatus = Field(
+        ..., description="The expected tip presence status on the pipette."
+    )
+
+
+class VerifyTipPresenceResult(BaseModel):
+    """Result data from the execution of a VerifyTipPresence command."""
+
+    pass
+
+
+class VerifyTipPresenceImplementation(
+    AbstractCommandImpl[VerifyTipPresenceParams, VerifyTipPresenceResult]
+):
+    """VerifyTipPresence command implementation."""
+
+    def __init__(
+        self,
+        tip_handler: TipHandler,
+        **kwargs: object,
+    ) -> None:
+        self._tip_handler = tip_handler
+
+    async def execute(self, params: VerifyTipPresenceParams) -> VerifyTipPresenceResult:
+        """Verify if tip presence is as expected for the requested pipette."""
+        pipette_id = params.pipetteId
+        expected_state = params.expectedState
+
+        await self._tip_handler.verify_tip_presence(
+            pipette_id=pipette_id,
+            expected=expected_state,
+        )
+
+        return VerifyTipPresenceResult()
+
+
+class VerifyTipPresence(BaseCommand[VerifyTipPresenceParams, VerifyTipPresenceResult]):
+    """VerifyTipPresence command model."""
+
+    commandType: VerifyTipPresenceCommandType = "verifyTipPresence"
+    params: VerifyTipPresenceParams
+    result: Optional[VerifyTipPresenceResult]
+
+    _ImplementationCls: Type[
+        VerifyTipPresenceImplementation
+    ] = VerifyTipPresenceImplementation
+
+
+class VerifyTipPresenceCreate(BaseCommandCreate[VerifyTipPresenceParams]):
+    """VerifyTipPresence command creation request model."""
+
+    commandType: VerifyTipPresenceCommandType = "verifyTipPresence"
+    params: VerifyTipPresenceParams
+
+    _CommandCls: Type[VerifyTipPresence] = VerifyTipPresence

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -8,9 +8,10 @@ from opentrons_shared_data.errors.exceptions import (
     CommandParameterLimitViolated,
 )
 
-from ..resources import LabwareDataProvider
+from ..resources import LabwareDataProvider, ensure_ot3_hardware
 from ..state import StateView
-from ..types import TipGeometry
+from ..types import TipGeometry, TipPresenceStatus
+from ..errors import HardwareNotSupportedError
 
 
 PRIMARY_NOZZLE_TO_ENDING_NOZZLE_MAP = {
@@ -61,6 +62,14 @@ class TipHandler(TypingProtocol):
 
     async def add_tip(self, pipette_id: str, tip: TipGeometry) -> None:
         """Tell the Hardware API that a tip is attached."""
+
+    async def get_tip_presence(self, pipette_id: str) -> TipPresenceStatus:
+        """Get tip presence status on the pipette."""
+
+    async def verify_tip_presence(
+        self, pipette_id: str, expected: TipPresenceStatus
+    ) -> None:
+        """Verify the expected tip presence status."""
 
 
 async def _available_for_nozzle_layout(
@@ -159,6 +168,7 @@ class HardwareTipHandler(TipHandler):
             presses=None,
             increment=None,
         )
+        await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
 
         self._hardware_api.set_current_tiprack_diameter(
             mount=hw_mount,
@@ -188,6 +198,7 @@ class HardwareTipHandler(TipHandler):
             kwargs = {}
 
         await self._hardware_api.drop_tip(mount=hw_mount, **kwargs)
+        await self.verify_tip_presence(pipette_id, TipPresenceStatus.ABSENT)
 
     async def add_tip(self, pipette_id: str, tip: TipGeometry) -> None:
         """Tell the Hardware API that a tip is attached."""
@@ -204,6 +215,31 @@ class HardwareTipHandler(TipHandler):
             mount=hw_mount,
             tip_volume=tip.volume,
         )
+
+    async def get_tip_presence(self, pipette_id: str) -> TipPresenceStatus:
+        """Get the tip presence status of the pipette."""
+        try:
+            ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
+
+            hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()
+
+            status = await ot3api.get_tip_presence_status(hw_mount)
+            return TipPresenceStatus.from_hw_state(status)
+        except HardwareNotSupportedError:
+            # Tip presence sensing is not supported on the OT2
+            return TipPresenceStatus.UNKNOWN
+
+    async def verify_tip_presence(
+        self, pipette_id: str, expected: TipPresenceStatus
+    ) -> None:
+        """Verify the expecterd tip presence status of the pipette."""
+        try:
+            ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
+            hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()
+            await ot3api.verify_tip_presence(hw_mount, expected.to_hw_state())
+        except HardwareNotSupportedError:
+            # Tip presence sensing is not supported on the OT2
+            pass
 
 
 class VirtualTipHandler(TipHandler):
@@ -273,6 +309,14 @@ class VirtualTipHandler(TipHandler):
         This should not be called when using virtual pipettes.
         """
         assert False, "TipHandler.add_tip should not be used with virtual pipettes"
+
+    async def verify_tip_presence(
+        self, pipette_id: str, expected: TipPresenceStatus
+    ) -> None:
+        """Verify tip presence.
+
+        This should not be called when using virtual pipettes.
+        """
 
 
 def create_tip_handler(

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -10,6 +10,7 @@ from typing_extensions import Literal, TypeGuard
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName, Point
+from opentrons.hardware_control.types import TipStateType as HwTipStateType
 from opentrons.hardware_control.modules import (
     ModuleType as ModuleType,
 )
@@ -799,3 +800,27 @@ NozzleLayoutConfigurationType = Union[
 
 # TODO make the below some sort of better type
 DeckConfigurationType = List[Tuple[str, str]]  # cutout_id, cutout_fixture_id
+
+
+class TipPresenceStatus(str, Enum):
+    """Tip presence status reported by a pipette."""
+
+    PRESENT = "present"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+    def to_hw_state(self) -> HwTipStateType:
+        """Convert to hardware tip state."""
+        assert self != TipPresenceStatus.UNKNOWN
+        return {
+            TipPresenceStatus.PRESENT: HwTipStateType.PRESENT,
+            TipPresenceStatus.ABSENT: HwTipStateType.ABSENT,
+        }[self]
+
+    @classmethod
+    def from_hw_state(cls, state: HwTipStateType) -> "TipPresenceStatus":
+        """Convert from hardware tip state."""
+        return {
+            HwTipStateType.PRESENT: TipPresenceStatus.PRESENT,
+            HwTipStateType.ABSENT: TipPresenceStatus.ABSENT,
+        }[state]

--- a/api/tests/opentrons/protocol_engine/commands/test_get_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_get_tip_presence.py
@@ -1,0 +1,42 @@
+"""Test get tip presence commands."""
+from decoy import Decoy
+import pytest
+
+from opentrons.protocol_engine.execution import TipHandler
+from opentrons.protocol_engine.types import TipPresenceStatus
+
+from opentrons.protocol_engine.commands.get_tip_presence import (
+    GetTipPresenceParams,
+    GetTipPresenceResult,
+    GetTipPresenceImplementation,
+)
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        TipPresenceStatus.PRESENT,
+        TipPresenceStatus.ABSENT,
+        TipPresenceStatus.UNKNOWN,
+    ],
+)
+async def test_get_tip_presence_implementation(
+    decoy: Decoy,
+    tip_handler: TipHandler,
+    status: TipPresenceStatus,
+) -> None:
+    """A GetTipPresence command should have an execution implementation."""
+    subject = GetTipPresenceImplementation(tip_handler=tip_handler)
+    data = GetTipPresenceParams(
+        pipetteId="pipette-id",
+    )
+
+    decoy.when(
+        await tip_handler.get_tip_presence(
+            pipette_id="pipette-id",
+        )
+    ).then_return(status)
+
+    result = await subject.execute(data)
+
+    assert result == GetTipPresenceResult(status=status)

--- a/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
@@ -1,0 +1,34 @@
+"""Test verify tip presence commands."""
+from decoy import Decoy
+
+from opentrons.protocol_engine.execution import TipHandler
+from opentrons.protocol_engine.types import TipPresenceStatus
+
+from opentrons.protocol_engine.commands.verify_tip_presence import (
+    VerifyTipPresenceParams,
+    VerifyTipPresenceResult,
+    VerifyTipPresenceImplementation,
+)
+
+
+async def test_verify_tip_presence_implementation(
+    decoy: Decoy,
+    tip_handler: TipHandler,
+) -> None:
+    """A VerifyTipPresence command should have an execution implementation."""
+    subject = VerifyTipPresenceImplementation(tip_handler=tip_handler)
+    data = VerifyTipPresenceParams(
+        pipetteId="pipette-id",
+        expectedState=TipPresenceStatus.PRESENT,
+    )
+
+    decoy.when(
+        await tip_handler.verify_tip_presence(
+            pipette_id="pipette-id",
+            expected=TipPresenceStatus.PRESENT,
+        )
+    ).then_return(None)
+
+    result = await subject.execute(data)
+
+    assert isinstance(result, VerifyTipPresenceResult)

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -96,6 +96,12 @@
       "$ref": "#/definitions/SetStatusBarCreate"
     },
     {
+      "$ref": "#/definitions/VerifyTipPresenceCreate"
+    },
+    {
+      "$ref": "#/definitions/GetTipPresenceCreate"
+    },
+    {
       "$ref": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate"
     },
     {
@@ -2383,6 +2389,106 @@
         },
         "params": {
           "$ref": "#/definitions/SetStatusBarParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "TipPresenceStatus": {
+      "title": "TipPresenceStatus",
+      "description": "Tip presence status reported by a pipette.",
+      "enum": ["present", "absent", "unknown"],
+      "type": "string"
+    },
+    "VerifyTipPresenceParams": {
+      "title": "VerifyTipPresenceParams",
+      "description": "Payload required for a VerifyTipPresence command.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "expectedState": {
+          "description": "The expected tip presence status on the pipette.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TipPresenceStatus"
+            }
+          ]
+        }
+      },
+      "required": ["pipetteId", "expectedState"]
+    },
+    "VerifyTipPresenceCreate": {
+      "title": "VerifyTipPresenceCreate",
+      "description": "VerifyTipPresence command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "verifyTipPresence",
+          "enum": ["verifyTipPresence"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/VerifyTipPresenceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "GetTipPresenceParams": {
+      "title": "GetTipPresenceParams",
+      "description": "Payload required for a GetTipPresence command.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": ["pipetteId"]
+    },
+    "GetTipPresenceCreate": {
+      "title": "GetTipPresenceCreate",
+      "description": "GetTipPresence command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "getTipPresence",
+          "enum": ["getTipPresence"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/GetTipPresenceParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -13,6 +13,7 @@ export type PipettingRunTimeCommand =
   | PickUpTipRunTimeCommand
   | PrepareToAspirateRunTimeCommand
   | TouchTipRunTimeCommand
+  | GetTipPresenceRunTimeCommand
 
 export type PipettingCreateCommand =
   | AspirateCreateCommand
@@ -27,6 +28,7 @@ export type PipettingCreateCommand =
   | PickUpTipCreateCommand
   | PrepareToAspirateCreateCommand
   | TouchTipCreateCommand
+  | GetTipPresenceCreateCommand
 
 export interface ConfigureForVolumeCreateCommand
   extends CommonCommandCreateInfo {
@@ -152,6 +154,17 @@ export interface PrepareToAspirateRunTimeCommand
   result?: any
 }
 
+export interface GetTipPresenceCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'getTipPresence'
+  params: PipetteIdentityParams
+}
+
+export interface GetTipPresenceRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    GetTipPresenceCreateCommand {
+  result?: TipPresenceResult
+}
+
 export type AspDispAirgapParams = FlowRateParams &
   PipetteAccessParams &
   VolumeParams &
@@ -225,4 +238,9 @@ interface WellLocationParam {
 
 interface BasicLiquidHandlingResult {
   volume: number // Amount of liquid in uL handled in the operation
+}
+
+interface TipPresenceResult {
+  // ot2 should alwasy return unknown
+  status?: 'present' | 'absent' | 'unknown'
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds the `get_tip_presence` command in protocol engine so we can actually get the realtime tip presence response from the pipette, instead of having to rely on the instrument endpoint which only returns the cached tip detected value.
Closes RQA-1992