### PR TITLE
fix(api): Flex 2 15 api fixed trash auto tipdrop support

### DIFF
--- a/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_hardware_stopper.py
@@ -15,7 +15,12 @@ from opentrons.protocol_engine.execution import (
     TipHandler,
     HardwareStopper,
 )
-from opentrons.protocol_engine.types import MotorAxis, TipGeometry, PostRunHardwareState
+from opentrons.protocol_engine.types import (
+    MotorAxis,
+    TipGeometry,
+    PostRunHardwareState,
+    AddressableOffsetVector,
+)
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
@@ -228,4 +233,108 @@ async def test_hardware_stopping_sequence_with_gripper(
             axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
         ),
         await ot3_hardware_api.stop(home_after=True),
+    )
+
+
+@pytest.mark.ot3_only
+async def test_hardware_stopping_sequence_with_fixed_trash(
+    decoy: Decoy,
+    state_store: StateStore,
+    ot3_hardware_api: OT3API,
+    movement: MovementHandler,
+    mock_tip_handler: TipHandler,
+) -> None:
+    """It should stop the hardware, and home the robot. Flex no longer performs automatic drop tip."""
+    subject = HardwareStopper(
+        hardware_api=ot3_hardware_api,
+        state_store=state_store,
+        movement=movement,
+        tip_handler=mock_tip_handler,
+    )
+    decoy.when(state_store.pipettes.get_all_attached_tips()).then_return(
+        [
+            ("pipette-id", TipGeometry(length=1.0, volume=2.0, diameter=3.0)),
+        ]
+    )
+    decoy.when(state_store.labware.get_fixed_trash_id()).then_return("fixedTrash")
+    decoy.when(state_store.config.use_virtual_gripper).then_return(False)
+    decoy.when(ot3_hardware_api.has_gripper()).then_return(True)
+
+    await subject.do_stop_and_recover(
+        drop_tips_after_run=True,
+        post_run_hardware_state=PostRunHardwareState.HOME_AND_STAY_ENGAGED,
+    )
+
+    decoy.verify(
+        await ot3_hardware_api.stop(home_after=False),
+        await ot3_hardware_api.home_z(mount=OT3Mount.GRIPPER),
+        await movement.home(
+            axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
+        ),
+        await mock_tip_handler.add_tip(
+            pipette_id="pipette-id",
+            tip=TipGeometry(length=1.0, volume=2.0, diameter=3.0),
+        ),
+        await movement.move_to_well(
+            pipette_id="pipette-id",
+            labware_id="fixedTrash",
+            well_name="A1",
+        ),
+        await mock_tip_handler.drop_tip(
+            pipette_id="pipette-id",
+            home_after=False,
+        ),
+        await ot3_hardware_api.stop(home_after=True),
+    )
+
+
+async def test_hardware_stopping_sequence_with_OT2_addressable_area(
+    decoy: Decoy,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    movement: MovementHandler,
+    mock_tip_handler: TipHandler,
+) -> None:
+    """It should stop the hardware, and home the robot. Flex no longer performs automatic drop tip."""
+    subject = HardwareStopper(
+        hardware_api=hardware_api,
+        state_store=state_store,
+        movement=movement,
+        tip_handler=mock_tip_handler,
+    )
+    decoy.when(state_store.pipettes.get_all_attached_tips()).then_return(
+        [
+            ("pipette-id", TipGeometry(length=1.0, volume=2.0, diameter=3.0)),
+        ]
+    )
+    decoy.when(state_store.config.robot_type).then_return("OT-2 Standard")
+    decoy.when(state_store.config.use_virtual_gripper).then_return(False)
+
+    await subject.do_stop_and_recover(
+        drop_tips_after_run=True,
+        post_run_hardware_state=PostRunHardwareState.HOME_AND_STAY_ENGAGED,
+    )
+
+    decoy.verify(
+        await hardware_api.stop(home_after=False),
+        await movement.home(
+            axes=[MotorAxis.X, MotorAxis.Y, MotorAxis.LEFT_Z, MotorAxis.RIGHT_Z]
+        ),
+        await mock_tip_handler.add_tip(
+            pipette_id="pipette-id",
+            tip=TipGeometry(length=1.0, volume=2.0, diameter=3.0),
+        ),
+        await movement.move_to_addressable_area(
+            pipette_id="pipette-id",
+            addressable_area_name="fixedTrash",
+            offset=AddressableOffsetVector(x=0, y=0, z=0),
+            force_direct=False,
+            speed=None,
+            minimum_z_height=None,
+        ),
+        await mock_tip_handler.drop_tip(
+            pipette_id="pipette-id",
+            home_after=False,
+        ),
+        await hardware_api.stop(home_after=True),
     )

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -188,9 +188,6 @@ class EngineStore:
 
         post_run_hardware_state = PostRunHardwareState.HOME_AND_STAY_ENGAGED
         drop_tips_after_run = True
-        if self._robot_type == "OT-3 Standard":
-            post_run_hardware_state = PostRunHardwareState.HOME_AND_STAY_ENGAGED
-            drop_tips_after_run = False
 
         runner = create_protocol_runner(
             protocol_engine=engine,


### PR DESCRIPTION

# Overview
Seeks to solve the API 2 15 support for RQA-1990

# Test Plan
Run a 2.15 protocol on Flex that ends with a tip attached, ensure it auto drops in the fixed trash. Also run a 2.16 protocol on flex and ensure it does not auto drop them.
Run both on OT2 and ensure that the OT2 always drops tips.

# Risk assessment
This should be fixing support for Flex, but has changed how we gate behavior exclusively for OT2, test thoroughly.