### PR TITLE
fix(app): allow users to use the same name after device reset 

### DIFF
--- a/app/src/pages/OnDeviceDisplay/NameRobot.tsx
+++ b/app/src/pages/OnDeviceDisplay/NameRobot.tsx
@@ -81,8 +81,6 @@ export function NameRobot(): JSX.Element {
     getUnreachableRobots(state)
   )
 
-  console.log('robot.ip', ipAddress)
-
   const formik = useFormik({
     initialValues: {
       newRobotName: '',

--- a/app/src/pages/OnDeviceDisplay/NameRobot.tsx
+++ b/app/src/pages/OnDeviceDisplay/NameRobot.tsx
@@ -59,6 +59,7 @@ export function NameRobot(): JSX.Element {
   const history = useHistory()
   const trackEvent = useTrackEvent()
   const localRobot = useSelector(getLocalRobot)
+  const ipAddress = localRobot?.ip
   const previousName = localRobot?.name != null ? localRobot.name : null
   const [name, setName] = React.useState<string>('')
   const [newName, setNewName] = React.useState<string>('')
@@ -87,7 +88,7 @@ export function NameRobot(): JSX.Element {
     onSubmit: (values, { resetForm }) => {
       const newName = values.newRobotName.concat(name)
       const sameNameRobotInUnavailable = unreachableRobots.find(
-        robot => robot.name === newName
+        robot => robot.name === newName && robot.ip === ipAddress
       )
       if (sameNameRobotInUnavailable != null) {
         dispatch(removeRobot(sameNameRobotInUnavailable.name))

--- a/app/src/pages/OnDeviceDisplay/NameRobot.tsx
+++ b/app/src/pages/OnDeviceDisplay/NameRobot.tsx
@@ -81,6 +81,8 @@ export function NameRobot(): JSX.Element {
     getUnreachableRobots(state)
   )
 
+  console.log('robot.ip', ipAddress)
+
   const formik = useFormik({
     initialValues: {
       newRobotName: '',
@@ -88,7 +90,7 @@ export function NameRobot(): JSX.Element {
     onSubmit: (values, { resetForm }) => {
       const newName = values.newRobotName.concat(name)
       const sameNameRobotInUnavailable = unreachableRobots.find(
-        robot => robot.name === newName && robot.ip === ipAddress
+        robot => robot.name === newName
       )
       if (sameNameRobotInUnavailable != null) {
         dispatch(removeRobot(sameNameRobotInUnavailable.name))
@@ -106,7 +108,7 @@ export function NameRobot(): JSX.Element {
       }
       if (
         [...connectableRobots, ...reachableRobots].some(
-          robot => newName === robot.name
+          robot => newName === robot.name && robot.ip !== ipAddress
         )
       ) {
         errors.newRobotName = t('name_rule_error_exist')


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This change allows users to use the same robot's name after device reset.

In the future, device reset will support clear a robot name when doing device reset. 

close RQA-2077
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Need to check 2 cases.
case1
1. reset device (clear all stored data)
2. doing unboxing flow and use the same name
no error message

case2
1. reset device (clear all stored data)
2. doing unboxing flow and use a different name
no error message

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
