### PR TITLE
refactor(step-generation): update nozzles in robotState not from initialRobotState

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -55,33 +55,10 @@ export const getInitialRobotState: (
   stepFormSelectors.getInvariantContext,
   getLabwareLiquidState,
   (initialDeckSetup, invariantContext, labwareLiquidState) => {
-    // const onlyPipettingFormSteps = Object.entries(savedStepForms).filter(
-    //   ([stepId, form]) =>
-    //     form.stepType === 'moveLiquid' || form.stepType === 'mix'
-    // )
-    // const lastPipetteFormStep =
-    //   onlyPipettingFormSteps.length > 0
-    //     ? onlyPipettingFormSteps[onlyPipettingFormSteps.length - 1]
-    //     : null
-    // const lastPipettingStepNozzles =
-    //   lastPipetteFormStep != null ? lastPipetteFormStep[1]?.nozzles : undefined
-
-    // const prevPipetteFormStep =
-    //   onlyPipettingFormSteps.length > 1
-    //     ? onlyPipettingFormSteps[onlyPipettingFormSteps.length - 2]
-    //     : null
-    //  NOTE: previous pipetting step nozzles is necessary
-    //  in order to know when to emit the configureNozzleLayout
-    //  command
-    // const prevPipettingStepNozzles =
-    //   prevPipetteFormStep != null ? prevPipetteFormStep[1]?.nozzles : undefined
     const pipettes: Record<string, PipetteTemporalProperties> = mapValues(
       initialDeckSetup.pipettes,
       (p: PipetteOnDeck): PipetteTemporalProperties => ({
         mount: p.mount,
-        // nozzles: p.name === 'p1000_96' ? lastPipettingStepNozzles : undefined,
-        // prevNozzles:
-        //   p.name === 'p1000_96' ? prevPipettingStepNozzles : undefined,
       })
     )
     const labware: Record<string, LabwareTemporalProperties> = mapValues(

--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -54,41 +54,40 @@ export const getInitialRobotState: (
   stepFormSelectors.getInitialDeckSetup,
   stepFormSelectors.getInvariantContext,
   getLabwareLiquidState,
-  stepFormSelectors.getSavedStepForms,
-  (initialDeckSetup, invariantContext, labwareLiquidState, savedStepForms) => {
-    const onlyPipettingFormSteps = Object.entries(savedStepForms).filter(
-      ([stepId, form]) =>
-        form.stepType === 'moveLiquid' || form.stepType === 'mix'
-    )
-    const lastPipetteFormStep =
-      onlyPipettingFormSteps.length > 0
-        ? onlyPipettingFormSteps[onlyPipettingFormSteps.length - 1]
-        : null
-    const lastPipettingStepNozzles =
-      lastPipetteFormStep != null ? lastPipetteFormStep[1]?.nozzles : undefined
+  (initialDeckSetup, invariantContext, labwareLiquidState) => {
+    // const onlyPipettingFormSteps = Object.entries(savedStepForms).filter(
+    //   ([stepId, form]) =>
+    //     form.stepType === 'moveLiquid' || form.stepType === 'mix'
+    // )
+    // const lastPipetteFormStep =
+    //   onlyPipettingFormSteps.length > 0
+    //     ? onlyPipettingFormSteps[onlyPipettingFormSteps.length - 1]
+    //     : null
+    // const lastPipettingStepNozzles =
+    //   lastPipetteFormStep != null ? lastPipetteFormStep[1]?.nozzles : undefined
 
-    const prevPipetteFormStep =
-      onlyPipettingFormSteps.length > 1
-        ? onlyPipettingFormSteps[onlyPipettingFormSteps.length - 2]
-        : null
+    // const prevPipetteFormStep =
+    //   onlyPipettingFormSteps.length > 1
+    //     ? onlyPipettingFormSteps[onlyPipettingFormSteps.length - 2]
+    //     : null
     //  NOTE: previous pipetting step nozzles is necessary
     //  in order to know when to emit the configureNozzleLayout
     //  command
-    const prevPipettingStepNozzles =
-      prevPipetteFormStep != null ? prevPipetteFormStep[1]?.nozzles : undefined
-    const labware: Record<string, LabwareTemporalProperties> = mapValues(
-      initialDeckSetup.labware,
-      (l: LabwareOnDeck): LabwareTemporalProperties => ({
-        slot: l.slot,
-      })
-    )
+    // const prevPipettingStepNozzles =
+    //   prevPipetteFormStep != null ? prevPipetteFormStep[1]?.nozzles : undefined
     const pipettes: Record<string, PipetteTemporalProperties> = mapValues(
       initialDeckSetup.pipettes,
       (p: PipetteOnDeck): PipetteTemporalProperties => ({
         mount: p.mount,
-        nozzles: p.name === 'p1000_96' ? lastPipettingStepNozzles : undefined,
-        prevNozzles:
-          p.name === 'p1000_96' ? prevPipettingStepNozzles : undefined,
+        // nozzles: p.name === 'p1000_96' ? lastPipettingStepNozzles : undefined,
+        // prevNozzles:
+        //   p.name === 'p1000_96' ? prevPipettingStepNozzles : undefined,
+      })
+    )
+    const labware: Record<string, LabwareTemporalProperties> = mapValues(
+      initialDeckSetup.labware,
+      (l: LabwareOnDeck): LabwareTemporalProperties => ({
+        slot: l.slot,
       })
     )
     const modules: Record<string, ModuleTemporalProperties> = mapValues(

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -466,11 +466,10 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       const dropTipAfterDispenseAirGap =
         airGapAfterDispenseCommands.length > 0 ? dropTipCommand : []
 
-      const nozzles = prevRobotState.pipettes[args.pipette].nozzles
-      const prevNozzles = prevRobotState.pipettes[args.pipette].prevNozzles
+      const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
       const configureNozzleLayoutCommand: CurriedCommandCreator[] =
         //  only emit the command if previous nozzle state is different
-        is96Channel && args.nozzles != null && nozzles !== prevNozzles
+        is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
           ? [
               curryCommandCreator(configureNozzleLayout, {
                 nozzles: args.nozzles,
@@ -480,7 +479,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           : []
       const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
         args.pipette,
-        prevNozzles
+        stateNozzles
       )
 
       return [

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -18,7 +18,6 @@ import {
   airGapHelper,
   dispenseLocationHelper,
   moveHelper,
-  getConfigureNozzleLayoutCommandReset,
   getIsTallLabwareWestOf96Channel,
   getWasteChuteAddressableAreaNamePip,
 } from '../../utils'
@@ -477,10 +476,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               }),
             ]
           : []
-      const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
-        args.pipette,
-        stateNozzles
-      )
 
       return [
         ...configureNozzleLayoutCommand,
@@ -496,7 +491,6 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         ...blowoutCommand,
         ...airGapAfterDispenseCommands,
         ...dropTipAfterDispenseAirGap,
-        ...configureNozzleLayoutCommandReset,
       ]
     }
   )

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -16,7 +16,6 @@ import {
   blowoutUtil,
   wasteChuteCommandsUtil,
   getDispenseAirGapLocation,
-  getConfigureNozzleLayoutCommandReset,
   getIsTallLabwareWestOf96Channel,
   getWasteChuteAddressableAreaNamePip,
 } from '../../utils'
@@ -459,10 +458,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
               }),
             ]
           : []
-      const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
-        args.pipette,
-        stateNozzles
-      )
 
       return [
         ...configureNozzleLayoutCommand,
@@ -484,7 +479,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
         ...blowoutCommands,
         ...airGapAfterDispenseCommands,
         ...dropTipAfterDispenseAirGap,
-        ...configureNozzleLayoutCommandReset,
       ]
     }
   )

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -448,11 +448,10 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ]
         : []
 
