### PR TITLE
feat(app): disable robot overflow menu when robot has an existing maintenance run

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -3,6 +3,7 @@ import {
   useAllSessionsQuery,
   useAllRunsQuery,
   useEstopQuery,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 import {
   DISENGAGED,
@@ -34,6 +35,9 @@ const mockUseAllSessionsQuery = useAllSessionsQuery as jest.MockedFunction<
 const mockUseAllRunsQuery = useAllRunsQuery as jest.MockedFunction<
   typeof useAllRunsQuery
 >
+const mockUseCurrentMaintenanceRun = useCurrentMaintenanceRun as jest.MockedFunction<
+  typeof useCurrentMaintenanceRun
+>
 const mockUseEstopQuery = useEstopQuery as jest.MockedFunction<
   typeof useEstopQuery
 >
@@ -51,6 +55,9 @@ describe('useIsRobotBusy', () => {
         },
       },
     } as UseQueryResult<Runs, AxiosError>)
+    mockUseCurrentMaintenanceRun.mockReturnValue({
+      data: {},
+    } as any)
     mockUseEstopQuery.mockReturnValue({ data: mockEstopStatus } as any)
     mockUseIsFlex.mockReturnValue(false)
   })
@@ -180,15 +187,15 @@ describe('useIsRobotBusy', () => {
     expect(result).toBe(false)
   })
 
-  // TODO: kj 07/13/2022 This test is temporary pending but should be solved by another PR.
-  // it('should poll the run and sessions if poll option is true', async () => {
-  //   const result = useIsRobotBusy({ poll: true })
-  //   expect(result).toBe(true)
-
-  //   act(() => {
-  //     jest.advanceTimersByTime(30000)
-  //   })
-  //   expect(mockUseAllRunsQuery).toHaveBeenCalled()
-  //   expect(mockUseAllSessionsQuery).toHaveBeenCalled()
-  // })
+  it('returns true when a maintenance run exists', () => {
+    mockUseCurrentMaintenanceRun.mockReturnValue({
+      data: {
+        data: {
+          id: '123',
+        },
+      },
+    } as any)
+    const result = useIsRobotBusy()
+    expect(result).toBe(true)
+  })
 })

--- a/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
+++ b/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
@@ -3,6 +3,7 @@ import {
   useAllRunsQuery,
   useEstopQuery,
   useHost,
+  useCurrentMaintenanceRun,
 } from '@opentrons/react-api-client'
 import { DISENGAGED } from '../../EmergencyStop'
 import { useIsFlex } from './useIsFlex'
@@ -19,6 +20,8 @@ export function useIsRobotBusy(
   const queryOptions = poll ? { refetchInterval: ROBOT_STATUS_POLL_MS } : {}
   const robotHasCurrentRun =
     useAllRunsQuery({}, queryOptions)?.data?.links?.current != null
+  const { data: maintenanceRunData } = useCurrentMaintenanceRun(queryOptions)
+  const isMaintenanceRunExisting = maintenanceRunData?.data?.id != null
   const allSessionsQueryResponse = useAllSessionsQuery(queryOptions)
   const host = useHost()
   const robotName = host?.robotName
@@ -30,6 +33,7 @@ export function useIsRobotBusy(
 
   return (
     robotHasCurrentRun ||
+    isMaintenanceRunExisting ||
     (allSessionsQueryResponse?.data?.data != null &&
       allSessionsQueryResponse?.data?.data?.length !== 0) ||
     (isFlex && estopStatus?.data.status !== DISENGAGED && estopError == null)


### PR DESCRIPTION
# Overview
This PR updates the `useisRobotBusy` hook to check for the existence of a current maintenance run. This will affect:

- The robot overflow menu (whether or not we allow users to create a run)
- Advanced settings on the desktop app (whether to enable/disable toggles)
- Advanced settings on the ODD (whether to enable/disable toggles)
- The desktop app’s update modal (whether or not we allow users to initiate an update)

Closes RQA-1170

# Risk assessment

low