### PR TITLE
docs(api): replace single quotes with double quotes

### DIFF
--- a/api/docs/v1/atomic_commands.rst
+++ b/api/docs/v1/atomic_commands.rst
@@ -22,19 +22,19 @@ This section demonstrates the options available for controlling tips
     '''
     from opentrons import labware, instruments, robot
 
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '2')
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "2")
 
-    pipette = instruments.P300_Single(mount='left')
+    pipette = instruments.P300_Single(mount="left")
 
 
 Pick Up Tip
 ===========
 
-Before any liquid handling can be done, your pipette must have a tip on it. The command ``pick_up_tip()`` will move the pipette over to the specified tip, the press down into it to create a vacuum seal. The below example picks up the tip at location ``'A1'``.
+Before any liquid handling can be done, your pipette must have a tip on it. The command ``pick_up_tip()`` will move the pipette over to the specified tip, the press down into it to create a vacuum seal. The below example picks up the tip at location ``"A1"``.
 
 .. code-block:: python
 
-    pipette.pick_up_tip(tiprack.wells('A1'))
+    pipette.pick_up_tip(tiprack.wells("A1"))
 
 Drop Tip
 ===========
@@ -44,24 +44,24 @@ If no location is specified, it will go to the fixed trash location on the deck.
 
 .. code-block:: python
 
-    pipette.drop_tip(tiprack.wells('A1'))
+    pipette.drop_tip(tiprack.wells("A1"))
 
 Instead of returning a tip to the tip rack, we can also drop it in an alternative trash container besides the fixed trash on the deck.
 
 .. code-block:: python
 
-    trash = labware.load('trash-box', '1')
-    pipette.pick_up_tip(tiprack.wells('A2'))
+    trash = labware.load("trash-box", "1")
+    pipette.pick_up_tip(tiprack.wells("A2"))
     pipette.drop_tip(trash)
 
 Return Tip
 ===========
 
-When we need to return the tip to its originating location on the tip rack, we can simply call ``return_tip()``. The example below will automatically return the tip to ``'A3'`` on the tip rack.
+When we need to return the tip to its originating location on the tip rack, we can simply call ``return_tip()``. The example below will automatically return the tip to ``"A3"`` on the tip rack.
 
 .. code-block:: python
 
-    pipette.pick_up_tip(tiprack.wells('A3'))
+    pipette.pick_up_tip(tiprack.wells("A3"))
     pipette.return_tip()
 
 
@@ -80,9 +80,9 @@ If no location is specified, the pipette will move to the next available tip by 
     '''
     from opentrons import labware, instruments, robot
 
-    trash = labware.load('trash-box', '1')
-    tip_rack_1 = containers.load('opentrons_96_tiprack_300ul', '2')
-    tip_rack_2 = containers.load('opentrons_96_tiprack_300ul', '3')
+    trash = labware.load("trash-box", "1")
+    tip_rack_1 = containers.load("opentrons_96_tiprack_300ul", "2")
+    tip_rack_2 = containers.load("opentrons_96_tiprack_300ul", "3")
 
 Attach Tip Rack to Pipette
 --------------------------
@@ -95,7 +95,7 @@ Multiple tip racks are can be attached with the option ``tip_racks=[RACK_1, RACK
 
 .. code-block:: python
 
-    pipette = instruments.P300_Single(mount='left',
+    pipette = instruments.P300_Single(mount="left",
                                       tip_racks=[tip_rack_1, tip_rack_2],
                                       trash_container=trash)
 
@@ -147,18 +147,18 @@ If you plan to change out tipracks during the protocol run, you must reset tip t
 Select Starting Tip
 -------------------
 
-Calls to ``pick_up_tip()`` will by default start at the attached tip rack's ``'A1'`` location in order of tipracks listed. If you however want to start automatic tip iterating at a different tip, you can use ``start_at_tip()``.
+Calls to ``pick_up_tip()`` will by default start at the attached tip rack's ``"A1"`` location in order of tipracks listed. If you however want to start automatic tip iterating at a different tip, you can use ``start_at_tip()``.
 
 .. code-block:: python
 
-    pipette.start_at_tip(tip_rack_1.well('C3'))
+    pipette.start_at_tip(tip_rack_1.well("C3"))
     pipette.pick_up_tip()  # pick up C3 from "tip_rack_1"
     pipette.return_tip()
 
 Get Current Tip
 ---------------
 
-Get the source location of the pipette's current tip by calling ``current_tip()``. If the tip was from the ``'A1'`` position on our tip rack, ``current_tip()`` will return that position.
+Get the source location of the pipette's current tip by calling ``current_tip()``. If the tip was from the ``"A1"`` position on our tip rack, ``current_tip()`` will return that position.
 
 .. code-block:: python
 
@@ -191,8 +191,8 @@ Please note that the default now for pipette aspirate and dispense location is a
     '''
     Examples in this section expect the following:
     '''
-    plate = labware.load('96-flat', '1')
-    pipette = instruments.P300_Single(mount='left')
+    plate = labware.load("96-flat", "1")
+    pipette = instruments.P300_Single(mount="left")
     pipette.pick_up_tip()
 
 
@@ -203,11 +203,11 @@ To aspirate is to pull liquid up into the pipette's tip. When calling aspirate o
 
 .. code-block:: python
 
-    pipette.aspirate(50, plate.wells('A1'))  # aspirate 50uL from plate:A1
+    pipette.aspirate(50, plate.wells("A1"))  # aspirate 50uL from plate:A1
 
 Now our pipette's tip is holding 50uL.
 
-We can also simply specify how many microliters to aspirate, and not mention a location. The pipette in this circumstance will aspirate from it's current location (which we previously set as ``plate.wells('A1'))``.
+We can also simply specify how many microliters to aspirate, and not mention a location. The pipette in this circumstance will aspirate from it's current location (which we previously set as ``plate.wells("A1"))``.
 
 .. code-block:: python
 
@@ -219,7 +219,7 @@ We can also specify only the location to aspirate from. If we do not tell the pi
 
 .. code-block:: python
 
-    pipette.aspirate(plate.wells('A2'))      # aspirate until pipette fills from plate:A2
+    pipette.aspirate(plate.wells("A2"))      # aspirate until pipette fills from plate:A2
 
 
 Dispense
@@ -229,11 +229,11 @@ To dispense is to push out liquid from the pipette's tip. It's usage in the Open
 
 .. code-block:: python
 
-    pipette.dispense(50, plate.wells('B1')) # dispense 50uL to plate:B1
+    pipette.dispense(50, plate.wells("B1")) # dispense 50uL to plate:B1
     pipette.dispense(50)                    # dispense 50uL to current position
-    pipette.dispense(plate.wells('B2'))     # dispense until pipette empties to plate:B2
+    pipette.dispense(plate.wells("B2"))     # dispense until pipette empties to plate:B2
 
-That final dispense without specifying a micoliter amount will dispense all remaining liquids in the tip to ``plate.wells('B2')``, and now our pipette is empty.
+That final dispense without specifying a micoliter amount will dispense all remaining liquids in the tip to ``plate.wells("B2")``, and now our pipette is empty.
 
 Blow Out
 ========
@@ -245,7 +245,7 @@ When calling ``blow_out()`` on a pipette, we have the option to specify a locati
 .. code-block:: python
 
     pipette.blow_out()                  # blow out in current location
-    pipette.blow_out(plate.wells('B3')) # blow out in current plate:B3
+    pipette.blow_out(plate.wells("B3")) # blow out in current plate:B3
 
 
 Touch Tip
@@ -259,7 +259,7 @@ When calling ``touch_tip()`` on a pipette, we have the option to specify a locat
 
     pipette.touch_tip()                  # touch tip within current location
     pipette.touch_tip(v_offset=-2)       # touch tip 2mm below the top of the current location
-    pipette.touch_tip(plate.wells('B1')) # touch tip within plate:B1
+    pipette.touch_tip(plate.wells("B1")) # touch tip within plate:B1
 
 
 Mix
@@ -271,7 +271,7 @@ The mix command takes three arguments: ``mix(repetitions, volume, location)``
 
 .. code-block:: python
 
-    pipette.mix(4, 100, plate.wells('A2'))   # mix 4 times, 100uL, in plate:A2
+    pipette.mix(4, 100, plate.wells("A2"))   # mix 4 times, 100uL, in plate:A2
     pipette.mix(3, 50)                       # mix 3 times, 50uL, in current location
     pipette.mix(2)                           # mix 2 times, pipette's max volume, in current location
 
@@ -283,7 +283,7 @@ Some liquids need an extra amount of air in the pipette's tip to prevent it from
 
 .. code-block:: python
 
-    pipette.aspirate(100, plate.wells('B4'))
+    pipette.aspirate(100, plate.wells("B4"))
     pipette.air_gap(20)
     pipette.drop_tip()
 
@@ -297,10 +297,10 @@ Some liquids need an extra amount of air in the pipette's tip to prevent it from
     '''
     Examples in this section expect the following
     '''
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
-    plate = labware.load('96-flat', '2')
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "1")
+    plate = labware.load("96-flat", "2")
 
-    pipette = instruments.P300_Single(mount='right', tip_racks=[tiprack])
+    pipette = instruments.P300_Single(mount="right", tip_racks=[tiprack])
 
 Controlling Speed
 =================
@@ -316,10 +316,10 @@ using our `set_flow_rate` function. This can be called at any time during the pr
     '''
     Examples in this section expect the following
     '''
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
-    plate = labware.load('96-flat', '2')
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "1")
+    plate = labware.load("96-flat", "2")
 
-    pipette = instruments.P300_Single(mount='right', tip_racks=[tiprack])
+    pipette = instruments.P300_Single(mount="right", tip_racks=[tiprack])
 
     pipette.set_flow_rate(aspirate=50, dispense=100)
 
@@ -341,35 +341,35 @@ For example, we can move to the first tip in our tip rack:
 
 .. code-block:: python
 
-    pipette.move_to(tiprack.wells('A1'))
+    pipette.move_to(tiprack.wells("A1"))
 
 You can also specify at what height you would like the robot to move to inside of a location using ``top()`` and ``bottom()`` methods on that location.
 
 .. code-block:: python
 
-    pipette.move_to(plate.wells('A1').bottom())  # move to the bottom of well A1
-    pipette.move_to(plate.wells('A1').top())     # move to the top of well A1
-    pipette.move_to(plate.wells('A1').bottom(2)) # move to 2mm above the bottom of well A1
-    pipette.move_to(plate.wells('A1').top(-2))   # move to 2mm below the top of well A1
+    pipette.move_to(plate.wells("A1").bottom())  # move to the bottom of well A1
+    pipette.move_to(plate.wells("A1").top())     # move to the top of well A1
+    pipette.move_to(plate.wells("A1").bottom(2)) # move to 2mm above the bottom of well A1
+    pipette.move_to(plate.wells("A1").top(-2))   # move to 2mm below the top of well A1
 
-The above commands will cause the robot's head to first move upwards, then over to above the target location, then finally downwards until the target location is reached. If instead you would like the robot to move in a straight line to the target location, you can set the movement strategy to ``'direct'``.
+The above commands will cause the robot's head to first move upwards, then over to above the target location, then finally downwards until the target location is reached. If instead you would like the robot to move in a straight line to the target location, you can set the movement strategy to ``"direct"``.
 
 .. code-block:: python
 
-    pipette.move_to(plate.wells('A1'), strategy='direct')
+    pipette.move_to(plate.wells("A1"), strategy="direct")
 
 .. note::
 
-    Moving with ``strategy='direct'`` will run the risk of colliding with things on your deck. Be very careful when using this option.
+    Moving with ``strategy="direct"`` will run the risk of colliding with things on your deck. Be very careful when using this option.
 
-Usually the ``strategy='direct'`` option is useful when moving inside of a well. Take a look at the below sequence of movements, which first move the head to a well, and use 'direct' movements inside that well, then finally move on to a different well.
+Usually the ``strategy="direct"`` option is useful when moving inside of a well. Take a look at the below sequence of movements, which first move the head to a well, and use "direct" movements inside that well, then finally move on to a different well.
 
 .. code-block:: python
 
-    pipette.move_to(plate.wells('A1'))
-    pipette.move_to(plate.wells('A1').bottom(1), strategy='direct')
-    pipette.move_to(plate.wells('A1').top(-2), strategy='direct')
-    pipette.move_to(plate.wells('A1'))
+    pipette.move_to(plate.wells("A1"))
+    pipette.move_to(plate.wells("A1").bottom(1), strategy="direct")
+    pipette.move_to(plate.wells("A1").top(-2), strategy="direct")
+    pipette.move_to(plate.wells("A1"))
 
 Delay
 =====

--- a/api/docs/v1/complex_commands.rst
+++ b/api/docs/v1/complex_commands.rst
@@ -12,12 +12,12 @@ The examples below will use the following set-up:
 
     from opentrons import robot, labware, instruments
 
-    plate = labware.load('96-flat', '1')
+    plate = labware.load("96-flat", "1")
 
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '2')
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "2")
 
     pipette = instruments.P300_Single(
-        mount='left',
+        mount="left",
         tip_racks=[tiprack])
 
 You could simulate the protocol using our protocol simulator, which can be installed by following the instructions `here. <https://github.com/Opentrons/opentrons/tree/edge/api#simulating-protocols>`_
