### PR TITLE
fix(protocol-designer): getNextAvailableDeckSlot to filter out unneeded addressable areas

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -124,8 +124,9 @@ export const duplicateLabware: (
   const templateLabwareIdIsOffDeck =
     initialDeckSetup.labware[templateLabwareId].slot === 'offDeck'
   const duplicateSlot = getNextAvailableDeckSlot(initialDeckSetup, robotType)
-  if (!duplicateSlot)
-    console.warn('no slots available, cannot duplicate labware')
+  if (duplicateSlot == null) {
+    console.error('no slots available, cannot duplicate labware')
+  }
   const allNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
   const templateNickname = allNicknamesById[templateLabwareId]
   const duplicateLabwareNickname = getNextNickname(
@@ -133,7 +134,7 @@ export const duplicateLabware: (
     templateNickname
   )
 
-  if (templateLabwareDefURI && duplicateSlot) {
+  if (templateLabwareDefURI && duplicateSlot != null) {
     dispatch({
       type: 'DUPLICATE_LABWARE',
       payload: {

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -25,13 +25,12 @@ export function getNextAvailableDeckSlot(
       cutoutIds
     )
     const addressableAreaName = stagingAreaAddressableAreaNames.find(
-      aa => aa === slot?.id
+      aa => aa === slot.id
     )
     let isSlotEmpty: boolean = getSlotIsEmpty(initialDeckSetup, slot.id)
     if (addressableAreaName == null && COLUMN_4_SLOTS.includes(slot.id)) {
       isSlotEmpty = false
-    }
-    if (
+    } else if (
       MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slot.id) ||
       WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slot.id) ||
       slot.id === FIXED_TRASH_ID

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -1,16 +1,45 @@
-import { RobotType, getDeckDefFromRobotType } from '@opentrons/shared-data'
+import {
+  FIXED_TRASH_ID,
+  getDeckDefFromRobotType,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
+} from '@opentrons/shared-data'
+import { COLUMN_4_SLOTS } from '@opentrons/step-generation'
 import { getSlotIsEmpty } from '../step-forms/utils'
-import { InitialDeckSetup } from '../step-forms/types'
-import { DeckSlot } from '../types'
+import { getStagingAreaAddressableAreas } from '../utils'
+import type { RobotType, CutoutId } from '@opentrons/shared-data'
+import type { InitialDeckSetup } from '../step-forms/types'
+import type { DeckSlot } from '../types'
 
 export function getNextAvailableDeckSlot(
   initialDeckSetup: InitialDeckSetup,
   robotType: RobotType
 ): DeckSlot | null | undefined {
   const deckDef = getDeckDefFromRobotType(robotType)
-  return deckDef.locations.addressableAreas.find(slot =>
-    getSlotIsEmpty(initialDeckSetup, slot.id)
-  )?.id
+
+  return deckDef.locations.addressableAreas.find(slot => {
+    const cutoutIds = Object.values(initialDeckSetup.additionalEquipmentOnDeck)
+      .filter(ae => ae.name === 'stagingArea')
+      .map(ae => ae.location as CutoutId)
+    const stagingAreaAddressableAreaNames = getStagingAreaAddressableAreas(
+      cutoutIds
+    )
+    const addressableAreaName = stagingAreaAddressableAreaNames.find(
+      aa => aa === slot?.id
+    )
+    let isSlotEmpty: boolean = getSlotIsEmpty(initialDeckSetup, slot.id)
+    if (addressableAreaName == null && COLUMN_4_SLOTS.includes(slot.id)) {
+      isSlotEmpty = false
+    }
+    if (
+      MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slot.id) ||
+      WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slot.id) ||
+      slot.id === FIXED_TRASH_ID
+    ) {
+      isSlotEmpty = false
+    }
+    return isSlotEmpty
+  })?.id
 }
 
 const getMatchOrNull = (


### PR DESCRIPTION
closes RQA-2150

# Overview

Fixes 2 bugs related to `getNextAvailableDeckSlot` and filtering out certain addressable areas

# Test Plan

Create a flex protocol and go to the deck map and duplicate the tiprack as much as possible. The tiprack should not duplicate into a column 4 and should not duplicate at all. If you open dev tools, you should see a "cannot duplicate labware" error if you duplicate more. If you add a staging area slot, make sure that can be duplicated into.

Create an ot-2 protocol and do the same thing and duplicate the tiprack as much as possible, it should not duplicate into the fixed trash.

# Changelog

- add filtering for the staging area slots and trash addressable areas 
- fix a bit of stuff in the thunk to make it more readable

# Review requests

see test plan

# Risk assessment

low