### PR TITLE
fix(shared-data, app): fix deck view diff between deck and labware de…

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/utils/getLabwareRenderInfo.ts
+++ b/app/src/organisms/Devices/ProtocolRun/utils/getLabwareRenderInfo.ts
@@ -62,7 +62,9 @@ export const getLabwareRenderInfo = (
         return acc
       }
       const isSlot = deckDef.locations.addressableAreas.some(
-        aa => aa.id === slotName && aa.areaType === 'slot'
+        aa =>
+          aa.id === slotName &&
+          (aa.areaType === 'slot' || aa.areaType === 'stagingSlot')
       )
 
       return isSlot

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -269,7 +269,12 @@ export interface CutoutFixture {
   height: number
 }
 
-type AreaType = 'slot' | 'movableTrash' | 'wasteChute' | 'fixedTrash'
+type AreaType =
+  | 'slot'
+  | 'movableTrash'
+  | 'wasteChute'
+  | 'fixedTrash'
+  | 'stagingSlot'
 
 export interface AddressableArea {
   id: AddressableAreaName


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
close RQA-2008

https://github.com/Opentrons/opentrons/pull/14127#issuecomment-1845993280

[before]
![IMG_4577](https://github.com/Opentrons/opentrons/assets/474225/35200d74-1f89-4edb-8f68-0cc9863f213c)


[after]
![Screenshot 2023-12-07 at 3 33 19 PM](https://github.com/Opentrons/opentrons/assets/474225/4e7f4e96-040c-463e-b078-24716988b548)

close RQO-2008
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
