### PR TITLE
fix(app): remove choose robot slideout selector warnings

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -33,7 +33,7 @@ interface AvailableRobotOptionProps {
   robot: Robot
   onClick: () => void
   isSelected: boolean
-  isOnDifferentSoftwareVersion: boolean
+  isSelectedRobotOnDifferentSoftwareVersion: boolean
   registerRobotBusyStatus: React.Dispatch<RobotBusyStatusAction>
   isError?: boolean
   showIdleOnly?: boolean
@@ -47,7 +47,7 @@ export function AvailableRobotOption(
     onClick,
     isSelected,
     isError = false,
-    isOnDifferentSoftwareVersion,
+    isSelectedRobotOnDifferentSoftwareVersion,
     showIdleOnly = false,
     registerRobotBusyStatus,
   } = props
@@ -99,7 +99,9 @@ export function AvailableRobotOption(
       <MiniCard
         onClick={onClick}
         isSelected={isSelected}
-        isError={(isError || isOnDifferentSoftwareVersion) && isSelected}
+        isError={
+          (isError || isSelectedRobotOnDifferentSoftwareVersion) && isSelected
+        }
       >
         <img
           src={robotModel === 'OT-2' ? OT2_PNG : FLEX_PNG}
@@ -134,7 +136,8 @@ export function AvailableRobotOption(
             </StyledText>
           </Box>
         </Flex>
-        {(isError || isOnDifferentSoftwareVersion) && isSelected ? (
+        {(isError || isSelectedRobotOnDifferentSoftwareVersion) &&
+        isSelected ? (
           <>
             <Box flex="1 1 auto" />
             <Icon
@@ -146,7 +149,7 @@ export function AvailableRobotOption(
         ) : null}
       </MiniCard>
 
-      {isOnDifferentSoftwareVersion && isSelected ? (
+      {isSelectedRobotOnDifferentSoftwareVersion && isSelected ? (
         <StyledText
           as="label"
           color={COLORS.errorText}

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -11,7 +11,6 @@ import {
   getUnreachableRobots,
   startDiscovery,
 } from '../../../redux/discovery'
-import { getRobotUpdateDisplayInfo } from '../../../redux/robot-update'
 import {
   mockConnectableRobot,
   mockReachableRobot,
@@ -24,9 +23,6 @@ jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/robot-update')
 jest.mock('../../../redux/networking')
 
-const mockGetBuildrootUpdateDisplayInfo = getRobotUpdateDisplayInfo as jest.MockedFunction<
-  typeof getRobotUpdateDisplayInfo
->
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots
 >
@@ -59,11 +55,6 @@ const mockSetSelectedRobot = jest.fn()
 
 describe('ChooseRobotSlideout', () => {
   beforeEach(() => {
-    mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
-      autoUpdateAction: '',
-      autoUpdateDisabledReason: null,
-      updateFromFileDisabledReason: null,
-    })
     mockGetConnectableRobots.mockReturnValue([mockConnectableRobot])
     mockGetUnreachableRobots.mockReturnValue([mockUnreachableRobot])
     mockGetReachableRobots.mockReturnValue([mockReachableRobot])

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -79,6 +79,7 @@ describe('ChooseRobotSlideout', () => {
     render({
       onCloseClick: jest.fn(),
       isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
@@ -90,6 +91,7 @@ describe('ChooseRobotSlideout', () => {
     render({
       onCloseClick: jest.fn(),
       isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
@@ -104,6 +106,7 @@ describe('ChooseRobotSlideout', () => {
     render({
       onCloseClick: jest.fn(),
       isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
@@ -117,6 +120,7 @@ describe('ChooseRobotSlideout', () => {
     render({
       onCloseClick: jest.fn(),
       isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
       selectedRobot: null,
       setSelectedRobot: jest.fn(),
       title: 'choose robot slideout title',
@@ -131,6 +135,7 @@ describe('ChooseRobotSlideout', () => {
     const { dispatch } = render({
       onCloseClick: jest.fn(),
       isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
@@ -149,6 +154,7 @@ describe('ChooseRobotSlideout', () => {
     render({
       onCloseClick: jest.fn(),
       isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -32,7 +32,6 @@ import {
   RE_ROBOT_MODEL_OT2,
   RE_ROBOT_MODEL_OT3,
 } from '../../redux/discovery'
-import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
 import { Banner } from '../../atoms/Banner'
 import { Slideout } from '../../atoms/Slideout'
 import { StyledText } from '../../atoms/text'

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -83,10 +83,11 @@ function robotBusyStatusByNameReducer(
 interface ChooseRobotSlideoutProps
   extends Omit<SlideoutProps, 'children'>,
     Partial<UseCreateRun> {
+  isSelectedRobotOnDifferentSoftwareVersion: boolean
+  robotType: RobotType | null
   selectedRobot: Robot | null
   setSelectedRobot: (robot: Robot | null) => void
   isAnalysisError?: boolean
-  robotType: RobotType | null
   showIdleOnly?: boolean
 }
 
@@ -101,6 +102,7 @@ export function ChooseRobotSlideout(
     footer,
     isAnalysisError = false,
     isCreatingRun = false,
+    isSelectedRobotOnDifferentSoftwareVersion,
     reset: resetCreateRun,
     runCreationError,
     runCreationErrorCode,
@@ -163,19 +165,6 @@ export function ChooseRobotSlideout(
       setSelectedRobot(null)
     }
   }, [healthyReachableRobots, selectedRobot, setSelectedRobot])
-
-  const isSelectedRobotOnWrongVersionOfSoftware = [
-    'upgrade',
-    'downgrade',
-  ].includes(
-    useSelector((state: State) => {
-      const value =
-        selectedRobot != null
-          ? getRobotUpdateDisplayInfo(state, selectedRobot.name)
-          : { autoUpdateAction: '' }
-      return value
-    })?.autoUpdateAction
-  )
 
   const unavailableCount =
     unhealthyReachableRobots.length + unreachableRobots.length
@@ -246,7 +235,6 @@ export function ChooseRobotSlideout(
               <React.Fragment key={robot.ip}>
                 <AvailableRobotOption
                   robot={robot}
-                  // TODO: generalize to a disabled/reset prop
                   onClick={() => {
                     if (!isCreatingRun) {
                       resetCreateRun?.()
@@ -255,8 +243,8 @@ export function ChooseRobotSlideout(
                   }}
                   isError={runCreationError != null}
                   isSelected={isSelected}
-                  isOnDifferentSoftwareVersion={
-                    isSelectedRobotOnWrongVersionOfSoftware
+                  isSelectedRobotOnDifferentSoftwareVersion={
+                    isSelectedRobotOnDifferentSoftwareVersion
                   }
                   showIdleOnly={showIdleOnly}
                   registerRobotBusyStatus={registerRobotBusyStatus}

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -104,18 +104,14 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     createRunFromProtocolSource({ files: srcFileObjects, protocolKey })
   }
 
-  const isSelectedRobotOnWrongVersionOfSoftware = [
+  const { autoUpdateAction } = useSelector((state: State) =>
+    getRobotUpdateDisplayInfo(state, selectedRobot?.name ?? '')
+  )
+
+  const isSelectedRobotOnDifferentSoftwareVersion = [
     'upgrade',
     'downgrade',
-  ].includes(
-    useSelector((state: State) => {
-      const value =
-        selectedRobot != null
-          ? getRobotUpdateDisplayInfo(state, selectedRobot.name)
-          : { autoUpdateAction: '' }
-      return value
-    })?.autoUpdateAction
-  )
+  ].includes(autoUpdateAction)
 
   if (
     protocolKey == null ||
@@ -144,6 +140,9 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   return (
     <ChooseRobotSlideout
       isExpanded={showSlideout}
+      isSelectedRobotOnDifferentSoftwareVersion={
+        isSelectedRobotOnDifferentSoftwareVersion
+      }
       onCloseClick={onCloseClick}
       title={t('choose_robot_to_run', {
         protocol_name: protocolDisplayName,
@@ -164,7 +163,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
             disabled={
               isCreatingRun ||
               selectedRobot == null ||
-              isSelectedRobotOnWrongVersionOfSoftware
+              isSelectedRobotOnDifferentSoftwareVersion
             }
           >
             {isCreatingRun ? (

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -37,7 +37,7 @@ jest.mock('../../../redux/custom-labware/selectors')
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/protocol-storage/selectors')
 jest.mock('../../../organisms/ChooseRobotToRunProtocolSlideout')
-jest.mock('../../../organisms/SendProtocolToOT3Slideout')
+jest.mock('../../../organisms/SendProtocolToFlexSlideout')
 
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { screen, waitFor } from '@testing-library/react'
+import { act, screen, waitFor } from '@testing-library/react'
 import { StaticRouter } from 'react-router-dom'
 import { resetAllWhenMocks, when } from 'jest-when'
 
@@ -9,10 +9,12 @@ import {
 } from '@opentrons/components'
 
 import { i18n } from '../../../i18n'
+import { ChooseRobotToRunProtocolSlideout } from '../../../organisms/ChooseRobotToRunProtocolSlideout'
 import {
   useTrackEvent,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
 } from '../../../redux/analytics'
+import { getValidCustomLabwareFiles } from '../../../redux/custom-labware/selectors'
 import {
   getConnectableRobots,
   getReachableRobots,
@@ -27,8 +29,6 @@ import {
 } from '../../../redux/discovery/__fixtures__'
 import { storedProtocolData } from '../../../redux/protocol-storage/__fixtures__'
 import { ProtocolDetails } from '..'
-import { getValidCustomLabwareFiles } from '../../../redux/custom-labware/selectors'
-import { ChooseRobotToRunProtocolSlideout } from '../../ChooseRobotToRunProtocolSlideout'
 
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 
@@ -36,7 +36,8 @@ jest.mock('../../../redux/analytics')
 jest.mock('../../../redux/custom-labware/selectors')
 jest.mock('../../../redux/discovery/selectors')
 jest.mock('../../../redux/protocol-storage/selectors')
-jest.mock('../../ChooseRobotToRunProtocolSlideout')
+jest.mock('../../../organisms/ChooseRobotToRunProtocolSlideout')
+jest.mock('../../../organisms/SendProtocolToOT3Slideout')
 
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots
@@ -95,10 +96,10 @@ describe('ProtocolDetails', () => {
 
     when(mockChooseRobotToRunProtocolSlideout)
       .calledWith(partialComponentPropsMatcher({ showSlideout: true }))
-      .mockReturnValue(<div>open Slideout</div>)
+      .mockReturnValue(<div>open ChooseRobotToRunProtocolSlideout</div>)
     when(mockChooseRobotToRunProtocolSlideout)
       .calledWith(partialComponentPropsMatcher({ showSlideout: false }))
-      .mockReturnValue(<div>close Slideout</div>)
+      .mockReturnValue(<div>close ChooseRobotToRunProtocolSlideout</div>)
     mockGetIsProtocolAnalysisInProgress.mockReturnValue(false)
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
   })
@@ -162,9 +163,9 @@ describe('ProtocolDetails', () => {
     expect(
       screen.getByRole('heading', { name: 'Deck View' })
     ).toBeInTheDocument()
-    screen.getByText('close Slideout')
+    screen.getByText('close ChooseRobotToRunProtocolSlideout')
   })
-  it('opens choose robot slideout when Start setup button is clicked', async () => {
+  it('opens choose robot to run protocol slideout when Start setup button is clicked', async () => {
     render({
       mostRecentAnalysis: {
         ...mockMostRecentAnalysis,
@@ -182,14 +183,16 @@ describe('ProtocolDetails', () => {
     const runProtocolButton = screen.getByRole('button', {
       name: 'Start setup',
     })
-    runProtocolButton.click()
+    act(() => {
+      runProtocolButton.click()
+    })
     await waitFor(() => {
       expect(mockTrackEvent).toHaveBeenCalledWith({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
         properties: { sourceLocation: 'ProtocolsDetail' },
       })
     })
-    screen.getByText('open Slideout')
+    screen.getByText('open ChooseRobotToRunProtocolSlideout')
   })
   it('renders the protocol creation method', () => {
     render({

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -58,7 +58,7 @@ import {
 } from '../../redux/protocol-storage'
 import { useFeatureFlag } from '../../redux/config'
 import { ChooseRobotToRunProtocolSlideout } from '../ChooseRobotToRunProtocolSlideout'
-import { SendProtocolToOT3Slideout } from '../SendProtocolToOT3Slideout'
+import { SendProtocolToFlexSlideout } from '../SendProtocolToFlexSlideout'
 import { ProtocolAnalysisFailure } from '../ProtocolAnalysisFailure'
 import {
   getAnalysisStatus,
@@ -200,8 +200,8 @@ export function ProtocolDetails(
     setShowChooseRobotToRunProtocolSlideout,
   ] = React.useState<boolean>(false)
   const [
-    showSendProtocolToOT3Slideout,
-    setShowSendProtocolToOT3Slideout,
+    showSendProtocolToFlexSlideout,
+    setShowSendProtocolToFlexSlideout,
   ] = React.useState<boolean>(false)
   const [showDeckViewModal, setShowDeckViewModal] = React.useState(false)
 
@@ -379,9 +379,9 @@ export function ProtocolDetails(
             showSlideout={showChooseRobotToRunProtocolSlideout}
             storedProtocolData={props}
           />
-          <SendProtocolToOT3Slideout
-            isExpanded={showSendProtocolToOT3Slideout}
-            onCloseClick={() => setShowSendProtocolToOT3Slideout(false)}
+          <SendProtocolToFlexSlideout
+            isExpanded={showSendProtocolToFlexSlideout}
+            onCloseClick={() => setShowSendProtocolToFlexSlideout(false)}
             storedProtocolData={props}
           />
 
@@ -518,8 +518,8 @@ export function ProtocolDetails(
                 handleRunProtocol={() =>
                   setShowChooseRobotToRunProtocolSlideout(true)
                 }
-                handleSendProtocolToOT3={() =>
-                  setShowSendProtocolToOT3Slideout(true)
+                handleSendProtocolToFlex={() =>
+                  setShowSendProtocolToFlexSlideout(true)
                 }
                 storedProtocolData={props}
                 data-testid="ProtocolDetails_overFlowMenu"

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -53,14 +53,14 @@ import { getProtocolUsesGripper } from '../ProtocolSetupInstruments/utils'
 
 interface ProtocolCardProps {
   handleRunProtocol: (storedProtocolData: StoredProtocolData) => void
-  handleSendProtocolToOT3: (storedProtocolData: StoredProtocolData) => void
+  handleSendProtocolToFlex: (storedProtocolData: StoredProtocolData) => void
   storedProtocolData: StoredProtocolData
 }
 export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   const history = useHistory()
   const {
     handleRunProtocol,
-    handleSendProtocolToOT3,
+    handleSendProtocolToFlex,
     storedProtocolData,
   } = props
   const {
@@ -116,7 +116,7 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
       >
         <ProtocolOverflowMenu
           handleRunProtocol={handleRunProtocol}
-          handleSendProtocolToOT3={handleSendProtocolToOT3}
+          handleSendProtocolToFlex={handleSendProtocolToFlex}
           storedProtocolData={storedProtocolData}
         />
       </Box>

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -133,13 +133,13 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
       {selectedProtocol != null ? (
         <>
           <ChooseRobotToRunProtocolSlideout
-            key={selectedProtocol.protocolKey}
+            key={`ChooseRobotToRunProtocolSlideout_${selectedProtocol.protocolKey}`}
             onCloseClick={() => setShowChooseRobotToRunProtocolSlideout(false)}
             showSlideout={showChooseRobotToRunProtocolSlideout}
             storedProtocolData={selectedProtocol}
           />
           <SendProtocolToOT3Slideout
-            key={selectedProtocol.protocolKey}
+            key={`SendProtocolToOT3Slideout_${selectedProtocol.protocolKey}`}
             isExpanded={showSendProtocolToOT3Slideout}
             onCloseClick={() => setShowSendProtocolToOT3Slideout(false)}
             storedProtocolData={selectedProtocol}

--- a/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolList.tsx
@@ -28,7 +28,7 @@ import { useSortedProtocols } from './hooks'
 import { StyledText } from '../../atoms/text'
 import { Slideout } from '../../atoms/Slideout'
 import { ChooseRobotToRunProtocolSlideout } from '../ChooseRobotToRunProtocolSlideout'
-import { SendProtocolToOT3Slideout } from '../SendProtocolToOT3Slideout'
+import { SendProtocolToFlexSlideout } from '../SendProtocolToFlexSlideout'
 import { ProtocolUploadInput } from './ProtocolUploadInput'
 import { ProtocolCard } from './ProtocolCard'
 import { EmptyStateLinks } from './EmptyStateLinks'
@@ -64,8 +64,8 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
     setShowChooseRobotToRunProtocolSlideout,
   ] = React.useState<boolean>(false)
   const [
-    showSendProtocolToOT3Slideout,
-    setShowSendProtocolToOT3Slideout,
+    showSendProtocolToFlexSlideout,
+    setShowSendProtocolToFlexSlideout,
   ] = React.useState<boolean>(false)
   const sortBy = useSelector(getProtocolsDesktopSortKey) ?? 'alphabetical'
   const [showSortByMenu, setShowSortByMenu] = React.useState<boolean>(false)
@@ -121,11 +121,11 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
     setShowChooseRobotToRunProtocolSlideout(true)
   }
 
-  const handleSendProtocolToOT3 = (
+  const handleSendProtocolToFlex = (
     storedProtocol: StoredProtocolData
   ): void => {
     setSelectedProtocol(storedProtocol)
-    setShowSendProtocolToOT3Slideout(true)
+    setShowSendProtocolToFlexSlideout(true)
   }
 
   return (
@@ -138,10 +138,10 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
             showSlideout={showChooseRobotToRunProtocolSlideout}
             storedProtocolData={selectedProtocol}
           />
-          <SendProtocolToOT3Slideout
-            key={`SendProtocolToOT3Slideout_${selectedProtocol.protocolKey}`}
-            isExpanded={showSendProtocolToOT3Slideout}
-            onCloseClick={() => setShowSendProtocolToOT3Slideout(false)}
+          <SendProtocolToFlexSlideout
+            key={`SendProtocolToFlexSlideout_${selectedProtocol.protocolKey}`}
+            isExpanded={showSendProtocolToFlexSlideout}
+            onCloseClick={() => setShowSendProtocolToFlexSlideout(false)}
             storedProtocolData={selectedProtocol}
           />
         </>
@@ -242,7 +242,7 @@ export function ProtocolList(props: ProtocolListProps): JSX.Element | null {
           <ProtocolCard
             key={storedProtocol.protocolKey}
             handleRunProtocol={handleRunProtocol}
-            handleSendProtocolToOT3={handleSendProtocolToOT3}
+            handleSendProtocolToFlex={handleSendProtocolToFlex}
             storedProtocolData={storedProtocol}
           />
         ))}

--- a/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -35,7 +35,7 @@ import type { Dispatch } from '../../redux/types'
 
 interface ProtocolOverflowMenuProps extends StyleProps {
   handleRunProtocol: (storedProtocolData: StoredProtocolData) => void
-  handleSendProtocolToOT3: (storedProtocolData: StoredProtocolData) => void
+  handleSendProtocolToFlex: (storedProtocolData: StoredProtocolData) => void
   storedProtocolData: StoredProtocolData
 }
 
@@ -45,7 +45,7 @@ export function ProtocolOverflowMenu(
   const {
     storedProtocolData,
     handleRunProtocol,
-    handleSendProtocolToOT3,
+    handleSendProtocolToFlex,
   } = props
   const { mostRecentAnalysis, protocolKey } = storedProtocolData
   const { t } = useTranslation(['protocol_list', 'shared'])
@@ -90,7 +90,7 @@ export function ProtocolOverflowMenu(
   const handleClickSendToOT3: React.MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
-    handleSendProtocolToOT3(storedProtocolData)
+    handleSendProtocolToFlex(storedProtocolData)
     setShowOverflowMenu(currentShowOverflowMenu => !currentShowOverflowMenu)
   }
   const handleClickDelete: React.MouseEventHandler<HTMLButtonElement> = e => {

--- a/app/src/organisms/ProtocolsLanding/__tests__/ProtocolOverflowMenu.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/ProtocolOverflowMenu.test.tsx
@@ -21,7 +21,7 @@ jest.mock('../../../redux/analytics')
 jest.mock('../../../redux/protocol-storage')
 
 const mockHandleRunProtocol = jest.fn()
-const mockHandleSendProtocolToOT3 = jest.fn()
+const mockHandleSendProtocolToFlex = jest.fn()
 
 const mockViewProtocolSourceFolder = viewProtocolSourceFolder as jest.MockedFunction<
   typeof viewProtocolSourceFolder
@@ -38,7 +38,7 @@ const render = () => {
     <MemoryRouter>
       <ProtocolOverflowMenu
         handleRunProtocol={mockHandleRunProtocol}
-        handleSendProtocolToOT3={mockHandleSendProtocolToOT3}
+        handleSendProtocolToFlex={mockHandleSendProtocolToFlex}
         storedProtocolData={storedProtocolData}
       />
     </MemoryRouter>,

--- a/app/src/organisms/SendProtocolToFlexSlideout/__tests__/SendProtocolToFlexSlideout.test.tsx
+++ b/app/src/organisms/SendProtocolToFlexSlideout/__tests__/SendProtocolToFlexSlideout.test.tsx
@@ -34,7 +34,7 @@ import {
 import { getNetworkInterfaces } from '../../../redux/networking'
 import { getIsProtocolAnalysisInProgress } from '../../../redux/protocol-storage/selectors'
 import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/protocol-storage/__fixtures__'
-import { SendProtocolToOT3Slideout } from '..'
+import { SendProtocolToFlexSlideout } from '..'
 
 import type { State } from '../../../redux/types'
 import { getValidCustomLabwareFiles } from '../../../redux/custom-labware'
@@ -81,11 +81,11 @@ const mockGetValidCustomLabwareFiles = getValidCustomLabwareFiles as jest.Mocked
 >
 
 const render = (
-  props: React.ComponentProps<typeof SendProtocolToOT3Slideout>
+  props: React.ComponentProps<typeof SendProtocolToFlexSlideout>
 ) => {
   return renderWithProviders(
     <StaticRouter>
-      <SendProtocolToOT3Slideout {...props} />
+      <SendProtocolToFlexSlideout {...props} />
     </StaticRouter>,
     {
       i18nInstance: i18n,
@@ -118,7 +118,7 @@ const mockEatToast = jest.fn()
 const mockMutateAsync = jest.fn()
 const mockCustomLabwareFile: File = { path: 'fake_custom_labware_path' } as any
 
-describe('SendProtocolToOT3Slideout', () => {
+describe('SendProtocolToFlexSlideout', () => {
   beforeEach(() => {
     mockGetBuildrootUpdateDisplayInfo.mockReturnValue({
       autoUpdateAction: '',

--- a/app/src/organisms/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/SendProtocolToFlexSlideout/index.tsx
@@ -26,14 +26,14 @@ import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
 import { getValidCustomLabwareFiles } from '../../redux/custom-labware'
 
-interface SendProtocolToOT3SlideoutProps extends StyleProps {
+interface SendProtocolToFlexSlideoutProps extends StyleProps {
   storedProtocolData: StoredProtocolData
   onCloseClick: () => void
   isExpanded: boolean
 }
 
-export function SendProtocolToOT3Slideout(
-  props: SendProtocolToOT3SlideoutProps
+export function SendProtocolToFlexSlideout(
+  props: SendProtocolToFlexSlideoutProps
 ): JSX.Element | null {
   const { isExpanded, onCloseClick, storedProtocolData } = props
   const {

--- a/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
+++ b/app/src/organisms/SendProtocolToOT3Slideout/index.tsx
@@ -46,18 +46,14 @@ export function SendProtocolToOT3Slideout(
 
   const [selectedRobot, setSelectedRobot] = React.useState<Robot | null>(null)
 
-  const isSelectedRobotOnWrongVersionOfSoftware = [
+  const { autoUpdateAction } = useSelector((state: State) =>
+    getRobotUpdateDisplayInfo(state, selectedRobot?.name ?? '')
+  )
+
+  const isSelectedRobotOnDifferentSoftwareVersion = [
     'upgrade',
     'downgrade',
-  ].includes(
-    useSelector((state: State) => {
-      const updateInfo =
-        selectedRobot != null
-          ? getRobotUpdateDisplayInfo(state, selectedRobot.name)
-          : { autoUpdateAction: '' }
-      return updateInfo
-    })?.autoUpdateAction
-  )
+  ].includes(autoUpdateAction)
 
   const { eatToast, makeToast } = useToaster()
 
@@ -150,6 +146,9 @@ export function SendProtocolToOT3Slideout(
   return (
     <ChooseRobotSlideout
       isExpanded={isExpanded}
+      isSelectedRobotOnDifferentSoftwareVersion={
+        isSelectedRobotOnDifferentSoftwareVersion
+      }
       onCloseClick={onCloseClick}
       title={t('protocol_list:send_to_robot', {
         robot_display_name: FLEX_DISPLAY_NAME,
@@ -157,7 +156,7 @@ export function SendProtocolToOT3Slideout(
       footer={
         <PrimaryButton
           disabled={
-            selectedRobot == null || isSelectedRobotOnWrongVersionOfSoftware
+            selectedRobot == null || isSelectedRobotOnDifferentSoftwareVersion
           }
           onClick={handleSendClick}
           width="100%"


### PR DESCRIPTION
# Overview

refactors choose robot slideout usage of getRobotUpdateDisplayInfo to eliminate selector console warnings. fixes a react duplicate key warning.

# Test Plan

 - verified console warnings fixed

# Changelog

 - Removes choose robot slideout selector warnings

# Review requests

# Risk assessment

low