### PR TITLE
fix(app): ODD - Remove dismisscurrentrun on protocol cancel button

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -22,7 +22,6 @@ import {
   useRunQuery,
   useModulesQuery,
   usePipettesQuery,
-  useDismissCurrentRunMutation,
   useEstopQuery,
   useDoorQuery,
   useInstrumentsQuery,
@@ -186,9 +185,6 @@ const mockUseModulesQuery = useModulesQuery as jest.MockedFunction<
 >
 const mockUsePipettesQuery = usePipettesQuery as jest.MockedFunction<
   typeof usePipettesQuery
->
-const mockUseDismissCurrentRunMutation = useDismissCurrentRunMutation as jest.MockedFunction<
-  typeof useDismissCurrentRunMutation
 >
 const mockConfirmCancelModal = ConfirmCancelModal as jest.MockedFunction<
   typeof ConfirmCancelModal
@@ -396,11 +392,6 @@ describe('ProtocolRunHeader', () => {
       .mockReturnValue({
         data: { data: mockIdleUnstartedRun },
       } as UseQueryResult<Run>)
-    when(mockUseDismissCurrentRunMutation)
-      .calledWith()
-      .mockReturnValue({
-        dismissCurrentRun: jest.fn(),
-      } as any)
     when(mockUseProtocolDetailsForRun)
       .calledWith(RUN_ID)
       .mockReturnValue(PROTOCOL_DETAILS)

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -68,7 +68,6 @@ export function ConfirmCancelRunModal({
   React.useEffect(() => {
     if (runStatus === RUN_STATUS_STOPPED) {
       trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_CANCEL })
-      dismissCurrentRun(runId)
       if (!isActiveRun) {
         if (protocolId != null) {
           history.push(`/protocols/${protocolId}`)

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -40,10 +40,7 @@ export function ConfirmCancelRunModal({
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
   const { stopRun } = useStopRunMutation()
-  const {
-    dismissCurrentRun,
-    isLoading: isDismissing,
-  } = useDismissCurrentRunMutation()
+  const { isLoading: isDismissing } = useDismissCurrentRunMutation()
   const runStatus = useRunStatus(runId)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
   const history = useHistory()

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -10,10 +10,7 @@ import {
   Flex,
   SPACING,
 } from '@opentrons/components'
-import {
-  useStopRunMutation,
-  useDismissCurrentRunMutation,
-} from '@opentrons/react-api-client'
+import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { StyledText } from '../../../atoms/text'
 import { SmallButton } from '../../../atoms/buttons'
@@ -40,7 +37,6 @@ export function ConfirmCancelRunModal({
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
   const { stopRun } = useStopRunMutation()
-  const { isLoading: isDismissing } = useDismissCurrentRunMutation()
   const runStatus = useRunStatus(runId)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
   const history = useHistory()
@@ -75,7 +71,7 @@ export function ConfirmCancelRunModal({
     }
   }, [runStatus])
 
-  return isCanceling || isDismissing ? (
+  return isCanceling ? (
     <CancelingRunModal />
   ) : (
     <Modal

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -118,15 +118,6 @@ describe('ConfirmCancelRunModal', () => {
     getByText('Cancel run')
   })
 
-  it('shoudler render the canceling run modal when run is dismissing', () => {
-    mockUseDismissCurrentRunMutation.mockReturnValue({
-      dismissCurrentRun: mockDismissCurrentRun,
-      isLoading: true,
-    } as any)
-    const [{ getByText }] = render(props)
-    getByText('mock CancelingRunModal')
-  })
-
   it('when tapping go back, the mock function is called', () => {
     const [{ getByText }] = render(props)
     const button = getByText('Go back')
@@ -147,7 +138,7 @@ describe('ConfirmCancelRunModal', () => {
       .mockReturnValue(RUN_STATUS_STOPPED)
     render(props)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
   })
 
@@ -161,7 +152,7 @@ describe('ConfirmCancelRunModal', () => {
       .mockReturnValue(RUN_STATUS_STOPPED)
     render(props)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
     expect(mockPush).toHaveBeenCalledWith('/protocols')
   })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Thank you for spotting this @jbleon95 ! This PR fixes a behavior mismatch issue between the desktop app & ODD. The cancel run button on the ODD removes the run context, which drop tip needs to work. This behavior doesn't need to be tied to the cancel button as far as I can tell. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- I already tested this -- just double check the logic. 
- Tested running a protocol, pushing a protocol, canceling a run, starting a new run, etc. Drop tip works as expected on ODD now and there doesn't seem to be any regression.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Cancelling a run on the ODD will allow a user to access drop tip wizard.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Just check my logic.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low (likely)
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
