### PR TITLE
docs(api): corrections to docstrings involving `TrashBin`s

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -945,7 +945,7 @@ class InstrumentContext(publisher.CommandPublisher):
         See :ref:`pipette-drop-tip` for examples.
 
         If no location is passed (e.g. ``pipette.drop_tip()``), the pipette will drop
-        the attached tip into its default :py:attr:`trash_container`.
+        the attached tip into its :py:attr:`trash_container`.
 
         Starting with API version 2.15, if the trash container is the default fixed
         trash, the API will instruct the pipette to drop tips in different locations
@@ -1524,12 +1524,14 @@ class InstrumentContext(publisher.CommandPublisher):
         This is the property used to determine where to drop tips and blow out liquids
         when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without arguments.
 
-        On a Flex running a protocol with API version 2.16 or higher, ``trash_container`` is
-        the first ``TrashBin`` or ``WasteChute`` object loaded in the protocol.
-        On a Flex running a protocol with API version 2.15, ``trash_container`` is
-        a single-well fixed trash labware in slot D3.
-        On a an OT-2, ``trash_container`` is always a single-well fixed trash labware
-        in slot 12.
+        The default value depends on the robot type and API version:
+
+        - On a Flex running a protocol with API version 2.16 and later, the first
+          ``TrashBin`` or ``WasteChute`` object loaded in the protocol.
+        - On a Flex running a protocol with API version 2.15, a single-well fixed trash
+          ``Labware`` in slot D3.
+        - On an OT-2, it is always in slot 12. It is a ``Labware`` in API version 2.15
+          or earlier, or a ``TrashBin`` in API version 2.16 and later.
 
         .. versionchanged:: 2.16
             Added support for ``TrashBin`` and ``WasteChute`` objects.

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1524,6 +1524,8 @@ class InstrumentContext(publisher.CommandPublisher):
         This is the property used to determine where to drop tips and blow out liquids
         when calling :py:meth:`drop_tip` or :py:meth:`blow_out` without arguments.
 
+        You can set this to a :py:obj:`Labware`, :py:obj:`TrashBin`, or :py:obj:`WasteChute`.
+
         The default value depends on the robot type and API version:
 
         - On a Flex running a protocol with API version 2.16 and later, the first

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1528,12 +1528,10 @@ class InstrumentContext(publisher.CommandPublisher):
 
         The default value depends on the robot type and API version:
 
-        - On a Flex running a protocol with API version 2.16 and later, the first
-          ``TrashBin`` or ``WasteChute`` object loaded in the protocol.
-        - On a Flex running a protocol with API version 2.15, a single-well fixed trash
-          ``Labware`` in slot D3.
-        - On an OT-2, it is always in slot 12. It is a ``Labware`` in API version 2.15
-          or earlier, or a ``TrashBin`` in API version 2.16 and later.
+        - :py:obj:`ProtocolContext.fixed_trash`, if it exists.
+        - Otherwise, the first item previously loaded with
+          :py:obj:`ProtocolContext.load_trash_bin()` or
+          :py:obj:`ProtocolContext.load_waste_chute()`.
 
         .. versionchanged:: 2.16
             Added support for ``TrashBin`` and ``WasteChute`` objects.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1058,7 +1058,7 @@ class ProtocolContext(CommandPublisher):
 
         In API version 2.15 only, Flex protocols have a fixed trash in slot A3.
 
-        In API version 2.16 and later, the fixed trash only exists in OT-2 protocols. It is a :py:class:`.TrashBin` object, which doesn't have any wells. Trying to access ``fixed_trash`` in a Flex protocol will raise an error.
+        In API version 2.16 and later, the fixed trash only exists in OT-2 protocols. It is a :py:class:`.TrashBin` object, which doesn't have any wells. Trying to access ``fixed_trash`` in a Flex protocol will raise an error. See :ref:`configure-trash-bin` for details on using the movable trash in Flex protocols.
 
         .. versionchanged:: 2.16
             Returns a :py:class:`.TrashBin` object.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1052,12 +1052,16 @@ class ProtocolContext(CommandPublisher):
     @property  # type: ignore
     @requires_version(2, 0)
     def fixed_trash(self) -> Union[Labware, TrashBin]:
-        """The trash fixed to slot 12 of the robot deck.
+        """The trash fixed to slot 12 of an OT-2's deck.
 
-        In API Versions prior to 2.16 it has one well and should be accessed like labware in your protocol.
-        e.g. ``protocol.fixed_trash['A1']``
+        In API version 2.15 and earlier, the fixed trash is a :py:class:`.Labware` object with one well. Access it like labware in your protocol. For example, ``protocol.fixed_trash['A1']``.
 
-        In API Version 2.16 and above it returns a Trash fixture for OT-2 Protocols.
+        In API version 2.15 only, Flex protocols have a fixed trash in slot A3.
+
+        In API version 2.16 and later, the fixed trash only exists in OT-2 protocols. It is a :py:class:`.TrashBin` object, which doesn't have any wells. Trying to access ``fixed_trash`` in a Flex protocol will raise an error.
+
+        .. versionchanged:: 2.16
+            Returns a :py:class:`.TrashBin` object.
         """
         if self._api_version >= APIVersion(2, 16):
             if self._core.robot_type == "OT-3 Standard":


### PR DESCRIPTION

# Overview

Updates the docstrings for `fixed_trash` and `trash_container` to accurately reflect how they work with different robot types and API versions.

# Test Plan

Check API reference entries.
- [`fixed_trash`](http://sandbox.docs.opentrons.com/docstring-trashbin-fixes/v2/new_protocol_api.html#opentrons.protocol_api.ProtocolContext.fixed_trash)
- [`trash_container`](http://sandbox.docs.opentrons.com/docstring-trashbin-fixes/v2/new_protocol_api.html#opentrons.protocol_api.InstrumentContext.trash_container)

# Changelog

- Two docstrings mentioned above.
- `drop_tip()` doesn't go to the "default" `trash_container` — it goes to the current value.

# Review requests

I love it because it's trash?

# Risk assessment

v low, docstrings only