### PR TITLE
feat(api): Allow omitting the mount when loading a 96-channel

### DIFF
--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -48,7 +48,7 @@ If you're writing a protocol that uses the Flex Gripper, you might think that th
 Loading a Flex 96-Channel Pipette
 ---------------------------------
 
-This code sample loads the Flex 96-Channel Pipette. Because of its size, the Flex 96-Channel Pipette requires the left *and* right pipette mounts. You cannot use this pipette with 1- or 8-Channel Pipette in the same protocol or when these instruments are attached to the robot. To load the 96-Channel Pipette, omit the ``mount`` argument from ``load_instrument()`` as shown here:
+This code sample loads the Flex 96-Channel Pipette. Because of its size, the Flex 96-Channel Pipette requires the left *and* right pipette mounts. You cannot use this pipette with 1- or 8-Channel Pipette in the same protocol or when these instruments are attached to the robot. When loading the 96-Channel Pipette, you can omit the ``mount`` argument from ``load_instrument()`` as shown here:
 
 .. code-block:: python
 

--- a/api/docs/v2/new_pipette.rst
+++ b/api/docs/v2/new_pipette.rst
@@ -48,13 +48,13 @@ If you're writing a protocol that uses the Flex Gripper, you might think that th
 Loading a Flex 96-Channel Pipette
 ---------------------------------
 
-This code sample loads the Flex 96-Channel Pipette. Because of its size, the Flex 96-Channel Pipette requires the left *and* right pipette mounts. You cannot use this pipette with 1- or 8-Channel Pipette in the same protocol or when these instruments are attached to the robot. To load the 96-Channel Pipette, specify its position as ``mount='left'`` as shown here:
+This code sample loads the Flex 96-Channel Pipette. Because of its size, the Flex 96-Channel Pipette requires the left *and* right pipette mounts. You cannot use this pipette with 1- or 8-Channel Pipette in the same protocol or when these instruments are attached to the robot. To load the 96-Channel Pipette, omit the ``mount`` argument from ``load_instrument()`` as shown here:
 
 .. code-block:: python
 
     def run(protocol: protocol_api.ProtocolContext):
-        left = protocol.load_instrument(
-            instrument_name='flex_96channel_1000', mount='left')
+        pipette = protocol.load_instrument(
+            instrument_name='flex_96channel_1000')
 
 .. versionadded:: 2.15
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -851,18 +851,11 @@ class ProtocolContext(CommandPublisher):
         """
         instrument_name = validation.ensure_lowercase_name(instrument_name)
         checked_instrument_name = validation.ensure_pipette_name(instrument_name)
-        # Always validate the input mount, even if we're loading a 96-channel and the mount doesn't
-        # matter.
-        checked_mount = validation.ensure_mount(mount)
+        checked_mount = validation.ensure_mount_for_pipette(
+            mount, checked_instrument_name
+        )
 
         is_96_channel = checked_instrument_name == PipetteNameType.P1000_96
-        if is_96_channel:
-            checked_mount = Mount.LEFT
-        else:
-            if checked_mount is None:
-                raise ValueError(
-                    f"You must specify a mount to load {repr(instrument_name)}."
-                )
 
         tip_racks = tip_racks or []
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -833,7 +833,7 @@ class ProtocolContext(CommandPublisher):
 
         :param str instrument_name: Which instrument you want to load. See :ref:`new-pipette-models`
                                     for the valid values.
-        :param mount: The mount to which this instrument should be attached.
+        :param mount: The mount where this instrument should be attached.
                       This can either be an instance of the enum type
                       :py:class:`.types.Mount` or one of the strings ``"left"``
                       or ``"right"``. If you're loading a Flex 96-Channel Pipette

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -851,6 +851,8 @@ class ProtocolContext(CommandPublisher):
         """
         instrument_name = validation.ensure_lowercase_name(instrument_name)
         checked_instrument_name = validation.ensure_pipette_name(instrument_name)
+        # Always validate the input mount, even if we're loading a 96-channel and the mount doesn't
+        # matter.
         checked_mount = validation.ensure_mount(mount)
 
         is_96_channel = checked_instrument_name == PipetteNameType.P1000_96

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -821,7 +821,7 @@ class ProtocolContext(CommandPublisher):
     def load_instrument(
         self,
         instrument_name: str,
-        mount: Union[Mount, str, None],
+        mount: Union[Mount, str, None] = None,
         tip_racks: Optional[List[Labware]] = None,
         replace: bool = False,
     ) -> InstrumentContext:

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -821,7 +821,7 @@ class ProtocolContext(CommandPublisher):
     def load_instrument(
         self,
         instrument_name: str,
-        mount: Union[Mount, str],
+        mount: Union[Mount, str, None],
         tip_racks: Optional[List[Labware]] = None,
         replace: bool = False,
     ) -> InstrumentContext:
