### PR TITLE
feat(app): add deck config option to device reset

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -34,7 +34,7 @@
   "choose_reset_settings": "Choose reset settings",
   "clear_all_data": "Clear all data",
   "clear_all_stored_data": "Clear all stored data",
-  "clear_all_stored_data_description": "Resets all settings. You’ll have to redo initial setup before using the robot again.",
+  "clear_all_stored_data_description": "Clears calibrations, protocols, and all settings except robot name and network settings.",
   "clear_calibration_data": "Clear calibration data",
   "clear_data_and_restart_robot": "Clear data and restart robot",
   "clear_individual_data": "Clear individual data",

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/DeviceResetSlideout.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/__tests__/DeviceResetSlideout.test.tsx
@@ -120,7 +120,7 @@ describe('RobotSettings DeviceResetSlideout', () => {
     const [{ getByText, getByRole, queryByRole, queryByText }] = render()
     getByText('Clear all data')
     getByText(
-      'Resets all settings. You’ll have to redo initial setup before using the robot again.'
+      'Clears calibrations, protocols, and all settings except robot name and network settings.'
     )
     expect(queryByText('Clear deck calibration')).toBeNull()
     getByText('Clear pipette calibration')

--- a/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
@@ -177,8 +177,6 @@ export function DeviceReset({
     }
   }, [resetOptions])
 
-  console.log(resetOptions)
-
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       {showConfirmationModal && (

--- a/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/DeviceReset.tsx
@@ -73,7 +73,10 @@ export function DeviceReset({
   const availableOptions = options
     // filtering out ODD setting because this gets implicitly cleared if all settings are selected
     // filtering out boot scripts since product doesn't want this exposed to ODD users
-    .filter(({ id }) => !['onDeviceDisplay', 'bootScripts'].includes(id))
+    .filter(
+      ({ id }) =>
+        !['onDeviceDisplay', 'bootScripts', 'deckConfiguration'].includes(id)
+    )
     .sort(
       (a, b) =>
         targetOptionsOrder.indexOf(a.id) - targetOptionsOrder.indexOf(b.id)
@@ -145,12 +148,15 @@ export function DeviceReset({
   React.useEffect(() => {
     if (
       isEveryOptionSelected(resetOptions) &&
-      (!resetOptions.authorizedKeys || !resetOptions.onDeviceDisplay)
+      (!resetOptions.authorizedKeys ||
+        !resetOptions.onDeviceDisplay ||
+        !resetOptions.deckConfiguration)
     ) {
       setResetOptions({
         ...resetOptions,
         authorizedKeys: true,
         onDeviceDisplay: true,
+        deckConfiguration: true,
       })
     }
   }, [resetOptions])
@@ -159,15 +165,19 @@ export function DeviceReset({
     if (
       !isEveryOptionSelected(resetOptions) &&
       resetOptions.authorizedKeys &&
-      resetOptions.onDeviceDisplay
+      resetOptions.onDeviceDisplay &&
+      resetOptions.deckConfiguration
     ) {
       setResetOptions({
         ...resetOptions,
         authorizedKeys: false,
         onDeviceDisplay: false,
+        deckConfiguration: false,
       })
     }
   }, [resetOptions])
+
+  console.log(resetOptions)
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>

--- a/app/src/organisms/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/__tests__/DeviceReset.test.tsx
@@ -89,7 +89,7 @@ describe('DeviceReset', () => {
     getByText('Clears information about past runs of all protocols.')
     getByText('Clear all stored data')
     getByText(
-      'Resets all settings. You’ll have to redo initial setup before using the robot again.'
+      'Clears calibrations, protocols, and all settings except robot name and network settings.'
     )
     expect(queryByText('Clear the ssh authorized keys')).not.toBeInTheDocument()
     expect(getByTestId('DeviceReset_clear_data_button')).toBeDisabled()
@@ -128,6 +128,7 @@ describe('DeviceReset', () => {
       gripperOffsetCalibrations: true,
       authorizedKeys: true,
       onDeviceDisplay: true,
+      deckConfiguration: true,
     }
 
     const [{ getByText }] = render(props)
@@ -149,6 +150,7 @@ describe('DeviceReset', () => {
       gripperOffsetCalibrations: true,
       authorizedKeys: true,
       onDeviceDisplay: true,
+      deckConfiguration: true,
     }
 
     const [{ getByText }] = render(props)
@@ -173,6 +175,7 @@ describe('DeviceReset', () => {
       gripperOffsetCalibrations: true,
       authorizedKeys: false,
       onDeviceDisplay: false,
+      deckConfiguration: false,
     }
 
     const [{ getByText }] = render(props)


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add a new reset option, deck configuration to desktop and odd. 
This pr will fix odd device reset screen's UI issue.

For deck configuration reset, the design team decided to include that option into all stored data only. We don't need to add a new checkbox for deck configuration which means no design changes in this PR. In terms of the text of all stored data, Ed updated the text. All information is the following Slack thread.
https://opentrons.slack.com/archives/CSCLVUW3C/p1701889363390079
The text update got approval from Ed. 

[before]
![Screenshot 2023-12-06 at 1 51 11 PM](https://github.com/Opentrons/opentrons/assets/474225/08d1db99-e8ee-4393-b26b-999a777cf9e4)


[after]
![Screenshot 2023-12-07 at 11 09 34 AM](https://github.com/Opentrons/opentrons/assets/474225/0a2b502d-8692-41dd-b78b-13e05e6c4ba2)

close RAUT-895
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. update deck configuration on Desktop App/ODD
2. check the endpoint `/deck_configuration` and `lastModifiedAt` is updated

[Desktop]
go to Robot Settings on Desktop App and check clear all stored data.
then check the endpoint. 

[ODD]
go to Robot Settings on ODD App and check clear all stored data.
then check the endpoint.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update DeviceReset component and its test
- update DeviceReset Slideout component and its test
- update the text for clear all stored data
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
