### PR TITLE
refactor(hardware-testing): Account for InstrumentContext.trash_container not being a Labware anymore

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/trial.py
+++ b/hardware-testing/hardware_testing/gravimetric/trial.py
@@ -241,11 +241,18 @@ def _finish_test(
         resources.ctx.home()
         if resources.pipette.current_volume > 0:
             ui.print_info("dispensing liquid to trash")
-            trash = resources.pipette.trash_container.wells()[0]
+            trash_container = resources.pipette.trash_container
+            dispense_location = (
+                trash_container.wells()[0].top()
+                if isinstance(trash_container, Labware)
+                else trash_container
+            )
             # FIXME: this should be a blow_out() at max volume,
             #        but that is not available through PyAPI yet
             #        so instead just dispensing.
-            resources.pipette.dispense(resources.pipette.current_volume, trash.top())
+            resources.pipette.dispense(
+                resources.pipette.current_volume, dispense_location
+            )
             resources.pipette.aspirate(10)  # to pull any droplets back up
         ui.print_info("dropping tip")
         helpers._drop_tip(resources.pipette, return_tip)

--- a/hardware-testing/hardware_testing/gravimetric/trial.py
+++ b/hardware-testing/hardware_testing/gravimetric/trial.py
@@ -242,9 +242,6 @@ def _finish_test(
         if resources.pipette.current_volume > 0:
             ui.print_info("dispensing liquid to trash")
             trash = resources.pipette.trash_container.wells()[0]
-            dispense_location = trash.top()
-            if resources.pipette.channels == 96:
-                dispense_location = dispense_location.move(Point(-36.0, -25.5, 0))
             # FIXME: this should be a blow_out() at max volume,
             #        but that is not available through PyAPI yet
             #        so instead just dispensing.


### PR DESCRIPTION
# Overview

Fixes these CI errors:

```
hardware_testing/gravimetric/trial.py:244: error: Item "TrashBin" of "Union[Labware, TrashBin, WasteChute]" has no attribute "wells"  [union-attr]
hardware_testing/gravimetric/trial.py:244: error: Item "WasteChute" of "Union[Labware, TrashBin, WasteChute]" has no attribute "wells"  [union-attr]
```

# Test Plan

I don't have an easy way to test this today (I'm sick and working from home) so I'm relying on code review.

# Changelog

* Add handling for the case where `InstrumentContext.trash_container` is a `WasteChute` or `TrashBin`, and so it doesn't have a "well A1."
* Delete some dead code.

# Review requests

See my inline notes.

# Risk assessment

Low.
