### PR TITLE
fix(protocol-designer): 96-channel display category to say Flex

### DIFF
--- a/components/src/instrument/PipetteSelect.tsx
+++ b/components/src/instrument/PipetteSelect.tsx
@@ -142,7 +142,9 @@ const PipetteNameItem = (props: PipetteNameSpecs): JSX.Element => {
     >
       <div className={styles.pipette_volume_class}>{volumeClass}</div>
       <div className={styles.pipette_channels}>{displayChannels}</div>
-      <div className={styles.pipette_category}>{displayCategory}</div>
+      <div className={styles.pipette_category}>
+        {displayChannels === '96-Channel' ? 'FLEX' : displayCategory}
+      </div>
     </Flex>
   )
 }

--- a/components/src/instrument/PipetteSelect.tsx
+++ b/components/src/instrument/PipetteSelect.tsx
@@ -143,7 +143,7 @@ const PipetteNameItem = (props: PipetteNameSpecs): JSX.Element => {
       <div className={styles.pipette_volume_class}>{volumeClass}</div>
       <div className={styles.pipette_channels}>{displayChannels}</div>
       <div className={styles.pipette_category}>
-        {displayChannels === '96-Channel' ? 'FLEX' : displayCategory}
+        {channels === 96 ? 'FLEX' : displayCategory}
       </div>
     </Flex>
   )


### PR DESCRIPTION
closes RQA-2182

# Overview

Fix the dropdown for 96-channel to say "flex" instead of "Gen 1"

<img width="631" alt="Screen Shot 2024-01-03 at 10 28 20 AM" src="https://github.com/Opentrons/opentrons/assets/66035149/d2296f82-0c5d-424f-9003-54c289de1dd5">

# Test Plan

create a flex protocol and edit the pipettes. look at the change pipette dropdown options. the 96-channel should say "flex" instead of "gen 1"

# Changelog

- branching logic for the 96-channel since its display category is gen1 instead of flex

# Review requests

see test plan

# Risk assessment

low