### PR TITLE
fix(api): Remove experimental `with_staging_area_slot_d4` parameter

### DIFF
--- a/api/src/opentrons/protocol_api/_waste_chute.py
+++ b/api/src/opentrons/protocol_api/_waste_chute.py
@@ -3,9 +3,3 @@ class WasteChute:
 
     See :py:obj:`ProtocolContext.load_waste_chute`.
     """
-
-    def __init__(
-        self,
-        with_staging_area_slot_d4: bool,
-    ) -> None:
-        self._with_staging_area_slot_d4 = with_staging_area_slot_d4

--- a/api/src/opentrons/protocol_api/_waste_chute_dimensions.py
+++ b/api/src/opentrons/protocol_api/_waste_chute_dimensions.py
@@ -1,18 +1,11 @@
 """Constants for the dimensions of the Flex waste chute.
 
-TODO: These should be moved into shared-data and interpreted by Protocol Engine.
+TODO: Delete this when we resolve https://opentrons.atlassian.net/browse/RSS-418.
 """
 
 
 from opentrons.types import Point
 
-
-SLOT_ORIGIN_TO_1_OR_8_TIP_A1 = Point(64, 21.91, 115)
-SLOT_ORIGIN_TO_96_TIP_A1 = Point(14.445, 42.085, 115)
-
 # TODO: This z-coord is misleading. We need to account for the labware height and the paddle height;
 # we can't define this as a single coordinate.
 SLOT_ORIGIN_TO_GRIPPER_JAW_CENTER = Point(64, 29, 136.5)
-
-# This is the same with or without the cover attached, since the cover is flush with the rim.
-ENVELOPE_HEIGHT = 125

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -471,8 +471,6 @@ class ProtocolContext(CommandPublisher):
     @requires_version(2, 16)
     def load_waste_chute(
         self,
-        *,
-        with_staging_area_slot_d4: bool = False,
     ) -> WasteChute:
         """Load the waste chute on the deck.
 
@@ -480,11 +478,7 @@ class ProtocolContext(CommandPublisher):
         load another item in slot D3 after loading the waste chute, or vice versa, the
         API will raise an error.
         """
-        if with_staging_area_slot_d4:
-            raise NotImplementedError(
-                "The waste chute staging area slot is not currently implemented."
-            )
-        waste_chute = WasteChute(with_staging_area_slot_d4=with_staging_area_slot_d4)
+        waste_chute = WasteChute()
         self._core.append_disposal_location(waste_chute)
         return waste_chute
 


### PR DESCRIPTION
# Overview

In #13828, I added a `with_staging_area_slot_d4` parameter to `ProtocolContext.load_waste_chute()`. We ended up not needing it. So, remove it from the public Python Protocol API.

# Test Plan

None needed.

# Changelog

* Remove the unused `with_staging_area_slot_d4` parameter from `ProtocolContext.load_waste_chute()`.
* Also remove some constants from `_waste_chute_dimensions` that are unused now that we're pulling those positions from `shared-data`.

# Review requests

None in particular.

# Risk assessment

No risk.
