### PR TITLE
fix(app): always enable BackToTop button

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
@@ -2,18 +2,12 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 
-import { useHoverTooltip, SecondaryButton } from '@opentrons/components'
+import { SecondaryButton } from '@opentrons/components'
 
-import { Tooltip } from '../../../atoms/Tooltip'
 import {
   useTrackEvent,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
 } from '../../../redux/analytics'
-import {
-  useUnmatchedModulesForProtocol,
-  useRunCalibrationStatus,
-  useRunHasStarted,
-} from '../hooks'
 
 interface BackToTopButtonProps {
   protocolRunHeaderRef: React.RefObject<HTMLDivElement> | null
@@ -29,34 +23,7 @@ export function BackToTopButton({
   sourceLocation,
 }: BackToTopButtonProps): JSX.Element | null {
   const { t } = useTranslation('protocol_setup')
-  const [targetProps, tooltipProps] = useHoverTooltip()
-  const { missingModuleIds } = useUnmatchedModulesForProtocol(robotName, runId)
   const trackEvent = useTrackEvent()
-  const { complete: isCalibrationComplete } = useRunCalibrationStatus(
-    robotName,
-    runId
-  )
-  const runHasStarted = useRunHasStarted(runId)
-
-  const calibrationIncomplete =
-    missingModuleIds.length === 0 && !isCalibrationComplete
-  const moduleSetupIncomplete =
-    missingModuleIds.length > 0 && isCalibrationComplete
-  const moduleAndCalibrationIncomplete =
-    missingModuleIds.length > 0 && !isCalibrationComplete
-
-  let proceedToRunDisabledReason = null
-  if (runHasStarted) {
-    proceedToRunDisabledReason = t('protocol_run_started')
-  } else if (moduleAndCalibrationIncomplete) {
-    proceedToRunDisabledReason = t(
-      'run_disabled_modules_and_calibration_not_complete'
-    )
-  } else if (calibrationIncomplete) {
-    proceedToRunDisabledReason = t('run_disabled_calibration_not_complete')
-  } else if (moduleSetupIncomplete) {
-    proceedToRunDisabledReason = t('run_disabled_modules_not_connected')
-  }
 
   return (
     <Link
@@ -71,18 +38,9 @@ export function BackToTopButton({
         })
       }}
     >
-      <SecondaryButton
-        disabled={proceedToRunDisabledReason != null}
-        id="LabwareSetup_proceedToRunButton"
-        {...targetProps}
-      >
+      <SecondaryButton id="LabwareSetup_proceedToRunButton">
         {t('back_to_top')}
       </SecondaryButton>
-      {proceedToRunDisabledReason != null && (
-        <Tooltip tooltipProps={tooltipProps}>
-          {proceedToRunDisabledReason}
-        </Tooltip>
-      )}
     </Link>
   )
 }

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
@@ -9,11 +9,6 @@ import {
   useTrackEvent,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
 } from '../../../../redux/analytics'
-import {
-  useRunCalibrationStatus,
-  useRunHasStarted,
-  useUnmatchedModulesForProtocol,
-} from '../../hooks'
 import { BackToTopButton } from '../BackToTopButton'
 
 jest.mock('@opentrons/components', () => {
@@ -24,17 +19,7 @@ jest.mock('@opentrons/components', () => {
   }
 })
 jest.mock('../../../../redux/analytics')
-jest.mock('../../hooks')
 
-const mockUseUnmatchedModulesForProtocol = useUnmatchedModulesForProtocol as jest.MockedFunction<
-  typeof useUnmatchedModulesForProtocol
->
-const mockUseRunCalibrationStatus = useRunCalibrationStatus as jest.MockedFunction<
-  typeof useRunCalibrationStatus
->
-const mockUseRunHasStarted = useRunHasStarted as jest.MockedFunction<
-  typeof useRunHasStarted
->
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
@@ -62,20 +47,6 @@ let mockTrackEvent: jest.Mock
 
 describe('BackToTopButton', () => {
   beforeEach(() => {
-    when(mockUseUnmatchedModulesForProtocol)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        missingModuleIds: [],
-        remainingAttachedModules: [],
-      })
-
-    when(mockUseRunCalibrationStatus)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        complete: true,
-      })
-    when(mockUseRunHasStarted).calledWith(RUN_ID).mockReturnValue(false)
-
     mockTrackEvent = jest.fn()
     when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
   })
@@ -102,46 +73,7 @@ describe('BackToTopButton', () => {
     })
   })
 
