### PR TITLE
fix(app): Copy fixes in app flows

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -39,7 +39,7 @@
   "detach": "Detaching Pipette",
   "exit_cal": "Exit calibration",
   "firmware_updating": "A firmware update is required, instrument is updating...",
-  "firmware_up_to_date": "Firmware is up to date.",
+  "firmware_up_to_date": "No firmware update found.",
   "gantry_empty_for_96_channel_success": "Now that both mounts are empty, you can begin the 96-Channel Pipette attachment process.",
   "get_started_detach": "<block>To get started, remove labware from the deck and clean up the working area to make detachment easier. Also gather the needed equipment shown to the right.</block>",
   "grab_screwdriver": "While continuing to hold in place, grab your 2.5mm driver and tighten screws as shown in the animation. Test the pipette attachment by giving it a wiggle before pressing continue",

--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -20,7 +20,7 @@
   "labware": "labware",
   "last_analyzed": "last analyzed",
   "last_updated": "last updated",
-  "left_and_right_mounts": "Both Mounts",
+  "both_mounts": "Both Mounts",
   "left_mount": "left mount",
   "liquid_name": "liquid name",
   "liquids_not_in_protocol": "no liquids are specified for this protocol",

--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -20,7 +20,7 @@
   "labware": "labware",
   "last_analyzed": "last analyzed",
   "last_updated": "last updated",
-  "left_and_right_mounts": "Left+Right Mounts",
+  "left_and_right_mounts": "Both Mounts",
   "left_mount": "left mount",
   "liquid_name": "liquid name",
   "liquids_not_in_protocol": "no liquids are specified for this protocol",

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -131,8 +131,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         i18nKey={'pipette_wizard_flows:install_probe'}
         values={{ location: probeLocation }}
         components={{
-          strong: <strong />,
-          block: <StyledText css={BODY_STYLE} />,
+          bold: <strong />,
         }}
       />
       {wasteChuteConflict && (

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -39,6 +39,13 @@ const IN_PROGRESS_STYLE = css`
     margin-top: ${SPACING.spacing4};
   }
 `
+const BODY_STYLE = css`
+  ${TYPOGRAPHY.pRegular};
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    font-size: 1.275rem;
+    line-height: 1.75rem;
+  }
+`
 
 export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const {
@@ -118,14 +125,17 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   const bodyText = (
     <>
-      <Trans
-        t={t}
-        i18nKey={'pipette_wizard_flows:install_probe'}
-        values={{ location: probeLocation }}
-        components={{
-          bold: <strong />,
-        }}
-      />
+      <StyledText css={BODY_STYLE}>
+        <Trans
+          t={t}
+          i18nKey={'pipette_wizard_flows:install_probe'}
+          values={{ location: probeLocation }}
+          components={{
+            bold: <strong />,
+          }}
+        />
+      </StyledText>
+
       {wasteChuteConflict && (
         <Banner
           type={isWasteChuteOnDeck ? 'error' : 'warning'}

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -39,14 +39,6 @@ const IN_PROGRESS_STYLE = css`
     margin-top: ${SPACING.spacing4};
   }
 `
-const BODY_STYLE = css`
-  ${TYPOGRAPHY.pRegular};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    font-size: 1.275rem;
-    line-height: 1.75rem;
-  }
-`
 
 export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
   const {

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -117,7 +117,7 @@ export const RobotConfigurationDetails = (
       />
       <Divider marginY={SPACING.spacing12} width="100%" />
       <RobotConfigurationDetailsItem
-        label={is96PipetteUsed ? t('left_and_right_mounts') : t('left_mount')}
+        label={is96PipetteUsed ? t('both_mounts') : t('left_mount')}
         item={isLoading ? loadingText : leftMountItem}
       />
       {!is96PipetteUsed && (

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -35,7 +35,6 @@ import type {
   RobotType,
   SingleSlotCutoutFixtureId,
 } from '@opentrons/shared-data'
-import { getIs96ChannelPipetteAttached } from '../Devices/utils'
 
 interface RobotConfigurationDetailsProps {
   leftMountPipetteName: PipetteName | null

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -35,6 +35,7 @@ import type {
   RobotType,
   SingleSlotCutoutFixtureId,
 } from '@opentrons/shared-data'
+import { getIs96ChannelPipetteAttached } from '../Devices/utils'
 
 interface RobotConfigurationDetailsProps {
   leftMountPipetteName: PipetteName | null
@@ -67,25 +68,7 @@ export const RobotConfigurationDetails = (
     </StyledText>
   )
 
-  // TODO(bh, 2022-10-18): insert 96-channel display name
-  // const leftAndRightMountsPipetteDisplayName = 'P20 96-Channel GEN1'
-  const leftAndRightMountsPipetteDisplayName = null
-  const leftAndRightMountsItem =
-    leftAndRightMountsPipetteDisplayName != null ? (
-      <RobotConfigurationDetailsItem
-        label={t('left_and_right_mounts')}
-        item={
-          isLoading ? (
-            loadingText
-          ) : (
-            <InstrumentContainer
-              displayName={leftAndRightMountsPipetteDisplayName}
-            />
-          )
-        }
-      />
-    ) : null
-
+  const is96PipetteUsed = leftMountPipetteName === 'p1000_96'
   const leftMountPipetteDisplayName =
     getPipetteNameSpecs(leftMountPipetteName as PipetteName)?.displayName ??
     null
@@ -134,12 +117,12 @@ export const RobotConfigurationDetails = (
         }
       />
       <Divider marginY={SPACING.spacing12} width="100%" />
-      {leftAndRightMountsItem ?? (
+      <RobotConfigurationDetailsItem
+        label={is96PipetteUsed ? t('left_and_right_mounts') : t('left_mount')}
+        item={isLoading ? loadingText : leftMountItem}
+      />
+      {!is96PipetteUsed && (
         <>
-          <RobotConfigurationDetailsItem
-            label={t('left_mount')}
-            item={isLoading ? loadingText : leftMountItem}
-          />
           <Divider marginY={SPACING.spacing12} width="100%" />
           <RobotConfigurationDetailsItem
             label={t('right_mount')}


### PR DESCRIPTION
RQA-2048, RQA-2016, RQA-2023
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR fixes a few small copy related bugs
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Tested all of these out:
<img width="742" alt="Screen Shot 2023-12-11 at 5 16 30 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/6ee8127d-5ac6-4499-80ce-caa4973c98cb">
<img width="862" alt="Screen Shot 2023-12-11 at 5 13 59 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/7f82a26b-fa42-4bf0-98bc-3a7c490f322e">
<img width="1014" alt="Screen Shot 2023-12-11 at 5 06 57 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/fe3b5c04-5d50-445d-b432-de15b1753375">

<!--

Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Change firmware copy to say "No firmware update found" within pipette attachment modal so that if no pipette is attached the copy isn't confusing
2. Fix bold i18n key in attach probe step of module calibration
3. Show "Both mounts" for 96 channel pipette in protocol details

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Sanity check code
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
