### PR TITLE
feat(protocol-designer): update the defaulted flowrates for blowout

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -3984,7 +3984,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3996,7 +3996,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4031,7 +4031,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4043,7 +4043,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4078,7 +4078,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4090,7 +4090,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "B1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4125,7 +4125,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4137,7 +4137,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "B1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4172,7 +4172,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4184,7 +4184,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "C1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4219,7 +4219,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4231,7 +4231,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "C1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4266,7 +4266,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4278,7 +4278,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "D1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4313,7 +4313,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4325,7 +4325,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "D1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4360,7 +4360,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4372,7 +4372,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "E1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4407,7 +4407,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4419,7 +4419,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "E1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4454,7 +4454,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4466,7 +4466,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "F1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4501,7 +4501,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4513,7 +4513,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "F1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4548,7 +4548,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4560,7 +4560,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "G1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4595,7 +4595,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4607,7 +4607,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "G1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4642,7 +4642,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4654,7 +4654,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "H1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4689,7 +4689,7 @@
         "labwareId": "a793a135-06aa-4ed6-a1d3-c176c7810afa:opentrons/opentrons_24_aluminumblock_nest_1.5ml_snapcap/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4701,7 +4701,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "H1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -4744,7 +4744,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 7.85
+        "flowRate": 35
       }
     },
     {
@@ -4756,7 +4756,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 7.85
+        "flowRate": 57
       }
     },
     {
@@ -4768,7 +4768,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 7.85
+        "flowRate": 35
       }
     },
     {
@@ -4780,7 +4780,7 @@
         "labwareId": "fcba73e7-b88e-438e-963e-f8b9a5de0983:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 7.85
+        "flowRate": 57
       }
     },
     {

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -3557,7 +3557,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3569,7 +3569,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3604,7 +3604,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3616,7 +3616,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "B1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3651,7 +3651,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3663,7 +3663,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "C1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3698,7 +3698,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3710,7 +3710,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "D1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3745,7 +3745,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3757,7 +3757,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "E1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3792,7 +3792,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3804,7 +3804,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "F1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3839,7 +3839,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3851,7 +3851,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "G1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3886,7 +3886,7 @@
         "labwareId": "8bacda22-9e05-45e8-bef4-cc04414a204f:opentrons/axygen_1_reservoir_90ml/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {
@@ -3898,7 +3898,7 @@
         "labwareId": "54370838-4fca-4a14-b88a-7840e4903649:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
         "wellName": "H1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 0.5 } },
-        "flowRate": 137.35
+        "flowRate": 478
       }
     },
     {

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3637,7 +3637,7 @@
       "key": "74eea806-cdc8-4f1b-b987-0f71f530ae13",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -3841,7 +3841,7 @@
       "key": "444ea927-757f-46ca-92d1-1bc5829b0f58",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -4045,7 +4045,7 @@
       "key": "601fa810-f65e-49a7-9ed5-fc2a4d94a72d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -4249,7 +4249,7 @@
       "key": "04cd26db-2bea-4782-b42c-0d64cd22f36c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -4453,7 +4453,7 @@
       "key": "8c424e40-a61a-4945-9aa3-38b4f83b4230",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -4657,7 +4657,7 @@
       "key": "314ea593-149e-456a-bc11-1b1d241eb609",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -4861,7 +4861,7 @@
       "key": "f76c6a5c-207e-43c9-9a41-c3c612aac0dc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -5065,7 +5065,7 @@
       "key": "f97aedb2-422c-45d8-a517-c2d2cb3ca441",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {
@@ -5269,7 +5269,7 @@
       "key": "7370cef2-4d30-48ac-93fd-c1e111acf0ff",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 10
+        "flowRate": 1000
       }
     },
     {

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -2321,7 +2321,7 @@
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 7.85
+        "flowRate": 6
       }
     },
     {
@@ -2339,7 +2339,7 @@
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
-        "flowRate": 7.85
+        "flowRate": 6
       }
     },
     {
@@ -2382,7 +2382,7 @@
         "labwareId": "fe1942b1-1b75-4d3a-9c12-d23004958a12:opentrons/biorad_96_wellplate_200ul_pcr/2",
         "wellName": "A7",
         "wellLocation": { "origin": "bottom", "offset": { "z": 1 } },
-        "flowRate": 7.85
+        "flowRate": 6
       }
     },
     {
@@ -2400,7 +2400,7 @@
       "params": {
         "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9",
         "volume": 10,
-        "flowRate": 7.85
+        "flowRate": 6
       }
     },
     {

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -86,6 +86,10 @@ export const toV8MigrationMessage: ModalContents = {
         next to them in the Protocol Timeline. To resolve the error, choose
         another location for aspirating or mixing.
       </p>
+      <p>
+        Additionally, we have addressed a bug where blow out speeds were slower
+        than expected.
+      </p>
       <p>As always, please contact us with any questions or feedback.</p>
     </div>
   ),

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -88,7 +88,8 @@ export const toV8MigrationMessage: ModalContents = {
       </p>
       <p>
         Additionally, we have addressed a bug where blow out speeds were slower
-        than expected.
+        than expected. Your protocol will automatically update the flow rates
+        unless they were specifically initialized.
       </p>
       <p>As always, please contact us with any questions or feedback.</p>
     </div>

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/mixFormToArgs.ts
@@ -55,7 +55,9 @@ export const mixFormToArgs = (
     ? hydratedFormData.blowout_location
     : null
   // Blowout settings
-  const blowoutFlowRateUlSec = dispenseFlowRateUlSec
+  const blowoutFlowRateUlSec =
+    hydratedFormData.dispense_flowRate ??
+    pipette.spec.defaultBlowOutFlowRate.value
   const blowoutOffsetFromTopMm = blowoutLocation
     ? DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP
     : 0

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/moveLiquidFormToArgs.ts
@@ -186,7 +186,7 @@ export const moveLiquidFormToArgs = (
     dispenseOffsetFromBottomMm:
       fields.dispense_mmFromBottom || DEFAULT_MM_FROM_BOTTOM_DISPENSE,
     blowoutFlowRateUlSec:
-      fields.dispense_flowRate || pipetteSpec.defaultDispenseFlowRate.value,
+      fields.dispense_flowRate || pipetteSpec.defaultBlowOutFlowRate.value,
     blowoutOffsetFromTopMm,
     changeTip: fields.changeTip,
     preWetTip: Boolean(fields.preWetTip),

--- a/shared-data/pipette/definitions/1/pipetteNameSpecs.json
+++ b/shared-data/pipette/definitions/1/pipetteNameSpecs.json
@@ -460,27 +460,30 @@
     "displayName": "Flex 1-Channel 50 μL",
     "displayCategory": "FLEX",
     "defaultAspirateFlowRate": {
-      "value": 7.85,
+      "value": 35,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 35
       }
     },
     "defaultDispenseFlowRate": {
-      "value": 7.85,
+      "value": 57,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 57
       }
     },
     "defaultBlowOutFlowRate": {
-      "value": 7.85,
+      "value": 57,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 57
       }
     },
     "channels": 1,
@@ -502,30 +505,33 @@
     "displayName": "Flex 1-Channel 1000 μL",
     "displayCategory": "FLEX",
     "defaultAspirateFlowRate": {
-      "value": 137.35,
+      "value": 478,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
         "2.0": 137.35,
-        "2.6": 274.7
+        "2.6": 274.7,
+        "2.14": 478
       }
     },
     "defaultDispenseFlowRate": {
-      "value": 137.35,
+      "value": 478,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
         "2.0": 137.35,
-        "2.6": 274.7
+        "2.6": 274.7,
+        "2.14": 478
       }
     },
     "defaultBlowOutFlowRate": {
-      "value": 137.35,
+      "value": 478,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
         "2.0": 137.35,
-        "2.6": 274.7
+        "2.6": 274.7,
+        "2.14": 478
       }
     },
     "channels": 1,
