### PR TITLE
fix(app): show 4th column slot label for waste chute with staging area

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/index.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/index.tsx
@@ -144,7 +144,10 @@ export function DeckConfigurator(props: DeckConfiguratorProps): JSX.Element {
       <SlotLabels
         robotType={FLEX_ROBOT_TYPE}
         color={darkFill}
-        show4thColumn={stagingAreaFixtures.length > 0}
+        show4thColumn={
+          stagingAreaFixtures.length > 0 ||
+          wasteChuteStagingAreaFixtures.length > 0
+        }
       />
       {children}
     </RobotCoordinateSpace>


### PR DESCRIPTION
closes [RQA-1920](https://opentrons.atlassian.net/browse/RQA-1920)

# Overview

show 4th column slot label for waste chute with staging area

# Test Plan

<img width="660" alt="Screen Shot 2023-12-06 at 12 16 14 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/17c2056c-8e74-4be0-a7f5-41458319b443">

# Risk assessment

low

[RQA-1920]: https://opentrons.atlassian.net/browse/RQA-1920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