### PR TITLE
fix(app): filter lpc labware combos by single slot

### DIFF
--- a/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
+++ b/app/src/organisms/ApplyHistoricOffsets/hooks/getLabwareLocationCombos.ts
@@ -1,6 +1,11 @@
 import isEqual from 'lodash/isEqual'
-import { getLabwareDefURI } from '@opentrons/shared-data'
+import {
+  FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
+  getLabwareDefURI,
+  OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
 import type {
+  AddressableAreaName,
   ProtocolAnalysisOutput,
   RunTimeCommand,
 } from '@opentrons/shared-data'
@@ -18,114 +23,126 @@ export function getLabwareLocationCombos(
   labware: ProtocolAnalysisOutput['labware'],
   modules: ProtocolAnalysisOutput['modules']
 ): LabwareLocationCombo[] {
-  return commands.reduce<LabwareLocationCombo[]>((acc, command) => {
-    if (command.commandType === 'loadLabware') {
-      if (
-        command.result?.definition == null ||
-        command.result.definition.parameters.format === 'trash'
-      )
-        return acc
-      const definitionUri = getLabwareDefURI(command.result.definition)
-      if (command.params.location === 'offDeck') {
-        return acc
-      } else if ('moduleId' in command.params.location) {
-        const { moduleId } = command.params.location
-        const modLocation = resolveModuleLocation(modules, moduleId)
-        return modLocation == null
-          ? acc
-          : appendLocationComboIfUniq(acc, {
-              location: modLocation,
-              definitionUri,
-              labwareId: command.result.labwareId,
-              moduleId,
-            })
-      } else if ('labwareId' in command.params.location) {
-        const {
-          adapterOffsetLocation,
-          moduleIdUnderAdapter,
-        } = resolveAdapterLocation(
-          labware,
-          modules,
-          command.params.location.labwareId
+  return commands
+    .reduce<LabwareLocationCombo[]>((acc, command) => {
+      if (command.commandType === 'loadLabware') {
+        if (
+          command.result?.definition == null ||
+          command.result.definition.parameters.format === 'trash'
         )
-        return adapterOffsetLocation == null
-          ? acc
-          : appendLocationComboIfUniq(acc, {
-              location: adapterOffsetLocation,
-              definitionUri,
-              labwareId: command.result.labwareId,
-              moduleId: moduleIdUnderAdapter,
-              adapterId: command.params.location.labwareId,
-            })
+          return acc
+        const definitionUri = getLabwareDefURI(command.result.definition)
+        if (command.params.location === 'offDeck') {
+          return acc
+        } else if ('moduleId' in command.params.location) {
+          const { moduleId } = command.params.location
+          const modLocation = resolveModuleLocation(modules, moduleId)
+          return modLocation == null
+            ? acc
+            : appendLocationComboIfUniq(acc, {
+                location: modLocation,
+                definitionUri,
+                labwareId: command.result.labwareId,
+                moduleId,
+              })
+        } else if ('labwareId' in command.params.location) {
+          const {
+            adapterOffsetLocation,
+            moduleIdUnderAdapter,
+          } = resolveAdapterLocation(
+            labware,
+            modules,
+            command.params.location.labwareId
+          )
+          return adapterOffsetLocation == null
+            ? acc
+            : appendLocationComboIfUniq(acc, {
+                location: adapterOffsetLocation,
+                definitionUri,
+                labwareId: command.result.labwareId,
+                moduleId: moduleIdUnderAdapter,
+                adapterId: command.params.location.labwareId,
+              })
+        } else {
+          return appendLocationComboIfUniq(acc, {
+            location: {
+              slotName:
+                'addressableAreaName' in command.params.location
+                  ? command.params.location.addressableAreaName
+                  : command.params.location.slotName,
+            },
+            definitionUri,
+            labwareId: command.result.labwareId,
+          })
+        }
+      } else if (command.commandType === 'moveLabware') {
+        const labwareEntity = labware.find(
+          l => l.id === command.params.labwareId
+        )
+        if (labwareEntity == null) {
+          console.warn(
+            'moveLabware command specified a labwareId that could not be found in the labware entities'
+          )
+          return acc
+        }
+        if (command.params.newLocation === 'offDeck') {
+          return acc
+        } else if ('moduleId' in command.params.newLocation) {
+          const modLocation = resolveModuleLocation(
+            modules,
+            command.params.newLocation.moduleId
+          )
+          return modLocation == null
+            ? acc
+            : appendLocationComboIfUniq(acc, {
+                location: modLocation,
+                definitionUri: labwareEntity.definitionUri,
+                labwareId: command.params.labwareId,
+                moduleId: command.params.newLocation.moduleId,
+              })
+        } else if ('labwareId' in command.params.newLocation) {
+          const {
+            adapterOffsetLocation,
+            moduleIdUnderAdapter,
+          } = resolveAdapterLocation(
+            labware,
+            modules,
+            command.params.newLocation.labwareId
+          )
+          return adapterOffsetLocation == null
+            ? acc
+            : appendLocationComboIfUniq(acc, {
+                location: adapterOffsetLocation,
+                definitionUri: labwareEntity.definitionUri,
+                labwareId: command.params.labwareId,
+                moduleId: moduleIdUnderAdapter,
+                adapterId: command.params.newLocation.labwareId,
+              })
+        } else {
+          return appendLocationComboIfUniq(acc, {
+            location: {
+              slotName:
+                'addressableAreaName' in command.params.newLocation
+                  ? command.params.newLocation.addressableAreaName
+                  : command.params.newLocation.slotName,
+            },
+            definitionUri: labwareEntity.definitionUri,
+            labwareId: command.params.labwareId,
+          })
+        }
       } else {
-        return appendLocationComboIfUniq(acc, {
-          location: {
-            slotName:
-              'addressableAreaName' in command.params.location
-                ? command.params.location.addressableAreaName
-                : command.params.location.slotName,
-          },
-          definitionUri,
-          labwareId: command.result.labwareId,
-        })
-      }
-    } else if (command.commandType === 'moveLabware') {
-      const labwareEntity = labware.find(l => l.id === command.params.labwareId)
-      if (labwareEntity == null) {
-        console.warn(
-          'moveLabware command specified a labwareId that could not be found in the labware entities'
-        )
         return acc
       }
-      if (command.params.newLocation === 'offDeck') {
-        return acc
-      } else if ('moduleId' in command.params.newLocation) {
-        const modLocation = resolveModuleLocation(
-          modules,
-          command.params.newLocation.moduleId
+    }, [])
+    .filter(
+      ({ location }) =>
+        FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS.includes(
+          location.slotName as AddressableAreaName
+        ) ||
+        OT2_SINGLE_SLOT_ADDRESSABLE_AREAS.includes(
+          location.slotName as AddressableAreaName
         )
-        return modLocation == null
-          ? acc
-          : appendLocationComboIfUniq(acc, {
-              location: modLocation,
-              definitionUri: labwareEntity.definitionUri,
-              labwareId: command.params.labwareId,
-              moduleId: command.params.newLocation.moduleId,
-            })
-      } else if ('labwareId' in command.params.newLocation) {
-        const {
-          adapterOffsetLocation,
-          moduleIdUnderAdapter,
-        } = resolveAdapterLocation(
-          labware,
-          modules,
-          command.params.newLocation.labwareId
-        )
-        return adapterOffsetLocation == null
-          ? acc
-          : appendLocationComboIfUniq(acc, {
-              location: adapterOffsetLocation,
-              definitionUri: labwareEntity.definitionUri,
-              labwareId: command.params.labwareId,
-              moduleId: moduleIdUnderAdapter,
-              adapterId: command.params.newLocation.labwareId,
-            })
-      } else {
-        return appendLocationComboIfUniq(acc, {
-          location: {
-            slotName:
-              'addressableAreaName' in command.params.newLocation
-                ? command.params.newLocation.addressableAreaName
-                : command.params.newLocation.slotName,
-          },
-          definitionUri: labwareEntity.definitionUri,
-          labwareId: command.params.labwareId,
-        })
-      }
-    } else {
-      return acc
-    }
-  }, [])
+    )
 }
 
 function appendLocationComboIfUniq(

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -255,6 +255,32 @@ export const NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA: '96ChannelWasteChu
 export const GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA: 'gripperWasteChute' =
   'gripperWasteChute'
 
+export const ADDRESSABLE_AREA_1: '1' = '1'
+export const ADDRESSABLE_AREA_2: '2' = '2'
+export const ADDRESSABLE_AREA_3: '3' = '3'
+export const ADDRESSABLE_AREA_4: '4' = '4'
+export const ADDRESSABLE_AREA_5: '5' = '5'
+export const ADDRESSABLE_AREA_6: '6' = '6'
+export const ADDRESSABLE_AREA_7: '7' = '7'
+export const ADDRESSABLE_AREA_8: '8' = '8'
+export const ADDRESSABLE_AREA_9: '9' = '9'
+export const ADDRESSABLE_AREA_10: '10' = '10'
+export const ADDRESSABLE_AREA_11: '11' = '11'
+
+export const OT2_SINGLE_SLOT_ADDRESSABLE_AREAS: AddressableAreaName[] = [
+  ADDRESSABLE_AREA_1,
+  ADDRESSABLE_AREA_2,
+  ADDRESSABLE_AREA_3,
+  ADDRESSABLE_AREA_4,
+  ADDRESSABLE_AREA_5,
+  ADDRESSABLE_AREA_6,
+  ADDRESSABLE_AREA_7,
+  ADDRESSABLE_AREA_8,
+  ADDRESSABLE_AREA_9,
+  ADDRESSABLE_AREA_10,
+  ADDRESSABLE_AREA_11,
+]
+
 export const FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS: AddressableAreaName[] = [
   A1_ADDRESSABLE_AREA,
   A2_ADDRESSABLE_AREA,


### PR DESCRIPTION
# Overview

filters the labware location combos generated by `getLabwareLocationCombos` by Flex or OT-2 single slot addressable area name, to exclude labware in staging area slots as LPC options

closes RQA-1989

# Test Plan

# Changelog

 -  Filters lpc labware combos by single slot

# Review requests

check LPC on Flex and OT-2 - labware in staging area slots should not be available. confirm nothing else is broken

# Risk assessment

low
