### PR TITLE
feat(app): filter robots on slideout menu from protocol

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -82,6 +82,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
+      robotType: 'OT-2 Standard',
     })
     screen.getByText('choose robot slideout title')
   })
@@ -93,6 +94,7 @@ describe('ChooseRobotSlideout', () => {
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
       isAnalysisError: true,
+      robotType: 'OT-2 Standard',
     })
     screen.getByText(
       'This protocol failed in-app analysis. It may be unusable on robots without custom software configurations.'
@@ -105,6 +107,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
+      robotType: 'OT-2 Standard',
     })
     screen.getByText('opentrons-robot-name')
     screen.getByText('2 unavailable robots are not listed.')
@@ -117,6 +120,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
+      robotType: 'OT-2 Standard',
     })
     screen.getByText('opentrons-robot-name')
     expect(
@@ -130,6 +134,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
+      robotType: 'OT-2 Standard',
     })[1]
     const refreshButton = screen.getByRole('button', { name: 'refresh' })
     fireEvent.click(refreshButton)
@@ -147,6 +152,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
+      robotType: 'OT-2 Standard',
     })
     expect(mockSetSelectedRobot).toBeCalledWith({
       ...mockConnectableRobot,

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -22,6 +22,7 @@ import {
   DIRECTION_ROW,
 } from '@opentrons/components'
 
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import {
   getConnectableRobots,
   getReachableRobots,
@@ -30,8 +31,6 @@ import {
   startDiscovery,
   RE_ROBOT_MODEL_OT2,
   RE_ROBOT_MODEL_OT3,
-  ROBOT_MODEL_OT2,
-  ROBOT_MODEL_OT3,
 } from '../../redux/discovery'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
 import { Banner } from '../../atoms/Banner'
@@ -39,6 +38,7 @@ import { Slideout } from '../../atoms/Slideout'
 import { StyledText } from '../../atoms/text'
 import { AvailableRobotOption } from './AvailableRobotOption'
 
+import type { RobotType } from '@opentrons/shared-data'
 import type { SlideoutProps } from '../../atoms/Slideout'
 import type { UseCreateRun } from '../../organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol'
 import type { State, Dispatch } from '../../redux/types'
@@ -86,7 +86,7 @@ interface ChooseRobotSlideoutProps
   selectedRobot: Robot | null
   setSelectedRobot: (robot: Robot | null) => void
   isAnalysisError?: boolean
-  robotType: 'OT-2 Standard' | 'OT-3 Standard' | null
+  robotType: RobotType | null
   showIdleOnly?: boolean
 }
 
@@ -115,9 +115,9 @@ export function ChooseRobotSlideout(
   const unhealthyReachableRobots = useSelector((state: State) =>
     getReachableRobots(state)
   ).filter(robot => {
-    if (robotType === ROBOT_MODEL_OT3) {
+    if (robotType === FLEX_ROBOT_TYPE) {
       return RE_ROBOT_MODEL_OT3.test(robot.robotModel)
-    } else if (robotType === ROBOT_MODEL_OT2) {
+    } else if (robotType === OT2_ROBOT_TYPE) {
       return RE_ROBOT_MODEL_OT2.test(robot.robotModel)
     } else {
       return true
@@ -126,9 +126,9 @@ export function ChooseRobotSlideout(
   const unreachableRobots = useSelector((state: State) =>
     getUnreachableRobots(state)
   ).filter(robot => {
-    if (robotType === ROBOT_MODEL_OT3) {
+    if (robotType === FLEX_ROBOT_TYPE) {
       return RE_ROBOT_MODEL_OT3.test(robot.robotModel)
-    } else if (robotType === ROBOT_MODEL_OT2) {
+    } else if (robotType === OT2_ROBOT_TYPE) {
       return RE_ROBOT_MODEL_OT2.test(robot.robotModel)
     } else {
       return true
@@ -137,10 +137,10 @@ export function ChooseRobotSlideout(
   const healthyReachableRobots = useSelector((state: State) =>
     getConnectableRobots(state)
   ).filter(robot => {
-    if (robotType === ROBOT_MODEL_OT3) {
-      return robot.robotModel === ROBOT_MODEL_OT3
-    } else if (robotType === ROBOT_MODEL_OT2) {
-      return robot.robotModel === ROBOT_MODEL_OT2
+    if (robotType === FLEX_ROBOT_TYPE) {
+      return robot.robotModel === FLEX_ROBOT_TYPE
+    } else if (robotType === OT2_ROBOT_TYPE) {
+      return robot.robotModel === OT2_ROBOT_TYPE
     } else {
       return true
     }

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -28,7 +28,9 @@ import {
   getUnreachableRobots,
   getScanning,
   startDiscovery,
+  RE_ROBOT_MODEL_OT2,
   RE_ROBOT_MODEL_OT3,
+  ROBOT_MODEL_OT2,
   ROBOT_MODEL_OT3,
 } from '../../redux/discovery'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
@@ -83,8 +85,9 @@ interface ChooseRobotSlideoutProps
     Partial<UseCreateRun> {
   selectedRobot: Robot | null
   setSelectedRobot: (robot: Robot | null) => void
-  showOT3Only?: boolean
   isAnalysisError?: boolean
+  robotType: 'OT-2 Standard' | 'OT-3 Standard' | null
+  showIdleOnly?: boolean
 }
 
 export function ChooseRobotSlideout(
@@ -96,7 +99,6 @@ export function ChooseRobotSlideout(
     onCloseClick,
     title,
     footer,
-    showOT3Only = false,
     isAnalysisError = false,
     isCreatingRun = false,
     reset: resetCreateRun,
@@ -104,23 +106,45 @@ export function ChooseRobotSlideout(
     runCreationErrorCode,
     selectedRobot,
     setSelectedRobot,
+    robotType,
+    showIdleOnly = false,
   } = props
   const dispatch = useDispatch<Dispatch>()
   const isScanning = useSelector((state: State) => getScanning(state))
 
   const unhealthyReachableRobots = useSelector((state: State) =>
     getReachableRobots(state)
-  ).filter(robot =>
-    showOT3Only ? RE_ROBOT_MODEL_OT3.test(robot.robotModel) : true
-  )
+  ).filter(robot => {
+    if (robotType === ROBOT_MODEL_OT3) {
+      return RE_ROBOT_MODEL_OT3.test(robot.robotModel)
+    } else if (robotType === ROBOT_MODEL_OT2) {
+      return RE_ROBOT_MODEL_OT2.test(robot.robotModel)
+    } else {
+      return true
+    }
+  })
   const unreachableRobots = useSelector((state: State) =>
     getUnreachableRobots(state)
-  ).filter(robot =>
-    showOT3Only ? RE_ROBOT_MODEL_OT3.test(robot.robotModel) : true
-  )
+  ).filter(robot => {
+    if (robotType === ROBOT_MODEL_OT3) {
+      return RE_ROBOT_MODEL_OT3.test(robot.robotModel)
+    } else if (robotType === ROBOT_MODEL_OT2) {
+      return RE_ROBOT_MODEL_OT2.test(robot.robotModel)
+    } else {
+      return true
+    }
+  })
   const healthyReachableRobots = useSelector((state: State) =>
     getConnectableRobots(state)
-  ).filter(robot => (showOT3Only ? robot.robotModel === ROBOT_MODEL_OT3 : true))
+  ).filter(robot => {
+    if (robotType === ROBOT_MODEL_OT3) {
+      return robot.robotModel === ROBOT_MODEL_OT3
+    } else if (robotType === ROBOT_MODEL_OT2) {
+      return robot.robotModel === ROBOT_MODEL_OT2
+    } else {
+      return true
+    }
+  })
 
   const [robotBusyStatusByName, registerRobotBusyStatus] = React.useReducer(
     robotBusyStatusByNameReducer,
@@ -155,9 +179,6 @@ export function ChooseRobotSlideout(
 
   const unavailableCount =
     unhealthyReachableRobots.length + unreachableRobots.length
-
-  // for now, the only use case for showing idle only is also the only use case for showing OT-3 only
-  const showIdleOnly = showOT3Only
 
   return (
     <Slideout

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -187,8 +187,14 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
       onCloseClick: jest.fn(),
       showSlideout: true,
     })
+    mockGetUnreachableRobots.mockReturnValue([
+      { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
+    ])
+    mockGetReachableRobots.mockReturnValue([
+      { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
+    ])
     screen.getByText('opentrons-robot-name')
-    screen.getByText('2 unavailable robots are not listed.')
+    screen.getByText('2 unavailable or busy robots are not listed.')
   })
   it('if scanning, show robots, but do not show link to other devices', () => {
     mockGetScanning.mockReturnValue(true)

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -191,7 +191,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
       { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
     ])
     mockGetReachableRobots.mockReturnValue([
-      { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
+      { ...mockReachableRobot, robotModel: 'OT-3 Standard' },
     ])
     screen.getByText('opentrons-robot-name')
     screen.getByText('2 unavailable or busy robots are not listed.')

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@opentrons/components'
 
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
-import { OPENTRONS_USB, ROBOT_MODEL_OT2 } from '../../redux/discovery'
+import { OPENTRONS_USB } from '../../redux/discovery'
 import { appShellRequestor } from '../../redux/shell/remote'
 import { useTrackCreateProtocolRunEvent } from '../Devices/hooks'
 import { ApplyHistoricOffsets } from '../ApplyHistoricOffsets'

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -14,7 +14,7 @@ import {
 } from '@opentrons/components'
 
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
-import { OPENTRONS_USB } from '../../redux/discovery'
+import { OPENTRONS_USB, ROBOT_MODEL_OT2 } from '../../redux/discovery'
 import { appShellRequestor } from '../../redux/shell/remote'
 import { useTrackCreateProtocolRunEvent } from '../Devices/hooks'
 import { ApplyHistoricOffsets } from '../ApplyHistoricOffsets'
@@ -135,6 +135,12 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     first(srcFileNames) ??
     protocolKey
 
+  // intentionally show both robot types if analysis has any error
+  const robotType =
+    mostRecentAnalysis != null && mostRecentAnalysis.errors.length === 0
+      ? mostRecentAnalysis?.robotType ?? null
+      : null
+
   return (
     <ChooseRobotSlideout
       isExpanded={showSlideout}
@@ -171,10 +177,12 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       }
       selectedRobot={selectedRobot}
       setSelectedRobot={setSelectedRobot}
+      robotType={robotType}
       isCreatingRun={isCreatingRun}
       reset={resetCreateRun}
       runCreationError={runCreationError}
       runCreationErrorCode={runCreationErrorCode}
+      showIdleOnly={true}
     />
   )
 }

--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -47,7 +47,7 @@ export function ProtocolOverflowMenu(
     handleRunProtocol,
     handleSendProtocolToOT3,
   } = props
-  const { protocolKey } = storedProtocolData
+  const { mostRecentAnalysis, protocolKey } = storedProtocolData
   const { t } = useTranslation(['protocol_list', 'shared'])
   const {
     menuOverlay,
@@ -65,6 +65,11 @@ export function ProtocolOverflowMenu(
     dispatch(removeProtocol(protocolKey))
     trackEvent({ name: ANALYTICS_DELETE_PROTOCOL_FROM_APP, properties: {} })
   }, true)
+
+  const robotType =
+    mostRecentAnalysis != null && mostRecentAnalysis.errors.length === 0
+      ? mostRecentAnalysis?.robotType ?? null
+      : null
 
   const handleClickShowInFolder: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
@@ -135,14 +140,16 @@ export function ProtocolOverflowMenu(
           >
             {t('shared:reanalyze')}
           </MenuItem>
-          <MenuItem
-            onClick={handleClickSendToOT3}
-            data-testid="ProtocolOverflowMenu_sendToOT3"
-          >
-            {t('protocol_list:send_to_robot_overflow', {
-              robot_display_name: FLEX_DISPLAY_NAME,
-            })}
-          </MenuItem>
+          {robotType !== 'OT-2 Standard' ? (
+            <MenuItem
+              onClick={handleClickSendToOT3}
+              data-testid="ProtocolOverflowMenu_sendToOT3"
+            >
+              {t('protocol_list:send_to_robot_overflow', {
+                robot_display_name: FLEX_DISPLAY_NAME,
+              })}
+            </MenuItem>
+          ) : null}
           <MenuItem
             onClick={handleClickShowInFolder}
             data-testid="ProtocolOverflowMenu_showInFolder"

--- a/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
@@ -176,10 +176,16 @@ describe('SendProtocolToOT3Slideout', () => {
       onCloseClick: jest.fn(),
       isExpanded: true,
     })
+    mockGetUnreachableRobots.mockReturnValue([
+      { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
+    ])
+    mockGetReachableRobots.mockReturnValue([
+      { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
+    ])
     screen.getByText('opentrons-robot-name')
-    screen.getByText('2 unavailable or busy robots are not listed.')
+    screen.getByText('2 unavailable robots are not listed.')
   })
-  it('does not render a robot option for a busy OT-3', () => {
+  it('does render a robot option for a busy OT-3', () => {
     when(mockUseAllRunsQuery)
       .calledWith(expect.any(Object), expect.any(Object), {
         hostname: mockConnectableOT3.ip,
@@ -195,7 +201,7 @@ describe('SendProtocolToOT3Slideout', () => {
       onCloseClick: jest.fn(),
       isExpanded: true,
     })
-    expect(screen.queryByText('opentrons-robot-name')).not.toBeInTheDocument()
+    expect(screen.queryByText('opentrons-robot-name')).toBeInTheDocument()
   })
   it('does not render an available robot option for a connectable OT-2', () => {
     mockGetConnectableRobots.mockReturnValue([

--- a/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
@@ -180,7 +180,7 @@ describe('SendProtocolToOT3Slideout', () => {
       { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
     ])
     mockGetReachableRobots.mockReturnValue([
-      { ...mockUnreachableRobot, robotModel: 'OT-3 Standard' },
+      { ...mockReachableRobot, robotModel: 'OT-3 Standard' },
     ])
     screen.getByText('opentrons-robot-name')
     screen.getByText('2 unavailable robots are not listed.')

--- a/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/__tests__/SendProtocolToOT3Slideout.test.tsx
@@ -201,7 +201,7 @@ describe('SendProtocolToOT3Slideout', () => {
       onCloseClick: jest.fn(),
       isExpanded: true,
     })
-    expect(screen.queryByText('opentrons-robot-name')).toBeInTheDocument()
+    expect(screen.getByText('opentrons-robot-name')).toBeInTheDocument()
   })
   it('does not render an available robot option for a connectable OT-2', () => {
     mockGetConnectableRobots.mockReturnValue([

--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../organisms/ProtocolsLanding/utils'
 import { useToaster } from '../../organisms/ToasterOven'
 import { appShellRequestor } from '../../redux/shell/remote'
-import { OPENTRONS_USB } from '../../redux/discovery'
+import { OPENTRONS_USB, ROBOT_MODEL_OT3 } from '../../redux/discovery'
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 
 import type { AxiosError } from 'axios'
@@ -167,7 +167,7 @@ export function SendProtocolToOT3Slideout(
       }
       selectedRobot={selectedRobot}
       setSelectedRobot={setSelectedRobot}
-      showOT3Only
+      robotType={ROBOT_MODEL_OT3}
       isAnalysisError={isAnalysisError}
     />
   )

--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux'
 
 import { useCreateProtocolMutation } from '@opentrons/react-api-client'
 
-import { FLEX_DISPLAY_NAME } from '@opentrons/shared-data'
+import { FLEX_DISPLAY_NAME, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { PrimaryButton, IconProps, StyleProps } from '@opentrons/components'
 import { ERROR_TOAST, INFO_TOAST, SUCCESS_TOAST } from '../../atoms/Toast'
@@ -16,7 +16,7 @@ import {
 } from '../../organisms/ProtocolsLanding/utils'
 import { useToaster } from '../../organisms/ToasterOven'
 import { appShellRequestor } from '../../redux/shell/remote'
-import { OPENTRONS_USB, ROBOT_MODEL_OT3 } from '../../redux/discovery'
+import { OPENTRONS_USB } from '../../redux/discovery'
 import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 
 import type { AxiosError } from 'axios'
@@ -167,7 +167,7 @@ export function SendProtocolToOT3Slideout(
       }
       selectedRobot={selectedRobot}
       setSelectedRobot={setSelectedRobot}
-      robotType={ROBOT_MODEL_OT3}
+      robotType={FLEX_ROBOT_TYPE}
       isAnalysisError={isAnalysisError}
     />
   )


### PR DESCRIPTION
closes [RQA-2028](https://opentrons.atlassian.net/browse/RQA-2028)

# Overview

Available robots in ChooseRobotSlideout should be filtered based on the analysis of the protocol that renders the slideout. Also, the protocol overflow menu should only render the option to "Send protocol to Opentrons Flex" if the protocol does not provide a successful OT-2 analysis.

In the future, we will possibly collaborate with Design to display reachable, but busy or unhealthy robot options in the slideout

# Test Plan

ChooseRobotSlideout:
- successful Flex analysis provides all healthy reachable Flexes only
- successful OT-2 analysis provides all healthy reachable OT-2s only
- unsuccessful analysis provides all healthy reachable Flexes and OT-2s

ProtocolOverflowMenu
- successful Flex analysis provides "Send protocol to Opentrons Flex" option
- successful OT-2 analysis _does not_ provide "Send protocol to Opentrons Flex" option
- unsuccessful analysis provides "Send protocol to Opentrons Flex" option

# Changelog

- Removed protocol overflow menu option for "Send protocol to Opentrons Flex" for successful OT-2 protocol analysis
- Show appropriate robot types depending upon analysis result (possibilities: OT-2, Flex, or failed)
- Filter out unavailable and busy robots for OT-2 protocol analysis
- Filter out unavailable robots _only_ for Flex protocol or failed analysis
- Base unavailable/busy count on above filtering

# Risk assessment

Medium. We need to make sure we aren't accidentally filtering out any valid robots from selection


[RQA-2028]: https://opentrons.atlassian.net/browse/RQA-2028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