### PR TITLE
Rh 23 remove hw api from hw tests

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -636,3 +636,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
         self._engine_client.configure_nozzle_layout(
             pipette_id=self._pipette_id, configuration_params=configuration_model
         )
+
+    def retract(self) -> None:
+        """Retract this instrument to the top of the gantry."""
+        self._sync_hardware_api.retract(self.get_mount())

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -263,5 +263,9 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         """
         ...
 
+    def _retract(self) -> None:
+        """Retract this instrument to the top of the gantry."""
+        ...
+
 
 InstrumentCoreType = TypeVar("InstrumentCoreType", bound=AbstractInstrument[Any])

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -529,3 +529,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
     ) -> None:
         """This will never be called because it was added in API 2.15."""
         pass
+
+    def _retract(self) -> None:
+        """Retract this instrument to the top of the gantry."""
+        self._protocol_interface.get_hardware.retract(self._mount)  # type: ignore [attr-defined]

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -445,3 +445,7 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
     ) -> None:
         """This will never be called because it was added in API 2.15."""
         pass
+
+    def _retract(self) -> None:
+        """Retract this instrument to the top of the gantry."""
+        self._protocol_interface.get_hardware.retract(self._mount)  # type: ignore [attr-defined]

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1363,6 +1363,12 @@ class InstrumentContext(publisher.CommandPublisher):
 
         return self
 
+    @requires_version(2, 0)
+    def _retract(
+        self,
+    ) -> None:
+        self._core._retract()
+
     @property  # type: ignore
     @requires_version(2, 0)
     def mount(self) -> str:

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -49,8 +49,7 @@ from hardware_testing.drivers import asair_sensor
 from opentrons.protocol_api import InstrumentContext
 from opentrons.protocol_engine.types import LabwareOffset
 
-# FIXME: bump to v2.15 to utilize protocol engine
-API_LEVEL = "2.15"
+API_LEVEL = "2.16"
 
 LABWARE_OFFSETS: List[LabwareOffset] = []
 

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -314,7 +314,7 @@ class RunArgs:
                 trials=trials,
                 name=name,
                 robot_serial=robot_serial,
-                fw_version=_ctx._core.get_hardware().fw_version,
+                fw_version=_ctx._hw_manager.fw_version,
             )
         else:
             if args.increment:
@@ -347,7 +347,7 @@ class RunArgs:
                 name=name,
                 environment_sensor=environment_sensor,
                 trials=trials,
-                fw_version=_ctx._core.get_hardware().fw_version,
+                fw_version=_ctx._hw_manager.fw_version,
             )
 
         return RunArgs(

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -314,7 +314,7 @@ class RunArgs:
                 trials=trials,
                 name=name,
                 robot_serial=robot_serial,
-                fw_version=_ctx._hw_manager.fw_version,
+                fw_version=workarounds.get_sync_hw_api(_ctx).fw_version,
             )
         else:
             if args.increment:
@@ -347,7 +347,7 @@ class RunArgs:
                 name=name,
                 environment_sensor=environment_sensor,
                 trials=trials,
-                fw_version=_ctx._hw_manager.fw_version,
+                fw_version=workarounds.get_sync_hw_api(_ctx).fw_version,
             )
 
         return RunArgs(
@@ -591,7 +591,7 @@ if __name__ == "__main__":
             shell=True,
         )
         sleep(1)
-    hw = run_args.ctx._core.get_hardware()
+    hw = workarounds.get_sync_hw_api(run_args.ctx)
     try:
         if not run_args.ctx.is_simulating() and not args.photometric:
             ui.get_user_ready("CLOSE the door, and MOVE AWAY from machine")

--- a/hardware-testing/hardware_testing/gravimetric/daily_setup.py
+++ b/hardware-testing/hardware_testing/gravimetric/daily_setup.py
@@ -13,8 +13,9 @@ from hardware_testing.gravimetric.measurement.record import (
 )
 from hardware_testing.gravimetric.config import GANTRY_MAX_SPEED
 from hardware_testing.gravimetric.measurement.scale import Scale  # type: ignore[import]
-from hardware_testing.gravimetric import helpers, workarounds
+from hardware_testing.gravimetric import helpers
 from hardware_testing.gravimetric.__main__ import API_LEVEL
+from hardware_testing.gravimetric.workarounds import get_sync_hw_api
 
 TEST_NAME = "gravimetric-daily-setup"
 
@@ -253,7 +254,7 @@ if __name__ == "__main__":
         API_LEVEL,  # type: ignore[attr-defined]
         is_simulating=args.simulate,
     )
-    _hw = workarounds.get_sync_hw_api(_ctx)
+    _hw = get_sync_hw_api(_ctx)
     _hw.set_status_bar_state(COLOR_STATES["idle"])
     _rec = GravimetricRecorder(
         GravimetricRecorderConfig(

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -52,6 +52,7 @@ from .tips import MULTI_CHANNEL_TEST_ORDER
 import glob
 
 from opentrons.hardware_control.types import StatusBarState
+from hardware_testing.gravimetric.workarounds import get_sync_hw_api
 
 _MEASUREMENTS: List[Tuple[str, MeasurementData]] = list()
 
@@ -88,7 +89,7 @@ def _generate_callbacks_for_trial(
     if blank_measurement:
         volume = None
 
-    hw_api = ctx._core.get_hardware()
+    hw_api = get_sync_hw_api(ctx)
     hw_mount = OT3Mount.LEFT if pipette.mount == "left" else OT3Mount.RIGHT
     pip_ax = Axis.of_main_tool_actuator(hw_mount)
     estimate_bottom: float = -1
@@ -547,7 +548,7 @@ def _get_liquid_height(
         if not resources.ctx.is_simulating() and not cfg.same_tip:
             ui.alert_user_ready(
                 f"Please replace the {cfg.tip_volume}ul tips in slot 2",
-                resources.ctx._core.get_hardware(),
+                get_sync_hw_api(resources.ctx),
             )
         _tip_counter[0] = 0
     if cfg.jog:
@@ -597,7 +598,7 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:  # noq
     recorder._recording = GravimetricRecording()
     report.store_config_gm(resources.test_report, cfg)
     calibration_tip_in_use = True
-    hw_api = resources.ctx._core.get_hardware()
+    hw_api = get_sync_hw_api(resources.ctx)
     if resources.ctx.is_simulating():
         _PREV_TRIAL_GRAMS = None
         _MEASUREMENTS = list()

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -330,8 +330,7 @@ def _run_trial(
     else:
         # center channel over well
         trial.pipette.move_to(trial.well.top(50).move(trial.channel_offset))
-    mnt = OT3Mount.RIGHT if trial.pipette.mount == "right" else OT3Mount.LEFT
-    trial.ctx._core.get_hardware().retract(mnt)  # retract to top of gantry
+    trial.pipette._retract()  # retract to top of gantry
     m_data_init = _record_measurement_and_store(MeasurementType.INIT)
     ui.print_info(f"\tinitial grams: {m_data_init.grams_average} g")
     # update the vials volumes, using the last-known weight
@@ -360,7 +359,7 @@ def _run_trial(
         mode=trial.mode,
         clear_accuracy_function=trial.cfg.increment,
     )
-    trial.ctx._core.get_hardware().retract(mnt)  # retract to top of gantry
+    trial.pipette._retract()  # retract to top of gantry
 
     _take_photos(trial, "aspirate")
     m_data_aspirate = _record_measurement_and_store(MeasurementType.ASPIRATE)
@@ -382,7 +381,7 @@ def _run_trial(
         mode=trial.mode,
         clear_accuracy_function=trial.cfg.increment,
     )
-    trial.ctx._core.get_hardware().retract(mnt)  # retract to top of gantry
+    trial.pipette._retract()  # retract to top of gantry
     _take_photos(trial, "dispense")
     m_data_dispense = _record_measurement_and_store(MeasurementType.DISPENSE)
     ui.print_info(f"\tgrams after dispense: {m_data_dispense.grams_average} g")
@@ -503,8 +502,7 @@ def _calculate_evaporation(
         resources.env_sensor,
     )
     ui.print_info(f"running {config.NUM_BLANK_TRIALS}x blank measurements")
-    mnt = OT3Mount.RIGHT if resources.pipette.mount == "right" else OT3Mount.LEFT
-    resources.ctx._core.get_hardware().retract(mnt)
+    resources.pipette._retract()
     for i in range(config.SCALE_SECONDS_TO_TRUE_STABILIZE):
         ui.print_info(
             f"wait for scale to stabilize "
@@ -695,12 +693,7 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:  # noq
                             cfg,
                             location=next_tip_location,
                         )
-                        mnt = (
-                            OT3Mount.LEFT
-                            if cfg.pipette_mount == "left"
-                            else OT3Mount.RIGHT
-                        )
-                        resources.ctx._core.get_hardware().retract(mnt)
+                        resources.pipette._retract()  # retract to top of gantry
                     (
                         actual_aspirate,
                         aspirate_data,
@@ -743,12 +736,7 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:  # noq
                     )
                     ui.print_info("dropping tip")
                     if not cfg.same_tip:
-                        mnt = (
-                            OT3Mount.LEFT
-                            if cfg.pipette_mount == "left"
-                            else OT3Mount.RIGHT
-                        )
-                        resources.ctx._core.get_hardware().retract(mnt)
+                        resources.pipette._retract()  # retract to top of gantry
                         _drop_tip(
                             resources.pipette, cfg.return_tip, _minimum_z_height(cfg)
                         )

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -608,8 +608,6 @@ def run(cfg: config.GravimetricConfig, resources: TestResources) -> None:  # noq
         setup_channel_offset = _get_channel_offset(cfg, channel=0)
         first_tip_location = first_tip.top().move(setup_channel_offset)
         _pick_up_tip(resources.ctx, resources.pipette, cfg, location=first_tip_location)
-        mnt = OT3Mount.LEFT if cfg.pipette_mount == "left" else OT3Mount.RIGHT
-        resources.ctx._core.get_hardware().retract(mnt)
         ui.print_info("moving to scale")
         well = labware_on_scale["A1"]
         _liquid_height = _get_liquid_height(resources, cfg, well)

--- a/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute_photometric.py
@@ -5,7 +5,7 @@ from math import ceil
 from opentrons.protocol_api import ProtocolContext, Well, Labware
 
 from hardware_testing.data import ui
-from hardware_testing.opentrons_api.types import Point, OT3Mount
+from hardware_testing.opentrons_api.types import Point
 from .measurement import (
     MeasurementType,
     create_measurement_tag,
@@ -215,7 +215,7 @@ def _run_trial(trial: PhotometricTrial) -> None:
             touch_tip=trial.cfg.touch_tip,
         )
         _record_measurement_and_store(MeasurementType.DISPENSE)
-        trial.ctx._core.get_hardware().retract(OT3Mount.LEFT)
+        trial.pipette._retract()  # retract to top of gantry
         if (i + 1) == num_dispenses:
             if not trial.cfg.same_tip:
                 _drop_tip(trial.pipette, trial.cfg.return_tip)

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -81,9 +81,9 @@ def get_api_context(
             loop=loop,
             stall_detection_enable=stall_detection_enable,
         )
-
+    papi: protocol_api.ProtocolContext
     if is_simulating:
-        return simulate.get_protocol_api(
+        papi = simulate.get_protocol_api(
             version=APIVersion.from_string(api_level),
             extra_labware=extra_labware,
             hardware_simulator=ThreadManager(_thread_manager_build_hw_api),
@@ -91,9 +91,12 @@ def get_api_context(
             use_virtual_hardware=False,
         )
     else:
-        return execute.get_protocol_api(
+        papi = execute.get_protocol_api(
             version=APIVersion.from_string(api_level), extra_labware=extra_labware
         )
+
+    papi.load_labware("opentrons_1_trash_3200ml_fixed", "A3")
+    return papi
 
 
 def well_is_reservoir(well: protocol_api.labware.Well) -> bool:

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -295,8 +295,6 @@ def _pick_up_tip(
         f"from slot #{location.labware.parent.parent}"
     )
     pipette.pick_up_tip(location)
-    if pipette.channels == 96:
-        get_sync_hw_api(ctx).retract(OT3Mount.LEFT)
     # NOTE: the accuracy-adjust function gets set on the Pipette
     #       each time we pick-up a new tip.
     if cfg.increment:

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -16,6 +16,7 @@ from opentrons.protocols.api_support.deck_type import (
 )
 from opentrons.protocol_api.labware import Well, Labware
 from opentrons.protocol_api._types import OffDeckType
+from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.types import APIVersion
 from opentrons.hardware_control.thread_manager import ThreadManager
 from opentrons.hardware_control.types import OT3Mount, Axis
@@ -386,12 +387,9 @@ def _load_pipette(
     # NOTE: 8ch QC testing means testing 1 channel at a time,
     #       so we need to decrease the pick-up current to work with 1 tip.
     if pipette.channels == 8 and not increment and not photometric:
-        hwapi = get_sync_hw_api(ctx)
-        mnt = OT3Mount.LEFT if pipette_mount == "left" else OT3Mount.RIGHT
-        hwpipette: Pipette = hwapi.hardware_pipettes[mnt.to_mount()]
-        hwpipette._config.pick_up_tip_configurations.press_fit.current_by_tip_count[
-            8
-        ] = 0.2
+        pipette.configure_nozzle_layout(NozzleLayout.SINGLE, "A1")
+    else:
+        pipette.configure_nozzle_layout(NozzleLayout.ALL)
     return pipette
 
 

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -388,8 +388,6 @@ def _load_pipette(
     #       so we need to decrease the pick-up current to work with 1 tip.
     if pipette.channels == 8 and not increment and not photometric:
         pipette.configure_nozzle_layout(NozzleLayout.SINGLE, "A1")
-    else:
-        pipette.configure_nozzle_layout(NozzleLayout.ALL)
     return pipette
 
 

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -81,6 +81,7 @@ def get_api_context(
             loop=loop,
             stall_detection_enable=stall_detection_enable,
         )
+
     papi: protocol_api.ProtocolContext
     if is_simulating:
         papi = simulate.get_protocol_api(

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -223,16 +223,16 @@ def _pipette_with_liquid_settings(  # noqa: C901
                 "WARNING: removing trailing air-gap from pipette, "
                 "this should only happen during blank trials"
             )
-            hw_api.dispense(hw_mount)
+            pipette.dispense(volume=pipette.current_volume)
         if mode:
             # NOTE: increment test requires the plunger's "bottom" position
             #       does not change during the entire test run
             hw_api.set_liquid_class(hw_mount, mode)
         else:
-            hw_api.configure_for_volume(hw_mount, aspirate if aspirate else dispense)
+            pipette.configure_for_volume(hw_mount, aspirate if aspirate else dispense)
         if clear_accuracy_function:
             clear_pipette_ul_per_mm(hw_api, hw_mount)  # type: ignore[arg-type]
-        hw_api.prepare_for_aspirate(hw_mount)
+        pipette.prepare_for_aspirate(hw_mount)
         if liquid_class.aspirate.leading_air_gap > 0:
             pipette.aspirate(liquid_class.aspirate.leading_air_gap)
 
@@ -257,7 +257,7 @@ def _pipette_with_liquid_settings(  # noqa: C901
             ctx, pipette, well, channel_offset, approach_mm, retract_speed, _z_disc
         )
         pipette.blow_out()
-        hw_api.prepare_for_aspirate(hw_mount)
+        pipette.prepare_for_aspirate(hw_mount)
         assert pipette.current_volume == 0
 
     def _aspirate_on_submerge() -> None:

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -8,6 +8,7 @@ from opentrons.protocol_api.labware import Well
 
 from hardware_testing.opentrons_api.types import OT3AxisKind
 from hardware_testing.gravimetric import config
+from hardware_testing.gravimetric.workarounds import get_sync_hw_api
 from hardware_testing.gravimetric.liquid_height.height import LiquidTracker
 from hardware_testing.opentrons_api.types import OT3Mount, Point
 from hardware_testing.opentrons_api.helpers_ot3 import clear_pipette_ul_per_mm
@@ -131,7 +132,7 @@ def _retract(
     z_discontinuity: float,
 ) -> None:
     # change discontinuity per the liquid-class settings
-    hw_api = ctx._core.get_hardware()
+    hw_api = get_sync_hw_api(ctx)
     if pipette.channels == 96:
         hw_api.config.motion_settings.max_speed_discontinuity.high_throughput[
             OT3AxisKind.Z
@@ -177,7 +178,7 @@ def _pipette_with_liquid_settings(  # noqa: C901
 ) -> None:
     """Run a pipette given some Pipetting Liquid Settings."""
     # FIXME: stop using hwapi, and get those functions into core software
-    hw_api = ctx._core.get_hardware()
+    hw_api = get_sync_hw_api(ctx)
     hw_mount = OT3Mount.LEFT if pipette.mount == "left" else OT3Mount.RIGHT
     hw_pipette = hw_api.hardware_pipettes[hw_mount.to_mount()]
     _check_aspirate_dispense_args(mix, aspirate, dispense)

--- a/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
+++ b/hardware-testing/hardware_testing/gravimetric/liquid_class/pipetting.py
@@ -230,10 +230,11 @@ def _pipette_with_liquid_settings(  # noqa: C901
             #       does not change during the entire test run
             hw_api.set_liquid_class(hw_mount, mode)
         else:
-            pipette.configure_for_volume(hw_mount, aspirate if aspirate else dispense)
+            cfg_volume: float = aspirate if aspirate else dispense  # type: ignore[assignment]
+            pipette.configure_for_volume(cfg_volume)
         if clear_accuracy_function:
             clear_pipette_ul_per_mm(hw_api, hw_mount)  # type: ignore[arg-type]
-        pipette.prepare_for_aspirate(hw_mount)
+        pipette.prepare_to_aspirate()
         if liquid_class.aspirate.leading_air_gap > 0:
             pipette.aspirate(liquid_class.aspirate.leading_air_gap)
 
@@ -258,7 +259,7 @@ def _pipette_with_liquid_settings(  # noqa: C901
             ctx, pipette, well, channel_offset, approach_mm, retract_speed, _z_disc
         )
         pipette.blow_out()
-        pipette.prepare_for_aspirate(hw_mount)
+        pipette.prepare_to_aspirate()
         assert pipette.current_volume == 0
 
     def _aspirate_on_submerge() -> None:

--- a/hardware-testing/tests/hardware_testing/liquid/test_heights.py
+++ b/hardware-testing/tests/hardware_testing/liquid/test_heights.py
@@ -17,7 +17,7 @@ CUSTOM_LABWARE_DEFINITION_DIR = (
 
 
 def _create_context() -> ProtocolContext:
-    return get_api_context(api_level="2.15", is_simulating=True)
+    return get_api_context(api_level="2.16", is_simulating=True)
 
 
 def _load_labware(ctx: ProtocolContext) -> Tuple[Labware, Labware, Labware, Labware]:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
