### PR TITLE
fix(app): make button cta text the same across odd and app

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -42,7 +42,6 @@
   "configured": "configured",
   "confirm_heater_shaker_module_modal_description": "Before the run begins, module should have both anchors fully extended for a firm attachment. The thermal adapter should be attached to the module. ",
   "confirm_heater_shaker_module_modal_title": "Confirm Heater-Shaker Module is attached",
-  "confirm_removal": "Confirm removal",
   "connect_all_hardware": "Connect and calibrate all hardware first",
   "connect_all_mod": "Connect all modules first",
   "connection_info_not_available": "Connection info not available once run has started",

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
@@ -185,7 +185,7 @@ export const LocationConflictModal = (
               />
               <SmallButton
                 onClick={handleUpdateDeck}
-                buttonText={i18n.format(t('confirm_removal'), 'capitalize')}
+                buttonText={i18n.format(t('update_deck'), 'capitalize')}
                 width="100%"
               />
             </Flex>
@@ -282,9 +282,7 @@ export const LocationConflictModal = (
                 {i18n.format(t('shared:cancel'), 'capitalize')}
               </SecondaryButton>
               <PrimaryButton onClick={handleUpdateDeck}>
-                {requiredModule != null
-                  ? t('confirm_removal')
-                  : t('update_deck')}
+                {t('update_deck')}
               </PrimaryButton>
             </Flex>
           </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/LocationConflictModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/LocationConflictModal.test.tsx
@@ -75,7 +75,7 @@ describe('LocationConflictModal', () => {
     getByText('Heater-Shaker Module GEN1')
     getByRole('button', { name: 'Cancel' }).click()
     expect(props.onCloseClick).toHaveBeenCalled()
-    getByRole('button', { name: 'Confirm removal' }).click()
+    getByRole('button', { name: 'Update deck' }).click()
     expect(mockUpdate).toHaveBeenCalled()
   })
   it('should render correct info for a odd', () => {
@@ -92,7 +92,7 @@ describe('LocationConflictModal', () => {
     getByText('Trash bin')
     getByText('Cancel').click()
     expect(props.onCloseClick).toHaveBeenCalled()
-    getByText('Confirm removal').click()
+    getByText('Update deck').click()
     expect(mockUpdate).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
closes RQA-2010

# Overview

Fixes the button for updating a deck fixture so the text is the same between ODD and app

# Test Plan

Look at the location conflict modal when there is a fixture conflict on ODD and app and see that the confirm button text says "update deck" for both.

# Changelog

- update the button text to say `update deck` only for both cases, and remove the branching logic for the app button
- fix test
- remove now unused i18n string

# Review requests

see test plan

# Risk assessment

low