-  it('should not disabled with modules not connected tooltip when there are missing moduleIds', () => {
-    when(mockUseUnmatchedModulesForProtocol)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        missingModuleIds: ['temperatureModuleV1'],
-        remainingAttachedModules: [],
-      })
-    const { getByRole } = render()
-    const button = getByRole('button', { name: 'Back to top' })
-    expect(button).not.toBeDisabled()
-  })
-  it('should not be disabled with modules not connected and calibration not completed tooltip if missing cal and moduleIds', async () => {
-    when(mockUseUnmatchedModulesForProtocol)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        missingModuleIds: ['temperatureModuleV1'],
-        remainingAttachedModules: [],
-      })
-    when(mockUseRunCalibrationStatus)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        complete: false,
-      })
-    const { getByRole } = render()
-    const button = getByRole('button', { name: 'Back to top' })
-    expect(button).not.toBeDisabled()
-  })
-  it('should not be disabled with calibration not complete tooltip when calibration not complete', async () => {
-    when(mockUseRunCalibrationStatus)
-      .calledWith(ROBOT_NAME, RUN_ID)
-      .mockReturnValue({
-        complete: false,
-      })
-    const { getByRole } = render()
-    const button = getByRole('button', { name: 'Back to top' })
-    expect(button).not.toBeDisabled()
-  })
-  it('should not be disabled with protocol run started tooltip when run has started', async () => {
-    when(mockUseRunHasStarted).calledWith(RUN_ID).mockReturnValue(true)
-
+  it('should always be enabled', () => {
     const { getByRole } = render()
     const button = getByRole('button', { name: 'Back to top' })
     expect(button).not.toBeDisabled()

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
@@ -102,19 +102,18 @@ describe('BackToTopButton', () => {
     })
   })
 
-  it('should be disabled with modules not connected tooltip when there are missing moduleIds', () => {
+  it('should not disabled with modules not connected tooltip when there are missing moduleIds', () => {
     when(mockUseUnmatchedModulesForProtocol)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({
         missingModuleIds: ['temperatureModuleV1'],
         remainingAttachedModules: [],
       })
-    const { getByRole, getByText } = render()
+    const { getByRole } = render()
     const button = getByRole('button', { name: 'Back to top' })
-    expect(button).toBeDisabled()
-    getByText('Make sure all modules are connected before proceeding to run')
+    expect(button).not.toBeDisabled()
   })
-  it('should be disabled with modules not connected and calibration not completed tooltip if missing cal and moduleIds', async () => {
+  it('should not be disabled with modules not connected and calibration not completed tooltip if missing cal and moduleIds', async () => {
     when(mockUseUnmatchedModulesForProtocol)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({
@@ -126,32 +125,25 @@ describe('BackToTopButton', () => {
       .mockReturnValue({
         complete: false,
       })
-    const { getByRole, getByText } = render()
+    const { getByRole } = render()
     const button = getByRole('button', { name: 'Back to top' })
-    expect(button).toBeDisabled()
-    getByText(
-      'Make sure robot calibration is complete and all modules are connected before proceeding to run'
-    )
+    expect(button).not.toBeDisabled()
   })
-  it('should be disabled with calibration not complete tooltip when calibration not complete', async () => {
+  it('should not be disabled with calibration not complete tooltip when calibration not complete', async () => {
     when(mockUseRunCalibrationStatus)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({
         complete: false,
       })
-    const { getByRole, getByText } = render()
+    const { getByRole } = render()
     const button = getByRole('button', { name: 'Back to top' })
-    expect(button).toBeDisabled()
-    getByText(
-      'Make sure robot calibration is complete before proceeding to run'
-    )
+    expect(button).not.toBeDisabled()
   })
-  it('should be disabled with protocol run started tooltip when run has started', async () => {
+  it('should not be disabled with protocol run started tooltip when run has started', async () => {
     when(mockUseRunHasStarted).calledWith(RUN_ID).mockReturnValue(true)
 
-    const { getByRole, getByText } = render()
+    const { getByRole } = render()
     const button = getByRole('button', { name: 'Back to top' })
-    expect(button).toBeDisabled()
-    getByText('Protocol run started.')
+    expect(button).not.toBeDisabled()
   })
 })


### PR DESCRIPTION
closes [RQA-1954](https://opentrons.atlassian.net/browse/RQA-1954)

# Overview

Remove checks for disabling `BackToTop` button at the last setup step and remove hover tooltips for disabled reason. The user should always be enabled to click `BackToTop` in `ProtocolRun` even if proceeding to run is disabled.

Note: I set the disabled prop for the button to always `false` because the only time component is rendered is within `ProtocolRun`. If we utilize the button elsewhere, we can add a prop for disabling.

# Test Plan

- Proceed to protocol setup that should not be ready to run (missing calibrations, incorrect pipettes, etc.)
- Observe that the `BackToTop` button renders after the last setup step and is enabled.

# Changelog

- remove disabling `BackToTop` inside component
- update tests to always expect the button to be enabled

# Risk assessment

low

[RQA-1954]: https://opentrons.atlassian.net/browse/RQA-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