### PR TITLE
fix(app): properly display no liquids used text in protocol details/setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -144,7 +144,7 @@ export function ProtocolRunSetup({
       ? parseLiquidsInLoadOrder(liquids, protocolAnalysis.commands)
       : []
 
-  const hasLiquids = protocolAnalysis != null && liquidsInLoadOrder.length > 0
+  const hasLiquids = liquidsInLoadOrder.length > 0
 
   const hasModules = protocolAnalysis != null && modules.length > 0
 

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { parseAllRequiredModuleModels } from '@opentrons/api-client'
+import {
+  parseAllRequiredModuleModels,
+  parseLiquidsInLoadOrder,
+} from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   COLORS,
@@ -133,8 +136,16 @@ export function ProtocolRunSetup({
   })
 
   if (robot == null) return null
-  const hasLiquids =
-    protocolAnalysis != null && protocolAnalysis.liquids?.length > 0
+
+  const liquids = protocolAnalysis?.liquids ?? []
+
+  const liquidsInLoadOrder =
+    protocolAnalysis != null
+      ? parseLiquidsInLoadOrder(liquids, protocolAnalysis.commands)
+      : []
+
+  const hasLiquids = protocolAnalysis != null && liquidsInLoadOrder.length > 0
+
   const hasModules = protocolAnalysis != null && modules.length > 0
 
   const protocolDeckConfig = getSimplestDeckConfigForProtocol(protocolAnalysis)

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react'
 import { when, resetAllWhenMocks } from 'jest-when'
 
-import { parseAllRequiredModuleModels } from '@opentrons/api-client'
+import {
+  parseAllRequiredModuleModels,
+  parseLiquidsInLoadOrder,
+} from '@opentrons/api-client'
 import {
   partialComponentPropsMatcher,
   renderWithProviders,
@@ -76,6 +79,9 @@ const mockUseStoredProtocolAnalysis = useStoredProtocolAnalysis as jest.MockedFu
 const mockParseAllRequiredModuleModels = parseAllRequiredModuleModels as jest.MockedFunction<
   typeof parseAllRequiredModuleModels
 >
+const mockParseLiquidsInLoadOrder = parseLiquidsInLoadOrder as jest.MockedFunction<
+  typeof parseLiquidsInLoadOrder
+>
 const mockSetupLabware = SetupLabware as jest.MockedFunction<
   typeof SetupLabware
 >
@@ -142,6 +148,7 @@ describe('ProtocolRunSetup', () => {
         ...MOCK_ROTOCOL_LIQUID_KEY,
       } as unknown) as ProtocolAnalysisOutput)
     when(mockParseAllRequiredModuleModels).mockReturnValue([])
+    when(mockParseLiquidsInLoadOrder).mockReturnValue([])
     when(mockUseRobot)
       .calledWith(ROBOT_NAME)
       .mockReturnValue(mockConnectedRobot)

--- a/app/src/organisms/ProtocolDetails/ProtocolLiquidsDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLiquidsDetails.tsx
@@ -45,7 +45,7 @@ export const ProtocolLiquidsDetails = (
       overflowY="auto"
       data-testid="LiquidsDetailsTab"
     >
-      {liquids.length > 0 ? (
+      {liquidsInLoadOrder.length > 0 ? (
         liquidsInLoadOrder?.map((liquid, index) => {
           return (
             <React.Fragment key={liquid.id}>

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolLiquidsDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolLiquidsDetails.test.tsx
@@ -63,6 +63,7 @@ describe('ProtocolLiquidsDetails', () => {
   })
   it('renders the correct info for no liquids in the protocol', () => {
     props.liquids = []
+    mockParseLiquidsInLoadOrder.mockReturnValue([])
     const [{ getByText, getByLabelText }] = render(props)
     getByText('No liquids are specified for this protocol')
     getByLabelText('ProtocolLIquidsDetails_noLiquidsIcon')


### PR DESCRIPTION
closes [RQA-2006](https://opentrons.atlassian.net/browse/RQA-2006)

# Overview

When we decide whether or not to display liquids in ProtocolDetails or ProtocolSetup, we need to determine if the liquids are actually loaded in protocol (commands) rather than accessing the liquids property of the protocol analysis.

# Test Plan

- create protocol that specifies liquids but does not load them in any wells [example](https://github.com/Opentrons/opentrons/files/13605826/96_ch.Tip.Drop.200uL_Tip.Rack.Drop.Well.Plate.Drop.Waste.chute.no.cover.1.json)
- upload protocol to App
- confirm that ProtocolDetails and ProtocolSetup properly render "No liquids are specified for this protocol."

<img width="1153" alt="Screen Shot 2023-12-07 at 10 41 26 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/5721777f-1c9d-49e4-b395-a879fb14c182">
<img width="1116" alt="Screen Shot 2023-12-07 at 4 57 31 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/4a8d33a3-f90e-4dd6-a70a-d40bd6dccf4b">

# Risk assessment

low

[RQA-2006]: https://opentrons.atlassian.net/browse/RQA-2006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