### PR TITLE
test(api): Add integration tests for new trash APIs

### DIFF
--- a/api/tests/opentrons/protocol_api_integration/__init__.py
+++ b/api/tests/opentrons/protocol_api_integration/__init__.py
@@ -1,0 +1,10 @@
+"""Integration tests for the Python Protocol API.
+
+These test the Python Protocol API from the point of view of the user's Python protocol.
+
+They do not make sure the robot would actually move to the right place--that is the job of
+other tests, such as g-code-testing.
+
+These are supplementary for Python Protocol API features that depend on nontrivial interaction
+between those layers.
+"""

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -32,7 +32,12 @@ import pytest
                 ),
             ],
         ),
-        ("2.16", "Flex", None),
+        pytest.param(
+            "2.16",
+            "Flex",
+            None,
+            marks=pytest.mark.ot3_only,  # Simulating a Flex protocol requires a Flex hardware API.
+        ),
     ],
 )
 def test_fixed_trash_presence(
@@ -63,6 +68,7 @@ def test_fixed_trash_presence(
         assert instrument.trash_container is protocol.fixed_trash
 
 
+@pytest.mark.ot3_only  # Simulating a Flex protocol requires a Flex hardware API.
 def test_trash_search() -> None:
     """Test the automatic trash search for protocols without a fixed trash."""
     protocol = simulate.get_protocol_api(version="2.16", robot_type="Flex")

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -1,0 +1,105 @@
+from opentrons import protocol_api, simulate
+
+from typing import Optional, Type
+from typing_extensions import Literal
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("version", "robot_type", "expected_trash_class"),
+    [
+        ("2.13", "OT-2", protocol_api.Labware),
+        ("2.14", "OT-2", protocol_api.Labware),
+        ("2.15", "OT-2", protocol_api.Labware),
+        ("2.15", "Flex", protocol_api.Labware),
+        pytest.param(
+            "2.16",
+            "OT-2",
+            protocol_api.TrashBin,
+            marks=pytest.mark.xfail(
+                strict=True, reason="https://opentrons.atlassian.net/browse/RSS-417"
+            ),
+        ),
+        ("2.16", "Flex", None),
+    ],
+)
+def test_fixed_trash_return_type(
+    robot_type: Literal["OT-2", "Flex"],
+    version: str,
+    expected_trash_class: Optional[Type[object]],
+) -> None:
+    """The return type of ProtocolContext.fixed_trash varies depending on API version."""
+    protocol = simulate.get_protocol_api(version=version, robot_type=robot_type)
+
+    if expected_trash_class is None:
+        with pytest.raises(Exception, match="No trash container has been defined"):
+            protocol.fixed_trash
+    else:
+        assert isinstance(protocol.fixed_trash, expected_trash_class)
+
+
+@pytest.mark.parametrize(
+    ("version", "robot_type"),
+    [
+        ("2.13", "OT-2"),
+        ("2.14", "OT-2"),
+        ("2.15", "OT-2"),
+        ("2.15", "Flex"),
+        pytest.param(
+            "2.16",
+            "OT-2",
+            marks=pytest.mark.xfail(
+                strict=True, reason="https://opentrons.atlassian.net/browse/RSS-417"
+            ),
+        ),
+    ],
+)
+def test_default_instrument_trash_container_is_fixed_trash(
+    robot_type: Literal["OT-2", "Flex"], version: str
+) -> None:
+    """When ProtocolContext.fixed_trash exists, InstrumentContext.trash_container should
+    match it by default."""
+    protocol = simulate.get_protocol_api(version=version, robot_type=robot_type)
+
+    instrument = protocol.load_instrument(
+        "p300_single_gen2" if robot_type == "OT-2" else "flex_1channel_50",
+        mount="left",
+    )
+
+    assert instrument.trash_container is protocol.fixed_trash
+
+
+def test_default_instrument_trash_container_does_not_exist() -> None:
+    """Flex protocols with API version ≥2.16 have no fixed trash--so, no default
+    InstrumentContext.trash_container either."""
+    protocol = simulate.get_protocol_api(version="2.16", robot_type="Flex")
+    instrument = protocol.load_instrument("flex_1channel_50", mount="left")
+
+    with pytest.raises(Exception, match="No trash container has been defined"):
+        instrument.trash_container
+
+
+def test_trash_search() -> None:
+    """Test the automatic trash search behavior for protocols without a fixed trash."""
+    protocol = simulate.get_protocol_api(version="2.16", robot_type="Flex")
+    instrument = protocol.load_instrument("flex_1channel_50", mount="left")
+
+    # By default, there will be no trash.
+    with pytest.raises(Exception, match="No trash container has been defined"):
+        protocol.fixed_trash
+    with pytest.raises(Exception, match="No trash container has been defined"):
+        instrument.trash_container
+
+    loaded_first = protocol.load_trash_bin("A1")
+    loaded_second = protocol.load_trash_bin("B1")
+
+    # After loading some trashes, there is still no protocol.fixed_trash...
+    with pytest.raises(Exception, match="No trash container has been defined"):
+        protocol.fixed_trash
+    # ...but instrument.trash_container automatically updates to be the first trash we loaded.
+    assert instrument.trash_container is loaded_first
+
+    # You can override instrument.trash_container explicitly.
+    instrument.trash_container = loaded_second
+    assert instrument.trash_container is loaded_second

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -15,14 +15,22 @@ import pytest
         ("2.13", "OT-2", protocol_api.Labware),
         ("2.14", "OT-2", protocol_api.Labware),
         ("2.15", "OT-2", protocol_api.Labware),
-        ("2.15", "Flex", protocol_api.Labware),
+        pytest.param(
+            "2.15",
+            "Flex",
+            protocol_api.Labware,
+            marks=pytest.mark.ot3_only,  # Simulating a Flex protocol requires a Flex hardware API.
+        ),
         pytest.param(
             "2.16",
             "OT-2",
             protocol_api.TrashBin,
-            marks=pytest.mark.xfail(
-                strict=True, reason="https://opentrons.atlassian.net/browse/RSS-417"
-            ),
+            marks=[
+                pytest.mark.ot3_only,  # Simulating a Flex protocol requires a Flex hardware API.
+                pytest.mark.xfail(
+                    strict=True, reason="https://opentrons.atlassian.net/browse/RSS-417"
+                ),
+            ],
         ),
         ("2.16", "Flex", None),
     ],

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -1,3 +1,6 @@
+"""Tests for the APIs around waste chutes and trash bins."""
+
+
 from opentrons import protocol_api, simulate
 
 from typing import Optional, Type
