### PR TITLE
feat(scripts): automate promote to staging/prod/rollback for LL/docs

### DIFF
--- a/scripts/deploy/check-current-profile.js
+++ b/scripts/deploy/check-current-profile.js
@@ -11,8 +11,9 @@ function checkCurrentAWSProfile() {
         )
       )
     } else {
+      const currentProfile = credentials.profile
       console.log(`Current AWS profile: ${credentials.profile}`)
-      resolve()
+      resolve(currentProfile)
     }
   })
 }

--- a/scripts/deploy/check-current-profile.js
+++ b/scripts/deploy/check-current-profile.js
@@ -1,0 +1,20 @@
+const AWS = require('aws-sdk')
+
+function checkCurrentAWSProfile() {
+  return new Promise((resolve, reject) => {
+    const credentials = new AWS.SharedIniFileCredentials()
+
+    if (!credentials.accessKeyId || !credentials.secretAccessKey) {
+      reject(
+        new Error(
+          'AWS credentials not found. Please configure your AWS credentials before running this script.'
+        )
+      )
+    } else {
+      console.log(`Current AWS profile: ${credentials.profile}`)
+      resolve()
+    }
+  })
+}
+
+module.exports = { checkCurrentAWSProfile }

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -76,28 +76,24 @@ if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
       console.error(err)
     })
 } else {
-  const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-1' })
+  const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-2' })
+
+  const stagingBucket = `staging.${projectDomain}`
+  const productionBucket = projectDomain
 
   getDeployMetadata(s3, stagingBucket)
     .then(deployMetadata => {
       const { current } = deployMetadata
+      console.log('current', current)
       console.log(
         `Promoting ${projectDomain} ${current} from staging to production\n`
       )
 
       return syncBuckets(
         s3,
-        { bucket: sandboxBucket, path: tag },
         { bucket: stagingBucket },
+        { bucket: productionBucket },
         dryrun
-      ).then(() =>
-        setDeployMetadata(
-          s3,
-          stagingBucket,
-          '',
-          { previous: prevDeployMetadata.current || null, current: tag },
-          dryrun
-        )
       )
     })
     .then(() => {

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -37,15 +37,14 @@ if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
 } else {
   cloudfrontArn = PROD_LL_CLOUDFRONT_ARN
 }
+const ROLE_ARN =
+  projectDomain === PROTOCOL_DESIGNER_DOMAIN
+    ? ADMINISTRATOR_ROLE_ARN
+    : ROBOTICS_STATIC_WEBSITE_ROLE_ARN
 
 assert(projectDomain, USAGE)
 
-getAssumeRole(
-  PROTOCOL_DESIGNER_DOMAIN
-    ? ADMINISTRATOR_ROLE_ARN
-    : ROBOTICS_STATIC_WEBSITE_ROLE_ARN,
-  'promoteToProduction'
-)
+getAssumeRole(ROLE_ARN, 'promoteToProduction')
   .then(credentials => {
     const productionCredentials = new AWS.Credentials({
       accessKeyId: credentials.AccessKeyId,

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -48,12 +48,12 @@ assert(projectDomain, USAGE)
 
 async function runPromoteToProduction() {
   try {
-    await checkCurrentAWSProfile()
+    const AWS_PROFILE = await checkCurrentAWSProfile()
     const confirmation = await promptUser('Is the AWS profile correct?')
 
     if (!confirmation) {
       console.log(
-        'Exiting script. Please configure the correct AWS profile and run the script again.'
+        `Exiting script. Please configure the correct AWS profile through the ${AWS_PROFILE} environment and run the script again.`
       )
       process.exit(0)
     }

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -9,6 +9,8 @@ const syncBuckets = require('./lib/syncBuckets')
 const { getDeployMetadata } = require('./lib/deploy-metadata')
 const { getAssumeRole } = require('./assume-role')
 const { getCreateInvalidation } = require('./create-invalidation')
+const { checkCurrentAWSProfile } = require('./check-current-profile')
+const { promptUser } = require('./prompt-user')
 
 const PROTOCOL_DESIGNER_DOMAIN = 'designer.opentrons.com'
 const DOCS_DOMAIN = 'docs.opentrons.com'
@@ -44,50 +46,69 @@ const ROLE_ARN =
 
 assert(projectDomain, USAGE)
 
-getAssumeRole(ROLE_ARN, 'promoteToProduction')
-  .then(credentials => {
-    const productionCredentials = new AWS.Credentials({
-      accessKeyId: credentials.AccessKeyId,
-      secretAccessKey: credentials.SecretAccessKey,
-      sessionToken: credentials.SessionToken,
-    })
+async function runPromoteToProduction() {
+  try {
+    await checkCurrentAWSProfile()
+    const confirmation = await promptUser('Is the AWS profile correct?')
 
-    const s3 = new AWS.S3({
-      apiVersion: '2006-03-01',
-      region: 'us-east-1',
-      credentials: productionCredentials,
-    })
+    if (!confirmation) {
+      console.log(
+        'Exiting script. Please configure the correct AWS profile and run the script again.'
+      )
+      process.exit(0)
+    }
 
-    const stagingBucket = `staging.${projectDomain}`
-    const productionBucket = projectDomain
+    await getAssumeRole(ROLE_ARN, 'promoteToProduction')
+      .then(credentials => {
+        const productionCredentials = new AWS.Credentials({
+          accessKeyId: credentials.AccessKeyId,
+          secretAccessKey: credentials.SecretAccessKey,
+          sessionToken: credentials.SessionToken,
+        })
 
-    getDeployMetadata(s3, stagingBucket)
-      .then(deployMetadata => {
-        const { current } = deployMetadata
-        console.log(
-          `Promoting ${projectDomain} ${current} from staging to production\n`
-        )
+        const s3 = new AWS.S3({
+          apiVersion: '2006-03-01',
+          region: 'us-east-1',
+          credentials: productionCredentials,
+        })
 
-        return syncBuckets(
-          s3,
-          { bucket: stagingBucket },
-          { bucket: productionBucket },
-          dryrun
-        )
+        const stagingBucket = `staging.${projectDomain}`
+        const productionBucket = projectDomain
+
+        getDeployMetadata(s3, stagingBucket)
+          .then(deployMetadata => {
+            const { current } = deployMetadata
+            console.log(
+              `Promoting ${projectDomain} ${current} from staging to production\n`
+            )
+
+            return syncBuckets(
+              s3,
+              { bucket: stagingBucket },
+              { bucket: productionBucket },
+              dryrun
+            )
+          })
+          .then(() => {
+            console.log('Promotion to production done\n')
+            getCreateInvalidation(productionCredentials, cloudfrontArn)
+          })
+          .then(() => {
+            console.log('Cache invalidation initiated for production\n')
+            process.exit(0)
+          })
+          .catch(error => {
+            console.error(error.message)
+            process.exit(1)
+          })
       })
-      .then(() => {
-        console.log('Promotion to production done\n')
-        getCreateInvalidation(productionCredentials, cloudfrontArn)
+      .catch(err => {
+        console.error(err)
       })
-      .then(() => {
-        console.log('Cache invalidation initiated for production\n')
-        process.exit(0)
-      })
-      .catch(error => {
-        console.error(error.message)
-        process.exit(1)
-      })
-  })
-  .catch(err => {
-    console.error(err)
-  })
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+}
+
+runPromoteToProduction()

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -11,6 +11,16 @@ const { getAssumeRole } = require('./assume-role')
 const { getCreateInvalidation } = require('./create-invalidation')
 
 const PROTOCOL_DESIGNER_DOMAIN = 'designer.opentrons.com'
+const DOCS_DOMAIN = 'docs.opentrons.com'
+
+const ADMINISTRATOR_ROLE_ARN = 'arn:aws:iam::043748923082:role/administrator'
+const ROBOTICS_STATIC_WEBSITE_ROLE_ARN =
+  'arn:aws:iam::480034758691:role/robotics-static-website-deployer-root'
+const PROD_DOCS_CLOUDFRONT_ARN =
+  'arn:aws:cloudfront::480034758691:distribution/E16BZZXDTINN0S'
+const PROD_LL_CLOUDFRONT_ARN =
+  'arn:aws:cloudfront::480034758691:distribution/E3B7DCQCQCYUDJ'
+const PROD_PD_CLOUDFRONT_ARN = `arn:aws:cloudfront::043748923082:distribution/E20OHY6J3BRVIF`
 
 const USAGE =
   '\nUsage:\n  node ./scripts/deploy/promote-to-production <project_domain> [--deploy]'
@@ -19,88 +29,66 @@ const { args, flags } = parseArgs(process.argv.slice(2))
 const [projectDomain] = args
 const dryrun = !flags.includes('--deploy')
 
+let cloudfrontArn
+if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
+  cloudfrontArn = PROD_PD_CLOUDFRONT_ARN
+} else if (projectDomain === DOCS_DOMAIN) {
+  cloudfrontArn = PROD_DOCS_CLOUDFRONT_ARN
+} else {
+  cloudfrontArn = PROD_LL_CLOUDFRONT_ARN
+}
+
 assert(projectDomain, USAGE)
 
-if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
-  getAssumeRole(
-    'arn:aws:iam::043748923082:role/administrator',
-    'promoteToProduction'
-  )
-    .then(credentials => {
-      const productionCredentials = new AWS.Credentials({
-        accessKeyId: credentials.AccessKeyId,
-        secretAccessKey: credentials.SecretAccessKey,
-        sessionToken: credentials.SessionToken,
+getAssumeRole(
+  PROTOCOL_DESIGNER_DOMAIN
+    ? ADMINISTRATOR_ROLE_ARN
+    : ROBOTICS_STATIC_WEBSITE_ROLE_ARN,
+  'promoteToProduction'
+)
+  .then(credentials => {
+    const productionCredentials = new AWS.Credentials({
+      accessKeyId: credentials.AccessKeyId,
+      secretAccessKey: credentials.SecretAccessKey,
+      sessionToken: credentials.SessionToken,
+    })
+
+    const s3 = new AWS.S3({
+      apiVersion: '2006-03-01',
+      region: 'us-east-1',
+      credentials: productionCredentials,
+    })
+
+    const stagingBucket = `staging.${projectDomain}`
+    const productionBucket = projectDomain
+
+    getDeployMetadata(s3, stagingBucket)
+      .then(deployMetadata => {
+        const { current } = deployMetadata
+        console.log(
+          `Promoting ${projectDomain} ${current} from staging to production\n`
+        )
+
+        return syncBuckets(
+          s3,
+          { bucket: stagingBucket },
+          { bucket: productionBucket },
+          dryrun
+        )
       })
-
-      const s3 = new AWS.S3({
-        apiVersion: '2006-03-01',
-        region: 'us-east-1',
-        credentials: productionCredentials,
+      .then(() => {
+        console.log('Promotion to production done\n')
+        getCreateInvalidation(productionCredentials, cloudfrontArn)
       })
-
-      const stagingBucket = `staging.${projectDomain}`
-      const productionBucket = projectDomain
-
-      getDeployMetadata(s3, stagingBucket)
-        .then(deployMetadata => {
-          const { current } = deployMetadata
-          console.log(
-            `Promoting ${projectDomain} ${current} from staging to production\n`
-          )
-
-          return syncBuckets(
-            s3,
-            { bucket: stagingBucket },
-            { bucket: productionBucket },
-            dryrun
-          )
-        })
-        .then(() => {
-          console.log('Promotion to production done\n')
-          getCreateInvalidation(
-            productionCredentials,
-            `arn:aws:cloudfront::043748923082:distribution/E20OHY6J3BRVIF`
-          )
-        })
-        .then(() => {
-          console.log('Cache invalidation initiated for production\n')
-          process.exit(0)
-        })
-        .catch(error => {
-          console.error(error.message)
-          process.exit(1)
-        })
-    })
-    .catch(err => {
-      console.error(err)
-    })
-} else {
-  const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-2' })
-
-  const stagingBucket = `staging.${projectDomain}`
-  const productionBucket = projectDomain
-
-  getDeployMetadata(s3, stagingBucket)
-    .then(deployMetadata => {
-      const { current } = deployMetadata
-      console.log(
-        `Promoting ${projectDomain} ${current} from staging to production\n`
-      )
-
-      return syncBuckets(
-        s3,
-        { bucket: stagingBucket },
-        { bucket: productionBucket },
-        dryrun
-      )
-    })
-    .then(() => {
-      console.log('Promotion to production done\n')
-      process.exit(0)
-    })
-    .catch(error => {
-      console.error(error.message)
-      process.exit(1)
-    })
-}
+      .then(() => {
+        console.log('Cache invalidation initiated for production\n')
+        process.exit(0)
+      })
+      .catch(error => {
+        console.error(error.message)
+        process.exit(1)
+      })
+  })
+  .catch(err => {
+    console.error(err)
+  })

--- a/scripts/deploy/promote-to-production.js
+++ b/scripts/deploy/promote-to-production.js
@@ -84,7 +84,6 @@ if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
   getDeployMetadata(s3, stagingBucket)
     .then(deployMetadata => {
       const { current } = deployMetadata
-      console.log('current', current)
       console.log(
         `Promoting ${projectDomain} ${current} from staging to production\n`
       )

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -57,7 +57,6 @@ async function runPromoteToStaging() {
   try {
     await checkCurrentAWSProfile()
 
-    // Prompt the user for confirmation
     const confirmation = await promptUser('Is the AWS profile correct?')
 
     if (!confirmation) {
@@ -67,7 +66,6 @@ async function runPromoteToStaging() {
       process.exit(0)
     }
 
-    // Proceed with assuming the role and other operations
     await getAssumeRole(ROLE_ARN, 'promoteToStaging')
       .then(credentials => {
         const stagingCredentials = new AWS.Credentials({

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -46,13 +46,12 @@ if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
 } else {
   cloudfrontArn = STAGING_LL_CLOUDFRONT_ARN
 }
-
-getAssumeRole(
-  PROTOCOL_DESIGNER_DOMAIN
+const ROLE_ARN =
+  projectDomain === PROTOCOL_DESIGNER_DOMAIN
     ? ADMINISTRATOR_ROLE_ARN
-    : ROBOTICS_STATIC_WEBSITE_ROLE_ARN,
-  'promoteToStaging'
-)
+    : ROBOTICS_STATIC_WEBSITE_ROLE_ARN
+
+getAssumeRole(ROLE_ARN, 'promoteToStaging')
   .then(credentials => {
     const stagingCredentials = new AWS.Credentials({
       accessKeyId: credentials.AccessKeyId,

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -55,13 +55,13 @@ const ROLE_ARN =
 
 async function runPromoteToStaging() {
   try {
-    await checkCurrentAWSProfile()
+    const AWS_PROFILE = await checkCurrentAWSProfile()
 
     const confirmation = await promptUser('Is the AWS profile correct?')
 
     if (!confirmation) {
       console.log(
-        'Exiting script. Please configure the correct AWS profile and run the script again.'
+        `Exiting script. Please configure the correct AWS profile through the ${AWS_PROFILE} environment and run the script again.`
       )
       process.exit(0)
     }

--- a/scripts/deploy/promote-to-staging.js
+++ b/scripts/deploy/promote-to-staging.js
@@ -13,6 +13,8 @@ const {
 const { getAssumeRole } = require('./assume-role')
 const { getCreateInvalidation } = require('./create-invalidation')
 
+const PROTOCOL_DESIGNER_DOMAIN = 'designer.opentrons.com'
+
 const USAGE =
   '\nUsage:\n  node ./scripts/deploy/promote-to-staging <project_domain> <tag> [--deploy]'
 
@@ -22,60 +24,92 @@ const dryrun = !flags.includes('--deploy')
 
 assert(projectDomain && tag, USAGE)
 
-getAssumeRole(
-  'arn:aws:iam::043748923082:role/administrator',
-  'promoteToStaging'
-)
-  .then(credentials => {
-    const stagingCredentials = new AWS.Credentials({
-      accessKeyId: credentials.AccessKeyId,
-      secretAccessKey: credentials.SecretAccessKey,
-      sessionToken: credentials.SessionToken,
-    })
+const sandboxBucket = `sandbox.${projectDomain}`
+const stagingBucket = `staging.${projectDomain}`
 
-    const s3 = new AWS.S3({
-      apiVersion: '2006-03-01',
-      region: 'us-east-1',
-      credentials: stagingCredentials,
-    })
+if (projectDomain === PROTOCOL_DESIGNER_DOMAIN) {
+  getAssumeRole(
+    'arn:aws:iam::043748923082:role/administrator',
+    'promoteToStaging'
+  )
+    .then(credentials => {
+      const stagingCredentials = new AWS.Credentials({
+        accessKeyId: credentials.AccessKeyId,
+        secretAccessKey: credentials.SecretAccessKey,
+        sessionToken: credentials.SessionToken,
+      })
 
-    const sandboxBucket = `sandbox.${projectDomain}`
-    const stagingBucket = `staging.${projectDomain}`
+      const s3WithCreds = new AWS.S3({
+        apiVersion: '2006-03-01',
+        region: 'us-east-1',
+        credentials: stagingCredentials,
+      })
 
-    getDeployMetadata(s3, stagingBucket)
-      .then(prevDeployMetadata => {
-        console.log('Previous deploy metadata: %j', prevDeployMetadata)
-        return syncBuckets(
-          s3,
-          { bucket: sandboxBucket, path: tag },
-          { bucket: stagingBucket },
-          dryrun
-        ).then(() =>
-          setDeployMetadata(
-            s3,
-            stagingBucket,
-            '',
-            { previous: prevDeployMetadata.current || null, current: tag },
+      getDeployMetadata(s3WithCreds, stagingBucket)
+        .then(prevDeployMetadata => {
+          console.log('Previous deploy metadata: %j', prevDeployMetadata)
+          return syncBuckets(
+            s3WithCreds,
+            { bucket: sandboxBucket, path: tag },
+            { bucket: stagingBucket },
             dryrun
+          ).then(() =>
+            setDeployMetadata(
+              s3WithCreds,
+              stagingBucket,
+              '',
+              { previous: prevDeployMetadata.current || null, current: tag },
+              dryrun
+            )
           )
+        })
+        .then(() => {
+          console.log('Promotion to staging done\n')
+          getCreateInvalidation(
+            stagingCredentials,
+            `arn:aws:cloudfront::043748923082:distribution/EB2QTLE7OJ8O6`
+          )
+        })
+        .then(() => {
+          console.log('Cache invalidation initiated for staging\n')
+          process.exit(0)
+        })
+        .catch(error => {
+          console.error(error.message)
+          process.exit(1)
+        })
+    })
+    .catch(err => {
+      console.error(err)
+    })
+} else {
+  const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-1' })
+
+  getDeployMetadata(s3, stagingBucket)
+    .then(prevDeployMetadata => {
+      console.log('Previous deploy metadata: %j', prevDeployMetadata)
+
+      return syncBuckets(
+        s3,
+        { bucket: sandboxBucket, path: tag },
+        { bucket: stagingBucket },
+        dryrun
+      ).then(() =>
+        setDeployMetadata(
+          s3,
+          stagingBucket,
+          '',
+          { previous: prevDeployMetadata.current || null, current: tag },
+          dryrun
         )
-      })
-      .then(() => {
-        console.log('Promotion to staging done\n')
-        getCreateInvalidation(
-          stagingCredentials,
-          `arn:aws:cloudfront::043748923082:distribution/EB2QTLE7OJ8O6`
-        )
-      })
-      .then(() => {
-        console.log('Cache invalidation initiated for staging\n')
-        process.exit(0)
-      })
-      .catch(error => {
-        console.error(error.message)
-        process.exit(1)
-      })
-  })
-  .catch(err => {
-    console.error(err)
-  })
+      )
+    })
+    .then(() => {
+      console.log('Promotion to staging done\n')
+      process.exit(0)
+    })
+    .catch(error => {
+      console.error(error.message)
+      process.exit(1)
+    })
+}

--- a/scripts/deploy/prompt-user.js
+++ b/scripts/deploy/prompt-user.js
@@ -1,0 +1,17 @@
+const readline = require('readline')
+
+function promptUser(message) {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  return new Promise(resolve => {
+    rl.question(`${message} (Y/N): `, answer => {
+      rl.close()
+      resolve(answer.toUpperCase() === 'Y')
+    })
+  })
+}
+
+module.exports = { promptUser }

--- a/scripts/deploy/rollback.js
+++ b/scripts/deploy/rollback.js
@@ -4,6 +4,9 @@
 const assert = require('assert')
 const AWS = require('aws-sdk')
 
+const { getAssumeRole } = require('./assume-role')
+const { checkCurrentAWSProfile } = require('./check-current-profile')
+const { promptUser } = require('./prompt-user')
 const parseArgs = require('./lib/parseArgs')
 const syncBuckets = require('./lib/syncBuckets')
 const {
@@ -11,11 +14,16 @@ const {
   setDeployMetadata,
 } = require('./lib/deploy-metadata')
 
+const PROTOCOL_DESIGNER_DOMAIN = 'designer.opentrons.com'
+const ADMINISTRATOR_ROLE_ARN = 'arn:aws:iam::043748923082:role/administrator'
+const ROBOTICS_STATIC_WEBSITE_ROLE_ARN =
+  'arn:aws:iam::480034758691:role/robotics-static-website-deployer-root'
 const USAGE =
   '\nUsage:\n  node ./scripts/deploy/rollback <project_domain> <environment> [--deploy]'
 
 const { args, flags } = parseArgs(process.argv.slice(2))
 const [projectDomain, environment] = args
+
 const dryrun = !flags.includes('--deploy')
 
 assert(
@@ -23,43 +31,88 @@ assert(
   USAGE
 )
 
-const s3 = new AWS.S3({ apiVersion: '2006-03-01', region: 'us-east-2' })
+function performRollback(s3, sandboxBucket, rollbackBucket, dryrun) {
+  return getDeployMetadata(s3, rollbackBucket)
+    .then(deployMetadata => {
+      const { previous } = deployMetadata
 
-const sandboxBucket = `sandbox.${projectDomain}`
-const rollbackBucket =
-  environment === 'production' ? projectDomain : `staging.${projectDomain}`
-
-getDeployMetadata(s3, rollbackBucket)
-  .then(deployMetadata => {
-    const { previous } = deployMetadata
-
-    console.log(`${rollbackBucket} deploy metadata: %j`, deployMetadata)
-    assert(
-      previous,
-      'Unable to find previous deploy tag; was this environment already rolled back?'
-    )
-
-    return syncBuckets(
-      s3,
-      { bucket: sandboxBucket, path: previous },
-      { bucket: rollbackBucket },
-      dryrun
-    )
-      .then(() =>
-        setDeployMetadata(
-          s3,
-          rollbackBucket,
-          '',
-          { previous: null, current: previous || null },
-          dryrun
-        )
+      console.log(`${rollbackBucket} deploy metadata: %j`, deployMetadata)
+      assert(
+        previous,
+        'Unable to find previous deploy tag; was this environment already rolled back?'
       )
-      .then(() => {
-        console.log(`Rollback of ${rollbackBucket} to ${previous} done\n`)
+
+      return syncBuckets(
+        s3,
+        { bucket: sandboxBucket, path: previous },
+        { bucket: rollbackBucket },
+        dryrun
+      )
+        .then(() =>
+          setDeployMetadata(
+            s3,
+            rollbackBucket,
+            '',
+            { previous: null, current: previous || null },
+            dryrun
+          )
+        )
+        .then(() => {
+          console.log(`Rollback of ${rollbackBucket} to ${previous} done\n`)
+        })
+    })
+    .then(() => process.exit(0))
+    .catch(error => {
+      console.error(error.message)
+      process.exit(1)
+    })
+}
+
+async function runRollback() {
+  try {
+    await checkCurrentAWSProfile()
+
+    const confirmation = await promptUser('Is the AWS profile correct?')
+
+    if (!confirmation) {
+      console.log(
+        'Exiting script. Please configure the correct AWS profile and run the script again.'
+      )
+      process.exit(0)
+    }
+
+    await getAssumeRole(
+      projectDomain === PROTOCOL_DESIGNER_DOMAIN
+        ? ADMINISTRATOR_ROLE_ARN
+        : ROBOTICS_STATIC_WEBSITE_ROLE_ARN,
+      'rollBack'
+    )
+      .then(credentials => {
+        const rollBackCredentials = new AWS.Credentials({
+          accessKeyId: credentials.AccessKeyId,
+          secretAccessKey: credentials.SecretAccessKey,
+          sessionToken: credentials.SessionToken,
+        })
+
+        const s3 = new AWS.S3({
+          apiVersion: '2006-03-01',
+          region: 'us-east-1',
+          credentials: rollBackCredentials,
+        })
+
+        const sandboxBucket = `sandbox.${projectDomain}`
+        const rollbackBucket =
+          environment === 'production'
+            ? projectDomain
+            : `staging.${projectDomain}`
+        return performRollback(s3, sandboxBucket, rollbackBucket, dryrun)
       })
-  })
-  .then(() => process.exit(0))
-  .catch(error => {
+      .catch(error => {
+        console.error(error)
+      })
+  } catch (error) {
     console.error(error.message)
     process.exit(1)
-  })
+  }
+}
+runRollback()

--- a/scripts/deploy/rollback.js
+++ b/scripts/deploy/rollback.js
@@ -70,13 +70,13 @@ function performRollback(s3, sandboxBucket, rollbackBucket, dryrun) {
 
 async function runRollback() {
   try {
-    await checkCurrentAWSProfile()
+    const AWS_PROFILE = await checkCurrentAWSProfile()
 
     const confirmation = await promptUser('Is the AWS profile correct?')
 
     if (!confirmation) {
       console.log(
-        'Exiting script. Please configure the correct AWS profile and run the script again.'
+        `Exiting script. Please configure the correct AWS profile through the ${AWS_PROFILE} environment and run the script again.`
       )
       process.exit(0)
     }


### PR DESCRIPTION
# Overview

The Labware Library and docs s3 buckets are still in the root account and haven't been moved over to the PL Production account. This PR updates the `promote to staging`, `promote to production`, and `rollback` scripts to have branching logic that assumes roles into the root account, leaving PD to assume roles into the PL production account.

Additionally, a newly made `checkCurrentAWSProfile` and `promptUser` fn is created to check the user's AWS creds before promoting to staging and prod to ensure the user is on the correct profile.

# Test Plan

Test with dry runs using each project's latest tags. Run each of these at the root of the monorepo

The beginning of each should prompt you to type "Y/N" if you're on the correct aws profile to run the scripts.

1. `node ./scripts/deploy/promote-to-staging docs.opentrons.com docs@2.16` -> should see the text `Promotion to staging done`
2. `node ./scripts/deploy/promote-to-production docs.opentrons.com` -> should see the text `Promotion to production done`
3. `node ./scripts/deploy/promote-to-staging labware.opentrons.com labware-library@2.1.0-candidate-b` -> should see the text `Promotion to staging done`
4. `node ./scripts/deploy/promote-to-production labware.opentrons.com` -> should see the text `Promotion to production done`
5. for the rollback: `node ./scripts/deploy/rollback labware.opentrons.com production`/ `node ./scripts/deploy/rollback labware.opentrons.com staging` , `node ./scripts/deploy/rollback docs.opentrons.com production`/ `node ./scripts/deploy/rollback docs.opentrons.com staging`, `node ./scripts/deploy/rollback designer.opentrons.com production`/ `node ./scripts/deploy/rollback designer.opentrons.com staging`

# Changelog

- branching logic to assume roles into another account 
- branching logic to invalidate cache for each (staging/production, LL/docs/PD)
- create new fns `promptUser` to prompt yes or no and `checkCurrentAWSProfile` to let the user know which aws profile they are on
- add assume roles logic to the rollback script that wasn't added previous for PD but also includes assuming roles for LL and docs

# Review requests

see test test plan

# Risk assessment

low