### PR TITLE
chore(robot-server): Make Opentrons-Version header friendlier for Postman

### DIFF
--- a/robot-server/robot_server/versioning.py
+++ b/robot-server/robot_server/versioning.py
@@ -56,7 +56,7 @@ class OutdatedApiVersionResponse(ErrorDetails):
 async def check_version_header(
     request: Request,
     response: Response,
-    opentrons_version: Union[int, Literal["*"]] = Header(
+    opentrons_version: Union[Literal["*"], int] = Header(
         ...,
         description=(
             "The HTTP API version to use for this request. Must be "


### PR DESCRIPTION
# Overview

This is a tiny thing to make it easier to develop on robot-server.

Most of our HTTP endpoints require an `Opentrons-Version` header, whose value must either be an integer like `2`, or the special "latest version" value `*`.

Currently, when you import our OpenAPI spec into Postman, it auto-fills the header value with the placeholder string `<integer>`.

<img width="1073" alt="Screenshot 2023-12-16 at 2 03 31 AM" src="https://github.com/Opentrons/opentrons/assets/3236864/8734515f-5ef7-42be-944e-b69b14c57c8a">

This is annoying because, for each endpoint, you need to manually replace `<integer>` with a real value, like `*`. If you leave it as `<integer>`, the server will reject the request.

This turns out to be easy to fix by reordering the types in our OpenAPI spec. If we put the `*` first, Postman will use that as the placeholder.

<img width="1075" alt="Screenshot 2023-12-16 at 2 04 50 AM" src="https://github.com/Opentrons/opentrons/assets/3236864/02e45fdc-b3e1-4728-8fbd-0b07a5d10ca3">

# Test Plan

Just make sure all CI checks keep passing.

# Risk assessment

Low.
