### PR TITLE
chore: add probe-based LPC to app release notes

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,14 +10,14 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.1.0 release of the Opentrons App! This release includes new deck and pipette functionality for Opentrons Flex, a new workflow for dropping tips after a protocol is canceled, and other improvements.
 
-### New features
+### New Features
 
 - Specify the deck configuration of Flex, including the movable trash bin, waste chute, and staging area slots.
 - Resolve conflicts between the hardware a protocol requires and the current deck configuration as part of run setup.
 - Run protocols that use the Flex 96-Channel Pipette, including partial tip pickup.
 - Choose where to dispense liquid and drop tips held by a pipette when a protocol is canceled.
 
-### Improved features
+### Improved Features
 
 - Labware Position Check on Flex uses the pipette calibration probe, instead of a tip, for greater accuracy.
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -17,6 +17,10 @@ Welcome to the v7.1.0 release of the Opentrons App! This release includes new de
 - Run protocols that use the Flex 96-Channel Pipette, including partial tip pickup.
 - Choose where to dispense liquid and drop tips held by a pipette when a protocol is canceled.
 
+### Improved features
+
+- Labware Position Check on Flex uses the pipette calibration probe, instead of a tip, for greater accuracy.
+
 ### Bug Fixes
 
 - Labware Position Check no longer tries to check the same labware in the same position twice, which was leading to errors.


### PR DESCRIPTION

# Overview

Probe-based LPC is enforced for Flex in 7.1. Users should know.

# Changelog

Another bullet in app notes.

# Review requests

Sawreeeee for the cascade of PRs.

# Risk assessment

none, notes only