### PR TITLE
fix(app): get addressable area from configured deck for drop tip wizard

### DIFF
--- a/app/src/organisms/DropTipWizard/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizard/ChooseLocation.tsx
@@ -27,7 +27,7 @@ import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal
 import { TwoUpTileLayout } from '../LabwarePositionCheck/TwoUpTileLayout'
 
 import type { CommandData } from '@opentrons/api-client'
-import type { RobotType } from '@opentrons/shared-data'
+import type { AddressableAreaName, RobotType } from '@opentrons/shared-data'
 
 // TODO: get help link article URL
 // const NEED_HELP_URL = ''
@@ -39,7 +39,7 @@ interface ChooseLocationProps {
   body: string | JSX.Element
   robotType: RobotType
   moveToAddressableArea: (
-    addressableArea: string
+    addressableArea: AddressableAreaName
   ) => Promise<CommandData | null>
   isRobotMoving: boolean
   isOnDevice: boolean

--- a/app/src/organisms/DropTipWizard/getAddressableAreaFromConfig.ts
+++ b/app/src/organisms/DropTipWizard/getAddressableAreaFromConfig.ts
@@ -1,0 +1,87 @@
+import {
+  EIGHT_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
+  getCutoutIdForAddressableArea,
+  getDeckDefFromRobotType,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+  NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
+  ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
+
+import type {
+  AddressableAreaName,
+  DeckConfiguration,
+  RobotType,
+} from '@opentrons/shared-data'
+
+export function getAddressableAreaFromConfig(
+  addressableArea: AddressableAreaName,
+  deckConfig: DeckConfiguration,
+  pipetteChannels: number,
+  robotType: RobotType
+): AddressableAreaName | null {
+  const deckDef = getDeckDefFromRobotType(robotType)
+
+  let addressableAreaFromConfig: AddressableAreaName | null = null
+
+  // match the cutout id to aa
+  const cutoutIdForAddressableArea = getCutoutIdForAddressableArea(
+    addressableArea,
+    deckDef.cutoutFixtures
+  )
+
+  // get addressable areas provided by current deck config
+  const configuredCutoutFixture =
+    deckConfig.find(fixture => fixture.cutoutId === cutoutIdForAddressableArea)
+      ?.cutoutFixtureId ?? null
+
+  const providedAddressableAreas =
+    cutoutIdForAddressableArea != null
+      ? deckDef.cutoutFixtures.find(
+          fixture => fixture.id === configuredCutoutFixture
+        )?.providesAddressableAreas[cutoutIdForAddressableArea] ?? []
+      : []
+
+  // check if configured cutout fixture id provides target addressableArea
+  if (providedAddressableAreas.includes(addressableArea)) {
+    addressableAreaFromConfig = addressableArea
+  } else if (
+    // if no, check if provides a movable trash
+    providedAddressableAreas.some(aa =>
+      MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(aa)
+    )
+  ) {
+    addressableAreaFromConfig = providedAddressableAreas[0]
+  } else if (
+    // if no, check if provides waste chute
+    providedAddressableAreas.some(aa =>
+      WASTE_CHUTE_ADDRESSABLE_AREAS.includes(aa)
+    )
+  ) {
+    // match number of channels to provided waste chute addressable area
+    if (
+      pipetteChannels === 1 &&
+      providedAddressableAreas.includes(
+        ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+      )
+    ) {
+      addressableAreaFromConfig = ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+    } else if (
+      pipetteChannels === 8 &&
+      providedAddressableAreas.includes(
+        EIGHT_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+      )
+    ) {
+      addressableAreaFromConfig = EIGHT_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+    } else if (
+      pipetteChannels === 96 &&
+      providedAddressableAreas.includes(
+        NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+      )
+    ) {
+      addressableAreaFromConfig = NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+    }
+  }
+
+  return addressableAreaFromConfig
+}

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -17,7 +17,6 @@ import {
   useDeckConfigurationQuery,
   CreateMaintenanceRunType,
 } from '@opentrons/react-api-client'
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
@@ -364,19 +363,20 @@ export const DropTipWizardComponent = (
           robotType
         )
 
-        if (
-          currentPosition != null &&
-          (robotType !== FLEX_ROBOT_TYPE || addressableAreaFromConfig != null)
-        ) {
+        const zOffset =
+          addressableAreaFromConfig === addressableArea
+            ? (currentPosition as Coordinates).z - 10
+            : 0
+
+        if (currentPosition != null && addressableAreaFromConfig != null) {
           return createRunCommand({
             maintenanceRunId: createdMaintenanceRunId,
             command: {
               commandType: 'moveToAddressableArea',
               params: {
                 pipetteId: MANAGED_PIPETTE_ID,
-                addressableAreaName:
-                  addressableAreaFromConfig ?? addressableArea,
-                offset: { x: 0, y: 0, z: currentPosition.z - 10 },
+                addressableAreaName: addressableAreaFromConfig,
+                offset: { x: 0, y: 0, z: zOffset },
               },
             },
             waitUntilComplete: true,


### PR DESCRIPTION
# Overview

translates a selected "slot" from the deck location select single slot representation to an addressable area compatible with the configured deck and selected pipette.

closes RQA-2099

# Test Plan

verified correct deck location select addressable area name output for a variety of flex configurations and OT-2

# Changelog

 - get addressable area from configured deck for drop tip wizard

# Review requests

check drop tip wizard for Flex trash bins and waste chutes. check OT-2 for parity.

# Risk assessment

low
