### PR TITLE
feat(api): add tiprack adapter check for 96 ch tip pickup and return

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -221,16 +221,16 @@ def check_safe_for_tip_pickup_and_return(
             )
         elif not is_partial_config and tiprack_height > adapter_height:
             raise PipetteMovementNotAllowed(
-                f"Tiprack {tiprack_name}  must be on a Flex Tiprack Adapter (or similar)"
-                f" in order to pick up or drop tips with full 96-channel nozzles."
+                f"Tiprack {tiprack_name} must be on a Flex Tiprack Adapter (or similar)"
+                f" in order to pick up or return tips with all 96-channel nozzles."
             )
 
     elif (
         not is_partial_config
     ):  # tiprack is not on adapter and pipette is in full config
         raise PipetteMovementNotAllowed(
-            f"Tiprack {tiprack_name}  must be on a Flex Tiprack Adapter (or similar)"
-            f" in order to pick up or drop tips with full 96-channel nozzles."
+            f"Tiprack {tiprack_name} must be on a Flex Tiprack Adapter (or similar)"
+            f" in order to pick up or return tips with all 96-channel nozzles."
         )
 
 

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -36,6 +36,15 @@ class PartialTipMovementNotAllowedError(MotionPlanningFailureError):
         )
 
 
+class PipetteMovementNotAllowed(MotionPlanningFailureError):
+    """Error raised when trying to perform a pipette movement to a tiprack beased on adapter status."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(
+            message=message,
+        )
+
+
 _log = logging.getLogger(__name__)
 
 # TODO (spp, 2023-12-06): move this to a location like motion planning where we can
@@ -171,6 +180,57 @@ def check_safe_for_pipette_movement(
             labware_id=labware_id,
             well_name=well_name,
             well_location=well_location,
+        )
+
+
+def check_safe_for_tip_pickup_and_return(
+    engine_state: StateView,
+    pipette_id: str,
+    labware_id: str,
+) -> None:
+    """Check if the presence or absence of a tiprack adapter might cause any pipette movement issues.
+
+    A 96 channel pipette will pick up tips using cam action when it's configured
+    to use ALL nozzles. For this, the tiprack needs to be on the Flex 96 channel tiprack adapter
+    or similar or the tips will not be picked up.
+
+    On the other hand, if the pipette is configured with partial nozzle configuration,
+    it uses the usual pipette presses to pick the tips up, in which case, having the tiprack
+    on the Flex 96 channel tiprack adapter (or similar) will cause the pipette to
+    crash against the adapter posts.
+
+    In order to check if the 96-channel can move and pickup/drop tips safely, this method
+    checks for the height attribute of the tiprack adapter rather than checking for the
+    specific official adapter since users might create custom labware &/or definitions
+    compatible with the official adapter.
+    """
+    if not engine_state.pipettes.get_channels(pipette_id) == 96:
+        # Adapters only matter to 96 ch.
+        return
+
+    is_partial_config = engine_state.pipettes.get_is_partially_configured(pipette_id)
+    tiprack_name = engine_state.labware.get_load_name(labware_id)
+    tiprack_parent = engine_state.labware.get_location(labware_id)
+    if isinstance(tiprack_parent, OnLabwareLocation):  # tiprack is on an adapter
+        tiprack_height = engine_state.labware.get_dimensions(labware_id).z
+        adapter_height = engine_state.labware.get_dimensions(tiprack_parent.labwareId).z
+        if is_partial_config and tiprack_height < adapter_height:
+            raise PartialTipMovementNotAllowedError(
+                f"Tiprack {tiprack_name} cannot be on an adapter taller than the tiprack"
+                f"  when the 96-channel is configured for using partial nozzles."
+            )
+        elif not is_partial_config and tiprack_height > adapter_height:
+            raise PipetteMovementNotAllowed(
+                f"Tiprack {tiprack_name}  must be on a Flex Tiprack Adapter (or similar)"
+                f" in order to pick up or drop tips with full 96-channel nozzles."
+            )
+
+    elif (
+        not is_partial_config
+    ):  # tiprack is not on adapter and pipette is in full config
+        raise PipetteMovementNotAllowed(
+            f"Tiprack {tiprack_name}  must be on a Flex Tiprack Adapter (or similar)"
+            f" in order to pick up or drop tips with full 96-channel nozzles."
         )
 
 

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -212,6 +212,9 @@ def check_safe_for_tip_pickup_and_return(
     tiprack_name = engine_state.labware.get_display_name(labware_id)
     tiprack_parent = engine_state.labware.get_location(labware_id)
     if isinstance(tiprack_parent, OnLabwareLocation):  # tiprack is on an adapter
+        is_96_ch_tiprack_adapter = engine_state.labware.get_has_quirk(
+            labware_id=labware_id, quirk="tiprackAdapterFor96Channel"
+        )
         tiprack_height = engine_state.labware.get_dimensions(labware_id).z
         adapter_height = engine_state.labware.get_dimensions(tiprack_parent.labwareId).z
         if is_partial_config and tiprack_height < adapter_height:
@@ -219,7 +222,7 @@ def check_safe_for_tip_pickup_and_return(
                 f"{tiprack_name} cannot be on an adapter taller than the tip rack"
                 f" when picking up fewer than 96 tips."
             )
-        elif not is_partial_config and tiprack_height > adapter_height:
+        elif not is_partial_config and not is_96_ch_tiprack_adapter:
             raise UnsuitableTiprackForPipetteMotion(
                 f"{tiprack_name} must be on an Opentrons Flex 96 Tip Rack Adapter"
                 f" in order to pick up or return all 96 tips simultaneously."

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -37,7 +37,7 @@ class PartialTipMovementNotAllowedError(MotionPlanningFailureError):
 
 
 class PipetteMovementNotAllowed(MotionPlanningFailureError):
-    """Error raised when trying to perform a pipette movement to a tiprack beased on adapter status."""
+    """Error raised when trying to perform a pipette movement to a tip rack, based on adapter status."""
 
     def __init__(self, message: str) -> None:
         super().__init__(
@@ -216,13 +216,13 @@ def check_safe_for_tip_pickup_and_return(
         adapter_height = engine_state.labware.get_dimensions(tiprack_parent.labwareId).z
         if is_partial_config and tiprack_height < adapter_height:
             raise PartialTipMovementNotAllowedError(
-                f"Tiprack {tiprack_name} cannot be on an adapter taller than the tiprack"
-                f"  when the 96-channel is configured for using partial nozzles."
+                f"Tip rack {tiprack_name} cannot be on an adapter taller than the tip rack"
+                f" when picking up fewer than 96 tips."
             )
         elif not is_partial_config and tiprack_height > adapter_height:
             raise PipetteMovementNotAllowed(
-                f"Tiprack {tiprack_name} must be on a Flex Tiprack Adapter (or similar)"
-                f" in order to pick up or return tips with all 96-channel nozzles."
+                f"Tip rack {tiprack_name} must be on an Opentrons Flex 96 Tip Rack Adapter"
+                f" in order to pick up or return 96 tips simultaneously."
             )
 
     elif (

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -383,6 +383,11 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             well_name=well_name,
             absolute_point=location.point,
         )
+        deck_conflict.check_safe_for_tip_pickup_and_return(
+            engine_state=self._engine_client.state,
+            pipette_id=self._pipette_id,
+            labware_id=labware_id,
+        )
         deck_conflict.check_safe_for_pipette_movement(
             engine_state=self._engine_client.state,
             pipette_id=self._pipette_id,
@@ -434,12 +439,19 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             )
         else:
             well_location = DropTipWellLocation()
+
+        if self._engine_client.state.labware.is_tiprack(labware_id):
+            deck_conflict.check_safe_for_tip_pickup_and_return(
+                engine_state=self._engine_client.state,
+                pipette_id=self._pipette_id,
+                labware_id=labware_id,
+            )
         deck_conflict.check_safe_for_pipette_movement(
             engine_state=self._engine_client.state,
             pipette_id=self._pipette_id,
             labware_id=labware_id,
             well_name=well_name,
-            well_location=WellLocation(),
+            well_location=well_location,
         )
         self._engine_client.drop_tip(
             pipette_id=self._pipette_id,

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -490,8 +490,8 @@ def test_deck_conflict_raises_for_bad_partial_8_channel_move(
             Dimensions(x=0, y=0, z=50),
             False,
             pytest.raises(
-                deck_conflict.PipetteMovementNotAllowed,
-                match="must be on a Flex Tiprack Adapter",
+                deck_conflict.UnsuitableTiprackForPipetteMotion,
+                match="A cool tiprack must be on an Opentrons Flex 96 Tip Rack Adapter",
             ),
         ),
         (
@@ -505,8 +505,8 @@ def test_deck_conflict_raises_for_bad_partial_8_channel_move(
             Dimensions(x=0, y=0, z=101),
             False,
             pytest.raises(
-                deck_conflict.PipetteMovementNotAllowed,
-                match="must be on a Flex Tiprack Adapter",
+                deck_conflict.UnsuitableTiprackForPipetteMotion,
+                match="A cool tiprack must be on an Opentrons Flex 96 Tip Rack Adapter",
             ),
         ),
         (
@@ -515,7 +515,7 @@ def test_deck_conflict_raises_for_bad_partial_8_channel_move(
             True,
             pytest.raises(
                 deck_conflict.PartialTipMovementNotAllowedError,
-                match="cannot be on an adapter taller than the tiprack",
+                match="A cool tiprack cannot be on an adapter taller than the tip rack",
             ),
         ),
         (
@@ -545,7 +545,9 @@ def test_valid_96_pipette_movement_for_tiprack_and_adapter(
     decoy.when(mock_state_view.labware.get_dimensions("adapter-id")).then_return(
         Dimensions(x=0, y=0, z=100)
     )
-
+    decoy.when(mock_state_view.labware.get_display_name("labware-id")).then_return(
+        "A cool tiprack"
+    )
     decoy.when(
         mock_state_view.pipettes.get_is_partially_configured("pipette-id")
     ).then_return(is_partial_config)

--- a/shared-data/js/__tests__/labwareDefQuirks.test.ts
+++ b/shared-data/js/__tests__/labwareDefQuirks.test.ts
@@ -11,6 +11,7 @@ const EXPECTED_VALID_QUIRKS = [
   'touchTipDisabled',
   'fixedTrash',
   'gripperIncompatible',
+  'tiprackAdapterFor96Channel',
 ]
 
 describe('check quirks for all labware defs', () => {

--- a/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_adapter/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_96_tiprack_adapter/1.json
@@ -24,7 +24,7 @@
   ],
   "parameters": {
     "format": "96Standard",
-    "quirks": [],
+    "quirks": ["tiprackAdapterFor96Channel"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_flex_96_tiprack_adapter"


### PR DESCRIPTION
# Overview

Adds error raising if:
- you are using a 96 channel with all nozzles and are picking up from or returning tips to a tiprack NOT on an appropriate adapter
- you are using a 96 channel with partial nozzles and are picking up from or returning tips to a tiprack that IS on an adapter that is taller than the tiprack (like the Flex 96 tiprack adapter)

# Test Plan

- Test that analysis raises error when the above conditions are met in a protocol.
Sample protocol:
```
from opentrons.protocol_api import COLUMN, ALL


requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16"
}

def run(protocol_context):
	trash_labware = protocol_context.load_labware("opentrons_1_trash_3200ml_fixed", "A3")

	tip_rack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C3")
	tip_rack2 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C3")

	tip_rack3 = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "B3", adapter="opentrons_flex_96_tiprack_adapter")
	tip_rack4 = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "D3", adapter="opentrons_flex_96_tiprack_adapter")


	instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack1, tip_rack2, tip_rack3, tip_rack4])
	instrument.trash_container = trash_labware

	# Should raise error because tiprack1 is not on adapter
	instrument.pick_up_tip()
	instrument.drop_tip()

	instrument.configure_nozzle_layout(style=COLUMN, start="A12")
	instrument.tip_racks = [tip_rack3]
	
	# Should pick tips up column-wise from tiprack3
	for _ in range(12):
		# Should raise error because tiprack3 is on adapter
		instrument.pick_up_tip()
		instrument.drop_tip()

	######### CHANGE CONFIG TO ALL #########
	instrument.configure_nozzle_layout(style=ALL, tip_racks=[tip_rack2])

	# Should raise error because tiprack2 is not on adapter
	instrument.pick_up_tip()
	instrument.drop_tip()
```

# Changelog

- added the above checks to `core/engine/deck_conflict.py`
- added tests for it. Also added other deck conflict checks that were missing. Found a bug in drop_tip deck conflict checking so fixed that

# Review requests

- mainly looking for opinions on the approach to the check. I am not checking if the tiprack is or isn't on the Flex 96 tiprack adapter, and instead checking if it is on an adapter that matches the height attribute of Flex tiprack (that it's taller than the tipracks). I decided on this approach after considering the number of labware definitions in use internally that are variants of the official Flex adapter definition. I can imagine that there will be customers that might write their own variants as well and the check should work for those too.

# Risk assessment

- Low-medium. Affects only 96 channel pickup & returns
