### PR TITLE
chore: add direct Ethernet feature to release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -18,6 +18,7 @@ Welcome to the v7.1.0 release of the Opentrons robot software! This release incl
 
 ### Improved Features
 
+- The Ethernet port on Flex now supports direct connection to a computer.
 - Improves aspirate, dispense, and mix behavior with volumes set to zero.
 - The `opentrons_simulate` command-line tool now works with all Python API versions.
 


### PR DESCRIPTION

# Overview

One-liner to add the fact that Flex will support direct Ethernet connections in 7.1.

# Test Plan

👀 

# Changelog

just one bullet

# Review requests

Accurate? Good position in notes?

# Risk assessment

zero