### PR TITLE
docs(api): Correct and tidy up docs for ProtocolContext.fixed_trash and InstrumentContext.trash_container

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1525,12 +1525,14 @@ class InstrumentContext(publisher.CommandPublisher):
         This is the property used to determine where to drop tips and blow out liquids
         when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without arguments.
 
-        On a Flex running a protocol with API version 2.16 or higher, ``trash_container`` is
-        the first ``TrashBin`` or ``WasteChute`` object loaded in the protocol.
-        On a Flex running a protocol with API version 2.15, ``trash_container`` is
-        a single-well fixed trash labware in slot D3.
-        On a an OT-2, ``trash_container`` is always a single-well fixed trash labware
-        in slot 12.
+        You can set this to a :py:obj:`Labware`, :py:obj:`TrashBin`, or :py:obj:`WasteChute`.
+
+        If you haven't set this to anything, this will either be:
+
+        * :py:obj:`ProtocolContext.fixed_trash`, if it exists.
+        * Otherwise, the first thing that you've loaded so far with
+          :py:obj:`ProtocolContext.load_trash_bin()`
+          or :py:obj:`ProtocolContext.load_waste_chute()`.
 
         .. versionchanged:: 2.16
             Added support for ``TrashBin`` and ``WasteChute`` objects.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1052,12 +1052,20 @@ class ProtocolContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def fixed_trash(self) -> Union[Labware, TrashBin]:
-        """The trash fixed to slot 12 of the robot deck.
+        """The immovable and irreplacable trash bin in the back-right corner of the deck.
 
-        In API Versions prior to 2.16 it has one well and should be accessed like labware in your protocol.
-        e.g. ``protocol.fixed_trash['A1']``
+        On OT-2 robots, this is always present because the trash has a reserved place on the OT-2's
+        deck.
 
-        In API Version 2.16 and above it returns a Trash fixture for OT-2 Protocols.
+        On Flex robots, this is only present in API version 2.15. Newer API versions on the Flex
+        let you put the trash wherever you want (see :ref:`configure-trash-bin`), so there is no
+        fixed trash, and accessing this property will raise an exception.
+
+        :return: In API versions 2.15 and below, a special :py:obj:`Labware` with one well, e.g.
+            ``protocol.fixed_trash["A1"]``.
+            In API versions 2.16 and above, a :py:obj:`TrashBin`.
+
+        :raises Exception: If there is no fixed trash.
         """
         if self._api_version >= APIVersion(2, 16):
             if self._core.robot_type == "OT-3 Standard":


### PR DESCRIPTION
# Overview

Corrections and clarifications in the reference documentation for `ProtocolContext.fixed_trash` and `InstrumentContext.trash_container`.

# Test Plan

Preview:

* [`ProtocolContext.fixed_trash`](http://sandbox.docs.opentrons.com/docs_cleanup_fixed_trash_and_trash_container/v2/new_protocol_api.html#opentrons.protocol_api.ProtocolContext.fixed_trash)
* [`InstrumentContext.trash_container`](http://sandbox.docs.opentrons.com/docs_cleanup_fixed_trash_and_trash_container/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.trash_container)

# Changelog

See my inline notes.

# Review requests

* Does this harmonize well with http://sandbox.docs.opentrons.com/docs_cleanup_fixed_trash_and_trash_container/v2/deck_slots.html#deck-configuration? Are we duplicating anything or spreading any information out?
* I'm adding cross-references to the `TrashBin` class, which we have prepared to be public but which is not yet actually published. My vision is that we will publish it; it is a public, stable part of the API just like `Labware`. Does that vision sound good?

# Risk assessment

No risk. Docs only.
