### PR TITLE
test(app): fix LPC test after mergeback PR

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/__tests__/useLaunchLPC.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/useLaunchLPC.test.tsx
@@ -182,6 +182,9 @@ describe('useLaunchLPC hook', () => {
         maintenanceRunId: MOCK_MAINTENANCE_RUN_ID,
         labwareDef: mockLabwareDef,
       })
+    })
+
+    await waitFor(() => {
       expect(mockCreateMaintenanceRun).toHaveBeenCalledWith({
         labwareOffsets: mockCurrentOffsets.map(
           ({ vector, location, definitionUri }) => ({
@@ -191,6 +194,9 @@ describe('useLaunchLPC hook', () => {
           })
         ),
       })
+    })
+
+    await waitFor(() => {
       expect(result.current.LPCWizard).not.toBeNull()
     })
     renderWithProviders(result.current.LPCWizard ?? <></>)


### PR DESCRIPTION
# Overview

This PR fixes a linting error inside an app LPC test that happened during the 7.1 release merge back into edge

# Risk assessment
Low