### PR TITLE
feat(hardware-control): disengage 96-channel and gripper z after retract

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1305,9 +1305,25 @@ class OT3API(
         (and :py:attr:`_last_moved_mount` exists) then retract the mount
         in :py:attr:`_last_moved_mount`. Also unconditionally update
         :py:attr:`_last_moved_mount` to contain `mount`.
+
+        Disengage the 96-channel and gripper mount if retracted.
         """
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
+
+            # disengage Axis.Q motor and engage the brake to lower power
+            # consumption and reduce the chance of the 96-channel pipette dropping
+            if (
+                self.gantry_load == GantryLoad.HIGH_THROUGHPUT
+                and self._last_moved_mount == OT3Mount.LEFT
+            ):
+                await self.disengage_axes([Axis.Z_L])
+
+            # disegnage Axis.Z_G when we can to reduce the chance of
+            # the gripper dropping
+            if self._last_moved_mount == OT3Mount.GRIPPER:
+                await self.disengage_axes([Axis.Z_G])
+
         if mount != OT3Mount.GRIPPER:
             await self.idle_gripper()
         self._last_moved_mount = mount

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1311,7 +1311,7 @@ class OT3API(
         if mount != self._last_moved_mount and self._last_moved_mount:
             await self.retract(self._last_moved_mount, 10)
 
-            # disengage Axis.Q motor and engage the brake to lower power
+            # disengage Axis.Z_L motor and engage the brake to lower power
             # consumption and reduce the chance of the 96-channel pipette dropping
             if (
                 self.gantry_load == GantryLoad.HIGH_THROUGHPUT


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We should disengage the 96-channel pipette mount and the gripper mount motor whenever they're not active. This helps reduce current consumption and lower the chances of them dropping due to noise.

Note: This only affect the `_cache_and_maybe_retract` func in the hardware control API, this means you would only see this change if `ot3api.move_to()/move_rel()` is used.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Make sure protocols with a 96-channel pipette and a gripper still work like normal