### PR TITLE
docs(api): fix a couple missing apiLevel substitutions

### DIFF
--- a/api/docs/v2/modules/multiple_same_type.rst
+++ b/api/docs/v2/modules/multiple_same_type.rst
@@ -46,10 +46,11 @@ When working with multiple modules of the same type, load them in your protocol 
     In this example, ``temperature_module_1`` loads first because it's connected to USB port 1. ``temperature_module_2`` loads next because it's connected to USB port 3.
 
     .. code-block:: python
+    :substitutions:
 
       from opentrons import protocol_api
 
-      metadata = { 'apiLevel': '|apiLevel|'}
+      metadata = { "apiLevel": "|apiLevel|"}
 
       def run(protocol: protocol_api.ProtocolContext):
         # Load Temperature Module 1 in deck slot C1 on USB port 1

--- a/api/docs/v2/modules/multiple_same_type.rst
+++ b/api/docs/v2/modules/multiple_same_type.rst
@@ -46,22 +46,23 @@ When working with multiple modules of the same type, load them in your protocol 
     In this example, ``temperature_module_1`` loads first because it's connected to USB port 1. ``temperature_module_2`` loads next because it's connected to USB port 3.
 
     .. code-block:: python
-    :substitutions:
+        :substitutions:
 
-      from opentrons import protocol_api
+        from opentrons import protocol_api
 
-      metadata = { "apiLevel": "|apiLevel|"}
+        metadata = {"apiLevel": "|apiLevel|"}
 
-      def run(protocol: protocol_api.ProtocolContext):
-        # Load Temperature Module 1 in deck slot C1 on USB port 1
-        temperature_module_1 = protocol.load_module(
-          load_name='temperature module gen2',
-          location="1")
 
-        # Load Temperature Module 2 in deck slot D3 on USB port 2
-        temperature_module_2 = protocol.load_module(
-          load_name='temperature module gen2',
-          location="3")
+        def run(protocol: protocol_api.ProtocolContext):
+            # Load Temperature Module 1 in deck slot C1 on USB port 1
+            temperature_module_1 = protocol.load_module(
+                load_name="temperature module gen2", location="1"
+            )
+
+            # Load Temperature Module 2 in deck slot D3 on USB port 2
+            temperature_module_2 = protocol.load_module(
+                load_name="temperature module gen2", location="3"
+            )
         
     The Temperature Modules are connected as shown here:
     

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -160,7 +160,10 @@ Remove labware from the deck to perform tasks like retrieving samples or discard
 
 Moving labware off-deck always requires user intervention, because the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise an error.
 
-You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it `onto` the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one::
+You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it `onto` the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one:
+
+    .. code-block:: python
+    :substitutions:
 
     from opentrons import protocol_api
 

--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -160,34 +160,34 @@ Remove labware from the deck to perform tasks like retrieving samples or discard
 
 Moving labware off-deck always requires user intervention, because the gripper can't reach outside of the robot. Omit the ``use_gripper`` parameter or explicitly set it to ``False``. If you try to move labware off-deck with ``use_gripper=True``, the API will raise an error.
 
-You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it `onto` the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one:
+You can also load labware off-deck, in preparation for a ``move_labware()`` command that brings it *onto* the deck. For example, you could assign two tip racks to a pipette — one on-deck, and one off-deck — and then swap out the first rack for the second one:
 
     .. code-block:: python
-    :substitutions:
+        :substitutions:
 
-    from opentrons import protocol_api
+        from opentrons import protocol_api
 
-    metadata = {"apiLevel": "|apiLevel|", "protocolName": "Tip rack replacement"}
-    requirements = {"robotType": "OT-2"}
+        metadata = {"apiLevel": "|apiLevel|", "protocolName": "Tip rack replacement"}
+        requirements = {"robotType": "OT-2"}
 
 
-    def run(protocol: protocol_api.ProtocolContext):
-        tips1 = protocol.load_labware("opentrons_96_tiprack_1000ul", 1)
-        # load another tip rack but don't put it in a slot yet
-        tips2 = protocol.load_labware(
-            "opentrons_96_tiprack_1000ul", protocol_api.OFF_DECK
-        )
-        pipette = protocol.load_instrument(
-            "p1000_single_gen2", "left", tip_racks=[tips1, tips2]
-        )
-        # use all the on-deck tips
-        for i in range(96):
+        def run(protocol: protocol_api.ProtocolContext):
+            tips1 = protocol.load_labware("opentrons_96_tiprack_1000ul", 1)
+            # load another tip rack but don't put it in a slot yet
+            tips2 = protocol.load_labware(
+                "opentrons_96_tiprack_1000ul", protocol_api.OFF_DECK
+            )
+            pipette = protocol.load_instrument(
+                "p1000_single_gen2", "left", tip_racks=[tips1, tips2]
+            )
+            # use all the on-deck tips
+            for i in range(96):
+                pipette.pick_up_tip()
+                pipette.drop_tip()
+            # pause to move the spent tip rack off-deck
+            protocol.move_labware(labware=tips1, new_location=protocol_api.OFF_DECK)
+            # pause to move the fresh tip rack on-deck
+            protocol.move_labware(labware=tips2, new_location=1)
             pipette.pick_up_tip()
-            pipette.drop_tip()
-        # pause to move the spent tip rack off-deck
-        protocol.move_labware(labware=tips1, new_location=protocol_api.OFF_DECK)
-        # pause to move the fresh tip rack on-deck
-        protocol.move_labware(labware=tips2, new_location=1)
-        pipette.pick_up_tip()
 
 Using the off-deck location to remove or replace labware lets you continue your workflow in a single protocol, rather than needing to end a protocol, reset the deck, and start a new protocol run.


### PR DESCRIPTION

# Overview

I missed a couple required `:substitutions:` options on code blocks. This fixes those.

# Test Plan

Checked that there are no more instances of `|apiLevel|` coming through in the [sandbox](http://sandbox.docs.opentrons.com/docs-fix-substitutions/v2/) build.

# Changelog

Fixed code block syntax on
- Moving Labware
- Multiples of a Module

Single to double quotes to avoid merge conflict with #14269.

# Review requests

Did I miss any others?

# Risk assessment

nil, docs