### PR TITLE
fix(app): dqa protocol details screen

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -283,7 +283,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
 
   // TODO (sb:6/12/23) Create a notification manager to set up preference and order of takeover modals
   return (
-    <ApiHostProvider hostname="127.0.0.1">
+    <ApiHostProvider hostname="192.168.0.107">
       <ErrorBoundary FallbackComponent={OnDeviceDisplayAppFallback}>
         <Box width="100%" css="user-select: none;">
           {isIdle ? (

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -283,7 +283,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
 
   // TODO (sb:6/12/23) Create a notification manager to set up preference and order of takeover modals
   return (
-    <ApiHostProvider hostname="192.168.0.107">
+    <ApiHostProvider hostname="127.0.0.1">
       <ErrorBoundary FallbackComponent={OnDeviceDisplayAppFallback}>
         <Box width="100%" css="user-select: none;">
           {isIdle ? (

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Deck.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Deck.tsx
@@ -18,7 +18,7 @@ export const Deck = (props: { protocolId: string }): JSX.Element => {
   )
 
   return (
-    <Flex height="26.9375rem" marginY={SPACING.spacing24}>
+    <Flex height="26.9375rem" paddingY={SPACING.spacing24}>
       {mostRecentAnalysis != null ? (
         <ProtocolDeck
           protocolAnalysis={mostRecentAnalysis}

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/Deck.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/Deck.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import last from 'lodash/last'
 
-import { Flex, ProtocolDeck } from '@opentrons/components'
+import { Flex, ProtocolDeck, SPACING } from '@opentrons/components'
 import {
   useProtocolAnalysisAsDocumentQuery,
   useProtocolQuery,
@@ -18,7 +18,7 @@ export const Deck = (props: { protocolId: string }): JSX.Element => {
   )
 
   return (
-    <Flex height="26.9375rem">
+    <Flex height="26.9375rem" marginY={SPACING.spacing24}>
       {mostRecentAnalysis != null ? (
         <ProtocolDeck
           protocolAnalysis={mostRecentAnalysis}

--- a/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
+++ b/app/src/pages/OnDeviceDisplay/ProtocolDetails/index.tsx
@@ -173,7 +173,7 @@ const ProtocolSectionTabs = ({
   setCurrentOption,
 }: ProtocolSectionTabsProps): JSX.Element => {
   return (
-    <Flex gridGap={SPACING.spacing8} marginX={SPACING.spacing16}>
+    <Flex gridGap={SPACING.spacing8}>
       {protocolSectionTabOptions.map(option => {
         return (
           <TabbedButton
@@ -270,7 +270,7 @@ const ProtocolSectionContent = ({
   }
   return (
     <Flex
-      margin={SPACING.spacing16}
+      marginTop={SPACING.spacing32}
       justifyContent={currentOption === 'Deck' ? JUSTIFY_CENTER : undefined}
     >
       {protocolSection}
@@ -453,8 +453,8 @@ export function ProtocolDetails(): JSX.Element | null {
       ) : null}
       <Flex
         flexDirection={DIRECTION_COLUMN}
-        paddingX={SPACING.spacing32}
-        paddingBottom={SPACING.spacing32}
+        paddingX={SPACING.spacing40}
+        paddingBottom={SPACING.spacing40}
       >
         {showMaxPinsAlert && (
           <SmallModalChildren
@@ -495,7 +495,6 @@ export function ProtocolDetails(): JSX.Element | null {
               // Skeleton is large. Better UX not to scroll to see buttons while loading.
               !isProtocolFetching ? SPACING.spacing60 : SPACING.spacing24
             }
-            marginX={SPACING.spacing16}
           >
             <MediumButton
               buttonText={
@@ -506,14 +505,14 @@ export function ProtocolDetails(): JSX.Element | null {
               buttonType="secondary"
               iconName="pin"
               onClick={handlePinClick}
-              width="29.25rem"
+              width="100%"
             />
             <MediumButton
               buttonText={t('protocol_info:delete_protocol')}
               buttonType="alertSecondary"
               iconName="trash"
               onClick={() => setShowConfirmationDeleteProtocol(true)}
-              width="29.25rem"
+              width="100%"
             />
           </Flex>
         </Flex>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update margin and padding to align with the design.

in terms of scroll bar, I will work on that later.

close RAUT-833

design
https://www.figma.com/file/0kuPeCi1t2Auu2GPMnqRb2/branch/nSiJa9cnwtTLKOkd8kth49/Primary%3A-Opentrons-Flex-Touchscreen?node-id=19643%3A163048&mode=dev
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. run odd mode or push this branch to a dev kit/Flex
2. go to Protocol Details screen
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
