### PR TITLE
fix(app): check firmware update status in instrument cards

### DIFF
--- a/app-shell-odd/src/config/__fixtures__/index.ts
+++ b/app-shell-odd/src/config/__fixtures__/index.ts
@@ -8,6 +8,7 @@ import type {
   ConfigV18,
   ConfigV19,
   ConfigV20,
+  ConfigV21,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V12: ConfigV12 = {
@@ -128,4 +129,9 @@ export const MOCK_CONFIG_V20: ConfigV20 = {
       OT2: 'not-used-on-ODD',
     },
   },
+}
+
+export const MOCK_CONFIG_V21: ConfigV21 = {
+  ...MOCK_CONFIG_V20,
+  version: 21,
 }

--- a/app-shell-odd/src/config/__tests__/migrate.test.ts
+++ b/app-shell-odd/src/config/__tests__/migrate.test.ts
@@ -9,10 +9,11 @@ import {
   MOCK_CONFIG_V18,
   MOCK_CONFIG_V19,
   MOCK_CONFIG_V20,
+  MOCK_CONFIG_V21,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
-const NEWEST_VERSION = 20
+const NEWEST_VERSION = 21
 
 describe('config migration', () => {
   it('should migrate version 12 to latest', () => {
@@ -20,7 +21,7 @@ describe('config migration', () => {
     const result = migrate(v12Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 13 to latest', () => {
@@ -28,7 +29,7 @@ describe('config migration', () => {
     const result = migrate(v13Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 14 to latest', () => {
@@ -36,7 +37,7 @@ describe('config migration', () => {
     const result = migrate(v14Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 15 to latest', () => {
@@ -44,7 +45,7 @@ describe('config migration', () => {
     const result = migrate(v15Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 16 to latest', () => {
@@ -52,7 +53,7 @@ describe('config migration', () => {
     const result = migrate(v16Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 17 to latest', () => {
@@ -60,7 +61,7 @@ describe('config migration', () => {
     const result = migrate(v17Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migration version 18 to latest', () => {
@@ -68,7 +69,7 @@ describe('config migration', () => {
     const result = migrate(v18Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migration version 19 to latest', () => {
@@ -76,14 +77,21 @@ describe('config migration', () => {
     const result = migrate(v19Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
-  it('should keep version 20', () => {
+  it('should migration version 20 to latest', () => {
     const v20Config = MOCK_CONFIG_V20
     const result = migrate(v20Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(v20Config)
+    expect(result).toEqual(MOCK_CONFIG_V21)
+  })
+  it('should keep version 21', () => {
+    const v21Config = MOCK_CONFIG_V21
+    const result = migrate(v21Config)
+
+    expect(result.version).toBe(NEWEST_VERSION)
+    expect(result).toEqual(v21Config)
   })
 })

--- a/app-shell-odd/src/config/migrate.ts
+++ b/app-shell-odd/src/config/migrate.ts
@@ -14,6 +14,7 @@ import type {
   ConfigV18,
   ConfigV19,
   ConfigV20,
+  ConfigV21,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v12 defaults
@@ -169,6 +170,21 @@ const toVersion20 = (prevConfig: ConfigV19): ConfigV20 => {
   }
 }
 
+const toVersion21 = (prevConfig: ConfigV20): ConfigV21 => {
+  return {
+    ...prevConfig,
+    version: 21 as const,
+    onDeviceDisplaySettings: {
+      ...prevConfig.onDeviceDisplaySettings,
+      unfinishedUnboxingFlowRoute:
+        prevConfig.onDeviceDisplaySettings.unfinishedUnboxingFlowRoute ===
+        '/dashboard'
+          ? null
+          : prevConfig.onDeviceDisplaySettings.unfinishedUnboxingFlowRoute,
+    },
+  }
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV12) => ConfigV13,
   (prevConfig: ConfigV13) => ConfigV14,
@@ -177,7 +193,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV16) => ConfigV17,
   (prevConfig: ConfigV17) => ConfigV18,
   (prevConfig: ConfigV18) => ConfigV19,
-  (prevConfig: ConfigV19) => ConfigV20
+  (prevConfig: ConfigV19) => ConfigV20,
+  (prevConfig: ConfigV20) => ConfigV21
 ] = [
   toVersion13,
   toVersion14,
@@ -187,6 +204,7 @@ const MIGRATIONS: [
   toVersion18,
   toVersion19,
   toVersion20,
+  toVersion21,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V12)
@@ -202,6 +220,7 @@ export function migrate(
     | ConfigV18
     | ConfigV19
     | ConfigV20
+    | ConfigV21
 ): Config {
   let result = prevConfig
   // loop through the migrations, skipping any migrations that are unnecessary

--- a/app-shell/src/config/__fixtures__/index.ts
+++ b/app-shell/src/config/__fixtures__/index.ts
@@ -20,6 +20,7 @@ import type {
   ConfigV18,
   ConfigV19,
   ConfigV20,
+  ConfigV21,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V0: ConfigV0 = {
@@ -261,4 +262,9 @@ export const MOCK_CONFIG_V20: ConfigV20 = {
         'https://opentrons-buildroot-ci.s3.us-east-2.amazonaws.com/releases.json',
     },
   },
+}
+
+export const MOCK_CONFIG_V21: ConfigV21 = {
+  ...MOCK_CONFIG_V20,
+  version: 21,
 }

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -21,10 +21,11 @@ import {
   MOCK_CONFIG_V18,
   MOCK_CONFIG_V19,
   MOCK_CONFIG_V20,
+  MOCK_CONFIG_V21,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
-const NEWEST_VERSION = 20
+const NEWEST_VERSION = 21
 
 describe('config migration', () => {
   it('should migrate version 0 to latest', () => {
@@ -32,7 +33,7 @@ describe('config migration', () => {
     const result = migrate(v0Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 1 to latest', () => {
@@ -40,7 +41,7 @@ describe('config migration', () => {
     const result = migrate(v1Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 2 to latest', () => {
@@ -48,7 +49,7 @@ describe('config migration', () => {
     const result = migrate(v2Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 3 to latest', () => {
@@ -56,7 +57,7 @@ describe('config migration', () => {
     const result = migrate(v3Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 4 to latest', () => {
@@ -64,7 +65,7 @@ describe('config migration', () => {
     const result = migrate(v4Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 5 to latest', () => {
@@ -72,7 +73,7 @@ describe('config migration', () => {
     const result = migrate(v5Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 6 to latest', () => {
@@ -80,7 +81,7 @@ describe('config migration', () => {
     const result = migrate(v6Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 7 to latest', () => {
@@ -88,7 +89,7 @@ describe('config migration', () => {
     const result = migrate(v7Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 8 to latest', () => {
@@ -96,7 +97,7 @@ describe('config migration', () => {
     const result = migrate(v8Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 9 to latest', () => {
@@ -104,7 +105,7 @@ describe('config migration', () => {
     const result = migrate(v9Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 10 to latest', () => {
@@ -112,7 +113,7 @@ describe('config migration', () => {
     const result = migrate(v10Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 11 to latest', () => {
@@ -120,7 +121,7 @@ describe('config migration', () => {
     const result = migrate(v11Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 12 to latest', () => {
@@ -128,7 +129,7 @@ describe('config migration', () => {
     const result = migrate(v12Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 13 to latest', () => {
@@ -136,7 +137,7 @@ describe('config migration', () => {
     const result = migrate(v13Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 14 to latest', () => {
@@ -144,7 +145,7 @@ describe('config migration', () => {
     const result = migrate(v14Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 15 to latest', () => {
@@ -152,7 +153,7 @@ describe('config migration', () => {
     const result = migrate(v15Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 16 to latest', () => {
@@ -160,7 +161,7 @@ describe('config migration', () => {
     const result = migrate(v16Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
 
   it('should migrate version 17 to latest', () => {
@@ -168,26 +169,34 @@ describe('config migration', () => {
     const result = migrate(v17Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
   it('should migrate version 18 to latest', () => {
     const v18Config = MOCK_CONFIG_V18
     const result = migrate(v18Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
   it('should keep migrate version 19 to latest', () => {
     const v19Config = MOCK_CONFIG_V19
     const result = migrate(v19Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V20)
+    expect(result).toEqual(MOCK_CONFIG_V21)
   })
-  it('should keep version 20', () => {
+  it('should migration version 20 to latest', () => {
     const v20Config = MOCK_CONFIG_V20
     const result = migrate(v20Config)
+
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(v20Config)
+    expect(result).toEqual(MOCK_CONFIG_V21)
+  })
+  it('should keep version 21', () => {
+    const v21Config = MOCK_CONFIG_V21
+    const result = migrate(v21Config)
+
+    expect(result.version).toBe(NEWEST_VERSION)
+    expect(result).toEqual(v21Config)
   })
 })

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -26,6 +26,7 @@ import type {
   ConfigV18,
   ConfigV19,
   ConfigV20,
+  ConfigV21,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v0 defaults
@@ -373,6 +374,20 @@ const toVersion20 = (prevConfig: ConfigV19): ConfigV20 => {
   }
   return nextConfig
 }
+const toVersion21 = (prevConfig: ConfigV20): ConfigV21 => {
+  return {
+    ...prevConfig,
+    version: 21 as const,
+    onDeviceDisplaySettings: {
+      ...prevConfig.onDeviceDisplaySettings,
+      unfinishedUnboxingFlowRoute:
+        prevConfig.onDeviceDisplaySettings.unfinishedUnboxingFlowRoute ===
+        '/dashboard'
+          ? null
+          : prevConfig.onDeviceDisplaySettings.unfinishedUnboxingFlowRoute,
+    },
+  }
+}
 
 const MIGRATIONS: [
   (prevConfig: ConfigV0) => ConfigV1,
@@ -394,7 +409,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV16) => ConfigV17,
   (prevConfig: ConfigV17) => ConfigV18,
   (prevConfig: ConfigV18) => ConfigV19,
-  (prevConfig: ConfigV19) => ConfigV20
+  (prevConfig: ConfigV19) => ConfigV20,
+  (prevConfig: ConfigV20) => ConfigV21
 ] = [
   toVersion1,
   toVersion2,
@@ -416,6 +432,7 @@ const MIGRATIONS: [
   toVersion18,
   toVersion19,
   toVersion20,
+  toVersion21,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V0)
@@ -443,6 +460,7 @@ export function migrate(
     | ConfigV18
     | ConfigV19
     | ConfigV20
+    | ConfigV21
 ): Config {
   const prevVersion = prevConfig.version
   let result = prevConfig

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -135,7 +135,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       setPollForSubsystemUpdate(true)
     } else if (
       subsystemUpdateData != null &&
-      subsystemUpdateData.updateStatus === 'done'
+      subsystemUpdateData.data.updateStatus === 'done'
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -135,7 +135,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       setPollForSubsystemUpdate(true)
     } else if (
       subsystemUpdateData != null &&
-      subsystemUpdateData.status === 'done'
+      subsystemUpdateData.updateStatus === 'done'
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -78,7 +78,7 @@ const INSTRUMENT_CARD_STYLE = css`
   }
 `
 
-const SUBSYSTEM_UPDATE_POLL_MS = 5000
+const POLL_DURATION = 5000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const { t, i18n } = useTranslation(['device_details', 'protocol_setup'])
@@ -123,7 +123,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     subsystem,
     {
       enabled: pollForSubsystemUpdate,
-      refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
+      refetchInterval: POLL_DURATION,
     }
   )
   // we should poll for a subsystem update from the time a bad instrument is
@@ -139,13 +139,13 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)
-      }, 5000)
+      }, POLL_DURATION)
     }
   }, [pipetteIsBad, subsystemUpdateData, isFlex])
 
   const settings =
     usePipetteSettingsQuery({
-      refetchInterval: 5000,
+      refetchInterval: POLL_DURATION,
       enabled: pipetteId != null,
     })?.data?.[pipetteId ?? '']?.fields ?? null
 

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -78,7 +78,7 @@ const INSTRUMENT_CARD_STYLE = css`
   }
 `
 
-const POLL_DURATION = 5000
+const POLL_DURATION_MS = 5000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const { t, i18n } = useTranslation(['device_details', 'protocol_setup'])
@@ -123,7 +123,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     subsystem,
     {
       enabled: pollForSubsystemUpdate,
-      refetchInterval: POLL_DURATION,
+      refetchInterval: POLL_DURATION_MS,
     }
   )
   // we should poll for a subsystem update from the time a bad instrument is
@@ -139,13 +139,13 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)
-      }, POLL_DURATION)
+      }, POLL_DURATION_MS)
     }
   }, [pipetteIsBad, subsystemUpdateData, isFlex])
 
   const settings =
     usePipetteSettingsQuery({
-      refetchInterval: POLL_DURATION,
+      refetchInterval: POLL_DURATION_MS,
       enabled: pipetteId != null,
     })?.data?.[pipetteId ?? '']?.fields ?? null
 

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -92,7 +92,7 @@ export function FirmwareUpdateTakeover(): JSX.Element {
             if (instrumentsToUpdate.length <= indexToUpdate) {
               setShowUpdateNeededModal(false)
             } else {
-              setIndexToUpdate(indexToUpdate + 1)
+              setIndexToUpdate(prevIndexToUpdate => prevIndexToUpdate + 1)
             }
           }}
           shouldExit={instrumentsToUpdate.length <= indexToUpdate}

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -42,13 +42,6 @@ export function FirmwareUpdateTakeover(): JSX.Element {
   })
   const [indexToUpdate, setIndexToUpdate] = React.useState(0)
 
-  // for debugging - remove before merge
-  React.useEffect(() => {
-    console.log('Change in index or instruments array:')
-    console.log('index to update: ', indexToUpdate)
-    console.log('instruments to update array:', instrumentsToUpdate)
-  }, [indexToUpdate, instrumentsToUpdate])
-
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
     refetchInterval: POLL_INTERVAL_MS,
   })
@@ -97,13 +90,13 @@ export function FirmwareUpdateTakeover(): JSX.Element {
           onClose={() => {
             // if no more instruments need updating, close the modal
             // otherwise start over with next instrument
-            if (instrumentsToUpdate.length <= indexToUpdate) {
+            if (instrumentsToUpdate.length <= indexToUpdate + 1) {
               setShowUpdateNeededModal(false)
             } else {
               setIndexToUpdate(prevIndexToUpdate => prevIndexToUpdate + 1)
             }
           }}
-          shouldExit={instrumentsToUpdate.length <= indexToUpdate}
+          shouldExit={instrumentsToUpdate.length <= indexToUpdate + 1}
           setInitiatedSubsystemUpdate={setInitiatedSubsystemUpdate}
         />
       ) : null}

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -28,7 +28,7 @@ interface UpdateNeededModalProps {
 export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
   const { onClose, shouldExit, subsystem, setInitiatedSubsystemUpdate } = props
   const { t } = useTranslation('firmware_update')
-  const [updateId, setUpdateId] = React.useState('')
+  const [updateId, setUpdateId] = React.useState<string | null>(null)
   const {
     data: instrumentsData,
     refetch: refetchInstruments,

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -19,13 +19,14 @@ import type { Subsystem } from '@opentrons/api-client'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 
 interface UpdateNeededModalProps {
-  setShowUpdateModal: React.Dispatch<React.SetStateAction<boolean>>
+  onClose: () => void
+  shouldExit: boolean
   subsystem: Subsystem
   setInitiatedSubsystemUpdate: (subsystem: Subsystem | null) => void
 }
 
 export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
-  const { setShowUpdateModal, subsystem, setInitiatedSubsystemUpdate } = props
+  const { onClose, shouldExit, subsystem, setInitiatedSubsystemUpdate } = props
   const { t } = useTranslation('firmware_update')
   const [updateId, setUpdateId] = React.useState('')
   const {
@@ -102,10 +103,11 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
       <UpdateResultsModal
         instrument={instrument}
         isSuccess={updateError === undefined}
-        closeModal={() => {
+        onClose={() => {
           refetchInstruments().catch(error => console.error(error))
-          setShowUpdateModal(false)
+          onClose()
         }}
+        shouldExit={shouldExit}
       />
     )
   }

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -29,6 +29,11 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
   const { onClose, shouldExit, subsystem, setInitiatedSubsystemUpdate } = props
   const { t } = useTranslation('firmware_update')
   const [updateId, setUpdateId] = React.useState<string | null>(null)
+  // when we move to the next subsystem to update, set updateId back to null
+  React.useEffect(() => {
+    setUpdateId(null)
+  }, [subsystem])
+
   const {
     data: instrumentsData,
     refetch: refetchInstruments,
@@ -91,14 +96,14 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
       </Flex>
     </Modal>
   )
-  if (status === 'updating' || status === 'queued') {
+  if ((status === 'updating' || status === 'queued') && updateId != null) {
     modalContent = (
       <UpdateInProgressModal
         percentComplete={percentComplete}
         subsystem={subsystem}
       />
     )
-  } else if (status === 'done') {
+  } else if (status === 'done' && updateId != null) {
     modalContent = (
       <UpdateResultsModal
         instrument={instrument}

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -98,7 +98,7 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
         subsystem={subsystem}
       />
     )
-  } else if (status === 'done' || instrument?.ok) {
+  } else if (status === 'done') {
     modalContent = (
       <UpdateResultsModal
         instrument={instrument}

--- a/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateNeededModal.tsx
@@ -50,6 +50,8 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
 
   const { data: updateData } = useSubsystemUpdateQuery(updateId)
   const status = updateData?.data.updateStatus
+  const ongoingUpdateId = updateData?.data.id
+
   React.useEffect(() => {
     if (status === 'done') {
       setInitiatedSubsystemUpdate(null)
@@ -96,14 +98,17 @@ export function UpdateNeededModal(props: UpdateNeededModalProps): JSX.Element {
       </Flex>
     </Modal>
   )
-  if ((status === 'updating' || status === 'queued') && updateId != null) {
+  if (
+    (status === 'updating' || status === 'queued') &&
+    ongoingUpdateId != null
+  ) {
     modalContent = (
       <UpdateInProgressModal
         percentComplete={percentComplete}
         subsystem={subsystem}
       />
     )
-  } else if (status === 'done' && updateId != null) {
+  } else if (status === 'done' && ongoingUpdateId != null) {
     modalContent = (
       <UpdateResultsModal
         instrument={instrument}

--- a/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
@@ -94,7 +94,9 @@ export function UpdateResultsModal(
                   i18nKey="ready_to_use"
                   values={{
                     instrument: capitalize(
-                      instrument?.instrumentModel ?? 'instrument'
+                      instrument?.ok && instrument?.instrumentModel != null
+                        ? instrument?.instrumentModel
+                        : 'instrument'
                     ),
                   }}
                   components={{

--- a/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
@@ -39,7 +39,7 @@ export function UpdateResultsModal(
 
   return (
     <>
-      {!isSuccess || instrument?.ok !== true ? (
+      {!isSuccess ? (
         <Modal header={updateFailedHeader}>
           <Flex flexDirection={DIRECTION_COLUMN}>
             <StyledText as="p" marginBottom={SPACING.spacing32}>

--- a/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
@@ -20,14 +20,15 @@ import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 
 interface UpdateResultsModalProps {
   isSuccess: boolean
-  closeModal: () => void
+  shouldExit: boolean
+  onClose: () => void
   instrument?: InstrumentData
 }
 
 export function UpdateResultsModal(
   props: UpdateResultsModalProps
 ): JSX.Element {
-  const { isSuccess, closeModal, instrument } = props
+  const { isSuccess, shouldExit, onClose, instrument } = props
   const { i18n, t } = useTranslation(['firmware_update', 'shared'])
 
   const updateFailedHeader: ModalHeaderBaseProps = {
@@ -45,8 +46,12 @@ export function UpdateResultsModal(
               {t('download_logs')}
             </StyledText>
             <SmallButton
-              onClick={() => closeModal()}
-              buttonText={i18n.format(t('shared:close'), 'capitalize')}
+              onClick={onClose}
+              buttonText={
+                shouldExit
+                  ? i18n.format(t('shared:close'), 'capitalize')
+                  : t('shared:next')
+              }
               width="100%"
             />
           </Flex>
@@ -99,8 +104,12 @@ export function UpdateResultsModal(
               </StyledText>
             </Flex>
             <SmallButton
-              onClick={() => closeModal()}
-              buttonText={i18n.format(t('shared:close'), 'capitalize')}
+              onClick={onClose}
+              buttonText={
+                shouldExit
+                  ? i18n.format(t('shared:close'), 'capitalize')
+                  : t('shared:next')
+              }
               width="100%"
             />
           </Flex>

--- a/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
@@ -36,7 +36,13 @@ export function UpdateResultsModal(
     iconName: 'ot-alert',
     iconColor: COLORS.red2,
   }
-
+  let instrumentName = 'instrument'
+  if (instrument?.ok) {
+    instrumentName =
+      instrument?.instrumentType === 'pipette'
+        ? instrument?.instrumentName
+        : instrument.instrumentType
+  }
   return (
     <>
       {!isSuccess ? (
@@ -93,11 +99,7 @@ export function UpdateResultsModal(
                   t={t}
                   i18nKey="ready_to_use"
                   values={{
-                    instrument: capitalize(
-                      instrument?.ok && instrument?.instrumentName != null
-                        ? instrument?.instrumentName
-                        : 'instrument'
-                    ),
+                    instrument: capitalize(instrumentName),
                   }}
                   components={{
                     bold: <strong />,

--- a/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/UpdateResultsModal.tsx
@@ -94,8 +94,8 @@ export function UpdateResultsModal(
                   i18nKey="ready_to_use"
                   values={{
                     instrument: capitalize(
-                      instrument?.ok && instrument?.instrumentModel != null
-                        ? instrument?.instrumentModel
+                      instrument?.ok && instrument?.instrumentName != null
+                        ? instrument?.instrumentName
                         : 'instrument'
                     ),
                   }}

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateNeededModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateNeededModal.test.tsx
@@ -46,8 +46,9 @@ describe('UpdateNeededModal', () => {
   const updateSubsystem = jest.fn(() => Promise.resolve())
   beforeEach(() => {
     props = {
-      setShowUpdateModal: jest.fn(),
+      onClose: jest.fn(),
       subsystem: 'pipette_left',
+      shouldExit: true,
       setInitiatedSubsystemUpdate: jest.fn(),
     }
     mockUseInstrumentQuery.mockReturnValue({

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateNeededModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateNeededModal.test.tsx
@@ -43,7 +43,17 @@ const render = (props: React.ComponentProps<typeof UpdateNeededModal>) => {
 describe('UpdateNeededModal', () => {
   let props: React.ComponentProps<typeof UpdateNeededModal>
   const refetch = jest.fn(() => Promise.resolve())
-  const updateSubsystem = jest.fn(() => Promise.resolve())
+  const updateSubsystem = jest.fn(() =>
+    Promise.resolve({
+      data: {
+        data: {
+          id: 'update id',
+          updateStatus: 'updating',
+          updateProgress: 20,
+        } as any,
+      },
+    })
+  )
   beforeEach(() => {
     props = {
       onClose: jest.fn(),
@@ -71,13 +81,6 @@ describe('UpdateNeededModal', () => {
       } as SubsystemUpdateProgressData,
     } as any)
     mockUseUpdateSubsystemMutation.mockReturnValue({
-      data: {
-        data: {
-          id: 'update id',
-          updateStatus: 'updating',
-          updateProgress: 20,
-        } as any,
-      } as SubsystemUpdateProgressData,
       updateSubsystem,
     } as any)
     mockUpdateInProgressModal.mockReturnValue(
@@ -95,7 +98,7 @@ describe('UpdateNeededModal', () => {
       )
     )
     getByText('Update firmware').click()
-    expect(mockUseUpdateSubsystemMutation).toHaveBeenCalled()
+    expect(updateSubsystem).toHaveBeenCalled()
   })
   it('renders the update in progress modal when update is pending', () => {
     const { getByText } = render(props)
@@ -109,16 +112,6 @@ describe('UpdateNeededModal', () => {
           updateStatus: 'done',
         } as any,
       } as SubsystemUpdateProgressData,
-    } as any)
-    mockUseUpdateSubsystemMutation.mockReturnValue({
-      data: {
-        data: {
-          id: 'update id',
-          updateStatus: 'done',
-          updateProgress: 100,
-        } as any,
-      } as SubsystemUpdateProgressData,
-      updateSubsystem,
     } as any)
     const { getByText } = render(props)
     getByText('Mock Update Results Modal')

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateResultsModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateResultsModal.test.tsx
@@ -18,6 +18,7 @@ describe('UpdateResultsModal', () => {
       onClose: jest.fn(),
       instrument: {
         ok: true,
+        instrumentType: 'gripper',
         subsystem: 'gripper',
         instrumentModel: 'gripper',
       } as any,

--- a/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateResultsModal.test.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/__tests__/UpdateResultsModal.test.tsx
@@ -14,7 +14,8 @@ describe('UpdateResultsModal', () => {
   beforeEach(() => {
     props = {
       isSuccess: true,
-      closeModal: jest.fn(),
+      shouldExit: true,
+      onClose: jest.fn(),
       instrument: {
         ok: true,
         subsystem: 'gripper',
@@ -30,12 +31,13 @@ describe('UpdateResultsModal', () => {
   it('calls close modal when the close button is pressed', () => {
     const { getByText } = render(props)
     getByText('Close').click()
-    expect(props.closeModal).toHaveBeenCalled()
+    expect(props.onClose).toHaveBeenCalled()
   })
   it('renders correct text for a failed instrument update', () => {
     props = {
       isSuccess: false,
-      closeModal: jest.fn(),
+      shouldExit: true,
+      onClose: jest.fn(),
       instrument: {
         ok: false,
       } as any,

--- a/app/src/organisms/FirmwareUpdateModal/index.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/index.tsx
@@ -80,7 +80,7 @@ export const FirmwareUpdateModal = (
     description,
     isOnDevice,
   } = props
-  const [updateId, setUpdateId] = React.useState('')
+  const [updateId, setUpdateId] = React.useState<string | null>(null)
   const [firmwareText, setFirmwareText] = React.useState('')
   const {
     data: attachedInstruments,

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -83,7 +83,7 @@ export function GripperCard({
       setPollForSubsystemUpdate(true)
     } else if (
       subsystemUpdateData != null &&
-      subsystemUpdateData.updateStatus === 'done'
+      subsystemUpdateData.data.updateStatus === 'done'
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -35,7 +35,7 @@ const INSTRUMENT_CARD_STYLE = css`
   }
 `
 
-const POLL_DURATION = 5000
+const POLL_DURATION_MS = 5000
 
 export function GripperCard({
   attachedGripper,
@@ -71,7 +71,7 @@ export function GripperCard({
     'gripper',
     {
       enabled: pollForSubsystemUpdate,
-      refetchInterval: POLL_DURATION,
+      refetchInterval: POLL_DURATION_MS,
     }
   )
   // we should poll for a subsystem update from the time a bad instrument is
@@ -87,7 +87,7 @@ export function GripperCard({
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)
-      }, POLL_DURATION)
+      }, POLL_DURATION_MS)
     }
   }, [attachedGripper?.ok, subsystemUpdateData])
 

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -83,7 +83,7 @@ export function GripperCard({
       setPollForSubsystemUpdate(true)
     } else if (
       subsystemUpdateData != null &&
-      subsystemUpdateData.status === 'done'
+      subsystemUpdateData.updateStatus === 'done'
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)

--- a/app/src/organisms/GripperCard/index.tsx
+++ b/app/src/organisms/GripperCard/index.tsx
@@ -35,7 +35,7 @@ const INSTRUMENT_CARD_STYLE = css`
   }
 `
 
-const SUBSYSTEM_UPDATE_POLL_MS = 5000
+const POLL_DURATION = 5000
 
 export function GripperCard({
   attachedGripper,
@@ -71,7 +71,7 @@ export function GripperCard({
     'gripper',
     {
       enabled: pollForSubsystemUpdate,
-      refetchInterval: SUBSYSTEM_UPDATE_POLL_MS,
+      refetchInterval: POLL_DURATION,
     }
   )
   // we should poll for a subsystem update from the time a bad instrument is
@@ -87,7 +87,7 @@ export function GripperCard({
     ) {
       setTimeout(() => {
         setPollForSubsystemUpdate(false)
-      }, 5000)
+      }, POLL_DURATION)
     }
   }, [attachedGripper?.ok, subsystemUpdateData])
 

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -235,4 +235,8 @@ export type ConfigV20 = Omit<ConfigV19, 'version'> & {
   }
 }
 
-export type Config = ConfigV20
+export type ConfigV21 = Omit<ConfigV20, 'version'> & {
+  version: 21
+}
+
+export type Config = ConfigV21

--- a/app/src/redux/config/selectors.ts
+++ b/app/src/redux/config/selectors.ts
@@ -112,7 +112,6 @@ export const getOnDeviceDisplaySettings: (
       brightness: config?.onDeviceDisplaySettings?.brightness ?? 4,
       textSize: config?.onDeviceDisplaySettings?.textSize ?? 1,
       unfinishedUnboxingFlowRoute:
-        config?.onDeviceDisplaySettings.unfinishedUnboxingFlowRoute ??
-        '/welcome',
+        config?.onDeviceDisplaySettings.unfinishedUnboxingFlowRoute ?? null,
     }
 )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:
Closes RQA-1961, RQA-2003

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Improve accuracy of instrument status available on instrument card and fix bug where firmware update modal was never popping up on ODD
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Without going through an attachment flow, attach a pipette that will need a firmware update to a robot. See that the firmware update needed modal pops up on ODD. Initiate update via ODD and simultaneously watch the steps that occur on the corresponding instrument card via the desktop app. The card should show "Update in progress..." until about 5 seconds after the update is completed. Then, the instrument card should populate with the attached pipette
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Add migration from stale `/dashboard` config value to `null` - this was preventing the firmware update modal from popping up on ODD because we rely on a `null` value to tell us that the unboxing flow is not in progress
2. Update poll for subsystem endpoint to continue until after the status of an update is `done`. Use that same value to determine when to start showing the attached instrument card, as this should give the `/instruments` endpoint enough time to reliably report what is attached

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over changes (especially the config migration - did I cover everything?) & run through the test plan if you can 
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
