### PR TITLE
feat(app): add gradient scrim to ODD protocol command list

### DIFF
--- a/app/src/pages/OnDeviceDisplay/RunningProtocol.tsx
+++ b/app/src/pages/OnDeviceDisplay/RunningProtocol.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useParams } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { useSelector } from 'react-redux'
 
 import {
@@ -12,6 +12,8 @@ import {
   JUSTIFY_CENTER,
   OVERFLOW_HIDDEN,
   POSITION_RELATIVE,
+  POSITION_ABSOLUTE,
+  ALIGN_FLEX_END,
   SPACING,
   useSwipe,
 } from '@opentrons/components'
@@ -216,18 +218,33 @@ export function RunningProtocol(): JSX.Element {
                 }
               />
             ) : (
-              <RunningProtocolCommandList
-                protocolName={protocolName}
-                runStatus={runStatus}
-                robotType={robotType}
-                playRun={playRun}
-                pauseRun={pauseRun}
-                setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
-                trackProtocolRunEvent={trackProtocolRunEvent}
-                robotAnalyticsData={robotAnalyticsData}
-                currentRunCommandIndex={currentRunCommandIndex}
-                robotSideAnalysis={robotSideAnalysis}
-              />
+              <>
+                <RunningProtocolCommandList
+                  protocolName={protocolName}
+                  runStatus={runStatus}
+                  robotType={robotType}
+                  playRun={playRun}
+                  pauseRun={pauseRun}
+                  setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
+                  trackProtocolRunEvent={trackProtocolRunEvent}
+                  robotAnalyticsData={robotAnalyticsData}
+                  currentRunCommandIndex={currentRunCommandIndex}
+                  robotSideAnalysis={robotSideAnalysis}
+                />
+                <Flex
+                  css={css`
+                    background: linear-gradient(
+                      rgba(255, 0, 0, 0) 85%,
+                      #ffffff
+                    );
+                  `}
+                  position={POSITION_ABSOLUTE}
+                  height="324px"
+                  width="944px"
+                  marginTop="148px"
+                  alignSelf={ALIGN_FLEX_END}
+                />
+              </>
             )
           ) : (
             <RunningProtocolSkeleton currentOption={currentOption} />

--- a/app/src/pages/OnDeviceDisplay/RunningProtocol.tsx
+++ b/app/src/pages/OnDeviceDisplay/RunningProtocol.tsx
@@ -239,9 +239,9 @@ export function RunningProtocol(): JSX.Element {
                     );
                   `}
                   position={POSITION_ABSOLUTE}
-                  height="324px"
-                  width="944px"
-                  marginTop="148px"
+                  height="20.25rem"
+                  width="59rem"
+                  marginTop="9.25rem"
                   alignSelf={ALIGN_FLEX_END}
                 />
               </>


### PR DESCRIPTION
closes [RQA-1630](https://opentrons.atlassian.net/browse/RQA-1630)

# Overview

To indicate that the RunningProtocolCommandList on ODD is not scrollable, designs specify a gradient scrim at the bottom of the list. Here, I add a sibling component that occupies that same space as the command list and provides this gradient scrim.

# Test Plan

on physical ODD:
- verify that scrim is present at the bottom of the command list and does not affect functionality of buttons.

<img width="1025" alt="Screen Shot 2023-12-18 at 12 13 09 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/8256b41e-f944-46d5-87d0-1ca9eeb514cb">

# Changelog

- add placeholder Flex to provide scrim at bottom of running protocol command list

# Risk assessment

low

[RQA-1630]: https://opentrons.atlassian.net/browse/RQA-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