### PR TITLE
fix(api): center only active column on 12-well

### DIFF
--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -141,6 +141,13 @@ class NozzleMap:
         )
 
     @property
+    def y_center_offset(self) -> Point:
+        """The position in the center of the primary column of the map."""
+        front_left = next(reversed(list(self.rows.values())))[0]
+        difference = self.map_store[front_left] - self.map_store[self.back_left]
+        return self.map_store[self.back_left] + Point(0, difference[1] / 2, 0)
+
+    @property
     def front_nozzle_offset(self) -> Point:
         """The offset for the front_left nozzle."""
         # front left-most nozzle of the 96 channel in a given configuration
@@ -319,6 +326,8 @@ class NozzleConfigurationManager:
     ) -> Point:
         if cp_override == CriticalPoint.XY_CENTER:
             current_nozzle = self._current_nozzle_configuration.xy_center_offset
+        elif cp_override == CriticalPoint.Y_CENTER:
+            current_nozzle = self._current_nozzle_configuration.y_center_offset
         elif cp_override == CriticalPoint.FRONT_NOZZLE:
             current_nozzle = self._current_nozzle_configuration.front_nozzle_offset
         else:

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -505,6 +505,16 @@ class CriticalPoint(enum.Enum):
     back calibration pin slot.
     """
 
+    Y_CENTER = enum.auto()
+    """
+    Y_CENTER means the critical point under consideration is at the same X
+    coordinate as the default nozzle point (i.e. TIP | NOZZLE | FRONT_NOZZLE)
+    but halfway in between the Y axis bounding box of the pipette - it is the
+    XY center of the first column in the pipette. It's really only relevant for
+    the 96; it will produce the same position as XY_CENTER on an eight or one
+    channel pipette.
+    """
+
 
 class ExecutionState(enum.Enum):
     RUNNING = enum.auto()

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -381,6 +381,30 @@ class LabwareView(HasState[LabwareState]):
         definition = self.get_definition(labware_id)
         return definition.parameters.quirks or []
 
+    def get_should_center_column_on_target_well(self, labware_id: str) -> bool:
+        """True if a pipette moving to this labware should center its active column on the target.
+
+        This is true for labware that have wells spanning entire columns.
+        """
+        has_quirk = self.get_has_quirk(labware_id, "centerMultichannelOnWells")
+        return (
+            has_quirk
+            and len(self.get_definition(labware_id).wells) > 1
+            and len(self.get_definition(labware_id).wells) < 96
+        )
+
+    def get_should_center_pipette_on_target_well(self, labware_id: str) -> bool:
+        """True if a pipette moving to a well of this labware should center its body on the target.
+
+        This is true for 1-well reservoirs no matter the pipette, and for large plates.
+        """
+        has_quirk = self.get_has_quirk(labware_id, "centerMultichannelOnWells")
+        return (
+            has_quirk
+            and len(self.get_definition(labware_id).wells) == 1
+            or len(self.get_definition(labware_id).wells) >= 96
+        )
+
     def get_well_definition(
         self,
         labware_id: str,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -387,9 +387,8 @@ class LabwareView(HasState[LabwareState]):
         This is true for labware that have wells spanning entire columns.
         """
         has_quirk = self.get_has_quirk(labware_id, "centerMultichannelOnWells")
