### PR TITLE
fix(protocol-designer): remove fixed trash option from dropdowns

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -1198,49 +1198,6 @@
       "schemaVersion": 2,
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
     },
-    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
-      "ordering": [["A1"]],
-      "metadata": {
-        "displayCategory": "trash",
-        "displayVolumeUnits": "mL",
-        "displayName": "Opentrons Fixed Trash",
-        "tags": []
-      },
-      "schemaVersion": 2,
-      "version": 1,
-      "namespace": "opentrons",
-      "dimensions": {
-        "xDimension": 172.86,
-        "yDimension": 165.86,
-        "zDimension": 82
-      },
-      "parameters": {
-        "format": "trash",
-        "isTiprack": false,
-        "loadName": "opentrons_1_trash_1100ml_fixed",
-        "isMagneticModuleCompatible": false,
-        "quirks": [
-          "fixedTrash",
-          "centerMultichannelOnWells",
-          "touchTipDisabled"
-        ]
-      },
-      "wells": {
-        "A1": {
-          "shape": "rectangular",
-          "yDimension": 165.67,
-          "xDimension": 107.11,
-          "totalLiquidVolume": 1100000,
-          "depth": 0,
-          "x": 82.84,
-          "y": 80,
-          "z": 82
-        }
-      },
-      "brand": { "brand": "Opentrons" },
-      "groups": [{ "wells": ["A1"], "metadata": {} }],
-      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-    },
     "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
       "ordering": [
         ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -1227,49 +1227,6 @@
       "schemaVersion": 2,
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
     },
-    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
-      "ordering": [["A1"]],
-      "metadata": {
-        "displayCategory": "trash",
-        "displayVolumeUnits": "mL",
-        "displayName": "Opentrons Fixed Trash",
-        "tags": []
-      },
-      "schemaVersion": 2,
-      "version": 1,
-      "namespace": "opentrons",
-      "dimensions": {
-        "xDimension": 172.86,
-        "yDimension": 165.86,
-        "zDimension": 82
-      },
-      "parameters": {
-        "format": "trash",
-        "isTiprack": false,
-        "loadName": "opentrons_1_trash_1100ml_fixed",
-        "isMagneticModuleCompatible": false,
-        "quirks": [
-          "fixedTrash",
-          "centerMultichannelOnWells",
-          "touchTipDisabled"
-        ]
-      },
-      "wells": {
-        "A1": {
-          "shape": "rectangular",
-          "yDimension": 165.67,
-          "xDimension": 107.11,
-          "totalLiquidVolume": 1100000,
-          "depth": 0,
-          "x": 82.84,
-          "y": 80,
-          "z": 82
-        }
-      },
-      "brand": { "brand": "Opentrons" },
-      "groups": [{ "wells": ["A1"], "metadata": {} }],
-      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-    },
     "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1": {
       "ordering": [
         ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -2207,49 +2207,6 @@
       ],
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
     },
