### PR TITLE
fix(app): make sure pipette flow wizard title and results copy is correct

### DIFF
--- a/app/src/assets/localization/en/pipette_wizard_flows.json
+++ b/app/src/assets/localization/en/pipette_wizard_flows.json
@@ -56,7 +56,7 @@
   "ninety_six_detached_success": "{{pipetteName}} pipette successfully detached",
   "ninety_six_probe_location": "A1 (back left corner)",
   "pip_cal_failed": "pipette calibration failed",
-  "pip_cal_success": "{{pipetteName}} successfully attached and calibrated",
+  "pip_cal_success": "{{pipetteName}} successfully calibrated",
   "pip_recal_success": "{{pipetteName}} successfully recalibrated",
   "pipette_attached": "{{pipetteName}} successfully attached",
   "pipette_calibrating": "Stand back, {{pipetteName}} is calibrating",

--- a/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/Results.test.tsx
@@ -241,7 +241,7 @@ describe('Results', () => {
       flowType: FLOWS.CALIBRATE,
     }
     const { getByText, getByRole } = render(props)
-    getByText('Flex 1-Channel 1000 μL successfully attached and calibrated')
+    getByText('Flex 1-Channel 1000 μL successfully calibrated')
     const image = getByRole('img', { name: 'Success Icon' })
     expect(image.getAttribute('src')).toEqual('icon_success.png')
     getByRole('img', { name: 'Success Icon' })
@@ -256,7 +256,7 @@ describe('Results', () => {
       totalStepCount: 9,
     }
     const { getByText, getByRole } = render(props)
-    getByText('Flex 1-Channel 1000 μL successfully attached and calibrated')
+    getByText('Flex 1-Channel 1000 μL successfully calibrated')
     const image = getByRole('img', { name: 'Success Icon' })
     expect(image.getAttribute('src')).toEqual('icon_success.png')
     getByRole('img', { name: 'Success Icon' })
@@ -271,7 +271,7 @@ describe('Results', () => {
       totalStepCount: 5,
     }
     const { getByText, getByRole } = render(props)
-    getByText('Flex 1-Channel 1000 μL successfully attached and calibrated')
+    getByText('Flex 1-Channel 1000 μL successfully calibrated')
     const image = getByRole('img', { name: 'Success Icon' })
     expect(image.getAttribute('src')).toEqual('icon_success.png')
     getByRole('img', { name: 'Success Icon' })

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -104,6 +104,7 @@ export const PipetteWizardFlows = (
     attachedPipettes: memoizedAttachedPipettes,
     pipetteInfo: memoizedPipetteInfo,
   })
+  const memoizedWizardTitle = React.useMemo(() => wizardTitle, [])
   const [createdMaintenanceRunId, setCreatedMaintenanceRunId] = React.useState<
     string | null
   >(null)
@@ -396,7 +397,7 @@ export const PipetteWizardFlows = (
   const wizardHeader = (
     <WizardHeader
       exitDisabled={isRobotMoving || isFetchingPipettes}
-      title={wizardTitle}
+      title={memoizedWizardTitle}
       currentStep={
         progressBarForCalError ? currentStepIndex - 1 : currentStepIndex
       }


### PR DESCRIPTION
fix RQA-2018, RQA-2039

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fixing a few bugs related to pipette flow wizard header and result screen copy
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- [x] With two pipettes attached to a flex, start run setup for a protocol that uses a 96 channel pipette. When going through the wizard flow, the title should be "Detach Pipettes and Attach 96-Channel Pipette" instead of referencing one specific pipette to detach: 
<img width="1026" alt="Screen Shot 2023-12-12 at 3 47 37 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/28a8e43a-915d-452d-865b-f6948dbc0ecc">
- [ ] When calibrating a pipette, results screen should now say "{{pipette_name}} successfully calibrated" instead of "successfully attached and calibrated" regardless of whether the calibration followed an attachment flow since we show an "successfully attached" screen 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Change "attached and calibrated" to "calibrated"
2. Memoize wizard title so that no changing inputs like different pipettes being attached through the duration of the flow will affect the title
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
sanity check code - I've tested this
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
