### PR TITLE
fix(app): Fix persistent cancelled state

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -249,8 +249,9 @@ export function ProtocolRunHeader({
           ...robotAnalyticsData,
         },
       })
+      closeCurrentRun()
     }
-  }, [runStatus, isRunCurrent, runId])
+  }, [runStatus, isRunCurrent, runId, closeCurrentRun])
 
   const startedAtTimestamp =
     startedAt != null ? formatTimestamp(startedAt) : EMPTY_TIMESTAMP
@@ -786,6 +787,11 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
   } = props
   const { t } = useTranslation('run_details')
 
+  const handleClick = (): void => {
+    handleClearClick()
+    setShowRunFailedModal(true)
+  }
+
   if (runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED) {
     return (
       <>
@@ -810,7 +816,7 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
               </StyledText>
 
               <LinkButton
-                onClick={() => setShowRunFailedModal(true)}
+                onClick={handleClick}
                 textDecoration={TYPOGRAPHY.textDecorationUnderline}
               >
                 {t('view_error')}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -106,6 +106,7 @@ import { RunProgressMeter } from '../../RunProgressMeter'
 import { getIsFixtureMismatch } from '../../../resources/deck_configuration/utils'
 import { useDeckConfigurationCompatibility } from '../../../resources/deck_configuration/hooks'
 import { useMostRecentCompletedAnalysis } from '../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { useMostRecentRunId } from '../../ProtocolUpload/hooks/useMostRecentRunId'
 
 import type { Run, RunError } from '@opentrons/api-client'
 import type { State } from '../../../redux/types'
@@ -161,6 +162,7 @@ export function ProtocolRunHeader({
   const { analysisErrors } = useProtocolAnalysisErrors(runId)
   const { data: attachedInstruments } = useInstrumentsQuery()
   const isRunCurrent = Boolean(useRunQuery(runId)?.data?.data?.current)
+  const mostRecentRunId = useMostRecentRunId()
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
   const [showRunFailedModal, setShowRunFailedModal] = React.useState(false)
@@ -373,7 +375,9 @@ export function ProtocolRunHeader({
             }}
           />
         ) : null}
-        {isRunCurrent && showDropTipBanner && pipettesWithTip.length !== 0 ? (
+        {mostRecentRunId === runId &&
+        showDropTipBanner &&
+        pipettesWithTip.length !== 0 ? (
           <ProtocolDropTipBanner
             onLaunchWizardClick={setShowDropTipWizard}
             onCloseClick={() => {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -22,6 +22,7 @@ import {
   useRunQuery,
   useModulesQuery,
   usePipettesQuery,
+  useDismissCurrentRunMutation,
   useEstopQuery,
   useDoorQuery,
   useInstrumentsQuery,
@@ -188,6 +189,9 @@ const mockUsePipettesQuery = usePipettesQuery as jest.MockedFunction<
 >
 const mockConfirmCancelModal = ConfirmCancelModal as jest.MockedFunction<
   typeof ConfirmCancelModal
+>
+const mockUseDismissCurrentRunMutation = useDismissCurrentRunMutation as jest.MockedFunction<
+  typeof useDismissCurrentRunMutation
 >
 const mockHeaterShakerIsRunningModal = HeaterShakerIsRunningModal as jest.MockedFunction<
   typeof HeaterShakerIsRunningModal
@@ -398,6 +402,11 @@ describe('ProtocolRunHeader', () => {
     when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
       trackProtocolRunEvent: mockTrackProtocolRunEvent,
     })
+    when(mockUseDismissCurrentRunMutation)
+      .calledWith()
+      .mockReturnValue({
+        dismissCurrentRun: jest.fn(),
+      } as any)
     when(mockUseUnmatchedModulesForProtocol)
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({ missingModuleIds: [], remainingAttachedModules: [] })
@@ -514,7 +523,7 @@ describe('ProtocolRunHeader', () => {
         data: { data: { ...mockIdleUnstartedRun, current: true } },
       } as UseQueryResult<Run>)
     render()
-    expect(mockCloseCurrentRun).not.toBeCalled()
+    expect(mockCloseCurrentRun).toBeCalled()
     expect(mockTrackProtocolRunEvent).toBeCalled()
     expect(mockTrackProtocolRunEvent).toBeCalledWith({
       name: ANALYTICS_PROTOCOL_RUN_FINISH,
@@ -822,7 +831,7 @@ describe('ProtocolRunHeader', () => {
     const [{ getByText }] = render()
 
     getByText('View error').click()
-    expect(mockCloseCurrentRun).not.toHaveBeenCalled()
+    expect(mockCloseCurrentRun).toBeCalled()
     getByText('mock RunFailedModal')
   })
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -92,6 +92,7 @@ import { getPipettesWithTipAttached } from '../../../DropTipWizard/getPipettesWi
 import { getIsFixtureMismatch } from '../../../../resources/deck_configuration/utils'
 import { useDeckConfigurationCompatibility } from '../../../../resources/deck_configuration/hooks'
 import { useMostRecentCompletedAnalysis } from '../../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { useMostRecentRunId } from '../../../ProtocolUpload/hooks/useMostRecentRunId'
 
 import type { UseQueryResult } from 'react-query'
 import type { Run } from '@opentrons/api-client'
@@ -140,6 +141,7 @@ jest.mock('../../../DropTipWizard/getPipettesWithTipAttached')
 jest.mock('../../../../resources/deck_configuration/utils')
 jest.mock('../../../../resources/deck_configuration/hooks')
 jest.mock('../../../LabwarePositionCheck/useMostRecentCompletedAnalysis')
+jest.mock('../../../ProtocolUpload/hooks/useMostRecentRunId')
 
 const mockGetIsHeaterShakerAttached = getIsHeaterShakerAttached as jest.MockedFunction<
   typeof getIsHeaterShakerAttached
@@ -245,6 +247,9 @@ const mockUseDeckConfigurationCompatibility = useDeckConfigurationCompatibility 
 >
 const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
   typeof useMostRecentCompletedAnalysis
+>
+const mockUseMostRecentRunId = useMostRecentRunId as jest.MockedFunction<
+  typeof useMostRecentRunId
 >
 
 const ROBOT_NAME = 'otie'
@@ -438,6 +443,7 @@ describe('ProtocolRunHeader', () => {
       } as any)
     mockUseDeckConfigurationCompatibility.mockReturnValue([])
     when(mockGetIsFixtureMismatch).mockReturnValue(false)
+    when(mockUseMostRecentRunId).mockReturnValue(RUN_ID)
   })
 
   afterEach(() => {

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -10,7 +10,10 @@ import {
   Flex,
   SPACING,
 } from '@opentrons/components'
-import { useStopRunMutation } from '@opentrons/react-api-client'
+import {
+  useStopRunMutation,
+  useDismissCurrentRunMutation,
+} from '@opentrons/react-api-client'
 
 import { StyledText } from '../../../atoms/text'
 import { SmallButton } from '../../../atoms/buttons'
@@ -37,6 +40,10 @@ export function ConfirmCancelRunModal({
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
   const { stopRun } = useStopRunMutation()
+  const {
+    dismissCurrentRun,
+    isLoading: isDismissing,
+  } = useDismissCurrentRunMutation()
   const runStatus = useRunStatus(runId)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
   const history = useHistory()
@@ -61,6 +68,7 @@ export function ConfirmCancelRunModal({
   React.useEffect(() => {
     if (runStatus === RUN_STATUS_STOPPED) {
       trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_CANCEL })
+      dismissCurrentRun(runId)
       if (!isActiveRun) {
         if (protocolId != null) {
           history.push(`/protocols/${protocolId}`)
@@ -71,7 +79,7 @@ export function ConfirmCancelRunModal({
     }
   }, [runStatus])
 
-  return isCanceling ? (
+  return isCanceling || isDismissing ? (
     <CancelingRunModal />
   ) : (
     <Modal

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -118,6 +118,15 @@ describe('ConfirmCancelRunModal', () => {
     getByText('Cancel run')
   })
 
+  it('shoudler render the canceling run modal when run is dismissing', () => {
+    mockUseDismissCurrentRunMutation.mockReturnValue({
+      dismissCurrentRun: mockDismissCurrentRun,
+      isLoading: true,
+    } as any)
+    const [{ getByText }] = render(props)
+    getByText('mock CancelingRunModal')
+  })
+
   it('when tapping go back, the mock function is called', () => {
     const [{ getByText }] = render(props)
     const button = getByText('Go back')
@@ -138,7 +147,7 @@ describe('ConfirmCancelRunModal', () => {
       .mockReturnValue(RUN_STATUS_STOPPED)
     render(props)
 
-    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
+    expect(mockDismissCurrentRun).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
   })
 
@@ -152,7 +161,7 @@ describe('ConfirmCancelRunModal', () => {
       .mockReturnValue(RUN_STATUS_STOPPED)
     render(props)
 
-    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
+    expect(mockDismissCurrentRun).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
     expect(mockPush).toHaveBeenCalledWith('/protocols')
   })

--- a/app/src/pages/OnDeviceDisplay/RunSummary.tsx
+++ b/app/src/pages/OnDeviceDisplay/RunSummary.tsx
@@ -63,6 +63,7 @@ import { formatTimeWithUtcLabel } from '../../resources/runs/utils'
 import { handleTipsAttachedModal } from '../../organisms/DropTipWizard/TipsAttachedModal'
 import { getPipettesWithTipAttached } from '../../organisms/DropTipWizard/getPipettesWithTipAttached'
 import { getPipetteModelSpecs, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import { useMostRecentRunId } from '../../organisms/ProtocolUpload/hooks/useMostRecentRunId'
 
 import type { OnDeviceRouteParams } from '../../App/types'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
@@ -79,6 +80,7 @@ export function RunSummary(): JSX.Element {
   const host = useHost()
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const isRunCurrent = Boolean(runRecord?.data?.current)
+  const mostRecentRunId = useMostRecentRunId()
   const { data: attachedInstruments } = useInstrumentsQuery()
   const runStatus = runRecord?.data.status ?? null
   const didRunSucceed = runStatus === RUN_STATUS_SUCCEEDED
@@ -130,7 +132,11 @@ export function RunSummary(): JSX.Element {
 
   const handleReturnToDash = (): void => {
     const { mount, specs } = pipettesWithTip[0] || {}
-    if (isRunCurrent && pipettesWithTip.length !== 0 && specs != null) {
+    if (
+      mostRecentRunId === runId &&
+      pipettesWithTip.length !== 0 &&
+      specs != null
+    ) {
       handleTipsAttachedModal(
         mount,
         specs,


### PR DESCRIPTION
Closes RQA-2123 and RQA-2122

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We actually do want to close the current run as we were before, as this logic is used elsewhere in the app. This PR adds back this logic and only shows the drop tip banner if the most recent run is equal to the runId passed into the run details page. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Test drop tip flows work. 
- Cancelling a run should allow you to perform actions from the devices page overflow menu such as homing the gantry or restarting the robot (these are no longer disabled). 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->


# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
