### PR TITLE
feat(api): raise error if tip tracking is not available for current nozzle configuration

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -681,6 +681,28 @@ class InstrumentCore(AbstractInstrument[WellCore]):
             self._pipette_id
         )
 
+    def is_tip_tracking_available(self) -> bool:
+        primary_nozzle = self._engine_client.state.pipettes.get_primary_nozzle(
+            self._pipette_id
+        )
+        if self.get_nozzle_configuration() == NozzleConfigurationType.FULL:
+            return True
+        else:
+            if self.get_channels() == 96:
+                # SINGLE configuration with H12 nozzle is technically supported by the
+                # current tip tracking implementation but we don't do any deck conflict
+                # checks for it, so we won't provide full support for it yet.
+                return (
+                    self.get_nozzle_configuration() == NozzleConfigurationType.COLUMN
+                    and primary_nozzle == "A12"
+                )
+            if self.get_channels() == 8:
+                return (
+                    self.get_nozzle_configuration() == NozzleConfigurationType.SINGLE
+                    and primary_nozzle == "H1"
+                )
+        return False
+
     def set_flow_rate(
         self,
         aspirate: Optional[float] = None,

--- a/api/src/opentrons/protocol_api/core/instrument.py
+++ b/api/src/opentrons/protocol_api/core/instrument.py
@@ -274,5 +274,9 @@ class AbstractInstrument(ABC, Generic[WellCoreType]):
         """
         ...
 
+    def is_tip_tracking_available(self) -> bool:
+        """Return whether auto tip tracking is available for the pipette's current nozzle configuration."""
+        ...
+
 
 InstrumentCoreType = TypeVar("InstrumentCoreType", bound=AbstractInstrument[Any])

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_instrument_core.py
@@ -547,3 +547,7 @@ class LegacyInstrumentCore(AbstractInstrument[LegacyWellCore]):
     def get_active_channels(self) -> int:
         """This will never be called because it was added in API 2.16."""
         assert False, "get_active_channels only supported in API 2.16 & later"
+
+    def is_tip_tracking_available(self) -> bool:
+        # Tip tracking is always available in legacy context
+        return True

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_instrument_core.py
@@ -465,3 +465,7 @@ class LegacyInstrumentCoreSimulator(AbstractInstrument[LegacyWellCore]):
     def get_active_channels(self) -> int:
         """This will never be called because it was added in API 2.16."""
         assert False, "get_active_channels only supported in API 2.16 & later"
+
+    def is_tip_tracking_available(self) -> bool:
+        # Tip tracking is always available in legacy context
+        return True


### PR DESCRIPTION
Closes RSS-426

# Overview

Raises error when `pick_up_tip` is called without a location when using pipette nozzle configurations that aren't supported in 7.1.0. See ticket for more deets.

# Test Plan

Test protocol:

```
from opentrons.protocol_api import COLUMN, ALL
from opentrons.protocol_api._nozzle_layout import NozzleLayout


requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16"
}

def run(protocol_context):
	trash_labware = protocol_context.load_labware("opentrons_1_trash_3200ml_fixed", "A3")

	tip_rack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C3")
	tip_rack2 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "D2", adapter="opentrons_flex_96_tiprack_adapter")
	tip_rack3 = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "B3", adapter="opentrons_flex_96_tiprack_adapter")

	instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack3, tip_rack2, tip_rack1])
	instrument.trash_container = trash_labware

	instrument.pick_up_tip()
	instrument.drop_tip()

	instrument.configure_nozzle_layout(style=COLUMN, start="A1")
	instrument.tip_racks = [tip_rack1]

	# Should raise error 
	instrument.pick_up_tip()

	instrument.configure_nozzle_layout(style=NozzleLayout.SINGLE, start="A12")
	instrument.tip_racks = [tip_rack1]

	# Should raise error 
	instrument.pick_up_tip()

	instrument.configure_nozzle_layout(style=NozzleLayout.ROW, start="H1")
	instrument.tip_racks = [tip_rack1]

	# Should raise error 
	instrument.pick_up_tip()

	instrument.configure_nozzle_layout(style=COLUMN, start="A12")
	instrument.tip_racks = [tip_rack1]
	
	# Should pick tips up column-wise from tiprack1
	for _ in range(12):
		instrument.pick_up_tip()
		instrument.drop_tip()

	######### CHANGE CONFIG TO ALL #########
	instrument.configure_nozzle_layout(style=ALL, tip_racks=[tip_rack2])
	instrument.pick_up_tip()
	instrument.drop_tip()
```

# Changelog

- added a new `is_tip_tracking_available()` method to instrument core
- made `pick_up_tip` to check if tip tracking is available when no pickup location is passed else raise error

# Review requests

- test the above protocol on a robot
- I don't think we need to update anything in `return_tip()` since it uses the tiprack/tip state to determine location to return tips to. But let me know if I'm wrong

# Risk assessment

Medium. Impacts auto-tip-pickups
