### PR TITLE
fix(protocol-designer): slot conflict logic fix for stagingAreaModal

### DIFF
--- a/protocol-designer/src/components/modules/StagingAreasModal.tsx
+++ b/protocol-designer/src/components/modules/StagingAreasModal.tsx
@@ -44,17 +44,19 @@ const StagingAreasModalComponent = (
   const { onCloseClick, stagingAreas } = props
   const { values, setFieldValue } = useFormikContext<StagingAreasValues>()
   const initialDeckSetup = useSelector(getInitialDeckSetup)
-  const areSlotsEmpty = values.selectedSlots.map(slot =>
-    getSlotIsEmpty(initialDeckSetup, slot)
-  )
   const hasWasteChute =
     Object.values(initialDeckSetup.additionalEquipmentOnDeck).find(
       aE => aE.name === 'wasteChute'
     ) != null
-  const hasConflictedSlot =
-    hasWasteChute && values.selectedSlots.find(slot => slot === 'cutoutD3')
-      ? false
-      : areSlotsEmpty.includes(false)
+  const areSlotsEmpty = values.selectedSlots.map(slot => {
+    if (slot === 'cutoutD3' && hasWasteChute) {
+      return true
+    } else {
+      return getSlotIsEmpty(initialDeckSetup, slot)
+    }
+  })
+
+  const hasConflictedSlot = areSlotsEmpty.includes(false)
 
   const mappedStagingAreas: DeckConfiguration = stagingAreas.flatMap(area => {
     return area.location != null


### PR DESCRIPTION
closes RQA-2146

# Overview

the staging area modal was incorrectly not showing the slot conflict banner when the slot was full.

# Test Plan

Create a flex protocol and add the waste chute then go through and add the staging area slots in the edit additional items section. See the ticket for details. Make sure the conflict slot banner correctly appears when adding the staging area in A3 with the trash bin.

# Changelog

fix logic to filter out the waste chute slot earlier

# Review requests

see test plan

# Risk assessment

low