### PR TITLE
feat(hardware): add can message to adjust gripper jaw holdoff ms value

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -154,6 +154,9 @@ class MessageId(int, Enum):
     set_gripper_error_tolerance = 0x47
     gripper_jaw_state_request = 0x48
     gripper_jaw_state_response = 0x49
+    set_gripper_jaw_holdoff_request = 0x401
+    gripper_jaw_holdoff_request = 0x402
+    gripper_jaw_holdoff_response = 0x403
 
     acknowledgement = 0x50
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -641,7 +641,11 @@ class GripperJawStateResponse(BaseMessage):  # noqa: D101
 
 
 @dataclass
-class SetGripperJawHoldoffRequest(EmptyPayloadMessage):  # noqa: D101
+class SetGripperJawHoldoffRequest(BaseMessage):  # noqa: D101
+    payload: payloads.GripperJawHoldoffPayload
+    payload_type: Type[
+        payloads.GripperJawHoldoffPayload
+    ] = payloads.GripperJawHoldoffPayload
     message_id: Literal[
         MessageId.set_gripper_jaw_holdoff_request
     ] = MessageId.set_gripper_jaw_holdoff_request

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -641,6 +641,31 @@ class GripperJawStateResponse(BaseMessage):  # noqa: D101
 
 
 @dataclass
+class SetGripperJawHoldoffRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[
+        MessageId.set_gripper_jaw_holdoff_request
+    ] = MessageId.set_gripper_jaw_holdoff_request
+
+
+@dataclass
+class GripperJawHoldoffResponse(BaseMessage):  # noqa: D101
+    payload: payloads.GripperJawHoldoffPayload
+    payload_type: Type[
+        payloads.GripperJawHoldoffPayload
+    ] = payloads.GripperJawHoldoffPayload
+    message_id: Literal[
+        MessageId.gripper_jaw_holdoff_response
+    ] = MessageId.gripper_jaw_holdoff_response
+
+
+@dataclass
+class GripperJawHoldoffRequest(EmptyPayloadMessage):  # noqa: D101
+    message_id: Literal[
+        MessageId.gripper_jaw_holdoff_request
+    ] = MessageId.gripper_jaw_holdoff_request
+
+
+@dataclass
 class GripperGripRequest(BaseMessage):  # noqa: D101
     payload: payloads.GripperMoveRequestPayload
     payload_type: Type[

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -96,6 +96,9 @@ MessageDefinition = Union[
     defs.GetMotorUsageResponse,
     defs.GripperJawStateRequest,
     defs.GripperJawStateResponse,
+    defs.SetGripperJawHoldoffRequest,
+    defs.GripperJawHoldoffRequest,
+    defs.GripperJawHoldoffResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -531,7 +531,7 @@ class GripperJawStatePayload(EmptyPayload):
 class GripperJawHoldoffPayload(EmptyPayload):
     """A respones carrying info about the jaw holdoff value of a gripper."""
 
-    ticks: utils.UInt32Field
+    holdoff_ms: utils.UInt32Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -528,6 +528,13 @@ class GripperJawStatePayload(EmptyPayload):
 
 
 @dataclass(eq=False)
+class GripperJawHoldoffPayload(EmptyPayload):
+    """A respones carrying info about the jaw holdoff value of a gripper."""
+
+    ticks: utils.UInt32Field
+
+
+@dataclass(eq=False)
 class GripperMoveRequestPayload(AddToMoveGroupRequestPayload):
     """A request to move gripper."""
 

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -21,6 +21,9 @@ from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     BrushedMotorConfResponse,
     GripperJawStateRequest,
     GripperJawStateResponse,
+    SetGripperJawHoldoffRequest,
+    GripperJawHoldoffRequest,
+    GripperJawHoldoffResponse,
 )
 from opentrons_hardware.firmware_bindings.utils import (
     UInt8Field,
@@ -98,6 +101,49 @@ async def set_error_tolerance(
     )
     if error != ErrorCode.ok:
         log.error(f"recieved error trying to set gripper error tolerance {str(error)}")
+
+
+async def set_jaw_holdoff(
+    can_messenger: CanMessenger, holdoff_ms: int,
+) -> None:
+    """Set the idle holdoff value for gripper jaw."""
+    error = await can_messenger.ensure_send(
+        node_id=NodeId.gripper_g,
+        message=SetGripperJawHoldoffRequest(
+            payload=payloads.GripperJawHoldoffPayload(
+                ticks=UInt32Field(
+                    int(1 / holdoff_ms * brushed_motor_interrupts_per_sec)
+                )
+            )
+        ),
+        expected_nodes=[NodeId.gripper_g],
+    )
+    if error != ErrorCode.ok:
+        log.error(f"recieved error trying to set gripper jaw holdoff value {str(error)}")
+
+
+async def get_jaw_holdoff_ms(can_messenger: CanMessenger) -> int:
+    """Get the idle holdoff value for gripper jaw."""
+    def _filter(arbitration_id: ArbitrationId) -> bool:
+        return NodeId(arbitration_id.parts.originating_node_id) == NodeId.gripper_g
+
+    async def _wait_for_response(reader: WaitableCallback) -> int:
+        """Listener for receiving messages back."""
+        async for response, _ in reader:
+            if isinstance(response, GripperJawHoldoffResponse):
+                return int(response.payload.ticks / brushed_motor_interrupts_per_sec * 1000)
+        raise StopAsyncIteration
+
+    with WaitableCallback(can_messenger, _filter) as reader:
+        await can_messenger.send(
+            node_id=NodeId.gripper_g,
+            message=GripperJawHoldoffRequest(),
+        )
+        try:
+            return await asyncio.wait_for(_wait_for_response(reader), 1.0)
+        except asyncio.TimeoutError:
+            log.warning("Read gripper jaw idle holdoff value timed out")
+            raise StopAsyncIteration
 
 
 async def get_gripper_jaw_motor_param(

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -131,7 +131,7 @@ async def get_jaw_holdoff_ms(can_messenger: CanMessenger) -> int:
         """Listener for receiving messages back."""
         async for response, _ in reader:
             if isinstance(response, GripperJawHoldoffResponse):
-                return int(response.payload.ticks / brushed_motor_interrupts_per_sec * 1000)
+                return int(response.payload.ticks.value / brushed_motor_interrupts_per_sec * 1000)
         raise StopAsyncIteration
 
     with WaitableCallback(can_messenger, _filter) as reader:

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -104,7 +104,8 @@ async def set_error_tolerance(
 
 
 async def set_jaw_holdoff(
-    can_messenger: CanMessenger, holdoff_ms: int,
+    can_messenger: CanMessenger,
+    holdoff_ms: int,
 ) -> None:
     """Set the idle holdoff value for gripper jaw."""
     error = await can_messenger.ensure_send(
@@ -119,11 +120,14 @@ async def set_jaw_holdoff(
         expected_nodes=[NodeId.gripper_g],
     )
     if error != ErrorCode.ok:
-        log.error(f"recieved error trying to set gripper jaw holdoff value {str(error)}")
+        log.error(
+            f"recieved error trying to set gripper jaw holdoff value {str(error)}"
+        )
 
 
 async def get_jaw_holdoff_ms(can_messenger: CanMessenger) -> int:
     """Get the idle holdoff value for gripper jaw."""
+
     def _filter(arbitration_id: ArbitrationId) -> bool:
         return NodeId(arbitration_id.parts.originating_node_id) == NodeId.gripper_g
 
@@ -131,7 +135,11 @@ async def get_jaw_holdoff_ms(can_messenger: CanMessenger) -> int:
         """Listener for receiving messages back."""
         async for response, _ in reader:
             if isinstance(response, GripperJawHoldoffResponse):
-                return int(response.payload.ticks.value / brushed_motor_interrupts_per_sec * 1000)
+                return int(
+                    response.payload.ticks.value
+                    / brushed_motor_interrupts_per_sec
+                    * 1000
+                )
         raise StopAsyncIteration
 
     with WaitableCallback(can_messenger, _filter) as reader:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds a new can message so that we can adjust the gripper jaw idle holdoff value from python. Requires fw changes in https://github.com/Opentrons/ot3-firmware/pull/735

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
