### PR TITLE
refactor(app): Remove drop tip banner after OT-2 protocol run

### DIFF
--- a/app/src/assets/localization/en/drop_tip_wizard.json
+++ b/app/src/assets/localization/en/drop_tip_wizard.json
@@ -12,7 +12,7 @@
   "drop_tips": "drop tips",
   "error_dropping_tips": "Error dropping tips",
   "exit_screen_title": "Exit before completing drop tip?",
-  "getting_ready": "Getting ready...",
+  "getting_ready": "Getting ready…",
   "go_back": "go back",
   "move_to_slot": "move to slot",
   "no_proceed_to_drop_tip": "No, proceed to tip removal",

--- a/app/src/assets/localization/en/drop_tip_wizard.json
+++ b/app/src/assets/localization/en/drop_tip_wizard.json
@@ -12,6 +12,7 @@
   "drop_tips": "drop tips",
   "error_dropping_tips": "Error dropping tips",
   "exit_screen_title": "Exit before completing drop tip?",
+  "getting_ready": "Getting ready...",
   "go_back": "go back",
   "move_to_slot": "move to slot",
   "no_proceed_to_drop_tip": "No, proceed to tip removal",

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -241,11 +241,6 @@ export function ProtocolRunHeader({
     }
   }, [protocolData, isRobotViewable, history])
 