@@ -549,28 +555,31 @@
     "displayName": "Flex 8-Channel 1000 μL",
     "displayCategory": "FLEX",
     "defaultAspirateFlowRate": {
-      "value": 159.04,
+      "value": 478,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
         "2.0": 159.04,
-        "2.6": 159.04
+        "2.6": 159.04,
+        "2.14": 478
       }
     },
     "defaultDispenseFlowRate": {
-      "value": 159.04,
+      "value": 478,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 159.04
+        "2.0": 159.04,
+        "2.14": 478
       }
     },
     "defaultBlowOutFlowRate": {
-      "value": 78.52,
+      "value": 478,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 78.52
+        "2.0": 78.52,
+        "2.14": 478
       }
     },
     "channels": 8,
@@ -594,27 +603,30 @@
     "displayName": "Flex 8-Channel 50 μL",
     "displayCategory": "FLEX",
     "defaultAspirateFlowRate": {
-      "value": 7.85,
+      "value": 35,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 35
       }
     },
     "defaultDispenseFlowRate": {
-      "value": 7.85,
+      "value": 57,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 57
       }
     },
     "defaultBlowOutFlowRate": {
-      "value": 7.85,
+      "value": 57,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 57
       }
     },
     "channels": 8,
@@ -636,27 +648,30 @@
     "displayName": "Flex 96-Channel 1000 μL",
     "displayCategory": "GEN1",
     "defaultAspirateFlowRate": {
-      "value": 7.85,
+      "value": 6,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 6
       }
     },
     "defaultDispenseFlowRate": {
-      "value": 7.85,
+      "value": 6,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 6
       }
     },
     "defaultBlowOutFlowRate": {
-      "value": 7.85,
+      "value": 80,
       "min": 3,
       "max": 812,
       "valuesByApiLevel": {
-        "2.0": 7.85
+        "2.0": 7.85,
+        "2.14": 80
       }
     },
     "channels": 96,

--- a/shared-data/pipette/fixtures/name/pipetteNameSpecFixtures.json
+++ b/shared-data/pipette/fixtures/name/pipetteNameSpecFixtures.json
@@ -13,6 +13,11 @@
       "value": 10,
       "min": 0.001,
       "max": 50
