### PR TITLE
fix(api-client): update initial loaded labware to support addressable areas

### DIFF
--- a/api-client/src/protocols/__tests__/utils.test.ts
+++ b/api-client/src/protocols/__tests__/utils.test.ts
@@ -261,7 +261,7 @@ describe('parseInitialLoadedLabwareByAdapter', () => {
   })
 })
 describe('parseInitialLoadedLabwareBySlot', () => {
-  it('returns only labware loaded in slots', () => {
+  it('returns labware loaded in slots', () => {
     const expected = {
       2: mockRunTimeCommands.find(
         c =>
@@ -281,6 +281,48 @@ describe('parseInitialLoadedLabwareBySlot', () => {
     expect(parseInitialLoadedLabwareBySlot(mockRunTimeCommands)).toEqual(
       expected
     )
+  })
+  it('returns labware loaded in addressable areas', () => {
+    const mockAddressableAreaLoadedLabwareCommand = ([
+      {
+        id: 'commands.LOAD_LABWARE-3',
+        createdAt: '2022-04-01T15:46:01.745870+00:00',
+        commandType: 'loadLabware',
+        key: 'commands.LOAD_LABWARE-3',
+        status: 'succeeded',
+        params: {
+          location: {
+            addressableAreaName: 'D4',
+          },
+          loadName: 'nest_96_wellplate_100ul_pcr_full_skirt',
+          namespace: 'opentrons',
+          version: 1,
+          labwareId: null,
+          displayName: 'NEST 96 Well Plate 100 µL PCR Full Skirt',
+        },
+        result: {
+          labwareId: 'labware-3',
+          definition: {},
+          offsetId: null,
+        },
+        error: null,
+        startedAt: '2022-04-01T15:46:01.745870+00:00',
+        completedAt: '2022-04-01T15:46:01.745870+00:00',
+      },
+    ] as any) as RunTimeCommand[]
+
+    const expected = {
+      D4: mockAddressableAreaLoadedLabwareCommand.find(
+        c =>
+          c.commandType === 'loadLabware' &&
+          typeof c.params.location === 'object' &&
+          'addressableAreaName' in c.params?.location &&
+          c.params?.location?.addressableAreaName === 'D4'
+      ),
+    }
+    expect(
+      parseInitialLoadedLabwareBySlot(mockAddressableAreaLoadedLabwareCommand)
+    ).toEqual(expected)
   })
 })
 describe('parseInitialLoadedLabwareByModuleId', () => {

--- a/api-client/src/protocols/utils.ts
+++ b/api-client/src/protocols/utils.ts
@@ -117,11 +117,14 @@ export function parseInitialLoadedLabwareBySlot(
   return reduce<LoadLabwareRunTimeCommand, LoadedLabwareBySlot>(
     loadLabwareCommandsReversed,
     (acc, command) => {
-      if (
-        typeof command.params.location === 'object' &&
-        'slotName' in command.params.location
-      ) {
-        return { ...acc, [command.params.location.slotName]: command }
+      if (typeof command.params.location === 'object') {
+        let slot: string
+        if ('slotName' in command.params.location) {
+          slot = command.params.location.slotName
+        } else if ('addressableAreaName' in command.params.location) {
+          slot = command.params.location.addressableAreaName
+        } else return acc
+        return { ...acc, [slot]: command }
       } else {
         return acc
       }


### PR DESCRIPTION
Closes RQA-2005

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Labware loaded into staging areas are not included into the total labware count. parseInitialLoadedLabwareBySlot utility now includes addressableAreaName in its reduce criteria. 

### Current Behavior

<img width="997" alt="Screenshot 2023-12-06 at 2 18 01 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/fe2d8d67-372d-4460-9591-6acb17825815">

### Fixed Behavior

<img width="1018" alt="Screenshot 2023-12-08 at 11 00 11 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/1df26194-1686-4055-8f32-48864dcec249">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Just verify the correct number of labware is displayed on the protocol details page - this number should include labware loaded into a staging area.
- Here's a protocol for use if you don't want to make your own: 
[96_ch Tip Drop 200uL_Tip Rack Drop Well Plate Drop Waste chute no cover.json](https://github.com/Opentrons/opentrons/files/13618588/96_ch.Tip.Drop.200uL_Tip.Rack.Drop.Well.Plate.Drop.Waste.chute.no.cover.1.json)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- The loaded labware total count correctly reflects all loaded labware.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
