### PR TITLE
refactor(api): FailedGripperPickupError follow-up

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -24,7 +24,6 @@ from ..instrument_abc import AbstractInstrument
 from opentrons.hardware_control.dev_types import AttachedGripper, GripperDict
 from opentrons_shared_data.errors.exceptions import (
     CommandPreconditionViolated,
-    FailedGripperPickupError,
 )
 
 from opentrons_shared_data.gripper import (
@@ -200,23 +199,6 @@ class Gripper(AbstractInstrument[GripperDefinition]):
                 detail={
                     "probe": str(self._attached_probe),
                     "jaw_state": str(self.state),
-                },
-            )
-
-    def check_labware_pickup(self, labware_width: float) -> None:
-        """Ensure that a gripper pickup succeeded."""
-        # check if the gripper is at an acceptable position after attempting to
-        #  pick up labware
-        expected_gripper_position = labware_width
-        current_gripper_position = self.jaw_width
-        if (
-            abs(current_gripper_position - expected_gripper_position)
-            > self.max_allowed_grip_error
-        ):
-            raise FailedGripperPickupError(
-                details={
-                    "expected jaw width": expected_gripper_position,
-                    "actual jaw width": current_gripper_position,
                 },
             )
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -36,6 +36,7 @@ from opentrons_shared_data.pipette import (
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons_shared_data.errors.exceptions import (
     StallOrCollisionDetectedError,
+    FailedGripperPickupError,
 )
 
 from opentrons import types as top_types
@@ -1313,6 +1314,24 @@ class OT3API(
                 )
         except GripperNotPresentError:
             pass
+
+    def raise_error_if_gripper_pickup_failed(self, labware_width: float) -> None:
+        """Ensure that a gripper pickup succeeded."""
+        # check if the gripper is at an acceptable position after attempting to
+        #  pick up labware
+        assert self.hardware_gripper
+        expected_gripper_position = labware_width
+        current_gripper_position = self.hardware_gripper.jaw_width
+        if (
+            abs(current_gripper_position - expected_gripper_position)
+            > self.hardware_gripper.max_allowed_grip_error
+        ):
+            raise FailedGripperPickupError(
+                details={
+                    "expected jaw width": expected_gripper_position,
+                    "actual jaw width": current_gripper_position,
+                },
+            )
 
     def gripper_jaw_can_home(self) -> bool:
         return self._gripper_handler.is_ready_for_jaw_home()

--- a/api/src/opentrons/hardware_control/protocols/gripper_controller.py
+++ b/api/src/opentrons/hardware_control/protocols/gripper_controller.py
@@ -33,6 +33,9 @@ class GripperController(Protocol):
         """
         ...
 
+    def raise_error_if_gripper_pickup_failed(self, labware_width: float) -> None:
+        """Ensure that a gripper pickup succeeded."""
+
     @property
     def attached_gripper(self) -> Optional[GripperDict]:
         """Get a dict of all attached grippers."""

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -135,7 +135,7 @@ class LabwareMovementHandler:
                 post_drop_slide_offset=post_drop_slide_offset,
             )
             labware_grip_force = self._state_store.labware.get_grip_force(labware_id)
-            gripper_opened = False
+            holding_labware = False
             for waypoint_data in movement_waypoints:
                 if waypoint_data.jaw_open:
                     if waypoint_data.dropping:
@@ -146,7 +146,7 @@ class LabwareMovementHandler:
                         # on the side of a falling tiprack catches the jaw.
                         await ot3api.disengage_axes([Axis.Z_G])
                     await ot3api.ungrip()
-                    gripper_opened = True
+                    holding_labware = True
                     if waypoint_data.dropping:
                         # We lost the position estimation after disengaging the axis, so
                         # it is necessary to home it next
@@ -155,9 +155,8 @@ class LabwareMovementHandler:
                     await ot3api.grip(force_newtons=labware_grip_force)
                     # we only want to check position after the gripper has opened and
                     # should be holding labware
-                    if gripper_opened:
-                        assert ot3api.hardware_gripper
-                        ot3api.hardware_gripper.check_labware_pickup(
+                    if holding_labware:
+                        ot3api.raise_error_if_gripper_pickup_failed(
                             labware_width=self._state_store.labware.get_dimensions(
                                 labware_id
                             ).y

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -177,7 +177,7 @@ def subject(
 
 
 @pytest.mark.ot3_only
-async def test_check_labware_pickup(
+async def test_raise_error_if_gripper_pickup_failed(
     decoy: Decoy,
     state_store: StateStore,
     thermocycler_plate_lifter: ThermocyclerPlateLifter,
@@ -226,7 +226,7 @@ async def test_check_labware_pickup(
         )
     ).then_return(Point(201, 202, 219.5))
 
-    decoy.when(ot3_hardware_api.hardware_gripper.check_labware_pickup(85)).then_return()
+    decoy.when(ot3_hardware_api.raise_error_if_gripper_pickup_failed(85)).then_return()
 
     await subject.move_labware_with_gripper(
         labware_id="my-teleporting-labware",
@@ -242,11 +242,11 @@ async def test_check_labware_pickup(
         await ot3_hardware_api.grip(force_newtons=100),
         await ot3_hardware_api.ungrip(),
         await ot3_hardware_api.grip(force_newtons=100),
-        ot3_hardware_api.hardware_gripper.check_labware_pickup(labware_width=85),
+        ot3_hardware_api.raise_error_if_gripper_pickup_failed(labware_width=85),
         await ot3_hardware_api.grip(force_newtons=100),
-        ot3_hardware_api.hardware_gripper.check_labware_pickup(labware_width=85),
+        ot3_hardware_api.raise_error_if_gripper_pickup_failed(labware_width=85),
         await ot3_hardware_api.grip(force_newtons=100),
-        ot3_hardware_api.hardware_gripper.check_labware_pickup(labware_width=85),
+        ot3_hardware_api.raise_error_if_gripper_pickup_failed(labware_width=85),
         await ot3_hardware_api.disengage_axes([Axis.Z_G]),
         await ot3_hardware_api.ungrip(),
         await ot3_hardware_api.ungrip(),


### PR DESCRIPTION
## Overview
This is a follow-up to [this pr](https://github.com/Opentrons/opentrons/pull/14130), which introduces the `FailedGripperPickupError`. This just addresses some feedback about surface-level bits of the code.

## Changelog
- renamed the `check_labware_pickup` function to `raise_error_if_gripper_pickup_failed`
- moved the above function from `gripper.py` to `ot3api.py`
- change the `gripper_opened` variable in `labware_movement.py` to `holding_labware` 