### PR TITLE
fix(app): fix various drop tip wizard issues

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -71,6 +71,10 @@ export function InstrumentsAndModules({
   const { data: attachedInstruments } = useInstrumentsQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })
+  console.log(
+    '🚀 ~ file: InstrumentsAndModules.tsx:74 ~ attachedInstruments:',
+    attachedInstruments
+  )
 
   const attachedGripper =
     (attachedInstruments?.data ?? []).find(

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -71,10 +71,6 @@ export function InstrumentsAndModules({
   const { data: attachedInstruments } = useInstrumentsQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
   })
-  console.log(
-    '🚀 ~ file: InstrumentsAndModules.tsx:74 ~ attachedInstruments:',
-    attachedInstruments
-  )
 
   const attachedGripper =
     (attachedInstruments?.data ?? []).find(

--- a/app/src/organisms/DropTipWizard/BeforeBeginning.tsx
+++ b/app/src/organisms/DropTipWizard/BeforeBeginning.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import styled, { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
+
 import {
   Flex,
   SPACING,
@@ -19,34 +20,23 @@ import {
   JUSTIFY_FLEX_END,
   JUSTIFY_SPACE_AROUND,
 } from '@opentrons/components'
+
 import { StyledText } from '../../atoms/text'
 import { SmallButton, MediumButton } from '../../atoms/buttons'
+import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 // import { NeedHelpLink } from '../CalibrationPanels'
 
 import blowoutVideo from '../../assets/videos/droptip-wizard/Blowout-Liquid.webm'
 import droptipVideo from '../../assets/videos/droptip-wizard/Drop-tip.webm'
-
-import type { UseMutateFunction } from 'react-query'
-import type { AxiosError } from 'axios'
-import type {
-  CreateMaintenanceRunData,
-  MaintenanceRun,
-} from '@opentrons/api-client'
 
 // TODO: get help link article URL
 // const NEED_HELP_URL = ''
 
 interface BeforeBeginningProps {
   setShouldDispenseLiquid: (shouldDispenseLiquid: boolean) => void
-  createMaintenanceRun: UseMutateFunction<
-    MaintenanceRun,
-    AxiosError<any>,
-    CreateMaintenanceRunData,
-    unknown
-  >
   createdMaintenanceRunId: string | null
-  isCreateLoading: boolean
   isOnDevice: boolean
+  isRobotMoving: boolean
 }
 
 export const BeforeBeginning = (
@@ -54,10 +44,9 @@ export const BeforeBeginning = (
 ): JSX.Element | null => {
   const {
     setShouldDispenseLiquid,
-    createMaintenanceRun,
     createdMaintenanceRunId,
-    isCreateLoading,
     isOnDevice,
+    isRobotMoving,
   } = props
   const { i18n, t } = useTranslation(['drop_tip_wizard', 'shared'])
   const [flowType, setFlowType] = React.useState<
@@ -68,11 +57,10 @@ export const BeforeBeginning = (
     setShouldDispenseLiquid(flowType === 'liquid_and_tips')
   }
 
-  React.useEffect(() => {
-    if (createdMaintenanceRunId == null) {
-      createMaintenanceRun({})
-    }
-  }, [])
+  //
+  if (isRobotMoving || createdMaintenanceRunId == null) {
+    return <InProgressModal description={t('stand_back_exiting')} />
+  }
 
   if (isOnDevice) {
     return (
@@ -118,7 +106,7 @@ export const BeforeBeginning = (
           <SmallButton
             buttonText={i18n.format(t('shared:continue'), 'capitalize')}
             onClick={handleProceed}
-            disabled={isCreateLoading || flowType == null}
+            disabled={flowType == null}
           />
         </Flex>
       </Flex>
@@ -181,7 +169,7 @@ export const BeforeBeginning = (
         <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
           {/* <NeedHelpLink href={NEED_HELP_URL} /> */}
           <PrimaryButton
-            disabled={isCreateLoading || flowType == null}
+            disabled={createdMaintenanceRunId == null || flowType == null}
             onClick={handleProceed}
           >
             {i18n.format(t('shared:continue'), 'capitalize')}

--- a/app/src/organisms/DropTipWizard/BeforeBeginning.tsx
+++ b/app/src/organisms/DropTipWizard/BeforeBeginning.tsx
@@ -57,7 +57,6 @@ export const BeforeBeginning = (
     setShouldDispenseLiquid(flowType === 'liquid_and_tips')
   }
 
-  //
   if (isRobotMoving || createdMaintenanceRunId == null) {
     return <InProgressModal description={t('stand_back_exiting')} />
   }
@@ -168,10 +167,7 @@ export const BeforeBeginning = (
         </Flex>
         <Flex flexDirection={DIRECTION_ROW} justifyContent={JUSTIFY_FLEX_END}>
           {/* <NeedHelpLink href={NEED_HELP_URL} /> */}
-          <PrimaryButton
-            disabled={createdMaintenanceRunId == null || flowType == null}
-            onClick={handleProceed}
-          >
+          <PrimaryButton disabled={flowType == null} onClick={handleProceed}>
             {i18n.format(t('shared:continue'), 'capitalize')}
           </PrimaryButton>
         </Flex>

--- a/app/src/organisms/DropTipWizard/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizard/ChooseLocation.tsx
@@ -18,10 +18,7 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import {
-  getDeckDefFromRobotType,
-  getPositionFromSlotId,
-} from '@opentrons/shared-data'
+import { getDeckDefFromRobotType } from '@opentrons/shared-data'
 
 import { SmallButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
@@ -41,7 +38,9 @@ interface ChooseLocationProps {
   title: string
   body: string | JSX.Element
   robotType: RobotType
-  moveToXYCoordinate: (x: number, y: number) => Promise<CommandData[] | null>
+  moveToAddressableArea: (
+    addressableArea: string
+  ) => Promise<CommandData | null>
   isRobotMoving: boolean
   isOnDevice: boolean
   setErrorMessage: (arg0: string) => void
@@ -56,7 +55,7 @@ export const ChooseLocation = (
     title,
     body,
     robotType,
-    moveToXYCoordinate,
+    moveToAddressableArea,
     isRobotMoving,
     isOnDevice,
     setErrorMessage,
@@ -70,26 +69,10 @@ export const ChooseLocation = (
   const handleConfirmPosition = (): void => {
     const deckSlot = deckDef.locations.addressableAreas.find(
       l => l.id === selectedLocation.slotName
-    )
+    )?.id
 
-    const slotPosition = getPositionFromSlotId(
-      selectedLocation.slotName,
-      deckDef
-    )
-
-    const slotX = slotPosition?.[0]
-    const slotY = slotPosition?.[1]
-    const xDimension = deckSlot?.boundingBox.xDimension
-    const yDimension = deckSlot?.boundingBox.yDimension
-    if (
-      slotX != null &&
-      slotY != null &&
-      xDimension != null &&
-      yDimension != null
-    ) {
-      const targetX = slotX + xDimension / 2
-      const targetY = slotY + yDimension / 2
-      moveToXYCoordinate(targetX, targetY)
+    if (deckSlot != null) {
+      moveToAddressableArea(deckSlot)
         .then(() => handleProceed())
         .catch(e => setErrorMessage(`${e.message}`))
     }

--- a/app/src/organisms/DropTipWizard/ExitConfirmation.tsx
+++ b/app/src/organisms/DropTipWizard/ExitConfirmation.tsx
@@ -27,9 +27,11 @@ export function ExitConfirmation(props: ExitConfirmationProps): JSX.Element {
   const flowTitle = t('drop_tips')
   const isOnDevice = useSelector(getIsOnDevice)
 
-  return isRobotMoving ? (
-    <InProgressModal description={t('stand_back_exiting')} />
-  ) : (
+  if (isRobotMoving) {
+    return <InProgressModal description={t('stand_back_exiting')} />
+  }
+
+  return (
     <SimpleWizardBody
       iconColor={COLORS.warningEnabled}
       header={t('exit_screen_title', { flow: flowTitle })}

--- a/app/src/organisms/DropTipWizard/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizard/JogToPosition.tsx
@@ -170,9 +170,16 @@ export const JogToPosition = (
     showPositionConfirmation,
     setShowPositionConfirmation,
   ] = React.useState(false)
+  // Includes special case homing only present in this step.
+  const [isRobotInMotion, setIsRobotInMotion] = React.useState(isRobotMoving)
+
+  const onGoBack = (): void => {
+    setIsRobotInMotion(() => true)
+    handleGoBack()
+  }
 
   if (showPositionConfirmation) {
-    return isRobotMoving ? (
+    return isRobotInMotion ? (
       <InProgressModal
         alternativeSpinner={null}
         description={
@@ -183,12 +190,20 @@ export const JogToPosition = (
       />
     ) : (
       <ConfirmPosition
-        handlePipetteAction={handleProceed}
+        handlePipetteAction={() => {
+          setIsRobotInMotion(true)
+          handleProceed()
+        }}
         handleGoBack={() => setShowPositionConfirmation(false)}
         isOnDevice={isOnDevice}
         currentStep={currentStep}
       />
     )
+  }
+
+  // Moving due to "Exit" or "Go back" click.
+  if (isRobotInMotion) {
+    return <InProgressModal description={t('stand_back_exiting')} />
   }
 
   if (isOnDevice) {
@@ -206,7 +221,7 @@ export const JogToPosition = (
             <SmallButton
               buttonType="tertiaryLowLight"
               buttonText={t('shared:go_back')}
-              onClick={handleGoBack}
+              onClick={onGoBack}
             />
           </Flex>
           <Flex justifyContent={JUSTIFY_FLEX_END} width="100%">
@@ -254,7 +269,7 @@ export const JogToPosition = (
           >
             {/* <NeedHelpLink href={NEED_HELP_URL} /> */}
             <Flex gridGap={SPACING.spacing8}>
-              <SecondaryButton onClick={handleGoBack}>
+              <SecondaryButton onClick={onGoBack}>
                 {t('shared:go_back')}
               </SecondaryButton>
               <PrimaryButton onClick={() => setShowPositionConfirmation(true)}>

--- a/app/src/organisms/DropTipWizard/Success.tsx
+++ b/app/src/organisms/DropTipWizard/Success.tsx
@@ -15,28 +15,19 @@ interface SuccessProps {
   message: string
   proceedText: string
   handleProceed: () => void
-  isRobotMoving: boolean
   isExiting: boolean
   isOnDevice: boolean
 }
 export const Success = (props: SuccessProps): JSX.Element => {
-  const {
-    message,
-    proceedText,
-    handleProceed,
-    isRobotMoving,
-    isExiting,
-    isOnDevice,
-  } = props
+  const { message, proceedText, handleProceed, isExiting, isOnDevice } = props
 
   const { i18n, t } = useTranslation(['drop_tip_wizard', 'shared'])
 
-  return isRobotMoving && !isExiting ? (
-    <InProgressModal
-      alternativeSpinner={null}
-      description={t('stand_back_exiting')}
-    />
-  ) : (
+  if (isExiting) {
+    return <InProgressModal description={t('stand_back_exiting')} />
+  }
+
+  return (
     <SimpleWizardBody
       iconColor={COLORS.successEnabled}
       header={i18n.format(message, 'capitalize')}

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -140,12 +140,8 @@ export function DropTipWizard(props: MaintenanceRunManagerProps): JSX.Element {
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
-    onSuccess: () => {
-      closeFlow()
-    },
-    onError: () => {
-      closeFlow()
-    },
+    onSuccess: () => closeFlow(),
+    onError: () => closeFlow(),
   })
 
   const handleCleanUpAndClose = (): void => {

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
+
 import {
   useConditionalConfirm,
   Flex,
@@ -15,6 +16,7 @@ import {
   useCurrentMaintenanceRun,
   CreateMaintenanceRunType,
 } from '@opentrons/react-api-client'
+
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
 import { WizardHeader } from '../../molecules/WizardHeader'
@@ -49,6 +51,8 @@ import type {
   SavePositionRunTimeCommand,
   CreateCommand,
 } from '@opentrons/shared-data'
+import type { Axis, Sign, StepSize } from '../../molecules/JogControls/types'
+
 const RUN_REFETCH_INTERVAL_MS = 5000
 const JOG_COMMAND_TIMEOUT_MS = 10000
 const MANAGED_PIPETTE_ID = 'managedPipetteId'
@@ -70,6 +74,7 @@ export function DropTipWizard(props: MaintenanceRunManagerProps): JSX.Element {
   const [createdMaintenanceRunId, setCreatedMaintenanceRunId] = React.useState<
     string | null
   >(null)
+  const hasCleanedUpAndClosed = React.useRef(false)
 
   // we should start checking for run deletion only after the maintenance run is created
   // and the useCurrentRun poll has returned that created id
@@ -80,7 +85,6 @@ export function DropTipWizard(props: MaintenanceRunManagerProps): JSX.Element {
 
   const {
     createTargetedMaintenanceRun,
-    isLoading: isCreateLoading,
   } = useCreateTargetedMaintenanceRunMutation({
     onSuccess: response => {
       chainRunCommands(
@@ -102,6 +106,7 @@ export function DropTipWizard(props: MaintenanceRunManagerProps): JSX.Element {
         })
         .catch(e => e)
     },
+    onError: error => setErrorMessage(error.message),
   })
 
   const { data: maintenanceRunData } = useCurrentMaintenanceRun({
@@ -135,21 +140,39 @@ export function DropTipWizard(props: MaintenanceRunManagerProps): JSX.Element {
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
-    onSuccess: () => closeFlow(),
-    onError: () => closeFlow(),
+    onSuccess: () => {
+      closeFlow()
+    },
+    onError: () => {
+      closeFlow()
+    },
   })
 
   const handleCleanUpAndClose = (): void => {
+    if (hasCleanedUpAndClosed.current) return
+
+    hasCleanedUpAndClosed.current = true
     setIsExiting(true)
     if (maintenanceRunData?.data.id == null) {
       closeFlow()
     } else {
-      deleteMaintenanceRun(maintenanceRunData?.data.id, {
-        onSuccess: () => {
-          closeFlow()
-          setIsExiting(false)
-        },
-      })
+      chainRunCommands(
+        maintenanceRunData?.data.id,
+        [
+          {
+            commandType: 'home' as const,
+            params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
+          },
+        ],
+        true
+      )
+        .then(() => {
+          deleteMaintenanceRun(maintenanceRunData?.data.id)
+        })
+        .catch(error => {
+          console.error(error.message)
+          deleteMaintenanceRun(maintenanceRunData?.data.id)
+        })
     }
   }
 
@@ -161,7 +184,6 @@ export function DropTipWizard(props: MaintenanceRunManagerProps): JSX.Element {
       mount={mount}
       instrumentModelSpecs={instrumentModelSpecs}
       createMaintenanceRun={createTargetedMaintenanceRun}
-      isCreateLoading={isCreateLoading}
       isRobotMoving={isChainCommandMutationLoading || isExiting}
       handleCleanUpAndClose={handleCleanUpAndClose}
       chainRunCommands={chainRunCommands}
@@ -178,7 +200,6 @@ interface DropTipWizardProps {
   mount: PipetteData['mount']
   createdMaintenanceRunId: string | null
   createMaintenanceRun: CreateMaintenanceRunType
-  isCreateLoading: boolean
   isRobotMoving: boolean
   isExiting: boolean
   setErrorMessage: (message: string | null) => void
@@ -203,7 +224,6 @@ export const DropTipWizardComponent = (
     handleCleanUpAndClose,
     chainRunCommands,
     // attachedInstrument,
-    isCreateLoading,
     isRobotMoving,
     createRunCommand,
     setErrorMessage,
@@ -226,8 +246,26 @@ export const DropTipWizardComponent = (
       : null
   const isFinalStep = currentStepIndex === DropTipWizardSteps.length - 1
 
+  React.useEffect(() => {
+    if (createdMaintenanceRunId == null) {
+      createMaintenanceRun({}).catch((e: Error) =>
+        setErrorMessage(`Error creating maintenance run: ${e.message}`)
+      )
+    }
+  }, [])
+
   const goBack = (): void => {
-    setCurrentStepIndex(isFinalStep ? currentStepIndex : currentStepIndex - 1)
+    if (createdMaintenanceRunId != null) {
+      retractAllAxesAndSavePosition()
+        .then(() =>
+          setCurrentStepIndex(
+            isFinalStep ? currentStepIndex : currentStepIndex - 1
+          )
+        )
+        .catch((e: Error) =>
+          setErrorMessage(`Error issuing jog command: ${e.message}`)
+        )
+    }
   }
 
   const proceed = (): void => {
@@ -238,7 +276,7 @@ export const DropTipWizardComponent = (
     }
   }
 
-  const handleJog: Jog = (axis, dir, step) => {
+  const handleJog: Jog = (axis: Axis, dir: Sign, step: StepSize): void => {
     if (createdMaintenanceRunId != null) {
       createRunCommand({
         maintenanceRunId: createdMaintenanceRunId,
@@ -248,11 +286,9 @@ export const DropTipWizardComponent = (
         },
         waitUntilComplete: true,
         timeout: JOG_COMMAND_TIMEOUT_MS,
-      })
-        .then(data => {})
-        .catch((e: Error) =>
-          setErrorMessage(`Error issuing jog command: ${e.message}`)
-        )
+      }).catch((e: Error) =>
+        setErrorMessage(`Error issuing jog command: ${e.message}`)
+      )
     }
   }
 
@@ -269,24 +305,8 @@ export const DropTipWizardComponent = (
       )
     const commands: CreateCommand[] = [
       {
-        commandType: 'retractAxis' as const,
-        params: {
-          axis: 'leftZ',
-        },
-      },
-      {
-        commandType: 'retractAxis' as const,
-        params: {
-          axis: 'rightZ',
-        },
-      },
-      {
-        commandType: 'retractAxis' as const,
-        params: { axis: 'x' },
-      },
-      {
-        commandType: 'retractAxis' as const,
-        params: { axis: 'y' },
+        commandType: 'home' as const,
+        params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
       },
       {
         commandType: 'savePosition' as const,
@@ -321,10 +341,9 @@ export const DropTipWizardComponent = (
       })
   }
 
-  const moveToXYCoordinate = (
-    x: number,
-    y: number
-  ): Promise<CommandData[] | null> => {
+  const moveToAddressableArea = (
+    addressableArea: string
+  ): Promise<CommandData | null> => {
     if (createdMaintenanceRunId == null)
       return Promise.reject(
         new Error('no maintenance run present to send move commands to')
@@ -333,28 +352,18 @@ export const DropTipWizardComponent = (
     return retractAllAxesAndSavePosition()
       .then(currentPosition => {
         if (currentPosition != null) {
-          return chainRunCommands(
-            createdMaintenanceRunId,
-            [
-              {
-                commandType: 'moveRelative',
-                params: {
-                  pipetteId: MANAGED_PIPETTE_ID,
-                  distance: y - currentPosition.y,
-                  axis: 'y',
-                },
+          return createRunCommand({
+            maintenanceRunId: createdMaintenanceRunId,
+            command: {
+              commandType: 'moveToAddressableArea',
+              params: {
+                pipetteId: MANAGED_PIPETTE_ID,
+                addressableAreaName: addressableArea,
+                offset: { x: 0, y: 0, z: currentPosition.z - 10 },
               },
-              {
-                commandType: 'moveRelative',
-                params: {
-                  pipetteId: MANAGED_PIPETTE_ID,
-                  distance: x - currentPosition.x,
-                  axis: 'x',
-                },
-              },
-            ],
-            true
-          )
+            },
+            waitUntilComplete: true,
+          })
         } else return null
       })
       .catch(e => {
@@ -368,7 +377,10 @@ export const DropTipWizardComponent = (
     modalContent = (
       <ExitConfirmation
         handleGoBack={cancelExit}
-        handleExit={confirmExit}
+        handleExit={() => {
+          hasInitiatedExit.current = true
+          confirmExit()
+        }}
         isRobotMoving={isRobotMoving}
       />
     )
@@ -391,10 +403,9 @@ export const DropTipWizardComponent = (
       <BeforeBeginning
         {...{
           setShouldDispenseLiquid,
-          createMaintenanceRun,
           createdMaintenanceRunId,
-          isCreateLoading,
           isOnDevice,
+          isRobotMoving,
         }}
       />
     )
@@ -416,7 +427,10 @@ export const DropTipWizardComponent = (
       <ChooseLocation
         robotType={robotType}
         handleProceed={proceed}
-        handleGoBack={() => setShouldDispenseLiquid(null)}
+        handleGoBack={() => {
+          setCurrentStepIndex(0)
+          setShouldDispenseLiquid(null)
+        }}
         title={
           currentStep === CHOOSE_BLOWOUT_LOCATION
             ? i18n.format(t('choose_blowout_location'), 'capitalize')
@@ -429,7 +443,7 @@ export const DropTipWizardComponent = (
             components={{ block: <StyledText as="p" /> }}
           />
         }
-        moveToXYCoordinate={moveToXYCoordinate}
+        moveToAddressableArea={moveToAddressableArea}
         isRobotMoving={isRobotMoving}
         isOnDevice={isOnDevice}
         setErrorMessage={setErrorMessage}
@@ -463,13 +477,7 @@ export const DropTipWizardComponent = (
               ],
               true
             )
-              .then(() => {
-                retractAllAxesAndSavePosition()
-                  .then(() => proceed())
-                  .catch(e =>
-                    setErrorMessage(`Error moving to position: ${e.message}`)
-                  )
-              })
+              .then(() => proceed())
               .catch(e =>
                 setErrorMessage(
                   `Error issuing ${
@@ -511,19 +519,16 @@ export const DropTipWizardComponent = (
             ? i18n.format(t('shared:continue'), 'capitalize')
             : i18n.format(t('shared:exit'), 'capitalize')
         }
-        isRobotMoving={isRobotMoving}
         isExiting={isExiting}
         isOnDevice={isOnDevice}
       />
     )
   }
 
-  let handleExit: (() => void) | null = confirmExit
-  if (isRobotMoving || showConfirmExit) {
-    handleExit = null
-  } else if (errorMessage != null) {
-    handleExit = handleCleanUpAndClose
-  }
+  const hasInitiatedExit = React.useRef(false)
+  let handleExit: () => void = () => null
+  if (!hasInitiatedExit.current) handleExit = confirmExit
+  else if (errorMessage != null) handleExit = handleCleanUpAndClose
 
   const wizardHeader = (
     <WizardHeader

--- a/app/src/pages/OnDeviceDisplay/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import NiceModal from '@ebay/nice-modal-react'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, queryAllByText } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
@@ -157,12 +157,12 @@ describe('UpdateBuildroot', () => {
   })
 
   it('renders the drop tip wizard  when Drop tips is clicked', () => {
-    const [{ getByTestId, getByText }] = render(MOCK_PIPETTE)
+    const [{ getByTestId, getByText, getAllByText }] = render(MOCK_PIPETTE)
     const btn = getByTestId('testButton')
     fireEvent.click(btn)
     fireEvent.click(getByText('Drop tips'))
 
-    getByText('Before you begin, do you need to preserve aspirated liquid?')
+    expect(getAllByText('Drop tips')).toHaveLength(2)
   })
 
   it('renders the gripper calibration wizard when recalibrate is clicked', () => {

--- a/app/src/pages/OnDeviceDisplay/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
+++ b/app/src/pages/OnDeviceDisplay/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import NiceModal from '@ebay/nice-modal-react'
-import { fireEvent, queryAllByText } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'


### PR DESCRIPTION
Closes RQA-2083, RQA-2094, RQA-2066, RQA-2068, RQA-2024, RQA-2100

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR is a general second-pass of the drop tip wizard. There's a good bit refactoring, but in terms of functional changes:

- The wizard doesn't render BeforeBeginning until the maintenance run has been successfully created - renders a spinner now. This prevents some bugs and is better UX.
- Exiting the drop tip wizard now renders a spinner and exits properly.
- The home command occurs in a predictable spot - no more instantly homing after completing blowout. 
- Use moveToAddressableArea instead of moveRelative to prevent unexpected pipette movements (you CANNOT move to a slot with a moveable trash or waste chute loaded -- this is a known issue and currently being fixed). 
- Fixes an issue where an unreachable step could be hit.
- More error messaging!

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run through the flows on OT-2 and Flex and make sure it works properly!
- NOTE: you CANNOT move to a slot with a moveable trash or waste chute loaded -- this is a known issue and currently being addressed by @brenthagen 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixes several issues related to the drop tip wizard concerning exiting, error messaging, and missing loading spinners.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Test on a physical robot. Do the desktop and ODD flows. Test on OT-2 as well.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
medium
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
