### PR TITLE
fix(api): remove fixed trash restriction from PAPI deck conflict check

### DIFF
--- a/api/src/opentrons/motion_planning/deck_conflict.py
+++ b/api/src/opentrons/motion_planning/deck_conflict.py
@@ -146,21 +146,11 @@ class _NoHeaterShakerModule(NamedTuple):
         return not isinstance(item, HeaterShakerModule)
 
 
-class _FixedTrashOnly(NamedTuple):
-    """Only fixed-trash labware is allowed in this slot."""
-
-    location: DeckSlotName
-
-    def is_allowed(self, item: DeckItem) -> bool:
-        return _is_fixed_trash(item)
-
-
 _DeckRestriction = Union[
     _NothingAllowed,
     _MaxHeight,
     _NoModule,
     _NoHeaterShakerModule,
-    _FixedTrashOnly,
 ]
 """A restriction on what is allowed in a given slot."""
 
@@ -189,11 +179,7 @@ def check(
     Raises:
         DeckConflictError: Adding this item should not be allowed.
     """
-    restrictions: List[_DeckRestriction] = [
-        _FixedTrashOnly(
-            location=DeckSlotName.FIXED_TRASH.to_equivalent_for_robot_type(robot_type)
-        )
-    ]
+    restrictions: List[_DeckRestriction] = []
     # build restrictions driven by existing items
     for location, item in existing_items.items():
         restrictions += _create_restrictions(
@@ -333,10 +319,7 @@ def _create_deck_conflict_error_message(
         new_item is not None or existing_item is not None
     ), "Conflict error expects either new_item or existing_item"
 
-    if isinstance(restriction, _FixedTrashOnly):
-        message = f"Only fixed-trash is allowed in slot {restriction.location}"
-
-    elif new_item is not None:
+    if new_item is not None:
         message = (
             f"{restriction.source_item.name_for_errors}"
             f" in slot {restriction.source_location}"

--- a/api/tests/opentrons/motion_planning/test_deck_conflict.py
+++ b/api/tests/opentrons/motion_planning/test_deck_conflict.py
@@ -14,7 +14,11 @@ from opentrons.types import DeckSlotName
 
 @pytest.mark.parametrize(
     "robot_type, slot_name",
-    [("OT-2 Standard", DeckSlotName.SLOT_1), ("OT-3 Standard", DeckSlotName.SLOT_A1)],
+    [
+        ("OT-2 Standard", DeckSlotName.SLOT_1),
+        ("OT-3 Standard", DeckSlotName.SLOT_A1),
+        ("OT-3 Standard", DeckSlotName.SLOT_A3),
+    ],
 )
 def test_empty_no_conflict(robot_type: RobotType, slot_name: DeckSlotName) -> None:
     """It should not raise on empty input."""
@@ -48,124 +52,6 @@ def test_no_multiple_locations(robot_type: RobotType, slot_name: DeckSlotName) -
         deck_conflict.check(
             existing_items={slot_name: item_1},
             new_item=item_2,
-            new_location=slot_name,
-            robot_type=robot_type,
-        )
-
-
-@pytest.mark.parametrize(
-    "slot_name, robot_type",
-    [
-        (DeckSlotName.FIXED_TRASH, "OT-2 Standard"),
-        (DeckSlotName.SLOT_A3, "OT-3 Standard"),
-    ],
-)
-def test_only_trash_in_fixed_slot(
-    slot_name: DeckSlotName, robot_type: RobotType
-) -> None:
-    """It should only allow trash labware in slot 12."""
-    trash_labware = deck_conflict.Labware(
-        uri=LabwareUri("trash_labware_uri"),
-        highest_z=123,
-        is_fixed_trash=True,
-        name_for_errors="trash_labware",
-    )
-    not_trash_labware = deck_conflict.Labware(
-        uri=LabwareUri("not_trash_labware_uri"),
-        highest_z=123,
-        is_fixed_trash=False,
-        name_for_errors="not_trash_labware",
-    )
-    not_trash_module = deck_conflict.OtherModule(
-        highest_z_including_labware=123, name_for_errors="not_trash_module"
-    )
-
-    deck_conflict.check(
-        existing_items={},
-        new_item=trash_labware,
-        new_location=slot_name,
-        robot_type=robot_type,
-    )
-
-    with pytest.raises(
-        deck_conflict.DeckConflictError,
-        match=f"Only fixed-trash is allowed in slot {slot_name}",
-    ):
-        deck_conflict.check(
-            existing_items={},
-            new_item=not_trash_labware,
-            new_location=slot_name,
-            robot_type=robot_type,
-        )
-
-    with pytest.raises(
-        deck_conflict.DeckConflictError,
-        match=f"Only fixed-trash is allowed in slot {slot_name}",
-    ):
-        deck_conflict.check(
-            existing_items={},
-            new_item=not_trash_module,
-            new_location=slot_name,
-            robot_type=robot_type,
-        )
-
-
-@pytest.mark.parametrize(
-    "slot_name, robot_type",
-    [
-        (DeckSlotName.FIXED_TRASH, "OT-2 Standard"),
-        (DeckSlotName.SLOT_A3, "OT-3 Standard"),
-    ],
-)
-def test_trash_override(slot_name: DeckSlotName, robot_type: RobotType) -> None:
-    """It should allow the trash labware to be replaced with another trash labware."""
-    trash_labware_1 = deck_conflict.Labware(
-        uri=LabwareUri("trash_labware_1_uri"),
-        highest_z=123,
-        is_fixed_trash=True,
-        name_for_errors="trash_labware_1",
-    )
-    trash_labware_2 = deck_conflict.Labware(
-        uri=LabwareUri("trash_labware_2_uri"),
-        highest_z=123,
-        is_fixed_trash=True,
-        name_for_errors="trash_labware_2",
-    )
-    not_trash_labware = deck_conflict.Labware(
-        uri=LabwareUri("not_trash_labware_uri"),
-        highest_z=123,
-        is_fixed_trash=False,
-        name_for_errors="not_trash_labware",
-    )
-    not_trash_module = deck_conflict.OtherModule(
-        highest_z_including_labware=123, name_for_errors="not_trash_module"
-    )
-
-    deck_conflict.check(
-        existing_items={slot_name: trash_labware_1},
-        new_item=trash_labware_2,
-        new_location=slot_name,
-        robot_type=robot_type,
-    )
-
-    with pytest.raises(
-        deck_conflict.DeckConflictError,
-        match=f"Only fixed-trash is allowed in slot {slot_name}",
-    ):
-        deck_conflict.check(
-            existing_items={slot_name: trash_labware_1},
-            new_item=not_trash_labware,
-            new_location=slot_name,
-            robot_type=robot_type,
-        )
-
-    with pytest.raises(
-        deck_conflict.DeckConflictError,
-        match=f"Only fixed-trash is allowed in slot {slot_name}",
-    ):
-        deck_conflict.check(
-            existing_items={slot_name: trash_labware_1},
-            new_item=not_trash_module,
             new_location=slot_name,
             robot_type=robot_type,
         )


### PR DESCRIPTION
# Overview

Fixes RQA-2015

This PR removes the restriction from PAPI based deck conflict checking that prevented labware and modules from being loaded into slot 12/A3. With deck configuration, a trash does not necessarily need to be in that slot, and addressable area engine logic will prevent a trash and the deck slot it exists in from being used in the same protocol.

This change is safe to make for older protocols as well, as the newly added engine based conflict checking will prevent labware or modules from being loaded where the fixed trash labware has been automatically loaded.

# Test Plan

Confirmed that the first protocol passes analysis and the second one correctly fails.

```
metadata = {
    'protocolName': 'Load on A3 Test',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.16"
}


def run(context):
    tiprack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'A3')
    
    waste = context.load_waste_chute()
    pipette = context.load_instrument('flex_1channel_1000', 'left', tip_racks=[tiprack])

    pipette.pick_up_tip()
    pipette.drop_tip()
```

```
metadata = {
    'protocolName': 'Load on A3 Test 2.15',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.15"
}


def run(context):
    # This line will raise an error since fixed trash labware has been automatically loaded here
    tiprack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'A3')
```

# Changelog

- Removed fixed trash restriction from PAPI deck conflict check

# Review requests

# Risk assessment

Low.