### PR TITLE
fix(app): case insensitively sort labware list

### DIFF
--- a/app/src/pages/Labware/hooks.tsx
+++ b/app/src/pages/Labware/hooks.tsx
@@ -37,10 +37,17 @@ export function useAllLabware(
       : null
   )
   const sortLabware = (a: LabwareDefAndDate, b: LabwareDefAndDate): number => {
-    if (a.definition.metadata.displayName < b.definition.metadata.displayName) {
+    console.log(a.definition.metadata.displayName)
+    if (
+      a.definition.metadata.displayName.toUpperCase() <
+      b.definition.metadata.displayName.toUpperCase()
+    ) {
       return sortBy === 'alphabetical' ? -1 : 1
     }
-    if (a.definition.metadata.displayName > b.definition.metadata.displayName) {
+    if (
+      a.definition.metadata.displayName.toUpperCase() >
+      b.definition.metadata.displayName.toUpperCase()
+    ) {
       return sortBy === 'alphabetical' ? 1 : -1
     }
     return 0

--- a/app/src/pages/Labware/hooks.tsx
+++ b/app/src/pages/Labware/hooks.tsx
@@ -37,7 +37,6 @@ export function useAllLabware(
       : null
   )
   const sortLabware = (a: LabwareDefAndDate, b: LabwareDefAndDate): number => {
-    console.log(a.definition.metadata.displayName)
     if (
       a.definition.metadata.displayName.toUpperCase() <
       b.definition.metadata.displayName.toUpperCase()


### PR DESCRIPTION
# Overview

This PR ignores case when sorting labware display names in the app's labware list.

closes RQA-1955

# Risk assessment

Low