-    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
-      "ordering": [["A1"]],
-      "metadata": {
-        "displayCategory": "trash",
-        "displayVolumeUnits": "mL",
-        "displayName": "Opentrons Fixed Trash",
-        "tags": []
-      },
-      "schemaVersion": 2,
-      "version": 1,
-      "namespace": "opentrons",
-      "dimensions": {
-        "xDimension": 172.86,
-        "yDimension": 165.86,
-        "zDimension": 82
-      },
-      "parameters": {
-        "format": "trash",
-        "isTiprack": false,
-        "loadName": "opentrons_1_trash_1100ml_fixed",
-        "isMagneticModuleCompatible": false,
-        "quirks": [
-          "fixedTrash",
-          "centerMultichannelOnWells",
-          "touchTipDisabled"
-        ]
-      },
-      "wells": {
-        "A1": {
-          "shape": "rectangular",
-          "yDimension": 165.67,
-          "xDimension": 107.11,
-          "totalLiquidVolume": 1100000,
-          "depth": 0,
-          "x": 82.84,
-          "y": 80,
-          "z": 82
-        }
-      },
-      "brand": { "brand": "Opentrons" },
-      "groups": [{ "wells": ["A1"], "metadata": {} }],
-      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-    },
     "opentrons/usascientific_96_wellplate_2.4ml_deep/1": {
       "ordering": [
         ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -1104,49 +1104,6 @@
       "schemaVersion": 2,
       "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
     },
-    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
-      "ordering": [["A1"]],
-      "metadata": {
-        "displayCategory": "trash",
-        "displayVolumeUnits": "mL",
-        "displayName": "Opentrons Fixed Trash",
-        "tags": []
-      },
-      "schemaVersion": 2,
-      "version": 1,
-      "namespace": "opentrons",
-      "dimensions": {
-        "xDimension": 172.86,
-        "yDimension": 165.86,
-        "zDimension": 82
-      },
-      "parameters": {
-        "format": "trash",
-        "isTiprack": false,
-        "loadName": "opentrons_1_trash_1100ml_fixed",
-        "isMagneticModuleCompatible": false,
-        "quirks": [
-          "fixedTrash",
-          "centerMultichannelOnWells",
-          "touchTipDisabled"
-        ]
-      },
-      "wells": {
-        "A1": {
-          "shape": "rectangular",
-          "yDimension": 165.67,
-          "xDimension": 107.11,
-          "totalLiquidVolume": 1100000,
-          "depth": 0,
-          "x": 82.84,
-          "y": 80,
-          "z": 82
-        }
-      },
-      "brand": { "brand": "Opentrons" },
-      "groups": [{ "wells": ["A1"], "metadata": {} }],
-      "cornerOffsetFromSlot": { "x": 0, "y": 0, "z": 0 }
-    },
     "opentrons/biorad_96_wellplate_200ul_pcr/1": {
       "ordering": [
         ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],

--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -14,6 +14,7 @@ import type {
 import type {
   CommandAnnotationV1Mixin,
   CommandV8Mixin,
+  CreateCommand as CreateCommandV8,
   LabwareV2Mixin,
   LiquidV1Mixin,
   LoadPipetteCreateCommand,
@@ -22,6 +23,7 @@ import type {
   ProtocolBase,
   ProtocolFile,
 } from '@opentrons/shared-data/protocol/types/schemaV8'
+import type { CreateCommand as CreateCommandV7 } from '@opentrons/shared-data/protocol/types/schemaV7'
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 
 // NOTE: this migration is to schema v8 and updates fixed trash by
@@ -68,8 +70,8 @@ export const migrateFile = (
   ]
 
   const migrateCommands = (
-    v7Commands: ProtocolFileV7<{}>['commands']
-  ): ProtocolFile['commands'] => {
+    v7Commands: CreateCommandV7[]
+  ): CreateCommandV8[] => {
     return v7Commands.filter(
       v7Command =>
         !(

--- a/protocol-designer/src/load-file/migration/8_0_0.ts
+++ b/protocol-designer/src/load-file/migration/8_0_0.ts
@@ -67,6 +67,20 @@ export const migrateFile = (
     },
   ]
 
+  const migrateCommands = (
+    v7Commands: ProtocolFileV7<{}>['commands']
+  ): ProtocolFile['commands'] => {
+    return v7Commands.filter(
+      v7Command =>
+        !(
+          v7Command.commandType === 'loadLabware' &&
+          v7Command.params.labwareId === 'fixedTrash'
+        )
+    )
+  }
+
+  const migratedV7Commands = migrateCommands(commands)
+
   const newLabwareLocationUpdate: LabwareLocationUpdate = Object.keys(
     labwareLocationUpdate
   ).reduce((acc: LabwareLocationUpdate, labwareId: string) => {
@@ -178,7 +192,7 @@ export const migrateFile = (
 
   const commandv8Mixin: CommandV8Mixin = {
     commandSchemaId: 'opentronsCommandSchemaV8',
-    commands: [...commands, ...trashMoveToAddressableAreaCommand],
+    commands: [...migratedV7Commands, ...trashMoveToAddressableAreaCommand],
   }
 
   const commandAnnotionaV1Mixin: CommandAnnotationV1Mixin = {

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -137,7 +137,6 @@ export const getLabwareOptions: Selector<Options> = createSelector(
       },
       []
     )
-
     return _sortLabwareDropdownOptions(labwareOptions)
   }
 )

--- a/protocol-designer/src/ui/labware/selectors.ts
+++ b/protocol-designer/src/ui/labware/selectors.ts
@@ -137,6 +137,7 @@ export const getLabwareOptions: Selector<Options> = createSelector(
       },
       []
     )
+
     return _sortLabwareDropdownOptions(labwareOptions)
   }
 )


### PR DESCRIPTION
closes [RAUT-908](https://opentrons.atlassian.net/browse/RAUT-908)

# Overview

In PD schemaV8, we use trash bin entities on OT-2 rather than implictly loaded fixed trash single-well labwares. Here, I update the v8 migration to remove loadLabware command for fixedTrash so that it is not present as an option alongside Trash Bin in dropdowns for dispense, droptip, etc.

# Test Plan

- import an old version of PD protocol ([like this v3 protocol](https://github.com/Opentrons/opentrons/files/13720048/doItAllV3.json))
- in protocol design, select a step that accepts trash locations (dispense, blowout, droptip...)
- observe that 'Fixed Trash' is no longer present. Only 'Trash Bin' should be present (refers to OT-2 slot 12 trash addressable area) 

<img width="502" alt="Screen Shot 2023-12-19 at 3 27 55 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/ff7d0dbc-26ea-4d41-8cbf-4f9fbd8b9180">

# Changelog

- filter loadLabware command specific to fixedTrash in v8 migration file

[RAUT-908]: https://opentrons.atlassian.net/browse/RAUT-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