### PR TITLE
fix(app): prevent terminalrunbanner from closing the current run

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -785,11 +785,6 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
   } = props
   const { t } = useTranslation('run_details')
 
-  const handleClick = (): void => {
-    handleClearClick()
-    setShowRunFailedModal(true)
-  }
-
   if (runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED) {
     return (
       <>
@@ -814,7 +809,7 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
               </StyledText>
 
               <LinkButton
-                onClick={handleClick}
+                onClick={() => setShowRunFailedModal(true)}
                 textDecoration={TYPOGRAPHY.textDecorationUnderline}
               >
                 {t('view_error')}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -831,7 +831,7 @@ describe('ProtocolRunHeader', () => {
     const [{ getByText }] = render()
 
     getByText('View error').click()
-    expect(mockCloseCurrentRun).toBeCalled()
+    expect(mockCloseCurrentRun).not.toHaveBeenCalled()
     getByText('mock RunFailedModal')
   })
 


### PR DESCRIPTION
Closes RQA-2013

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Clicking the error banner within ProtcolRunHeader has the behavior of clearing the current run, but this behavior is probably not desired. First, it actually unrenders the error banner, and second, all conditional rendering tied to the current run (such as the drop tip banner) are unrendered as well. The "Run Again" button component is the only thing that really needs to clear/reset the current run, so let's just rely on that functionality. 

### 

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/9d240261-bc4c-4960-9a13-8b4a3c14fd7d

### With PR

https://github.com/Opentrons/opentrons/assets/64858653/a9406bda-5463-4ef4-9427-cf3ba8000dfa


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Trigger any sort of error during a protocol run (on the desktop app -- estop is always fun), and then click the terminal error banner. Observe that the current run no longer gets reset.
- Clicking Run Again should properly reset the run.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Clicking the error banner on the desktop app during a protocol run no longer unrenders the error banner and other banners. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Just double check my logic here - I don't think we actually lose anything by not clearing the protocol run here. I think the reason this bug was in the code for so long was that it wasn't really that noticeable of a problem until we added other conditional banners, such as the drop tip banner.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