@@ -33,11 +33,11 @@ For transferring with a multi-channel, please refer to the :ref:`multi-channel-l
 Basic
 -----
 
-The example below will transfer 100 uL from well ``'A1'`` to well ``'B1'``, automatically picking up a new tip and then disposing it when finished.
+The example below will transfer 100 uL from well ``"A1"`` to well ``"B1"``, automatically picking up a new tip and then disposing it when finished.
 
 .. code-block:: python
 
-    pipette.transfer(100, plate.wells('A1'), plate.wells('B1'))
+    pipette.transfer(100, plate.wells("A1"), plate.wells("B1"))
 
 Transfer commands will automatically create entire series of ``aspirate()``, ``dispense()``, and other ``Pipette`` commands.
 
@@ -49,7 +49,7 @@ Volumes larger than the pipette's ``max_volume`` will automatically divide into 
 
 .. code-block:: python
 
-    pipette.transfer(700, plate.wells('A2'), plate.wells('B2'))
+    pipette.transfer(700, plate.wells("A2"), plate.wells("B2"))
 
 will have the steps...
 
@@ -72,7 +72,7 @@ Transfer commands are most useful when moving liquid between multiple wells.
 
 .. code-block:: python
 
-    pipette.transfer(100, plate.cols('1'), plate.cols('2'))
+    pipette.transfer(100, plate.cols("1"), plate.cols("2"))
 
 will have the steps...
 
@@ -105,7 +105,7 @@ You can transfer from a single source to multiple destinations, and the other wa
 
 .. code-block:: python
 
-    pipette.transfer(100, plate.wells('A1'), plate.cols('2'))
+    pipette.transfer(100, plate.wells("A1"), plate.cols("2"))
 
 
 will have the steps...
@@ -141,8 +141,8 @@ What happens if, for example, you tell your pipette to transfer from 2 source we
 
     pipette.transfer(
         100,
-        plate.wells('A1', 'A2'),
-        plate.wells('B1', 'B2', 'B3', 'B4'))
+        plate.wells("A1", "A2"),
+        plate.wells("B1", "B2", "B3", "B4"))
 
 will have the steps...
 
@@ -169,8 +169,8 @@ Instead of applying a single volume amount to all source/destination wells, you 
 
     pipette.transfer(
         [20, 40, 60],
-        plate.wells('A1'),
-        plate.wells('B1', 'B2', 'B3'))
+        plate.wells("A1"),
+        plate.wells("B1", "B2", "B3"))
 
 
 will have the steps...
@@ -196,8 +196,8 @@ Create a linear gradient between a start and ending volume (uL). The start and e
 
     pipette.transfer(
         (100, 30),
-        plate.wells('A1'),
-        plate.cols('2'))
+        plate.wells("A1"),
+        plate.cols("2"))
 
 
 will have the steps...
@@ -238,7 +238,7 @@ Volumes going to the same destination well are combined within the same tip, so 
 
 .. code-block:: python
 
-    pipette.consolidate(30, plate.cols('2'), plate.wells('A1'))
+    pipette.consolidate(30, plate.cols("2"), plate.wells("A1"))
 
 will have the steps...
 
@@ -262,7 +262,7 @@ If there are multiple destination wells, the pipette will never combine their vo
 
 .. code-block:: python
 
-    pipette.consolidate(30, plate.cols('1'), plate.wells('A1', 'A2'))
+    pipette.consolidate(30, plate.cols("1"), plate.wells("A1", "A2"))
 
 
 will have the steps...
@@ -291,7 +291,7 @@ Volumes from the same source well are combined within the same tip, so that one 
 
 .. code-block:: python
 
-    pipette.distribute(55, plate.wells('A1'), plate.rows('A'))
+    pipette.distribute(55, plate.wells("A1"), plate.rows("A"))
 
 
 will have the steps...
@@ -326,7 +326,7 @@ If there are multiple source wells, the pipette will never combine their volumes
 
 .. code-block:: python
 
-    pipette.distribute(30, plate.wells('A1', 'A2'), plate.rows('A'))
+    pipette.distribute(30, plate.wells("A1", "A2"), plate.rows("A"))
 
 will have the steps...
 
@@ -362,8 +362,8 @@ When dispensing multiple times from the same tip, it is recommended to aspirate 
 
     pipette.distribute(
         30,
-        plate.wells('A1', 'A2'),
-        plate.cols('2'),
+        plate.wells("A1", "A2"),
+        plate.cols("2"),
         disposal_vol=10)   # include extra liquid to make dispenses more accurate
 
 
@@ -406,9 +406,9 @@ The pipette can optionally get a new tip at the beginning of each aspirate, to h
 
     pipette.transfer(
         100,
-        plate.wells('A1', 'A2', 'A3'),
-        plate.wells('B1', 'B2', 'B3'),
-        new_tip='always')    # always pick up a new tip
+        plate.wells("A1", "A2", "A3"),
+        plate.wells("B1", "B2", "B3"),
+        new_tip="always")    # always pick up a new tip
 
 
 will have the steps...
@@ -440,9 +440,9 @@ For scenarios where you instead are calling ``pick_up_tip()`` and ``drop_tip()``
     ...
     pipette.transfer(
         100,
-        plate.wells('A1', 'A2', 'A3'),
-        plate.wells('B1', 'B2', 'B3'),
-        new_tip='never')    # never pick up or drop a tip
+        plate.wells("A1", "A2", "A3"),
+        plate.wells("B1", "B2", "B3"),
+        new_tip="never")    # never pick up or drop a tip
     ...
     pipette.drop_tip()
 
@@ -473,9 +473,9 @@ The default behavior of complex commands is to use one tip:
 
     pipette.transfer(
         100,
-        plate.wells('A1', 'A2', 'A3'),
-        plate.wells('B1', 'B2', 'B3'),
-        new_tip='once')    # use one tip (default behavior)
+        plate.wells("A1", "A2", "A3"),
+        plate.wells("B1", "B2", "B3"),
+        new_tip="once")    # use one tip (default behavior)
 
 will have the steps...
 
@@ -500,8 +500,8 @@ By default, the transfer command will drop the pipette's tips in the trash conta
 
     pipette.transfer(
         100,
-        plate.wells('A1'),
-        plate.wells('B1'),
+        plate.wells("A1"),
+        plate.wells("B1"),
         trash=False)       # do not trash tip
 
 
@@ -525,8 +525,8 @@ A touch-tip can be performed after every aspirate and dispense by setting ``touc
 
     pipette.transfer(
         100,
-        plate.wells('A1'),
-        plate.wells('A2'),
+        plate.wells("A1"),
+        plate.wells("A2"),
         touch_tip=True)     # touch tip to each well's edge
 
 
@@ -551,8 +551,8 @@ A blow-out can be performed after every dispense that leaves the tip empty by se
 
     pipette.transfer(
         100,
-        plate.wells('A1'),
-        plate.wells('A2'),
+        plate.wells("A1"),
+        plate.wells("A2"),
         blow_out=True)      # blow out droplets when tip is empty
 
 
@@ -576,8 +576,8 @@ A mix can be performed before every aspirate by setting ``mix_before=``. The val
 
     pipette.transfer(
         100,
-        plate.wells('A1'),
-        plate.wells('A2'),
+        plate.wells("A1"),
+        plate.wells("A2"),
         mix_before=(2, 50), # mix 2 times with 50uL before aspirating
         mix_after=(3, 75))  # mix 3 times with 75uL after dispensing
 
@@ -613,8 +613,8 @@ An air gap can be performed after every aspirate by setting ``air_gap=int``, whe
 
     pipette.transfer(
         100,
-        plate.wells('A1'),
-        plate.wells('A2'),
+        plate.wells("A1"),
+        plate.wells("A2"),
         air_gap=20)         # add 20uL of air after each aspirate
 
 
@@ -648,14 +648,14 @@ We will be using the code-block below to perform our examples.
 
     from opentrons import robot, labware, instruments
 
-    plate_96 = labware.load('96-flat', '1')
-    plate_384 = labware.load('384-plate', '3')
-    trough = labware.load('trough-12row', '4')
+    plate_96 = labware.load("96-flat", "1")
+    plate_384 = labware.load("384-plate", "3")
+    trough = labware.load("trough-12row", "4")
 
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '2')
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "2")
 
     multi_pipette = instruments.P300_Multi(
-        mount='left',
+        mount="left",
         tip_racks=[tiprack])
 
 Transfer in a 96 Well Plate
@@ -666,7 +666,7 @@ following:
 
 .. code-block:: python
 
-    multi_pipette.transfer(50, plate_96.columns('1'), plate_96.columns('2', to='12'))
+    multi_pipette.transfer(50, plate_96.columns("1"), plate_96.columns("2", to="12"))
 
 will have the steps
 
@@ -702,7 +702,7 @@ or
 
 .. code-block:: python
 
-    multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.columns('2', to='12'))
+    multi_pipette.transfer(50, plate_96.wells("A1"), plate_96.columns("2", to="12"))
 
 will have the steps
 
@@ -740,14 +740,14 @@ will have the steps
 
     .. code-block:: python
 
-        multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.wells())
+        multi_pipette.transfer(50, plate_96.wells("A1"), plate_96.wells())
 
     The multi-channel would visit **every** well in the plate and dispense liquid
     outside of the plate boundaries so be careful!
 
     .. code-block:: python
 
-        multi_pipette.transfer(50, plate_96.wells('A1'), plate_96.rows('A'))
+        multi_pipette.transfer(50, plate_96.wells("A1"), plate_96.rows("A"))
 
     In this scenario, the multi-channel would only visit the first column of the plate.
 
@@ -755,8 +755,8 @@ will have the steps
 Transfer in a 384 Well Plate
 ----------------------------
 
-In a 384 Well plate, there are 2 sets of 'columns' that the multi-channel can
-dispense into ['A1', 'C1'...'A2', 'C2'...] and ['B1', 'D1'...'B2', 'D2'].
+In a 384 Well plate, there are 2 sets of "columns" that the multi-channel can
+dispense into ["A1", "C1"..."A2", "C2"...] and ["B1", "D1"..."B2", "D2"].
 
 If you want to transfer to a 384 well plate in order, you can do:
 
@@ -764,9 +764,9 @@ If you want to transfer to a 384 well plate in order, you can do:
 
     alternating_wells = []
     for row in plate_384.rows():
-        alternating_wells.append(row.wells('A'))
-        alternating_wells.append(row.wells('B'))
-    multi_pipette.transfer(50, trough.wells('A1'), alternating_wells)
+        alternating_wells.append(row.wells("A"))
+        alternating_wells.append(row.wells("B"))
+    multi_pipette.transfer(50, trough.wells("A1"), alternating_wells)
 
 
 or you can choose to dispense by row first, moving first through row A
@@ -774,5 +774,5 @@ and then through row B of the 384 well plate.
 
 .. code-block:: python
 
-    list_of_wells = [for well in plate_384.rows('A')] + [for well in plate_384.rows('B')]
-    multi_pipette.transfer(50, trough.wells('A1'), list_of_wells)
+    list_of_wells = [for well in plate_384.rows("A")] + [for well in plate_384.rows("B")]
+    multi_pipette.transfer(50, trough.wells("A1"), list_of_wells)

--- a/api/docs/v1/examples.rst
+++ b/api/docs/v1/examples.rst
@@ -10,14 +10,14 @@ All examples on this page assume the following labware and pipette:
 
   from opentrons import robot, labware, instruments
 
-  plate = labware.load('96-flat', '1')
-  trough = labware.load('trough-12row', '2')
+  plate = labware.load("96-flat", "1")
+  trough = labware.load("trough-12row", "2")
 
-  tiprack_1 = labware.load('opentrons_96_tiprack_300ul', '3')
-  tiprack_2 = labware.load('opentrons_96_tiprack_300ul', '4')
+  tiprack_1 = labware.load("opentrons_96_tiprack_300ul", "3")
+  tiprack_2 = labware.load("opentrons_96_tiprack_300ul", "4")
 
   p300 = instruments.P300_Single(
-      mount='left',
+      mount="left",
       tip_racks=[tiprack_2])
 
 ******************************
@@ -30,15 +30,15 @@ Moving 100uL from one well to another:
 
 .. code-block:: python
 
-  p300.transfer(100, plate.wells('A1'), plate.wells('B1'))
+  p300.transfer(100, plate.wells("A1"), plate.wells("B1"))
 
 If you prefer to not use the ``.transfer()`` command, the following pipette commands will create the some results:
 
 .. code-block:: python
 
   p300.pick_up_tip()
-  p300.aspirate(100, plate.wells('A1'))
-  p300.dispense(100, plate.wells('A1'))
+  p300.aspirate(100, plate.wells("A1"))
+  p300.dispense(100, plate.wells("A1"))
   p300.return_tip()
 
 ******************************
@@ -74,7 +74,7 @@ The Opentrons liquid handler can do some things that a human cannot do with a pi
   for well in trough.wells():
     p300.aspirate(35, well).air_gap(10)
 
-  p300.dispense(plate.wells('A1'))
+  p300.dispense(plate.wells("A1"))
 
   p300.return_tip()
 
@@ -88,7 +88,7 @@ This example first spreads a dilutent to all wells of a plate. It then dilutes 8
 
 .. code-block:: python
 
-  p300.distribute(50, trough.wells('A12'), plate.wells())  # dilutent
+  p300.distribute(50, trough.wells("A12"), plate.wells())  # dilutent
 
   # loop through each row
   for i in range(8):
@@ -98,11 +98,11 @@ This example first spreads a dilutent to all wells of a plate. It then dilutes 8
     row = plate.rows(i)
 
     # transfer 30uL of source to first well in column
-    p300.transfer(30, source, column.wells('1'))
+    p300.transfer(30, source, column.wells("1"))
 
     # dilute the sample down the column
     p300.transfer(
-      30, row.wells('1', to='11'), row.wells('2', to='12'),
+      30, row.wells("1", to="11"), row.wells("2", to="12"),
       mix_after=(3, 25))
 
 ******************************
@@ -131,7 +131,7 @@ Deposit various volumes of liquids into the same plate of wells, and automatical
     89, 90, 91, 92, 93, 94, 95, 96
   ]
 
-  p300.distribute(water_volumes, trough.wells('A12'), plate)
+  p300.distribute(water_volumes, trough.wells("A12"), plate)
 
 The final volumes can also be read from a CSV, and opened by your protocol.
 
@@ -155,7 +155,7 @@ The final volumes can also be read from a CSV, and opened by your protocol.
 
   # open file with absolute path (will be different depending on operating system)
   # file paths on Windows look more like 'C:\\path\\to\\your\\csv_file.csv'
-  with open('/path/to/your/csv_file.csv') as my_file:
+  with open("/path/to/your/csv_file.csv") as my_file:
 
       # save all volumes from CSV file into a list
       volumes = []
@@ -163,11 +163,11 @@ The final volumes can also be read from a CSV, and opened by your protocol.
       # loop through each line (the plate's columns)
       for l in my_file.read().splitlines():
           # loop through each comma-separated value (the plate's rows)
-          for v in l.split(','):
+          for v in l.split(","):
               volumes.append(float(v))  # save the volume
 
       # distribute those volumes to the plate
-      p300.distribute(volumes, trough.wells('A1'), plate.wells())
+      p300.distribute(volumes, trough.wells("A1"), plate.wells())
 
 
 
@@ -183,16 +183,16 @@ This example shows how to deposit liquid around the edge of a well using
 .. code-block:: python
 
   p300.pick_up_tip()
-  p300.aspirate(200, trough.wells('A1'))
+  p300.aspirate(200, trough.wells("A1"))
   # rotate around the edge of the well, dropping 20ul at a time
   theta = 0.0
   while p300.current_volume > 0:
       # we can move around a circle with radius (r) and theta (degrees)
-      well_edge = plate.wells('B1').from_center(r=1.0, theta=theta, h=0.9)
+      well_edge = plate.wells("B1").from_center(r=1.0, theta=theta, h=0.9)
 
       # combine a Well with a Vector in a tuple
-      destination = (plate.wells('B1'), well_edge)
-      p300.move_to(destination, strategy='direct')  # move straight there
+      destination = (plate.wells("B1"), well_edge)
+      p300.move_to(destination, strategy="direct")  # move straight there
       p300.dispense(20)
 
       theta += 0.314

--- a/api/docs/v1/hardware_control.rst
+++ b/api/docs/v1/hardware_control.rst
@@ -22,16 +22,16 @@ The robot module can be thought of as the parent for all aspects of the Opentron
     '''
     from opentrons import robot, labware, instruments
 
-    plate = labware.load('96-flat', 'B1', 'my-plate')
-    tiprack = labware.load('opentrons_96_tiprack_300ul', 'A1', 'my-rack')
+    plate = labware.load("96-flat", "B1", "my-plate")
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "A1", "my-rack")
 
-    pipette = instruments.P300_Single(mount='left', tip_racks=[tiprack])
+    pipette = instruments.P300_Single(mount="left", tip_racks=[tiprack])
 
 
 User-Specified Pause
 ====================
 
-This will pause your protocol at a specific step. You can resume by pressing 'resume' in your OT App.
+This will pause your protocol at a specific step. You can resume by pressing "resume" in your OT App.
 
 .. code-block:: python
 
@@ -42,7 +42,7 @@ Head Speed
 
 The speed of the robot's motors can be set using ``robot.head_speed()``. The units are all millimeters-per-second (mm/sec). The ``x``, ``y``, ``z``, ``a``, ``b``, ``c`` parameters set the maximum speed of the corresponding axis on Smoothie.
 
-'x': lateral motion, 'y': front to back motion, 'z': vertical motion of the left mount, 'a': vertical motion of the right mount, 'b': plunger motor for the left pipette, 'c': plunger motor for the right pipette.
+"x": lateral motion, "y": front to back motion, "z": vertical motion of the left mount, "a": vertical motion of the right mount, "b": plunger motor for the left pipette, "c": plunger motor for the right pipette.
 
 The ``combined_speed`` parameter sets the speed across all axes to either the specified value or the axis max, whichever is lower. Defaults are specified by ``DEFAULT_MAX_SPEEDS`` in `robot_configs.py`__.
 
@@ -51,7 +51,7 @@ __ https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/config/rob
 .. code-block:: python
 
     max_speed_per_axis = {
-        'x': 600, 'y': 400, 'z': 125, 'a': 125, 'b': 50, 'c': 50}
+        "x": 600, "y": 400, "z": 125, "a": 125, "b": 50, "c": 50}
     robot.head_speed(
         combined_speed=max(max_speed_per_axis.values()),
         **max_speed_per_axis)
@@ -65,7 +65,7 @@ You can `home` the robot by calling ``home()``. You can also specify axes. The r
 .. code-block:: python
 
     robot.home()           # home the robot on all axis
-    robot.home('z')        # home the Z axis only
+    robot.home("z")        # home the Z axis only
 
 Commands
 ========
@@ -76,8 +76,8 @@ __ https://docs.python.org/3.5/tutorial/datastructures.html#more-on-lists
 
 .. code-block:: python
 
-    pipette.pick_up_tip(tiprack.wells('A1'))
-    pipette.drop_tip(tiprack.wells('A1'))
+    pipette.pick_up_tip(tiprack.wells("A1"))
+    pipette.drop_tip(tiprack.wells("A1"))
 
     for c in robot.commands():
         print(c)
@@ -97,11 +97,11 @@ We can erase the robot command history by calling ``robot.clear_commands()``. An
 .. code-block:: python
 
     robot.clear_commands()
-    pipette.pick_up_tip(tiprack['A1'])
-    print('There is', len(robot.commands()), 'command')
+    pipette.pick_up_tip(tiprack["A1"])
+    print("There is", len(robot.commands()), "command")
 
     robot.clear_commands()
-    print('There are now', len(robot.commands()), 'commands')
+    print("There are now", len(robot.commands()), "commands")
 
 will print out...
 
@@ -119,10 +119,10 @@ You can add a custom message to the list of command descriptions you see when ru
 
     robot.clear_commands()
 
-    pipette.pick_up_tip(tiprack['A1'])
+    pipette.pick_up_tip(tiprack["A1"])
     robot.comment("Hello, just picked up tip A1")
 
-    pipette.pick_up_tip(tiprack['A1'])
+    pipette.pick_up_tip(tiprack["A1"])
     robot.comment("Goodbye, just dropped tip A1")
 
     for c in robot.commands():

--- a/api/docs/v1/index.rst
+++ b/api/docs/v1/index.rst
@@ -36,7 +36,7 @@ Overview
 How it Looks
 ++++++++++++
 
-The design goal of the Opentrons API is to make code readable and easy to understand. For example, below is a short set of instruction to transfer from well ``'A1'`` to well ``'B1'`` that even a computer could understand:
+The design goal of the Opentrons API is to make code readable and easy to understand. For example, below is a short set of instruction to transfer from well ``"A1"`` to well ``"B1"`` that even a computer could understand:
 
 .. code-block:: none
 
@@ -44,12 +44,12 @@ The design goal of the Opentrons API is to make code readable and easy to unders
 
     This protocol is by me; it’s called Opentrons Protocol Tutorial and is used for demonstrating the Opentrons API
 
-    Add a 96 well plate, and place it in slot '2' of the robot deck
-    Add a 200uL tip rack, and place it in slot '1' of the robot deck
+    Add a 96 well plate, and place it in slot "2" of the robot deck
+    Add a 200uL tip rack, and place it in slot "1" of the robot deck
 
     Add a single-channel 300uL pipette to the left mount, and tell it to use that tip rack
 
-    Transfer 100uL from the plate's 'A1' well to it's 'B2' well
+    Transfer 100uL from the plate's "A1" well to it's "B2" well
 
 If we were to rewrite this with the Opentrons API, it would look like the following:
 
@@ -60,20 +60,20 @@ If we were to rewrite this with the Opentrons API, it would look like the follow
 
     # metadata
     metadata = {
-        'protocolName': 'My Protocol',
-        'author': 'Name <email@address.com>',
-        'description': 'Simple protocol to get started using OT2',
+        "protocolName": "My Protocol",
+        "author": "Name <email@address.com>",
+        "description": "Simple protocol to get started using OT2",
     }
 
     # labware
-    plate = labware.load('96-flat', '2')
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
+    plate = labware.load("96-flat", "2")
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "1")
 
     # pipettes
-    pipette = instruments.P300_Single(mount='left', tip_racks=[tiprack])
+    pipette = instruments.P300_Single(mount="left", tip_racks=[tiprack])
 
     # commands
-    pipette.transfer(100, plate.wells('A1'), plate.wells('B2'))
+    pipette.transfer(100, plate.wells("A1"), plate.wells("B2"))
 
 
 How it's Organized
@@ -118,21 +118,21 @@ Labware
 
 While the imports section is usually the same across protocols, the labware section is different depending on the tip racks, well plates, troughs, or tubes you're using on the robot.
 
-Each labware is given a type (ex: ``'96-flat'``), and the slot on the robot it will be placed (ex: ``'2'``).
+Each labware is given a type (ex: ``"96-flat"``), and the slot on the robot it will be placed (ex: ``"2"``).
 
 From the example above, the "labware" section looked like:
 
 .. code-block:: python
 
-    plate = labware.load('96-flat', '2')
-    tiprack = labware.load('opentrons_96_tiprack_300ul', '1')
+    plate = labware.load("96-flat", "2")
+    tiprack = labware.load("opentrons_96_tiprack_300ul", "1")
 
 .. _index-pipettes:
 
 Pipettes
 ^^^^^^^^
 
-Next, pipettes are created and attached to a specific mount on the OT-2 (``'left'`` or ``'right'``).
+Next, pipettes are created and attached to a specific mount on the OT-2 (``"left"`` or ``"right"``).
 
 There are other parameters for pipettes, but the most important are the tip rack(s) it will use during the protocol.
 
@@ -140,7 +140,7 @@ From the example above, the "pipettes" section looked like:
 
 .. code-block:: python
 
-    pipette = instruments.P300_Single(mount='left', tip_racks=[tiprack])
+    pipette = instruments.P300_Single(mount="left", tip_racks=[tiprack])
 
 .. _index-commands:
 
@@ -155,7 +155,7 @@ From the example above, the "commands" section looked like:
 
 .. code-block:: python
 
-    pipette.transfer(100, plate.wells('A1'), plate.wells('B1'))
+    pipette.transfer(100, plate.wells("A1"), plate.wells("B1"))
 
 
 ******************

--- a/api/docs/v1/labware.rst
+++ b/api/docs/v1/labware.rst
@@ -65,7 +65,7 @@ To tell the robot what labware will be on the deck for your protocol, use
 
     # ...
 
-    tiprack = labware.load('opentrons_96_tiprack_300ul', slot='1')
+    tiprack = labware.load("opentrons_96_tiprack_300ul", slot="1")
 
 
 **********************
@@ -89,16 +89,16 @@ labware in a certain slot.
 
 .. code-block:: python
 
-    my_labware = labware.load('usascientific_12_reservoir_22ml', slot='1')
+    my_labware = labware.load("usascientific_12_reservoir_22ml", slot="1")
 
 A third optional argument can be used to give a labware a nickname for display
 in the Opentrons App.
 
 .. code-block:: python
 
-    my_labware = labware.load('usascientific_12_reservoir_22ml',
-                     slot='2',
-                     label='any-name-you-want')
+    my_labware = labware.load("usascientific_12_reservoir_22ml",
+                     slot="2",
+                     label="any-name-you-want")
 
 
 Sometimes, you may need to place a labware on top of something else on the
@@ -108,9 +108,9 @@ deck, like modules. For this, you should use the ``share`` parameter.
 
     from opentrons import labware, modules
 
-    td = modules.load('tempdeck', slot='1')
-    plate = labware.load('opentrons_96_aluminumblock_biorad_wellplate_200ul',
-                         slot='1',
+    td = modules.load("tempdeck", slot="1")
+    plate = labware.load("opentrons_96_aluminumblock_biorad_wellplate_200ul",
+                         slot="1",
                          share=True)
 
 To specify the version of the labware definition to use, you can use the ``version``
@@ -120,16 +120,16 @@ parameter:
 
    from opentrons import labware
    block1 = labware.load(
-                'opentrons_96_aluminumblock_biorad_wellplate_200ul',
-                slot='1',
+                "opentrons_96_aluminumblock_biorad_wellplate_200ul",
+                slot="1",
                 version=2)  # version 2 of the aluminum block definition
    block2 = labware.load(
-                'opentrons_96_aluminumblock_biorad_wellplate_200ul',
-                 slot='2',
+                "opentrons_96_aluminumblock_biorad_wellplate_200ul",
+                 slot="2",
                  version=1)  # version 1 of the aluminum block definition
    block3 = labware.load(
-                'opentrons_96_aluminumblock_biorad_wellplate_200ul',
-                slot='2')  # if you don't specify version, version 1 is used
+                "opentrons_96_aluminumblock_biorad_wellplate_200ul",
+                slot="2")  # if you don't specify version, version 1 is used
 
 
 Create
@@ -147,7 +147,7 @@ regularly-spaced columns and rows.
 
 .. code-block:: python
 
-    custom_plate_name = 'custom_18_wellplate_200ul'
+    custom_plate_name = "custom_18_wellplate_200ul"
 
     if plate_name not in labware.list():
         labware.create(
@@ -158,7 +158,7 @@ regularly-spaced columns and rows.
             depth=10,           # depth (mm) of each well
             volume=200)         # volume (µL) of each well
 
-    custom_plate = labware.load(custom_plate_name, slot='3')
+    custom_plate = labware.load(custom_plate_name, slot="3")
 
     for well in custom_plate.wells():
         print(well)
@@ -202,7 +202,7 @@ If you would like to delete a labware you have already added to the database
 
     from opentrons.data_storage import database
 
-    database.delete_container('custom_18_wellplate_200ul')
+    database.delete_container("custom_18_wellplate_200ul")
 
 .. Note::
     There is some specialty labware that will require you to specify the
@@ -239,8 +239,8 @@ transfer liquids to and from.
 
 The OT-2 deck and labware are all set up with the same coordinate system
 
-- Lettered rows ``['A']-['END']``
-- Numbered columns ``['1']-['END']``.
+- Lettered rows ``["A"]-["END"]``
+- Numbered columns ``["1"]-["END"]``.
 
 .. image:: ../img/well_iteration/Well_Iteration.png
 
@@ -251,7 +251,7 @@ The OT-2 deck and labware are all set up with the same coordinate system
     '''
     from opentrons import labware
 
-    plate = labware.load('corning_24_wellplate_3.4ml_flat', slot='1')
+    plate = labware.load("corning_24_wellplate_3.4ml_flat", slot="1")
 
 Wells by Name
 -------------
@@ -262,8 +262,8 @@ well as an argument, and will return the well at that location.
 
 .. code-block:: python
 
-    a1 = plate.wells('A1')
-    d6 = plate.wells('D6')
+    a1 = plate.wells("A1")
+    d6 = plate.wells("D6")
 
 Wells by Index
 --------------
@@ -289,8 +289,8 @@ Columns and Rows
 
 A labware's wells are organized within a series of columns and rows, which are
 also labelled on standard labware. In the API, rows are given letter names
-(``'A'`` through ``'D'`` for example) and go left to right, while columns are
-given numbered names (``'1'`` through ``'6'`` for example) and go from front to
+(``"A"`` through ``"D"`` for example) and go left to right, while columns are
+given numbered names (``"1"`` through ``"6"`` for example) and go from front to
 back.
 
 You can access a specific row or column by using the ``rows()`` and
@@ -299,8 +299,8 @@ or column.
 
 .. code-block:: python
 
-    row = plate.rows('A')
-    column = plate.columns('1')
+    row = plate.rows("A")
+    column = plate.columns("1")
 
     print('Column "1" has', len(column), 'wells')
     print('Row "A" has', len(row), 'wells')
@@ -314,16 +314,16 @@ will print out...
 
 The ``rows()`` or ``cols()`` methods can be used in combination with the
 ``wells()`` method to access wells within that row or column. In the example
-below, both lines refer to well ``'A1'``.
+below, both lines refer to well ``"A1"``.
 
 .. code-block:: python
 
-    plate.cols('1').wells('A')
-    plate.rows('A').wells('1')
+    plate.cols("1").wells("A")
+    plate.rows("A").wells("1")
 
 .. Tip::
     The example above works but is a little convoluted. If you can, always get
-    individual wells like A1 with ``wells('A1')`` or ``wells(0)``
+    individual wells like A1 with ``wells("A1")`` or ``wells(0)``
 
 
 Multiple Wells
@@ -344,7 +344,7 @@ liquid's source and/or destination. Or, we can get a group of wells and loop
     '''
     from opentrons import labware
 
-    plate = labware.load('corning_24_wellplate_3.4ml_flat', slot='1')
+    plate = labware.load("corning_24_wellplate_3.4ml_flat", slot="1")
 
 Wells
 -----
@@ -356,7 +356,7 @@ Here is an example or accessing a list of wells, each specified by name:
 
 .. code-block:: python
 
-    w = plate.wells('A1', 'B2', 'C3', 'D4')
+    w = plate.wells("A1", "B2", "C3", "D4")
 
     print(w)
 
@@ -371,7 +371,7 @@ iterated through:
 
 .. code-block:: python
 
-    for w in plate.wells('A1', 'B2', 'C3', 'D4'):
+    for w in plate.wells("A1", "B2", "C3", "D4"):
         print(w)
 
 will print out...
@@ -392,7 +392,7 @@ the ``to=`` argument is the last well.
 
 .. code-block:: python
 
-    for w in plate.wells('A1', to='D1'):
+    for w in plate.wells("A1", to="D1"):
         print(w)
 
 will print out...
@@ -410,7 +410,7 @@ starting position is allowed:
 
 .. code-block:: python
 
-    for w in plate.wells('D1', to='A1'):
+    for w in plate.wells("D1", to="A1"):
         print(w)
 
 will print out...
@@ -427,11 +427,11 @@ Wells Length
 
 Another way you can create a list of wells is by specifying the length of the
 well list you need, including the starting well. The example below will
-return 4 wells, starting at well ``'A1'``:
+return 4 wells, starting at well ``"A1"``:
 
 .. code-block:: python
 
-    for w in plate.wells('A1', length=4):
+    for w in plate.wells("A1", length=4):
         print(w)
 
 will print out...
@@ -453,7 +453,7 @@ Here is an example of iterating through rows:
 
 .. code-block:: python
 
-    for r in plate.rows('A', length=3):
+    for r in plate.rows("A", length=3):
         print(r)
 
 will print out...
@@ -468,7 +468,7 @@ And here is an example of iterating through columns:
 
 .. code-block:: python
 
-    for c in plate.cols('1', to='6'):
+    for c in plate.cols("1", to="6"):
         print(c)
 
 will print out...
@@ -511,7 +511,7 @@ The API's labware are also prepared to take string values for the slice's
 
 .. code-block:: python
 
-    for w in plate['A1':'A2':2]:
+    for w in plate["A1":"A2":2]:
         print(w)
 
 will print out...
@@ -523,7 +523,7 @@ will print out...
 
 .. code-block:: python
 
-    for w in plate.rows['B']['1'::2]:
+    for w in plate.rows["B"]["1"::2]:
         print(w)
 
 will print out...

--- a/api/docs/v1/modules.rst
+++ b/api/docs/v1/modules.rst
@@ -18,7 +18,7 @@ within a protocol. To do this, you call:
 
     from opentrons import modules
 
-    module = modules.load('Module Name', slot)
+    module = modules.load("Module Name", slot)
 
 
 Above, `Module Name` represents either `tempdeck` or `magdeck`.
@@ -29,7 +29,7 @@ To add a labware onto a given module, you will need to use the `share=True` call
 
    from opentrons import labware
 
-   labware = labware.load('96-flat', slot, share=True)
+   labware = labware.load("96-flat", slot, share=True)
 
 Where slot is the same slot in which you loaded your module.
 
@@ -49,7 +49,7 @@ be done like the following:
     robot.connect()
     robot.discover_modules()
 
-    module = modules.load('Module Name', slot)
+    module = modules.load("Module Name", slot)
     ... etc
 
 Checking the status of your Module
@@ -60,7 +60,7 @@ Both modules have the ability to check what state they are currently in. To do t
 
     from opentrons import modules
 
-    module = modules.load('Module Name', slot)
+    module = modules.load("Module Name", slot)
     status = module.status
 
 For the temperature module this will return a string stating whether it's `heating`, `cooling`, `holding at target` or `idle`.
@@ -84,8 +84,8 @@ To set the temperature module to a given temperature in degrees celsius do the f
 
     from opentrons import modules, labware
 
-    module = modules.load('tempdeck', slot)
-    plate = labware.load('96-flat', slot, share=True)
+    module = modules.load("tempdeck", slot)
+    plate = labware.load("96-flat", slot, share=True)
 
     module.set_temperature(4)
 
@@ -99,8 +99,8 @@ This function will pause your protocol until your target temperature is reached.
 
     from opentrons import modules, labware
 
-    module = modules.load('tempdeck', slot)
-    plate = labware.load('96-flat', slot, share=True)
+    module = modules.load("tempdeck", slot)
+    plate = labware.load("96-flat", slot, share=True)
 
     module.set_temperature(4)
     module.wait_for_temp()
@@ -120,8 +120,8 @@ You can read the current real-time temperature of the module by the following:
 
     from opentrons import modules, labware
 
-    module = modules.load('tempdeck', slot)
-    plate = labware.load('96-flat', slot, share=True)
+    module = modules.load("tempdeck", slot)
+    plate = labware.load("96-flat", slot, share=True)
 
     temperature = module.temperature
 
@@ -135,8 +135,8 @@ We can read the target temperature of the module by the following:
 
     from opentrons import modules, labware
 
-    module = modules.load('tempdeck', slot)
-    plate = labware.load('96-flat', slot, share=True)
+    module = modules.load("tempdeck", slot)
+    plate = labware.load("96-flat", slot, share=True)
 
     temperature = module.target
 
@@ -152,8 +152,8 @@ or cooling phase again.
 
     from opentrons import modules, labware
 
-    module = modules.load('tempdeck', slot)
-    plate = labware.load('96-flat', slot, share=True)
+    module = modules.load("tempdeck", slot)
+    plate = labware.load("96-flat", slot, share=True)
 
     module.set_temperature(4)
     module.wait_for_temp()
@@ -192,8 +192,8 @@ Engage
 
     from opentrons import modules, labware
 
-    module = modules.load('magdeck', slot)
-    plate = labware.load('biorad-hardshell-96-PCR', slot, share=True)
+    module = modules.load("magdeck", slot)
+    plate = labware.load("biorad-hardshell-96-PCR", slot, share=True)
 
     module.engage()
 
@@ -213,8 +213,8 @@ You can also use a custom height parameter with engage():
 
     from opentrons import modules, labware
 
-    module = modules.load('magdeck', slot)
-    plate = labware.load('96-deep-well', slot, share=True)
+    module = modules.load("magdeck", slot)
+    plate = labware.load("96-deep-well", slot, share=True)
 
     module.engage(height=12)
 
@@ -232,8 +232,8 @@ Disengage
 
     from opentrons import modules, labware
 
-    module = modules.load('magdeck', slot)
-    plate = labware.load('biorad-hardshell-96-PCR', slot, share=True)
+    module = modules.load("magdeck", slot)
+    plate = labware.load("biorad-hardshell-96-PCR", slot, share=True)
 
     module.engage()
     ## OTHER PROTOCOL ACTIONS

--- a/api/docs/v1/pipettes.rst
+++ b/api/docs/v1/pipettes.rst
@@ -36,12 +36,12 @@ They are as follows:
 
 For every pipette type you are using in a protocol, you must use one of the
 model names specified above and call it out as ``instruments.(Model Name)``.
-You must also specify a mount. The mount can be either ``'left'`` or ``'right'``.
+You must also specify a mount. The mount can be either ``"left"`` or ``"right"``.
 In this example, we are using a Single-Channel 300uL pipette.
 
 .. code-block:: python
 
-    pipette = instruments.P300_Single(mount='left')
+    pipette = instruments.P300_Single(mount="left")
 
 Pipette GEN2 Backwards Compatibility
 ====================================
@@ -72,7 +72,7 @@ The speeds at which the pipette will aspirate and dispense can be set through ``
 .. code-block:: python
 
     pipette = instruments.P300_Single(
-        mount='right',
+        mount="right",
         aspirate_flow_rate=200,
         dispense_flow_rate=600,
         blow_out_flow_rate=600)
@@ -89,7 +89,7 @@ varying defaults depending on the model.
 .. code-block:: python
 
     pipette = instruments.P10_Single(
-        mount='right',
+        mount="right",
         min_volume=2,
         max_volume=8)
 

--- a/api/docs/v1/writing.rst
+++ b/api/docs/v1/writing.rst
@@ -115,7 +115,7 @@ This also provides an entrypoint to use the Opentrons simulation package from ot
 
    from opentrons.simulate import simulate, format_runlog
    # read the file
-   protocol_file = open('/path/to/protocol.py')
+   protocol_file = open("/path/to/protocol.py")
    # simulate() the protocol, keeping the runlog
    runlog, _bundle = simulate(protocol_file)
    # print the runlog

--- a/api/docs/v2/adapting_ot2_flex.rst
+++ b/api/docs/v2/adapting_ot2_flex.rst
@@ -20,7 +20,7 @@ Flex requires you to specify an ``apiLevel`` of 2.15 or higher. If your OT-2 pro
 .. note::
     Consult the :ref:`list of changes in API versions <version-notes>` to see what effect raising the ``apiLevel`` will have. If you increased it by multiple minor versions to get your protocol running on Flex, make sure that your protocol isn't using removed commands or commands whose behavior has changed in a way that may affect your scientific results.
 
-You also need to specify ``'robotType': 'Flex'``. If you omit ``robotType`` in the ``requirements`` dictionary, the API will assume the protocol is designed for the OT-2.
+You also need to specify ``"robotType": "Flex"``. If you omit ``robotType`` in the ``requirements`` dictionary, the API will assume the protocol is designed for the OT-2.
 
 .. tabs::
     

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -18,14 +18,14 @@ To draw liquid up into a pipette tip, call the :py:meth:`.InstrumentContext.aspi
 .. code-block:: python
 
     pipette.pick_up_tip()
