### PR TITLE
fix(protocol-designer): remove expansionSlot from staging area deck maps

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/StagingAreaTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/StagingAreaTile.tsx
@@ -120,6 +120,7 @@ export function StagingAreaTile(props: WizardTileProps): JSX.Element | null {
             deckConfig={updatedSlots}
             handleClickAdd={handleClickAdd}
             handleClickRemove={handleClickRemove}
+            showExpansion={false}
           />
         </Flex>
         <Flex

--- a/protocol-designer/src/components/modules/StagingAreasModal.tsx
+++ b/protocol-designer/src/components/modules/StagingAreasModal.tsx
@@ -122,7 +122,7 @@ const StagingAreasModalComponent = (
 
   return (
     <Form>
-      <Flex height="20rem" flexDirection={DIRECTION_COLUMN}>
+      <Flex height="23rem" flexDirection={DIRECTION_COLUMN}>
         <Flex
           justifyContent={JUSTIFY_END}
           alignItems={ALIGN_CENTER}
@@ -145,12 +145,12 @@ const StagingAreasModalComponent = (
           deckConfig={updatedSlots}
           handleClickAdd={handleClickAdd}
           handleClickRemove={handleClickRemove}
+          showExpansion={false}
         />
       </Flex>
       <Flex
         flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_FLEX_END}
-        paddingTop="4rem"
         paddingRight={SPACING.spacing32}
         paddingBottom={SPACING.spacing32}
         gridGap={SPACING.spacing8}


### PR DESCRIPTION
closes RQA-2147

# Overview

The ticket mentions that the staging area modal deck maps show the expansion slots but the module maps don't. So i removed showing the expansion slots to make it consistent. I also made the size of the staging area slot modal deck map bigger.

# Test Plan

See that in create file wizard and editing the staging area slots, the deck maps don't show the expansion slots.

# Changelog

- specify expansion slot boolean as false
- adjust size of deck map

# Review requests

see test plan

# Risk assessment

low