### PR TITLE
feat(protocol-engine): Allow moving to addressable areas without descending

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -54,6 +54,14 @@ class MoveToAddressableAreaParams(PipetteIdMixin, MovementMixin):
         AddressableOffsetVector(x=0, y=0, z=0),
         description="Relative offset of addressable area to move pipette's critical point.",
     )
+    stayAtHighestPossibleZ: bool = Field(
+        False,
+        description=(
+            "If `true`, the pipette will retract to its highest possible height"
+            " and stay there instead of descending to the destination."
+            " `minimumZHeight` and the z-coordinate of `offset` will be ignored."
+        ),
+    )
 
 
 class MoveToAddressableAreaResult(DestinationPositionResult):
@@ -93,6 +101,7 @@ class MoveToAddressableAreaImplementation(
             force_direct=params.forceDirect,
             minimum_z_height=params.minimumZHeight,
             speed=params.speed,
+            stay_at_highest_possible_z=params.stayAtHighestPossibleZ,
         )
 
         return MoveToAddressableAreaResult(position=DeckPoint(x=x, y=y, z=z))

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -59,7 +59,7 @@ class MoveToAddressableAreaParams(PipetteIdMixin, MovementMixin):
         description=(
             "If `true`, the pipette will retract to its highest possible height"
             " and stay there instead of descending to the destination."
-            " `minimumZHeight` and the z-coordinate of `offset` will be ignored."
+            " `minimumZHeight` will be ignored."
         ),
     )
 

--- a/api/src/opentrons/protocol_engine/execution/movement.py
+++ b/api/src/opentrons/protocol_engine/execution/movement.py
@@ -146,6 +146,7 @@ class MovementHandler:
         force_direct: bool = False,
         minimum_z_height: Optional[float] = None,
         speed: Optional[float] = None,
+        stay_at_highest_possible_z: bool = False,
     ) -> Point:
         """Move to a specific addressable area."""
         # Check for presence of heater shakers on deck, and if planned
@@ -191,6 +192,7 @@ class MovementHandler:
             max_travel_z=max_travel_z,
             force_direct=force_direct,
             minimum_z_height=minimum_z_height,
+            stay_at_max_travel_z=stay_at_highest_possible_z,
         )
 
         speed = self._state_store.pipettes.get_movement_speed(

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -163,15 +163,19 @@ class MotionView:
                 addressable_area_name
             )
         )
-        destination = base_destination + Point(x=offset.x, y=offset.y, z=offset.z)
         if stay_at_max_travel_z:
-            destination = Point(
-                destination.x,
-                destination.y,
+            base_destination_at_max_z = Point(
+                base_destination.x,
+                base_destination.y,
                 # FIX BEFORE MERGE: Explain this hack.
                 # Possibly related: https://github.com/Opentrons/opentrons/pull/6882#discussion_r514248062
                 max_travel_z - _STAY_AT_MAX_TRAVEL_Z_MARGIN,
             )
+            destination = base_destination_at_max_z + Point(
+                offset.x, offset.y, offset.z
+            )
+        else:
+            destination = base_destination + Point(offset.x, offset.y, offset.z)
 
         # TODO(jbl 11-28-2023) This may need to change for partial tip configurations on a 96
         destination_cp = CriticalPoint.XY_CENTER

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -28,10 +28,6 @@ from .modules import ModuleView
 from .module_substates import HeaterShakerModuleId
 
 
-_STAY_AT_MAX_TRAVEL_Z_MARGIN = 10
-assert _STAY_AT_MAX_TRAVEL_Z_MARGIN > motion_planning.waypoints.MINIMUM_Z_MARGIN
-
-
 @dataclass(frozen=True)
 class PipetteLocationData:
     """Pipette data used to determine the current gantry position."""
@@ -167,9 +163,12 @@ class MotionView:
             base_destination_at_max_z = Point(
                 base_destination.x,
                 base_destination.y,
-                # FIX BEFORE MERGE: Explain this hack.
+                # HACK(mm, 2023-12-18): We want to travel exactly at max_travel_z, but
+                # motion_planning.get_waypoints() won't let us--the highest we can go is this margin
+                # beneath max_travel_z. Investigate why motion_planning.get_waypoints() does not
+                # let us travel at max_travel_z, and whether it's safe to make it do that.
                 # Possibly related: https://github.com/Opentrons/opentrons/pull/6882#discussion_r514248062
-                max_travel_z - _STAY_AT_MAX_TRAVEL_Z_MARGIN,
+                max_travel_z - motion_planning.waypoints.MINIMUM_Z_MARGIN,
             )
             destination = base_destination_at_max_z + Point(
                 offset.x, offset.y, offset.z

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -30,6 +30,7 @@ async def test_move_to_addressable_area_implementation(
         forceDirect=True,
         minimumZHeight=4.56,
         speed=7.89,
+        stayAtHighestPossibleZ=True,
     )
 
     decoy.when(
@@ -40,6 +41,7 @@ async def test_move_to_addressable_area_implementation(
             force_direct=True,
             minimum_z_height=4.56,
             speed=7.89,
+            stay_at_highest_possible_z=True,
         )
     ).then_return(Point(x=9, y=8, z=7))
 

--- a/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_movement_handler.py
@@ -353,6 +353,7 @@ async def test_move_to_addressable_area(
             max_travel_z=42.0,
             force_direct=True,
             minimum_z_height=12.3,
+            stay_at_max_travel_z=True,
         )
     ).then_return(
         [Waypoint(Point(1, 2, 3), CriticalPoint.XY_CENTER), Waypoint(Point(4, 5, 6))]
@@ -376,6 +377,7 @@ async def test_move_to_addressable_area(
         force_direct=True,
         minimum_z_height=12.3,
         speed=45.6,
+        stay_at_highest_possible_z=True,
     )
 
     assert result == Point(x=4, y=5, z=6)

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -378,7 +378,6 @@ export const DropTipWizardComponent = (
                 commandType: 'moveToAddressableArea',
                 params: {
                   pipetteId: MANAGED_PIPETTE_ID,
-                  stayAtHighestPossibleZ: true,
                   addressableAreaName: addressableAreaFromConfig,
                   offset: { x: 0, y: 0, z: zOffset },
                 },

--- a/app/src/organisms/DropTipWizard/index.tsx
+++ b/app/src/organisms/DropTipWizard/index.tsx
@@ -378,6 +378,7 @@ export const DropTipWizardComponent = (
                 commandType: 'moveToAddressableArea',
                 params: {
                   pipetteId: MANAGED_PIPETTE_ID,
+                  stayAtHighestPossibleZ: true,
                   addressableAreaName: addressableAreaFromConfig,
                   offset: { x: 0, y: 0, z: zOffset },
                 },

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -1965,6 +1965,12 @@
               "$ref": "#/definitions/AddressableOffsetVector"
             }
           ]
+        },
+        "stayAtHighestPossibleZ": {
+          "title": "Stayathighestpossiblez",
+          "description": "If `true`, the pipette will retract to its highest possible height and stay there instead of descending to the destination. `minimumZHeight` will be ignored.",
+          "default": false,
+          "type": "boolean"
         }
       },
       "required": ["pipetteId", "addressableAreaName"]

--- a/shared-data/command/types/gantry.ts
+++ b/shared-data/command/types/gantry.ts
@@ -180,4 +180,5 @@ export interface MoveToAddressableAreaParams {
   speed?: number
   minimumZHeight?: number
   forceDirect?: boolean
+  stayAtHighestPossibleZ?: boolean
 }

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -69,6 +69,7 @@ class Params(BaseModel):
     # schema v8 add-ons
     addressableAreaName: Optional[str]
     configurationParams: Optional[NozzleConfigurationParams]
+    stayAtHighestPossibleZ: Optional[bool]
 
 
 class Command(BaseModel):


### PR DESCRIPTION
# Overview

Goes towards RQA-2129, with the app half to be done separately. Closes RSS-427.

# Test Plan

I've tested this by using the HTTP API to run `moveToAddressableArea` commands with various `addressableAreaName`s and `offset`s.

# Changelog

* Implement a new parameter, `stayAtHighestPossibleZ`, in the Protocol Engine `moveToAddressableArea` command.

# Review requests

None in particular.

# Risk assessment

Low.