-  console.log(
-    '🚀 ~ file: ProtocolRunHeader.tsx:246 ~ React.useEffect ~ RUN_STATUS_STOPPED:',
-    RUN_STATUS_STOPPED
-  )
-
   React.useEffect(() => {
     if (runStatus === RUN_STATUS_STOPPED && isRunCurrent && runId != null) {
       trackProtocolRunEvent({

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -203,33 +203,35 @@ export function ProtocolRunHeader({
   }
 
   React.useEffect(() => {
-    // Reset drop tip state when a new run occurs.
-    if (runStatus === RUN_STATUS_IDLE) {
-      setShowDropTipBanner(true)
-      setPipettesWithTip([])
-    } else if (runStatus != null && RUN_OVER_STATUSES.includes(runStatus)) {
-      getPipettesWithTipAttached({
-        host,
-        runId,
-        runRecord,
-        attachedInstruments,
-        isFlex,
-      })
-        .then(pipettesWithTipAttached => {
-          const newPipettesWithTipAttached = pipettesWithTipAttached.map(
-            pipette => {
-              const specs = getPipetteModelSpecs(pipette.instrumentModel)
-              return {
-                specs,
-                mount: pipette.mount,
+    if (isFlex) {
+      // Reset drop tip state when a new run occurs.
+      if (runStatus === RUN_STATUS_IDLE) {
+        setShowDropTipBanner(true)
+        setPipettesWithTip([])
+      } else if (runStatus != null && RUN_OVER_STATUSES.includes(runStatus)) {
+        getPipettesWithTipAttached({
+          host,
+          runId,
+          runRecord,
+          attachedInstruments,
+          isFlex,
+        })
+          .then(pipettesWithTipAttached => {
+            const newPipettesWithTipAttached = pipettesWithTipAttached.map(
+              pipette => {
+                const specs = getPipetteModelSpecs(pipette.instrumentModel)
+                return {
+                  specs,
+                  mount: pipette.mount,
+                }
               }
-            }
-          )
-          setPipettesWithTip(() => newPipettesWithTipAttached)
-        })
-        .catch(e => {
-          console.log(`Error checking pipette tip attachement state: ${e}`)
-        })
+            )
+            setPipettesWithTip(() => newPipettesWithTipAttached)
+          })
+          .catch(e => {
+            console.log(`Error checking pipette tip attachement state: ${e}`)
+          })
+      }
     }
   }, [runStatus, attachedInstruments, host, runId, runRecord, isFlex])
 

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -241,6 +241,11 @@ export function ProtocolRunHeader({
     }
   }, [protocolData, isRobotViewable, history])
 
+  console.log(
+    '🚀 ~ file: ProtocolRunHeader.tsx:246 ~ React.useEffect ~ RUN_STATUS_STOPPED:',
+    RUN_STATUS_STOPPED
+  )
+
   React.useEffect(() => {
     if (runStatus === RUN_STATUS_STOPPED && isRunCurrent && runId != null) {
       trackProtocolRunEvent({
@@ -249,7 +254,6 @@ export function ProtocolRunHeader({
           ...robotAnalyticsData,
         },
       })
-      closeCurrentRun()
     }
   }, [runStatus, isRunCurrent, runId, closeCurrentRun])
 

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -250,7 +250,7 @@ export function ProtocolRunHeader({
         },
       })
     }
-  }, [runStatus, isRunCurrent, runId, closeCurrentRun])
+  }, [runStatus, isRunCurrent, runId])
 
   const startedAtTimestamp =
     startedAt != null ? formatTimestamp(startedAt) : EMPTY_TIMESTAMP

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -1007,7 +1007,7 @@ describe('ProtocolRunHeader', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('renders the drop tip banner when the run is over and a pipette has a tip attached', async () => {
+  it('renders the drop tip banner when the run is over and a pipette has a tip attached and is a flex', async () => {
     when(mockUseRunQuery)
       .calledWith(RUN_ID)
       .mockReturnValue({

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -523,7 +523,7 @@ describe('ProtocolRunHeader', () => {
         data: { data: { ...mockIdleUnstartedRun, current: true } },
       } as UseQueryResult<Run>)
     render()
-    expect(mockCloseCurrentRun).toBeCalled()
+    expect(mockCloseCurrentRun).not.toBeCalled()
     expect(mockTrackProtocolRunEvent).toBeCalled()
     expect(mockTrackProtocolRunEvent).toBeCalledWith({
       name: ANALYTICS_PROTOCOL_RUN_FINISH,

--- a/app/src/organisms/DropTipWizard/BeforeBeginning.tsx
+++ b/app/src/organisms/DropTipWizard/BeforeBeginning.tsx
@@ -58,7 +58,15 @@ export const BeforeBeginning = (
   }
 
   if (isRobotMoving || createdMaintenanceRunId == null) {
-    return <InProgressModal description={t('stand_back_exiting')} />
+    return (
+      <InProgressModal
+        description={
+          createdMaintenanceRunId == null
+            ? t('getting_ready')
+            : t('stand_back_exiting')
+        }
+      />
+    )
   }
 
   if (isOnDevice) {

--- a/app/src/organisms/DropTipWizard/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizard/ChooseLocation.tsx
@@ -27,6 +27,7 @@ import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal
 import { TwoUpTileLayout } from '../LabwarePositionCheck/TwoUpTileLayout'
 
 import type { RobotType } from '@opentrons/shared-data'
+import type { CommandData } from '@opentrons/api-client'
 
 // TODO: get help link article URL
 // const NEED_HELP_URL = ''
@@ -37,7 +38,9 @@ interface ChooseLocationProps {
   title: string
   body: string | JSX.Element
   robotType: RobotType
-  moveToAddressableArea: (addressableArea: string) => Error | null
+  moveToAddressableArea: (
+    addressableArea: string
+  ) => Promise<CommandData | null>
   isRobotMoving: boolean
   isOnDevice: boolean
   setErrorMessage: (arg0: string) => void

--- a/app/src/organisms/DropTipWizard/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizard/ChooseLocation.tsx
@@ -26,7 +26,6 @@ import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal
 // import { NeedHelpLink } from '../CalibrationPanels'
 import { TwoUpTileLayout } from '../LabwarePositionCheck/TwoUpTileLayout'
 
-import type { CommandData } from '@opentrons/api-client'
 import type { RobotType } from '@opentrons/shared-data'
 
 // TODO: get help link article URL
@@ -38,9 +37,7 @@ interface ChooseLocationProps {
   title: string
   body: string | JSX.Element
   robotType: RobotType
-  moveToAddressableArea: (
-    addressableArea: string
-  ) => Promise<CommandData | null>
+  moveToAddressableArea: (addressableArea: string) => Error | null
   isRobotMoving: boolean
   isOnDevice: boolean
   setErrorMessage: (arg0: string) => void

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -371,19 +371,21 @@ export const DropTipWizardComponent = (
             : 0
 
         if (currentPosition != null && addressableAreaFromConfig != null) {
-          return createRunCommand({
-            maintenanceRunId: createdMaintenanceRunId,
-            command: {
-              commandType: 'moveToAddressableArea',
-              params: {
-                pipetteId: MANAGED_PIPETTE_ID,
-                addressableAreaName: addressableAreaFromConfig,
-                offset: { x: 0, y: 0, z: zOffset },
+          return chainRunCommands(
+            createdMaintenanceRunId,
+            [
+              {
+                commandType: 'moveToAddressableArea',
+                params: {
+                  pipetteId: MANAGED_PIPETTE_ID,
+                  addressableAreaName: addressableAreaFromConfig,
+                  offset: { x: 0, y: 0, z: zOffset },
+                },
               },
-            },
-            waitUntilComplete: true,
-          }).then(response => {
-            const error = response.data.error
+            ],
+            true
+          ).then(commandData => {
+            const error = commandData[0].data.error
             if (error != null) {
               setErrorMessage(`error moving to position: ${error.detail}`)
             }

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -507,7 +507,12 @@ export const DropTipWizardComponent = (
               ],
               true
             )
-              .then(() => proceed())
+              .then(commandData => {
+                const error = commandData[0].data.error
+                if (error != null) {
+                  setErrorMessage(`error moving to position: ${error.detail}`)
+                } else proceed()
+              })
               .catch(e =>
                 setErrorMessage(
                   `Error issuing ${

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -43,7 +43,7 @@ import { ChooseLocation } from './ChooseLocation'
 import { JogToPosition } from './JogToPosition'
 import { Success } from './Success'
 
-import type { PipetteData } from '@opentrons/api-client'
+import type { PipetteData, CommandData } from '@opentrons/api-client'
 import type {
   Coordinates,
   PipetteModelSpecs,
@@ -337,12 +337,16 @@ export const DropTipWizardComponent = (
       })
   }
 
-  const moveToAddressableArea = (addressableArea: string): Error | null => {
+  const moveToAddressableArea = (
+    addressableArea: string
+  ): Promise<CommandData | null> => {
     if (createdMaintenanceRunId == null) {
-      return new Error('no maintenance run present to send move commands to')
+      return Promise.reject(
+        new Error('no maintenance run present to send move commands to')
+      )
     }
 
-    retractAllAxesAndSavePosition()
+    return retractAllAxesAndSavePosition()
       .then(currentPosition => {
         if (currentPosition != null) {
           return createRunCommand({
@@ -361,15 +365,17 @@ export const DropTipWizardComponent = (
             if (error != null) {
               setErrorMessage(`error moving to position: ${error.detail}`)
             }
+            return null
           })
         } else {
           setErrorMessage(`error moving to position: invalid addressable area.`)
+          return null
         }
       })
       .catch(e => {
         setErrorMessage(`error moving to position: ${e.message}`)
+        return null
       })
-    return null
   }
 
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -365,7 +365,8 @@ export const DropTipWizardComponent = (
         )
 
         const zOffset =
-          addressableAreaFromConfig === addressableArea
+          addressableAreaFromConfig === addressableArea &&
+          addressableAreaFromConfig !== 'fixedTrash'
             ? (currentPosition as Coordinates).z - 10
             : 0
 


### PR DESCRIPTION
Closes RQA-2106

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Because OT-2s implicitly drop tips at the end of the run, there's no need to render the drop tip banner now. This PR also adds more error handling to the moveToAddressableArea command during drop tip flows, and adds reasonable display text when flows start. Also fixes bugs where the drop tip banner unrenders during run cancel and the OT-2 can't move to fixedTrash. Also fixes an issue where the confirm select location step would flash after selecting a location.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run through flows on OT-2 that pick up a tip. Cancel a run after a tip has been picked up. Note that no banner displays. 
- Confirm banner still displays properly on the Flex.
- Observe the start up text when launching a flow.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- OT-2 no longer displays the drop tip banner after a protocol run is in a terminal state.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
