### PR TITLE
fix(app): fix styling of read-only deck configurator

### DIFF
--- a/components/src/hardware-sim/DeckConfigurator/StagingAreaConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/StagingAreaConfigFixture.tsx
@@ -47,7 +47,7 @@ export function StagingAreaConfigFixture(
       <Btn
         css={
           handleClickRemove != null
-            ? STAGING_AREA_CONFIG_STYLE
+            ? STAGING_AREA_CONFIG_STYLE_EDITABLE
             : STAGING_AREA_CONFIG_STYLE_READ_ONLY
         }
         cursor={handleClickRemove != null ? 'pointer' : 'default'}
@@ -68,29 +68,6 @@ export function StagingAreaConfigFixture(
   )
 }
 
-const STAGING_AREA_CONFIG_STYLE = css`
-  display: ${DISPLAY_FLEX};
-  align-items: ${ALIGN_CENTER};
-  background-color: ${COLORS.grey2};
-  border-radius: ${BORDERS.borderRadiusSize1};
-  color: ${COLORS.white};
-  grid-gap: ${SPACING.spacing8};
-  justify-content: ${JUSTIFY_CENTER};
-  width: 100%;
-
-  &:active {
-    background-color: ${COLORS.darkBlack90};
-  }
-
-  &:hover {
-    background-color: ${COLORS.grey1};
-  }
-
-  &:focus-visible {
-    border: 3px solid ${COLORS.fundamentalsFocus};
-  }
-`
-
 const STAGING_AREA_CONFIG_STYLE_READ_ONLY = css`
   display: ${DISPLAY_FLEX};
   align-items: ${ALIGN_CENTER};
@@ -100,6 +77,18 @@ const STAGING_AREA_CONFIG_STYLE_READ_ONLY = css`
   grid-gap: ${SPACING.spacing8};
   justify-content: ${JUSTIFY_CENTER};
   width: 100%;
