### PR TITLE
fix(app): Fix overeager drop tip errors

### DIFF
--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -507,12 +507,7 @@ export const DropTipWizardComponent = (
               ],
               true
             )
-              .then(commandData => {
-                const error = commandData[0].data.error
-                if (error != null) {
-                  setErrorMessage(`error moving to position: ${error.detail}`)
-                } else proceed()
-              })
+              .then(() => proceed())
               .catch(e =>
                 setErrorMessage(
                   `Error issuing ${


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Woops. This PR fixes a tip check that occurs by the hardware controller after a tip has dropped. HWC throws an error here, which we are catching and displaying to the user. This results in drop tip always failing after dropping. The long term solution is to talk to embedded.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Dropping tips shouldn't fail now.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
