### PR TITLE
chore(hardware-testing): Mergeback production script fixes

### DIFF
--- a/hardware-testing/hardware_testing/drivers/asair_sensor.py
+++ b/hardware-testing/hardware_testing/drivers/asair_sensor.py
@@ -92,8 +92,9 @@ def BuildAsairSensor(simulate: bool, autosearch: bool = True) -> AsairSensorBase
                     ui.print_info(f"Trying to connect to env sensor on port {port}")
                     sensor = AsairSensor.connect(port)
                     ser_id = sensor.get_serial()
-                    ui.print_info(f"Found env sensor {ser_id} on port {port}")
-                    return sensor
+                    if len(ser_id) != 0:
+                        ui.print_info(f"Found env sensor {ser_id} on port {port}")
+                        return sensor
                 except:  # noqa: E722
                     pass
             use_sim = ui.get_user_answer("No env sensor found, use simulator?")

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -472,7 +472,6 @@ def _connect_to_fixture(test_config: TestConfig) -> PressureFixtureBase:
     fixture = connect_to_fixture(
         test_config.simulate or test_config.skip_fixture, side=test_config.fixture_side
     )
-    fixture.connect()
     return fixture
 
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
