### PR TITLE
feat(protocol-designer): add biorad pcr plate as compatible with adapter

### DIFF
--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -98,6 +98,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   [PCR_ADAPTER_LOADNAME]: [
     'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',
     'opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
+    'opentrons/biorad_96_wellplate_200ul_pcr/2',
   ],
   [UNIVERSAL_FLAT_ADAPTER_LOADNAME]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
@@ -174,6 +175,12 @@ export const getAdapterLabwareIsAMatch = (
     'opentrons_flex_96_filtertiprack_1000ul',
   ]
 
+  const pcrLabwares = [
+    'biorad_96_wellplate_200ul_pcr',
+    'nest_96_wellplate_100ul_pcr_full_skirt',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  ]
+
   const deepWellPair =
     loadName === DEEP_WELL_ADAPTER_LOADNAME &&
     draggedLabwareLoadname === 'nest_96_wellplate_2ml_deep'
@@ -182,8 +189,7 @@ export const getAdapterLabwareIsAMatch = (
     draggedLabwareLoadname === 'nest_96_wellplate_200ul_flat'
   const pcrPair =
     loadName === PCR_ADAPTER_LOADNAME &&
-    (draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt' ||
-      draggedLabwareLoadname === 'opentrons_96_wellplate_200ul_pcr_full_skirt')
+    pcrLabwares.includes(draggedLabwareLoadname)
   const universalPair =
     loadName === UNIVERSAL_FLAT_ADAPTER_LOADNAME &&
     (draggedLabwareLoadname === 'corning_384_wellplate_112ul_flat' ||


### PR DESCRIPTION
# Overview

As per some discussions in the proj ot3 science slack channel, we needed to add the biorad hardplate as compatible with the H-S 96 channel adapter

# Test Plan

Create a flex or ot-2 protocol, add a heater-shaker. go to the deck setup and add a PCR 96 well adapter on top of the heater-shaker. Then see that the biorad plate is selectable to go on top of the adapter.

# Changelog

- add compatibility to the biorad labware to go on top of the pcr 96 well adapter

# Review requests

see test plan

# Risk assessment

low