### PR TITLE
fix(api): display name in deck conflict error message

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -30,7 +30,9 @@ class LabwareCore(AbstractLabware[WellCore]):
 
         labware_state = engine_client.state.labware
         self._definition = labware_state.get_definition(labware_id)
-        self._user_display_name = labware_state.get_display_name(labware_id)
+        self._user_display_name = labware_state.get_user_specified_display_name(
+            labware_id
+        )
 
     @property
     def labware_id(self) -> str:

--- a/api/src/opentrons/protocol_api/core/engine/stringify.py
+++ b/api/src/opentrons/protocol_api/core/engine/stringify.py
@@ -53,7 +53,9 @@ def _labware_location_string(
 
 def _labware_name(engine_client: SyncClient, labware_id: str) -> str:
     """Return the user-specified labware label, or fall back to the display name from the def."""
-    user_name = engine_client.state.labware.get_display_name(labware_id=labware_id)
+    user_name = engine_client.state.labware.get_user_specified_display_name(
+        labware_id=labware_id
+    )
     definition_name = engine_client.state.labware.get_definition(
         labware_id=labware_id
     ).metadata.displayName

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -309,9 +309,20 @@ class LabwareView(HasState[LabwareState]):
             LabwareUri(self.get(labware_id).definitionUri)
         )
 
-    def get_display_name(self, labware_id: str) -> Optional[str]:
+    def get_user_specified_display_name(self, labware_id: str) -> Optional[str]:
         """Get the labware's user-specified display name, if set."""
         return self.get(labware_id).displayName
+
+    def get_display_name(self, labware_id: str) -> str:
+        """Get the labware's display name.
+
+        If a user-specified display name exists, will return that, else will return
+        display name from the definition.
+        """
+        return (
+            self.get_user_specified_display_name(labware_id)
+            or self.get_definition(labware_id).metadata.displayName
+        )
 
     def get_deck_definition(self) -> DeckDefinitionV4:
         """Get the current deck definition."""

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -103,7 +103,7 @@ def test_get_definition(subject: LabwareCore) -> None:
 def test_get_user_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:
     """It should get the labware's user-provided label, if any."""
     decoy.when(
-        mock_engine_client.state.labware.get_display_name("cool-labware")
+        mock_engine_client.state.labware.get_user_specified_display_name("cool-labware")
     ).then_return("Cool Label")
 
     subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)
@@ -149,7 +149,7 @@ def test_get_name_load_name(subject: LabwareCore) -> None:
 def test_get_name_display_name(decoy: Decoy, mock_engine_client: EngineClient) -> None:
     """It should get the user display name when one is defined."""
     decoy.when(
-        mock_engine_client.state.labware.get_display_name("cool-labware")
+        mock_engine_client.state.labware.get_user_specified_display_name("cool-labware")
     ).then_return("my cool display name")
 
     subject = LabwareCore(labware_id="cool-labware", engine_client=mock_engine_client)

--- a/api/tests/opentrons/protocol_api/core/engine/test_stringify.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_stringify.py
@@ -33,9 +33,9 @@ def _make_dummy_module_definition(decoy: Decoy, display_name: str) -> ModuleDefi
 def test_well_on_labware_without_user_display_name(decoy: Decoy) -> None:
     """Test stringifying a well on a labware that doesn't have a user-defined label."""
     mock_client = decoy.mock(cls=SyncClient)
-    decoy.when(mock_client.state.labware.get_display_name("labware-id")).then_return(
-        None
-    )
+    decoy.when(
+        mock_client.state.labware.get_user_specified_display_name("labware-id")
+    ).then_return(None)
     decoy.when(mock_client.state.labware.get_definition("labware-id")).then_return(
         _make_dummy_labware_definition(decoy, "definition-display-name")
     )
@@ -52,9 +52,9 @@ def test_well_on_labware_without_user_display_name(decoy: Decoy) -> None:
 def test_well_on_labware_with_user_display_name(decoy: Decoy) -> None:
     """Test stringifying a well on a labware that does have a user-defined label."""
     mock_client = decoy.mock(cls=SyncClient)
