### PR TITLE
test(app): change OT-3 to Flex in code

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/Numpad/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/Numpad/index.tsx
@@ -17,7 +17,7 @@ export function Numpad({ onChange, keyboardRef }: NumpadProps): JSX.Element {
   }
   return (
     /*
-     *  autoUseTouchEvents: for OT-3 on-device app
+     *  autoUseTouchEvents: for Flex on-device app
      *  useButtonTag: this is for testing purpose that each key renders as a button
      */
     <Keyboard

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -79,7 +79,7 @@ describe('PipetteOverflowMenu', () => {
     fireEvent.click(btn)
     expect(props.handleChangePipette).toHaveBeenCalled()
   })
-  it('renders recalibrate pipette text for OT-3 pipette', () => {
+  it('renders recalibrate pipette text for Flex pipette', () => {
     mockisFlexPipette.mockReturnValue(true)
     props = {
       ...props,
@@ -93,7 +93,7 @@ describe('PipetteOverflowMenu', () => {
     expect(props.handleCalibrate).toHaveBeenCalled()
   })
 
-  it('should render recalibrate pipette text for OT-3 pipette', () => {
+  it('should render recalibrate pipette text for Flex pipette', () => {
     mockisFlexPipette.mockReturnValue(true)
     props = {
       ...props,

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -182,7 +182,7 @@ export function ProtocolRunSetup({
           calibrationStatus={calibrationStatusRobot}
         />
       ),
-      // change description for OT-3
+      // change description for Flex
       description: isFlex
         ? t(`${ROBOT_CALIBRATION_STEP_KEY}_description_pipettes_only`)
         : t(`${ROBOT_CALIBRATION_STEP_KEY}_description`),

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -235,7 +235,7 @@ describe('ProtocolRunSetup', () => {
       fireEvent.click(robotCalibrationSetup)
       expect(screen.getByText('Mock SetupRobotCalibration')).toBeVisible()
     })
-    it('renders robot calibration setup for OT-3', () => {
+    it('renders robot calibration setup for Flex', () => {
       when(mockUseIsFlex).calledWith(ROBOT_NAME).mockReturnValue(true)
       render()
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupRobotCalibration.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupRobotCalibration.test.tsx
@@ -105,7 +105,7 @@ describe('SetupRobotCalibration', () => {
     getByText('Mock SetupTipLengthCalibration')
   })
 
-  it('renders only pipette calibration component for OT-3', () => {
+  it('renders only pipette calibration component for Flex', () => {
     when(mockUseIsFlex).calledWith(ROBOT_NAME).mockReturnValue(true)
     const { getByText, queryByText } = render()[0]
 

--- a/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/__tests__/RobotSettingsNetworking.test.tsx
@@ -146,7 +146,7 @@ describe('RobotSettingsNetworking', () => {
     ).toBeNull()
   })
 
-  it('should render title and description for OT-3', () => {
+  it('should render title and description for Flex', () => {
     when(mockUseWifiList).calledWith(ROBOT_NAME).mockReturnValue(mockWifiList)
     when(mockUseIsFlex).calledWith(ROBOT_NAME).mockReturnValue(true)
     render()
@@ -162,7 +162,7 @@ describe('RobotSettingsNetworking', () => {
     expect(screen.queryByText('Go to Advanced App Settings')).toBeNull()
   })
 
-  it('should render USB connection message for OT-3 when connected via USB', () => {
+  it('should render USB connection message for Flex when connected via USB', () => {
     when(mockUseWifiList).calledWith(ROBOT_NAME).mockReturnValue(mockWifiList)
     when(mockUseIsFlex).calledWith(ROBOT_NAME).mockReturnValue(true)
     when(mockGetRobotAddressesByName)

--- a/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotCard.test.tsx
@@ -154,7 +154,7 @@ describe('RobotCard', () => {
     expect(image.getAttribute('src')).toEqual(OT2_PNG_FILE_NAME)
   })
 
-  it('renders an OT-3 image when robot model is OT-3', () => {
+  it('renders a Flex image when robot model is OT-3', () => {
     props = { robot: { ...mockConnectableRobot, name: 'buzz' } }
     when(mockGetRobotModelByName)
       .calledWith(MOCK_STATE, 'buzz')

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -212,7 +212,7 @@ describe('RobotOverview', () => {
     expect(image.getAttribute('src')).toEqual(OT2_PNG_FILE_NAME)
   })
 
-  it('renders an OT-3 image', () => {
+  it('renders a Flex image', () => {
     when(mockGetRobotModelByName)
       .calledWith(MOCK_STATE, mockConnectableRobot.name)
       .mockReturnValue('Opentrons Flex')

--- a/app/src/organisms/Devices/hooks/__tests__/useRunCalibrationStatus.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRunCalibrationStatus.test.tsx
@@ -65,7 +65,7 @@ describe('useRunCalibrationStatus hook', () => {
       reason: 'calibrate_deck_failure_reason',
     })
   })
-  it('should ignore deck calibration status of an OT-3', () => {
+  it('should ignore deck calibration status of a Flex', () => {
     when(mockUseDeckCalibrationStatus)
       .calledWith('otie')
       .mockReturnValue('BAD_CALIBRATION')
@@ -161,7 +161,7 @@ describe('useRunCalibrationStatus hook', () => {
       reason: 'calibrate_tiprack_failure_reason',
     })
   })
-  it('should ignore tip rack calibration for the OT-3', () => {
+  it('should ignore tip rack calibration for the Flex', () => {
     when(mockUseRunPipetteInfoByMount)
       .calledWith('1')
       .mockReturnValue({

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -398,7 +398,7 @@ describe('ModuleOverflowMenu', () => {
     fireEvent.click(btn)
   })
 
-  it('should disable overflow menu buttons for thermocycler gen 1 when the robot is an OT-3', () => {
+  it('should disable overflow menu buttons for thermocycler gen 1 when the robot is a Flex', () => {
     props = {
       ...props,
       module: mockTCBlockHeating,

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -83,7 +83,7 @@ describe('RobotConfigurationDetails', () => {
     getByText('OT-2')
   })
 
-  it('renders a robot section showing the intended robot model for an OT-3 protocol', () => {
+  it('renders a robot section showing the intended robot model for a Flex protocol', () => {
     props = {
       leftMountPipetteName: 'p10_single',
       rightMountPipetteName: null,

--- a/app/src/organisms/ProtocolsLanding/__tests__/utils.test.ts
+++ b/app/src/organisms/ProtocolsLanding/__tests__/utils.test.ts
@@ -10,7 +10,7 @@ const mockOT2ProtocolAnalysisOutput = {
 } as ProtocolAnalysisOutput
 
 describe('getisFlexProtocol', () => {
-  it('should return true for protocols intended for an OT-3', () => {
+  it('should return true for protocols intended for a Flex', () => {
     const result = getisFlexProtocol(mockOT3ProtocolAnalysisOutput)
     expect(result).toBe(true)
   })
@@ -32,7 +32,7 @@ describe('getisFlexProtocol', () => {
 })
 
 describe('getRobotTypeDisplayName', () => {
-  it('should return OT-3 for protocols intended for an OT-3', () => {
+  it('should return OT-3 for protocols intended for a Flex', () => {
     const result = getRobotTypeDisplayName('OT-3 Standard')
     expect(result).toBe('Opentrons Flex')
   })

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/PipetteOffsetCalibrationItems.tsx
@@ -80,7 +80,7 @@ export function PipetteOffsetCalibrationItems({
         <tr>
           <StyledTableHeader>{t('model_and_serial')}</StyledTableHeader>
           <StyledTableHeader>{t('mount')}</StyledTableHeader>
-          {/* omit tip rack column for OT-3 */}
+          {/* omit tip rack column for Flex */}
           {isFlex ? null : (
             <StyledTableHeader>{t('tiprack')}</StyledTableHeader>
           )}

--- a/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__tests__/PipetteOffsetCalibrationItems.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/CalibrationDetails/__tests__/PipetteOffsetCalibrationItems.test.tsx
@@ -110,7 +110,7 @@ describe('PipetteOffsetCalibrationItems', () => {
     getByText('Last Calibrated')
   })
 
-  it('should omit tip rack table header for OT-3', () => {
+  it('should omit tip rack table header for Flex', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ getByText, queryByText }] = render(props)
     getByText('Pipette Model and Serial')
@@ -119,7 +119,7 @@ describe('PipetteOffsetCalibrationItems', () => {
     getByText('Last Calibrated')
   })
 
-  it('should include the correct information for OT-3 when 1 pipette is attached', () => {
+  it('should include the correct information for Flex when 1 pipette is attached', () => {
     props = {
       ...props,
       formattedPipetteOffsetCalibrations: mockPipetteOffsetCalibrationsForOt3,

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -135,7 +135,7 @@ describe('CalibrationDataDownload', () => {
     getByText('Download Calibration Data')
   })
 
-  it('renders an OT-3 title and description - About Calibration', () => {
+  it('renders a Flex title and description - About Calibration', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ queryByText }] = render()
     queryByText(

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsCalibration.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsCalibration.test.tsx
@@ -204,7 +204,7 @@ describe('RobotSettingsCalibration', () => {
     getByText('Mock RobotSettingsDeckCalibration')
   })
 
-  it('does not render a Deck Calibration component for an OT-3', () => {
+  it('does not render a Deck Calibration component for a Flex', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ queryByText }] = render()
     expect(queryByText('Mock RobotSettingsDeckCalibration')).toBeNull()
@@ -220,7 +220,7 @@ describe('RobotSettingsCalibration', () => {
     getByText('Mock RobotSettingsTipLengthCalibration')
   })
 
-  it('does not render a Tip Length Calibration component for an OT-3', () => {
+  it('does not render a Tip Length Calibration component for a Flex', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ queryByText }] = render()
     expect(queryByText('Mock RobotSettingsTipLengthCalibration')).toBeNull()
@@ -231,13 +231,13 @@ describe('RobotSettingsCalibration', () => {
     getByText('Mock CalibrationHealthCheck')
   })
 
-  it('does not render a Calibration Health Check component for an OT-3', () => {
+  it('does not render a Calibration Health Check component for a Flex', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ queryByText }] = render()
     expect(queryByText('Mock CalibrationHealthCheck')).toBeNull()
   })
 
-  it('renders a Gripper Calibration component for an OT-3', () => {
+  it('renders a Gripper Calibration component for a Flex', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ getByText }] = render()
     getByText('Mock RobotSettingsGripperCalibration')
@@ -248,7 +248,7 @@ describe('RobotSettingsCalibration', () => {
     expect(queryByText('Mock RobotSettingsGripperCalibration')).toBeNull()
   })
 
-  it('does not render the OT-2 components when there is an OT-3 attached with pipettes', () => {
+  it('does not render the OT-2 components when there is a Flex attached with pipettes', () => {
     mockUseAttachedPipettesFromInstrumentsQuery.mockReturnValue({
       left: mockAttachedPipetteInformation,
       right: null,
@@ -260,7 +260,7 @@ describe('RobotSettingsCalibration', () => {
     expect(queryByText('Mock CalibrationHealthCheck')).toBeNull()
   })
 
-  it('renders the correct calibration data for an OT-3 pipette', () => {
+  it('renders the correct calibration data for a Flex pipette', () => {
     mockUseAttachedPipettesFromInstrumentsQuery.mockReturnValue({
       left: mockAttachedPipetteInformation,
       right: null,
@@ -270,7 +270,7 @@ describe('RobotSettingsCalibration', () => {
     getByText('Mock RobotSettingsPipetteOffsetCalibration')
   })
 
-  it('render a Module Calibration component for an OT-3 and module calibration feature flag is on', () => {
+  it('render a Module Calibration component for a Flex and module calibration feature flag is on', () => {
     mockUseFeatureFlag.mockReturnValue(true)
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     const [{ getByText }] = render()

--- a/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
+++ b/app/src/organisms/RobotSettingsCalibration/__tests__/RobotSettingsPipetteOffsetCalibration.test.tsx
@@ -85,7 +85,7 @@ describe('RobotSettingsPipetteOffsetCalibration', () => {
     getByText('PipetteOffsetCalibrationItems')
   })
 
-  it('renders an OT-3 title and description - Pipette Calibrations', () => {
+  it('renders a Flex title and description - Pipette Calibrations', () => {
     when(mockUseIsFlex).calledWith('otie').mockReturnValue(true)
     mockUseAttachedPipettesFromInstrumentsQuery.mockReturnValue({
       left: mockAttachedPipetteInformation,

--- a/app/src/redux/analytics/constants.ts
+++ b/app/src/redux/analytics/constants.ts
@@ -40,5 +40,5 @@ export const ANALYTICS_APP_UPDATE_NOTIFICATIONS_TOGGLED =
   'appUpdateNotificationsToggled'
 export const ANALYTICS_OPEN_LABWARE_CREATOR_FROM_BOTTOM_OF_LABWARE_LIBRARY_LIST =
   'openLabwareCreatorFromBottomOfLabwareLibraryList'
-export const ANALYTICS_SENT_TO_OT3 = 'sendToOT-3' // This would be changed
+export const ANALYTICS_SENT_TO_FLEX = 'sendToFlex' // This would be changed
 export const ANALYTICS_ODD_APP_ERROR = 'oddError'

--- a/app/src/resources/networking/__tests__/useCanDisconnect.test.tsx
+++ b/app/src/resources/networking/__tests__/useCanDisconnect.test.tsx
@@ -93,7 +93,7 @@ describe('useCanDisconnect', () => {
     expect(result.current).toBe(false)
   })
 
-  it('useCanDisconnect returns true for an OT-3', () => {
+  it('useCanDisconnect returns true for a Flex', () => {
     when(useWifiList)
       .calledWith('otie')
       .mockReturnValue([{ ...mockWifiNetwork, active: true }])


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
change OT-3 to Flex in code (mostly test code)
I leave `OT-3` for cases that are related to deck map and robot type.

RAUT-918
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
