### PR TITLE
fix(protocol-designer): TC renders for OT-2 and fix isSlotEmpty logic

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -39,6 +39,7 @@ import {
   TRASH_BIN_ADAPTER_FIXTURE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
+import { SPAN7_8_10_11_SLOT } from '../../constants'
 import { selectors as labwareDefSelectors } from '../../labware-defs'
 
 import { selectors as featureFlagSelectors } from '../../feature-flags'
@@ -190,16 +191,12 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
     <>
       {/* all modules */}
       {allModules.map(moduleOnDeck => {
-        // modules can be on the deck, including pseudo-slots (eg special 'spanning' slot for thermocycler position)
-        // const moduleParentSlots = [...deckSlots, ...values(PSEUDO_DECK_SLOTS)]
-        // const slot = moduleParentSlots.find(
-        //   slot => slot.id === moduleOnDeck.slot
-        // )
-        const slotPosition = getPositionFromSlotId(moduleOnDeck.slot, deckDef)
+        const slotId =
+          moduleOnDeck.slot === SPAN7_8_10_11_SLOT ? '7' : moduleOnDeck.slot
+
+        const slotPosition = getPositionFromSlotId(slotId, deckDef)
         if (slotPosition == null) {
-          console.warn(
-            `no slot ${moduleOnDeck.slot} for module ${moduleOnDeck.id}`
-          )
+          console.warn(`no slot ${slotId} for module ${moduleOnDeck.id}`)
           return null
         }
         const moduleDef = getModuleDef2(moduleOnDeck.model)
@@ -257,7 +254,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
             def={moduleDef}
             orientation={inferModuleOrientationFromXCoordinate(slotPosition[0])}
             innerProps={getModuleInnerProps(moduleOnDeck.moduleState)}
-            targetSlotId={moduleOnDeck.slot}
+            targetSlotId={slotId}
             targetDeckId={deckDef.otId}
           >
             {labwareLoadedOnModule != null && !shouldHideChildren ? (

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -32,6 +32,21 @@ import type {
 import type { FormData } from '../../form-types'
 export { createPresavedStepForm } from './createPresavedStepForm'
 
+const slotToCutoutOt2Map: { [key: string]: string } = {
+  '1': 'cutout1',
+  '2': 'cutout2',
+  '3': 'cutout3',
+  '4': 'cutout4',
+  '5': 'cutout5',
+  '6': 'cutout6',
+  '7': 'cutout7',
+  '8': 'cutout8',
+  '9': 'cutout9',
+  '10': 'cutout10',
+  '11': 'cutout11',
+  '12': 'cutout12',
+}
+
 export function getIdsInRange<T extends string | number>(
   orderedIds: T[],
   startId: T,
@@ -128,17 +143,22 @@ export const getSlotIsEmpty = (
     return false
   }
 
-  const filteredAdditionalEquipmentOnDeck = includeStagingAreas
-    ? values(
-        initialDeckSetup.additionalEquipmentOnDeck
-      ).filter((additionalEquipment: AdditionalEquipmentOnDeck) =>
-        additionalEquipment.location?.includes(slot)
-      )
-    : values(initialDeckSetup.additionalEquipmentOnDeck).filter(
-        (additionalEquipment: AdditionalEquipmentOnDeck) =>
-          additionalEquipment.location?.includes(slot) &&
-          additionalEquipment.name !== 'stagingArea'
-      )
+  const filteredAdditionalEquipmentOnDeck = values(
+    initialDeckSetup.additionalEquipmentOnDeck
+  ).filter((additionalEquipment: AdditionalEquipmentOnDeck) => {
+    const cutoutForSlotOt2 = slotToCutoutOt2Map[slot]
+    const includeStaging = includeStagingAreas
+      ? true
+      : additionalEquipment.name !== 'stagingArea'
+    if (cutoutForSlotOt2 != null) {
+      //  for Ot-2
+      return additionalEquipment.location === cutoutForSlotOt2 && includeStaging
+    } else {
+      //  for Flex
+      return additionalEquipment.location?.includes(slot) && includeStaging
+    }
+  })
+
   return (
     [
       ...values(initialDeckSetup.modules).filter((moduleOnDeck: ModuleOnDeck) =>

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -224,7 +224,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
         const isTrashSlot =
           robotType === FLEX_ROBOT_TYPE
             ? MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slotId)
-            : slotId === 'fixedTrash' || slotId === '12'
+            : ['fixedTrash', '12'].includes(slotId)
         return (
           !slotIdsOccupiedByModules.includes(slotId) &&
           !Object.values(labware)

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -224,8 +224,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
         const isTrashSlot =
           robotType === FLEX_ROBOT_TYPE
             ? MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slotId)
-            : slotId === 'fixedTrash'
-
+            : slotId === 'fixedTrash' || slotId === '12'
         return (
           !slotIdsOccupiedByModules.includes(slotId) &&
           !Object.values(labware)

--- a/shared-data/deck/types/schemaV4.ts
+++ b/shared-data/deck/types/schemaV4.ts
@@ -40,6 +40,7 @@ export type OT2AddressableAreaName =
   | '9'
   | '10'
   | '11'
+  | '12'
   | 'fixedTrash'
 
 export type AddressableAreaName =


### PR DESCRIPTION
closes RQA-2062

# Overview

Fixes 3 bugs: 
1. the TC wasn't rendering at all on the deck for the OT-2
2. the "getIsSlotEmpty" logic for the OT-2 didn't work completely
3. filter out slot 12 in the OT-2 new location dropdown

# Test Plan

Create an OT-2 protocol and add a thermocycler (gen1 or gen 2). Go to the deck map view and see that it renders correctly and that you can add a labware and the 4 slots are considered full. Move the tiprack into another slot and see that slot 1 and 2 are empty and available to add labware into.

Create a move labware step and see in the new location dropdown that slot 12 is not selectable

# Changelog

- pd is still special-casing GEN1 thermocyclers with the 'span7_8_10_11` slot, so i fixed the logic to change that to slot 7 in the deck setup component. we can probably stop special casing it in the future, post PD 8.0
- fix logic in `isSlotEmpty` util by mapping the slots to the cutouts and comparing that. the reason why there was an error only with the ot-2 is because the slot would be 1 or 2 and the trash bin is in cutout12, which includes 1 and 2.
- add 12 as an addressable area type for the ot-2
- filter out slot 12 in the selector for the new location dropdown

# Review requests

see test plan

# Risk assessment

low
