### PR TITLE
fix(protocol-designer): update help link

### DIFF
--- a/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
+++ b/protocol-designer/src/components/KnowledgeBaseLink/index.tsx
@@ -6,7 +6,7 @@ export const KNOWLEDGEBASE_ROOT_URL =
 export const links = {
   airGap: `https://support.opentrons.com/en/articles/4398106-air-gap`,
   multiDispense: `https://support.opentrons.com/en/articles/4170341-paths`,
-  protocolSteps: `https://support.opentrons.com/en/collections/493886-protocol-designer#building-a-protocol-steps`,
+  protocolSteps: `https://support.opentrons.com/s/protocol-designer?tabset-92ba3=2`,
   customLabware: `https://support.opentrons.com/en/articles/3136504-creating-custom-labware-definitions`,
   recommendedLabware:
     'https://support.opentrons.com/s/article/What-labware-can-I-use-with-my-modules',


### PR DESCRIPTION
closes [RQA-2148](https://opentrons.atlassian.net/browse/RQA-2148)

# Overview

Fixes help link in modal if exporting a PD protocol with no steps.

# Test Plan

- create new PD file
- export without creating any steps
- click the `help` link
- verify routing to [building a protocol tips](https://support.opentrons.com/s/protocol-designer?tabset-92ba3=2)


# Risk assessment

low

[RQA-2148]: https://opentrons.atlassian.net/browse/RQA-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