### PR TITLE
feat(app): add resolve button to protocol setup fixture table

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -39,6 +39,7 @@
   "calibration": "Calibration",
   "closing": "Closing...",
   "complete_setup_before_proceeding": "complete setup before continuing run",
+  "configure": "Configure",
   "configured": "configured",
   "confirm_heater_shaker_module_modal_description": "Before the run begins, module should have both anchors fully extended for a firm attachment. The thermal adapter should be attached to the module. ",
   "confirm_heater_shaker_module_modal_title": "Confirm Heater-Shaker Module is attached",

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -7,7 +7,6 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
-  Icon,
   JUSTIFY_SPACE_BETWEEN,
   LocationIcon,
   SPACING,
@@ -19,11 +18,13 @@ import {
   getSimplestDeckConfigForProtocol,
   SINGLE_SLOT_FIXTURES,
 } from '@opentrons/shared-data'
+
+import { SmallButton } from '../../atoms/buttons'
+import { Chip } from '../../atoms/Chip'
+import { StyledText } from '../../atoms/text'
 import { useDeckConfigurationCompatibility } from '../../resources/deck_configuration/hooks'
 import { getRequiredDeckConfig } from '../../resources/deck_configuration/utils'
 import { LocationConflictModal } from '../Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal'
-import { StyledText } from '../../atoms/text'
-import { Chip } from '../../atoms/Chip'
 
 import type {
   CompletedProtocolAnalysis,
@@ -122,7 +123,6 @@ function FixtureTableItem({
     compatibleCutoutFixtureIds.includes(cutoutFixtureId)
   const isRequiredSingleSlotMissing = missingLabwareDisplayName != null
   let chipLabel: JSX.Element
-  let handleClick
   if (!isCurrentFixtureCompatible) {
     const isConflictingFixtureConfigured =
       cutoutFixtureId != null && !SINGLE_SLOT_FIXTURES.includes(cutoutFixtureId)
@@ -138,16 +138,23 @@ function FixtureTableItem({
           background={false}
           iconName="connection-status"
         />
-        <Icon name="more" size="3rem" />
+        <SmallButton
+          buttonCategory="rounded"
+          buttonText={
+            isConflictingFixtureConfigured ? t('resolve') : t('configure')
+          }
+          onClick={
+            isConflictingFixtureConfigured
+              ? () => setShowLocationConflictModal(true)
+              : () => {
+                  setCutoutId(cutoutId)
+                  setProvidedFixtureOptions(compatibleCutoutFixtureIds)
+                  setSetupScreen('deck configuration')
+                }
+          }
+        />
       </>
     )
-    handleClick = isConflictingFixtureConfigured
-      ? () => setShowLocationConflictModal(true)
-      : () => {
-          setCutoutId(cutoutId)
-          setProvidedFixtureOptions(compatibleCutoutFixtureIds)
-          setSetupScreen('deck configuration')
-        }
   } else {
     chipLabel = (
       <Chip
@@ -178,7 +185,6 @@ function FixtureTableItem({
         borderRadius={BORDERS.borderRadiusSize3}
         gridGap={SPACING.spacing24}
         padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
-        onClick={handleClick}
         marginBottom={lastItem ? SPACING.spacing68 : 'none'}
       >
         <Flex flex="3.5 0 0" alignItems={ALIGN_CENTER}>


### PR DESCRIPTION
# Overview

replaces the existing fixture conflict chevron with a resolve or configure button

closes RAUT-900

<img width="1136" alt="Screen Shot 2023-12-12 at 4 06 43 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/6c843955-0b74-49c2-a7a6-46c50ae277fc">


# Test Plan

 - verified button and correct text

# Changelog

 - Adds resolve button to protocol setup fixture table

# Review requests

check that the resolve/configure button renders when needed and works

# Risk assessment

low
