### PR TITLE
fix(protocol-designer): getIsSlotEmpty logic util fix for modules and…

### DIFF
--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -161,11 +161,11 @@ export const getSlotIsEmpty = (
 
   return (
     [
-      ...values(initialDeckSetup.modules).filter((moduleOnDeck: ModuleOnDeck) =>
-        slot.includes(moduleOnDeck.slot)
+      ...values(initialDeckSetup.modules).filter(
+        (moduleOnDeck: ModuleOnDeck) => moduleOnDeck.slot === slot
       ),
-      ...values(initialDeckSetup.labware).filter((labware: LabwareOnDeckType) =>
-        slot.includes(labware.slot)
+      ...values(initialDeckSetup.labware).filter(
+        (labware: LabwareOnDeckType) => labware.slot === slot
       ),
       ...filteredAdditionalEquipmentOnDeck,
     ].length === 0


### PR DESCRIPTION
… labware

# Overview

Followup to my last PR that was fixing the `getIsSlotEmpty` logic for the addressable areas. This PR fixes the logic for labware and modules since i noticed there were still issues with some slots not being full but the util thinking they are full.

# Test Plan

First test with creating an ot-2 protocol. Mess around with adding/deleting modules in different locations and make sure the slot is full when it really is full! The case in particular that was erroring was if a TC is attached and trying to add a module to slot 1, the util thought slot 1 was full even though slots 7,8,10,11 were full

Then test with creating a flex protocol and do the same thing.

# Changelog

- change logic to === instead of `includes()`

# Review requests

see test plan

# Risk assessment

low
