### PR TITLE
refactor(app): special case 96-channel pipette mount text in drop tip wizard

### DIFF
--- a/app/src/organisms/DropTipWizard/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizard/TipsAttachedModal.tsx
@@ -38,7 +38,7 @@ export const handleTipsAttachedModal = (
 
 const TipsAttachedModal = NiceModal.create(
   (props: TipsAttachedModalProps): JSX.Element => {
-    const { mount, onCloseClick } = props
+    const { mount, onCloseClick, instrumentModelSpecs } = props
     const { t } = useTranslation(['drop_tip_wizard'])
     const modal = useModal()
     const [showWizard, setShowWizard] = React.useState(false)
@@ -51,6 +51,9 @@ const TipsAttachedModal = NiceModal.create(
       iconColor: COLORS.yellow2,
     }
 
+    const is96Channel = instrumentModelSpecs.displayName.includes('96-Channel')
+    const displayMountText = is96Channel ? '96-Channel' : capitalize(mount)
+
     return (
       <>
         <Modal header={tipsAttachedHeader}>
@@ -60,7 +63,7 @@ const TipsAttachedModal = NiceModal.create(
                 t={t}
                 i18nKey="remove_the_tips"
                 values={{
-                  mount: capitalize(mount),
+                  mount: displayMountText,
                 }}
                 components={{
                   mount: <strong />,

--- a/app/src/organisms/DropTipWizard/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizard/TipsAttachedModal.tsx
@@ -51,7 +51,7 @@ const TipsAttachedModal = NiceModal.create(
       iconColor: COLORS.yellow2,
     }
 
-    const is96Channel = instrumentModelSpecs.displayName.includes('96-Channel')
+    const is96Channel = instrumentModelSpecs.channels === 96
     const displayMountText = is96Channel ? '96-Channel' : capitalize(mount)
 
     return (

--- a/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
@@ -81,7 +81,7 @@ describe('TipsAttachedModal', () => {
   it('renders special text when the pipette is a 96-Channel', () => {
     const ninetySixSpecs = {
       ...MOCK_ACTUAL_PIPETTE,
-      displayName: 'Flex 96-Channel Pipette',
+      channels: 96,
     } as PipetteModelSpecs
 
     const [{ getByTestId, getByText }] = render(ninetySixSpecs)

--- a/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
@@ -22,14 +22,14 @@ const MOCK_ACTUAL_PIPETTE = {
 
 const mockOnClose = jest.fn()
 
-const render = () => {
+const render = (pipetteSpecs: PipetteModelSpecs) => {
   return renderWithProviders(
     <NiceModal.Provider>
       <button
         onClick={() =>
           handleTipsAttachedModal(
             LEFT,
-            MOCK_ACTUAL_PIPETTE,
+            pipetteSpecs,
             ROBOT_MODEL_OT3,
             mockOnClose
           )
@@ -51,16 +51,17 @@ describe('TipsAttachedModal', () => {
   })
 
   it('renders appropriate warning given the pipette mount', () => {
-    const [{ getByTestId, getByText, queryByText }] = render()
+    const [{ getByTestId, getByText, queryByText }] = render(
+      MOCK_ACTUAL_PIPETTE
+    )
     const btn = getByTestId('testButton')
     fireEvent.click(btn)
 
     getByText('Tips are attached')
     queryByText(`${LEFT} Pipette`)
   })
-
   it('clicking the close button properly closes the modal', () => {
-    const [{ getByTestId, getByText }] = render()
+    const [{ getByTestId, getByText }] = render(MOCK_ACTUAL_PIPETTE)
     const btn = getByTestId('testButton')
     fireEvent.click(btn)
 
@@ -68,9 +69,22 @@ describe('TipsAttachedModal', () => {
     fireEvent.click(skipBtn)
     expect(mockOnClose).toHaveBeenCalled()
   })
-
   it('clicking the launch wizard button properly launches the wizard', () => {
-    const [{ getByTestId, getByText }] = render()
+    const [{ getByTestId, getByText }] = render(MOCK_ACTUAL_PIPETTE)
+    const btn = getByTestId('testButton')
+    fireEvent.click(btn)
+
+    const skipBtn = getByText('Begin removal')
+    fireEvent.click(skipBtn)
+    getByText('Drop tips')
+  })
+  it('renders special text when the pipette is a 96-Channel', () => {
+    const ninetySixSpecs = {
+      ...MOCK_ACTUAL_PIPETTE,
+      displayName: 'Flex 96-Channel Pipette',
+    } as PipetteModelSpecs
+
+    const [{ getByTestId, getByText }] = render(ninetySixSpecs)
     const btn = getByTestId('testButton')
     fireEvent.click(btn)
 

--- a/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
@@ -84,12 +84,12 @@ describe('TipsAttachedModal', () => {
       channels: 96,
     } as PipetteModelSpecs
 
-    const [{ getByTestId, getByText }] = render(ninetySixSpecs)
+    const [{ getByTestId, queryByText, getByText }] = render(ninetySixSpecs)
     const btn = getByTestId('testButton')
     fireEvent.click(btn)
 
     const skipBtn = getByText('Begin removal')
     fireEvent.click(skipBtn)
-    getByText('Drop tips')
+    queryByText('96-Channel')
   })
 })


### PR DESCRIPTION
Closes RQA-2020

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Per QA/Design feedback. 

### Current Behavior

<img width="567" alt="Screenshot 2023-12-12 at 11 29 12 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/2b23d99a-f6d6-4451-89e9-d99f61e5b3f0">

### With Fix

<img width="589" alt="Screenshot 2023-12-12 at 11 19 21 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/1939efac-2858-4765-be4a-09b2c524c840">



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Launch the drop tip flows on the 96 channel via ODD. Easiest way to currently do this is to throw an estop error after picking up a tip. 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- 96-channel now has special drop tip wizard launch text.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