-    pipette.aspirate(200, plate['A1'])
+    pipette.aspirate(200, plate["A1"])
 
-If the pipette doesn't move, you can specify an additional aspiration action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and aspirates a second time from ``plate['A1']``).
+If the pipette doesn't move, you can specify an additional aspiration action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and aspirates a second time from ``plate["A1"]``).
 
 .. code-block:: python
 
     pipette.pick_up_tip()
-    pipette.aspirate(200, plate['A1'])
+    pipette.aspirate(200, plate["A1"])
     protocol.delay(seconds=5) # pause for 5 seconds
     pipette.aspirate(100)     # aspirate 100 µL at current position
 
@@ -36,16 +36,16 @@ Aspirate by Well or Location
 
 The :py:meth:`~.InstrumentContext.aspirate` method includes a ``location`` parameter that accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`. 
 
-If you specify a well, like ``plate['A1']``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, first set the ``aspirate`` attribute of :py:obj:`.well_bottom_clearance`:: 
+If you specify a well, like ``plate["A1"]``, the pipette will aspirate from a default position 1 mm above the bottom center of that well. To change the default clearance, first set the ``aspirate`` attribute of :py:obj:`.well_bottom_clearance`:: 
 
     pipette.pick_up_tip
     pipette.well_bottom_clearance.aspirate = 2  # tip is 2 mm above well bottom
-    pipette.aspirate(200, plate['A1'])
+    pipette.aspirate(200, plate["A1"])
 
 You can also aspirate from a location along the center vertical axis within a well using the :py:meth:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well::
 
     pipette.pick_up_tip()
-    depth = plate['A1'].bottom(z=2) # tip is 2 mm above well bottom
+    depth = plate["A1"].bottom(z=2) # tip is 2 mm above well bottom
     pipette.aspirate(200, depth)
 
 See also:
@@ -60,7 +60,7 @@ Aspiration Flow Rates
 Flex and OT-2 pipettes aspirate at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Specifying the ``rate`` parameter multiplies the flow rate by that value. As a best practice, don't set the flow rate higher than 3x the default. For example, this code causes the pipette to aspirate at twice its normal rate::
 
 
-    pipette.aspirate(200, plate['A1'], rate=2.0)
+    pipette.aspirate(200, plate["A1"], rate=2.0)
 
 .. versionadded:: 2.0
 
@@ -73,13 +73,13 @@ To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dis
 
 .. code-block:: python
 
-    pipette.dispense(200, plate['B1'])
+    pipette.dispense(200, plate["B1"])
 
 If the pipette doesn’t move, you can specify an additional dispense action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and dispense a second time from location B1.
 
 .. code-block:: python
     
-    pipette.dispense(100, plate['B1'])
+    pipette.dispense(100, plate["B1"])
     protocol.delay(seconds=5) # pause for 5 seconds
     pipette.dispense(100)     # dispense 100 µL at current position
     
@@ -88,14 +88,14 @@ Dispense by Well or Location
 
 The :py:meth:`~.InstrumentContext.dispense` method includes a ``location`` parameter that accepts either a :py:class:`.Well` or a :py:class:`~.types.Location`.
 
-If you specify a well, like ``plate['B1']``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`::
+If you specify a well, like ``plate["B1"]``, the pipette will dispense from a default position 1 mm above the bottom center of that well. To change the default clearance, you would call :py:obj:`.well_bottom_clearance`::
 
     pipette.well_bottom_clearance.dispense=2 # tip is 2 mm above well bottom
