### PR TITLE
refactor(step-generation): fix merge back error in replaceTip

### DIFF
--- a/step-generation/src/commandCreators/atomic/replaceTip.ts
+++ b/step-generation/src/commandCreators/atomic/replaceTip.ts
@@ -215,7 +215,6 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
     }
   }
 
-  const channels = pipetteSpec.channels
   const addressableAreaNameWasteChute = getWasteChuteAddressableAreaNamePip(
     channels
   )


### PR DESCRIPTION
# Overview

Fix merge back error. There was a duplicate `channels` const in the `replaceTip` component

# Test Plan

make sure CI passes

# Changelog


# Review requests

# Risk assessment