+`
+
+const STAGING_AREA_CONFIG_STYLE_EDITABLE = css`
+  ${STAGING_AREA_CONFIG_STYLE_READ_ONLY}
+
+  &:active {
+    background-color: ${COLORS.darkBlack90};
+  }
+
+  &:hover {
+    background-color: ${COLORS.grey1};
+  }
 
   &:focus-visible {
     border: 3px solid ${COLORS.fundamentalsFocus};

--- a/components/src/hardware-sim/DeckConfigurator/StagingAreaConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/StagingAreaConfigFixture.tsx
@@ -45,8 +45,12 @@ export function StagingAreaConfigFixture(
       foreignObjectProps={{ flex: '1' }}
     >
       <Btn
-        css={STAGING_AREA_CONFIG_STYLE}
-        cursor={handleClickRemove != null ? 'pointer' : 'none'}
+        css={
+          handleClickRemove != null
+            ? STAGING_AREA_CONFIG_STYLE
+            : STAGING_AREA_CONFIG_STYLE_READ_ONLY
+        }
+        cursor={handleClickRemove != null ? 'pointer' : 'default'}
         onClick={
           handleClickRemove != null
             ? () => handleClickRemove(fixtureLocation)
@@ -56,7 +60,9 @@ export function StagingAreaConfigFixture(
         <Text css={TYPOGRAPHY.smallBodyTextSemiBold}>
           {STAGING_AREA_DISPLAY_NAME}
         </Text>
-        <Icon name="remove" color={COLORS.white} size="2rem" />
+        {handleClickRemove != null ? (
+          <Icon name="remove" color={COLORS.white} size="2rem" />
+        ) : null}
       </Btn>
     </RobotCoordsForeignObject>
   )
@@ -79,6 +85,21 @@ const STAGING_AREA_CONFIG_STYLE = css`
   &:hover {
     background-color: ${COLORS.grey1};
   }
+
+  &:focus-visible {
+    border: 3px solid ${COLORS.fundamentalsFocus};
+  }
+`
+
+const STAGING_AREA_CONFIG_STYLE_READ_ONLY = css`
+  display: ${DISPLAY_FLEX};
+  align-items: ${ALIGN_CENTER};
+  background-color: ${COLORS.grey2};
+  border-radius: ${BORDERS.borderRadiusSize1};
+  color: ${COLORS.white};
+  grid-gap: ${SPACING.spacing8};
+  justify-content: ${JUSTIFY_CENTER};
+  width: 100%;
 
   &:focus-visible {
     border: 3px solid ${COLORS.fundamentalsFocus};

--- a/components/src/hardware-sim/DeckConfigurator/TrashBinConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/TrashBinConfigFixture.tsx
@@ -53,7 +53,7 @@ export function TrashBinConfigFixture(
       <Btn
         css={
           handleClickRemove != null
-            ? TRASH_BIN_CONFIG_STYLE
+            ? TRASH_BIN_CONFIG_STYLE_EDTIABLE
             : TRASH_BIN_CONFIG_STYLE_READ_ONLY
         }
         cursor={handleClickRemove != null ? 'pointer' : 'default'}
@@ -74,28 +74,6 @@ export function TrashBinConfigFixture(
   )
 }
 
-const TRASH_BIN_CONFIG_STYLE = css`
-  display: ${DISPLAY_FLEX};
-  align-items: ${ALIGN_CENTER};
-  background-color: ${COLORS.grey2};
-  border-radius: ${BORDERS.borderRadiusSize1};
-  color: ${COLORS.white};
-  justify-content: ${JUSTIFY_CENTER};
-  grid-gap: ${SPACING.spacing8};
-  width: 100%;
-
-  &:active {
-    background-color: ${COLORS.darkBlack90};
-  }
-
-  &:hover {
-    background-color: ${COLORS.grey1};
-  }
-
-  &:focus-visible {
-  }
-`
-
 const TRASH_BIN_CONFIG_STYLE_READ_ONLY = css`
   display: ${DISPLAY_FLEX};
   align-items: ${ALIGN_CENTER};
@@ -105,6 +83,18 @@ const TRASH_BIN_CONFIG_STYLE_READ_ONLY = css`
   justify-content: ${JUSTIFY_CENTER};
   grid-gap: ${SPACING.spacing8};
   width: 100%;
+`
+
+const TRASH_BIN_CONFIG_STYLE_EDTIABLE = css`
+  ${TRASH_BIN_CONFIG_STYLE_READ_ONLY}
+
+  &:active {
+    background-color: ${COLORS.darkBlack90};
+  }
+
+  &:hover {
+    background-color: ${COLORS.grey1};
+  }
 
   &:focus-visible {
   }

--- a/components/src/hardware-sim/DeckConfigurator/TrashBinConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/TrashBinConfigFixture.tsx
@@ -51,8 +51,12 @@ export function TrashBinConfigFixture(
       foreignObjectProps={{ flex: '1' }}
     >
       <Btn
-        css={TRASH_BIN_CONFIG_STYLE}
-        cursor={handleClickRemove != null ? 'pointer' : 'none'}
+        css={
+          handleClickRemove != null
+            ? TRASH_BIN_CONFIG_STYLE
+            : TRASH_BIN_CONFIG_STYLE_READ_ONLY
+        }
+        cursor={handleClickRemove != null ? 'pointer' : 'default'}
         onClick={
           handleClickRemove != null
             ? () => handleClickRemove(fixtureLocation)
@@ -62,7 +66,9 @@ export function TrashBinConfigFixture(
         <Text css={TYPOGRAPHY.smallBodyTextSemiBold}>
           {TRASH_BIN_DISPLAY_NAME}
         </Text>
-        <Icon name="remove" color={COLORS.white} size="2rem" />
+        {handleClickRemove != null ? (
+          <Icon name="remove" color={COLORS.white} size="2rem" />
+        ) : null}
       </Btn>
     </RobotCoordsForeignObject>
   )
@@ -85,6 +91,20 @@ const TRASH_BIN_CONFIG_STYLE = css`
   &:hover {
     background-color: ${COLORS.grey1};
   }
+
+  &:focus-visible {
+  }
+`
+
+const TRASH_BIN_CONFIG_STYLE_READ_ONLY = css`
+  display: ${DISPLAY_FLEX};
+  align-items: ${ALIGN_CENTER};
+  background-color: ${COLORS.grey2};
+  border-radius: ${BORDERS.borderRadiusSize1};
+  color: ${COLORS.white};
+  justify-content: ${JUSTIFY_CENTER};
+  grid-gap: ${SPACING.spacing8};
+  width: 100%;
 
   &:focus-visible {
   }

--- a/components/src/hardware-sim/DeckConfigurator/WasteChuteConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/WasteChuteConfigFixture.tsx
@@ -54,8 +54,12 @@ export function WasteChuteConfigFixture(
       foreignObjectProps={{ flex: '1' }}
     >
       <Btn
-        css={WASTE_CHUTE_CONFIG_STYLE}
-        cursor={handleClickRemove != null ? 'pointer' : 'none'}
+        css={
+          handleClickRemove != null
+            ? WASTE_CHUTE_CONFIG_STYLE
+            : WASTE_CHUTE_CONFIG_STYLE_READ_ONLY
+        }
+        cursor={handleClickRemove != null ? 'pointer' : 'default'}
         onClick={
           handleClickRemove != null
             ? () => handleClickRemove(fixtureLocation)
@@ -65,7 +69,9 @@ export function WasteChuteConfigFixture(
         <Text css={TYPOGRAPHY.smallBodyTextSemiBold}>
           {WASTE_CHUTE_DISPLAY_NAME}
         </Text>
-        <Icon name="remove" color={COLORS.white} size="2rem" />
+        {handleClickRemove != null ? (
+          <Icon name="remove" color={COLORS.white} size="2rem" />
+        ) : null}
       </Btn>
     </RobotCoordsForeignObject>
   )
@@ -88,6 +94,21 @@ const WASTE_CHUTE_CONFIG_STYLE = css`
   &:hover {
     background-color: ${COLORS.grey1};
   }
+
+  &:focus-visible {
+    border: 3px solid ${COLORS.fundamentalsFocus};
+  }
+`
+
+const WASTE_CHUTE_CONFIG_STYLE_READ_ONLY = css`
+  display: ${DISPLAY_FLEX};
+  align-items: ${ALIGN_CENTER};
+  background-color: ${COLORS.grey2};
+  border-radius: ${BORDERS.borderRadiusSize1};
+  color: ${COLORS.white};
+  justify-content: ${JUSTIFY_CENTER};
+  grid-gap: ${SPACING.spacing8};
+  width: 100%;
 
   &:focus-visible {
     border: 3px solid ${COLORS.fundamentalsFocus};

--- a/components/src/hardware-sim/DeckConfigurator/WasteChuteConfigFixture.tsx
+++ b/components/src/hardware-sim/DeckConfigurator/WasteChuteConfigFixture.tsx
@@ -56,7 +56,7 @@ export function WasteChuteConfigFixture(
       <Btn
         css={
           handleClickRemove != null
-            ? WASTE_CHUTE_CONFIG_STYLE
+            ? WASTE_CHUTE_CONFIG_STYLE_EDITABLE
             : WASTE_CHUTE_CONFIG_STYLE_READ_ONLY
         }
         cursor={handleClickRemove != null ? 'pointer' : 'default'}
@@ -77,29 +77,6 @@ export function WasteChuteConfigFixture(
   )
 }
 
-const WASTE_CHUTE_CONFIG_STYLE = css`
-  display: ${DISPLAY_FLEX};
-  align-items: ${ALIGN_CENTER};
-  background-color: ${COLORS.grey2};
-  border-radius: ${BORDERS.borderRadiusSize1};
-  color: ${COLORS.white};
-  justify-content: ${JUSTIFY_CENTER};
-  grid-gap: ${SPACING.spacing8};
-  width: 100%;
-
-  &:active {
-    background-color: ${COLORS.darkBlack90};
-  }
-
-  &:hover {
-    background-color: ${COLORS.grey1};
-  }
-
-  &:focus-visible {
-    border: 3px solid ${COLORS.fundamentalsFocus};
-  }
-`
-
 const WASTE_CHUTE_CONFIG_STYLE_READ_ONLY = css`
   display: ${DISPLAY_FLEX};
   align-items: ${ALIGN_CENTER};
@@ -109,6 +86,18 @@ const WASTE_CHUTE_CONFIG_STYLE_READ_ONLY = css`
   justify-content: ${JUSTIFY_CENTER};
   grid-gap: ${SPACING.spacing8};
   width: 100%;
+`
+
+const WASTE_CHUTE_CONFIG_STYLE_EDITABLE = css`
+  ${WASTE_CHUTE_CONFIG_STYLE_READ_ONLY}
+
+  &:active {
+    background-color: ${COLORS.darkBlack90};
+  }
+
+  &:hover {
+    background-color: ${COLORS.grey1};
+  }
 
   &:focus-visible {
     border: 3px solid ${COLORS.fundamentalsFocus};


### PR DESCRIPTION
closes [RQA-1987](https://opentrons.atlassian.net/browse/RQA-1987)

# Overview

When deck configurator is read only (during protocol/maintenance run), any loaded deck fixtures
should show default cursor on hover, not show remove icon, and not be clickable

# Test Plan

- Configure Flex deck with various fixtures on DeviceDetails
- Begin a protocol or maintenance run
- Move mouse over loaded fixtures and observe default cursor, no remove icon, and unselectable fixtures


https://github.com/Opentrons/opentrons/assets/47604184/e5ebaaf2-08c8-4283-9141-668d0e5206d1



# Risk assessment

low

[RQA-1987]: https://opentrons.atlassian.net/browse/RQA-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