+    },
+    "defaultBlowOutFlowRate": {
+      "value": 1000,
+      "min": 5,
+      "max": 1000
     }
   },
   "p10_multi": {
@@ -29,6 +34,11 @@
       "min": 0.001,
       "max": 50
     },
+    "defaultBlowOutFlowRate": {
+      "value": 1000,
+      "min": 5,
+      "max": 1000
+    },
     "channels": 8
   },
   "p50_single": {
@@ -42,6 +52,11 @@
       "value": 50,
       "min": 0.001,
       "max": 100
+    },
+    "defaultBlowOutFlowRate": {
+      "value": 3.78,
+      "min": 0.08,
+      "max": 24
     },
     "channels": 1,
     "minVolume": 5,
@@ -59,6 +74,11 @@
       "min": 0.001,
       "max": 100
     },
+    "defaultBlowOutFlowRate": {
+      "value": 1000,
+      "min": 5,
+      "max": 1000
+    },
     "channels": 8,
     "minVolume": 5,
     "maxVolume": 50
@@ -74,6 +94,11 @@
       "value": 300,
       "min": 0.001,
       "max": 600
+    },
+    "defaultBlowOutFlowRate": {
+      "value": 1000,
+      "min": 5,
+      "max": 1000
     },
     "channels": 1,
     "minVolume": 30,
@@ -91,6 +116,11 @@
       "min": 0.001,
       "max": 600
     },
+    "defaultBlowOutFlowRate": {
+      "value": 94,
+      "min": 1,
+      "max": 275
+    },
     "channels": 8,
     "minVolume": 30,
     "maxVolume": 300
@@ -107,6 +137,11 @@
       "min": 50,
       "max": 2000
     },
+    "defaultBlowOutFlowRate": {
+      "value": 1000,
+      "min": 5,
+      "max": 1000
+    },
     "channels": 1,
     "minVolume": 100,
     "maxVolume": 1000
@@ -120,6 +155,11 @@
     },
     "defaultDispenseFlowRate": {
       "value": 7.85,
+      "min": 3,
+      "max": 812
+    },
+    "defaultBlowOutFlowRate": {
+      "value": 80,
       "min": 3,
       "max": 812
     },

--- a/step-generation/src/__tests__/__snapshots__/fixtureGeneration.test.ts.snap
+++ b/step-generation/src/__tests__/__snapshots__/fixtureGeneration.test.ts.snap
@@ -9099,6 +9099,11 @@ Object {
           "min": 3,
           "value": 7.85,
         },
+        "defaultBlowOutFlowRate": Object {
+          "max": 812,
+          "min": 3,
+          "value": 80,
+        },
         "defaultDispenseFlowRate": Object {
           "max": 812,
           "min": 3,
@@ -10254,6 +10259,11 @@ Object {
           "min": 0.001,
           "value": 5,
         },
+        "defaultBlowOutFlowRate": Object {
+          "max": 1000,
+          "min": 5,
+          "value": 1000,
+        },
         "defaultDispenseFlowRate": Object {
           "max": 50,
           "min": 0.001,
@@ -11402,6 +11412,11 @@ Object {
           "max": 50,
           "min": 0.001,
           "value": 5,
+        },
+        "defaultBlowOutFlowRate": Object {
+          "max": 1000,
+          "min": 5,
+          "value": 1000,
         },
         "defaultDispenseFlowRate": Object {
           "max": 50,
@@ -12552,6 +12567,11 @@ Object {
           "min": 0.001,
           "value": 150,
         },
+        "defaultBlowOutFlowRate": Object {
+          "max": 275,
+          "min": 1,
+          "value": 94,
+        },
         "defaultDispenseFlowRate": Object {
           "max": 600,
           "min": 0.001,
@@ -13694,6 +13714,11 @@ Object {
           "max": 600,
           "min": 0.001,
           "value": 150,
+        },
+        "defaultBlowOutFlowRate": Object {
+          "max": 1000,
+          "min": 5,
+          "value": 1000,
         },
         "defaultDispenseFlowRate": Object {
           "max": 600,


### PR DESCRIPTION
# Overview

The flowrates in the mix and moveLiquid form for blow out were defaulted to the dispense flow rates which is incorrect since in most cases, the blowout rates are much higher.

# Test Plan

Just verify that the code looks good. Uploading an old protocol will migrate this information but I included a blurb about it in the migration modal.

FYI: i cherrypicked a few commits from this pr that was merged into the release branch. The PR was approved by Seth and Sanniti and updates the `pipetteNameSpecs` file: https://github.com/Opentrons/opentrons/pull/14137 The reason why i cherrypicked is so i don't have to merge the release branch back into edge again. But LMK if this is a bad idea and if i should do that merge back.


# Changelog

- fix logic to return blowout default instead of dispense default
- fix cypress test
- add migration text
- add on to fixture

# Review requests

see test plan

# Risk assessment

low