### PR TITLE
fix(app-shell,usb-bridge): improve flex usb communication

### DIFF
--- a/app-shell/src/robot-update/index.ts
+++ b/app-shell/src/robot-update/index.ts
@@ -180,13 +180,6 @@ export function getRobotSystemUpdateUrls(
     .then(manifest => {
       const urls = getReleaseSet(manifest, CURRENT_VERSION)
 
-      if (urls === null) {
-        log.warn('No release files in manifest', {
-          version: CURRENT_VERSION,
-          manifest,
-        })
-      }
-
       return urls
     })
     .catch((error: Error) => {

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -113,9 +113,11 @@ export function createSerialPortListMonitor(
 class SerialPortSocket extends SerialPort {
   // added these to squash keepAlive errors
   setKeepAlive(): void {}
+
   unref(): SerialPortSocket {
     return this
   }
+
   setTimeout(): void {}
 
   ref(): SerialPortSocket {

--- a/usb-bridge/ot3usb/serial_thread.py
+++ b/usb-bridge/ot3usb/serial_thread.py
@@ -49,7 +49,6 @@ def create_worker_thread(
     may be required to allow clients to process data in time, since many desktop
     OS serial drivers do not have very large data buffers.
     """
-
     queue: QUEUE_TYPE = Queue(QUEUE_MAX_ITEMS)
     thread = threading.Thread(
         target=_worker,

--- a/usb-bridge/ot3usb/serial_thread.py
+++ b/usb-bridge/ot3usb/serial_thread.py
@@ -12,15 +12,17 @@ QUEUE_TYPE: TypeAlias = "Queue[QUEUE_WRITE_ITEM]"
 
 QUEUE_MAX_ITEMS = 100
 
+DEFAULT_PACKET_LIMIT = 2048
 
-def _try_write_all_data(serial: serial.Serial, data: bytes) -> None:
+
+def _try_write_all_data(serial: serial.Serial, data: bytes, packet_limit: int) -> None:
     sent = 0
     tries = 0
     if len(data) == 0:
         return
     while sent < len(data):
         try:
-            sent += serial.write(data[sent:])
+            sent += serial.write(data[sent:min(sent+packet_limit, len(data))])
         except Exception as e:
             # Any exception means we need to quit
             print(f"Failed to write: {e}")
@@ -31,17 +33,24 @@ def _try_write_all_data(serial: serial.Serial, data: bytes) -> None:
             time.sleep(0.01)
 
 
-def _worker(queue: QUEUE_TYPE) -> None:
+def _worker(queue: QUEUE_TYPE, packet_limit: int) -> None:
     while True:
         ser, data = queue.get()
-        _try_write_all_data(ser, data)
+        _try_write_all_data(ser, data, packet_limit)
 
 
-def create_worker_thread() -> Tuple[threading.Thread, QUEUE_TYPE]:
-    """Create a serial worker thread. Returns the comms queue."""
+def create_worker_thread(packet_limit: int = DEFAULT_PACKET_LIMIT) -> Tuple[threading.Thread, QUEUE_TYPE]:
+    """Create a serial worker thread. Returns the comms queue.
+
+    packet_limit is a maximum size for a single usb packet which is sent no more
+    frequently than every 10 ms, establishing an effective bandwidth limit. This
+    may be required to allow clients to process data in time, since many desktop
+    OS serial drivers do not have very large data buffers.
+    """
+
     queue: QUEUE_TYPE = Queue(QUEUE_MAX_ITEMS)
     thread = threading.Thread(
-        target=_worker, name="serial worker", kwargs={"queue": queue}
+        target=_worker, name="serial worker", kwargs={"queue": queue, "packet_limit": packet_limit}
     )
 
     return (thread, queue)

--- a/usb-bridge/ot3usb/serial_thread.py
+++ b/usb-bridge/ot3usb/serial_thread.py
@@ -22,7 +22,7 @@ def _try_write_all_data(serial: serial.Serial, data: bytes, packet_limit: int) -
         return
     while sent < len(data):
         try:
-            sent += serial.write(data[sent:min(sent+packet_limit, len(data))])
+            sent += serial.write(data[sent : min(sent + packet_limit, len(data))])
         except Exception as e:
             # Any exception means we need to quit
             print(f"Failed to write: {e}")
@@ -39,7 +39,9 @@ def _worker(queue: QUEUE_TYPE, packet_limit: int) -> None:
         _try_write_all_data(ser, data, packet_limit)
 
 
-def create_worker_thread(packet_limit: int = DEFAULT_PACKET_LIMIT) -> Tuple[threading.Thread, QUEUE_TYPE]:
+def create_worker_thread(
+    packet_limit: int = DEFAULT_PACKET_LIMIT,
+) -> Tuple[threading.Thread, QUEUE_TYPE]:
     """Create a serial worker thread. Returns the comms queue.
 
     packet_limit is a maximum size for a single usb packet which is sent no more
@@ -50,7 +52,9 @@ def create_worker_thread(packet_limit: int = DEFAULT_PACKET_LIMIT) -> Tuple[thre
 
     queue: QUEUE_TYPE = Queue(QUEUE_MAX_ITEMS)
     thread = threading.Thread(
-        target=_worker, name="serial worker", kwargs={"queue": queue, "packet_limit": packet_limit}
+        target=_worker,
+        name="serial worker",
+        kwargs={"queue": queue, "packet_limit": packet_limit},
     )
 
     return (thread, queue)


### PR DESCRIPTION
Closes RSS-420, RQA-2053, RQA-1615

This branch has fixes for a couple of the underlying issues with flex usb communication.

First, we need to limit the flex->host directional bandwidth (which we do by limiting the size of the USB packets we send on the python side) because if we send too much we will blow through the host-side serial buffers in their drivers, which are very variable. When we do that, we lose data which is part of an HTTP response; and the node http parser can't really handle that and just hangs. Even if it didn't and found the error, we need that error not to happen.

Second, we need to fix a couple socket lifetime issues on the node side. These were basically
1. By hook or by crook, close sockets less
2. When you close sockets, do it correctly so you can reopen them

(1) has some gross results because the code that uses sockets is really gross and we have not gone high when they went low, but it's a minimal changeset.
(2) is a real pain because the control flow bounces around 3 different events on like 3 different emitters and you need to trace it through; what it boils down to is noting that both the readable and writable streams AND the serialport have a "close" event they fire, and that only means the serial port is _actually closed_ if it was the serial port that did it. 

This doesn't get us all the way there almost certainly; we do occasionally still drop parts of packets on heavy usage like fetching logs sometimes, and therefore probably need to introduce more timeouts. We also haven't fully tested all the OS's and flows yet but we do get a whole lot farther with that testing than we previously did.

### Testing more
At least the following:
- Getting logs should succeed on all platforms
- Updating robots should succeed on all platforms
- Start a protocol and ideally run it on all platforms
- Do something that the robot-server uses a redirect in on all platforms (attaching a pipette is a good example)
- Other hot button flows but those above should give a broad test.