### PR TITLE
fix(app): Don't render ProtocolRunHeader TerminalBanner on CurrentRun

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -364,7 +364,7 @@ export function ProtocolRunHeader({
         CANCELLABLE_STATUSES.includes(runStatus) ? (
           <Banner type="warning">{t('shared:close_robot_door')}</Banner>
         ) : null}
-        {isRunCurrent ? (
+        {mostRecentRunId === runId ? (
           <TerminalRunBanner
             {...{
               runStatus,
@@ -455,7 +455,7 @@ export function ProtocolRunHeader({
         ) : null}
         {showDropTipWizard &&
         pipettesWithTip[0]?.specs != null &&
-        isRunCurrent ? (
+        mostRecentRunId === runId ? (
           <DropTipWizard
             robotType={isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE}
             mount={pipettesWithTip[0].mount}

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -1054,26 +1054,4 @@ describe('ProtocolRunHeader', () => {
       expect(queryByText('Tips may be attached.')).not.toBeInTheDocument()
     })
   })
-
-  it('does not show the drop tip banner when the run is not over', async () => {
-    when(mockUseRunQuery)
-      .calledWith(RUN_ID)
-      .mockReturnValue({
-        data: {
-          data: {
-            ...mockIdleUnstartedRun,
-            current: false,
-            status: RUN_STATUS_SUCCEEDED,
-          },
-        },
-      } as UseQueryResult<Run>)
-    when(mockUseRunStatus)
-      .calledWith(RUN_ID)
-      .mockReturnValue(RUN_STATUS_SUCCEEDED)
-
-    const [{ queryByText }] = render()
-    await waitFor(() => {
-      expect(queryByText('Tips may be attached.')).not.toBeInTheDocument()
-    })
-  })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/useMostRecentRunId.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/useMostRecentRunId.test.tsx
@@ -33,4 +33,13 @@ describe('useMostRecentRunId hook', () => {
 
     expect(result.current).toBeNull()
   })
+  it('should return null if no run data exists', async () => {
+    when(mockUseAllRunsQuery)
+      .calledWith()
+      .mockReturnValue({ data: { data: null } } as any)
+
+    const { result } = renderHook(useMostRecentRunId)
+
+    expect(result.current).toBeNull()
+  })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/useMostRecentRunId.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useMostRecentRunId.ts
@@ -1,8 +1,9 @@
 import { useAllRunsQuery } from '@opentrons/react-api-client'
+import { last } from 'lodash'
 
 export function useMostRecentRunId(): string | null {
   const { data: allRuns } = useAllRunsQuery()
-  return allRuns != null && allRuns.data.length > 0
-    ? allRuns.data[allRuns.data.length - 1].id
+  return allRuns != null && allRuns.data?.length > 0
+    ? last(allRuns.data)?.id ?? null
     : null
 }

--- a/app/src/organisms/ProtocolUpload/hooks/useMostRecentRunId.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useMostRecentRunId.ts
@@ -1,5 +1,5 @@
 import { useAllRunsQuery } from '@opentrons/react-api-client'
-import { last } from 'lodash'
+import last from 'lodash/last'
 
 export function useMostRecentRunId(): string | null {
   const { data: allRuns } = useAllRunsQuery()


### PR DESCRIPTION
Closes RQA-2013

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an issue where opening the error banner would de-render the error banner. Instead of conditionally rendering the error banner on whether a run is current, let's follow the new pattern we use for the drop tip banner: render it if the mostRecentRunId is the currently viewed run. 

Addresses the same issue for clicking on "remove tips" within the drop tip banner - the wizard would never properly start after viewing the error message (since it clears the run). 

PR includes some refactoring for the getMostRecentRunId hook to make it a bit safer.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/7f0d985f-104b-49a8-b518-6a8f4f414d36

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/a8220c11-940d-4764-a185-c75760581491

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Follow video: Throw an error during a run, then confirm that the error banner/drop tip banner persists after opening the error modal.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a bug in which viewing the error modal in a protocol run unrenders the drop tip banner.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
