### PR TITLE
fix(app): add deck config query refetch interval

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -38,6 +38,7 @@ import { useRunStatuses } from '../Devices/hooks'
 
 import type { CutoutId } from '@opentrons/shared-data'
 
+const DECK_CONFIG_REFETCH_INTERVAL = 5000
 const RUN_REFETCH_INTERVAL = 5000
 
 interface DeviceDetailsDeckConfigurationProps {
@@ -59,7 +60,9 @@ export function DeviceDetailsDeckConfiguration({
     null
   )
 
-  const deckConfig = useDeckConfigurationQuery().data ?? []
+  const deckConfig =
+    useDeckConfigurationQuery({ refetchInterval: DECK_CONFIG_REFETCH_INTERVAL })
+      .data ?? []
   const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
   const { isRunRunning } = useRunStatuses()
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({

--- a/app/src/organisms/Devices/hooks/useModuleRenderInfoForProtocolById.ts
+++ b/app/src/organisms/Devices/hooks/useModuleRenderInfoForProtocolById.ts
@@ -25,11 +25,15 @@ export interface ModuleRenderInfoById {
   [moduleId: string]: ModuleRenderInfoForProtocol
 }
 
+const DECK_CONFIG_REFETCH_INTERVAL = 5000
+
 export function useModuleRenderInfoForProtocolById(
   runId: string
 ): ModuleRenderInfoById {
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
-  const { data: deckConfig } = useDeckConfigurationQuery()
+  const { data: deckConfig } = useDeckConfigurationQuery({
+    refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
+  })
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const protocolAnalysis = robotProtocolAnalysis ?? storedProtocolAnalysis
   const attachedModules = useAttachedModules()

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -69,6 +69,7 @@ import type { ProtocolCalibrationStatus } from '../../organisms/Devices/hooks'
 import type { AttachedProtocolModuleMatch } from './utils'
 
 const ATTACHED_MODULE_POLL_MS = 5000
+const DECK_CONFIG_REFETCH_INTERVAL = 5000
 
 interface RenderModuleStatusProps {
   isModuleReady: boolean
@@ -340,7 +341,9 @@ export function ProtocolSetupModulesAndDeck({
     prepCommandErrorMessage,
     setPrepCommandErrorMessage,
   ] = React.useState<string>('')
-  const { data: deckConfig } = useDeckConfigurationQuery()
+  const { data: deckConfig } = useDeckConfigurationQuery({
+    refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
+  })
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
 
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)

--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -62,6 +62,8 @@ export type ProtocolHardware =
   | ProtocolGripper
   | ProtocolFixture
 
+const DECK_CONFIG_REFETCH_INTERVAL = 5000
+
 export const useRequiredProtocolHardwareFromAnalysis = (
   analysis: CompletedProtocolAnalysis | null
 ): { requiredProtocolHardware: ProtocolHardware[]; isLoading: boolean } => {
@@ -79,7 +81,9 @@ export const useRequiredProtocolHardwareFromAnalysis = (
 
   const robotType = FLEX_ROBOT_TYPE
   const deckDef = getDeckDefFromRobotType(robotType)
-  const { data: deckConfig = [] } = useDeckConfigurationQuery()
+  const { data: deckConfig = [] } = useDeckConfigurationQuery({
+    refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
+  })
   const deckConfigCompatibility = useDeckConfigurationCompatibility(
     robotType,
     analysis

--- a/app/src/resources/deck_configuration/hooks.ts
+++ b/app/src/resources/deck_configuration/hooks.ts
@@ -15,6 +15,8 @@ import type {
   RobotType,
 } from '@opentrons/shared-data'
 
+const DECK_CONFIG_REFETCH_INTERVAL = 5000
+
 export interface CutoutConfigAndCompatibility extends CutoutConfigProtocolSpec {
   compatibleCutoutFixtureIds: CutoutFixtureId[]
 }
@@ -22,7 +24,9 @@ export function useDeckConfigurationCompatibility(
   robotType: RobotType,
   protocolAnalysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput | null
 ): CutoutConfigAndCompatibility[] {
-  const deckConfig = useDeckConfigurationQuery().data ?? []
+  const deckConfig =
+    useDeckConfigurationQuery({ refetchInterval: DECK_CONFIG_REFETCH_INTERVAL })
+      .data ?? []
   if (robotType !== FLEX_ROBOT_TYPE) return []
   const deckDef = getDeckDefFromRobotType(robotType)
   const allAddressableAreas =


### PR DESCRIPTION
# Overview

refetches the deck config on a 5 second interval on the device details page and in hooks that determine location conflicts

closes RQA-1993

# Test Plan

# Changelog

 - Adds deck config query polling

# Review requests

confirm that the deck config updates within 5 seconds when updated by another client

# Risk assessment

low
