### PR TITLE
fix(protocol-designer): loadLabware support for off-deck labware

### DIFF
--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -113,7 +113,6 @@ export const createFile: Selector<ProtocolFile> = createSelector(
   stepFormSelectors.getPipetteEntities,
   uiLabwareSelectors.getLabwareNicknamesById,
   labwareDefSelectors.getLabwareDefsByURI,
-
   (
     fileMetadata,
     initialRobotState,
@@ -283,6 +282,8 @@ export const createFile: Selector<ProtocolFile> = createSelector(
           location = { labwareId: labware.slot }
         } else if (isAddressableAreaName) {
           location = { addressableAreaName: labware.slot }
+        } else if (labware.slot === 'offDeck') {
+          location = 'offDeck'
         }
 
         const loadLabwareCommands = {


### PR DESCRIPTION
closes RQA-2058

# Overview

The `loadLabware` command's labware location logic didn't include loading labware off-deck. this is because loading labware off-deck wasn't a PD feature until now in 8.0. 

# Test Plan

Create a flex or ot-2 protocol. Click on the design tab and clock on the "off deck labware" button. Add a labware off-deck. Download the protocol. Look at the JSON file and see that the `loadLabware` command is correct where the location is `"location": "offDeck"`

# Changelog

extend `offDeck` location in the component

# Review requests

see test plan

# Risk assessment

low