### PR TITLE
docs(api): more partial tip pickup docstrings

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1818,11 +1818,12 @@ class InstrumentContext(publisher.CommandPublisher):
             should be of the same format used when identifying wells by name. 
             Required unless setting ``style=ALL``. 
 
-            .. warning::
-                Currently, when using the ``COLUMN`` layout, you *must* set
-                ``start="A12"``. Using any other value will cause the pipette to move to
-                unexpected locations, pick up incorrect tips, or crash into items on the
-                deck.
+            .. note::
+                When using the ``COLUMN`` layout, the only fully supported value is
+                ``start="A12"``. You can use ``start="A1"``, but this will disable tip
+                tracking and you will have to specify the ``location`` every time you
+                call :py:meth:`.pick_up_tip`, such that the pipette picks up columns of
+                tips *from right to left* on the tip rack.
 
         :type start: str or ``None``
         :param tip_racks: Behaves the same as setting the ``tip_racks`` parameter of

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1816,23 +1816,13 @@ class InstrumentContext(publisher.CommandPublisher):
             to determine how it will move to different locations on the deck. The string
             should be of the same format used when identifying wells by name. Use
             ``"A1"`` to have the pipette use its leftmost nozzles to pick up tips
-            *left-to-right* from a tip rack. Use ``"A12"`` to have the pipette use its
-            rightmost nozzles to pick up tips *right-to-left* from a tip rack.
+            *right-to-left* from a tip rack. Use ``"A12"`` to have the pipette use its
+            rightmost nozzles to pick up tips *left-to-right* from a tip rack.
         :type start: str or ``None``
         :param tip_racks: Behaves the same as setting the ``tip_racks`` parameter of
-            :py:meth:`.load_instrument`. If not specified,
-            :py:obj:`.InstrumentContext.tip_racks` will be reset to ``None`` and you
-            must specify the location every time you call
-            :py:meth:`~.InstrumentContext.pick_up_tip`.
-
-            To keep the same list of tip racks when changing configurations, reference
-            the same instrument's existing ``tip_racks`` parameter::
-
-                pipette.configure_nozzle_layout(
-                    style=COLUMN,
-                    tip_racks=pipette.tip_racks
-                )
-
+            :py:meth:`.load_instrument`. If not specified, the new configuration resets
+            :py:obj:`.InstrumentContext.tip_racks` and you must specify the location
+            every time you call :py:meth:`~.InstrumentContext.pick_up_tip`.
         :type tip_racks: List[:py:class:`.Labware`]
         """
         #       TODO: add the following back into the docstring when QUADRANT is supported

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1802,22 +1802,28 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. note::
             When picking up fewer than 96 tips at once, the tip rack *must not* be
-            placed in a tip rack adapter in the deck. If you try to perform partial tip
-            pickup on a tip rack that is in an adapter, the API will raise an error.
+            placed in a tip rack adapter in the deck. If you try to pick up fewer than 96
+            tips from a tip rack that is in an adapter, the API will raise an error.
 
         :param style: The shape of the nozzle layout.
 
             - ``COLUMN`` sets the pipette to use 8 nozzles, aligned from front to back
               with respect to the deck. This corresponds to a column of wells on labware.
-            - ``ALL`` resets the pipette to use all of its nozzles. Calling ``configure_nozzle_layout`` with no arguments also resets the pipette.
+            - ``ALL`` resets the pipette to use all of its nozzles. Calling
+              ``configure_nozzle_layout`` with no arguments also resets the pipette.
 
         :type style: ``NozzleLayout`` or ``None``
         :param start: The nozzle at the back left of the layout, which the robot uses
             to determine how it will move to different locations on the deck. The string
-            should be of the same format used when identifying wells by name. Use
-            ``"A1"`` to have the pipette use its leftmost nozzles to pick up tips
-            *right-to-left* from a tip rack. Use ``"A12"`` to have the pipette use its
-            rightmost nozzles to pick up tips *left-to-right* from a tip rack.
+            should be of the same format used when identifying wells by name. 
+            Required unless setting ``style=ALL``. 
+
+            .. warning::
+                Currently, when using the ``COLUMN`` layout, you *must* set
+                ``start="A12"``. Using any other value will cause the pipette to move to
+                unexpected locations, pick up incorrect tips, or crash into items on the
+                deck.
+
         :type start: str or ``None``
         :param tip_racks: Behaves the same as setting the ``tip_racks`` parameter of
             :py:meth:`.load_instrument`. If not specified, the new configuration resets

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1636,7 +1636,11 @@ class InstrumentContext(publisher.CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 16)
     def active_channels(self) -> int:
-        """The number of channels configured for active use using configure_nozzle_layout()."""
+        """The number of channels the pipette will use to pick up tips.
+
+        By default, all channels on the pipette. Use :py:meth:`.configure_nozzle_layout`
+        to set the pipette to use fewer channels.
+        """
         return self._core.get_active_channels()
 
     @property  # type: ignore
@@ -1815,7 +1819,21 @@ class InstrumentContext(publisher.CommandPublisher):
             *left-to-right* from a tip rack. Use ``"A12"`` to have the pipette use its
             rightmost nozzles to pick up tips *right-to-left* from a tip rack.
         :type start: str or ``None``
-        :param tip_racks: List of tip racks to use during this configuration.
+        :param tip_racks: Behaves the same as setting the ``tip_racks`` parameter of
+            :py:meth:`.load_instrument`. If not specified,
+            :py:obj:`.InstrumentContext.tip_racks` will be reset to ``None`` and you
+            must specify the location every time you call
+            :py:meth:`~.InstrumentContext.pick_up_tip`.
+
+            To keep the same list of tip racks when changing configurations, reference
+            the same instrument's existing ``tip_racks`` parameter::
+
+                pipette.configure_nozzle_layout(
+                    style=COLUMN,
+                    tip_racks=pipette.tip_racks
+                )
+
+        :type tip_racks: List[:py:class:`.Labware`]
         """
         #       TODO: add the following back into the docstring when QUADRANT is supported
         #

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1815,8 +1815,8 @@ class InstrumentContext(publisher.CommandPublisher):
         :type style: ``NozzleLayout`` or ``None``
         :param start: The nozzle at the back left of the layout, which the robot uses
             to determine how it will move to different locations on the deck. The string
-            should be of the same format used when identifying wells by name. 
-            Required unless setting ``style=ALL``. 
+            should be of the same format used when identifying wells by name.
+            Required unless setting ``style=ALL``.
 
             .. note::
                 When using the ``COLUMN`` layout, the only fully supported value is


### PR DESCRIPTION


# Overview

Expand on the initial docstring for `configure_nozzle_layout` (#13997) to include the new tip-tracking behavior (#14104).

# Test Plan

Check the entries in the sandbox.
- [active channels](http://sandbox.docs.opentrons.com/docstring-partial-tip_racks/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.active_channels)
- [configure nozzle layout](http://sandbox.docs.opentrons.com/docstring-partial-tip_racks/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.configure_nozzle_layout)

# Changelog

- Explained behavior of `tip_rack` parameter, with reference to same parameter of `load_instrument`, based on conversation with @sanni-t.
- Expanded docstring for related `active_channels` property.

# Review requests

This is how it works, yeah?

# Risk assessment

nil, docstrings.