### PR TITLE
fix(shared-data): add moveToAddressableAreaForDropTip to getAddressableAreasInProtocol

### DIFF
--- a/shared-data/js/helpers/getAddressableAreasInProtocol.ts
+++ b/shared-data/js/helpers/getAddressableAreasInProtocol.ts
@@ -75,6 +75,14 @@ export function getAddressableAreasInProtocol(
           ...acc,
           command.params.addressableAreaName as AddressableAreaName,
         ]
+      } else if (
+        command.commandType === 'moveToAddressableAreaForDropTip' &&
+        !acc.includes(command.params.addressableAreaName as AddressableAreaName)
+      ) {
+        return [
+          ...acc,
+          command.params.addressableAreaName as AddressableAreaName,
+        ]
       } else {
         return acc
       }


### PR DESCRIPTION
# Overview

adds the moveToAddressableAreaForDropTip command to the getAddressableAreasInProtocol helper that provides a list of addressable area names referenced in a protocol's commands

# Test Plan

# Changelog

 - Adds moveToAddressableAreaForDropTip to getAddressableAreasInProtocol

# Review requests

# Risk assessment

low