### PR TITLE
docs(api): add missing docstrings for Well properties

### DIFF
--- a/api/docs/v2/new_labware.rst
+++ b/api/docs/v2/new_labware.rst
@@ -187,10 +187,12 @@ The API provides many different ways to access wells inside labware. Different m
 Accessing Individual Wells
 ==========================
 
+.. _well-dictionary-access:
+
 Dictionary Access
 -----------------
 
-The simplest way to refer to a single well is by its name, like A1 or D6. :py:meth:`.Labware.wells_by_name` accomplishes this. This is such a common task that the API also has an equivalent shortcut: dictionary indexing.
+The simplest way to refer to a single well is by its :py:obj:`.well_name`, like A1 or D6. Referencing a particular key in the result of :py:meth:`.Labware.wells_by_name` accomplishes this. This is such a common task that the API also has an equivalent shortcut: dictionary indexing.
 
 .. code-block:: python
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -175,9 +175,12 @@ class Well:
     @property
     @requires_version(2, 7)
     def well_name(self) -> str:
-        """A human-readable name for the well's coordinates.
+        """A string representing the well's coordinates.
 
         For example, "A1" or "H12".
+
+        The format of strings that this property returns is the same format as the key
+        for :ref:`accessing wells in a dictionary <well-dictionary-access>`.
         """
         return self._core.get_name()
 

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -93,6 +93,7 @@ class Well:
     @property
     @requires_version(2, 0)
     def parent(self) -> Labware:
+        """The :py:class:`.Labware` object that the well is a part of."""
         return self._parent
 
     @property
@@ -113,6 +114,10 @@ class Well:
 
     @property
     def max_volume(self) -> float:
+        """The maximum volume, in µL, that the well can hold.
+
+        This amount is set by the JSON labware definition, specifically the ``totalLiquidVolume`` property of the particular well.
+        """
         return self._core.get_max_volume()
 
     @property
@@ -159,11 +164,21 @@ class Well:
 
     @property
     def display_name(self) -> str:
+        """A human-readable name for the well, including labware and deck location.
+
+        For example, "A1 of Corning 96 Well Plate 360 µL Flat on slot D1". Run log
+        entries use this format for identifying wells. See
+        :py:meth:`.ProtocolContext.commands`.
+        """
         return self._core.get_display_name()
 
     @property
     @requires_version(2, 7)
     def well_name(self) -> str:
+        """A human-readable name for the well's coordinates.
+
+        For example, "A1" or "H12".
+        """
         return self._core.get_name()
 
     @requires_version(2, 0)


### PR DESCRIPTION
# Overview

A handful of Well properties that have been in the API for years never got documented.

# Test Plan

Check out the [API Reference entries in the sandbox](http://sandbox.docs.opentrons.com/docs-well-properties/v2/new_protocol_api.html#wells-and-liquids).

# Changelog

Brand new docstrings for:
- `Well.parent`
- `Well.max_volume`
- `Well.display_name`
- `Well.well_name`

# Review requests

Words good? These all _should_ be documented, yes?

# Risk assessment

none, docs only