### PR TITLE
fix(api): do not tip check during attach

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -737,7 +737,7 @@ class OT3API(
         """Configure instruments"""
         await self.set_gantry_load(self._gantry_load_from_instruments())
         await self.refresh_positions()
-        await self.reset_tip_detectors()
+        await self.reset_tip_detectors(False)
 
     async def reset_tip_detectors(
         self,


### PR DESCRIPTION
Since on the 96, that moves motors while someone is holding it in their hands.

### Testing
- [x] on a flex with this pr, attach a 96. the motors shouldn't move
- [x] run calibration and make sure that it still checks for a tip

