### PR TITLE
fix(app): e-stop modal button state issue

### DIFF
--- a/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
@@ -133,10 +133,7 @@ function DesktopModal({
 }: EstopPressedModalProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const [isResuming, setIsResuming] = React.useState<boolean>(false)
-  const {
-    acknowledgeEstopDisengage,
-    data,
-  } = useAcknowledgeEstopDisengageMutation()
+  const { acknowledgeEstopDisengage } = useAcknowledgeEstopDisengageMutation()
 
   const handleCloseModal = (): void => {
     if (setIsDismissedModal != null) {
@@ -155,20 +152,17 @@ function DesktopModal({
   }
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e): void => {
+    e.preventDefault()
     setIsResuming(true)
     acknowledgeEstopDisengage({
-      onSuccess: () => {},
+      onSuccess: () => {
+        closeModal()
+      },
       onError: () => {
         setIsResuming(false)
       },
     })
   }
-
-  React.useEffect(() => {
-    if (data?.data.status === DISENGAGED) {
-      closeModal()
-    }
-  }, [data?.data.status, closeModal])
 
   return (
     <LegacyModal {...modalProps}>

--- a/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
@@ -26,7 +26,6 @@ import { StyledText } from '../../atoms/text'
 import { LegacyModal } from '../../molecules/LegacyModal'
 import { Modal } from '../../molecules/Modal'
 import { getIsOnDevice } from '../../redux/config'
-import { DISENGAGED } from './constants'
 
 import type {
   ModalHeaderBaseProps,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The issue was caused by unexpected state change via `useEffect`.
Remove `useEffect` and update `handleClick`. 
close RQA-2111
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. press e-stop button
2. twist e-stop button
3. click resume button
the button shows spinner and not back to normal state and for ODD, the modal is gone.
There will be some delay since fetching duration is 10sec. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
