### PR TITLE
fix(app): Improve ODD "run again" behavior

### DIFF
--- a/app/src/pages/OnDeviceDisplay/RunSummary.tsx
+++ b/app/src/pages/OnDeviceDisplay/RunSummary.tsx
@@ -64,7 +64,6 @@ import { handleTipsAttachedModal } from '../../organisms/DropTipWizard/TipsAttac
 import { getPipettesWithTipAttached } from '../../organisms/DropTipWizard/getPipettesWithTipAttached'
 import { getPipetteModelSpecs, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
-import type { Run } from '@opentrons/api-client'
 import type { OnDeviceRouteParams } from '../../App/types'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
@@ -106,9 +105,7 @@ export function RunSummary(): JSX.Element {
     runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED
   )
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
-  const onResetSuccess = (_createRunResponse: Run): void =>
-    history.push(`/runs/${runId}/setup`)
-  const { reset } = useRunControls(runId, onResetSuccess)
+  const { reset } = useRunControls(runId)
   const trackEvent = useTrackEvent()
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
   const localRobot = useSelector(getLocalRobot)

--- a/app/src/pages/OnDeviceDisplay/RunSummary.tsx
+++ b/app/src/pages/OnDeviceDisplay/RunSummary.tsx
@@ -120,6 +120,9 @@ export function RunSummary(): JSX.Element {
   const [pipettesWithTip, setPipettesWithTip] = React.useState<
     PipettesWithTip[]
   >([])
+  const [showRunAgainSpinner, setShowRunAgainSpinner] = React.useState<boolean>(
+    false
+  )
 
   let headerText = t('run_complete_splash')
   if (runStatus === RUN_STATUS_FAILED) {
@@ -153,6 +156,7 @@ export function RunSummary(): JSX.Element {
         setPipettesWithTip
       ).catch(e => console.log(`Error launching Tip Attachment Modal: ${e}`))
     } else {
+      setShowRunAgainSpinner(true)
       reset()
       trackEvent({
         name: 'proceedToRun',
@@ -196,6 +200,19 @@ export function RunSummary(): JSX.Element {
         console.log(`Error checking pipette tip attachement state: ${e}`)
       })
   }, [])
+
+  const RUN_AGAIN_SPINNER_TEXT = (
+    <Flex justifyContent={JUSTIFY_SPACE_BETWEEN} width="25.5rem">
+      {t('run_again')}
+      <Icon
+        name="ot-spinner"
+        aria-label="icon_ot-spinner"
+        spin={true}
+        size="2.5rem"
+        color={COLORS.white}
+      />
+    </Flex>
+  )
 
   return (
     <Btn
@@ -306,8 +323,11 @@ export function RunSummary(): JSX.Element {
               flex="1"
               iconName="play-round-corners"
               onClick={handleRunAgain}
-              buttonText={t('run_again')}
+              buttonText={
+                showRunAgainSpinner ? RUN_AGAIN_SPINNER_TEXT : t('run_again')
+              }
               height="17rem"
+              css={showRunAgainSpinner ? RUN_AGAIN_CLICKED_STYLE : undefined}
             />
             {!didRunSucceed ? (
               <LargeButton
@@ -399,9 +419,24 @@ const SummaryDatum = styled.div`
   font-weight: ${TYPOGRAPHY.fontWeightRegular};
   width: max-content;
 `
-
 const DURATION_TEXT_STYLE = css`
   font-size: ${TYPOGRAPHY.fontSize22};
   line-height: ${TYPOGRAPHY.lineHeight28};
   font-weight: ${TYPOGRAPHY.fontWeightRegular};
+`
+
+const RUN_AGAIN_CLICKED_STYLE = css`
+  background-color: ${COLORS.bluePressed};
+  &:focus {
+    background-color: ${COLORS.bluePressed};
+  }
+  &:hover {
+    background-color: ${COLORS.bluePressed};
+  }
+  &:focus-visible {
+    background-color: ${COLORS.bluePressed};
+  }
+  &:active {
+    background-color: ${COLORS.bluePressed};
+  }
 `


### PR DESCRIPTION
Closes RQA-1972, RQA-1973

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds a loading state to the "Run Again" button on the ODD. 

It also fixes a routing bug in which pressing "run again" would send the user to the protocol setup page, back to the /protocols page, then back to the protocol setup page. Changes to TopLevelRedirect did not account for ODD "run again" routing logic. By removing the onResetSuccess callback, we avoid the superfluous redirect.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/2b5fcbf6-d6ab-43e7-b1be-9cd59889e832

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/92bcfa5e-6564-4792-9272-6229a959bf6d

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Follow the video flow above. Just verify that there's loading state and there is no redirection to the /protocols route after pressing "run again".

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added loading state to the "Run again" button the ODD.
- Fixed a routing issue when pressing "Run again" on the ODD.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
