### PR TITLE
fix(api): use adapter labwareId when checking adapter quirk

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -213,7 +213,7 @@ def check_safe_for_tip_pickup_and_return(
     tiprack_parent = engine_state.labware.get_location(labware_id)
     if isinstance(tiprack_parent, OnLabwareLocation):  # tiprack is on an adapter
         is_96_ch_tiprack_adapter = engine_state.labware.get_has_quirk(
-            labware_id=labware_id, quirk="tiprackAdapterFor96Channel"
+            labware_id=tiprack_parent.labwareId, quirk="tiprackAdapterFor96Channel"
         )
         tiprack_height = engine_state.labware.get_dimensions(labware_id).z
         adapter_height = engine_state.labware.get_dimensions(tiprack_parent.labwareId).z

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -579,7 +579,7 @@ def test_valid_96_pipette_movement_for_tiprack_and_adapter(
     )
     decoy.when(
         mock_state_view.labware.get_has_quirk(
-            labware_id="labware-id", quirk="tiprackAdapterFor96Channel"
+            labware_id="adapter-id", quirk="tiprackAdapterFor96Channel"
         )
     ).then_return(is_on_flex_adapter)
 


### PR DESCRIPTION
# Overview

Fixes a bug where the deck conflict checker was looking for `tiprackAdapterFor96Channel` quirk on the tiprack instead of on the adapter

# Test Plan

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16"
}

def run(protocol_context):
	trash_labware = protocol_context.load_labware("opentrons_1_trash_3200ml_fixed", "A3")

	tip_rack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C3")
	tip_rack2 = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "B3", adapter="opentrons_flex_96_tiprack_adapter")

	instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack1, tip_rack2])
	instrument.trash_container = trash_labware

	# Should not error out
	instrument.pick_up_tip(tip_rack2.wells()[0])
	instrument.drop_tip()

	# Should raise error because tiprack1 is not on adapter
	instrument.pick_up_tip()
	instrument.drop_tip()

```

# Changelog

- use the correct labware id in deck conflict and test

# Risk assessment

None. Bug fix
