### PR TITLE
fix(components): provide OT-2 fixed trash dimensions for deck location select

### DIFF
--- a/components/src/hardware-sim/DeckSlotLocation/index.tsx
+++ b/components/src/hardware-sim/DeckSlotLocation/index.tsx
@@ -17,6 +17,10 @@ interface LegacyDeckSlotLocationProps extends React.SVGProps<SVGGElement> {
   slotClipColor?: React.SVGProps<SVGPathElement>['stroke']
 }
 
+// dimensions of the OT-2 fixed trash, not in deck definition
+export const OT2_FIXED_TRASH_X_DIMENSION = 172.86
+export const OT2_FIXED_TRASH_Y_DIMENSION = 165.86
+
 /**
  * This is a legacy component for rendering an OT-2 deck slot by reference to the V4 deck definition
  */
@@ -48,17 +52,23 @@ export function LegacyDeckSlotLocation(
     (ot2DeckDefV4 as unknown) as DeckDefinition
   )
 
-  const [xPosition, yPosition] = slotPosition ?? [0, 0]
-  const { xDimension, yDimension } = slotDef.boundingBox
-
   const isFixedTrash = slotName === 'fixedTrash'
 
-  // adjust the fixed trash position and dimension
+  const [xPosition, yPosition] = slotPosition ?? [0, 0]
+  const { xDimension, yDimension } = isFixedTrash
+    ? {
+        xDimension: OT2_FIXED_TRASH_X_DIMENSION,
+        yDimension: OT2_FIXED_TRASH_Y_DIMENSION,
+      }
+    : slotDef.boundingBox
+  const [xOffset, yOffset] = slotDef.offsetFromCutoutFixture
+
+  // adjust the fixed trash position and dimension to fit inside deck SVG
   const fixedTrashPositionAdjustment = isFixedTrash ? 7 : 0
   const fixedTrashDimensionAdjustment = isFixedTrash ? -9 : 0
 
-  const adjustedXPosition = xPosition + fixedTrashPositionAdjustment
-  const adjustedYPosition = yPosition + fixedTrashPositionAdjustment
+  const adjustedXPosition = xPosition + fixedTrashPositionAdjustment - xOffset
+  const adjustedYPosition = yPosition + fixedTrashPositionAdjustment - yOffset
   const adjustedXDimension = xDimension + fixedTrashDimensionAdjustment
   const adjustedYDimension = yDimension + fixedTrashDimensionAdjustment
 

--- a/components/src/hooks/useSelectDeckLocation/index.tsx
+++ b/components/src/hooks/useSelectDeckLocation/index.tsx
@@ -13,6 +13,8 @@ import {
 import {
   DeckFromLayers,
   LegacyDeckSlotLocation,
+  OT2_FIXED_TRASH_X_DIMENSION,
+  OT2_FIXED_TRASH_Y_DIMENSION,
   RobotCoordinateSpace,
   RobotCoordsForeignDiv,
   SingleSlotFixture,
@@ -187,10 +189,18 @@ export function DeckLocationSelect({
               )}
               {isSelected && slotPosition != null ? (
                 <RobotCoordsForeignDiv
-                  x={slotPosition[0]}
-                  y={slotPosition[1]}
-                  width={slot.boundingBox.xDimension}
-                  height={slot.boundingBox.yDimension}
+                  x={slotPosition[0] - slot.offsetFromCutoutFixture[0]}
+                  y={slotPosition[1] - slot.offsetFromCutoutFixture[1]}
+                  width={
+                    slot.id === 'fixedTrash'
+                      ? OT2_FIXED_TRASH_X_DIMENSION
+                      : slot.boundingBox.xDimension
+                  }
+                  height={
+                    slot.id === 'fixedTrash'
+                      ? OT2_FIXED_TRASH_Y_DIMENSION
+                      : slot.boundingBox.yDimension
+                  }
                   innerDivProps={INNER_DIV_PROPS}
                 >
                   <Text


### PR DESCRIPTION
# Overview

hard codes the OT-2 fixed trash dimensions for the sole purpose of legacy deck slot location select, used in drop tip wizard. needed because the OT-2 v4 deck definition no longer contains x and y bounding box dimensions

closes RQA-2042

# Test Plan

 - visually verified the dimensions of the drop tip wizard OT-2 fixed trash selection area

# Changelog

 - Provides OT-2 fixed trash dimensions for deck location select

# Review requests

check OT-2 drop tip wizard

# Risk assessment

low
