### PR TITLE
fix(api): clean up tip motor distance caching/usage

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -735,13 +735,19 @@ class OT3Controller:
             if not self._feature_flags.stall_detection_enabled
             else False,
         )
-        positions = await runner.run(can_messenger=self._messenger)
-        if NodeId.pipette_left in positions:
-            self._gear_motor_position = {
-                NodeId.pipette_left: positions[NodeId.pipette_left].motor_position
-            }
-        else:
-            log.debug("no position returned from NodeId.pipette_left")
+        try:
+            positions = await runner.run(can_messenger=self._messenger)
+            if NodeId.pipette_left in positions:
+                self._gear_motor_position = {
+                    NodeId.pipette_left: positions[NodeId.pipette_left].motor_position
+                }
+            else:
+                log.debug("no position returned from NodeId.pipette_left")
+                self._gear_motor_position = {}
+        except Exception as e:
+            log.error("Clearing tip motor position due to failed movement")
+            self._gear_motor_position = {}
+            raise e
 
     async def tip_action(
         self,
@@ -755,13 +761,19 @@ class OT3Controller:
             if not self._feature_flags.stall_detection_enabled
             else False,
         )
-        positions = await runner.run(can_messenger=self._messenger)
-        if NodeId.pipette_left in positions:
-            self._gear_motor_position = {
-                NodeId.pipette_left: positions[NodeId.pipette_left].motor_position
-            }
-        else:
-            log.debug("no position returned from NodeId.pipette_left")
+        try:
+            positions = await runner.run(can_messenger=self._messenger)
+            if NodeId.pipette_left in positions:
+                self._gear_motor_position = {
+                    NodeId.pipette_left: positions[NodeId.pipette_left].motor_position
+                }
+            else:
+                log.debug("no position returned from NodeId.pipette_left")
+                self._gear_motor_position = {}
+        except Exception as e:
+            log.error("Clearing tip motor position due to failed movement")
+            self._gear_motor_position = {}
+            raise e
 
     @requires_update
     @requires_estop

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -905,10 +905,11 @@ class OT3API(
             GantryLoad.HIGH_THROUGHPUT
         ][OT3AxisKind.Q]
 
+        max_distance = self._backend.axis_bounds[Axis.Q][1]
         # if position is not known, move toward limit switch at a constant velocity
-        if not any(self._backend.gear_motor_position):
+        if len(self._backend.gear_motor_position.keys()) == 0:
             await self._backend.home_tip_motors(
-                distance=self._backend.axis_bounds[Axis.Q][1],
+                distance=max_distance,
                 velocity=homing_velocity,
             )
             return
@@ -917,7 +918,13 @@ class OT3API(
             Axis.P_L
         ]
 
-        if current_pos_float > self._config.safe_home_distance:
+        # We filter out a distance more than `max_distance` because, if the tip motor was stopped during
+        # a slow-home motion, the position may be stuck at an enormous large value.
+        if (
+            current_pos_float > self._config.safe_home_distance
+            and current_pos_float < max_distance
+        ):
+
             fast_home_moves = self._build_moves(
                 {Axis.Q: current_pos_float}, {Axis.Q: self._config.safe_home_distance}
             )
@@ -931,7 +938,9 @@ class OT3API(
 
         # move until the limit switch is triggered, with no acceleration
         await self._backend.home_tip_motors(
-            distance=(current_pos_float + self._config.safe_home_distance),
+            distance=min(
+                current_pos_float + self._config.safe_home_distance, max_distance
+            ),
             velocity=homing_velocity,
         )
 
@@ -2001,15 +2010,16 @@ class OT3API(
         Check tip presence status. If a high throughput pipette is present,
         move the tip motors down before checking the sensor status.
         """
-        real_mount = OT3Mount.from_mount(mount)
-        async with contextlib.AsyncExitStack() as stack:
-            if (
-                real_mount == OT3Mount.LEFT
-                and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
-            ):
-                await stack.enter_async_context(self._high_throughput_check_tip())
-            result = await self._backend.get_tip_status(real_mount)
-        return result
+        async with self._motion_lock:
+            real_mount = OT3Mount.from_mount(mount)
+            async with contextlib.AsyncExitStack() as stack:
+                if (
+                    real_mount == OT3Mount.LEFT
+                    and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
+                ):
+                    await stack.enter_async_context(self._high_throughput_check_tip())
+                result = await self._backend.get_tip_status(real_mount)
+            return result
 
     async def verify_tip_presence(
         self, mount: Union[top_types.Mount, OT3Mount], expected: TipStateType


### PR DESCRIPTION


# Overview

[RQA-2038](https://opentrons.atlassian.net/browse/RQA-2038) seems to be related to the Tip Check that occurs when cancelling a protocol. The Serialization error was a result of the software attempting to send a move group with a duration far exceeding a 32-bit integer. I was able to replicate the issue by cancelling a run during the setup stage, and then re-entering setup at a time such that a Tip Motor home action got interrupted, leaving the tip motors with a "motor_position" estimate that is orders of magnitude higher than the actual max position of the axis. 

Once the tip motor is in this situation, the software will fail a subsequent Tip Presence Check because of the invalid cached position of the motor.

To fix this, I added a few bandaids
* Wrap tip presence checks in the motion lock
* If a tip action fails for any reason, clear the cached tip motor position
* (Most importantly) if the cached tip motor position is higher than the physical limit of the axis, force the software to run a slow home.

With all of these changes, I can no longer replicate the issue.

# Test Plan

Replication is mentioned above. 

# Changelog

Listed above

# Review requests



# Risk assessment

Medium/low, doesn't touch anything too integral

[RQA-2038]: https://opentrons.atlassian.net/browse/RQA-2038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