### PR TITLE
refactor(protocol-designer, step-generation): emit dropTipInPlace & m…

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -2783,6 +2783,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "814036fd-ea55-40d0-932b-d13f6113a77f",
+      "params": { "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5" }
+    },
+    {
       "commandType": "waitForResume",
       "key": "00cedccd-f5dc-4b12-9142-979758ba0dd9",
       "params": { "message": "Wait until user intervention" }
@@ -2905,7 +2910,11 @@
         "alternateDropLocation": true
       }
     },
-
+    {
+      "commandType": "dropTipInPlace",
+      "key": "c55edd6b-b323-4d72-81d3-39e08ec71a88",
+      "params": { "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5" }
+    },
     {
       "commandType": "pickUpTip",
       "key": "d83c457e-4183-4bac-a9cc-f58ece48e808",
@@ -3023,6 +3032,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "3bd0eb5c-3115-4953-aad4-a530dfb962fb",
+      "params": { "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5" }
     }
   ],
   "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -2743,6 +2743,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "e9745ff2-9404-432f-acb7-0f8400f37821",
+      "params": { "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "9969785e-f71d-4344-9241-c1b2d63845fa",
       "params": {
@@ -2784,6 +2789,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "1cf684b0-27e7-48c6-bb66-09ba0acf0630",
+      "params": { "pipetteId": "0b3f2210-75c7-11ea-b42f-4b64e50f43e5" }
     },
     {
       "commandType": "temperatureModule/waitForTemperature",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -4010,6 +4010,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "ac00f670-852b-4426-97dc-871b44ba66a1",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "57a9e3bc-16e5-4dbf-840f-ef209cf856e1",
       "params": {
@@ -4051,6 +4056,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "2090ef62-ea92-4b94-bd06-db2b728be791",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4096,6 +4106,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "bb648909-b03d-4968-8c70-2805f62e25ea",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "30b832e2-d26d-4a67-8a2f-e016fed5bf5f",
       "params": {
@@ -4137,6 +4152,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "976eb63e-6088-4557-8db5-03e7eea31c1e",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4182,6 +4202,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "f5dd6139-a8ed-4581-bf1b-0be264a64d7d",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "f6d713e8-89ff-4d3e-aaab-fbe2989dd179",
       "params": {
@@ -4223,6 +4248,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "89b50486-6526-4583-bf14-0e69b1c9e734",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4268,6 +4298,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "44e645f1-3e34-41d8-beb8-3f372040417f",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "faac2fd6-a6c2-4476-855f-050e6de30f50",
       "params": {
@@ -4309,6 +4344,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "8e019e03-08fb-4ffa-95f8-2b5772ead81f",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4354,6 +4394,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "c934ec98-5a28-40ec-88cb-3b1860d8bac7",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "bd57a694-9816-47fb-b4aa-c80d2c3a0b2c",
       "params": {
@@ -4395,6 +4440,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "95585fea-74b8-4d30-bd98-2019c1f024e9",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4440,6 +4490,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "479a02e3-e2f5-4c45-96f7-e8517fc17bd4",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "57d8e8c3-64ba-416d-bbed-eb7675ddde76",
       "params": {
@@ -4481,6 +4536,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "2f509f24-3b12-4fee-ad61-9f509021a38f",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4526,6 +4586,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "d90df5ec-8ec5-4d07-84eb-3b223096ad96",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "8779a116-4dd8-4e75-bb64-971be73ce999",
       "params": {
@@ -4567,6 +4632,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "825d8d92-b475-4ad1-bab3-59bce3790ad2",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4612,6 +4682,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "a2d3c0d6-eb9c-49e1-b956-714799ad22c4",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "fc43bd31-0414-4eaa-b5c2-f19569955525",
       "params": {
@@ -4653,6 +4728,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "4317a410-eceb-4130-b499-f6e717887fee",
+      "params": { "pipetteId": "2e7c6344-58ab-465c-b542-489883cb63fe" }
     },
     {
       "commandType": "pickUpTip",
@@ -4728,6 +4808,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "b7a75837-05f9-4fd5-ae46-d36c67717daf",
+      "params": { "pipetteId": "6d1e53c3-2db3-451b-ad60-3fe13781a193" }
     },
     {
       "commandType": "moveLabware",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3651,6 +3651,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "0164aa78-bccf-4a2f-99b7-cdfe57f40010",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "4eaeeb54-5696-4266-b6e0-0d1ea4e26871",
       "params": {
@@ -3849,6 +3854,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "0e5e034f-293c-4261-af84-2a1df0c4a8fc",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
@@ -4051,6 +4061,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "df138c35-ce81-4ecb-a034-0363e2ecaa06",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "c75fef6e-72d6-4736-ad4c-7c327996dab3",
       "params": {
@@ -4249,6 +4264,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "3b9ba522-a0a1-4313-b5e4-4b8177042416",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
@@ -4451,6 +4471,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "56cab34a-a9e5-4226-b443-74d0ee8e0aa6",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "cee54c07-b439-40e2-ac71-79792b48945d",
       "params": {
@@ -4649,6 +4674,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "abd37ed7-c6d8-46ac-93c1-0f6b8b0bbe7f",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
@@ -4851,6 +4881,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "abd37ed7-c6d8-46ac-93c1-0f6b8b0bbe7f",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "b7f37a99-be1d-4da9-bce2-d2b686240fab",
       "params": {
@@ -5049,6 +5084,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "09827fd5-e988-45a6-874c-95a35eec10e6",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
@@ -5251,6 +5291,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "322a1d13-dde1-4d05-8562-f152bbf78f27",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
       "commandType": "pickUpTip",
       "key": "d976581b-71a5-460f-b2e0-799777d6ea94",
       "params": {
@@ -5361,6 +5406,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "b4edbf18-d092-4668-b18a-99e13e7c7ce2",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "waitForDuration",

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -2353,6 +2353,11 @@
       }
     },
     {
+      "commandType": "dropTipInPlace",
+      "key": "fafbc2d4-6675-48c7-aff0-04aa4a5f4dcf",
+      "params": { "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9" }
+    },
+    {
       "commandType": "configureNozzleLayout",
       "key": "c0022ba6-ea8f-468e-b3db-3ab1137ac8e6",
       "params": {
@@ -2408,6 +2413,11 @@
         "offset": { "x": 0, "y": 0, "z": 0 },
         "alternateDropLocation": true
       }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "2b6cf6b5-73e6-46db-a52d-be7c1e09f281",
+      "params": { "pipetteId": "de7da440-95ec-43e8-8723-851321fbd6f9" }
     }
   ],
   "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",

--- a/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
+++ b/protocol-designer/src/timelineMiddleware/__tests__/generateRobotStateTimeline.test.ts
@@ -135,12 +135,14 @@ describe('generateRobotStateTimeline', () => {
           "aspirate",
           "dispense",
           "moveToAddressableAreaForDropTip",
+          "dropTipInPlace",
         ],
         Array [
           "pickUpTip",
           "aspirate",
           "dispense",
           "moveToAddressableAreaForDropTip",
+          "dropTipInPlace",
         ],
         Array [
           "pickUpTip",
@@ -149,12 +151,14 @@ describe('generateRobotStateTimeline', () => {
           "aspirate",
           "dispense",
           "moveToAddressableAreaForDropTip",
+          "dropTipInPlace",
           "pickUpTip",
           "aspirate",
           "dispense",
           "aspirate",
           "dispense",
           "moveToAddressableAreaForDropTip",
+          "dropTipInPlace",
         ],
       ]
     `)

--- a/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
+++ b/step-generation/src/__tests__/movableTrashCommandsUtil.test.ts
@@ -5,6 +5,7 @@ import {
   aspirateInPlace,
   blowOutInPlace,
   dispenseInPlace,
+  dropTipInPlace,
   moveToAddressableArea,
   moveToAddressableAreaForDropTip,
 } from '../commandCreators/atomic'
@@ -92,6 +93,9 @@ describe('movableTrashCommandsUtil', () => {
       moveToAddressableAreaForDropTip,
       mockMoveToAddressableAreaParams
     )
+    expect(curryCommandCreatorMock).toHaveBeenCalledWith(dropTipInPlace, {
+      pipetteId: mockId,
+    })
   })
   it('returns correct commands for aspirate in place (air gap)', () => {
     movableTrashCommandsUtil({

--- a/step-generation/src/__tests__/transfer.test.ts
+++ b/step-generation/src/__tests__/transfer.test.ts
@@ -2413,6 +2413,14 @@ describe('advanced options', () => {
           },
         },
         {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+          },
+        },
+
+        {
           commandType: 'pickUpTip',
           key: expect.any(String),
           params: {
@@ -3091,6 +3099,13 @@ describe('advanced options', () => {
           },
         },
         {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
+          },
+        },
+        {
           commandType: 'pickUpTip',
           key: expect.any(String),
           params: {
@@ -3463,6 +3478,13 @@ describe('advanced options', () => {
             addressableAreaName: 'movableTrashA3',
             offset: { x: 0, y: 0, z: 0 },
             alternateDropLocation: true,
+          },
+        },
+        {
+          commandType: 'dropTipInPlace',
+          key: expect.any(String),
+          params: {
+            pipetteId: 'p300SingleId',
           },
         },
         {

--- a/step-generation/src/fixtures/commandFixtures.ts
+++ b/step-generation/src/fixtures/commandFixtures.ts
@@ -308,6 +308,13 @@ export const dropTipHelper = (pipette?: string): CreateCommand[] => [
       alternateDropLocation: true,
     },
   },
+  {
+    commandType: 'dropTipInPlace',
+    key: expect.any(String),
+    params: {
+      pipetteId: pipette ?? DEFAULT_PIPETTE,
+    },
+  },
 ]
 export const dropTipIntoWasteChuteHelper = (
   pipette?: string

--- a/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
@@ -3,7 +3,6 @@ import type { AspirateInPlaceArgs } from '../commandCreators/atomic/aspirateInPl
 import type { BlowOutInPlaceArgs } from '../commandCreators/atomic/blowOutInPlace'
 import type { DispenseInPlaceArgs } from '../commandCreators/atomic/dispenseInPlace'
 import type { DropTipInPlaceArgs } from '../commandCreators/atomic/dropTipInPlace'
-import type { MoveToAddressableAreaForDropTipArgs } from '../commandCreators/atomic/moveToAddressableAreaForDropTip'
 import type { InvariantContext, RobotStateAndWarnings } from '../types'
 
 export const forAspirateInPlace = (
@@ -48,23 +47,6 @@ export const forBlowOutInPlace = (
 
 export const forDropTipInPlace = (
   params: DropTipInPlaceArgs,
-  invariantContext: InvariantContext,
-  robotStateAndWarnings: RobotStateAndWarnings
-): void => {
-  const { pipetteId } = params
-  const { robotState } = robotStateAndWarnings
-  robotState.tipState.pipettes[pipetteId] = false
-
-  dispenseUpdateLiquidState({
-    invariantContext,
-    prevLiquidState: robotState.liquidState,
-    pipetteId,
-    useFullVolume: true,
-  })
-}
-
-export const forMoveToAddressableAreaForDropTip = (
-  params: MoveToAddressableAreaForDropTipArgs,
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings
 ): void => {

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -38,7 +38,6 @@ import {
   forBlowOutInPlace,
   forDispenseInPlace,
   forDropTipInPlace,
-  forMoveToAddressableAreaForDropTip,
 } from './inPlaceCommandUpdates'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type {
@@ -112,14 +111,6 @@ function _getNextRobotStateAndWarningsSingleCommand(
       forDropTipInPlace(command.params, invariantContext, robotStateAndWarnings)
       break
 
-    case 'moveToAddressableAreaForDropTip':
-      forMoveToAddressableAreaForDropTip(
-        command.params,
-        invariantContext,
-        robotStateAndWarnings
-      )
-      break
-
     case 'blowOutInPlace':
       forBlowOutInPlace(command.params, invariantContext, robotStateAndWarnings)
       break
@@ -147,6 +138,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
     case 'delay':
     case 'configureForVolume':
     case 'moveToAddressableArea':
+    case 'moveToAddressableAreaForDropTip':
       // these commands don't have any effects on the state
       break
 

--- a/step-generation/src/utils/movableTrashCommandsUtil.ts
+++ b/step-generation/src/utils/movableTrashCommandsUtil.ts
@@ -7,6 +7,7 @@ import {
   aspirateInPlace,
   blowOutInPlace,
   dispenseInPlace,
+  dropTipInPlace,
   moveToAddressableArea,
   moveToAddressableAreaForDropTip,
 } from '../commandCreators/atomic'
@@ -106,6 +107,9 @@ export const movableTrashCommandsUtil = (
               curryCommandCreator(moveToAddressableAreaForDropTip, {
                 pipetteId,
                 addressableAreaName,
+              }),
+              curryCommandCreator(dropTipInPlace, {
+                pipetteId,
               }),
             ]
 


### PR DESCRIPTION
…oveToAddressableAreaForDropTip

# Overview

I made a big oopsy and was only emitting `moveToAddressableAreaForDropTip` without the `dropTipInPlace` afterwards! Luckily, since those sequence of commands are consolidated in `movableTrashCommandsUtil`, it was an easy fix. I also had to update all the cypress migration tests again 🤦 

# Test Plan

Create a flex or ot-2 protocol in PD and drop tip into the trash bin. It can be a simple transfer/mix step. Download the protocol and upload it to the app. It should work in alpha.7 or the dev env built off of this branch. It should pass analysis.

# Changelog

- emit dropTipInPlace in the `movableTrashCommandsUtil` and update the test
- delete now unnecessary robot state update fn for `moveToAddressableAreaForDropTip` 
- fix cypress test fixtures

# Review requests

see test plan

# Risk assessment

low