-      const nozzles = prevRobotState.pipettes[args.pipette].nozzles
-      const prevNozzles = prevRobotState.pipettes[args.pipette].prevNozzles
+      const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
       const configureNozzleLayoutCommand: CurriedCommandCreator[] =
         //  only emit the command if previous nozzle state is different
-        is96Channel && args.nozzles != null && nozzles !== prevNozzles
+        is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
           ? [
               curryCommandCreator(configureNozzleLayout, {
                 nozzles: args.nozzles,
@@ -462,7 +461,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           : []
       const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
         args.pipette,
-        prevNozzles
+        stateNozzles
       )
 
       return [

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -5,7 +5,6 @@ import {
   blowoutUtil,
   curryCommandCreator,
   reduceCommandCreators,
-  getConfigureNozzleLayoutCommandReset,
   getIsTallLabwareWestOf96Channel,
 } from '../../utils'
 import * as errorCreators from '../../errorCreators'
@@ -201,10 +200,6 @@ export const mix: CommandCreator<MixArgs> = (
         }),
       ]
     : []
-  const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
-    pipette,
-    stateNozzles
-  )
   // Command generation
   const commandCreators = flatMap(
     wells,
@@ -263,7 +258,6 @@ export const mix: CommandCreator<MixArgs> = (
         ...mixCommands,
         ...blowoutCommand,
         ...touchTipCommands,
-        ...configureNozzleLayoutCommandReset,
       ]
     }
   )

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -179,11 +179,10 @@ export const mix: CommandCreator<MixArgs> = (
       ],
     }
   }