@@ -24,68 +27,40 @@ import pytest
         ("2.16", "Flex", None),
     ],
 )
-def test_fixed_trash_return_type(
+def test_fixed_trash_presence(
     robot_type: Literal["OT-2", "Flex"],
     version: str,
     expected_trash_class: Optional[Type[object]],
 ) -> None:
-    """The return type of ProtocolContext.fixed_trash varies depending on API version."""
+    """Test the presence of the fixed trash.
+
+    Certain combinations of API version and robot type have a fixed trash.
+    For those that do, ProtocolContext.fixed_trash and InstrumentContext.trash_container
+    should point to it. The type of the object depends on the API version.
+    """
     protocol = simulate.get_protocol_api(version=version, robot_type=robot_type)
-
-    if expected_trash_class is None:
-        with pytest.raises(Exception, match="No trash container has been defined"):
-            protocol.fixed_trash
-    else:
-        assert isinstance(protocol.fixed_trash, expected_trash_class)
-
-
-@pytest.mark.parametrize(
-    ("version", "robot_type"),
-    [
-        ("2.13", "OT-2"),
-        ("2.14", "OT-2"),
-        ("2.15", "OT-2"),
-        ("2.15", "Flex"),
-        pytest.param(
-            "2.16",
-            "OT-2",
-            marks=pytest.mark.xfail(
-                strict=True, reason="https://opentrons.atlassian.net/browse/RSS-417"
-            ),
-        ),
-    ],
-)
-def test_default_instrument_trash_container_is_fixed_trash(
-    robot_type: Literal["OT-2", "Flex"], version: str
-) -> None:
-    """When ProtocolContext.fixed_trash exists, InstrumentContext.trash_container should
-    match it by default."""
-    protocol = simulate.get_protocol_api(version=version, robot_type=robot_type)
-
     instrument = protocol.load_instrument(
         "p300_single_gen2" if robot_type == "OT-2" else "flex_1channel_50",
         mount="left",
     )
 
-    assert instrument.trash_container is protocol.fixed_trash
+    if expected_trash_class is None:
+        with pytest.raises(Exception, match="No trash container has been defined"):
+            protocol.fixed_trash
+        with pytest.raises(Exception, match="No trash container has been defined"):
+            instrument.trash_container
 
-
-def test_default_instrument_trash_container_does_not_exist() -> None:
-    """Flex protocols with API version ≥2.16 have no fixed trash--so, no default
-    InstrumentContext.trash_container either."""
-    protocol = simulate.get_protocol_api(version="2.16", robot_type="Flex")
-    instrument = protocol.load_instrument("flex_1channel_50", mount="left")
-
-    with pytest.raises(Exception, match="No trash container has been defined"):
-        instrument.trash_container
+    else:
+        assert isinstance(protocol.fixed_trash, expected_trash_class)
+        assert instrument.trash_container is protocol.fixed_trash
 
 
 def test_trash_search() -> None:
-    """Test the automatic trash search behavior for protocols without a fixed trash."""
+    """Test the automatic trash search for protocols without a fixed trash."""
     protocol = simulate.get_protocol_api(version="2.16", robot_type="Flex")
     instrument = protocol.load_instrument("flex_1channel_50", mount="left")
 
-    # By default, there will be no trash.
+    # By default, there should be no trash.
     with pytest.raises(Exception, match="No trash container has been defined"):
         protocol.fixed_trash
     with pytest.raises(Exception, match="No trash container has been defined"):
@@ -94,12 +69,13 @@ def test_trash_search() -> None:
     loaded_first = protocol.load_trash_bin("A1")
     loaded_second = protocol.load_trash_bin("B1")
 
-    # After loading some trashes, there is still no protocol.fixed_trash...
+    # After loading some trashes, there should still be no protocol.fixed_trash...
     with pytest.raises(Exception, match="No trash container has been defined"):
         protocol.fixed_trash
-    # ...but instrument.trash_container automatically updates to be the first trash we loaded.
+    # ...but instrument.trash_container should automatically update to point to
+    # the first trash that we loaded.
     assert instrument.trash_container is loaded_first
 
-    # You can override instrument.trash_container explicitly.
+    # You should be able to override instrument.trash_container explicitly.
     instrument.trash_container = loaded_second
     assert instrument.trash_container is loaded_second


### PR DESCRIPTION
# Overview

Add tests to cover bugs like RSS-417.

# Changelog

Using the user-facing `opentrons.simulate.get_protocol_api()` function, test some of v7.1.0's new APIs for the waste chute and movable trash bin.

I'm starting a new place for these, in `tests/protocol_api_integration/`.

# Rationale

The existing tests in `tests/protocol_api/` are insufficient to prevent bugs because they're unit tests that cover the layers (e.g. PAPI, PAPI core, and engine) in isolation, whereas the behavior that we want to test depends on a complex interaction across those layers.

Historically, when we've had this problem, we've flipped into *full integration test mode* and included *as much as possible* in the integration. That meant testing through `robot-server`. That's why `robot-server` has tests for oddly specific things that are far beneath what it should care about, like ["if you upload a Python protocol that loads two things into the same deck slot but spells the slot differently, it should detect the conflict."](https://github.com/Opentrons/opentrons/blob/40727eea8561468a4d80effae8cf7778b931099a/robot-server/tests/integration/http_api/protocols/test_deck_coordinate_load_fail.tavern.yaml#L1)

An upside to doing it that way is that it has maintained a clear binary distinction between unit tests and integration tests. So we're never confused about how many layers a tests is supposed to cover. A downside is that it is a royal pain in the tuchus to write and maintain those tests—to the point where, in practice, we mostly just don't, leaving us vulnerable to bugs like RSS-417.

In my view, the downsides are outweighing the upsides, so it's time to do it a different way.

# Review requests

* Do we agree with my rationale above for adding this new test layer?
* Is it proper to call these "integration tests"? We're not looking at G-code, or hardware commands. We're just looking at public PAPI behavior.
* This will spawn ~13 threads that will last for the duration of the test session. This is because the user-facing `get_protocol_api()` function has no mechanism to signal when you're done with it so it can clean up resources.

  To fix this, we need to either:

  * Add a cleanup mechanism to the user-facing `get_protocol_api()` function.
  * Use something other than the user-facing `get_protocol_api()` function in these tests.
  * Rework Protocol Engine and the hardware API so that simulating a protocol does not require resources that need to be cleaned up.

  Until any of those happen, are we okay with merging this, or does this sound like the kind of thing that will cause spurious test failures depending on system resources?
* Organizationally, do we like these in `tests/opentrons/protocol_api_integration/`, a sibling of `protocol_api/` and `protocol_api_old/`?

# Risk assessment

Low. Tests only.