### PR TITLE
fix(app): center robot update modal

### DIFF
--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -67,7 +67,7 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
       header={modalHeader}
       onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
-      marginLeft="7.125rem"
+      marginLeft={styleProps.marginLeft ?? '7.125rem'}
       {...props}
       footer={footer}
     >

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -126,6 +126,7 @@ export function RobotUpdateProgressModal({
       title={`${t('updating')} ${robotName}`}
       width="40rem"
       textAlign="center"
+      marginLeft="0"
       onClose={
         hasStoppedUpdating || letUserExitUpdate
           ? completeRobotUpdateHandler


### PR DESCRIPTION
closes [RQA-1964](https://opentrons.atlassian.net/browse/RQA-1964)

# Overview

Without changing the default positioning of `LegacyModal`, pass a marginLeft of 0 to the modal when rendered by `RobotUpdateProgressModal`.

Note: We should probably go through other modal designs and determine whether to center within the entire desktop app (including nav) rather than center within just the whitespace of the app.

# Test Plan

- update robot
- observe update in progress modal is centered within entire app
<img width="974" alt="Screen Shot 2023-12-20 at 2 17 27 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/a6453961-c3ac-4adc-a818-a2f922018f1e">

- observe update success modal is centered within entire app
<img width="1150" alt="Screen Shot 2023-12-20 at 2 28 31 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/b8797168-0208-4423-a14a-dba608bbbe94">
<img width="748" alt="Screen Shot 2023-12-20 at 2 28 49 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/a386ee26-99b1-420e-b640-b67a2a17c4bf">

# Changelog

- pass `marginLeft` prop to `LegacyModal` rendered by `RobotUpdateProgressModal`
- check for `marginLeft` within `LegacyModal`, with default to 7.125rem as before

# Risk assessment

low

[RQA-1964]: https://opentrons.atlassian.net/browse/RQA-1964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