### PR TITLE
docs(api): docstring for `load_trash_bin()`

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -441,18 +441,14 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 16)
     def load_trash_bin(self, location: DeckLocation) -> TrashBin:
-        """Load a trash bin on the deck.
+        """Load a trash bin on the deck of a Flex.
 
-        If you try to load another item in a slot where you've loaded a trash bin, or
-        vice versa, the API will raise an error.
+        If you try to load a trash bin on an OT-2, the API will raise an error.
 
-        :param location: The :ref:`deck slot <deck-slots>` where the trash bin is. Valid
-            slots differ by robot type.
+        :param location: The :ref:`deck slot <deck-slots>` where the trash bin is. The
+            location can be any unoccupied slot in column 1 or 3.
 
-            - For Flex, any slot in column 1 or 3.
-            - For OT-2, slot 12 only.
-
-            If you try to load a trash bin in an invalid slot, the API will raise an error.
+            If you try to load a trash bin in column 2 or 4, the API will raise an error.
         """
         slot_name = validation.ensure_and_convert_deck_slot(
             location,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -441,6 +441,19 @@ class ProtocolContext(CommandPublisher):
 
     @requires_version(2, 16)
     def load_trash_bin(self, location: DeckLocation) -> TrashBin:
+        """Load a trash bin on the deck.
+
+        If you try to load another item in a slot where you've loaded a trash bin, or
+        vice versa, the API will raise an error.
+
+        :param location: The :ref:`deck slot <deck-slots>` where the trash bin is. Valid
+            slots differ by robot type.
+
+            - For Flex, any slot in column 1 or 3.
+            - For OT-2, slot 12 only.
+
+            If you try to load a trash bin in an invalid slot, the API will raise an error.
+        """
         slot_name = validation.ensure_and_convert_deck_slot(
             location,
             api_version=self._api_version,


### PR DESCRIPTION

# Overview

Adds an API Reference entry for `load_trash_bin()`

Further explanation of needing a trash container in every protocol will go in article pages, in a separate PR.

# Test Plan

Check out the [entry in the sandbox](http://sandbox.docs.opentrons.com/docstring-load_trash_bin/v2/new_protocol_api.html#opentrons.protocol_api.ProtocolContext.load_trash_bin).

# Changelog

New docstring only.

# Review requests

Oll korrect?

# Risk assessment

none, docstring.
