### PR TITLE
fix(app): moveLabware command text support for waste chute

### DIFF
--- a/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
+++ b/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
@@ -1,14 +1,13 @@
 import { useTranslation } from 'react-i18next'
-import {
-  CompletedProtocolAnalysis,
-  MoveLabwareRunTimeCommand,
-  RobotType,
-  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
-} from '@opentrons/shared-data'
+import { GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA } from '@opentrons/shared-data'
 import { getLabwareName } from './utils'
 import { getLabwareDisplayLocation } from './utils/getLabwareDisplayLocation'
 import { getFinalLabwareLocation } from './utils/getFinalLabwareLocation'
-
+import type {
+  CompletedProtocolAnalysis,
+  MoveLabwareRunTimeCommand,
+  RobotType,
+} from '@opentrons/shared-data'
 interface MoveLabwareCommandTextProps {
   command: MoveLabwareRunTimeCommand
   robotSideAnalysis: CompletedProtocolAnalysis

--- a/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
+++ b/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
@@ -1,9 +1,10 @@
 import { useTranslation } from 'react-i18next'
-import type {
+import {
   CompletedProtocolAnalysis,
   MoveLabwareRunTimeCommand,
   RobotType,
-} from '@opentrons/shared-data/'
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+} from '@opentrons/shared-data'
 import { getLabwareName } from './utils'
 import { getLabwareDisplayLocation } from './utils/getLabwareDisplayLocation'
 import { getFinalLabwareLocation } from './utils/getFinalLabwareLocation'
@@ -32,6 +33,12 @@ export function MoveLabwareCommandText(
     robotType
   )
 
+  const location = newDisplayLocation.includes(
+    GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA
+  )
+    ? 'Waste Chute'
+    : newDisplayLocation
+
   return strategy === 'usingGripper'
     ? t('move_labware_using_gripper', {
         labware: getLabwareName(robotSideAnalysis, labwareId),
@@ -44,7 +51,7 @@ export function MoveLabwareCommandText(
                 robotType
               )
             : '',
-        new_location: newDisplayLocation,
+        new_location: location,
       })
     : t('move_labware_manually', {
         labware: getLabwareName(robotSideAnalysis, labwareId),
@@ -57,6 +64,6 @@ export function MoveLabwareCommandText(
                 robotType
               )
             : '',
-        new_location: newDisplayLocation,
+        new_location: location,
       })
 }

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -1,28 +1,29 @@
 import * as React from 'react'
 import { renderWithProviders } from '@opentrons/components'
 import {
-  AspirateInPlaceRunTimeCommand,
-  BlowoutInPlaceRunTimeCommand,
-  DispenseInPlaceRunTimeCommand,
-  DropTipInPlaceRunTimeCommand,
   FLEX_ROBOT_TYPE,
-  MoveToAddressableAreaRunTimeCommand,
   OT2_ROBOT_TYPE,
-  PrepareToAspirateRunTimeCommand,
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 import { i18n } from '../../../i18n'
 import { CommandText } from '../'
 import { mockRobotSideAnalysis } from '../__fixtures__'
 
 import type {
+  AspirateInPlaceRunTimeCommand,
+  BlowoutInPlaceRunTimeCommand,
   BlowoutRunTimeCommand,
   ConfigureForVolumeRunTimeCommand,
+  DispenseInPlaceRunTimeCommand,
   DispenseRunTimeCommand,
+  DropTipInPlaceRunTimeCommand,
   DropTipRunTimeCommand,
   LabwareDefinition2,
   LoadLabwareRunTimeCommand,
   LoadLiquidRunTimeCommand,
+  MoveToAddressableAreaRunTimeCommand,
   MoveToWellRunTimeCommand,
+  PrepareToAspirateRunTimeCommand,
   RunTimeCommand,
 } from '@opentrons/shared-data'
 
@@ -1278,6 +1279,37 @@ describe('CommandText', () => {
     )[0]
     getByText(
       'Moving Opentrons 96 Tip Rack 300 µL using gripper from Slot 9 to off deck'
+    )
+  })
+  it('renders correct text for move labware with gripper to waste chute', () => {
+    const { getByText } = renderWithProviders(
+      <CommandText
+        command={{
+          commandType: 'moveLabware',
+          params: {
+            strategy: 'usingGripper',
+            labwareId: mockRobotSideAnalysis.labware[2].id,
+            newLocation: {
+              addressableAreaName: GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+            },
+          },
+          id: 'def456',
+          result: { offsetId: 'fake_offset_id' },
+          status: 'queued',
+          error: null,
+          createdAt: 'fake_timestamp',
+          startedAt: null,
+          completedAt: null,
+        }}
+        robotSideAnalysis={mockRobotSideAnalysis}
+        robotType={FLEX_ROBOT_TYPE}
+      />,
+      {
+        i18nInstance: i18n,
+      }
+    )[0]
+    getByText(
+      'Moving Opentrons 96 Tip Rack 300 µL using gripper from Slot 9 to Waste Chute'
     )
   })
   it('renders correct text for move labware with gripper to module', () => {


### PR DESCRIPTION
closes RQA-2037

# Overview

Add waste chute support in run log for moving labware into the waste chute

# Test Plan

Test with the protocol attached to the ticket! Look at the run log and see that the command text for moving labware into waste chute is correct

# Changelog

- expand logic in `moveLabwareCommandText` and add test coverage

# Review requests

see test plan

# Risk assessment

low