### PR TITLE
fix(app): add new text to updatebanner for module card

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -88,6 +88,7 @@
   "missing_module": "missing {{num}} module",
   "module_actions_unavailable": "Module actions unavailable while protocol is running",
   "module_calibration_required_no_pipette_attached": "Module calibration required. Attach a pipette before running module calibration.",
+  "module_calibration_required_no_pipette_calibrated": "Module calibration required. Calibrate pipette before running module calibration. ",
   "module_calibration_required_update_pipette_FW": "Update pipette firmware before proceeding with required module calibration.",
   "module_calibration_required": "Module calibration required.",
   "module_controls": "Module Controls",

--- a/app/src/molecules/UpdateBanner/__tests__/UpdateBanner.test.tsx
+++ b/app/src/molecules/UpdateBanner/__tests__/UpdateBanner.test.tsx
@@ -85,6 +85,14 @@ describe('Module Update Banner', () => {
     const { queryByText } = render(props)
     expect(queryByText('Calibrate now')).not.toBeInTheDocument()
   })
+  it('should not render a calibrate link if pipette calibration is required', () => {
+    props = {
+      ...props,
+      calibratePipetteRequired: true,
+    }
+    const { queryByText } = render(props)
+    expect(queryByText('Calibrate now')).not.toBeInTheDocument()
+  })
   it('should not render a calibrate link if pipette firmware update is required', () => {
     props = {
       ...props,
@@ -98,6 +106,7 @@ describe('Module Update Banner', () => {
       ...props,
       updateType: 'firmware',
       attachPipetteRequired: true,
+      calibratePipetteRequired: true,
       updatePipetteFWRequired: true,
     }
     const { queryByText } = render(props)

--- a/app/src/molecules/UpdateBanner/index.tsx
+++ b/app/src/molecules/UpdateBanner/index.tsx
@@ -56,7 +56,10 @@ export const UpdateBanner = ({
       bannerMessage = t('module_calibration_required_update_pipette_FW')
     else bannerMessage = t('module_calibration_required')
     hyperlinkText =
-      !attachPipetteRequired && !updatePipetteFWRequired && !isTooHot
+      !attachPipetteRequired &&
+      !updatePipetteFWRequired &&
+      !isTooHot &&
+      !calibratePipetteRequired
         ? t('calibrate_now')
         : ''
   } else {

--- a/app/src/molecules/UpdateBanner/index.tsx
+++ b/app/src/molecules/UpdateBanner/index.tsx
@@ -23,6 +23,7 @@ interface UpdateBannerProps {
   serialNumber: string
   isTooHot?: boolean
   attachPipetteRequired?: boolean
+  calibratePipetteRequired?: boolean
   updatePipetteFWRequired?: boolean
 }
 
@@ -33,6 +34,7 @@ export const UpdateBanner = ({
   setShowBanner,
   handleUpdateClick,
   attachPipetteRequired,
+  calibratePipetteRequired,
   updatePipetteFWRequired,
   isTooHot,
 }: UpdateBannerProps): JSX.Element | null => {
@@ -48,6 +50,8 @@ export const UpdateBanner = ({
     closeButtonRendered = false
     if (attachPipetteRequired)
       bannerMessage = t('module_calibration_required_no_pipette_attached')
+    else if (calibratePipetteRequired)
+      bannerMessage = t('module_calibration_required_no_pipette_calibrated')
     else if (updatePipetteFWRequired)
       bannerMessage = t('module_calibration_required_update_pipette_FW')
     else bannerMessage = t('module_calibration_required')

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -105,6 +105,8 @@ export function InstrumentsAndModules({
     attachedPipettes?.left ?? null
   )
   const attachPipetteRequired =
+    attachedLeftPipette == null && attachedRightPipette == null
+  const calibratePipetteRequired =
     attachedLeftPipette?.data?.calibratedOffset?.last_modified == null &&
     attachedRightPipette?.data?.calibratedOffset?.last_modified == null
   const updatePipetteFWRequired =
@@ -240,6 +242,7 @@ export function InstrumentsAndModules({
                   module={module}
                   isLoadedInRun={false}
                   attachPipetteRequired={attachPipetteRequired}
+                  calibratePipetteRequired={calibratePipetteRequired}
                   updatePipetteFWRequired={updatePipetteFWRequired}
                 />
               ))}
@@ -281,6 +284,7 @@ export function InstrumentsAndModules({
                   module={module}
                   isLoadedInRun={false}
                   attachPipetteRequired={attachPipetteRequired}
+                  calibratePipetteRequired={calibratePipetteRequired}
                   updatePipetteFWRequired={updatePipetteFWRequired}
                 />
               ))}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -15,6 +15,7 @@ import type { BadPipette, PipetteData } from '@opentrons/api-client'
 
 interface PipetteStatus {
   attachPipetteRequired: boolean
+  calibratePipetteRequired: boolean
   updatePipetteFWRequired: boolean
 }
 
@@ -51,9 +52,16 @@ const usePipetteIsReady = (): PipetteStatus => {
 
   const attachPipetteRequired =
     attachedLeftPipette == null && attachedRightPipette == null
+  const calibratePipetteRequired =
+    attachedLeftPipette?.data.calibratedOffset?.last_modified == null &&
+    attachedRightPipette?.data.calibratedOffset?.last_modified == null
   const updatePipetteFWRequired =
     leftPipetteRequiresFWUpdate != null || rightPipetteFWRequired != null
-  return { attachPipetteRequired, updatePipetteFWRequired }
+  return {
+    attachPipetteRequired,
+    calibratePipetteRequired,
+    updatePipetteFWRequired,
+  }
 }
 
 interface ProtocolRunModuleControlsProps {
@@ -67,7 +75,11 @@ export const ProtocolRunModuleControls = ({
 }: ProtocolRunModuleControlsProps): JSX.Element => {
   const { t } = useTranslation('protocol_details')
 
-  const { attachPipetteRequired, updatePipetteFWRequired } = usePipetteIsReady()
+  const {
+    attachPipetteRequired,
+    calibratePipetteRequired,
+    updatePipetteFWRequired,
+  } = usePipetteIsReady()
 
   const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
     runId
@@ -115,6 +127,7 @@ export const ProtocolRunModuleControls = ({
               slotName={module.slotName}
               isLoadedInRun={true}
               attachPipetteRequired={attachPipetteRequired}
+              calibratePipetteRequired={calibratePipetteRequired}
               updatePipetteFWRequired={updatePipetteFWRequired}
             />
           ) : null
@@ -135,6 +148,7 @@ export const ProtocolRunModuleControls = ({
               slotName={module.slotName}
               isLoadedInRun={true}
               attachPipetteRequired={attachPipetteRequired}
+              calibratePipetteRequired={calibratePipetteRequired}
               updatePipetteFWRequired={updatePipetteFWRequired}
             />
           ) : null

--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -227,6 +227,7 @@ describe('ModuleCard', () => {
       robotName: mockRobot.name,
       isLoadedInRun: false,
       attachPipetteRequired: false,
+      calibratePipetteRequired: false,
       updatePipetteFWRequired: false,
     }
 

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -79,6 +79,7 @@ interface ModuleCardProps {
   robotName: string
   isLoadedInRun: boolean
   attachPipetteRequired: boolean
+  calibratePipetteRequired: boolean
   updatePipetteFWRequired: boolean
   runId?: string
   slotName?: string
@@ -93,6 +94,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     runId,
     slotName,
     attachPipetteRequired,
+    calibratePipetteRequired,
     updatePipetteFWRequired,
   } = props
   const dispatch = useDispatch<Dispatch>()
@@ -125,7 +127,9 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   })
   const requireModuleCalibration = module.moduleOffset?.last_modified == null
   const isPipetteReady =
-    (!attachPipetteRequired ?? false) && (!updatePipetteFWRequired ?? false)
+    (!attachPipetteRequired ?? false) &&
+    (!calibratePipetteRequired ?? false) &&
+    (!updatePipetteFWRequired ?? false)
   const latestRequestId = last(requestIds)
   const latestRequest = useSelector<State, RequestState | null>(state =>
     latestRequestId ? getRequestById(state, latestRequestId) : null
@@ -303,6 +307,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
               />
             )}
             {attachPipetteRequired != null &&
+            calibratePipetteRequired != null &&
             updatePipetteFWRequired != null &&
             requireModuleCalibration &&
             !isPending ? (
@@ -313,6 +318,7 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
                 setShowBanner={() => null}
                 handleUpdateClick={handleCalibrateClick}
                 attachPipetteRequired={attachPipetteRequired}
+                calibratePipetteRequired={calibratePipetteRequired}
                 updatePipetteFWRequired={updatePipetteFWRequired}
                 isTooHot={isTooHot}
               />


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The design team added new text for the case required pipette calibration and module calibration.

[design]
https://www.figma.com/file/Nx7ORMnfyJNP4FQYxN4e5x/Primary%3A-Desktop-App?type=design&node-id=1766%3A165682&mode=design&t=opTVF3AR964bRuGd-1

require to attach a pipette
![Screenshot 2023-12-18 at 3 03 22 PM](https://github.com/Opentrons/opentrons/assets/474225/2746697f-4d33-4584-be47-da1b44486041)

require calibrating a pipette
![Screenshot 2023-12-18 at 3 34 45 PM](https://github.com/Opentrons/opentrons/assets/474225/25f81796-fd54-42ff-9cb8-b44b031651ac)


close RQA-2133
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
[require calibrating]
1. remove pipette calibration data and module calibration data
2. go to Device details page on Desktop app
Check the banner says required calibrating before running module calibration.

[require attaching]
1. detach all pipettes
2. go to Device details page on Desktop app
Check the banner says require attaching pipette before running module calibration.  
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add `calibratePipetteRequired` to check calibrated or not and update `attachPipetteRequired`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
