### PR TITLE
chore: release notes for 7.1.0

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -19,7 +19,11 @@ Welcome to the v7.1.0 release of the Opentrons robot software! This release incl
 ### Improved Features
 
 - Improves aspirate, dispense, and mix behavior with volumes set to zero.
-- `opentrons_simulate` now works with all API versions.
+- The `opentrons_simulate` command-line tool now works with all Python API versions.
+
+### Known Issues
+
+JSON protocols created or modified with Protocol Designer v6.0.0 or higher can't be simulated with `opentrons_simulate`.
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -5,13 +5,31 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 [opentrons issue tracker]: https://github.com/Opentrons/opentrons/issues?q=is%3Aopen+is%3Aissue+label%3Abug
 
 
+## Opentrons Robot Software Changes in 7.1.0
+
+Welcome to the v7.1.0 release of the Opentrons robot software! This release includes support for deck configuration on Opentrons Flex, partial tip pickup with the Flex 96-Channel Pipette, and other improvements.
+
+### New Features
+
+- Pick up either a column of 8 tips or all 96 tips with the Flex 96-Channel Pipette.
+- Specify the deck configuration of Flex, including the movable trash bin, waste chute, and staging area slots.
+- Use the Flex Gripper to drop labware into the waste chute, or use Flex pipettes to dispense liquid or drop tips into the waste chute.
+- Manually prepare a pipette for aspiration, when required for your application.
+
+### Improved Features
+
+- Improves aspirate, dispense, and mix behavior with volumes set to zero.
+- `opentrons_simulate` now works with all API versions.
+
+---
+
 ## Opentrons Robot Software Changes in 7.0.2
 
-The 7.0.2 hotfix release does not contain any changes to the robot software
+The 7.0.2 hotfix release does not contain any changes to the robot software.
 
 ### Known Issues
 
-JSON protocols created or modified with Protocol Designer v6.0.0 or higher can't be simulated with the `opentrons_simulate` command-line tool
+JSON protocols created or modified with Protocol Designer v6.0.0 or higher can't be simulated with the `opentrons_simulate` command-line tool.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,23 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons App Changes in 7.1.0
+
+Welcome to the v7.1.0 release of the Opentrons App! This release includes new deck and pipette functionality for Opentrons Flex, a new workflow for dropping tips after a protocol is canceled, and other improvements.
+
+### New features
+
+- Specify the deck configuration of Flex, including the movable trash bin, waste chute, and staging area slots.
+- Resolve conflicts between the hardware a protocol requires and the current deck configuration as part of run setup.
+- Run protocols that use the Flex 96-Channel Pipette, including partial tip pickup.
+- Choose where to dispense liquid and drop tips held by a pipette when a protocol is canceled.
+
+### Bug Fixes
+
+- Labware Position Check no longer tries to check the same labware in the same position twice, which was leading to errors.
+
+---
+
 ## Opentrons App Changes in 7.0.2
 
 Welcome to the v7.0.2 release of the Opentrons App!


### PR DESCRIPTION

# Overview

Adds release notes for 7.1.0.

# Test Plan

- Check the markdown preview on GitHub.
- Post-merge, check how these appear in the app and robot update flows.

# Changelog

- Updates to the usual two `release-notes.md` files.
- Added some trailing periods in 7.0.2 notes. 🧐 

# Review requests

Any features that I missed or miscategorized (app vs. API)?

# Risk assessment

Low. No code, but high-visibility text once we reach stable.