-    pipette.dispense(200, plate['B1'])
+    pipette.dispense(200, plate["B1"])
 
 You can also dispense from a location along the center vertical axis within a well using the :py:meth:`.Well.top` and :py:meth:`.Well.bottom` methods. These methods move the pipette to a specified distance relative to the top or bottom center of a well::
 
-    depth = plate['B1'].bottom(z=2) # tip is 2 mm above well bottom
+    depth = plate["B1"].bottom(z=2) # tip is 2 mm above well bottom
     pipette.dispense(200, depth)
 
 See also:
@@ -109,7 +109,7 @@ Dispense Flow Rates
 
 Flex and OT-2 pipettes dispense at :ref:`default flow rates <new-plunger-flow-rates>` measured in µL/s. Adding a number to the ``rate`` parameter multiplies the flow rate by that value. As a best practice, don't set the flow rate higher than 3x the default. For example, this code causes the pipette to dispense at twice its normal rate::
 
-    pipette.dispense(200, plate['B1'], rate=2.0)
+    pipette.dispense(200, plate["B1"], rate=2.0)
 
 .. versionadded:: 2.0
 
@@ -123,8 +123,8 @@ The optional ``push_out`` parameter of ``dispense()`` helps ensure all liquid le
 For example, this dispense action moves the plunger the equivalent of an additional 5 µL beyond where it would stop if ``push_out`` was set to zero or omitted::
 
     pipette.pick_up_tip()
-    pipette.aspirate(100, plate['A1'])
-    pipette.dispense(100, plate['B1'], push_out=5)
+    pipette.aspirate(100, plate["A1"])
+    pipette.dispense(100, plate["B1"], push_out=5)
     pipette.drop_tip()
 
 .. versionadded:: 2.15
@@ -145,7 +145,7 @@ To blow an extra amount of air through the pipette's tip, call the :py:meth:`.In
 
 You can also specify a particular well as the blowout location::
 
-    pipette.blow_out(plate['B1'])
+    pipette.blow_out(plate["B1"])
 
 Many protocols use a trash container for blowing out the pipette. You can specify the pipette's current trash container as the blowout location by using the :py:obj:`.InstrumentContext.trash_container` property::
 
@@ -171,7 +171,7 @@ These optional location arguments give you control over where the tip will touch
 
 This example demonstrates touching the tip in a specific well::
 
-    pipette.touch_tip(plate['B1'])
+    pipette.touch_tip(plate["B1"])
     
 This example uses an offset to set the touch tip location 2mm below the top of the current well::
 
@@ -179,7 +179,7 @@ This example uses an offset to set the touch tip location 2mm below the top of t
 
 This example moves the pipette 75% of well's total radius and 2 mm below the top of well::
 
-    pipette.touch_tip(plate['B1'], 
+    pipette.touch_tip(plate["B1"], 
                       radius=0.75,
                       v_offset=-2)
 
@@ -197,7 +197,7 @@ Touch speed controls how fast the pipette moves in mm/s during a touch tip step.
 
 This example specifies a well location and sets the speed to 20 mm/s::
 
-    pipette.touch_tip(plate['B1'], speed=20)
+    pipette.touch_tip(plate["B1"], speed=20)
 
 This example uses the current well and sets the speed to 80 mm/s::
 
@@ -221,7 +221,7 @@ This example draws 100 µL from the current well and mixes it three times::
 
 This example draws 100 µL from well B1 and mixes it three times:: 
 
-    pipette.mix(3, 100, plate['B1'])
+    pipette.mix(3, 100, plate["B1"])
 
 This example draws an amount equal to the pipette's maximum rated volume and mixes it three times::
 

--- a/api/docs/v2/basic_commands/pipette_tips.rst
+++ b/api/docs/v2/basic_commands/pipette_tips.rst
@@ -28,9 +28,9 @@ This simple statement works because the variable ``tiprack_1`` in the sample pro
 
 If you omit the ``tip_rack`` argument from the ``pipette`` variable, the API will raise an error. You must pass in the tip rack's location to ``pick_up_tip`` like this::
     
-    pipette.pick_up_tip(tiprack_1['A1'])
+    pipette.pick_up_tip(tiprack_1["A1"])
     pipette.drop_tip()
-    pipette.pick_up_tip(tiprack_1['B1']) 
+    pipette.pick_up_tip(tiprack_1["B1"]) 
 
 If coding the location of each tip seems inefficient or tedious, try using a ``for`` loop to automate a sequential tip pick up process. When using a loop, the API keeps track of tips and manages tip pickup for you. But ``pick_up_tip`` is still a powerful feature. It gives you direct control over tip use when that’s important in your protocol.
 
@@ -86,7 +86,7 @@ You can also specify where to drop the tip by passing in a location. For example
     pipette.pick_up_tip()            # picks up tip from rack location A1
     pipette.drop_tip()               # drops tip in trash bin 
     pipette.pick_up_tip()            # picks up tip from rack location B1
-    pipette.drop_tip(tiprack['A1'])  # drops tip in rack location A1
+    pipette.drop_tip(tiprack["A1"])  # drops tip in rack location A1
 
 .. versionadded:: 2.0
 
@@ -115,7 +115,7 @@ Currently, the API considers tips as "used" after being picked up. For example, 
     pipette.return_tip()                 # drops tip in rack location A1
     pipette.pick_up_tip()                # picks up tip from rack location B1
     pipette.drop_tip()                   # drops tip in trash bin
-    pipette.pick_up_tip(tiprack_1['A1']) # picks up tip from rack location A1
+    pipette.pick_up_tip(tiprack_1["A1"]) # picks up tip from rack location A1
 
 Early API versions treated returned tips as unused items. They could be picked up again without an explicit argument. For example:: 
 

--- a/api/docs/v2/basic_commands/utilities.rst
+++ b/api/docs/v2/basic_commands/utilities.rst
@@ -30,7 +30,7 @@ Pause Until Resumed
 
 Call the :py:meth:`.ProtocolContext.pause` method to stop a protocol at a specific step. Unlike a delay, :py:meth:`~.ProtocolContext.pause` does not restart your protocol automatically. To resume, you'll respond to a prompt on the touchscreen or in the Opentrons App. This method also lets you specify an optional message that provides on-screen or in-app instructions on how to proceed. This example inserts a pause and includes a brief message::
 
-    protocol.pause('Remember to get more pipette tips')
+    protocol.pause("Remember to get more pipette tips")
 
 .. versionadded:: 2.0
 
@@ -47,12 +47,12 @@ To home the gantry, call :py:meth:`.ProtocolContext.home`::
 
 To home a specific pipette's Z axis and plunger, call :py:meth:`.InstrumentContext.home`::
 
-    pipette = protocol.load_instrument('flex_1channel_1000', 'right')
+    pipette = protocol.load_instrument("flex_1channel_1000", "right")
     pipette.home()
 
 To home a specific pipette's plunger only, you can call :py:meth:`.InstrumentContext.home_plunger`::
 
-    pipette = protocol.load_instrument('flex_1channel_1000', 'right')
+    pipette = protocol.load_instrument("flex_1channel_1000", "right")
     pipette.home_plunger()
 
 .. versionadded:: 2.0
@@ -62,7 +62,7 @@ Comment
 
 Call the :py:meth:`.ProtocolContext.comment` method if you want to write and display a brief message in the Opentrons App during a protocol run::
 
-    protocol.comment('Hello, world!')
+    protocol.comment("Hello, world!")
 
 .. versionadded:: 2.0
 

--- a/api/docs/v2/complex_commands/sources_destinations.rst
+++ b/api/docs/v2/complex_commands/sources_destinations.rst
@@ -53,7 +53,7 @@ The following table summarizes the source and destination restrictions for each 
        - **Source:** Any number of wells.
        - **Destination:** Exactly one well.
 
-A single well can be passed by itself or as a list with one item: ``source=plate['A1']`` and ``source=[plate['A1']]`` are equivalent.
+A single well can be passed by itself or as a list with one item: ``source=plate["A1"]`` and ``source=[plate["A1"]]`` are equivalent.
     
 The section on :ref:`many-to-many transfers <many-to-many>` below covers how ``transfer()`` works when specifying sources and destinations of different sizes. However, if they don't meet the even divisibility requirement, the API will raise an error. You can work around such situations by making multiple calls to ``transfer()`` in sequence or by using a :ref:`list of volumes <complex-list-volumes>` to skip certain wells.
 

--- a/api/docs/v2/example_protocols/dilution_tutorial.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial.py
@@ -1,24 +1,24 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.16',
-    'protocolName': 'Serial Dilution Tutorial – OT-2 single-channel',
-    'description': '''This protocol is the outcome of following the
+    "apiLevel": "2.16",
+    "protocolName": "Serial Dilution Tutorial – OT-2 single-channel",
+    "description": """This protocol is the outcome of following the
                    Python Protocol API Tutorial located at
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
-                   stepwise across a plate.''',
-    'author': 'New API User'
+                   stepwise across a plate.""",
+    "author": "New API User"
     }
 
 def run(protocol: protocol_api.ProtocolContext):
-	tips = protocol.load_labware('opentrons_96_tiprack_300ul', 1)
-	reservoir = protocol.load_labware('nest_12_reservoir_15ml', 2)
-	plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 3)
-	left_pipette = protocol.load_instrument('p300_single_gen2', 'left', tip_racks=[tips])
+	tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+	reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
+	plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
+	left_pipette = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tips])
 
 	# distribute diluent
-	left_pipette.transfer(100, reservoir['A1'], plate.wells())
+	left_pipette.transfer(100, reservoir["A1"], plate.wells())
 
 	# loop through each row
 	for i in range(8):
@@ -27,7 +27,7 @@ def run(protocol: protocol_api.ProtocolContext):
 		row = plate.rows()[i]
 
 		# transfer solution to first well in column
-		left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
+		left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
 		# dilute the sample down the row
 		left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/example_protocols/dilution_tutorial_flex.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_flex.py
@@ -1,29 +1,29 @@
 from opentrons import protocol_api
 
 metadata = {
-    'protocolName': 'Serial Dilution Tutorial – Flex 1-channel',
-    'description': '''This protocol is the outcome of following the
+    "protocolName": "Serial Dilution Tutorial – Flex 1-channel",
+    "description": """This protocol is the outcome of following the
                    Python Protocol API Tutorial located at
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
-                   stepwise across a plate.''',
-    'author': 'New API User'
+                   stepwise across a plate.""",
+    "author": "New API User"
     }
     
 requirements = {
-    'robotType': 'Flex',
-    'apiLevel': '2.16'
+    "robotType": "Flex",
+    "apiLevel": "2.16"
     }
 
 def run(protocol: protocol_api.ProtocolContext):
-    tips = protocol.load_labware('opentrons_flex_96_tiprack_200ul', 'D1')
-    reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
-    plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
-    trash = protocol.load_trash_bin('A3')
-    left_pipette = protocol.load_instrument('flex_1channel_1000', 'left', tip_racks=[tips])
+    tips = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
+    reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D2")
+    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
+    trash = protocol.load_trash_bin("A3")
+    left_pipette = protocol.load_instrument("flex_1channel_1000", "left", tip_racks=[tips])
 
     # distribute diluent
-    left_pipette.transfer(100, reservoir['A1'], plate.wells())
+    left_pipette.transfer(100, reservoir["A1"], plate.wells())
 
     # loop through each row
     for i in range(8):
@@ -32,7 +32,7 @@ def run(protocol: protocol_api.ProtocolContext):
         row = plate.rows()[i]
 
         # transfer solution to first well in column
-        left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
+        left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
         # dilute the sample down the row
         left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi.py
@@ -1,24 +1,24 @@
 from opentrons import protocol_api
 
 metadata = {
-    'apiLevel': '2.16',
-    'protocolName': 'Serial Dilution Tutorial – OT-2 8-channel',
-    'description': '''This protocol is the outcome of following the
+    "apiLevel": "2.16",
+    "protocolName": "Serial Dilution Tutorial – OT-2 8-channel",
+    "description": """This protocol is the outcome of following the
                    Python Protocol API Tutorial located at
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
-                   stepwise across a plate.''',
-    'author': 'New API User'
+                   stepwise across a plate.""",
+    "author": "New API User"
     }
     
 def run(protocol: protocol_api.ProtocolContext):
-	tips = protocol.load_labware('opentrons_96_tiprack_300ul', 1)
-	reservoir = protocol.load_labware('nest_12_reservoir_15ml', 2)
-	plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 3)
-	left_pipette = protocol.load_instrument('p300_multi_gen2', 'right', tip_racks=[tips])
+	tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+	reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
+	plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
+	left_pipette = protocol.load_instrument("p300_multi_gen2", "right", tip_racks=[tips])
 
 	# distribute diluent
-	left_pipette.transfer(100, reservoir['A1'], plate.rows()[0])  
+	left_pipette.transfer(100, reservoir["A1"], plate.rows()[0])  
 
 	# no loop, 8-channel pipette
 
@@ -26,7 +26,7 @@ def run(protocol: protocol_api.ProtocolContext):
 	row = plate.rows()[0]
 
 	# transfer solution to first well in column
-	left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
+	left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
 	# dilute the sample down the row
 	left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/example_protocols/dilution_tutorial_multi_flex.py
