### PR TITLE
docs(api): update Tutorial and Protocol Examples for version 2.16

### DIFF
--- a/api/docs/v2/example_protocols/dilution_tutorial.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial.py
@@ -1,7 +1,7 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.15',
+    'apiLevel': '2.16',
     'protocolName': 'Serial Dilution Tutorial – OT-2 single-channel',
     'description': '''This protocol is the outcome of following the
                    Python Protocol API Tutorial located at

--- a/api/docs/v2/example_protocols/dilution_tutorial_flex.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_flex.py
@@ -12,13 +12,14 @@ metadata = {
     
 requirements = {
     'robotType': 'Flex',
-    'apiLevel': '2.15'
+    'apiLevel': '2.16'
     }
 
 def run(protocol: protocol_api.ProtocolContext):
     tips = protocol.load_labware('opentrons_flex_96_tiprack_200ul', 'D1')
     reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
     plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
+    trash = protocol.load_trash_bin('A3')
     left_pipette = protocol.load_instrument('flex_1channel_1000', 'left', tip_racks=[tips])
 
     # distribute diluent

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi.py
@@ -1,7 +1,7 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.15',
+    'apiLevel': '2.16',
     'protocolName': 'Serial Dilution Tutorial – OT-2 8-channel',
     'description': '''This protocol is the outcome of following the
                    Python Protocol API Tutorial located at

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi_flex.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi_flex.py
@@ -12,25 +12,26 @@ metadata = {
 
 requirements = {
     'robotType': 'Flex',
-    'apiLevel': '2.15'
+    'apiLevel': '2.16'
     }
     
 def run(protocol: protocol_api.ProtocolContext):
-	tips = protocol.load_labware('opentrons_96_tiprack_300ul', 'D1')
-	reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
-	plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
-	left_pipette = protocol.load_instrument('flex_8channel_1000', 'right', tip_racks=[tips])
+    tips = protocol.load_labware('opentrons_96_tiprack_300ul', 'D1')
+    reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
+    plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
+    trash = protocol.load_trash_bin('A3')
+    left_pipette = protocol.load_instrument('flex_8channel_1000', 'right', tip_racks=[tips])
 
-	# distribute diluent
-	left_pipette.transfer(100, reservoir['A1'], plate.rows()[0])  
+    # distribute diluent
+    left_pipette.transfer(100, reservoir['A1'], plate.rows()[0])  
 
-	# no loop, 8-channel pipette
+    # no loop, 8-channel pipette
 
-	# save the destination row to a variable
-	row = plate.rows()[0]
+    # save the destination row to a variable
+    row = plate.rows()[0]
 
-	# transfer solution to first well in column
-	left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
+    # transfer solution to first well in column
+    left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
 
-	# dilute the sample down the row
-	left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))
+    # dilute the sample down the row
+    left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -340,7 +340,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
                     load_name='corning_96_wellplate_360ul_flat',
                     location='D1')
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
+                    load_name='opentrons_flex_96_tiprack_1000ul',
                     location='D2')
                 reservoir = protocol.load_labware(
                     load_name='usascientific_12_reservoir_22ml',
@@ -354,10 +354,10 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
                 pipette.pick_up_tip()
 
                 # aspirate from the first 5 wells
-                for well in reservoir.wells()[:4]:
+                for well in reservoir.wells()[:5]:
                     pipette.aspirate(volume=35, location=well)
                     pipette.air_gap(10)
-        
+
                 pipette.dispense(225, plate['A1'])
 
                 pipette.return_tip()
@@ -389,7 +389,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
                 p300.pick_up_tip()
 
                 # aspirate from the first 5 wells
-                for well in reservoir.wells()[:4]:
+                for well in reservoir.wells()[:5]:
                     p300.aspirate(volume=35, location=well)
                     p300.air_gap(10)
         
@@ -510,7 +510,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel': '2.15'}
+            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
                 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -91,6 +91,8 @@ This code only loads the instruments and labware listed above, and performs no o
                 reservoir = protocol.load_labware(
                     load_name="usascientific_12_reservoir_22ml", location="D1"
                 )
+                # load trash bin in deck slot A3
+                trash = protocol.load_trash_bin("A3")
                 # Put protocol commands here
     
     .. tab:: OT-2 
@@ -100,7 +102,7 @@ This code only loads the instruments and labware listed above, and performs no o
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 # load tip rack in deck slot 3
@@ -151,15 +153,16 @@ This protocol uses some :ref:`building block commands <v2-atomic-commands>` to t
                 tiprack_1 = protocol.load_labware(
                     load_name='opentrons_flex_96_tiprack_200ul',
                     location='D2')
-                pipette_1 = protocol.load_instrument(
+                trash = protocol.load_trash_bin('A3')
+                pipette = protocol.load_instrument(
                     instrument_name='flex_1channel_1000',
                     mount='left',
                 tip_racks=[tiprack_1])
 
-                pipette_1.pick_up_tip()
-                pipette_1.aspirate(100, plate['A1'])
-                pipette_1.dispense(100, plate['B1'])
-                pipette_1.drop_tip()
+                pipette.pick_up_tip()
+                pipette.aspirate(100, plate['A1'])
+                pipette.dispense(100, plate['B1'])
+                pipette.drop_tip()
 
     .. tab:: OT-2
 
@@ -168,7 +171,7 @@ This protocol uses some :ref:`building block commands <v2-atomic-commands>` to t
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -210,12 +213,13 @@ This protocol accomplishes the same thing as the previous example, but does it a
                 tiprack_1 = protocol.load_labware(
                     load_name='opentrons_flex_96_tiprack_200ul',
                     location='D2')
-                pipette_1 = protocol.load_instrument(
+                trash = protocol.load_trash_bin('A3')
+                pipette = protocol.load_instrument(
                     instrument_name='flex_1channel_1000',
                     mount='left',
                     tip_racks=[tiprack_1])
                 # transfer 100 µL from well A1 to well B1
-                pipette_1.transfer(100, plate['A1'], plate['B1'])
+                pipette.transfer(100, plate['A1'], plate['B1'])
     
     .. tab:: OT-2
 
@@ -224,7 +228,7 @@ This protocol accomplishes the same thing as the previous example, but does it a
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -269,7 +273,8 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
                 reservoir = protocol.load_labware(
                     load_name='usascientific_12_reservoir_22ml',
                     location='D3')
-                pipette_1 = protocol.load_instrument(
+                trash = protocol.load_trash_bin('A3')
+                pipette = protocol.load_instrument(
                     instrument_name='flex_1channel_1000',
                     mount='left',
                     tip_racks=[tiprack_1])
@@ -279,7 +284,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
                 # etc...
                 # range() starts at 0 and stops before 8, creating a range of 0-7
                 for i in range(8):
-                    pipette_1.distribute(200, reservoir.wells()[i], plate.rows()[i])
+                    pipette.distribute(200, reservoir.wells()[i], plate.rows()[i])
 
     .. tab:: OT-2
 
@@ -288,7 +293,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -340,21 +345,22 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
                 reservoir = protocol.load_labware(
                     load_name='usascientific_12_reservoir_22ml',
                     location='D3')
-                pipette_1 = protocol.load_instrument(
+                trash = protocol.load_trash_bin('A3')
+                pipette = protocol.load_instrument(
                     instrument_name='flex_1channel_1000', 
                     mount='left',
                     tip_racks=[tiprack_1])
 
-                pipette_1.pick_up_tip()
+                pipette.pick_up_tip()
 
                 # aspirate from the first 5 wells
                 for well in reservoir.wells()[:4]:
-                    pipette_1.aspirate(volume=35, location=well)
-                    pipette_1.air_gap(10)
+                    pipette.aspirate(volume=35, location=well)
+                    pipette.air_gap(10)
         
-                pipette_1.dispense(225, plate['A1'])
+                pipette.dispense(225, plate['A1'])
 
-                pipette_1.return_tip()
+                pipette.return_tip()
 
     .. tab:: OT-2
 
@@ -363,7 +369,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -422,12 +428,13 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
                 reservoir = protocol.load_labware(
                     load_name='usascientific_12_reservoir_22ml',
                     location='C1')
-                pipette_1 = protocol.load_instrument(
+                trash = protocol.load_trash_bin('A3')
+                pipette = protocol.load_instrument(
                     instrument_name='flex_1channel_1000',
                     mount='left',
                     tip_racks=[tiprack_1, tiprack_2])
                 # Dispense diluent
-                pipette_1.distribute(50, reservoir['A12'], plate.wells())
+                pipette.distribute(50, reservoir['A12'], plate.wells())
 
                 # loop through each row
                 for i in range(8):
@@ -436,10 +443,10 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
                     row = plate.rows()[i]
 
                 # transfer 30 µL of source to first well in column
-                pipette_1.transfer(30, source, row[0], mix_after=(3, 25))
+                pipette.transfer(30, source, row[0], mix_after=(3, 25))
 
                 # dilute the sample down the column
-                pipette_1.transfer(
+                pipette.transfer(
                     30, row[:11], row[1:],
                     mix_after=(3, 25))
     
@@ -450,7 +457,7 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
@@ -518,7 +525,8 @@ This protocol dispenses different volumes of liquids to a well plate and automat
                 reservoir = protocol.load_labware(
                     load_name='usascientific_12_reservoir_22ml',
                     location='C1')
-                pipette_1 = protocol.load_instrument(
+                trash = protocol.load_trash_bin('A3')
+                pipette = protocol.load_instrument(
                     instrument_name='flex_1channel_1000',
                     mount='right',
                 tip_racks=[tiprack_1, tiprack_2])
@@ -539,7 +547,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
                     89, 90, 91, 92, 93, 94, 95, 96
                     ]
 
-                pipette_1.distribute(water_volumes, reservoir['A12'], plate.wells())
+                pipette.distribute(water_volumes, reservoir['A12'], plate.wells())
 
     .. tab:: OT-2
         
@@ -547,7 +555,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
             :substitutions:
 
             from opentrons import protocol_api
-            metadata = {'apiLevel': '2.14'}
+            metadata = {'apiLevel': '|apiLevel|'}
                 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -85,7 +85,6 @@ Every protocol needs to have a metadata dictionary with information about the pr
 You can include any other information you like in the metadata dictionary. The fields ``protocolName``, ``description``, and ``author`` are all displayed in the Opentrons App, so it’s a good idea to expand the dictionary to include them:
 
 .. code-block:: python
-    :substitutions:
 
     metadata = {
         'apiLevel': '2.16',
@@ -143,7 +142,6 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
         Here’s how to load the labware on a Flex in slots D1, D2, and D3 (repeating the ``def`` statement from above to show proper indenting):
 
         .. code-block:: python
-            :substitutions:
 
             def run(protocol: protocol_api.ProtocolContext):
                 tips = protocol.load_labware('opentrons_flex_96_tiprack_200ul', 'D1')
@@ -165,7 +163,6 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
         Here’s how to load the labware on an OT-2 in slots 1, 2, and 3 (repeating the ``def`` statement from above to show proper indenting):
         
         .. code-block:: python
-            :substitutions:
  
             def run(protocol: protocol_api.ProtocolContext):
                 tips = protocol.load_labware('opentrons_96_tiprack_300ul', 1)
@@ -332,9 +329,7 @@ If you get any errors in simulation, or you don't get the outcome you expected w
 In Simulation
 -------------
 
-.. suggest linking to pip install rather than just using text in ``code`` format. Help reader find resource
-
-Simulation doesn’t require having a robot connected to your computer. You just need to install the `Opentrons Python module <https://pypi.org/project/opentrons/>`_ from Pip (``pip install opentrons``). This will give you access to the ``opentrons_simulate`` command-line utility (``opentrons_simulate.exe`` on Windows).
+Simulation doesn’t require having a robot connected to your computer. You just need to install the `Opentrons Python module <https://pypi.org/project/opentrons/>`_ using pip (``pip install opentrons``). This will give you access to the ``opentrons_simulate`` command-line utility (``opentrons_simulate.exe`` on Windows).
 
 To see a text preview of the steps your Flex or OT-2 will take, use the change directory (``cd``) command to navigate to the location of your saved protocol file and run:
 

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -184,11 +184,11 @@ You may notice that these deck maps don't show where the liquids will be at the 
 Trash Bin
 ^^^^^^^^^
 
-Every protocol that disposes of tips needs a place where the pipette will put them.
+Flex and OT-2 both come with a trash bin for disposing used tips.
 
-OT-2 always has its trash container in slot 12. You don't need to write any code to tell the API where the trash is on OT-2. Skip ahead to the Pipettes section below.
+The OT-2 trash bin is fixed in slot 12. Since it can't go anywhere else on the deck, you don't need to write any code to tell the API where it is. Skip ahead to the Pipettes section below.
 
-Flex lets you put a :ref:`trash bin <configure-trash-bin>` in multiple locations on the deck. You can even have more than one trash bin, or none at all (if you use the :ref:`waste chute <configure-waste-chute>` instead, or if your protocol never trashes any tips). Loading a trash bin on Flex is done with the :py:meth:`.load_trash_bin` method, which takes one argument: its location. Here's how to load the trash in slot A3::
+Flex lets you put a :ref:`trash bin <configure-trash-bin>` in multiple locations on the deck. You can even have more than one trash bin, or none at all (if you use the :ref:`waste chute <configure-waste-chute>` instead, or if your protocol never trashes any tips). For serial dilution, you'll need to dispose used tips, so you also need to tell the API where the trash container is located on your robot. Loading a trash bin on Flex is done with the :py:meth:`.load_trash_bin` method, which takes one argument: its location. Here's how to load the trash in slot A3::
 
     trash = protocol.load_trash_bin('A3')
 

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -78,11 +78,11 @@ For this tutorial, you’ll write very little Python outside of the ``run()`` fu
 Metadata
 ^^^^^^^^
 
-Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version of the API <version-table>` the protocol requires. The `scripts <https://github.com/Opentrons/opentrons/blob/edge/api/docs/v2/example_protocols/>`_ for this tutorial were validated against API version 2.15, so specify:
+Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version of the API <version-table>` the protocol requires. The `scripts <https://github.com/Opentrons/opentrons/blob/edge/api/docs/v2/example_protocols/>`_ for this tutorial were validated against API version 2.16, so specify:
 
 .. code-block:: python
 
-    metadata = {'apiLevel': '2.15'}
+    metadata = {'apiLevel': '2.16'}
 
 You can include any other information you like in the metadata dictionary. The fields ``protocolName``, ``description``, and ``author`` are all displayed in the Opentrons App, so it’s a good idea to expand the dictionary to include them:
 
@@ -90,7 +90,7 @@ You can include any other information you like in the metadata dictionary. The f
     :substitutions:
 
     metadata = {
-        'apiLevel': '2.15',
+        'apiLevel': '2.16',
         'protocolName': 'Serial Dilution Tutorial',
         'description': '''This protocol is the outcome of following the 
                        Python Protocol API Tutorial located at 
@@ -114,11 +114,11 @@ Whether you need a ``requirements`` block depends on your robot model and API ve
 
 - **Flex:** The ``requirements`` block is always required. And, the API version does not go in the ``metadata`` section. The API version belongs in the ``requirements``. For example::
 
-    requirements = {"robotType": "Flex", "apiLevel": "2.15"}
+    requirements = {"robotType": "Flex", "apiLevel": "2.16"}
 
 - **OT-2:** The ``requirements`` block is optional, but including it is a recommended best practice, particularly if you’re using API version 2.15 or greater. If you do use it, remember to remove the API version from the ``metadata``. For example::
     
-    requirements = {"robotType": "OT-2", "apiLevel": "2.15"} 
+    requirements = {"robotType": "OT-2", "apiLevel": "2.16"}
 
 With the metadata and requirements defined, you can move on to creating the ``run()`` function for your protocol.
 
@@ -185,6 +185,18 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
             :alt: OT-2 deck map with a tip rack in slot 1, reservoir in slot 2, and well plate in slot 3.
 
 You may notice that these deck maps don't show where the liquids will be at the start of the protocol. Liquid definitions aren’t required in Python protocols, unlike protocols made in `Protocol Designer <https://designer.opentrons.com/>`_. If you want to identify liquids, see `Labeling Liquids in Wells <https://docs.opentrons.com/v2/new_labware.html#labeling-liquids-in-wells>`_. (Sneak peek: you’ll put the diluent in column 1 of the reservoir and the solution in column 2 of the reservoir.)
+
+Trash Bin
+---------
+
+Every protocol that disposes of tips needs a place where the pipette will put them.
+
+OT-2 always has its trash container in slot 12. You don't need to write any code to tell the API where the trash is on OT-2. Skip ahead to the Pipettes section below.
+
+Flex lets you put a :ref:`trash bin <configure-trash-bin>` in multiple locations on the deck. You can even have more than one trash bin, or none at all (if you use the :ref:`waste chute <configure-waste-chute>` instead, or if your protocol never trashes any tips). Loading a trash bin on Flex is done with the :py:meth:`.load_trash_bin` method, which takes one argument: its location. Here's how to load the trash in slot A3::
+
+    trash = protocol.load_trash_bin('A3')
+
 
 Pipettes
 --------

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -2,30 +2,29 @@
 
 .. _tutorial:
 
-########
+********
 Tutorial
-########
+********
 
-************
 Introduction
-************
+============
 
 This tutorial will guide you through creating a Python protocol file from scratch. At the end of this process you’ll have a complete protocol that can run on a Flex or an OT-2 robot. If you don’t have a Flex or an OT-2 (or if you’re away from your lab, or if your robot is in use), you can use the same file to simulate the protocol on your computer instead.
 
 What You’ll Automate
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 The lab task that you’ll automate in this tutorial is `serial dilution`: taking a solution and progressively diluting it by transferring it stepwise across a plate from column 1 to column 12. With just a dozen or so lines of code, you can instruct your robot to perform the hundreds of individual pipetting actions necessary to fill an entire 96-well plate. And all of those liquid transfers will be done automatically, so you’ll have more time to do other work in your lab.
 
 Before You Begin
-^^^^^^^^^^^^^^^^
+----------------
 
 You're going to write some Python code, but you don't need to be a Python expert to get started writing Opentrons protocols. You should know some basic Python syntax, like how it uses `indentation <https://docs.python.org/3/reference/lexical_analysis.html#indentation>`_ to group blocks of code, dot notation for `calling methods <https://docs.python.org/3/tutorial/classes.html#method-objects>`_, and the format of `lists <https://docs.python.org/3/tutorial/introduction.html#lists>`_ and `dictionaries <https://docs.python.org/3/tutorial/datastructures.html#dictionaries>`_. You’ll also be using `common control structures <https://docs.python.org/3/tutorial/controlflow.html#if-statements>`_ like ``if`` statements and ``for`` loops. 
 
 To run your code, make sure that you've installed `Python 3 <https://wiki.python.org/moin/BeginnersGuide/Download>`_ and the `pip package installer <https://pip.pypa.io/en/stable/getting-started/>`_. You should write your code in your favorite plaintext editor or development environment and save it in a file with a ``.py`` extension, like ``dilution-tutorial.py``.
 
 Hardware and Labware
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 Before running a protocol, you’ll want to have the right kind of hardware and labware ready for your Flex or OT-2.
 
@@ -57,9 +56,8 @@ The Flex and OT-2 use similar labware for serial dilution. The tutorial code wil
 
 For the liquids, you can use plain water as the diluent and water dyed with food coloring as the solution.
 
-**********************
 Create a Protocol File
-**********************
+======================
 
 Let’s start from scratch to create your serial dilution protocol. Open up a new file in your editor and start with the line: 
 
@@ -76,7 +74,7 @@ For this tutorial, you’ll write very little Python outside of the ``run()`` fu
 .. _tutorial-metadata:
 
 Metadata
-^^^^^^^^
+--------
 
 Every protocol needs to have a metadata dictionary with information about the protocol. At minimum, you need to specify what :ref:`version of the API <version-table>` the protocol requires. The `scripts <https://github.com/Opentrons/opentrons/blob/edge/api/docs/v2/example_protocols/>`_ for this tutorial were validated against API version 2.16, so specify:
 
@@ -105,7 +103,7 @@ Note, if you have a Flex, or are using an OT-2 with API v2.15 (or higher), we re
 .. _tutorial-requirements:
 
 Requirements
-^^^^^^^^^^^^
+------------
 
 The ``requirements`` code block can appear before *or* after the ``metadata`` code block in a Python protocol. It uses the following syntax and accepts two arguments: ``robotType`` and ``apiLevel``.
 
@@ -123,7 +121,7 @@ Whether you need a ``requirements`` block depends on your robot model and API ve
 With the metadata and requirements defined, you can move on to creating the ``run()`` function for your protocol.
 
 The ``run()`` function
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 Now it’s time to actually instruct the Flex or OT-2 how to perform serial dilution. All of this information is contained in a single Python function, which has to be named ``run``. This function takes one argument, which is the *protocol context*. Many examples in these docs use the argument name ``protocol``, and sometimes they specify the argument’s type:
 
@@ -134,7 +132,7 @@ Now it’s time to actually instruct the Flex or OT-2 how to perform serial dilu
 With the protocol context argument named and typed, you can start calling methods on ``protocol`` to add labware and hardware.
 
 Labware
--------
+^^^^^^^
 
 For serial dilution, you need to load a tip rack, reservoir, and 96-well plate on the deck of your Flex or OT-2. Loading labware is done with the :py:meth:`~.ProtocolContext.load_labware` method of the protocol context, which takes two arguments: the standard labware name as defined in the `Opentrons Labware Library <https://labware.opentrons.com/>`_, and the position where you'll place the labware on the robot's deck.
 
@@ -187,7 +185,7 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
 You may notice that these deck maps don't show where the liquids will be at the start of the protocol. Liquid definitions aren’t required in Python protocols, unlike protocols made in `Protocol Designer <https://designer.opentrons.com/>`_. If you want to identify liquids, see `Labeling Liquids in Wells <https://docs.opentrons.com/v2/new_labware.html#labeling-liquids-in-wells>`_. (Sneak peek: you’ll put the diluent in column 1 of the reservoir and the solution in column 2 of the reservoir.)
 
 Trash Bin
----------
+^^^^^^^^^
 
 Every protocol that disposes of tips needs a place where the pipette will put them.
 
@@ -199,7 +197,7 @@ Flex lets you put a :ref:`trash bin <configure-trash-bin>` in multiple locations
 
 
 Pipettes
---------
+^^^^^^^^
 
 Next you’ll specify what pipette to use in the protocol. Loading a pipette is done with the :py:meth:`.load_instrument` method, which takes three arguments: the name of the pipette, the mount it’s installed in, and the tip racks it should use when performing transfers. Load whatever pipette you have installed in your robot by using its :ref:`standard pipette name <new-pipette-models>`. Here’s how to load the pipette in the left mount and instantiate it as a variable named ``left_pipette``:
 
@@ -222,7 +220,7 @@ Since the pipette is so fundamental to the protocol, it might seem like you shou
 .. _tutorial-commands:
 
 Commands
---------
+^^^^^^^^
 
 Finally, all of your labware and hardware is in place, so it’s time to give the robot pipetting commands. The required steps of the serial dilution process break down into three main phases:
 
@@ -297,7 +295,7 @@ All that remains is for the loop to repeat these steps, filling each row down th
 That’s it! If you’re using a single-channel pipette, you’re ready to try out your protocol. 
 
 8-Channel Pipette
------------------
+^^^^^^^^^^^^^^^^^
 
 If you’re using an 8-channel pipette, you’ll need to make a couple tweaks to the single-channel code from above. Most importantly, whenever you target a well in row A of a plate with an 8-channel pipette, it will move its topmost tip to row A, lining itself up over the entire column.
 
@@ -317,9 +315,8 @@ And by accessing an entire column at once, the 8-channel pipette effectively imp
 
 Instead of tracking the current row in the ``row`` variable, this code sets it to always be row A (index 0). 
 
-*****************
 Try Your Protocol
-*****************
+=================
 
 There are two ways to try out your protocol: simulation on your computer, or a live run on a Flex or OT-2. Even if you plan to run your protocol on a robot, it’s a good idea to check the simulation output first.
 
@@ -333,7 +330,8 @@ If you get any errors in simulation, or you don't get the outcome you expected w
 .. _tutorial-simulate:
 
 In Simulation
-^^^^^^^^^^^^^
+-------------
+
 .. suggest linking to pip install rather than just using text in ``code`` format. Help reader find resource
 
 Simulation doesn’t require having a robot connected to your computer. You just need to install the `Opentrons Python module <https://pypi.org/project/opentrons/>`_ from Pip (``pip install opentrons``). This will give you access to the ``opentrons_simulate`` command-line utility (``opentrons_simulate.exe`` on Windows).
@@ -355,7 +353,7 @@ The ``-e`` flag estimates duration, and ``-o nothing`` suppresses printing the r
 If that’s too long, you can always cancel your run partway through or modify ``for i in range(8)`` to loop through fewer rows.
 
 On a Robot
-^^^^^^^^^^
+----------
 
 The simplest way to run your protocol on a Flex or OT-2 is to use the `Opentrons App <https://opentrons.com/ot-app>`_. When you first launch the Opentrons App, you will see the Protocols screen. (Click **Protocols** in the left sidebar to access it at any other time.) Click **Import** in the top right corner to reveal the Import a Protocol pane. Then click **Choose File** and find your protocol in the system file picker, or drag and drop your protocol file into the well.
 
@@ -372,8 +370,7 @@ When it’s all done, check the results of your serial dilution procedure — yo
     :align: center
     :alt: An overhead view of a well plate on the metal OT-2 deck, with dark blue liquid in the leftmost column smoothly transitioning to very light blue in the rightmost column.
 
-**********
 Next Steps
-**********
+==========
 
 This tutorial has relied heavily on the ``transfer()`` method, but there's much more that the Python Protocol API can do. Many advanced applications use :ref:`building block commands <v2-atomic-commands>` for finer control over the robot. These commands let you aspirate and dispense separately, add air gaps, blow out excess liquid, move the pipette to any location, and more. For protocols that use :ref:`Opentrons hardware modules <new_modules>`, there are methods to control their behavior. And all of the API's classes and methods are catalogued in the :ref:`API Reference <protocol-api-reference>`.


### PR DESCRIPTION
# Overview

Light edits to the Python API Tutorial and Protocol Examples so everything works in version 2.16.

The most important addition is loading the trash bin in the Flex protocols. They won't analyze on 2.16 without that.

# Test Plan

- 2.16 protocol files and example snippets simulated with 7.1.0 release
- [Page sandbox](http://sandbox.docs.opentrons.com/trash-for-the-trash-god/v2/tutorial.html)

# Changelog

- protocol files
  - `apiLevel` raised to 2.16 in all
  - `load_trash_bin()` in Flex protocols
  - fix weird indent in Flex 8-channel protocol
- Tutorial
  - `apiLevel` raised to 2.16 (manually, not substitution)
  - add Trash Bin section
  - standardize header markup
- Protocol Examples
  - `apiLevel` substitutions for Flex and OT-2
  - use `pipette` instead of `pipette_1` to better match rest of docs
  - fix incorrect counting and incompatible tip rack in air gap example

# Review requests

Give closest attention to the new prose in the Trash Bin section.

# Risk assessment

none, docs.