-    decoy.when(mock_client.state.labware.get_display_name("labware-id")).then_return(
-        "user-display-name"
-    )
+    decoy.when(
+        mock_client.state.labware.get_user_specified_display_name("labware-id")
+    ).then_return("user-display-name")
     decoy.when(mock_client.state.labware.get_definition("labware-id")).then_return(
         _make_dummy_labware_definition(decoy, "definition-display-name")
     )
@@ -72,9 +72,9 @@ def test_well_on_labware_with_complicated_location(decoy: Decoy) -> None:
     """Test stringifying a well on a labware with a deeply-nested location."""
     mock_client = decoy.mock(cls=SyncClient)
 
-    decoy.when(mock_client.state.labware.get_display_name("labware-id-1")).then_return(
-        None
-    )
+    decoy.when(
+        mock_client.state.labware.get_user_specified_display_name("labware-id-1")
+    ).then_return(None)
     decoy.when(mock_client.state.labware.get_definition("labware-id-1")).then_return(
         _make_dummy_labware_definition(decoy, "lw-1-display-name")
     )
@@ -82,9 +82,9 @@ def test_well_on_labware_with_complicated_location(decoy: Decoy) -> None:
         OnLabwareLocation(labwareId="labware-id-2")
     )
 
-    decoy.when(mock_client.state.labware.get_display_name("labware-id-2")).then_return(
-        None
-    )
+    decoy.when(
+        mock_client.state.labware.get_user_specified_display_name("labware-id-2")
+    ).then_return(None)
     decoy.when(mock_client.state.labware.get_definition("labware-id-2")).then_return(
         _make_dummy_labware_definition(decoy, "lw-2-display-name")
     )

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -985,7 +985,7 @@ def test_find_applicable_labware_offset() -> None:
     )
 
 
-def test_get_display_name() -> None:
+def test_get_user_specified_display_name() -> None:
     """It should get a labware's user-specified display name."""
     subject = get_labware_view(
         labware_by_id={
@@ -994,8 +994,38 @@ def test_get_display_name() -> None:
         },
     )
 
-    assert subject.get_display_name("plate_with_display_name") == "Fancy Plate Name"
-    assert subject.get_display_name("reservoir_without_display_name") is None
+    assert (
+        subject.get_user_specified_display_name("plate_with_display_name")
+        == "Fancy Plate Name"
+    )
+    assert (
+        subject.get_user_specified_display_name("reservoir_without_display_name")
+        is None
+    )
+
+
+def test_get_display_name(
+    well_plate_def: LabwareDefinition,
+    reservoir_def: LabwareDefinition,
+) -> None:
+    """It should get the labware's display name."""
+    subject = get_labware_view(
+        labware_by_id={
+            "plate_with_custom_display_name": plate,
+            "reservoir_with_default_display_name": reservoir,
+        },
+        definitions_by_uri={
+            "some-plate-uri": well_plate_def,
+            "some-reservoir-uri": reservoir_def,
+        },
+    )
+    assert (
+        subject.get_display_name("plate_with_custom_display_name") == "Fancy Plate Name"
+    )
+    assert (
+        subject.get_display_name("reservoir_with_default_display_name")
+        == "NEST 12 Well Reservoir 15 mL"
+    )
 
 
 def test_get_fixed_trash_id() -> None:


### PR DESCRIPTION
# Overview

In #14173 I didn't realize that `labware_view.get_display_name` provided only user-specified display name. So deck conflict error messages could say "None should be on an Opentrons adapter.." if no custom display name was specified for the tiprack. 
This PR fixes that mistake.

# Test Plan

The protocol attached in #14173 should now show errors with correct display names.

# Changelog

- renamed `labware_view.get_display_name` to `get_user_specified_display_name`
- added a new `labware_view.get_display_name` that returns the user specified display name if present, else returns the display name from labware definition
- use this new getter in the error message

# Review requests

- Usual code review stuff

# Risk assessment

Low. Bug fix
