### PR TITLE
fix(app, api): expose failOnNotHomed parameter for save_position command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -26,6 +26,9 @@ class SavePositionParams(BaseModel):
         description="An optional ID to assign to this command instance. "
         "Auto-assigned if not defined.",
     )
+    failOnNotHomed: Optional[bool] = Field(
+        True, descrption="Require all axes to be homed before saving position."
+    )
 
 
 class SavePositionResult(BaseModel):
@@ -58,8 +61,11 @@ class SavePositionImplementation(
     async def execute(self, params: SavePositionParams) -> SavePositionResult:
         """Check the requested pipette's current position."""
         position_id = self._model_utils.ensure_id(params.positionId)
+        fail_on_not_homed = (
+            params.failOnNotHomed if params.failOnNotHomed is not None else True
+        )
         x, y, z = await self._gantry_mover.get_position(
-            pipette_id=params.pipetteId, fail_on_not_homed=True
+            pipette_id=params.pipetteId, fail_on_not_homed=fail_on_not_homed
         )
 
         return SavePositionResult(

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -35,10 +35,7 @@ async def test_save_position_implementation(
     subject = SavePositionImplementation(
         model_utils=mock_model_utils, gantry_mover=mock_gantry_mover
     )
-    params = SavePositionParams(
-        pipetteId="abc",
-        positionId="123",
-    )
+    params = SavePositionParams(pipetteId="abc", positionId="123", failOnNotHomed=True)
 
     decoy.when(mock_model_utils.ensure_id("123")).then_return("456")
 

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -292,6 +292,7 @@ export const DropTipWizardComponent = (
         commandType: 'savePosition' as const,
         params: {
           pipetteId: MANAGED_PIPETTE_ID,
+          failOnNotHomed: false,
         },
       },
     ]

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -507,6 +507,7 @@ stages:
                 status: succeeded
                 params:
                   pipetteId: pipetteId
+                  failOnNotHomed: true
                 result:
                   positionId: !anystr
                   position:
@@ -539,6 +540,7 @@ stages:
                 params:
                   pipetteId: pipetteId
                   positionId: positionId
+                  failOnNotHomed: true
                 result:
                   positionId: positionId
                   position:

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
@@ -542,6 +542,7 @@ stages:
                 status: succeeded
                 params:
                   pipetteId: pipetteId
+                  failOnNotHomed: true
                 result:
                   positionId: !anystr
                   position:
@@ -574,6 +575,7 @@ stages:
                 params:
                   pipetteId: pipetteId
                   positionId: positionId
+                  failOnNotHomed: true
                 result:
                   positionId: positionId
                   position:

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
@@ -539,6 +539,7 @@ stages:
                 status: succeeded
                 params:
                   pipetteId: pipetteId
+                  failOnNotHomed: true
                 result:
                   positionId: !anystr
                   position:
@@ -571,6 +572,7 @@ stages:
                 params:
                   pipetteId: pipetteId
                   positionId: positionId
+                  failOnNotHomed: true
                 result:
                   positionId: positionId
                   position:

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -2205,6 +2205,12 @@
           "title": "Positionid",
           "description": "An optional ID to assign to this command instance. Auto-assigned if not defined.",
           "type": "string"
+        },
+        "failOnNotHomed": {
+          "title": "Failonnothomed",
+          "default": true,
+          "descrption": "Require all axes to be homed before saving position.",
+          "type": "boolean"
         }
       },
       "required": ["pipetteId"]

--- a/shared-data/command/types/gantry.ts
+++ b/shared-data/command/types/gantry.ts
@@ -156,6 +156,7 @@ interface MoveRelativeParams {
 interface SavePositionParams {
   pipetteId: string // pipette to use in measurement
   positionId?: string // position ID, auto-assigned if left blank
+  failOnNotHomed?: boolean // Defaults to true if blank. Require every possible axis to be homed to save.
 }
 
 interface HomeParams {


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Drop tip flows require saving pipette positions without homing the plunger axis (we definitely do not want to home the plunger). The save_position command should optionally expose a failOnNotHomed parameter to prevent an error from being thrown when the plunger is not homed - the plunger position value is not stored in saved_position, anyway. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- [x]  Run the drop tip wizard flows on a pipette such as the P300 8-Channel GEN2 and confirm via Network tab that the save position response is successful. NOTE: Drop tip flows will work on the OT-2 without a deckmap, just click Move to Slot - there's a default position. 
- [x] Test the flows on a couple pipettes and Flex/OT-2 to confirm there aren't any unforeseen issues.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- The savePosition command now takes an optional failOnNotHomed boolean. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->