-        return (
-            has_quirk
-            and len(self.get_definition(labware_id).wells) > 1
+        return has_quirk and (
+            len(self.get_definition(labware_id).wells) > 1
             and len(self.get_definition(labware_id).wells) < 96
         )
 
@@ -399,9 +398,8 @@ class LabwareView(HasState[LabwareState]):
         This is true for 1-well reservoirs no matter the pipette, and for large plates.
         """
         has_quirk = self.get_has_quirk(labware_id, "centerMultichannelOnWells")
-        return (
-            has_quirk
-            and len(self.get_definition(labware_id).wells) == 1
+        return has_quirk and (
+            len(self.get_definition(labware_id).wells) == 1
             or len(self.get_definition(labware_id).wells) >= 96
         )
 

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -99,13 +99,13 @@ def test_get_pipette_location_with_no_current_location(
     assert result == PipetteLocationData(mount=MountType.LEFT, critical_point=None)
 
 
-def test_get_pipette_location_with_current_location_with_quirks(
+def test_get_pipette_location_with_current_location_with_y_center(
     decoy: Decoy,
     labware_view: LabwareView,
     pipette_view: PipetteView,
     subject: MotionView,
 ) -> None:
-    """It should return cp=XY_CENTER if location labware has center quirk."""
+    """It should return cp=Y_CENTER if location labware requests."""
     decoy.when(pipette_view.get_current_location()).then_return(
         CurrentWell(pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1")
     )
@@ -119,9 +119,41 @@ def test_get_pipette_location_with_current_location_with_quirks(
     )
 
     decoy.when(
-        labware_view.get_has_quirk(
+        labware_view.get_should_center_column_on_target_well(
             "reservoir-id",
-            "centerMultichannelOnWells",
+        )
+    ).then_return(True)
+
+    result = subject.get_pipette_location("pipette-id")
+
+    assert result == PipetteLocationData(
+        mount=MountType.RIGHT,
+        critical_point=CriticalPoint.Y_CENTER,
+    )
+
+
+def test_get_pipette_location_with_current_location_with_xy_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    subject: MotionView,
+) -> None:
+    """It should return cp=XY_CENTER if location labware requests."""
+    decoy.when(pipette_view.get_current_location()).then_return(
+        CurrentWell(pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1")
+    )
+
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
+            mount=MountType.RIGHT,
+            pipetteName=PipetteNameType.P300_SINGLE,
+        )
+    )
+
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "reservoir-id",
         )
     ).then_return(True)
 
@@ -157,9 +189,14 @@ def test_get_pipette_location_with_current_location_different_pipette(
     )
 
     decoy.when(
-        labware_view.get_has_quirk(
+        labware_view.get_should_center_column_on_target_well(
             "reservoir-id",
-            "centerMultichannelOnWells",
+        )
+    ).then_return(False)
+
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "reservoir-id",
         )
     ).then_return(False)
 
@@ -171,13 +208,13 @@ def test_get_pipette_location_with_current_location_different_pipette(
     )
 
 
-def test_get_pipette_location_override_current_location(
+def test_get_pipette_location_override_current_location_xy_center(
     decoy: Decoy,
     labware_view: LabwareView,
     pipette_view: PipetteView,
     subject: MotionView,
 ) -> None:
-    """It should calculate pipette location from a passed in deck location."""
+    """It should calculate pipette location from a passed in deck location with xy override."""
     current_well = CurrentWell(
         pipette_id="pipette-id",
         labware_id="reservoir-id",
@@ -193,9 +230,8 @@ def test_get_pipette_location_override_current_location(
     )
 
     decoy.when(
-        labware_view.get_has_quirk(
+        labware_view.get_should_center_pipette_on_target_well(
             "reservoir-id",
-            "centerMultichannelOnWells",
         )
     ).then_return(True)
 
@@ -210,7 +246,45 @@ def test_get_pipette_location_override_current_location(
     )
 
 
-def test_get_movement_waypoints_to_well(
+def test_get_pipette_location_override_current_location_y_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    subject: MotionView,
+) -> None:
+    """It should calculate pipette location from a passed in deck location with xy override."""
+    current_well = CurrentWell(
+        pipette_id="pipette-id",
+        labware_id="reservoir-id",
+        well_name="A1",
+    )
+
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
+            mount=MountType.RIGHT,
+            pipetteName=PipetteNameType.P300_SINGLE,
+        )
+    )
+
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(True)
+
+    result = subject.get_pipette_location(
+        pipette_id="pipette-id",
+        current_location=current_well,
+    )
+
+    assert result == PipetteLocationData(
+        mount=MountType.RIGHT,
+        critical_point=CriticalPoint.Y_CENTER,
+    )
+
+
+def test_get_movement_waypoints_to_well_for_y_center(
     decoy: Decoy,
     labware_view: LabwareView,
     pipette_view: PipetteView,
@@ -222,8 +296,98 @@ def test_get_movement_waypoints_to_well(
     location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
 
     decoy.when(pipette_view.get_current_location()).then_return(location)
+
     decoy.when(
-        labware_view.get_has_quirk("labware-id", "centerMultichannelOnWells")
+        labware_view.get_should_center_column_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(True)
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(False)
+
+    decoy.when(
+        geometry_view.get_well_position("labware-id", "well-name", WellLocation())
+    ).then_return(Point(x=4, y=5, z=6))
+
+    decoy.when(
+        move_types.get_move_type_to_well(
+            "pipette-id", "labware-id", "well-name", location, True
+        )
+    ).then_return(motion_planning.MoveType.GENERAL_ARC)
+    decoy.when(
+        geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
+    ).then_return(42.0)
+
+    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
+        DeckSlotName.SLOT_2
+    )
+
+    decoy.when(
+        geometry_view.get_extra_waypoints(location, DeckSlotName.SLOT_2)
+    ).then_return([(456, 789)])
+
+    waypoints = [
+        motion_planning.Waypoint(
+            position=Point(1, 2, 3), critical_point=CriticalPoint.Y_CENTER
+        ),
+        motion_planning.Waypoint(
+            position=Point(4, 5, 6), critical_point=CriticalPoint.MOUNT
+        ),
+    ]
+
+    decoy.when(
+        motion_planning.get_waypoints(
+            move_type=motion_planning.MoveType.GENERAL_ARC,
+            origin=Point(x=1, y=2, z=3),
+            origin_cp=CriticalPoint.MOUNT,
+            max_travel_z=1337,
+            min_travel_z=42,
+            dest=Point(x=4, y=5, z=6),
+            dest_cp=CriticalPoint.Y_CENTER,
+            xy_waypoints=[(456, 789)],
+        )
+    ).then_return(waypoints)
+
+    result = subject.get_movement_waypoints_to_well(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="well-name",
+        well_location=WellLocation(),
+        origin=Point(x=1, y=2, z=3),
+        origin_cp=CriticalPoint.MOUNT,
+        max_travel_z=1337,
+        force_direct=True,
+        minimum_z_height=123,
+    )
+
+    assert result == waypoints
+
+
+def test_get_movement_waypoints_to_well_for_xy_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    geometry_view: GeometryView,
+    mock_module_view: ModuleView,
+    subject: MotionView,
+) -> None:
+    """It should call get_waypoints() with the correct args to move to a well."""
+    location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
+
+    decoy.when(pipette_view.get_current_location()).then_return(location)
+
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(False)
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "reservoir-id",
+        )
     ).then_return(True)
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -299,12 +299,12 @@ def test_get_movement_waypoints_to_well_for_y_center(
 
     decoy.when(
         labware_view.get_should_center_column_on_target_well(
-            "reservoir-id",
+            "labware-id",
         )
     ).then_return(True)
     decoy.when(
         labware_view.get_should_center_pipette_on_target_well(
-            "reservoir-id",
+            "labware-id",
         )
     ).then_return(False)
 
@@ -381,12 +381,12 @@ def test_get_movement_waypoints_to_well_for_xy_center(
 
     decoy.when(
         labware_view.get_should_center_column_on_target_well(
-            "reservoir-id",
+            "labware-id",
         )
     ).then_return(False)
     decoy.when(
         labware_view.get_should_center_pipette_on_target_well(
-            "reservoir-id",
+            "labware-id",
         )
     ).then_return(True)
 
@@ -761,8 +761,11 @@ def test_get_touch_tip_waypoints(
     center_point = Point(1, 2, 3)
 
     decoy.when(
-        labware_view.get_has_quirk("labware-id", "centerMultichannelOnWells")
+        labware_view.get_should_center_pipette_on_target_well("labware-id")
     ).then_return(True)
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well("labware-id")
+    ).then_return(False)
 
     decoy.when(pipette_view.get_mount("pipette-id")).then_return(MountType.LEFT)
 


### PR DESCRIPTION
We have a system to center pipettes appropriately on the wells of labware that span multiple "traditional" wells. For instance, in a 12-well reservoir, we need to move the center of an eight channel pipette to the center of a given well of the 12-well reservoir.

However, that code was moving the center of _any_ pipette to the center of a 12-well reservoir, inclunding the center of the 96-channel, which is definitely not right. Instead, what we want to do is move the center of the "active" column (the column that contains the active nozzle, which is the nozzle that is moved when a caller specifies a NOZZLE critical point) to the center of the well. And we only want to do this on labware that have roughly one well per column.

The fix is in two parts.

First, a Y_CENTER critical point needs to exist. This critical point is aligned in the X direction with the active nozzle of the pipette, but is halfway between the Y positions of the backmost and frontmost nozzles in the column containing the active nozzle of the currently active nozzlemap - so, on an eight channel with a full map it would be the same as XY_CENTER; on a single, an eight channel with a single nozzle map, or a 96 with a single nozzle map, it will be the same as NOZZLE (and the same as XY_CENTER); and on an eight channel or 96 with a partial-column map it will be halfway up the partial.

On a 96 with a rectangular map (i.e. either full or quadrant) it will be halfway between the back left and front left nozzles.

Next, we have to actually use that critical point. The engine would check for a labware to have the centerMultiChannelOnWells quirk and emit XY_CENTER for both source and destination if it was found; we now also consider how many wells the labware has if it has
centerMultiChannelOnWells and (somewhat hackily, sadly) emit
- Y_CENTER, if the labware has the centerMultiChannelOnWells quirk and 1 < wells < 96
- XY_CENTER, if the labware has the centerMultiChannelOnWells quirk and wells == 1, wells >= 96

This should probably change eventually into a new quirk called like centerActiveColumnOnWells or something but that's for a different time.

## Testing
- In LPC and in a protocol
   - Move an 8 channel to a 12-well reservoir
   - Move a 96 channel to a 12-well reservoir in a full config
   - Move a 96 channel to a 12-well reservoir in a single-tip config
   - Move a 96 channel to a 12-well reservoir in a column config

Closes RQA-2118
