### PR TITLE
fix(protocol-designer): make default disabled tooltip more generic

### DIFF
--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -63,10 +63,10 @@
     "moveLiquid": {
       "disabled": {
         "$generic": "Incompatible with current path",
-        "aspirate_touchTip_checkbox": "Touch tip is not supported with this labware",
+        "aspirate_touchTip_checkbox": "Touch tip is not supported",
         "blowout_checkbox": "Redundant with disposal volume",
-        "dispense_mix_checkbox": "Unable to mix in a waste chute",
-        "dispense_mmFromBottom": "Tip position adjustment not supported in waste chute",
+        "dispense_mix_checkbox": "Unable to mix in a waste chute or trash bin",
+        "dispense_mmFromBottom": "Tip position adjustment is not supported",
         "dispense_touchTip_checkbox": "Touch tip is not supported"
       }
     },


### PR DESCRIPTION
closes RQA-2153

# Overview

Make some tooltips that are defaulted more generic

# Test Plan

Create an OT-2 protocol and add a transfer step. Open the advanced settings and hover over "tip positioning" in the dispense labware section. See that the tooltip is generic and doesn't mention waste chute

Create a Flex protocol and add a trash bin and waste chute. Create a transfer step and open the advanced settings. For the dispense labware, add a trash bin and hover over the "mix" checkbox. see that the tooltip mentions that mix is not supported in waste chute or trash bin. And switch the dispense labware to waste chute and see the same tooltip.

Due to the current logic for the tooltips, they are pretty generic at the moment, so we can't have things be super specific.

# Changelog

- make tooltips more generic in the i18n strings

# Review requests

see test plan

# Risk assessment

low