@@ -831,15 +831,16 @@ class ProtocolContext(CommandPublisher):
         ensure that the correct instrument is attached in the specified
         location.
 
-        :param str instrument_name: The name of the instrument model, or a
-                                    prefix. For instance, 'p10_single' may be
-                                    used to request a P10 single regardless of
-                                    the version.
-        :param mount: The mount in which this instrument should be attached.
+        :param str instrument_name: Which instrument you want to load. See :ref:`new-pipette-models`
+                                    for the valid values.
+        :param mount: The mount to which this instrument should be attached.
                       This can either be an instance of the enum type
-                      :py:class:`.types.Mount` or one of the strings `'left'`
-                      and `'right'`.
-        :type mount: types.Mount or str
+                      :py:class:`.types.Mount` or one of the strings ``"left"``
+                      or ``"right"``. If you're loading a Flex 96-Channel Pipette
+                      (``instrument_name="flex_96channel_1000"``), you can leave this unspecified,
+                      since it always occupies both mounts; if you do specify a value, it will be
+                      ignored.
+        :type mount: types.Mount or str or ``None``
         :param tip_racks: A list of tip racks from which to pick tips if
                           :py:meth:`.InstrumentContext.pick_up_tip` is called
                           without arguments.
@@ -850,9 +851,16 @@ class ProtocolContext(CommandPublisher):
         """
         instrument_name = validation.ensure_lowercase_name(instrument_name)
         checked_instrument_name = validation.ensure_pipette_name(instrument_name)
-        is_96_channel = checked_instrument_name == PipetteNameType.P1000_96
+        checked_mount = validation.ensure_mount(mount)
 
-        checked_mount = Mount.LEFT if is_96_channel else validation.ensure_mount(mount)
+        is_96_channel = checked_instrument_name == PipetteNameType.P1000_96
+        if is_96_channel:
+            checked_mount = Mount.LEFT
+        else:
+            if checked_mount is None:
+                raise ValueError(
+                    f"You must specify a mount to load {repr(instrument_name)}."
+                )
 
         tip_racks = tip_racks or []
 

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -88,8 +88,11 @@ class InvalidTrashBinLocationError(ValueError):
     """An error raised when attempting to load trash bins in invalid slots."""
 
 
-def ensure_mount(mount: Union[str, Mount]) -> Mount:
+def ensure_mount(mount: Union[str, Mount, None]) -> Optional[Mount]:
     """Ensure that an input value represents a valid Mount."""
+    if mount is None:
+        return None
+
     if mount in [Mount.EXTENSION, "extension"]:
         # This would cause existing protocols that might be iterating over mount types
         # for loading pipettes to raise an error because Mount now includes Extension mount.
@@ -274,7 +277,6 @@ def ensure_module_model(load_name: str) -> ModuleModel:
 def ensure_and_convert_trash_bin_location(
     deck_slot: Union[int, str], api_version: APIVersion, robot_type: RobotType
 ) -> str:
-
     """Ensure trash bin load location is valid.
 
     Also, convert the deck slot to a valid trash bin addressable area.

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -201,13 +201,17 @@ def test_load_instrument_replace(
     """It should allow/disallow pipette replacement."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
 
-    decoy.when(mock_validation.ensure_lowercase_name("ada")).then_return("ada")
-    decoy.when(
-        mock_validation.ensure_mount_for_pipette("ada", matchers.IsA(Mount))
-    ).then_return(Mount.RIGHT)
+    decoy.when(mock_validation.ensure_lowercase_name(matchers.IsA(str))).then_return(
+        "ada"
+    )
     decoy.when(mock_validation.ensure_pipette_name(matchers.IsA(str))).then_return(
         PipetteNameType.P300_SINGLE
     )
+    decoy.when(
+        mock_validation.ensure_mount_for_pipette(
+            matchers.IsA(Mount), matchers.IsA(PipetteNameType)
+        )
+    ).then_return(Mount.RIGHT)
     decoy.when(
         mock_core.load_instrument(
             instrument_name=matchers.IsA(PipetteNameType),
@@ -239,12 +243,16 @@ def test_96_channel_pipette_raises_if_another_pipette_attached(
     """It should always raise when loading a 96-channel pipette when another pipette is attached."""
     mock_instrument_core = decoy.mock(cls=InstrumentCore)
 
-    decoy.when(mock_validation.ensure_lowercase_name("ada")).then_return("ada")
-    decoy.when(mock_validation.ensure_pipette_name("ada")).then_return(
-        PipetteNameType.P300_SINGLE
-    )
     decoy.when(
-        mock_validation.ensure_mount_for_pipette("ada", matchers.IsA(Mount))
+        mock_validation.ensure_lowercase_name("A Single Channel Name")
+    ).then_return("a single channel name")
+    decoy.when(
+        mock_validation.ensure_pipette_name("a single channel name")
+    ).then_return(PipetteNameType.P300_SINGLE)
+    decoy.when(
+        mock_validation.ensure_mount_for_pipette(
+            Mount.RIGHT, PipetteNameType.P300_SINGLE
+        )
     ).then_return(Mount.RIGHT)
 
     decoy.when(
@@ -260,7 +268,9 @@ def test_96_channel_pipette_raises_if_another_pipette_attached(
         NoTrashDefinedError("No trash!")
     )
 
-    pipette_1 = subject.load_instrument(instrument_name="ada", mount=Mount.RIGHT)
+    pipette_1 = subject.load_instrument(
+        instrument_name="A Single Channel Name", mount=Mount.RIGHT
+    )
     assert subject.loaded_instruments["right"] is pipette_1
 
     decoy.when(mock_validation.ensure_lowercase_name("A 96 Channel Name")).then_return(
@@ -270,7 +280,7 @@ def test_96_channel_pipette_raises_if_another_pipette_attached(
         PipetteNameType.P1000_96
     )
     decoy.when(
-        mock_validation.ensure_mount_for_pipette("shadowfax", matchers.IsA(Mount))
+        mock_validation.ensure_mount_for_pipette("shadowfax", PipetteNameType.P1000_96)
     ).then_return(Mount.LEFT)
     decoy.when(
         mock_core.load_instrument(

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -191,6 +191,15 @@ def test_load_instrument(
     )
 
 
+def test_load_instrument_usually_requires_mount(
+    decoy: Decoy, subject: ProtocolContext
+) -> None:
+    """For pipettes other than 96-channels, it should require a mount."""
+    decoy.when(mock_validation.ensure_mount("some_mount")).then_return(None)
+    with pytest.raises(ValueError, match="You must specify a mount"):
+        subject.load_instrument("some_instrument", "some_mount")
+
+
 def test_load_instrument_replace(
     decoy: Decoy, mock_core: ProtocolCore, subject: ProtocolContext
 ) -> None:
@@ -241,6 +250,9 @@ def test_96_channel_pipette_always_loads_on_the_left_mount(
     decoy.when(mock_validation.ensure_pipette_name("a 96 channel name")).then_return(
         PipetteNameType.P1000_96
     )
+    decoy.when(mock_validation.ensure_mount("shadowfax")).then_return(
+        Mount.RIGHT
+    )  # Should be ignored.
     decoy.when(
         mock_core.load_instrument(
             instrument_name=PipetteNameType.P1000_96,
@@ -295,6 +307,7 @@ def test_96_channel_pipette_raises_if_another_pipette_attached(
     decoy.when(mock_validation.ensure_pipette_name("a 96 channel name")).then_return(
         PipetteNameType.P1000_96
     )
+    decoy.when(mock_validation.ensure_mount("shadowfax")).then_return(None)
     decoy.when(
         mock_core.load_instrument(
             instrument_name=PipetteNameType.P1000_96,

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -35,6 +35,7 @@ from opentrons.protocol_api import validation as subject, Well, Labware
         ("LeFt", Mount.LEFT),
         (Mount.LEFT, Mount.LEFT),
         (Mount.RIGHT, Mount.RIGHT),
+        (None, None),
     ],
 )
 def test_ensure_mount(input_value: Union[str, Mount], expected: Mount) -> None:

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -28,19 +28,28 @@ from opentrons.protocol_api import validation as subject, Well, Labware
 
 
 @pytest.mark.parametrize(
-    ["input_value", "expected"],
+    ["input_mount", "input_pipette", "expected"],
     [
-        ("left", Mount.LEFT),
-        ("right", Mount.RIGHT),
-        ("LeFt", Mount.LEFT),
-        (Mount.LEFT, Mount.LEFT),
-        (Mount.RIGHT, Mount.RIGHT),
-        (None, None),
+        # Different string capitalizations:
+        ("left", PipetteNameType.P300_MULTI_GEN2, Mount.LEFT),
+        ("right", PipetteNameType.P300_MULTI_GEN2, Mount.RIGHT),
+        ("LeFt", PipetteNameType.P300_MULTI_GEN2, Mount.LEFT),
+        # Passing in a Mount:
+        (Mount.LEFT, PipetteNameType.P300_MULTI_GEN2, Mount.LEFT),
+        (Mount.RIGHT, PipetteNameType.P300_MULTI_GEN2, Mount.RIGHT),
+        # Special handling for the 96-channel:
+        ("left", PipetteNameType.P1000_96, Mount.LEFT),
+        ("right", PipetteNameType.P1000_96, Mount.LEFT),
+        (None, PipetteNameType.P1000_96, Mount.LEFT),
     ],
 )
-def test_ensure_mount(input_value: Union[str, Mount], expected: Mount) -> None:
+def test_ensure_mount(
+    input_mount: Union[str, Mount, None],
+    input_pipette: PipetteNameType,
+    expected: Mount,
+) -> None:
     """It should properly map strings and mounts."""
-    result = subject.ensure_mount(input_value)
+    result = subject.ensure_mount_for_pipette(input_mount, input_pipette)
     assert result == expected
 
 
@@ -49,18 +58,31 @@ def test_ensure_mount_input_invalid() -> None:
     with pytest.raises(
         subject.InvalidPipetteMountError, match="must be 'left' or 'right'"
     ):
-        subject.ensure_mount("oh no")
+        subject.ensure_mount_for_pipette("oh no", PipetteNameType.P300_MULTI_GEN2)
+
+    # Any mount is valid for the 96-Channel, but it needs to be a valid mount.
+    with pytest.raises(
+        subject.InvalidPipetteMountError, match="must be 'left' or 'right'"
+    ):
+        subject.ensure_mount_for_pipette("oh no", PipetteNameType.P1000_96)
 
     with pytest.raises(
         subject.PipetteMountTypeError,
         match="'left', 'right', or an opentrons.types.Mount",
     ):
-        subject.ensure_mount(42)  # type: ignore[arg-type]
+        subject.ensure_mount_for_pipette(42, PipetteNameType.P300_MULTI_GEN2)  # type: ignore[arg-type]
 
     with pytest.raises(
         subject.InvalidPipetteMountError, match="Use the left or right mounts instead"
     ):
-        subject.ensure_mount(Mount.EXTENSION)
+        subject.ensure_mount_for_pipette(
+            Mount.EXTENSION, PipetteNameType.P300_MULTI_GEN2
+        )
+
+    with pytest.raises(
+        subject.InvalidPipetteMountError, match="You must specify a left or right mount"
+    ):
+        subject.ensure_mount_for_pipette(None, PipetteNameType.P300_MULTI_GEN2)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

The 96-Channel Pipette physically occupies both mounts. But a quirk (not ticketed) of our current Python Protocol API is that you need to specify `mount="left"` or `mount="right"`. This PR fixes that quirk.

# Changelog

Before this PR:

* The Python Protocol API's `load_instrument()` method takes a `mount` argument that's required to be `"left"` or `"right"`.
* The documentation says to use `"left"` if you're loading a 96-Channel.
* The implementation ignores whichever value you pass in; `"left"` and `"right"` do the same thing in practice.

With this PR:

* The `mount` argument is allowed to be omitted or `None` if you're loading a 96-channel. For all other pipettes, it's still required to be `"left"` or `"right"`.
* The documentation says to omit `mount` if you're loading a 96-channel.
* The implementation continues to ignore whichever value you pass in. This is for compatibility with existing protocols.

This is roughly analogous to how we treat the Thermocycler Module, which can only be loaded into one location.

# Test Plan

* [x] Try out some different load syntaxes and make sure they raise errors, or don't raise them, according to your expectations.

# Review requests

Is this a good idea to do now, or were we deliberately making people do `mount="<something>"`?

# Risk assessment

Low.