### PR TITLE
chore(hardware-testing): remove default application of grav patches

### DIFF
--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -79,36 +79,36 @@ sdist:
 
 .PHONY: test
 test:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(pytest) $(tests) $(test_opts)
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-cov
 test-cov:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(pytest) $(tests) $(test_opts) $(cov_opts)
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-photometric-single
 test-photometric-single:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 50 --channels 1 --tip 50
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 50 --channels 1 --tip 50 --photoplate-col-offset 3
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 50 --channels 1 --tip 50 --dye-well-col-offset 3
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-photometric-multi
 test-photometric-multi:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 50 --channels 8 --tip 50
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-photometric
 test-photometric:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 1000 --channels 96 --tip 50 --trials 1
 	$(python) -m hardware_testing.gravimetric --photometric --simulate --pipette 1000 --channels 96 --tip 200 --trials 1
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-gravimetric-single
 test-gravimetric-single:
@@ -134,14 +134,14 @@ test-gravimetric-96:
 
 .PHONY: test-gravimetric
 test-gravimetric:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(python) -m hardware_testing.gravimetric.daily_setup --simulate
 	$(python) -m hardware_testing.gravimetric.daily_setup --simulate --calibrate
 	$(MAKE) test-gravimetric-single
 	$(MAKE) test-gravimetric-multi
 	$(MAKE) test-gravimetric-96
 	$(MAKE) test-photometric
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: test-production-qc
 test-production-qc:
@@ -172,11 +172,11 @@ test-integration: test-production-qc test-examples test-scripts test-gravimetric
 
 .PHONY: lint
 lint:
-	-$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) apply-patches-gravimetric
 	$(python) -m mypy hardware_testing tests
 	$(python) -m black --check hardware_testing tests setup.py
 	$(python) -m flake8 hardware_testing tests setup.py
-	-$(MAKE) remove-patches-gravimetric
+#	-$(MAKE) remove-patches-gravimetric
 
 .PHONY: format
 format:
@@ -297,10 +297,11 @@ sync-ot3: sync-sw-ot3 sync-fw-ot3
 
 .PHONY: push-ot3-gravimetric
 push-ot3-gravimetric:
-	$(MAKE) apply-patches-gravimetric
-	-$(MAKE) sync-sw-ot3
+#	$(MAKE) apply-patches-gravimetric
+#	-$(MAKE) sync-sw-ot3
+	$(MAKE) push-ot3
 	scp $(ssh_helper_ot3) -r hardware_testing/labware root@$(host):/data/labware/v2/custom_definitions/custom_beta/
-	$(MAKE) remove-patches-gravimetric
+#   $(MAKE) remove-patches-gravimetric
 
 .PHONY: apply-patches-gravimetric
 apply-patches-gravimetric:


### PR DESCRIPTION
We don't need the gravimetric patches anymore so this comments them out and changes the push-ot3-gravimetric to not push anything besides the custom labware defs (for the radwag vial) and the hardware-testing subdirectory this is in an effort to avoid changing the existing software on the bot

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