+++ b/api/docs/v2/example_protocols/dilution_tutorial_multi_flex.py
@@ -1,29 +1,29 @@
 from opentrons import protocol_api
 
 metadata = {
-    'protocolName': 'Serial Dilution Tutorial – Flex 8-channel',
-    'description': '''This protocol is the outcome of following the
+    "protocolName": "Serial Dilution Tutorial – Flex 8-channel",
+    "description": """This protocol is the outcome of following the
                    Python Protocol API Tutorial located at
                    https://docs.opentrons.com/v2/tutorial.html. It takes a
                    solution and progressively dilutes it by transferring it
-                   stepwise across a plate.''',
-    'author': 'New API User'
+                   stepwise across a plate.""",
+    "author": "New API User"
     }
 
 requirements = {
-    'robotType': 'Flex',
-    'apiLevel': '2.16'
+    "robotType": "Flex",
+    "apiLevel": "2.16"
     }
     
 def run(protocol: protocol_api.ProtocolContext):
-    tips = protocol.load_labware('opentrons_96_tiprack_300ul', 'D1')
-    reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
-    plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
-    trash = protocol.load_trash_bin('A3')
-    left_pipette = protocol.load_instrument('flex_8channel_1000', 'right', tip_racks=[tips])
+    tips = protocol.load_labware("opentrons_96_tiprack_300ul", "D1")
+    reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D2")
+    plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
+    trash = protocol.load_trash_bin("A3")
+    left_pipette = protocol.load_instrument("flex_8channel_1000", "right", tip_racks=[tips])
 
     # distribute diluent
-    left_pipette.transfer(100, reservoir['A1'], plate.rows()[0])  
+    left_pipette.transfer(100, reservoir["A1"], plate.rows()[0])  
 
     # no loop, 8-channel pipette
 
@@ -31,7 +31,7 @@ def run(protocol: protocol_api.ProtocolContext):
     row = plate.rows()[0]
 
     # transfer solution to first well in column
-    left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
+    left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
     # dilute the sample down the row
     left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))

--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -64,33 +64,33 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
             
             # metadata
             metadata = {
-                'protocolName': 'My Protocol',
-                'author': 'Name <opentrons@example.com>',
-                'description': 'Simple protocol to get started using the Flex',
+                "protocolName": "My Protocol",
+                "author": "Name <opentrons@example.com>",
+                "description": "Simple protocol to get started using the Flex",
             }
             
             # requirements
-            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel": "|apiLevel|"}
             
             # protocol run function
             def run(protocol: protocol_api.ProtocolContext):
                 # labware
                 plate = protocol.load_labware(
-                    'corning_96_wellplate_360ul_flat', location='D1'
+                    "corning_96_wellplate_360ul_flat", location="D1"
                 )
                 tiprack = protocol.load_labware(
-                    'opentrons_flex_96_tiprack_200ul', location='D2'
+                    "opentrons_flex_96_tiprack_200ul", location="D2"
                 )
             
                 # pipettes
                 left_pipette = protocol.load_instrument(
-                    'flex_1channel_1000', mount='left', tip_racks=[tiprack]
+                    "flex_1channel_1000", mount="left", tip_racks=[tiprack]
                 )
             
                 # commands
                 left_pipette.pick_up_tip()
-                left_pipette.aspirate(100, plate['A1'])
-                left_pipette.dispense(100, plate['B2'])
+                left_pipette.aspirate(100, plate["A1"])
+                left_pipette.dispense(100, plate["B2"])
                 left_pipette.drop_tip()
         
         This example proceeds completely linearly. Following it line-by-line, you can see that it has the following effects:
@@ -117,33 +117,33 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
 
             # metadata
             metadata = {
-                'protocolName': 'My Protocol',
-                'author': 'Name <opentrons@example.com>',
-                'description': 'Simple protocol to get started using the OT-2',
+                "protocolName": "My Protocol",
+                "author": "Name <opentrons@example.com>",
+                "description": "Simple protocol to get started using the OT-2",
             }
 
             # requirements
-            requirements = {'robotType': 'OT-2', 'apiLevel': '|apiLevel|'}
+            requirements = {"robotType": "OT-2", "apiLevel": "|apiLevel|"}
 
             # protocol run function
             def run(protocol: protocol_api.ProtocolContext):
                 # labware
                 plate = protocol.load_labware(
-                    'corning_96_wellplate_360ul_flat', location='1'
+                    "corning_96_wellplate_360ul_flat", location="1"
                 )
                 tiprack = protocol.load_labware(
-                    'opentrons_96_tiprack_300ul', location='2'
+                    "opentrons_96_tiprack_300ul", location="2"
                 )
 
                 # pipettes
                 left_pipette = protocol.load_instrument(
-                    'p300_single', mount='left', tip_racks=[tiprack]
+                    "p300_single", mount="left", tip_racks=[tiprack]
                 )
 
                 # commands
                 left_pipette.pick_up_tip()
-                left_pipette.aspirate(100, plate['A1'])
-                left_pipette.dispense(100, plate['B2'])
+                left_pipette.aspirate(100, plate["A1"])
+                left_pipette.dispense(100, plate["B2"])
                 left_pipette.drop_tip()
 
         This example proceeds completely linearly. Following it line-by-line, you can see that it has the following effects:

--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -117,7 +117,7 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
 
             # metadata
             metadata = {
-                protocolName': 'My Protocol',
+                'protocolName': 'My Protocol',
                 'author': 'Name <opentrons@example.com>',
                 'description': 'Simple protocol to get started using the OT-2',
             }

--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -64,33 +64,33 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
             
             # metadata
             metadata = {
-                "protocolName": "My Protocol",
-                "author": "Name <opentrons@example.com>",
-                "description": "Simple protocol to get started using the Flex",
+                'protocolName': 'My Protocol',
+                'author': 'Name <opentrons@example.com>',
+                'description': 'Simple protocol to get started using the Flex',
             }
             
             # requirements
-            requirements = {"robotType": "Flex", "apiLevel": "|apiLevel|"}
+            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
             
             # protocol run function
             def run(protocol: protocol_api.ProtocolContext):
                 # labware
                 plate = protocol.load_labware(
-                    "corning_96_wellplate_360ul_flat", location="D1"
+                    'corning_96_wellplate_360ul_flat', location='D1'
                 )
                 tiprack = protocol.load_labware(
-                    "opentrons_flex_96_tiprack_200ul", location="D2"
+                    'opentrons_flex_96_tiprack_200ul', location='D2'
                 )
             
                 # pipettes
                 left_pipette = protocol.load_instrument(
-                    "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+                    'flex_1channel_1000', mount='left', tip_racks=[tiprack]
                 )
             
                 # commands
                 left_pipette.pick_up_tip()
-                left_pipette.aspirate(100, plate["A1"])
-                left_pipette.dispense(100, plate["B2"])
+                left_pipette.aspirate(100, plate['A1'])
+                left_pipette.dispense(100, plate['B2'])
                 left_pipette.drop_tip()
         
         This example proceeds completely linearly. Following it line-by-line, you can see that it has the following effects:
@@ -117,33 +117,33 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
 
             # metadata
             metadata = {
-                "protocolName": "My Protocol",
-                "author": "Name <opentrons@example.com>",
-                "description": "Simple protocol to get started using the OT-2",
+                protocolName': 'My Protocol',
+                'author': 'Name <opentrons@example.com>',
+                'description': 'Simple protocol to get started using the OT-2',
             }
 
             # requirements
-            requirements = {"robotType": "OT-2", "apiLevel": "|apiLevel|"}
+            requirements = {'robotType': 'OT-2', 'apiLevel': '|apiLevel|'}
 
             # protocol run function
             def run(protocol: protocol_api.ProtocolContext):
                 # labware
                 plate = protocol.load_labware(
-                    "corning_96_wellplate_360ul_flat", location="1"
+                    'corning_96_wellplate_360ul_flat', location='1'
                 )
                 tiprack = protocol.load_labware(
-                    "opentrons_96_tiprack_300ul", location="2"
+                    'opentrons_96_tiprack_300ul', location='2'
                 )
 
                 # pipettes
                 left_pipette = protocol.load_instrument(
-                    "p300_single", mount="left", tip_racks=[tiprack]
+                    'p300_single', mount='left', tip_racks=[tiprack]
                 )
 
                 # commands
                 left_pipette.pick_up_tip()
-                left_pipette.aspirate(100, plate["A1"])
-                left_pipette.dispense(100, plate["B2"])
+                left_pipette.aspirate(100, plate['A1'])
+                left_pipette.dispense(100, plate['B2'])
                 left_pipette.drop_tip()
 
         This example proceeds completely linearly. Following it line-by-line, you can see that it has the following effects:

--- a/api/docs/v2/modules/heater_shaker.rst
+++ b/api/docs/v2/modules/heater_shaker.rst
@@ -101,8 +101,8 @@ You can use these standalone adapter definitions to load Opentrons verified or c
 
 For example, these commands load a well plate on top of the flat bottom adapter::
 
-    hs_adapter = hs_mod.load_adapter('opentrons_96_flat_bottom_adapter')
-    hs_plate = hs_adapter.load_labware('nest_96_wellplate_200ul_flat')
+    hs_adapter = hs_mod.load_adapter("opentrons_96_flat_bottom_adapter")
+    hs_plate = hs_adapter.load_labware("nest_96_wellplate_200ul_flat")
 
 .. versionadded:: 2.15
     The ``load_adapter()`` method.
@@ -183,8 +183,8 @@ To pipette while the Heater-Shaker is heating, use :py:meth:`~.HeaterShakerConte
 
     hs_mod.set_target_temperature(75)
     pipette.pick_up_tip()   
-    pipette.aspirate(50, plate['A1'])
-    pipette.dispense(50, plate['B1'])
+    pipette.aspirate(50, plate["A1"])
+    pipette.dispense(50, plate["B1"])
     pipette.drop_tip()
     hs_mod.wait_for_temperature()
     protocol.delay(minutes=1)
@@ -199,8 +199,8 @@ Additionally, if you want to pipette while the module holds a temperature for a 
     hs_mod.set_and_wait_for_temperature(75)
     start_time = time.monotonic()  # set reference time
     pipette.pick_up_tip()   
-    pipette.aspirate(50, plate['A1'])
-    pipette.dispense(50, plate['B1'])
+    pipette.aspirate(50, plate["A1"])
+    pipette.dispense(50, plate["B1"])
     pipette.drop_tip()
     # delay for the difference between now and 60 seconds after the reference time
     protocol.delay(max(0, start_time+60 - time.monotonic()))

--- a/api/docs/v2/modules/magnetic_module.rst
+++ b/api/docs/v2/modules/magnetic_module.rst
@@ -19,10 +19,10 @@ The examples in this section apply to an OT-2 with a Magnetic Module GEN2 loaded
 
     def run(protocol: protocol_api.ProtocolContext):
         mag_mod = protocol.load_module(
-          module_name='magnetic module gen2',
-          location='6')
+          module_name="magnetic module gen2",
+          location="6")
         plate = mag_mod.load_labware(
-          name='nest_96_wellplate_100ul_pcr_full_skirt')
+          name="nest_96_wellplate_100ul_pcr_full_skirt")
 
 .. versionadded:: 2.3
 

--- a/api/docs/v2/modules/multiple_same_type.rst
+++ b/api/docs/v2/modules/multiple_same_type.rst
@@ -28,12 +28,12 @@ When working with multiple modules of the same type, load them in your protocol 
       def run(protocol: protocol_api.ProtocolContext):
         # Load Temperature Module 1 in deck slot D1 on USB port 2
         temperature_module_1 = protocol.load_module(
-          module_name='temperature module gen2',
+          module_name="temperature module gen2",
           location="D1")
 
         # Load Temperature Module 2 in deck slot C1 on USB port 6
         temperature_module_2 = protocol.load_module(
-          module_name='temperature module gen2',
+          module_name="temperature module gen2",
           location="C1")
         
     The Temperature Modules are connected as shown here:
@@ -49,17 +49,17 @@ When working with multiple modules of the same type, load them in your protocol 
 
       from opentrons import protocol_api
 
-      metadata = { 'apiLevel': '|apiLevel|'}
+      metadata = { "apiLevel": "|apiLevel|"}
 
       def run(protocol: protocol_api.ProtocolContext):
         # Load Temperature Module 1 in deck slot C1 on USB port 1
         temperature_module_1 = protocol.load_module(
-          load_name='temperature module gen2',
+          load_name="temperature module gen2",
           location="1")
 
         # Load Temperature Module 2 in deck slot D3 on USB port 2
         temperature_module_2 = protocol.load_module(
-          load_name='temperature module gen2',
+          load_name="temperature module gen2",
           location="3")
         
     The Temperature Modules are connected as shown here:

--- a/api/docs/v2/modules/setup.rst
+++ b/api/docs/v2/modules/setup.rst
@@ -22,16 +22,16 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext): 
                 # Load a Heater-Shaker Module GEN1 in deck slot D1.
                 heater_shaker = protocol.load_module(
-                  module_name='heaterShakerModuleV1', location='D1')
+                  module_name="heaterShakerModuleV1", location="D1")
          
                 # Load a Temperature Module GEN2 in deck slot D3.
                 temperature_module = protocol.load_module(
-                  module_name='temperature module gen2', location='D3')
+                  module_name="temperature module gen2", location="D3")
 
         After the ``load_module()`` method loads the modules into your protocol, it returns the :py:class:`~opentrons.protocol_api.HeaterShakerContext` and :py:class:`~opentrons.protocol_api.TemperatureModuleContext` objects.
         
@@ -42,16 +42,16 @@ Use :py:meth:`.ProtocolContext.load_module` to load a module.
 
             from opentrons import protocol_api
             
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
             
             def run(protocol: protocol_api.ProtocolContext): 
                 # Load a Magnetic Module GEN2 in deck slot 1.
                 magnetic_module = protocol.load_module(
-                  module_name='magnetic module gen2', location=1)
+                  module_name="magnetic module gen2", location=1)
          
                 # Load a Temperature Module GEN1 in deck slot 3.
                 temperature_module = protocol.load_module(
-                  module_name='temperature module', location=3)
+                  module_name="temperature module", location=3)
 
         After the ``load_module()`` method loads the modules into your protocol, it returns the :py:class:`~opentrons.protocol_api.MagneticModuleContext` and :py:class:`~opentrons.protocol_api.TemperatureModuleContext` objects.
 

--- a/api/docs/v2/modules/temperature_module.rst
+++ b/api/docs/v2/modules/temperature_module.rst
@@ -43,10 +43,10 @@ You can use these standalone adapter definitions to load Opentrons verified or c
 For example, these commands load a PCR plate on top of the 96-well block::
 
     temp_adapter = temp_mod.load_adapter(
-        'opentrons_96_well_aluminum_block'
+        "opentrons_96_well_aluminum_block"
     )
     temp_plate = temp_adapter.load_labware(
-        'nest_96_wellplate_100ul_pcr_full_skirt'
+        "nest_96_wellplate_100ul_pcr_full_skirt"
     )
 
 .. versionadded:: 2.15
@@ -81,7 +81,7 @@ You can use these combination labware definitions to load various types of tubes
 For example, this command loads the 24-well block with generic 2 mL tubes::
 
     temp_tubes = temp_mod.load_labware(
-        'opentrons_24_aluminumblock_generic_2ml_screwcap'
+        "opentrons_24_aluminumblock_generic_2ml_screwcap"
     )
 
 .. versionadded:: 2.0
@@ -137,9 +137,9 @@ If you need to confirm in software whether the Temperature Module is holding at 
 .. code-block:: python
 
     temp_mod.set_temperature(celsius=90)
-    temp_mod.status  # 'holding at target'
+    temp_mod.status  # "holding at target"
     temp_mod.deactivate()
-    temp_mod.status  # 'idle'
+    temp_mod.status  # "idle"
     
 If you don't need to use the status value in your code, and you have physical access to the module, you can read its status and temperature from the LED and display on the module.
     

--- a/api/docs/v2/modules/thermocycler.rst
+++ b/api/docs/v2/modules/thermocycler.rst
@@ -14,8 +14,8 @@ The examples in this section will use a Thermocycler Module GEN2 loaded as follo
 
 .. code-block:: python
 
-    tc_mod = protocol.load_module(module_name='thermocyclerModuleV2')
-    plate = tc_mod.load_labware(name='nest_96_wellplate_100ul_pcr_full_skirt')
+    tc_mod = protocol.load_module(module_name="thermocyclerModuleV2")
+    plate = tc_mod.load_labware(name="nest_96_wellplate_100ul_pcr_full_skirt")
 
 .. versionadded:: 2.13
 
@@ -105,8 +105,8 @@ For example, this profile commands the Thermocycler to reach 10 °C and hold for
 .. code-block:: python
 
         profile = [
-            {'temperature':10, 'hold_time_seconds':30},
-            {'temperature':60, 'hold_time_seconds':45}
+            {"temperature":10, "hold_time_seconds":30},
+            {"temperature":60, "hold_time_seconds":45}
         ]
 
 Once you have written the steps of your profile, execute it with :py:meth:`~.ThermocyclerContext.execute_profile`. This function executes your profile steps multiple times depending on the ``repetitions`` parameter. It also takes a ``block_max_volume`` parameter, which is the same as that of the :py:meth:`~.ThermocyclerContext.set_block_temperature` function.
@@ -116,9 +116,9 @@ For instance, a PCR prep protocol might define and execute a profile like this:
 .. code-block:: python
 
         profile = [
-            {'temperature':95, 'hold_time_seconds':30},
-            {'temperature':57, 'hold_time_seconds':30},
-            {'temperature':72, 'hold_time_seconds':60}
+            {"temperature":95, "hold_time_seconds":30},
+            {"temperature":57, "hold_time_seconds":30},
+            {"temperature":72, "hold_time_seconds":60}
         ]
         tc_mod.execute_profile(steps=profile, repetitions=20, block_max_volume=32)
 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -17,8 +17,8 @@ Use the :py:meth:`.ProtocolContext.move_labware` method to initiate a move, rega
     :substitutions:
         
     def run(protocol: protocol_api.ProtocolContext):
-        plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D1')
-        protocol.move_labware(labware=plate, new_location='D2')
+        plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D1")
+        protocol.move_labware(labware=plate, new_location="D2")
         
 .. versionadded:: 2.15
 
@@ -26,8 +26,8 @@ The required arguments of ``move_labware()`` are the ``labware`` you want to mov
 
 When the move step is complete, the API updates the labware's location, so you can move the plate multiple times::
 
-    protocol.move_labware(labware=plate, new_location='D2')
-    protocol.move_labware(labware=plate, new_location='D3')
+    protocol.move_labware(labware=plate, new_location="D2")
+    protocol.move_labware(labware=plate, new_location="D3")
     
 For the first move, the API knows to find the plate in its initial load location, slot D1. For the second move, the API knows to find the plate in D2.
 
@@ -45,16 +45,16 @@ The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` deter
 .. code-block:: python
 
     def run(protocol: protocol_api.ProtocolContext):
-        plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D1')
+        plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D1")
         
         # have the gripper move the plate from D1 to D2
-        protocol.move_labware(labware=plate, new_location='D2', use_gripper=True)
+        protocol.move_labware(labware=plate, new_location="D2", use_gripper=True)
         
         # pause to move the plate manually from D2 to D3
-        protocol.move_labware(labware=plate, new_location='D3', use_gripper=False)
+        protocol.move_labware(labware=plate, new_location="D3", use_gripper=False)
         
         # pause to move the plate manually from D3 to C1
-        protocol.move_labware(labware=plate, new_location='C1')
+        protocol.move_labware(labware=plate, new_location="C1")
 
 .. versionadded:: 2.15
 

--- a/api/docs/v2/new_advanced_running.rst
+++ b/api/docs/v2/new_advanced_running.rst
@@ -32,7 +32,7 @@ Rather than writing a  ``run`` function and embedding commands within it, start 
     :substitutions:
 
     import opentrons.execute
-    protocol = opentrons.execute.get_protocol_api('|apiLevel|')
+    protocol = opentrons.execute.get_protocol_api("|apiLevel|")
     protocol.home()
 
 The first command you execute should always be :py:meth:`~opentrons.protocol_api.ProtocolContext.home`. If you try to execute other commands first, you will get a ``MustHomeError``. (When running protocols through the Opentrons App, the robot homes automatically.)
@@ -57,7 +57,7 @@ Since a typical protocol only `defines` the ``run`` function but doesn't `call` 
 .. code-block:: python
     :substitutions:
 
-    protocol = opentrons.execute.get_protocol_api('|apiLevel|')
+    protocol = opentrons.execute.get_protocol_api("|apiLevel|")
     run(protocol)  # your protocol will now run
 
 .. _using_lpc:

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -15,13 +15,13 @@ These sample protocols are designed for anyone using an Opentrons Flex or OT-2 l
 
     # This code uses named arguments
     tiprack_1 = protocol.load_labware(
-        load_name='opentrons_flex_96_tiprack_200ul',
-        location='D2')
+        load_name="opentrons_flex_96_tiprack_200ul",
+        location="D2")
 
     # This code uses positional arguments
-    tiprack_1 = protocol.load_labware('opentrons_flex_96_tiprack_200ul','D2')   
+    tiprack_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D2")   
 
-Both examples instantiate the variable ``tiprack_1`` with a Flex tip rack, but the former is more explicit. It shows the parameter name and its value together (e.g. ``location='D2'``), which may be helpful when you're unsure about what's going on in a protocol code sample.
+Both examples instantiate the variable ``tiprack_1`` with a Flex tip rack, but the former is more explicit. It shows the parameter name and its value together (e.g. ``location="D2"``), which may be helpful when you're unsure about what's going on in a protocol code sample.
 
 Python developers with more experience should feel free to ignore the code styling used here and work with these examples as you like.
 
@@ -102,7 +102,7 @@ This code only loads the instruments and labware listed above, and performs no o
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 # load tip rack in deck slot 3
@@ -144,24 +144,24 @@ This protocol uses some :ref:`building block commands <v2-atomic-commands>` to t
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel':'|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel":"|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
-                    location='D1')
+                    load_name="corning_96_wellplate_360ul_flat",
+                    location="D1")
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D2')
-                trash = protocol.load_trash_bin('A3')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D2")
+                trash = protocol.load_trash_bin("A3")
                 pipette = protocol.load_instrument(
-                    instrument_name='flex_1channel_1000',
-                    mount='left',
+                    instrument_name="flex_1channel_1000",
+                    mount="left",
                 tip_racks=[tiprack_1])
 
                 pipette.pick_up_tip()
-                pipette.aspirate(100, plate['A1'])
-                pipette.dispense(100, plate['B1'])
+                pipette.aspirate(100, plate["A1"])
+                pipette.dispense(100, plate["B1"])
                 pipette.drop_tip()
 
     .. tab:: OT-2
@@ -171,29 +171,29 @@ This protocol uses some :ref:`building block commands <v2-atomic-commands>` to t
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
+                    load_name="corning_96_wellplate_360ul_flat",
                     location=1)
                 tiprack_1 = protocol.load_labware(
-                        load_name='opentrons_96_tiprack_300ul',
+                        load_name="opentrons_96_tiprack_300ul",
                         location=2)
                 p300 = protocol.load_instrument(
-                        instrument_name='p300_single',
-                        mount='left',
+                        instrument_name="p300_single",
+                        mount="left",
                         tip_racks=[tiprack_1])
 
                 p300.pick_up_tip()
-                p300.aspirate(100, plate['A1'])
-                p300.dispense(100, plate['B1'])
+                p300.aspirate(100, plate["A1"])
+                p300.dispense(100, plate["B1"])
                 p300.drop_tip()
 
 Advanced Method
 ---------------
 
-This protocol accomplishes the same thing as the previous example, but does it a little more efficiently. Notice how it uses the :py:meth:`.InstrumentContext.transfer` method to move liquid between well plates. The source and destination well  arguments (e.g., ``plate['A1'], plate['B1']``) are part of ``transfer()`` method parameters. You don't need separate calls to ``aspirate`` or ``dispense`` here. 
+This protocol accomplishes the same thing as the previous example, but does it a little more efficiently. Notice how it uses the :py:meth:`.InstrumentContext.transfer` method to move liquid between well plates. The source and destination well  arguments (e.g., ``plate["A1"], plate["B1"]``) are part of ``transfer()`` method parameters. You don't need separate calls to ``aspirate`` or ``dispense`` here. 
 
 .. tabs::
 
@@ -204,22 +204,22 @@ This protocol accomplishes the same thing as the previous example, but does it a
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
-                    location='D1')
+                    load_name="corning_96_wellplate_360ul_flat",
+                    location="D1")
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D2')
-                trash = protocol.load_trash_bin('A3')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D2")
+                trash = protocol.load_trash_bin("A3")
                 pipette = protocol.load_instrument(
-                    instrument_name='flex_1channel_1000',
-                    mount='left',
+                    instrument_name="flex_1channel_1000",
+                    mount="left",
                     tip_racks=[tiprack_1])
                 # transfer 100 µL from well A1 to well B1
-                pipette.transfer(100, plate['A1'], plate['B1'])
+                pipette.transfer(100, plate["A1"], plate["B1"])
     
     .. tab:: OT-2
 
@@ -228,21 +228,21 @@ This protocol accomplishes the same thing as the previous example, but does it a
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
+                    load_name="corning_96_wellplate_360ul_flat",
                     location=1)
                 tiprack_1 = protocol.load_labware(
-                        load_name='opentrons_96_tiprack_300ul',
+                        load_name="opentrons_96_tiprack_300ul",
                         location=2)
                 p300 = protocol.load_instrument(
-                    instrument_name='p300_single',
-                    mount='left',
+                    instrument_name="p300_single",
+                    mount="left",
                     tip_racks=[tiprack_1])
                 # transfer 100 µL from well A1 to well B1
-                p300.transfer(100, plate['A1'], plate['B1'])
+                p300.transfer(100, plate["A1"], plate["B1"])
 
 
 Loops
@@ -261,22 +261,22 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel':'|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel":"|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
-                    location='D1')
+                    load_name="corning_96_wellplate_360ul_flat",
+                    location="D1")
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D2')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D2")
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
-                    location='D3')
-                trash = protocol.load_trash_bin('A3')
+                    load_name="usascientific_12_reservoir_22ml",
+                    location="D3")
+                trash = protocol.load_trash_bin("A3")
                 pipette = protocol.load_instrument(
-                    instrument_name='flex_1channel_1000',
-                    mount='left',
+                    instrument_name="flex_1channel_1000",
+                    mount="left",
                     tip_racks=[tiprack_1])
                 
                 # distribute 20 µL from reservoir:A1 -> plate:row:1
@@ -293,21 +293,21 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
+                    load_name="corning_96_wellplate_360ul_flat",
                     location=1)
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_96_tiprack_300ul',
+                    load_name="opentrons_96_tiprack_300ul",
                     location=2)
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
+                    load_name="usascientific_12_reservoir_22ml",
                     location=4)
                 p300 = protocol.load_instrument(
-                    instrument_name='p300_single',
-                    mount='left',
+                    instrument_name="p300_single",
+                    mount="left",
                     tip_racks=[tiprack_1])
                 
                 # distribute 20 µL from reservoir:A1 -> plate:row:1
@@ -333,22 +333,22 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel':'|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel":"|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
-                    location='D1')
+                    load_name="corning_96_wellplate_360ul_flat",
+                    location="D1")
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_1000ul',
-                    location='D2')
+                    load_name="opentrons_flex_96_tiprack_1000ul",
+                    location="D2")
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
-                    location='D3')
-                trash = protocol.load_trash_bin('A3')
+                    load_name="usascientific_12_reservoir_22ml",
+                    location="D3")
+                trash = protocol.load_trash_bin("A3")
                 pipette = protocol.load_instrument(
-                    instrument_name='flex_1channel_1000', 
-                    mount='left',
+                    instrument_name="flex_1channel_1000", 
+                    mount="left",
                     tip_racks=[tiprack_1])
 
                 pipette.pick_up_tip()
@@ -358,7 +358,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
                     pipette.aspirate(volume=35, location=well)
                     pipette.air_gap(10)
 
-                pipette.dispense(225, plate['A1'])
+                pipette.dispense(225, plate["A1"])
 
                 pipette.return_tip()
 
@@ -369,21 +369,21 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
+                    load_name="corning_96_wellplate_360ul_flat",
                     location=1)
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_96_tiprack_300ul',
+                    load_name="opentrons_96_tiprack_300ul",
                     location=2)
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
+                    load_name="usascientific_12_reservoir_22ml",
                     location=3)
                 p300 = protocol.load_instrument(
-                    instrument_name='p300_single', 
-                    mount='right',
+                    instrument_name="p300_single", 
+                    mount="right",
                     tip_racks=[tiprack_1])
 
                 p300.pick_up_tip()
@@ -393,7 +393,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
                     p300.aspirate(volume=35, location=well)
                     p300.air_gap(10)
         
-                p300.dispense(225, plate['A1'])
+                p300.dispense(225, plate["A1"])
 
                 p300.return_tip()
 
@@ -413,28 +413,28 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
-                    location='D1')
+                    load_name="corning_96_wellplate_360ul_flat",
+                    location="D1")
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D2')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D2")
                 tiprack_2 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D3')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D3")
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
-                    location='C1')
-                trash = protocol.load_trash_bin('A3')
+                    load_name="usascientific_12_reservoir_22ml",
+                    location="C1")
+                trash = protocol.load_trash_bin("A3")
                 pipette = protocol.load_instrument(
-                    instrument_name='flex_1channel_1000',
-                    mount='left',
+                    instrument_name="flex_1channel_1000",
+                    mount="left",
                     tip_racks=[tiprack_1, tiprack_2])
                 # Dispense diluent
-                pipette.distribute(50, reservoir['A12'], plate.wells())
+                pipette.distribute(50, reservoir["A12"], plate.wells())
 
                 # loop through each row
                 for i in range(8):
@@ -457,27 +457,27 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
 
             from opentrons import protocol_api
 
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
+                    load_name="corning_96_wellplate_360ul_flat",
                     location=1)
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_96_tiprack_300ul',
+                    load_name="opentrons_96_tiprack_300ul",
                     location=2)
                 tiprack_2 = protocol.load_labware(
-                    load_name='opentrons_96_tiprack_300ul',
+                    load_name="opentrons_96_tiprack_300ul",
                     location=3)
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
+                    load_name="usascientific_12_reservoir_22ml",
                     location=4)
                 p300 = protocol.load_instrument(
-                    instrument_name='p300_single',
-                    mount='right',
+                    instrument_name="p300_single",
+                    mount="right",
                     tip_racks=[tiprack_1, tiprack_2])
                 # Dispense diluent
-                p300.distribute(50, reservoir['A12'], plate.wells())
+                p300.distribute(50, reservoir["A12"], plate.wells())
 
                 # loop through each row
                 for i in range(8):
@@ -510,25 +510,25 @@ This protocol dispenses different volumes of liquids to a well plate and automat
 
             from opentrons import protocol_api
 
-            requirements = {'robotType': 'Flex', 'apiLevel': '|apiLevel|'}
+            requirements = {"robotType": "Flex", "apiLevel": "|apiLevel|"}
                 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
-                    location='D1')
+                    load_name="corning_96_wellplate_360ul_flat",
+                    location="D1")
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D2')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D2")
                 tiprack_2 = protocol.load_labware(
-                    load_name='opentrons_flex_96_tiprack_200ul',
-                    location='D3')
+                    load_name="opentrons_flex_96_tiprack_200ul",
+                    location="D3")
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
-                    location='C1')
-                trash = protocol.load_trash_bin('A3')
+                    load_name="usascientific_12_reservoir_22ml",
+                    location="C1")
+                trash = protocol.load_trash_bin("A3")
                 pipette = protocol.load_instrument(
-                    instrument_name='flex_1channel_1000',
-                    mount='right',
+                    instrument_name="flex_1channel_1000",
+                    mount="right",
                 tip_racks=[tiprack_1, tiprack_2])
 
                 # Volume amounts are for demonstration purposes only
@@ -547,7 +547,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
                     89, 90, 91, 92, 93, 94, 95, 96
                     ]
 
-                pipette.distribute(water_volumes, reservoir['A12'], plate.wells())
+                pipette.distribute(water_volumes, reservoir["A12"], plate.wells())
 
     .. tab:: OT-2
         
@@ -555,24 +555,24 @@ This protocol dispenses different volumes of liquids to a well plate and automat
             :substitutions:
 
             from opentrons import protocol_api
-            metadata = {'apiLevel': '|apiLevel|'}
+            metadata = {"apiLevel": "|apiLevel|"}
                 
             def run(protocol: protocol_api.ProtocolContext):
                 plate = protocol.load_labware(
-                    load_name='corning_96_wellplate_360ul_flat',
+                    load_name="corning_96_wellplate_360ul_flat",
                     location=1)
                 tiprack_1 = protocol.load_labware(
-                    load_name='opentrons_96_tiprack_300ul',
+                    load_name="opentrons_96_tiprack_300ul",
                     location=2)
                 tiprack_2 = protocol.load_labware(
-                    load_name='opentrons_96_tiprack_300ul',
+                    load_name="opentrons_96_tiprack_300ul",
                     location=3)
                 reservoir = protocol.load_labware(
-                    load_name='usascientific_12_reservoir_22ml',
+                    load_name="usascientific_12_reservoir_22ml",
                     location=4)
                 p300 = protocol.load_instrument(
-                    instrument_name='p300_single', 
-                    mount='right',
+                    instrument_name="p300_single", 
+                    mount="right",
                     tip_racks=[tiprack_1, tiprack_2])
 
                 # Volume amounts are for demonstration purposes only
@@ -591,4 +591,4 @@ This protocol dispenses different volumes of liquids to a well plate and automat
                     89, 90, 91, 92, 93, 94, 95, 96
                     ]
 
-                p300.distribute(water_volumes, reservoir['A12'], plate.wells())
+                p300.distribute(water_volumes, reservoir["A12"], plate.wells())

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -10,7 +10,7 @@ Labware are the durable or consumable items that you work with, reuse, or discar
 
 .. note::
 
-    Code snippets use coordinate deck slot locations (e.g. ``'D1'``, ``'D2'``), like those found on Flex. If you have an OT-2 and are using API version 2.14 or earlier, replace the coordinate with its numeric OT-2 equivalent. For example, slot D1 on Flex corresponds to slot 1 on an OT-2. See :ref:`deck-slots` for more information.
+    Code snippets use coordinate deck slot locations (e.g. ``"D1"``, ``"D2"``), like those found on Flex. If you have an OT-2 and are using API version 2.14 or earlier, replace the coordinate with its numeric OT-2 equivalent. For example, slot D1 on Flex corresponds to slot 1 on an OT-2. See :ref:`deck-slots` for more information.
 
 *************
 Labware Types
@@ -60,14 +60,14 @@ Similar to the code sample in :ref:`overview-section-v2`, here's how you use the
 .. code-block:: python
 
     #Flex
-    tiprack = protocol.load_labware('opentrons_flex_96_tiprack_200ul', 'D1')
-    plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 'D2')
+    tiprack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
+    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "D2")
 
 .. code-block:: python
 
     #OT-2
-    tiprack = protocol.load_labware('opentrons_96_tiprack_300ul', '1')
-    plate = protocol.load_labware('corning_96_wellplate_360ul_flat', '2')
+    tiprack = protocol.load_labware("opentrons_96_tiprack_300ul", "1")
+    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "2")
     
 .. versionadded:: 2.0
 
@@ -80,9 +80,9 @@ When the ``load_labware`` method loads labware into your protocol, it returns a 
     The ``load_labware`` method includes an optional ``label`` argument. You can use it to identify labware with a descriptive name. If used, the label value is displayed in the Opentrons App. For example::
         
         tiprack = protocol.load_labware(
-            load_name='corning_96_wellplate_360ul_flat',
-            location='D1',
-            label='any-name-you-want')
+            load_name="corning_96_wellplate_360ul_flat",
+            location="D1",
+            label="any-name-you-want")
 
 .. _labware-on-adapters:
 
@@ -98,9 +98,9 @@ Loading Separately
 
 The ``load_adapter()`` method is available on ``ProtocolContext`` and module contexts. It behaves similarly to ``load_labware()``, requiring the load name and location for the desired adapter. Load a module, adapter, and labware with separate calls to specify each layer of the physical stack of components individually::
 
-    hs_mod = protocol.load_module('heaterShakerModuleV1', 'D1')
-    hs_adapter = hs_mod.load_adapter('opentrons_96_flat_bottom_adapter')
-    hs_plate = hs_adapter.load_labware('nest_96_wellplate_200ul_flat')
+    hs_mod = protocol.load_module("heaterShakerModuleV1", "D1")
+    hs_adapter = hs_mod.load_adapter("opentrons_96_flat_bottom_adapter")
+    hs_plate = hs_adapter.load_labware("nest_96_wellplate_200ul_flat")
     
 .. versionadded:: 2.15
     The ``load_adapter()`` method.
@@ -111,8 +111,8 @@ Loading Together
 Use the ``adapter`` argument of ``load_labware()`` to load an adapter at the same time as labware. For example, to load the same 96-well plate and adapter from the previous section at once::
     
     hs_plate = hs_mod.load_labware(
-        name='nest_96_wellplate_200ul_flat',
-        adapter='opentrons_96_flat_bottom_adapter'
+        name="nest_96_wellplate_200ul_flat",
+        adapter="opentrons_96_flat_bottom_adapter"
     )
 
 .. versionadded:: 2.15
@@ -121,7 +121,7 @@ Use the ``adapter`` argument of ``load_labware()`` to load an adapter at the sam
 The API also has some "combination" labware definitions, which treat the adapter and labware as a unit::
 
     hs_combo = hs_mod.load_labware(
-        'opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat'
+        "opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat"
     )
 
 Loading labware this way prevents you from :ref:`moving the labware <moving-labware>` onto or off of the adapter, so it's less flexible than loading the two separately. Avoid using combination definitions unless your protocol specifies an ``apiLevel`` of 2.14 or lower.
@@ -137,9 +137,9 @@ Well Ordering
 
 You need to select which wells to transfer liquids to and from over the course of a protocol.
 
-Rows of wells on a labware have labels that are capital letters starting with A. For instance, an 96-well plate has 8 rows, labeled ``'A'`` through ``'H'``.
+Rows of wells on a labware have labels that are capital letters starting with A. For instance, an 96-well plate has 8 rows, labeled ``"A"`` through ``"H"``.
 
-Columns of wells on a labware have labels that are numbers starting with 1. For instance, a 96-well plate has columns ``'1'`` through ``'12'``.
+Columns of wells on a labware have labels that are numbers starting with 1. For instance, a 96-well plate has columns ``"1"`` through ``"12"``.
 
 All well-accessing functions start with the well at the top left corner of the labware. The ending well is in the bottom right. The order of travel from top left to bottom right depends on which function you use.
 
@@ -149,7 +149,7 @@ The code in this section assumes that ``plate`` is a 24-well plate. For example:
 
 .. code-block:: python
 
-    plate = protocol.load_labware('corning_24_wellplate_3.4ml_flat', location='D1')
+    plate = protocol.load_labware("corning_24_wellplate_3.4ml_flat", location="D1")
 
 .. _well-accessor-methods:
 
@@ -176,13 +176,13 @@ The API provides many different ways to access wells inside labware. Different m
      - ``[[labware:A1, labware:B1...], [labware:A2, labware:B2...]]``
    * - :py:meth:`.Labware.wells_by_name`
      - Dictionary with well names as keys.
-     - ``{'A1': labware:A1, 'B1': labware:B1}``
+     - ``{"A1": labware:A1, "B1": labware:B1}``
    * - :py:meth:`.Labware.rows_by_name`
      - Dictionary with row names as keys.
-     - ``{'A': [labware:A1, labware:A2...], 'B': [labware:B1, labware:B2...]}``
+     - ``{"A": [labware:A1, labware:A2...], "B": [labware:B1, labware:B2...]}``
    * - :py:meth:`.Labware.columns_by_name`
      - Dictionary with column names as keys.
-     - ``{'1': [labware:A1, labware:B1...], '2': [labware:A2, labware:B2...]}``
+     - ``{"1": [labware:A1, labware:B1...], "2": [labware:A2, labware:B2...]}``
 
 Accessing Individual Wells
 ==========================
@@ -194,10 +194,10 @@ The simplest way to refer to a single well is by its name, like A1 or D6. :py:me
 
 .. code-block:: python
 
-    a1 = plate.wells_by_name()['A1']
-    d6 = plate['D6']  # dictionary indexing
+    a1 = plate.wells_by_name()["A1"]
+    d6 = plate["D6"]  # dictionary indexing
     
-If a well does not exist in the labware, such as ``plate['H12']`` on a 24-well plate, the API will raise a ``KeyError``. In contrast, it would be a valid reference on a standard 96-well plate.
+If a well does not exist in the labware, such as ``plate["H12"]`` on a 24-well plate, the API will raise a ``KeyError``. In contrast, it would be a valid reference on a standard 96-well plate.
 
 .. versionadded:: 2.0
 
@@ -213,7 +213,7 @@ In addition to referencing wells by name, you can also reference them with zero-
 
 .. tip::
 
-    You may find coordinate well names like ``'B3'`` easier to reason with, especially when working with irregular labware, e.g.
+    You may find coordinate well names like ``"B3"`` easier to reason with, especially when working with irregular labware, e.g.
     ``opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical`` (see the `Opentrons 10 Tube Rack <https://labware.opentrons.com/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical>`_ in the Labware Library). Whichever well access method you use, your protocol will be most maintainable if you use only one access method consistently.
 
 .. versionadded:: 2.0
@@ -227,9 +227,9 @@ Use :py:meth:`.Labware.rows_by_name` to access a specific row of wells or  :py:m
 
 .. code-block:: python
 
-    row_dict = plate.rows_by_name()['A']
+    row_dict = plate.rows_by_name()["A"]
     row_list = plate.rows()[0]  # equivalent to the line above
-    column_dict = plate.columns_by_name()['1']
+    column_dict = plate.columns_by_name()["1"]
     column_list = plate.columns()[0]  # equivalent to the line above
 
     print('Column "1" has', len(column_dict), 'wells')  # Column "1" has 4 wells
@@ -237,15 +237,15 @@ Use :py:meth:`.Labware.rows_by_name` to access a specific row of wells or  :py:m
 
 Since these methods return either lists or dictionaries, you can iterate through them as you would regular Python data structures.
 
-For example, to transfer 50 µL of liquid from the first well of a reservoir to each of the wells of row ``'A'`` on a plate::
+For example, to transfer 50 µL of liquid from the first well of a reservoir to each of the wells of row ``"A"`` on a plate::
 
     for well in plate.rows()[0]:
-        pipette.transfer(reservoir['A1'], well, 50)
+        pipette.transfer(reservoir["A1"], well, 50)
 
 Equivalently, using ``rows_by_name``::
 
-    for well in plate.rows_by_name()['A'].values():
-        pipette.transfer(reservoir['A1'], well, 50)
+    for well in plate.rows_by_name()["A"].values():
+        pipette.transfer(reservoir["A1"], well, 50)
 
 .. versionadded:: 2.0
 
@@ -273,14 +273,14 @@ This example uses ``define_liquid`` to create two liquid objects and instantiate
 .. code-block:: python
 
         greenWater = protocol.define_liquid(
-            name='Green water',
-            description='Green colored water for demo',
-            display_color='#00FF00',
+            name="Green water",
+            description="Green colored water for demo",
+            display_color="#00FF00",
         )
         blueWater = protocol.define_liquid(
-            name='Blue water',
-            description='Blue colored water for demo',
-            display_color='#0000FF',
+            name="Blue water",
+            description="Blue colored water for demo",
+            display_color="#0000FF",
         )
 
 .. versionadded:: 2.14
@@ -294,12 +294,12 @@ This example uses ``load_liquid`` to label the initial well location, contents, 
 
 .. code-block:: python
 
-        well_plate['A1'].load_liquid(liquid=greenWater, volume=50)
-        well_plate['A2'].load_liquid(liquid=greenWater, volume=50)
-        well_plate['B1'].load_liquid(liquid=blueWater, volume=50)
-        well_plate['B2'].load_liquid(liquid=blueWater, volume=50)
-        reservoir['A1'].load_liquid(liquid=greenWater, volume=200)
-        reservoir['A2'].load_liquid(liquid=blueWater, volume=200)
+        well_plate["A1"].load_liquid(liquid=greenWater, volume=50)
+        well_plate["A2"].load_liquid(liquid=greenWater, volume=50)
+        well_plate["B1"].load_liquid(liquid=blueWater, volume=50)
+        well_plate["B2"].load_liquid(liquid=blueWater, volume=50)
+        reservoir["A1"].load_liquid(liquid=greenWater, volume=200)
+        reservoir["A2"].load_liquid(liquid=blueWater, volume=200)
         
 .. versionadded:: 2.14
 
@@ -331,8 +331,8 @@ Use :py:attr:`.Well.depth` to get the distance in mm between the very top of the
 .. code-block:: python
     :substitutions:
 
-    plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 'D1')
-    depth = plate['A1'].depth  # 10.67
+    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "D1")
+    depth = plate["A1"].depth  # 10.67
 
 Diameter
 ========
@@ -342,8 +342,8 @@ Use :py:attr:`.Well.diameter` to get the diameter of a given well in mm. Since d
 .. code-block:: python
     :substitutions:
 
-    plate = protocol.load_labware('corning_96_wellplate_360ul_flat', 'D1')
-    diameter = plate['A1'].diameter	 # 6.86
+    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "D1")
+    diameter = plate["A1"].diameter	 # 6.86
 
 Length
 ======
@@ -353,8 +353,8 @@ Use :py:attr:`.Well.length` to get the length of a given well in mm. Length is d
 .. code-block:: python
     :substitutions:
 
-    plate = protocol.load_labware('nest_12_reservoir_15ml', 'D1')
-    length = plate['A1'].length	 # 8.2
+    plate = protocol.load_labware("nest_12_reservoir_15ml", "D1")
+    length = plate["A1"].length	 # 8.2
 
 
 Width
@@ -366,8 +366,8 @@ Use :py:attr:`.Well.width` to get the width of a given well in mm. Width is defi
 .. code-block:: python
     :substitutions:
 
-    plate = protocol.load_labware('nest_12_reservoir_15ml', 'D1')
-    width = plate['A1'].width  # 71.2
+    plate = protocol.load_labware("nest_12_reservoir_15ml", "D1")
+    width = plate["A1"].width  # 71.2
 
 
 .. versionadded:: 2.9

--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -213,7 +213,7 @@ In addition to referencing wells by name, you can also reference them with zero-
 
 .. tip::
 
-    You may find coordinate well names like ``"B3"`` easier to reason with, especially when working with irregular labware, e.g.
+    You may find coordinate well names like ``'B3'`` easier to reason with, especially when working with irregular labware, e.g.
     ``opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical`` (see the `Opentrons 10 Tube Rack <https://labware.opentrons.com/opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical>`_ in the Labware Library). Whichever well access method you use, your protocol will be most maintainable if you use only one access method consistently.
 
 .. versionadded:: 2.0
@@ -273,14 +273,14 @@ This example uses ``define_liquid`` to create two liquid objects and instantiate
 .. code-block:: python
 
         greenWater = protocol.define_liquid(
-            name="Green water",
-            description="Green colored water for demo",
-            display_color="#00FF00",
+            name='Green water',
+            description='Green colored water for demo',
+            display_color='#00FF00',
         )
         blueWater = protocol.define_liquid(
-            name="Blue water",
-            description="Blue colored water for demo",
-            display_color="#0000FF",
+            name='Blue water',
+            description='Blue colored water for demo',
+            display_color='#0000FF',
         )
 
 .. versionadded:: 2.14
@@ -294,12 +294,12 @@ This example uses ``load_liquid`` to label the initial well location, contents, 
 
 .. code-block:: python
 
-        well_plate["A1"].load_liquid(liquid=greenWater, volume=50)
-        well_plate["A2"].load_liquid(liquid=greenWater, volume=50)
-        well_plate["B1"].load_liquid(liquid=blueWater, volume=50)
-        well_plate["B2"].load_liquid(liquid=blueWater, volume=50)
-        reservoir["A1"].load_liquid(liquid=greenWater, volume=200)
-        reservoir["A2"].load_liquid(liquid=blueWater, volume=200)
+        well_plate['A1'].load_liquid(liquid=greenWater, volume=50)
+        well_plate['A2'].load_liquid(liquid=greenWater, volume=50)
+        well_plate['B1'].load_liquid(liquid=blueWater, volume=50)
+        well_plate['B2'].load_liquid(liquid=blueWater, volume=50)
+        reservoir['A1'].load_liquid(liquid=greenWater, volume=200)
+        reservoir['A2'].load_liquid(liquid=blueWater, volume=200)
         
 .. versionadded:: 2.14
 

--- a/api/docs/v2/new_modules.rst
+++ b/api/docs/v2/new_modules.rst
@@ -33,5 +33,5 @@ Pages in this section of the documentation cover:
 
 .. note::
 
-    Throughout these pages, most code examples use coordinate deck slot locations (e.g. ``'D1'``, ``'D2'``), like those found on Flex. If you have an OT-2 and are using API version 2.14 or earlier, replace the coordinate with its numeric OT-2 equivalent. For example, slot D1 on Flex corresponds to slot 1 on an OT-2. See :ref:`deck-slots` for more information.
+    Throughout these pages, most code examples use coordinate deck slot locations (e.g. ``"D1"``, ``"D2"``), like those found on Flex. If you have an OT-2 and are using API version 2.14 or earlier, replace the coordinate with its numeric OT-2 equivalent. For example, slot D1 on Flex corresponds to slot 1 on an OT-2. See :ref:`deck-slots` for more information.
 

--- a/api/docs/v2/pipettes/characteristics.rst
+++ b/api/docs/v2/pipettes/characteristics.rst
@@ -55,19 +55,19 @@ To demonstrate these concepts, let's write a protocol that uses a Flex 8-Channel
 
     from opentrons import protocol_api
     
-    requirements = {'robotType': 'Flex', 'apiLevel':'|apiLevel|'}
+    requirements = {"robotType": "Flex", "apiLevel":"|apiLevel|"}
 
     def run(protocol: protocol_api.ProtocolContext):
         # Load a tiprack for 1000 µL tips
         tiprack1 = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_1000ul', location='D1')       
+            load_name="opentrons_flex_96_tiprack_1000ul", location="D1")       
         # Load a 96-well plate
         plate = protocol.load_labware(
-            load_name='corning_96_wellplate_360ul_flat', location='C1')       
+            load_name="corning_96_wellplate_360ul_flat", location="C1")       
         # Load an 8-channel pipette on the right mount
         right = protocol.load_instrument(
-            instrument_name='flex_8channel_1000',
-            mount='right',
+            instrument_name="flex_8channel_1000",
+            mount="right",
             tip_racks=[tiprack1])
 
 After loading our instruments and labware, let's tell the robot to pick up a pipette tip from location ``A1`` in ``tiprack1``::
@@ -78,13 +78,13 @@ With the backmost pipette channel above location A1 on the tip rack, all eight c
 
 After picking up a tip, let's tell the robot to aspirate 300 µL from the well plate at location ``A2``::
         
-    right.aspirate(volume=300, location=plate['A2'])
+    right.aspirate(volume=300, location=plate["A2"])
 
 With the backmost pipette tip above location A2 on the well plate, all eight channels are above the eight wells in column 2.
 
 Finally, let's tell the robot to dispense 300 µL into the well plate at location ``A3``::
 
-    right.dispense(volume=300, location=plate['A3'].top())
+    right.dispense(volume=300, location=plate["A3"].top())
 
 With the backmost pipette tip above location A3, all eight channels are above the eight wells in column 3. The pipette will dispense liquid into all the wells simultaneously.
 
@@ -100,14 +100,14 @@ To demonstrate these concepts, let's write a protocol that uses a Flex 8-Channel
     def run(protocol: protocol_api.ProtocolContext):
         # Load a tiprack for 200 µL tips
         tiprack1 = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_200ul', location="D1")
+            load_name="opentrons_flex_96_tiprack_200ul", location="D1")
         # Load a well plate
         plate = protocol.load_labware(
-            load_name='corning_384_wellplate_112ul_flat', location="D2")
+            load_name="corning_384_wellplate_112ul_flat", location="D2")
         # Load an 8-channel pipette on the right mount
         right = protocol.load_instrument(
-            instrument_name='flex_8channel_1000',
-            mount='right',
+            instrument_name="flex_8channel_1000",
+            mount="right",
             tip_racks=[tiprack1])
 
 
@@ -119,13 +119,13 @@ With the backmost pipette channel above location A1 on the tip rack, all eight c
 
 After picking up a tip, let's tell the robot to aspirate 100 µL from the well plate at location ``A1``::
 
-    right.aspirate(volume=100, location=plate['A1'])
+    right.aspirate(volume=100, location=plate["A1"])
 
 The eight pipette channels will only aspirate from every other well in the column: A1, C1, E1, G1, I1, K1, M1, and O1.
 
 Finally, let's tell the robot to dispense 100 µL into the well plate at location ``B1``::
 
-    right.dispense(volume=100, location=plate['B1'])
+    right.dispense(volume=100, location=plate["B1"])
 
 The eight pipette channels will only dispense into every other well in the column: B1, D1, F1, H1, J1, L1, N1, and P1.
 
@@ -147,19 +147,19 @@ These flow rate properties operate independently. This means you can specify dif
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack1 = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_1000ul', location='D1')       
+            load_name="opentrons_flex_96_tiprack_1000ul", location="D1")       
         pipette = protocol.load_instrument(
-            instrument_name='flex_1channel_1000',
-            mount='left',
+            instrument_name="flex_1channel_1000",
+            mount="left",
             tip_racks=[tiprack1])                
         plate = protocol.load_labware(
-            load_name='corning_96_wellplate_360ul_flat', location='D3')
+            load_name="corning_96_wellplate_360ul_flat", location="D3")
         pipette.pick_up_tip()
 
 Let's tell the robot to aspirate, dispense, and blow out the liquid using default flow rates. Notice how you don't need to specify a ``flow_rate`` attribute to use the defaults::
 
-        pipette.aspirate(200, plate['A1'])  # 160 µL/s
-        pipette.dispense(200, plate['A2'])  # 160 µL/s
+        pipette.aspirate(200, plate["A1"])  # 160 µL/s
+        pipette.dispense(200, plate["A2"])  # 160 µL/s
         pipette.blow_out()                  #  80 µL/s
 
 Now let's change the flow rates for each action::
@@ -167,8 +167,8 @@ Now let's change the flow rates for each action::
         pipette.flow_rate.aspirate = 50
         pipette.flow_rate.dispense = 100
         pipette.flow_rate.blow_out = 75
-        pipette.aspirate(200, plate['A1'])  #  50 µL/s
-        pipette.dispense(200, plate['A2'])  # 100 µL/s
+        pipette.aspirate(200, plate["A1"])  #  50 µL/s
+        pipette.dispense(200, plate["A2"])  # 100 µL/s
         pipette.blow_out()                  #  75 µL/s
         
 These flow rates will remain in effect until you change the ``flow_rate`` attribute again *or* call ``configure_for_volume()``. Calling ``configure_for_volume()`` always resets all pipette flow rates to the defaults for the mode that it sets.

--- a/api/docs/v2/pipettes/loading.rst
+++ b/api/docs/v2/pipettes/loading.rst
@@ -64,20 +64,20 @@ This code sample loads a Flex 1-Channel Pipette in the left mount and a Flex 8-C
 
     from opentrons import protocol_api
     
-    requirements = {'robotType': 'Flex', 'apiLevel':'|apiLevel|'}
+    requirements = {"robotType": "Flex", "apiLevel":"|apiLevel|"}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack1 = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_1000ul', location='D1')
+            load_name="opentrons_flex_96_tiprack_1000ul", location="D1")
         tiprack2 = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_1000ul', location='C1')       
+            load_name="opentrons_flex_96_tiprack_1000ul", location="C1")       
         left = protocol.load_instrument(
-            instrument_name='flex_1channel_1000',
-            mount='left',
+            instrument_name="flex_1channel_1000",
+            mount="left",
             tip_racks=[tiprack1])                
         right = protocol.load_instrument(
-            instrument_name='flex_8channel_1000',
-            mount='right',
+            instrument_name="flex_8channel_1000",
+            mount="right",
             tip_racks=[tiprack2]) 
 
 If you're writing a protocol that uses the Flex Gripper, you might think that this would be the place in your protocol to declare that. However, the gripper doesn't require ``load_instrument``! Whether your gripper requires a protocol is determined by the presence of :py:meth:`.ProtocolContext.move_labware` commands. See :ref:`moving-labware` for more details.
@@ -91,10 +91,10 @@ This code sample loads the Flex 96-Channel Pipette. Because of its size, the Fle
 
     def run(protocol: protocol_api.ProtocolContext):
         pipette = protocol.load_instrument(
-            instrument_name='flex_96channel_1000'
+            instrument_name="flex_96channel_1000"
         )
 
-In protocols specifying API version 2.15, also include ``mount='left'`` as a parameter of ``load_instrument()``.
+In protocols specifying API version 2.15, also include ``mount="left"`` as a parameter of ``load_instrument()``.
 
 .. versionadded:: 2.15
 .. versionchanged:: 2.16
@@ -110,20 +110,20 @@ This code sample loads a P1000 Single-Channel GEN2 pipette in the left mount and
 
     from opentrons import protocol_api
 
-    metadata = {'apiLevel': '|apiLevel|'}
+    metadata = {"apiLevel": "|apiLevel|"}
 
     def run(protocol: protocol_api.ProtocolContext):
         tiprack1 = protocol.load_labware(
-            load_name='opentrons_96_tiprack_1000ul', location=1)
+            load_name="opentrons_96_tiprack_1000ul", location=1)
         tiprack2 = protocol.load_labware(
-            load_name='opentrons_96_tiprack_1000ul', location=2)
+            load_name="opentrons_96_tiprack_1000ul", location=2)
         left = protocol.load_instrument(
-            instrument_name='p1000_single_gen2',
-            mount='left',
+            instrument_name="p1000_single_gen2",
+            mount="left",
             tip_racks=[tiprack1])
         right = protocol.load_instrument(
-            instrument_name='p300_multi_gen2',
-            mount='right',
+            instrument_name="p300_multi_gen2",
+            mount="right",
             tip_racks=[tiprack1])
 
 .. versionadded:: 2.0
@@ -142,28 +142,28 @@ The advantage of using ``tip_racks`` is twofold. First, associating tip racks wi
         
     def run(protocol: protocol_api.ProtocolContext):
         tiprack_left = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_200ul', location='D1')
+            load_name="opentrons_flex_96_tiprack_200ul", location="D1")
         tiprack_right = protocol.load_labware(
-            load_name='opentrons_flex_96_tiprack_200ul', location='D2')
+            load_name="opentrons_flex_96_tiprack_200ul", location="D2")
         left_pipette = protocol.load_instrument(
-            instrument_name='flex_8channel_1000', mount='left')
+            instrument_name="flex_8channel_1000", mount="left")
         right_pipette = protocol.load_instrument(
-            instrument_name='flex_8channel_1000',
-            mount='right',
+            instrument_name="flex_8channel_1000",
+            mount="right",
             tip_racks=[tiprack_right])
 
 Let's pick up a tip with the left pipette. We need to specify the location as an argument of ``pick_up_tip()``, since we loaded the left pipette without a ``tip_racks`` argument.
 
 .. code-block:: python
 
-    left_pipette.pick_up_tip(tiprack_left['A1'])
+    left_pipette.pick_up_tip(tiprack_left["A1"])
     left_pipette.drop_tip()
 
 But now you have to specify ``tiprack_left`` every time you call ``pick_up_tip``, which means you're doing all your own tip tracking::
 
-    left_pipette.pick_up_tip(tiprack_left['A2'])
+    left_pipette.pick_up_tip(tiprack_left["A2"])
     left_pipette.drop_tip()
-    left_pipette.pick_up_tip(tiprack_left['A3'])
+    left_pipette.pick_up_tip(tiprack_left["A3"])
     left_pipette.drop_tip()
 
 However, because you specified a tip rack location for the right pipette, the robot will automatically pick up from location ``A1`` of its associated tiprack::
@@ -192,13 +192,13 @@ The API automatically assigns a :py:obj:`.trash_container` to pipettes, if one i
 One example of when you might want to change the trash container is a Flex protocol that goes through a lot of tips. In a case where the protocol uses two pipettes, you could load two trash bins and assign one to each pipette::
 
     left_pipette = protocol.load_instrument(
-        instrument_name='flex_8channel_1000', mount='left'
+        instrument_name="flex_8channel_1000", mount="left"
     )
     right_pipette = protocol.load_instrument(
-        instrument_name='flex_8channel_50', mount='right'
+        instrument_name="flex_8channel_50", mount="right"
     )
-    left_trash = load_trash_bin('A3')
-    right_trash = load_trash_bin('B3')
+    left_trash = load_trash_bin("A3")
+    right_trash = load_trash_bin("B3")
     left_pipette.trash_container = left_trash
     right_pipette.trash_container = right_trash
 

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -28,14 +28,14 @@ Let's look at the :py:meth:`.Well.top` method. It returns a position level with 
 
 .. code-block:: python
     
-    plate['A1'].top()  # the top center of the well
+    plate["A1"].top()  # the top center of the well
 
 This is a good position to use for a :ref:`blow out operation <new-blow-out>` or an activity where you don't want the tip to contact the liquid. In addition, you can adjust the height of this position with the optional argument ``z``, which is measured in mm. Positive ``z`` numbers move the position up, negative ``z`` numbers move it down.
 
 .. code-block:: python
 
-   plate['A1'].top(z=1)  # 1 mm above the top center of the well
-   plate['A1'].top(z=-1) # 1 mm below the top center of the well
+   plate["A1"].top(z=1)  # 1 mm above the top center of the well
+   plate["A1"].top(z=-1) # 1 mm below the top center of the well
 
 .. versionadded:: 2.0
 
@@ -46,14 +46,14 @@ Let's look at the :py:meth:`.Well.bottom` method. It returns a position level wi
 
 .. code-block:: python
 
-   plate['A1'].bottom()  # the bottom center of the well
+   plate["A1"].bottom()  # the bottom center of the well
 
 This is a good position for :ref:`aspirating liquid <new-aspirate>` or an activity where you want the tip to contact the liquid. Similar to the ``Well.top()`` method, you can adjust the height of this position with the optional argument ``z``, which is measured in mm. Positive ``z`` numbers move the position up, negative ``z`` numbers move it down.
 
 .. code-block:: python
 
-   plate['A1'].bottom(z=1)  # 1 mm above the bottom center of the well
-   plate['A1'].bottom(z=-1) # 1 mm below the bottom center of the well
+   plate["A1"].bottom(z=1)  # 1 mm above the bottom center of the well
+   plate["A1"].bottom(z=-1) # 1 mm below the bottom center of the well
                             # this may be dangerous!
 
 .. warning::
@@ -73,7 +73,7 @@ Let's look at the :py:meth:`.Well.center` method. It returns a position centered
 
 .. code-block:: python
 
-   plate['A1'].center() # the vertical and horizontal center of the well
+   plate["A1"].center() # the vertical and horizontal center of the well
 
 .. versionadded:: 2.0
 
@@ -90,22 +90,22 @@ If you need to change the aspiration or dispensing height for multiple operation
 Modifying these attributes will affect all subsequent aspirate and dispense actions performed by the attached pipette, even those executed as part of a :py:meth:`.transfer` operation. This snippet from a sample protocol demonstrates how to work with and change the default clearance::
 
     # aspirate 1 mm above the bottom of the well (default)
-    pipette.aspirate(50, plate['A1'])
+    pipette.aspirate(50, plate["A1"])
     # dispense 1 mm above the bottom of the well (default)
-    pipette.dispense(50, plate['A1'])
+    pipette.dispense(50, plate["A1"])
 
     # change clearance for aspiration to 2 mm
     pipette.well_bottom_clearance.aspirate = 2
     # aspirate 2 mm above the bottom of the well
-    pipette.aspirate(50, plate['A1'])
+    pipette.aspirate(50, plate["A1"])
     # still dispensing 1 mm above the bottom
-    pipette.dispense(50, plate['A1'])
+    pipette.dispense(50, plate["A1"])
 
-    pipette.aspirate(50, plate['A1'])
+    pipette.aspirate(50, plate["A1"])
     # change clearance for dispensing to 10 mm      
     pipette.well_bottom_clearance.dispense = 10
     # dispense high above the well
-    pipette.dispense(50, plate['A1'])
+    pipette.dispense(50, plate["A1"])
 
 .. versionadded:: 2.0
 
@@ -146,17 +146,17 @@ The :py:meth:`~.InstrumentContext.move_to` method requires the :py:class:`.Locat
 
 .. code-block:: python
 
-    pipette.move_to(plate['A1'])              # error; can't move to a well itself
-    pipette.move_to(plate['A1'].bottom())     # move to the bottom of well A1
-    pipette.move_to(plate['A1'].top())        # move to the top of well A1
-    pipette.move_to(plate['A1'].bottom(z=2))  # move to 2 mm above the bottom of well A1
-    pipette.move_to(plate['A1'].top(z=-2))    # move to 2 mm below the top of well A1
+    pipette.move_to(plate["A1"])              # error; can't move to a well itself
+    pipette.move_to(plate["A1"].bottom())     # move to the bottom of well A1
+    pipette.move_to(plate["A1"].top())        # move to the top of well A1
+    pipette.move_to(plate["A1"].bottom(z=2))  # move to 2 mm above the bottom of well A1
+    pipette.move_to(plate["A1"].top(z=-2))    # move to 2 mm below the top of well A1
 
 When using ``move_to()``, by default the pipette will move in an arc: first upwards, then laterally to a position above the target location, and finally downwards to the target location. If you have a reason for doing so, you can force the pipette to move in a straight line to the target location:
 
 .. code-block:: python
 
-    pipette.move_to(plate['A1'].top(), force_direct=True)
+    pipette.move_to(plate["A1"].top(), force_direct=True)
 
 .. warning::
 
@@ -164,10 +164,10 @@ When using ``move_to()``, by default the pipette will move in an arc: first upwa
 
 Small, direct movements can be useful for working inside of a well, without having the tip exit and re-enter the well. This code sample demonstrates how to move the pipette to a well, make direct movements inside that well, and then move on to a different well::
 
-    pipette.move_to(plate['A1'].top())
-    pipette.move_to(plate['A1'].bottom(1), force_direct=True)
-    pipette.move_to(plate['A1'].top(-2), force_direct=True)
-    pipette.move_to(plate['A2'].top())
+    pipette.move_to(plate["A1"].top())
+    pipette.move_to(plate["A1"].bottom(1), force_direct=True)
+    pipette.move_to(plate["A1"].top(-2), force_direct=True)
+    pipette.move_to(plate["A2"].top())
 
 .. versionadded:: 2.0
 
@@ -187,7 +187,7 @@ When instructing the robot to move, it's important to consider the difference be
 This distinction is important for the :py:meth:`.Location.move` method, which operates on a location, takes a point as an argument, and outputs an updated location. To use this method, include ``from opentrons import types`` at the start of your protocol. The ``move()`` method does not mutate the location it is called on, so to perform an action at the updated location, use it as an argument of another method or save it to a variable. For example::
 
     # get the location at the center of well A1
-    center_location = plate['A1'].center()
+    center_location = plate["A1"].center()
 
     # get a location 1 mm right, 1 mm back, and 1 mm up from the center of well A1
     adjusted_location = center_location.move(types.Point(x=1, y=1, z=1))
@@ -205,11 +205,11 @@ This distinction is important for the :py:meth:`.Location.move` method, which op
 	.. code-block:: python
 
 		# the following are equivalent
-		pipette.move_to(plate['A1'].bottom(z=2))
-		pipette.move_to(plate['A1'].bottom().move(types.Point(z=2)))
+		pipette.move_to(plate["A1"].bottom(z=2))
+		pipette.move_to(plate["A1"].bottom().move(types.Point(z=2)))
 
 		# adjust along the y-axis
-		pipette.move_to(plate['A1'].bottom().move(types.Point(y=2)))	
+		pipette.move_to(plate["A1"].bottom().move(types.Point(y=2)))	
 
 .. versionadded:: 2.0
 
@@ -227,9 +227,9 @@ Gantry Speed
 The robot's gantry usually moves as fast as it can given its construction. The default speed for Flex varies between 300 and 350 mm/s. The OT-2 default is 400 mm/s. However, some experiments or liquids may require slower movements. In this case, you can reduce the gantry speed for a specific pipette by setting :py:obj:`.InstrumentContext.default_speed` like this::
         
 	
-	pipette.move_to(plate['A1'].top())  # move to the first well at default speed
+	pipette.move_to(plate["A1"].top())  # move to the first well at default speed
 	pipette.default_speed = 100         # reduce pipette speed
-	pipette.move_to(plate['D6'].top())  # move to the last well at the slower speed
+	pipette.move_to(plate["D6"].top())  # move to the last well at the slower speed
 
 .. warning::
 
@@ -249,10 +249,10 @@ In addition to controlling the overall gantry speed, you can set speed limits fo
 .. code-block:: python
     :substitutions:
 
-	protocol.max_speeds['x'] = 50    # limit x-axis to 50 mm/s
-	del protocol.max_speeds['x']     # reset x-axis limit
-	protocol.max_speeds['a'] = 10    # limit a-axis to 10 mm/s
-	protocol.max_speeds['a'] = None  # reset a-axis limit
+	protocol.max_speeds["x"] = 50    # limit x-axis to 50 mm/s
+	del protocol.max_speeds["x"]     # reset x-axis limit
+	protocol.max_speeds["a"] = 10    # limit a-axis to 10 mm/s
+	protocol.max_speeds["a"] = None  # reset a-axis limit
 
 
 Note that ``max_speeds`` can't set limits for the pipette plunger axes (``b`` and ``c``); instead, set the flow rates or plunger speeds as described in :ref:`new-plunger-flow-rates`.

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -111,11 +111,11 @@ Whether you need a ``requirements`` block depends on your robot model and API ve
 
 - **Flex:** The ``requirements`` block is always required. And, the API version does not go in the ``metadata`` section. The API version belongs in the ``requirements``. For example::
 
-    requirements = {"robotType": "Flex", "apiLevel": "2.16"}
+    requirements = {'robotType': 'Flex', 'apiLevel': '2.16'}
 
 - **OT-2:** The ``requirements`` block is optional, but including it is a recommended best practice, particularly if you’re using API version 2.15 or greater. If you do use it, remember to remove the API version from the ``metadata``. For example::
     
-    requirements = {"robotType": "OT-2", "apiLevel": "2.16"}
+    requirements = {'robotType': 'OT-2', 'apiLevel': '2.16'}
 
 With the metadata and requirements defined, you can move on to creating the ``run()`` function for your protocol.
 

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -9,12 +9,12 @@ Tutorial
 Introduction
 ============
 
-This tutorial will guide you through creating a Python protocol file from scratch. At the end of this process you’ll have a complete protocol that can run on a Flex or an OT-2 robot. If you don’t have a Flex or an OT-2 (or if you’re away from your lab, or if your robot is in use), you can use the same file to simulate the protocol on your computer instead.
+This tutorial will guide you through creating a Python protocol file from scratch. At the end of this process you'll have a complete protocol that can run on a Flex or an OT-2 robot. If you don’t have a Flex or an OT-2 (or if you’re away from your lab, or if your robot is in use), you can use the same file to simulate the protocol on your computer instead.
 
-What You’ll Automate
+What You'll Automate
 --------------------
 
-The lab task that you’ll automate in this tutorial is `serial dilution`: taking a solution and progressively diluting it by transferring it stepwise across a plate from column 1 to column 12. With just a dozen or so lines of code, you can instruct your robot to perform the hundreds of individual pipetting actions necessary to fill an entire 96-well plate. And all of those liquid transfers will be done automatically, so you’ll have more time to do other work in your lab.
+The lab task that you'll automate in this tutorial is `serial dilution`: taking a solution and progressively diluting it by transferring it stepwise across a plate from column 1 to column 12. With just a dozen or so lines of code, you can instruct your robot to perform the hundreds of individual pipetting actions necessary to fill an entire 96-well plate. And all of those liquid transfers will be done automatically, so you’ll have more time to do other work in your lab.
 
 Before You Begin
 ----------------
@@ -80,21 +80,21 @@ Every protocol needs to have a metadata dictionary with information about the pr
 
 .. code-block:: python
 
-    metadata = {'apiLevel': '2.16'}
+    metadata = {"apiLevel": "2.16"}
 
 You can include any other information you like in the metadata dictionary. The fields ``protocolName``, ``description``, and ``author`` are all displayed in the Opentrons App, so it’s a good idea to expand the dictionary to include them:
 
 .. code-block:: python
 
     metadata = {
-        'apiLevel': '2.16',
-        'protocolName': 'Serial Dilution Tutorial',
-        'description': '''This protocol is the outcome of following the 
+        "apiLevel": "2.16",
+        "protocolName": "Serial Dilution Tutorial",
+        "description": """This protocol is the outcome of following the 
                        Python Protocol API Tutorial located at 
                        https://docs.opentrons.com/v2/tutorial.html. It takes a 
                        solution and progressively dilutes it by transferring it 
-                       stepwise across a plate.''',
-        'author': 'New API User'
+                       stepwise across a plate.""",
+        "author": "New API User"
         }
 
 Note, if you have a Flex, or are using an OT-2 with API v2.15 (or higher), we recommend adding a ``requirements`` section to your code. See the Requirements section below.
@@ -111,11 +111,11 @@ Whether you need a ``requirements`` block depends on your robot model and API ve
 
 - **Flex:** The ``requirements`` block is always required. And, the API version does not go in the ``metadata`` section. The API version belongs in the ``requirements``. For example::
 
-    requirements = {'robotType': 'Flex', 'apiLevel': '2.16'}
+    requirements = {"robotType": "Flex", "apiLevel": "2.16"}
 
 - **OT-2:** The ``requirements`` block is optional, but including it is a recommended best practice, particularly if you’re using API version 2.15 or greater. If you do use it, remember to remove the API version from the ``metadata``. For example::
     
-    requirements = {'robotType': 'OT-2', 'apiLevel': '2.16'}
+    requirements = {"robotType": "OT-2", "apiLevel": "2.16"}
 
 With the metadata and requirements defined, you can move on to creating the ``run()`` function for your protocol.
 
@@ -144,9 +144,9 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
         .. code-block:: python
 
             def run(protocol: protocol_api.ProtocolContext):
-                tips = protocol.load_labware('opentrons_flex_96_tiprack_200ul', 'D1')
-                reservoir = protocol.load_labware('nest_12_reservoir_15ml', 'D2')
-                plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 'D3')
+                tips = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
+                reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D2")
+                plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
 
         If you’re using a different model of labware, find its name in the Labware Library and replace it in your code.
         
@@ -165,9 +165,9 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
         .. code-block:: python
  
             def run(protocol: protocol_api.ProtocolContext):
-                tips = protocol.load_labware('opentrons_96_tiprack_300ul', 1)
-                reservoir = protocol.load_labware('nest_12_reservoir_15ml', 2)
-                plate = protocol.load_labware('nest_96_wellplate_200ul_flat', 3)
+                tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+                reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
+                plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
         
         If you’re using a different model of labware, find its name in the Labware Library and replace it in your code.
        
@@ -190,7 +190,7 @@ The OT-2 trash bin is fixed in slot 12. Since it can't go anywhere else on the d
 
 Flex lets you put a :ref:`trash bin <configure-trash-bin>` in multiple locations on the deck. You can even have more than one trash bin, or none at all (if you use the :ref:`waste chute <configure-waste-chute>` instead, or if your protocol never trashes any tips). For serial dilution, you'll need to dispose used tips, so you also need to tell the API where the trash container is located on your robot. Loading a trash bin on Flex is done with the :py:meth:`.load_trash_bin` method, which takes one argument: its location. Here's how to load the trash in slot A3::
 
-    trash = protocol.load_trash_bin('A3')
+    trash = protocol.load_trash_bin("A3")
 
 
 Pipettes
@@ -201,12 +201,12 @@ Next you’ll specify what pipette to use in the protocol. Loading a pipette is 
 .. code-block:: python
 
         # Flex
-        left_pipette = protocol.load_instrument('flex_1channel_1000', 'left', tip_racks=[tips])
+        left_pipette = protocol.load_instrument("flex_1channel_1000", "left", tip_racks=[tips])
 
 .. code-block:: python
 
         # OT-2
-        left_pipette = protocol.load_instrument('p300_single_gen2', 'left', tip_racks=[tips])
+        left_pipette = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tips])
 
 Since the pipette is so fundamental to the protocol, it might seem like you should have specified it first. But there’s a good reason why pipettes are loaded after labware: you need to have already loaded ``tips`` in order to tell the pipette to use it. And now you won’t have to reference ``tips`` again in your code — it’s assigned to the ``left_pipette`` and the robot will know to use it when commanded to pick up tips.
 
@@ -231,7 +231,7 @@ Let’s start with the diluent. This phase takes a larger quantity of liquid and
 
 .. code-block:: python
 
-        left_pipette.transfer(100, reservoir['A1'], plate.wells())
+        left_pipette.transfer(100, reservoir["A1"], plate.wells())
 
 Breaking down these single lines of code shows the power of :ref:`complex commands <v2-complex-commands>`. The first argument is the amount to transfer to each destination, 100 µL. The second argument is the source, column 1 of the reservoir (which is still specified with grid-style coordinates as ``A1`` — a reservoir only has an A row). The third argument is the destination. Here, calling the :py:meth:`.wells` method of ``plate`` returns a list of *every well*, and the command will apply to all of them.
 
@@ -260,7 +260,7 @@ In each row, you first need to add solution. This will be similar to what you di
 
 .. code-block:: python
             
-        left_pipette.transfer(100, reservoir['A2'], row[0], mix_after(3, 50))
+        left_pipette.transfer(100, reservoir["A2"], row[0], mix_after(3, 50))
 
 As before, the first argument specifies to transfer 100 µL. The second argument is the source, column 2 of the reservoir. The third argument is the destination, the element at index 0 of the current ``row``. Since Python lists are zero-indexed, but columns on labware start numbering at 1, this will be well A1 on the first time through the loop, B1 the second time, and so on. The fourth argument specifies to mix 3 times with 50 µL of fluid each time.
 
@@ -300,14 +300,14 @@ Thus, when adding the diluent, instead of targeting every well on the plate, you
 
 .. code-block:: python
 
-        left_pipette.transfer(100, reservoir['A1'], plate.rows()[0]) 
+        left_pipette.transfer(100, reservoir["A1"], plate.rows()[0]) 
 
 And by accessing an entire column at once, the 8-channel pipette effectively implements the ``for`` loop in hardware, so you’ll need to remove it: 
 
 .. code-block:: python
     
     row = plate.rows()[0]
-    left_pipette.transfer(100, reservoir['A2'], row[0], mix_after=(3, 50))
+    left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
     left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))
 
 Instead of tracking the current row in the ``row`` variable, this code sets it to always be row A (index 0). 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -30,11 +30,11 @@ You must specify the API version you are targeting in your Python protocol. In a
    from opentrons import protocol_api
 
    metadata = {
-       'apiLevel': '|apiLevel|',
-       'author': 'A. Biologist'}
+       "apiLevel": "|apiLevel|",
+       "author": "A. Biologist"}
 
    def run(protocol: protocol_api.ProtocolContext):
-       protocol.comment('Hello, world!')
+       protocol.comment("Hello, world!")
        
 From version 2.15 onward, you can specify ``apiLevel`` in the ``requirements`` dictionary instead:
 
@@ -43,11 +43,11 @@ From version 2.15 onward, you can specify ``apiLevel`` in the ``requirements`` d
 
    from opentrons import protocol_api
 
-   metadata = {'author': 'A. Biologist'}
-   requirements = {'apiLevel': '|apiLevel|', 'robotType': 'Flex'}
+   metadata = {"author": "A. Biologist"}
+   requirements = {"apiLevel": "|apiLevel|", "robotType": "Flex"}
 
    def run(protocol: protocol_api.ProtocolContext):
-       protocol.comment('Hello, Flex!')
+       protocol.comment("Hello, Flex!")
 
 Choose only one of these places to specify ``apiLevel``. If you put it in neither or both places, you will not be able to simulate or run your protocol.
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Replaced single quotes with double quotes in tutorial docs, both v1 and v2 docs. 

This also changes some example protocols, located in `api/docs/v2/example_protocols/`, which are Python files.

And a minor change, this also changes some random non-standard single quotes at the beginning of `api/docs/v2/tutorial.rst` to regular single quotes.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
N/A

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
- Replaced single quotes with double quotes in v1 docs
- Replaced single quotes with double quotes in v2 docs
- Replaced single quotes with double quotes in v2 example protocols

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low