### PR TITLE
fix(protocol-engine): Fix `blowOutInPlace` and `aspirateInPlace` not updating current volume

### DIFF
--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -27,6 +27,7 @@ from ..commands import (
     Command,
     LoadPipetteResult,
     AspirateResult,
+    AspirateInPlaceResult,
     DispenseResult,
     DispenseInPlaceResult,
     MoveLabwareResult,
@@ -40,6 +41,7 @@ from ..commands import (
     HomeResult,
     RetractAxisResult,
     BlowOutResult,
+    BlowOutInPlaceResult,
     TouchTipResult,
     thermocycler,
     heater_shaker,
@@ -174,7 +176,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.attached_tip_by_id[pipette_id] = None
             self._state.nozzle_configuration_by_id[pipette_id] = None
 
-        elif isinstance(command.result, AspirateResult):
+        elif isinstance(command.result, (AspirateResult, AspirateInPlaceResult)):
             pipette_id = command.params.pipetteId
             previous_volume = self._state.aspirated_volume_by_id[pipette_id] or 0
             next_volume = previous_volume + command.result.volume
@@ -235,7 +237,7 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     default_aspirate=tip_configuration.default_aspirate_flowrate.values_by_api_level,
                     default_dispense=tip_configuration.default_dispense_flowrate.values_by_api_level,
                 )
-        elif isinstance(command.result, BlowOutResult):
+        elif isinstance(command.result, (BlowOutResult, BlowOutInPlaceResult)):
             pipette_id = command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = None
 

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -467,6 +467,27 @@ def create_blow_out_command(
     )
 
 
+def create_blow_out_in_place_command(
+    pipette_id: str,
+    flow_rate: float,
+) -> cmd.BlowOutInPlace:
+    """Get a completed blowOutInPlace command."""
+    params = cmd.BlowOutInPlaceParams(
+        pipetteId=pipette_id,
+        flowRate=flow_rate,
+    )
+    result = cmd.BlowOutInPlaceResult()
+
+    return cmd.BlowOutInPlace(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime(year=2022, month=1, day=1),
+        params=params,
+        result=result,
+    )
+
+
 def create_touch_tip_command(
     pipette_id: str,
     labware_id: str = "labware-id",

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -217,6 +217,29 @@ def create_aspirate_command(
     )
 
 
+def create_aspirate_in_place_command(
+    pipette_id: str,
+    volume: float,
+    flow_rate: float,
+) -> cmd.AspirateInPlace:
+    """Get a completed Aspirate command."""
+    params = cmd.AspirateInPlaceParams(
+        pipetteId=pipette_id,
+        volume=volume,
+        flowRate=flow_rate,
+    )
+    result = cmd.AspirateInPlaceResult(volume=volume)
+
+    return cmd.AspirateInPlace(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime.now(),
+        params=params,
+        result=result,
+    )
+
+
 def create_dispense_command(
     pipette_id: str,
     volume: float,

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -163,7 +163,7 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     assert subject.state.aspirated_volume_by_id["xyz"] is None
 
 
-def test_pipette_volume_adds_aspirate(subject: PipetteStore) -> None:
+def test_aspirate_adds_volume(subject: PipetteStore) -> None:
     """It should add volume to pipette after an aspirate."""
     load_command = create_load_pipette_command(
         pipette_id="pipette-id",
@@ -225,7 +225,7 @@ def test_handles_blow_out(subject: PipetteStore) -> None:
         ),
     ],
 )
-def test_pipette_volume_subtracts_dispense(
+def test_dispense_subtracts_volume(
     subject: PipetteStore, dispense_command: cmd.Command
 ) -> None:
     """It should subtract volume from pipette after a dispense."""

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -35,6 +35,7 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
 from .command_fixtures import (
     create_load_pipette_command,
     create_aspirate_command,
+    create_aspirate_in_place_command,
     create_dispense_command,
     create_dispense_in_place_command,
     create_pick_up_tip_command,
@@ -164,17 +165,23 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
     assert subject.state.aspirated_volume_by_id["xyz"] is None
 
 
-def test_aspirate_adds_volume(subject: PipetteStore) -> None:
+@pytest.mark.parametrize(
+    "aspirate_command",
+    [
+        create_aspirate_command(pipette_id="pipette-id", volume=42, flow_rate=1.23),
+        create_aspirate_in_place_command(
+            pipette_id="pipette-id", volume=42, flow_rate=1.23
+        ),
+    ],
+)
+def test_aspirate_adds_volume(
+    subject: PipetteStore, aspirate_command: cmd.Command
+) -> None:
     """It should add volume to pipette after an aspirate."""
     load_command = create_load_pipette_command(
         pipette_id="pipette-id",
         pipette_name=PipetteNameType.P300_SINGLE,
         mount=MountType.LEFT,
-    )
-    aspirate_command = create_aspirate_command(
-        pipette_id="pipette-id",
-        volume=42,
-        flow_rate=1.23,
     )
 
     subject.handle_action(


### PR DESCRIPTION
# Overview

Fixes RQA-2056.

# Test Plan

I've that the protocol from RQA-2056 and this more minimal protocol both pass analysis now, as expected:

```python
from opentrons import protocol_api


requirements = {"apiLevel": "2.16", "robotType": "Flex"}


def run(protocol: protocol_api.ProtocolContext):
    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "A1")
    well_plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "A2")
    pipette = protocol.load_instrument(
        "flex_1channel_1000", mount="right", tip_racks=[tip_rack]
    )

    trash = protocol.load_trash_bin("C3")

    pipette.pick_up_tip()

    pipette.aspirate(500, well_plate["A1"])
    pipette.air_gap()

    pipette.blow_out(trash)

    pipette.aspirate(1, well_plate["A1"])  # Should not raise.
```

And this protocol now raises an analysis error, as expected:

```python
from opentrons import protocol_api
from opentrons import types


requirements = {"apiLevel": "2.16", "robotType": "Flex"}


def run(protocol: protocol_api.ProtocolContext) -> None:
    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "A1")
    pipette = protocol.load_instrument(
        "flex_1channel_1000", mount="right", tip_racks=[tip_rack]
    )

    pipette.pick_up_tip()
    pipette.move_to(types.Location(types.Point(10, 20, 30), labware=None))

    pipette.aspirate(900)
    pipette.aspirate(101)  # Should raise.
```

# Changelog

When Protocol Engine processes an `aspirate`, `dispense`, `blowOut`, etc., it's supposed to keep track of how much liquid is in the pipette, for the purposes of preventing mistakes like aspirating more than 1000 µL into a 1000 µL pipette.

It was simply forgetting to do this for `aspirateInPlace` and `blowOutInPlace`. So, add in that handling, and make sure it's covered by unit tests.

# Review requests

I've skimmed `PipetteStore` and it doesn't look like it's forgetting any other commands. Do you have any other commands that you're worried about, off the top of your head?

# Risk assessment

Medium. This touches a core part of protocol analysis.

This *may* cause protocols to fail analysis where they were previously succeeding. I think that's good in this case because, at least to my understanding, these protocols always would have errored out when you actually went to run them.

We should keep an eye on this PR's effects on the analysis snapshots in #14148 to make sure there are no unexpected failures.