### PR TITLE
feat(app): add loading state to ODD protocol list

### DIFF
--- a/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
@@ -15,6 +15,7 @@ import {
   DIRECTION_ROW,
   Flex,
   Icon,
+  SIZE_2,
   SPACING,
   TYPOGRAPHY,
   useLongPress,
@@ -34,6 +35,8 @@ import { formatTimeWithUtcLabel } from '../../resources/runs/utils'
 import type { UseLongPressResult } from '@opentrons/components'
 import type { ProtocolResource } from '@opentrons/shared-data'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
+
+const REFETCH_INTERVAL = 5000
 
 export function ProtocolCard(props: {
   protocol: ProtocolResource
@@ -61,21 +64,24 @@ export function ProtocolCard(props: {
   const queryClient = useQueryClient()
   const host = useHost()
 
-  const {
-    data: mostRecentAnalysis,
-  } = useProtocolAnalysisAsDocumentQuery(
+  const { data: mostRecentAnalysis } = useProtocolAnalysisAsDocumentQuery(
     protocol.id,
     last(protocol.analysisSummaries)?.id ?? null,
-    { enabled: protocol != null }
+    {
+      enabled: protocol != null,
+      refetchInterval: analysisData =>
+        analysisData == null ? REFETCH_INTERVAL : false,
+    }
   )
 
   const isFailedAnalysis =
-    (mostRecentAnalysis == null ||
-      (mostRecentAnalysis != null &&
-        'result' in mostRecentAnalysis &&
-        (mostRecentAnalysis.result === 'error' ||
-          mostRecentAnalysis.result === 'not-ok'))) ??
+    (mostRecentAnalysis != null &&
+      'result' in mostRecentAnalysis &&
+      (mostRecentAnalysis.result === 'error' ||
+        mostRecentAnalysis.result === 'not-ok')) ??
     false
+
+  const isPendingAnalysis = mostRecentAnalysis == null
 
   const handleProtocolClick = (
     longpress: UseLongPressResult,
@@ -157,6 +163,15 @@ export function ProtocolCard(props: {
       ref={longpress.ref}
       css={PUSHED_STATE_STYLE}
     >
+      {isPendingAnalysis ? (
+        <Icon
+          name="ot-spinner"
+          spin
+          size={SIZE_2}
+          marginY={'-1.5rem'}
+          opacity={0.7}
+        />
+      ) : null}
       <Flex
         width="28.9375rem"
         overflowWrap="anywhere"
@@ -179,7 +194,11 @@ export function ProtocolCard(props: {
             </StyledText>
           </Flex>
         ) : null}
-        <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+        <StyledText
+          as="p"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          opacity={isPendingAnalysis ? 0.7 : 1}
+        >
           {protocolName}
         </StyledText>
       </Flex>

--- a/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ProtocolDashboard/ProtocolCard.tsx
@@ -166,6 +166,7 @@ export function ProtocolCard(props: {
       {isPendingAnalysis ? (
         <Icon
           name="ot-spinner"
+          aria-label="Protocol is loading"
           spin
           size={SIZE_2}
           marginY={'-1.5rem'}

--- a/app/src/pages/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { UseQueryResult } from 'react-query'
 import { useProtocolAnalysisAsDocumentQuery } from '@opentrons/react-api-client'
@@ -126,22 +126,16 @@ describe('ProtocolCard', () => {
     getByText('Delete protocol')
   })
 
-  it('should display the analysis failed error modal when clicking on the protocol when doing a long pressing - undefined case', async () => {
+  it('should display a loading spinner when analysis is pending', async () => {
     mockUseProtocolAnalysisAsDocumentQuery.mockReturnValue({
-      data: undefined as any,
+      data: null as any,
     } as UseQueryResult<CompletedProtocolAnalysis>)
-    const [{ getByText, getByLabelText }] = render()
-    const name = getByText('yay mock protocol')
+    render()
+    const name = screen.getByText('yay mock protocol')
     fireEvent.mouseDown(name)
     jest.advanceTimersByTime(1005)
     expect(props.longPress).toHaveBeenCalled()
-    getByLabelText('failedAnalysis_icon')
-    getByText('Failed analysis')
-    getByText('yay mock protocol').click()
-    getByText('Protocol analysis failed')
-    getByText(
-      'Delete the protocol, make changes to address the error, and resend the protocol to this robot from the Opentrons App.'
-    )
-    getByText('Delete protocol')
+    screen.getByLabelText('Protocol is loading')
+    screen.getByText('yay mock protocol').click()
   })
 })


### PR DESCRIPTION
# Overview

This PR adds a loading state to the protocols list page when there is a pending analysis. This fixes a bug where we were eagerly showing an error state before a protocol finished analyzing. 

closes RQA-2137

<img width="1007" alt="Screenshot 2023-12-18 at 3 19 12 PM" src="https://github.com/Opentrons/opentrons/assets/5788529/8caae5ff-d8b0-4b2d-8f35-c73905dbbda4">



# Risk assessment

Low