### PR TITLE
fix(api): Fix RuntimeError when calling InstrumentContext.type on a 96-channel

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1494,9 +1494,8 @@ class InstrumentContext(publisher.CommandPublisher):
     def type(self) -> str:
         """``'single'`` if this is a 1-channel pipette, or ``'multi'`` otherwise.
 
-        .. deprecated:: 2.16
-           Use :py:obj:`.channels` instead, which can distinguish between 8-channel and 96-channel
-           pipettes.
+        See also :py:obj:`.channels`, which can distinguish between 8-channel and 96-channel
+        pipettes.
         """
         if self.channels == 1:
             return "single"
@@ -1632,7 +1631,10 @@ class InstrumentContext(publisher.CommandPublisher):
     def channels(self) -> int:
         """The number of channels on the pipette.
 
-        Possible values are 1, 8, or 96."""
+        Possible values are 1, 8, or 96.
+
+        See also :py:obj:`.type`.
+        """
         return self._core.get_channels()
 
     @property  # type: ignore

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1492,14 +1492,16 @@ class InstrumentContext(publisher.CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def type(self) -> str:
-        """One of ``'single'`` or ``'multi'``."""
-        model = self.name
-        if "single" in model:
+        """``'single'`` if this is a 1-channel pipette, or ``'multi'`` otherwise.
+
+        .. deprecated:: 2.16
+           Use :py:obj:`.channels` instead, which can distinguish between 8-channel and 96-channel
+           pipettes.
+        """
+        if self.channels == 1:
             return "single"
-        elif "multi" in model:
-            return "multi"
         else:
-            raise RuntimeError("Bad pipette name: {}".format(model))
+            return "multi"
 
     @property  # type: ignore
     @requires_version(2, 0)

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -123,6 +123,38 @@ def test_api_version(api_version: APIVersion, subject: InstrumentContext) -> Non
     assert subject.api_version == api_version
 
 
+@pytest.mark.parametrize("channels_from_core", [1, 8, 96])
+def test_channels(
+    decoy: Decoy,
+    subject: InstrumentContext,
+    mock_instrument_core: InstrumentCore,
+    channels_from_core: int,
+) -> None:
+    """It should return the number of channels, as returned by the core."""
+    decoy.when(mock_instrument_core.get_channels()).then_return(channels_from_core)
+    assert subject.channels == channels_from_core
+
+
+@pytest.mark.parametrize(
+    ("channels_from_core", "expected_type"),
+    [
+        (1, "single"),
+        (8, "multi"),
+        (96, "multi"),
+    ],
+)
+def test_type(
+    decoy: Decoy,
+    subject: InstrumentContext,
+    mock_instrument_core: InstrumentCore,
+    channels_from_core: int,
+    expected_type: str,
+) -> None:
+    """It should map the number of channels from the core into the string "single" or "multi"."""
+    decoy.when(mock_instrument_core.get_channels()).then_return(channels_from_core)
+    assert subject.type == expected_type
+
+
 def test_trash_container(
     decoy: Decoy,
     mock_trash: Labware,


### PR DESCRIPTION
# Overview

Closes RSS-342.

# Test Plan

I've made sure that this passes analysis now:

```python
requirements = {"apiLevel": "2.16", "robotType": "Flex"}
def run(protocol):
    pipette = protocol.load_instrument("flex_96channel_1000", mount="left")
    protocol.comment(pipette.type)
```

# Changelog

* Make `InstrumentContext.type` return `"multi"` for 96-channels, the same way it does for 8-channels.
* In the docs, point people towards `InstrumentContext.channels` instead. It seems strictly better because it can distinguish between `1` and `8` and `96`.
* Add unit test coverage for `.channels` and `.type`.

# Review requests

None in particular.

# Risk assessment

Low.
