### PR TITLE
fix(api): allow double remove tip

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -510,7 +510,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         Remove the tip from the pipette (effectively updates the pipette's
         critical point)
         """
-        assert self.has_tip
         self._has_tip = False
         self._current_tip_length = 0.0
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -484,7 +484,6 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
         Remove the tip from the pipette (effectively updates the pipette's
         critical point)
         """
-        assert self.has_tip_length
         self._current_tip_length = 0.0
         self._has_tip_length = False
 

--- a/api/tests/opentrons/hardware_control/test_pipette.py
+++ b/api/tests/opentrons/hardware_control/test_pipette.py
@@ -85,8 +85,7 @@ def test_tip_tracking(
     model: Union[str, pipette_definition.PipetteModelVersionType],
 ) -> None:
     hw_pipette = pipette_builder(model)
-    with pytest.raises(AssertionError):
-        hw_pipette.remove_tip()
+    hw_pipette.remove_tip()
     assert not hw_pipette.has_tip
     tip_length = 25.0
     hw_pipette.add_tip(tip_length)
@@ -95,8 +94,7 @@ def test_tip_tracking(
         hw_pipette.add_tip(tip_length)
     hw_pipette.remove_tip()
     assert not hw_pipette.has_tip
-    with pytest.raises(AssertionError):
-        hw_pipette.remove_tip()
+    hw_pipette.remove_tip()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This seems like a logic problem with how we track tip state, but removing this check (which is really a nebulous "might be using it wrong" check) we fix some incorrect errors in the drop tip wizard.
