### PR TITLE
fix(app-shell): use a wrapping stream for usb

### DIFF
--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -164,7 +164,7 @@ function tryCreateAndStartUsbHttpRequests(dispatch: Dispatch): void {
       }
       if (usbHttpAgent == null) {
         createSerialPortHttpAgent(ot3UsbSerialPort.path, (err, agent?) => {
-          if (err) {
+          if (err != null) {
             const message = err?.message ?? err
             usbLog.error(`Failed to create serial port: ${message}`)
           }

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -34,25 +34,50 @@ let usbFetchInterval: NodeJS.Timeout
 export function getSerialPortHttpAgent(): SerialPortHttpAgent | undefined {
   return usbHttpAgent
 }
-export function createSerialPortHttpAgent(path: string): void {
-  const serialPortHttpAgent = new SerialPortHttpAgent({
-    maxFreeSockets: 1,
-    maxSockets: 1,
-    maxTotalSockets: 1,
-    keepAlive: true,
-    keepAliveMsecs: Infinity,
-    path,
-    logger: usbLog,
-    timeout: 100000,
-  })
-  usbHttpAgent = serialPortHttpAgent
+export function createSerialPortHttpAgent(
+  path: string,
+  onComplete: (err: Error | null, agent?: SerialPortHttpAgent) => void
+): void {
+  if (usbHttpAgent != null) {
+    onComplete(
+      new Error('Tried to make a USB http agent when one already existed')
+    )
+  } else {
+    usbHttpAgent = new SerialPortHttpAgent(
+      {
+        maxFreeSockets: 1,
+        maxSockets: 1,
+        maxTotalSockets: 1,
+        keepAlive: true,
+        keepAliveMsecs: Infinity,
+        path,
+        logger: usbLog,
+        timeout: 100000,
+      },
+      (err, agent?) => {
+        if (err != null) {
+          usbHttpAgent = undefined
+        }
+        onComplete(err, agent)
+      }
+    )
+  }
 }
 
-export function destroyUsbHttpAgent(): void {
+export function destroyAndStopUsbHttpRequests(dispatch: Dispatch): void {
   if (usbHttpAgent != null) {
     usbHttpAgent.destroy()
   }
   usbHttpAgent = undefined
+  ipcMain.removeHandler('usb:request')
+  dispatch(usbRequestsStop())
+  // handle any additional invocations of usb:request
+  ipcMain.handle('usb:request', () =>
+    Promise.resolve({
+      status: 400,
+      statusText: 'USB robot disconnected',
+    })
+  )
 }
 
 function isUsbDeviceOt3(device: UsbDevice): boolean {
@@ -115,42 +140,11 @@ function pollSerialPortAndCreateAgent(dispatch: Dispatch): void {
   }
   usbFetchInterval = setInterval(() => {
     // already connected to an Opentrons robot via USB
-    if (getSerialPortHttpAgent() != null) {
-      return
-    }
-    usbLog.debug('fetching serialport list')
-    fetchSerialPortList()
-      .then((list: PortInfo[]) => {
-        const ot3UsbSerialPort = list.find(
-          port =>
-            port.productId?.localeCompare(DEFAULT_PRODUCT_ID, 'en-US', {
-              sensitivity: 'base',
-            }) === 0 &&
-            port.vendorId?.localeCompare(DEFAULT_VENDOR_ID, 'en-US', {
-              sensitivity: 'base',
-            }) === 0
-        )
-
-        if (ot3UsbSerialPort == null) {
-          usbLog.debug('no OT-3 serial port found')
-          return
-        }
-
-        createSerialPortHttpAgent(ot3UsbSerialPort.path)
-        // remove any existing handler
-        ipcMain.removeHandler('usb:request')
-        ipcMain.handle('usb:request', usbListener)
-
-        dispatch(usbRequestsStart())
-      })
-      .catch(e =>
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        usbLog.debug(`fetchSerialPortList error ${e?.message ?? 'unknown'}`)
-      )
+    tryCreateAndStartUsbHttpRequests(dispatch)
   }, 10000)
 }
 
-function startUsbHttpRequests(dispatch: Dispatch): void {
+function tryCreateAndStartUsbHttpRequests(dispatch: Dispatch): void {
   fetchSerialPortList()
     .then((list: PortInfo[]) => {
       const ot3UsbSerialPort = list.find(
@@ -165,17 +159,22 @@ function startUsbHttpRequests(dispatch: Dispatch): void {
 
       // retry if no OT-3 serial port found - usb-detection and serialport packages have race condition
       if (ot3UsbSerialPort == null) {
-        usbLog.debug('no OT-3 serial port found, retrying')
-        setTimeout(() => startUsbHttpRequests(dispatch), 1000)
+        usbLog.debug('no OT-3 serial port found')
         return
       }
-
-      createSerialPortHttpAgent(ot3UsbSerialPort.path)
-      // remove any existing handler
-      ipcMain.removeHandler('usb:request')
-      ipcMain.handle('usb:request', usbListener)
-
-      dispatch(usbRequestsStart())
+      if (usbHttpAgent == null) {
+        createSerialPortHttpAgent(ot3UsbSerialPort.path, (err, agent?) => {
+          if (err) {
+            const message = err?.message ?? err
+            usbLog.error(`Failed to create serial port: ${message}`)
+          }
+          if (agent) {
+            ipcMain.removeHandler('usb:request')
+            ipcMain.handle('usb:request', usbListener)
+            dispatch(usbRequestsStart())
+          }
+        })
+      }
     })
     .catch(e =>
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -188,27 +187,18 @@ export function registerUsb(dispatch: Dispatch): (action: Action) => unknown {
     switch (action.type) {
       case SYSTEM_INFO_INITIALIZED:
         if (action.payload.usbDevices.find(isUsbDeviceOt3) != null) {
-          startUsbHttpRequests(dispatch)
+          tryCreateAndStartUsbHttpRequests(dispatch)
         }
         pollSerialPortAndCreateAgent(dispatch)
         break
       case USB_DEVICE_ADDED:
         if (isUsbDeviceOt3(action.payload.usbDevice)) {
-          startUsbHttpRequests(dispatch)
+          tryCreateAndStartUsbHttpRequests(dispatch)
         }
         break
       case USB_DEVICE_REMOVED:
         if (isUsbDeviceOt3(action.payload.usbDevice)) {
-          destroyUsbHttpAgent()
-          ipcMain.removeHandler('usb:request')
-          dispatch(usbRequestsStop())
-          // handle any additional invocations of usb:request
-          ipcMain.handle('usb:request', () =>
-            Promise.resolve({
-              status: 400,
-              statusText: 'USB robot disconnected',
-            })
-          )
+          destroyAndStopUsbHttpRequests(dispatch)
         }
         break
     }

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -156,11 +156,13 @@ function socketEmulatorFromPort(port: SerialPort): Socket {
   // since this socket is independent from the port, we can do stuff like "have an activity timeout"
   // without worrying that it will kill the socket
   let currentTimeout: NodeJS.Timeout | null = null
-  const refreshTimeout = (): void => { currentTimeout?.refresh() }
+  const refreshTimeout = (): void => {
+    currentTimeout?.refresh()
+  }
   socket.on('data', refreshTimeout)
   socket.setTimeout = (timeout, callable?) => {
     currentTimeout !== null && clearTimeout(currentTimeout)
-    if (timeout === 0 && (currentTimeout !== null)) {
+    if (timeout === 0 && currentTimeout !== null) {
       currentTimeout = null
     } else if (timeout !== 0) {
       currentTimeout = setTimeout(() => {

--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -1,7 +1,6 @@
 import * as http from 'http'
 import agent from 'agent-base'
 import { Duplex } from 'stream'
-import type { Timeout } from 'timers'
 
 import { SerialPort } from 'serialport'
 
@@ -156,19 +155,19 @@ function socketEmulatorFromPort(port: SerialPort): Socket {
 
   // since this socket is independent from the port, we can do stuff like "have an activity timeout"
   // without worrying that it will kill the socket
-  let currentTimeout: Timeout | null = null
-  const refreshTimeout = (): void => currentTimeout && currentTimeout.refresh()
+  let currentTimeout: NodeJS.Timeout | null = null
+  const refreshTimeout = (): void => { currentTimeout?.refresh() }
   socket.on('data', refreshTimeout)
   socket.setTimeout = (timeout, callable?) => {
-    clearTimeout(currentTimeout)
-    if (timeout === 0 && currentTimeout) {
+    currentTimeout !== null && clearTimeout(currentTimeout)
+    if (timeout === 0 && (currentTimeout !== null)) {
       currentTimeout = null
     } else if (timeout !== 0) {
       currentTimeout = setTimeout(() => {
         console.log('socket timed out')
         socket.emit('timeout')
       }, timeout)
-      if (callable) {
+      if (callable != null) {
         socket.once('timeout', callable)
       }
     }


### PR DESCRIPTION
Implement the tcp socket emulator by creating a separate stream that is piped through to the usb connection via its downward interface rather than using the same stream for both the port and the socket or pipelining the two streams together.

This implementation allows the lifecycles of the USB port connection, which we want to be the same as the physical robot connection; and the tcp socket emulators, which we want to be more like tcp sockets; to be separate, which really increases reliability because we don't have the port going up and down all the time anymore. This reduces spurious disconnects.

It will also allow us to add socket activity timeouts to help with the windows dropping data problem, though we can't really do that until the http requests that cause synchronous actions that we make get keep alive streaming responses.
## Risk
- Low (usb basically still doesn't work before this PR)
## Testing
- [x] on a windows machine disconnected from the internet
   - [x] repeated physical connections and disconnections reliably detect and remove the robot
   - [x] standard workflows (i.e. all the random polling in the device page) work and display the robot
   - [x] complex workflows (i.e. module calibration) work
   - [x] download-heavy workflows (i.e. logs) work
   - [x] upload-heavy workflows (i.e. updates) work
   - [x] the robot gets detected again when it boots after updates
## Review requests
- is there something we just can't stand for in here? it's definitely ugly but is probably going to stay that way. i'm definitely going to continue following up with improvements.