-  const nozzles = prevRobotState.pipettes[pipette].nozzles
-  const prevNozzles = prevRobotState.pipettes[pipette].prevNozzles
+  const stateNozzles = prevRobotState.pipettes[pipette].nozzles
   const configureNozzleLayoutCommand: CurriedCommandCreator[] =
     //  only emit the command if previous nozzle state is different
-    is96Channel && data.nozzles != null && nozzles !== prevNozzles
+    is96Channel && data.nozzles != null && data.nozzles !== stateNozzles
       ? [
           curryCommandCreator(configureNozzleLayout, {
             nozzles: data.nozzles,
@@ -204,7 +203,7 @@ export const mix: CommandCreator<MixArgs> = (
     : []
   const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
     pipette,
-    prevNozzles
+    stateNozzles
   )
   // Command generation
   const commandCreators = flatMap(

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -275,11 +275,10 @@ export const transfer: CommandCreator<TransferArgs> = (
             changeTipNow =
               isInitialSubtransfer || destinationWell !== prevDestWell
           }
-          const nozzles = prevRobotState.pipettes[args.pipette].nozzles
-          const prevNozzles = prevRobotState.pipettes[args.pipette].prevNozzles
+          const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
           const configureNozzleLayoutCommand: CurriedCommandCreator[] =
             //  only emit the command if previous nozzle state is different
-            is96Channel && args.nozzles != null && nozzles !== prevNozzles
+            is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
               ? [
                   curryCommandCreator(configureNozzleLayout, {
                     nozzles: args.nozzles,
@@ -289,7 +288,7 @@ export const transfer: CommandCreator<TransferArgs> = (
               : []
           const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
             args.pipette,
-            prevNozzles
+            stateNozzles
           )
 
           const configureForVolumeCommand: CurriedCommandCreator[] = LOW_VOLUME_PIPETTES.includes(

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -275,8 +275,6 @@ export const transfer: CommandCreator<TransferArgs> = (
               isInitialSubtransfer || destinationWell !== prevDestWell
           }
           const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
-          console.log('args.nozzles', args.nozzles)
-          console.log('state nozzles', stateNozzles)
           const configureNozzleLayoutCommand: CurriedCommandCreator[] =
             //  only emit the command if previous nozzle state is different
             is96Channel && args.nozzles != null && args.nozzles !== stateNozzles

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -18,7 +18,6 @@ import {
   getTrashOrLabware,
   dispenseLocationHelper,
   moveHelper,
-  getConfigureNozzleLayoutCommandReset,
   getIsTallLabwareWestOf96Channel,
   getWasteChuteAddressableAreaNamePip,
 } from '../../utils'
@@ -276,6 +275,8 @@ export const transfer: CommandCreator<TransferArgs> = (
               isInitialSubtransfer || destinationWell !== prevDestWell
           }
           const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
+          console.log('args.nozzles', args.nozzles)
+          console.log('state nozzles', stateNozzles)
           const configureNozzleLayoutCommand: CurriedCommandCreator[] =
             //  only emit the command if previous nozzle state is different
             is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
@@ -286,10 +287,6 @@ export const transfer: CommandCreator<TransferArgs> = (
                   }),
                 ]
               : []
-          const configureNozzleLayoutCommandReset = getConfigureNozzleLayoutCommandReset(
-            args.pipette,
-            stateNozzles
-          )
 
           const configureForVolumeCommand: CurriedCommandCreator[] = LOW_VOLUME_PIPETTES.includes(
             invariantContext.pipetteEntities[args.pipette].name
@@ -597,7 +594,6 @@ export const transfer: CommandCreator<TransferArgs> = (
             ...blowoutCommand,
             ...airGapAfterDispenseCommands,
             ...dropTipAfterDispenseAirGap,
-            ...configureNozzleLayoutCommandReset,
           ]
           // NOTE: side-effecting
           prevSourceWell = sourceWell

--- a/step-generation/src/getNextRobotStateAndWarnings/forConfigureNozzleLayout.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forConfigureNozzleLayout.ts
@@ -1,0 +1,21 @@
+import { NozzleConfigurationStyle } from '@opentrons/shared-data'
+import type { InvariantContext, RobotStateAndWarnings } from '../types'
+
+interface ConfigureNozzleLayoutParams {
+  pipetteId: string
+  configurationParams: {
+    style: NozzleConfigurationStyle
+    primaryNozzle?: string
+  }
+}
+
+export function forConfigureNozzleLayout(
+  params: ConfigureNozzleLayoutParams,
+  invariantContext: InvariantContext,
+  robotStateAndWarnings: RobotStateAndWarnings
+): void {
+  const { pipetteId, configurationParams } = params
+  const { robotState } = robotStateAndWarnings
+
+  robotState.pipettes[pipetteId].nozzles = configurationParams.style
+}

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -18,7 +18,6 @@ export function forPickUpTip(
   const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
   // pipette now has tip(s)
   tipState.pipettes[pipetteId] = true
-  console.log('nozzles in forpickuptip', nozzles)
   // remove tips from tiprack
   if (pipetteSpec.channels === 1) {
     tipState.tipracks[labwareId][wellName] = false

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -18,7 +18,7 @@ export function forPickUpTip(
   const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
   // pipette now has tip(s)
   tipState.pipettes[pipetteId] = true
-
+  console.log('nozzles in forpickuptip', nozzles)
   // remove tips from tiprack
   if (pipetteSpec.channels === 1) {
     tipState.tipracks[labwareId][wellName] = false

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -18,6 +18,7 @@ export function forPickUpTip(
   const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
   // pipette now has tip(s)
   tipState.pipettes[pipetteId] = true
+
   // remove tips from tiprack
   if (pipetteSpec.channels === 1) {
     tipState.tipracks[labwareId][wellName] = false

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -45,6 +45,7 @@ import type {
   RobotState,
   RobotStateAndWarnings,
 } from '../types'
+import { forConfigureNozzleLayout } from './forConfigureNozzleLayout'
 
 // WARNING this will mutate the prevRobotState
 function _getNextRobotStateAndWarningsSingleCommand(
@@ -123,6 +124,11 @@ function _getNextRobotStateAndWarningsSingleCommand(
       break
 
     case 'configureNozzleLayout':
+      forConfigureNozzleLayout(
+        command.params,
+        invariantContext,
+        robotStateAndWarnings
+      )
       break
 
     case 'touchTip':

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -42,7 +42,6 @@ export interface LabwareTemporalProperties {
 export interface PipetteTemporalProperties {
   mount: Mount
   nozzles?: NozzleConfigurationStyle
-  prevNozzles?: NozzleConfigurationStyle
 }
 
 export interface MagneticModuleState {

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -700,17 +700,3 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
 
   return reduceCommandCreators(commands, invariantContext, prevRobotState)
 }
-
-export const getConfigureNozzleLayoutCommandReset = (
-  pipetteId: string,
-  prevNozzles?: NozzleConfigurationStyle
-): CurriedCommandCreator[] => {
-  return prevNozzles === COLUMN
-    ? [
-        curryCommandCreator(configureNozzleLayout, {
-          nozzles: ALL,
-          pipetteId,
-        }),
-      ]
-    : []
-}

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -8,8 +8,6 @@ import {
   getWellsDepth,
   getWellNamePerMultiTip,
   WASTE_CHUTE_CUTOUT,
-  COLUMN,
-  ALL,
   PipetteChannels,
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   EIGHT_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
@@ -18,7 +16,6 @@ import {
 import { reduceCommandCreators, wasteChuteCommandsUtil } from './index'
 import {
   aspirate,
-  configureNozzleLayout,
   dispense,
   moveToAddressableArea,
   moveToWell,
@@ -26,10 +23,7 @@ import {
 import { blowout } from '../commandCreators/atomic/blowout'
 import { curryCommandCreator } from './curryCommandCreator'
 import { movableTrashCommandsUtil } from './movableTrashCommandsUtil'
-import type {
-  LabwareDefinition2,
-  NozzleConfigurationStyle,
-} from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { BlowoutParams } from '@opentrons/shared-data/protocol/types/schemaV4'
 import type {
   AdditionalEquipmentEntities,


### PR DESCRIPTION
# Overview

There was a PD bug where if you have multiple column pick up steps followed by a full tip pick up step, it'd error. This is for 96-channel! But this PR fixes it and cleans up the reset command

# Test Plan

Test by adding 2 column pick up transfer steps followed by a Full tip pick up step. See that it doesn't error. Check tip state and see that it updates correctly. Download the protocol and see that there are 2 `configureNozzleLayout` commands for column and then for All

# Changelog

- remove setting nozzles from the initial robot state and set it through `configureNozzleLayout` state update.
- remove prevNozzles since it isn't needed anymore
- clean up the usage the `configureNozzleLayout` reset command, it isn't needed since the robot will reset the nozzles after each run

# Review requests

see test plan

# Risk assessment

low