### PR TITLE
fix(protocol-designer): edit pipettes fixes with 96-channel

### DIFF
--- a/components/src/instrument/InstrumentGroup.tsx
+++ b/components/src/instrument/InstrumentGroup.tsx
@@ -29,7 +29,9 @@ export function InstrumentGroup(props: InstrumentGroupProps): JSX.Element {
   return (
     <section className={styles.pipette_group}>
       <InstrumentInfo {...leftProps} showMountLabel={showMountLabel} />
-      <InstrumentInfo {...rightProps} showMountLabel={showMountLabel} />
+      {leftProps.pipetteSpecs?.channels === 96 ? null : (
+        <InstrumentInfo {...rightProps} showMountLabel={showMountLabel} />
+      )}
     </section>
   )
 }

--- a/components/src/instrument/InstrumentInfo.tsx
+++ b/components/src/instrument/InstrumentInfo.tsx
@@ -33,6 +33,7 @@ export interface InstrumentInfoProps {
 }
 
 export function InstrumentInfo(props: InstrumentInfoProps): JSX.Element {
+  const has96Channel = props.pipetteSpecs?.channels === 96
   return (
     <Flex justifyContent={JUSTIFY_CENTER} gridGap={SPACING.spacing16}>
       {props.mount === RIGHT && props.pipetteSpecs && (
@@ -42,15 +43,21 @@ export function InstrumentInfo(props: InstrumentInfoProps): JSX.Element {
           mount={props.mount}
         />
       )}
+
       <Flex flexDirection={DIRECTION_COLUMN}>
         <InfoItem
-          title={props.showMountLabel ? `${props.mount} pipette` : 'pipette'}
+          title={
+            props.showMountLabel && !has96Channel
+              ? `${props.mount} pipette`
+              : 'pipette'
+          }
           value={props.description}
         />
         {props.tiprackModel && (
           <InfoItem title="tip rack" value={props.tiprackModel} />
         )}
       </Flex>
+
       {props.children}
       {props.mount === LEFT && props.pipetteSpecs && (
         <InstrumentDiagram

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -1357,7 +1357,7 @@
         "magneticBlockV1": { "x": 0, "y": 0, "z": 3.54 },
         "thermocyclerModuleV2": { "x": 0, "y": 0, "z": 10.7 }
       },
-      "gripForce": 9,
+      "gripForce": 15,
       "gripHeightFromLabwareBottom": 10,
       "ordering": [
         ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteDiagram.tsx
@@ -34,6 +34,7 @@ function PipetteGroup(props: Props): JSX.Element {
   const robotType = useSelector(getRobotType)
   const leftSpecs =
     leftPipette && getPipetteNameSpecs(leftPipette as PipetteName)
+  const has96Channel = leftPipette === 'p1000_96'
   const rightSpecs =
     rightPipette && getPipetteNameSpecs(rightPipette as PipetteName)
   return (
@@ -52,9 +53,14 @@ function PipetteGroup(props: Props): JSX.Element {
           }
         />
       ) : (
-        <div className={styles.left_pipette} />
+        <div
+          className={styles.left_pipette}
+          style={{
+            marginLeft: robotType === FLEX_ROBOT_TYPE ? '7rem' : '0rem',
+          }}
+        />
       )}
-      {rightPipette && rightSpecs ? (
+      {rightPipette && rightSpecs && !has96Channel ? (
         <InstrumentDiagram
           pipetteSpecs={rightSpecs}
           className={styles.right_pipette}
@@ -62,7 +68,7 @@ function PipetteGroup(props: Props): JSX.Element {
           imageStyle={
             robotType === FLEX_ROBOT_TYPE
               ? css`
-                  right: -1.5rem;
+                  right: -5rem;
                   position: absolute;
                 `
               : undefined

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -117,14 +117,14 @@ export function PipetteFields(props: Props): JSX.Element {
         pipetteName={pipetteName != null ? pipetteName : null}
         onPipetteChange={pipetteName => {
           const nameAccessor = `pipettesByMount.${mount}.pipetteName`
-          const value = pipetteName
+          const nameAccessorValue = pipetteName
           const targetToClear = `pipettesByMount.${mount}.tiprackDefURI`
           // this select does not return an event so we have to manually set the field val
-          onSetFieldValue(nameAccessor, value)
+          onSetFieldValue(nameAccessor, nameAccessorValue)
           onSetFieldValue(targetToClear, null)
           onSetFieldTouched(targetToClear, false)
         }}
-        disabled={mount === RIGHT && values.left.pipetteName === 'p1000_96'}
+        disabled={mount === RIGHT && has96Channel}
         id={`PipetteSelect_${mount}`}
         className={styles.pipette_select}
       />

--- a/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/PipetteFields.tsx
@@ -7,7 +7,6 @@ import {
   PipetteSelect,
   OutlineButton,
   Mount,
-  Flex,
 } from '@opentrons/components'
 import {
   getIncompatiblePipetteNames,
@@ -92,9 +91,10 @@ export function PipetteFields(props: Props): JSX.Element {
   const dispatch = useDispatch<ThunkDispatch<BaseState, any, any>>()
   const allLabware = useSelector(getLabwareDefsByURI)
   const initialTabIndex = props.initialTabIndex || 1
+  const has96Channel = values.left.pipetteName === 'p1000_96'
 
   React.useEffect(() => {
-    if (values.left.pipetteName === 'p1000_96') {
+    if (has96Channel) {
       values.right = { pipetteName: null, tiprackDefURI: null }
     }
   }, [values.left])
@@ -106,30 +106,28 @@ export function PipetteFields(props: Props): JSX.Element {
     const filter96 = mount === RIGHT ? ['p1000_96'] : []
 
     return (
-      <Flex width="13.8rem">
-        <PipetteSelect
-          nameBlocklist={
-            robotType === OT2_ROBOT_TYPE
-              ? OT3_PIPETTES
-              : [...OT2_PIPETTES, ...filter96]
-          }
-          enableNoneOption
-          tabIndex={tabIndex}
-          pipetteName={pipetteName != null ? pipetteName : null}
-          onPipetteChange={pipetteName => {
-            const nameAccessor = `pipettesByMount.${mount}.pipetteName`
-            const value = pipetteName
-            const targetToClear = `pipettesByMount.${mount}.tiprackDefURI`
-            // this select does not return an event so we have to manually set the field val
-            onSetFieldValue(nameAccessor, value)
-            onSetFieldValue(targetToClear, null)
-            onSetFieldTouched(targetToClear, false)
-          }}
-          disabled={mount === RIGHT && values.left.pipetteName === 'p1000_96'}
-          id={`PipetteSelect_${mount}`}
-          className={styles.pipette_select}
-        />
-      </Flex>
+      <PipetteSelect
+        nameBlocklist={
+          robotType === OT2_ROBOT_TYPE
+            ? OT3_PIPETTES
+            : [...OT2_PIPETTES, ...filter96]
+        }
+        enableNoneOption
+        tabIndex={tabIndex}
+        pipetteName={pipetteName != null ? pipetteName : null}
+        onPipetteChange={pipetteName => {
+          const nameAccessor = `pipettesByMount.${mount}.pipetteName`
+          const value = pipetteName
+          const targetToClear = `pipettesByMount.${mount}.tiprackDefURI`
+          // this select does not return an event so we have to manually set the field val
+          onSetFieldValue(nameAccessor, value)
+          onSetFieldValue(targetToClear, null)
+          onSetFieldTouched(targetToClear, false)
+        }}
+        disabled={mount === RIGHT && values.left.pipetteName === 'p1000_96'}
+        id={`PipetteSelect_${mount}`}
+        className={styles.pipette_select}
+      />
     )
   }
 
@@ -157,7 +155,7 @@ export function PipetteFields(props: Props): JSX.Element {
         tabIndex={initialTabIndex + 2}
         disabled={
           isEmpty(values[mount].pipetteName) ||
-          (mount === RIGHT && values.left.pipetteName === 'p1000_96')
+          (mount === RIGHT && has96Channel)
         }
         options={tiprackOptions}
         value={values[mount].tiprackDefURI}
@@ -171,10 +169,14 @@ export function PipetteFields(props: Props): JSX.Element {
   return (
     <>
       <div className={styles.mount_fields_row} style={{ overflowX: 'hidden' }}>
-        <div>
+        <div style={{ width: '13.8rem' }}>
           <FormGroup
             key="leftPipetteModel"
-            label={i18n.t('modal.pipette_fields.left_pipette')}
+            label={
+              has96Channel
+                ? i18n.t('modal.pipette_fields.pipette')
+                : i18n.t('modal.pipette_fields.left_pipette')
+            }
             className={formStyles.stacked_row}
           >
             {renderPipetteSelect({
@@ -188,7 +190,11 @@ export function PipetteFields(props: Props): JSX.Element {
           <FormGroup
             disabled={isEmpty(values.left.pipetteName)}
             key={'leftTiprackModel'}
-            label={i18n.t('modal.pipette_fields.left_tiprack')}
+            label={
+              has96Channel
+                ? i18n.t('modal.pipette_fields.tiprack')
+                : i18n.t('modal.pipette_fields.left_tiprack')
+            }
             className={formStyles.stacked_row}
           >
             {renderTiprackSelect({ mount: 'left', robotType })}
@@ -198,30 +204,33 @@ export function PipetteFields(props: Props): JSX.Element {
           leftPipette={values.left.pipetteName}
           rightPipette={values.right.pipetteName}
         />
-        <div style={{ width: '13.8rem' }}>
-          <FormGroup
-            key="rightPipetteModel"
-            label={i18n.t('modal.pipette_fields.right_pipette')}
-            className={formStyles.stacked_row}
-            disabled={values.left.pipetteName === 'p1000_96'}
-          >
-            {renderPipetteSelect({
-              mount: 'right',
-              tabIndex: initialTabIndex + 3,
-              nameBlocklist: getIncompatiblePipetteNames(
-                values.left.pipetteName as PipetteName
-              ),
-            })}
-          </FormGroup>
-          <FormGroup
-            disabled={isEmpty(values.right.pipetteName)}
-            key={'rightTiprackModel'}
-            label={i18n.t('modal.pipette_fields.right_tiprack')}
-            className={formStyles.stacked_row}
-          >
-            {renderTiprackSelect({ mount: 'right', robotType })}
-          </FormGroup>
-        </div>
+        {has96Channel ? (
+          <div style={{ width: '13.8rem' }} />
+        ) : (
+          <div style={{ width: '13.8rem' }}>
+            <FormGroup
+              key="rightPipetteModel"
+              label={i18n.t('modal.pipette_fields.right_pipette')}
+              className={formStyles.stacked_row}
+            >
+              {renderPipetteSelect({
+                mount: 'right',
+                tabIndex: initialTabIndex + 3,
+                nameBlocklist: getIncompatiblePipetteNames(
+                  values.left.pipetteName as PipetteName
+                ),
+              })}
+            </FormGroup>
+            <FormGroup
+              disabled={isEmpty(values.right.pipetteName)}
+              key={'rightTiprackModel'}
+              label={i18n.t('modal.pipette_fields.right_tiprack')}
+              className={formStyles.stacked_row}
+            >
+              {renderTiprackSelect({ mount: 'right', robotType })}
+            </FormGroup>
+          </div>
+        )}
       </div>
       <div>
         <OutlineButton Component="label" className={styles.upload_button}>

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -102,7 +102,9 @@
     "left_pipette": "Left Pipette",
     "right_pipette": "Right Pipette",
     "left_tiprack": "Left Tiprack*",
-    "right_tiprack": "Right Tiprack*"
+    "right_tiprack": "Right Tiprack*",
+    "pipette": "Pipette",
+    "tiprack": "Tiprack*"
   },
   "edit_pipettes": {
     "title": "Change Pipette Selection",


### PR DESCRIPTION
closes RQA-2140 RQA-2141 RQA-2142

# Overview

A bunch of fixes with the 96-channel and the edit pipette section

# Test Plan

Create a flex protocol and add a 96-channel. Open the edit pipette section and mess around with changing the pipettes, when the 96-channel is attached make sure:
1. the text changes from "left pipette" to just "pipette"
2. the right pipette field information disappears
3. if you have a right pipette selected then attach the 96-channel, make sure the right pipette is deleted

Smoke test with the ot-2 pipettes and make sure everything looks/works as expected.

# Changelog

- various changes with `PipetteFields` and `InstrumentDiagrams` to make sure everything works as expected for when a 96-channel is attached

# Review requests

see test plan

# Risk assessment

low