### PR TITLE
fix(app): fix magnetic module fixture conflicts

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -216,7 +216,7 @@ interface ModulesListItemProps {
   isFlex: boolean
   calibrationStatus: ProtocolCalibrationStatus
   deckDef: DeckDefinition
-  conflictedFixture?: CutoutConfig
+  conflictedFixture: CutoutConfig | null
 }
 
 export function ModulesListItem({

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/SetupModulesList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/__tests__/SetupModulesList.test.tsx
@@ -366,6 +366,7 @@ describe('SetupModulesList', () => {
             model: mockMagneticModule.model,
           } as any,
           slotName: '1',
+          conflictedFixture: null,
         },
         [dupModId]: {
           moduleId: dupModId,
@@ -386,6 +387,7 @@ describe('SetupModulesList', () => {
             },
           } as any,
           slotName: '3',
+          conflictedFixture: null,
         },
       })
     render(props)

--- a/app/src/organisms/Devices/hooks/__tests__/useModuleCalibrationStatus.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useModuleCalibrationStatus.test.tsx
@@ -121,6 +121,7 @@ describe('useModuleCalibrationStatus hook', () => {
             ...mockMagneticModuleGen2,
             moduleOffset: mockOffsetData,
           },
+          conflictedFixture: null,
           ...MAGNETIC_MODULE_INFO,
         },
       })
@@ -142,6 +143,7 @@ describe('useModuleCalibrationStatus hook', () => {
           attachedModuleMatch: {
             ...mockMagneticModuleGen2,
           },
+          conflictedFixture: null,
           ...MAGNETIC_MODULE_INFO,
         },
       })

--- a/app/src/organisms/Devices/hooks/__tests__/useUnmatchedModulesForProtocol.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useUnmatchedModulesForProtocol.test.tsx
@@ -81,6 +81,7 @@ describe('useModuleMatchResults', () => {
           protocolLoadOrder: 0,
           attachedModuleMatch: null,
           slotName: '1',
+          conflictedFixture: null,
         },
       })
 
@@ -108,6 +109,7 @@ describe('useModuleMatchResults', () => {
           protocolLoadOrder: 0,
           attachedModuleMatch: null,
           slotName: '1',
+          conflictedFixture: null,
         },
       })
     when(mockUseAttachedModules).calledWith().mockReturnValue([])
@@ -135,6 +137,7 @@ describe('useModuleMatchResults', () => {
           protocolLoadOrder: 0,
           attachedModuleMatch: null,
           slotName: '1',
+          conflictedFixture: null,
         },
       })
 
@@ -164,6 +167,7 @@ describe('useModuleMatchResults', () => {
           protocolLoadOrder: 0,
           attachedModuleMatch: null,
           slotName: '1',
+          conflictedFixture: null,
         },
       })
 

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/ModuleTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/ModuleTable.tsx
@@ -1,0 +1,342 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
+
+import {
+  ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_SPACE_BETWEEN,
+  LocationIcon,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
+import {
+  getCutoutIdForSlotName,
+  getModuleDisplayName,
+  getModuleType,
+  MAGNETIC_BLOCK_TYPE,
+  NON_CONNECTING_MODULE_TYPES,
+  SINGLE_SLOT_FIXTURES,
+  STAGING_AREA_RIGHT_SLOT_FIXTURE,
+  TC_MODULE_LOCATION_OT3,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
+import { SmallButton } from '../../atoms/buttons'
+import { Chip } from '../../atoms/Chip'
+import { StyledText } from '../../atoms/text'
+import { getModulePrepCommands } from '../../organisms/Devices/getModulePrepCommands'
+import { getModuleTooHot } from '../../organisms/Devices/getModuleTooHot'
+import { useRunCalibrationStatus } from '../../organisms/Devices/hooks'
+import { LocationConflictModal } from '../../organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal'
+import { ModuleWizardFlows } from '../../organisms/ModuleWizardFlows'
+import { useToaster } from '../../organisms/ToasterOven'
+import { getLocalRobot } from '../../redux/discovery'
+import { useChainLiveCommands } from '../../resources/runs/hooks'
+
+import type { CommandData } from '@opentrons/api-client'
+import type { CutoutConfig, DeckDefinition } from '@opentrons/shared-data'
+import type { ModulePrepCommandsType } from '../../organisms/Devices/getModulePrepCommands'
+import type { ProtocolCalibrationStatus } from '../../organisms/Devices/hooks'
+import type { ProtocolModuleInfo } from '../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
+import type { AttachedProtocolModuleMatch } from './utils'
+
+const DECK_CONFIG_REFETCH_INTERVAL = 5000
+
+interface ModuleTableProps {
+  attachedProtocolModuleMatches: AttachedProtocolModuleMatch[]
+  deckDef: DeckDefinition
+  protocolModulesInfo: ProtocolModuleInfo[]
+  runId: string
+  setShowMultipleModulesModal: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+export function ModuleTable(props: ModuleTableProps): JSX.Element {
+  const {
+    attachedProtocolModuleMatches,
+    deckDef,
+    protocolModulesInfo,
+    runId,
+    setShowMultipleModulesModal,
+  } = props
+
+  const { t } = useTranslation('protocol_setup')
+
+  const [
+    prepCommandErrorMessage,
+    setPrepCommandErrorMessage,
+  ] = React.useState<string>('')
+
+  const { data: deckConfig } = useDeckConfigurationQuery({
+    refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
+  })
+  const localRobot = useSelector(getLocalRobot)
+  const robotName = localRobot?.name != null ? localRobot.name : ''
+  const calibrationStatus = useRunCalibrationStatus(robotName, runId)
+  const { chainLiveCommands, isCommandMutationLoading } = useChainLiveCommands()
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+      <Flex
+        color={COLORS.darkBlack70}
+        fontSize={TYPOGRAPHY.fontSize22}
+        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+        gridGap={SPACING.spacing24}
+        lineHeight={TYPOGRAPHY.lineHeight28}
+        paddingX={SPACING.spacing24}
+      >
+        <StyledText flex="3.5 0 0">{t('module')}</StyledText>
+        <StyledText flex="2 0 0">{t('location')}</StyledText>
+        <StyledText flex="4 0 0"> {t('status')}</StyledText>
+      </Flex>
+      {attachedProtocolModuleMatches.map(module => {
+        // check for duplicate module model in list of modules for protocol
+        const isDuplicateModuleModel = protocolModulesInfo
+          // filter out current module
+          .filter(otherModule => otherModule.moduleId !== module.moduleId)
+          // check for existence of another module of same model
+          .some(
+            otherModule =>
+              otherModule.moduleDef.model === module.moduleDef.model
+          )
+
+        const cutoutIdForSlotName = getCutoutIdForSlotName(
+          module.slotName,
+          deckDef
+        )
+
+        const isMagneticBlockModule =
+          module.moduleDef.moduleType === MAGNETIC_BLOCK_TYPE
+
+        const conflictedFixture =
+          deckConfig?.find(
+            fixture =>
+              fixture.cutoutId === cutoutIdForSlotName &&
+              fixture.cutoutFixtureId != null &&
+              // do not generate a conflict for single slot fixtures, because modules are not yet fixtures
+              !SINGLE_SLOT_FIXTURES.includes(fixture.cutoutFixtureId) &&
+              // special case the magnetic module because unlike other modules it sits in a slot that can also be provided by a staging area fixture
+              (!isMagneticBlockModule ||
+                fixture.cutoutFixtureId !== STAGING_AREA_RIGHT_SLOT_FIXTURE)
+          ) ?? null
+
+        return (
+          <ModuleTableItem
+            key={module.moduleId}
+            module={module}
+            isDuplicateModuleModel={isDuplicateModuleModel}
+            setShowMultipleModulesModal={setShowMultipleModulesModal}
+            calibrationStatus={calibrationStatus}
+            chainLiveCommands={chainLiveCommands}
+            isLoading={isCommandMutationLoading}
+            prepCommandErrorMessage={prepCommandErrorMessage}
+            setPrepCommandErrorMessage={setPrepCommandErrorMessage}
+            conflictedFixture={conflictedFixture}
+          />
+        )
+      })}
+    </Flex>
+  )
+}
+
+interface ModuleTableItemProps {
+  calibrationStatus: ProtocolCalibrationStatus
+  chainLiveCommands: (
+    commands: ModulePrepCommandsType[],
+    continuePastCommandFailure: boolean
+  ) => Promise<CommandData[]>
+  conflictedFixture: CutoutConfig | null
+  isDuplicateModuleModel: boolean
+  isLoading: boolean
+  module: AttachedProtocolModuleMatch
+  prepCommandErrorMessage: string
+  setPrepCommandErrorMessage: React.Dispatch<React.SetStateAction<string>>
+  setShowMultipleModulesModal: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+function ModuleTableItem({
+  isDuplicateModuleModel,
+  module,
+  setShowMultipleModulesModal,
+  calibrationStatus,
+  chainLiveCommands,
+  isLoading,
+  prepCommandErrorMessage,
+  setPrepCommandErrorMessage,
+  conflictedFixture,
+}: ModuleTableItemProps): JSX.Element {
+  const { i18n, t } = useTranslation(['protocol_setup', 'module_wizard_flows'])
+
+  const { makeSnackbar } = useToaster()
+
+  const handleCalibrate = (): void => {
+    if (module.attachedModuleMatch != null) {
+      if (getModuleTooHot(module.attachedModuleMatch)) {
+        makeSnackbar(t('module_wizard_flows:module_too_hot'))
+      } else {
+        chainLiveCommands(
+          getModulePrepCommands(module.attachedModuleMatch),
+          false
+        ).catch((e: Error) => {
+          setPrepCommandErrorMessage(e.message)
+        })
+        setShowModuleWizard(true)
+      }
+    } else {
+      makeSnackbar(t('attach_module'))
+    }
+  }
+
+  const isNonConnectingModule = NON_CONNECTING_MODULE_TYPES.includes(
+    module.moduleDef.moduleType
+  )
+  const isModuleReady = module.attachedModuleMatch != null
+
+  const [showModuleWizard, setShowModuleWizard] = React.useState<boolean>(false)
+  const [
+    showLocationConflictModal,
+    setShowLocationConflictModal,
+  ] = React.useState<boolean>(false)
+
+  let moduleStatus: JSX.Element = (
+    <>
+      <Chip
+        text={t('module_disconnected')}
+        type="warning"
+        background={false}
+        iconName="connection-status"
+      />
+      {isDuplicateModuleModel ? <Icon name="information" size="2rem" /> : null}
+    </>
+  )
+  if (conflictedFixture != null) {
+    moduleStatus = (
+      <>
+        <Chip
+          text={t('location_conflict')}
+          type="warning"
+          background={false}
+          iconName="connection-status"
+        />
+        <SmallButton
+          buttonCategory="rounded"
+          buttonText={t('resolve')}
+          onClick={() => setShowLocationConflictModal(true)}
+        />
+      </>
+    )
+  } else if (isNonConnectingModule) {
+    moduleStatus = (
+      <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+        {t('n_a')}
+      </StyledText>
+    )
+  } else if (
+    isModuleReady &&
+    module.attachedModuleMatch?.moduleOffset?.last_modified != null
+  ) {
+    moduleStatus = (
+      <>
+        <Chip
+          text={t('module_connected')}
+          type="success"
+          background={false}
+          iconName="connection-status"
+        />
+        {isDuplicateModuleModel ? (
+          <Icon name="information" size="2rem" />
+        ) : null}
+      </>
+    )
+  } else if (
+    isModuleReady &&
+    calibrationStatus.complete &&
+    module.attachedModuleMatch?.moduleOffset?.last_modified == null
+  ) {
+    moduleStatus = (
+      <SmallButton
+        buttonCategory="rounded"
+        buttonText={i18n.format(t('calibrate'), 'capitalize')}
+        onClick={handleCalibrate}
+      />
+    )
+  } else if (!calibrationStatus?.complete) {
+    moduleStatus = (
+      <StyledText as="p">
+        {calibrationStatus?.reason === 'attach_pipette_failure_reason'
+          ? t('calibration_required_attach_pipette_first')
+          : t('calibration_required_calibrate_pipette_first')}
+      </StyledText>
+    )
+  }
+
+  return (
+    <>
+      {showModuleWizard && module.attachedModuleMatch != null ? (
+        <ModuleWizardFlows
+          attachedModule={module.attachedModuleMatch}
+          closeFlow={() => setShowModuleWizard(false)}
+          initialSlotName={module.slotName}
+          isPrepCommandLoading={isLoading}
+          prepCommandErrorMessage={
+            prepCommandErrorMessage === '' ? undefined : prepCommandErrorMessage
+          }
+        />
+      ) : null}
+      {showLocationConflictModal && conflictedFixture != null ? (
+        <LocationConflictModal
+          onCloseClick={() => setShowLocationConflictModal(false)}
+          cutoutId={conflictedFixture.cutoutId}
+          requiredModule={module.moduleDef.model}
+          isOnDevice={true}
+        />
+      ) : null}
+      <Flex
+        alignItems={ALIGN_CENTER}
+        backgroundColor={
+          isModuleReady &&
+          module.attachedModuleMatch?.moduleOffset?.last_modified != null &&
+          conflictedFixture == null
+            ? COLORS.green3
+            : isNonConnectingModule && conflictedFixture == null
+            ? COLORS.light1
+            : COLORS.yellow3
+        }
+        borderRadius={BORDERS.borderRadiusSize3}
+        cursor={isDuplicateModuleModel ? 'pointer' : 'inherit'}
+        gridGap={SPACING.spacing24}
+        padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
+        onClick={() =>
+          isDuplicateModuleModel ? setShowMultipleModulesModal(true) : null
+        }
+      >
+        <Flex flex="3.5 0 0" alignItems={ALIGN_CENTER}>
+          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+            {getModuleDisplayName(module.moduleDef.model)}
+          </StyledText>
+        </Flex>
+        <Flex alignItems={ALIGN_CENTER} flex="2 0 0">
+          <LocationIcon
+            slotName={
+              getModuleType(module.moduleDef.model) === THERMOCYCLER_MODULE_TYPE
+                ? TC_MODULE_LOCATION_OT3
+                : module.slotName
+            }
+          />
+        </Flex>
+        <Flex
+          flex="4 0 0"
+          alignItems={ALIGN_CENTER}
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+        >
+          {moduleStatus}
+        </Flex>
+      </Flex>
+    </>
+  )
+}

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/index.tsx
@@ -1,311 +1,33 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
-import {
-  ALIGN_CENTER,
-  BORDERS,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_SPACE_BETWEEN,
-  LocationIcon,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
-import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
+import { DIRECTION_COLUMN, Flex, SPACING } from '@opentrons/components'
 import {
   FLEX_ROBOT_TYPE,
-  getCutoutIdForSlotName,
   getDeckDefFromRobotType,
-  getModuleDisplayName,
-  getModuleType,
-  NON_CONNECTING_MODULE_TYPES,
-  SINGLE_SLOT_FIXTURES,
-  TC_MODULE_LOCATION_OT3,
-  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { Portal } from '../../App/portal'
-import { FloatingActionButton, SmallButton } from '../../atoms/buttons'
-import { Chip } from '../../atoms/Chip'
+import { FloatingActionButton } from '../../atoms/buttons'
 import { InlineNotification } from '../../atoms/InlineNotification'
-import { StyledText } from '../../atoms/text'
 import { ChildNavigation } from '../../organisms/ChildNavigation'
-import {
-  useAttachedModules,
-  useRunCalibrationStatus,
-} from '../../organisms/Devices/hooks'
-import { MultipleModulesModal } from '../Devices/ProtocolRun/SetupModuleAndDeck/MultipleModulesModal'
+import { useAttachedModules } from '../../organisms/Devices/hooks'
+import { MultipleModulesModal } from '../../organisms/Devices/ProtocolRun/SetupModuleAndDeck/MultipleModulesModal'
 import { getProtocolModulesInfo } from '../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
 import { useMostRecentCompletedAnalysis } from '../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
-import { getLocalRobot } from '../../redux/discovery'
-import { useChainLiveCommands } from '../../resources/runs/hooks'
-import {
-  getModulePrepCommands,
-  ModulePrepCommandsType,
-} from '../Devices/getModulePrepCommands'
-import { useToaster } from '../ToasterOven'
 import {
   getAttachedProtocolModuleMatches,
   getUnmatchedModulesForProtocol,
 } from './utils'
 import { SetupInstructionsModal } from './SetupInstructionsModal'
-import { ModuleWizardFlows } from '../ModuleWizardFlows'
-import { LocationConflictModal } from '../Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal'
-import { getModuleTooHot } from '../Devices/getModuleTooHot'
 import { FixtureTable } from './FixtureTable'
+import { ModuleTable } from './ModuleTable'
 import { ModulesAndDeckMapViewModal } from './ModulesAndDeckMapViewModal'
 
-import type { CommandData } from '@opentrons/api-client'
-import type {
-  CutoutConfig,
-  CutoutId,
-  CutoutFixtureId,
-} from '@opentrons/shared-data'
+import type { CutoutId, CutoutFixtureId } from '@opentrons/shared-data'
 import type { SetupScreens } from '../../pages/ProtocolSetup'
-import type { ProtocolCalibrationStatus } from '../../organisms/Devices/hooks'
-import type { AttachedProtocolModuleMatch } from './utils'
 
 const ATTACHED_MODULE_POLL_MS = 5000
-const DECK_CONFIG_REFETCH_INTERVAL = 5000
-
-interface RenderModuleStatusProps {
-  isModuleReady: boolean
-  isDuplicateModuleModel: boolean
-  module: AttachedProtocolModuleMatch
-  calibrationStatus: ProtocolCalibrationStatus
-  setShowModuleWizard: (showModuleWizard: boolean) => void
-  setPrepCommandErrorMessage: React.Dispatch<React.SetStateAction<string>>
-  chainLiveCommands: (
-    commands: ModulePrepCommandsType[],
-    continuePastCommandFailure: boolean
-  ) => Promise<CommandData[]>
-  conflictedFixture?: CutoutConfig
-  setShowLocationConflictModal: React.Dispatch<React.SetStateAction<boolean>>
-}
-
-function RenderModuleStatus({
-  isModuleReady,
-  isDuplicateModuleModel,
-  module,
-  calibrationStatus,
-  setShowModuleWizard,
-  setPrepCommandErrorMessage,
-  chainLiveCommands,
-  conflictedFixture,
-  setShowLocationConflictModal,
-}: RenderModuleStatusProps): JSX.Element {
-  const { makeSnackbar } = useToaster()
-  const { i18n, t } = useTranslation(['protocol_setup', 'module_wizard_flows'])
-
-  const handleCalibrate = (): void => {
-    if (module.attachedModuleMatch != null) {
-      if (getModuleTooHot(module.attachedModuleMatch)) {
-        makeSnackbar(t('module_wizard_flows:module_too_hot'))
-      } else {
-        chainLiveCommands(
-          getModulePrepCommands(module.attachedModuleMatch),
-          false
-        ).catch((e: Error) => {
-          setPrepCommandErrorMessage(e.message)
-        })
-        setShowModuleWizard(true)
-      }
-    } else {
-      makeSnackbar(t('attach_module'))
-    }
-  }
-
-  let moduleStatus: JSX.Element = (
-    <>
-      <Chip
-        text={t('module_disconnected')}
-        type="warning"
-        background={false}
-        iconName="connection-status"
-      />
-      {isDuplicateModuleModel ? <Icon name="information" size="2rem" /> : null}
-    </>
-  )
-  if (conflictedFixture != null) {
-    moduleStatus = (
-      <>
-        <Chip
-          text={t('location_conflict')}
-          type="warning"
-          background={false}
-          iconName="connection-status"
-        />
-        <SmallButton
-          buttonCategory="rounded"
-          buttonText={t('resolve')}
-          onClick={() => setShowLocationConflictModal(true)}
-        />
-      </>
-    )
-  } else if (
-    isModuleReady &&
-    module.attachedModuleMatch?.moduleOffset?.last_modified != null
-  ) {
-    moduleStatus = (
-      <>
-        <Chip
-          text={t('module_connected')}
-          type="success"
-          background={false}
-          iconName="connection-status"
-        />
-        {isDuplicateModuleModel ? (
-          <Icon name="information" size="2rem" />
-        ) : null}
-      </>
-    )
-  } else if (
-    isModuleReady &&
-    calibrationStatus.complete &&
-    module.attachedModuleMatch?.moduleOffset?.last_modified == null
-  ) {
-    moduleStatus = (
-      <SmallButton
-        buttonCategory="rounded"
-        buttonText={i18n.format(t('calibrate'), 'capitalize')}
-        onClick={handleCalibrate}
-      />
-    )
-  } else if (!calibrationStatus?.complete) {
-    moduleStatus = (
-      <StyledText as="p">
-        {calibrationStatus?.reason === 'attach_pipette_failure_reason'
-          ? t('calibration_required_attach_pipette_first')
-          : t('calibration_required_calibrate_pipette_first')}
-      </StyledText>
-    )
-  }
-  return moduleStatus
-}
-
-interface RowModuleProps {
-  isDuplicateModuleModel: boolean
-  module: AttachedProtocolModuleMatch
-  setShowMultipleModulesModal: (showMultipleModulesModal: boolean) => void
-  calibrationStatus: ProtocolCalibrationStatus
-  isLoading: boolean
-  chainLiveCommands: (
-    commands: ModulePrepCommandsType[],
-    continuePastCommandFailure: boolean
-  ) => Promise<CommandData[]>
-  prepCommandErrorMessage: string
-  setPrepCommandErrorMessage: React.Dispatch<React.SetStateAction<string>>
-  conflictedFixture?: CutoutConfig
-}
-
-function RowModule({
-  isDuplicateModuleModel,
-  module,
-  setShowMultipleModulesModal,
-  calibrationStatus,
-  chainLiveCommands,
-  isLoading,
-  prepCommandErrorMessage,
-  setPrepCommandErrorMessage,
-  conflictedFixture,
-}: RowModuleProps): JSX.Element {
-  const { t } = useTranslation('protocol_setup')
-  const isNonConnectingModule = NON_CONNECTING_MODULE_TYPES.includes(
-    module.moduleDef.moduleType
-  )
-  const isModuleReady =
-    isNonConnectingModule || module.attachedModuleMatch != null
-
-  const [showModuleWizard, setShowModuleWizard] = React.useState<boolean>(false)
-  const [
-    showLocationConflictModal,
-    setShowLocationConflictModal,
-  ] = React.useState<boolean>(false)
-
-  return (
-    <>
-      {showModuleWizard && module.attachedModuleMatch != null ? (
-        <ModuleWizardFlows
-          attachedModule={module.attachedModuleMatch}
-          closeFlow={() => setShowModuleWizard(false)}
-          initialSlotName={module.slotName}
-          isPrepCommandLoading={isLoading}
-          prepCommandErrorMessage={
-            prepCommandErrorMessage === '' ? undefined : prepCommandErrorMessage
-          }
-        />
-      ) : null}
-      {showLocationConflictModal && conflictedFixture != null ? (
-        <LocationConflictModal
-          onCloseClick={() => setShowLocationConflictModal(false)}
-          cutoutId={conflictedFixture.cutoutId}
-          requiredModule={module.moduleDef.model}
-          isOnDevice={true}
-        />
-      ) : null}
-      <Flex
-        alignItems={ALIGN_CENTER}
-        backgroundColor={
-          isModuleReady &&
-          module.attachedModuleMatch?.moduleOffset?.last_modified != null &&
-          conflictedFixture == null
-            ? COLORS.green3
-            : COLORS.yellow3
-        }
-        borderRadius={BORDERS.borderRadiusSize3}
-        cursor={isDuplicateModuleModel ? 'pointer' : 'inherit'}
-        gridGap={SPACING.spacing24}
-        padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
-        onClick={() =>
-          isDuplicateModuleModel ? setShowMultipleModulesModal(true) : null
-        }
-      >
-        <Flex flex="3.5 0 0" alignItems={ALIGN_CENTER}>
-          <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-            {getModuleDisplayName(module.moduleDef.model)}
-          </StyledText>
-        </Flex>
-        <Flex alignItems={ALIGN_CENTER} flex="2 0 0">
-          <LocationIcon
-            slotName={
-              getModuleType(module.moduleDef.model) === THERMOCYCLER_MODULE_TYPE
-                ? TC_MODULE_LOCATION_OT3
-                : module.slotName
-            }
-          />
-        </Flex>
-        {isNonConnectingModule ? (
-          <Flex flex="4 0 0" alignItems={ALIGN_CENTER}>
-            <StyledText as="p" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-              {t('n_a')}
-            </StyledText>
-          </Flex>
-        ) : (
-          <Flex
-            flex="4 0 0"
-            alignItems={ALIGN_CENTER}
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
-          >
-            <RenderModuleStatus
-              isModuleReady={isModuleReady}
-              isDuplicateModuleModel={isDuplicateModuleModel}
-              module={module}
-              calibrationStatus={calibrationStatus}
-              setShowModuleWizard={setShowModuleWizard}
-              chainLiveCommands={chainLiveCommands}
-              setPrepCommandErrorMessage={setPrepCommandErrorMessage}
-              conflictedFixture={conflictedFixture}
-              setShowLocationConflictModal={setShowLocationConflictModal}
-            />
-          </Flex>
-        )}
-      </Flex>
-    </>
-  )
-}
 
 interface ProtocolSetupModulesAndDeckProps {
   runId: string
@@ -324,7 +46,7 @@ export function ProtocolSetupModulesAndDeck({
   setProvidedFixtureOptions,
 }: ProtocolSetupModulesAndDeckProps): JSX.Element {
   const { i18n, t } = useTranslation('protocol_setup')
-  const { chainLiveCommands, isCommandMutationLoading } = useChainLiveCommands()
+
   const [
     showMultipleModulesModal,
     setShowMultipleModulesModal,
@@ -338,13 +60,6 @@ export function ProtocolSetupModulesAndDeck({
     clearModuleMismatchBanner,
     setClearModuleMismatchBanner,
   ] = React.useState<boolean>(false)
-  const [
-    prepCommandErrorMessage,
-    setPrepCommandErrorMessage,
-  ] = React.useState<string>('')
-  const { data: deckConfig } = useDeckConfigurationQuery({
-    refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
-  })
   const mostRecentAnalysis = useMostRecentCompletedAnalysis(runId)
 
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
@@ -353,10 +68,6 @@ export function ProtocolSetupModulesAndDeck({
     useAttachedModules({
       refetchInterval: ATTACHED_MODULE_POLL_MS,
     }) ?? []
-
-  const localRobot = useSelector(getLocalRobot)
-  const robotName = localRobot?.name != null ? localRobot.name : ''
-  const calibrationStatus = useRunCalibrationStatus(robotName, runId)
 
   const protocolModulesInfo =
     mostRecentAnalysis != null
@@ -428,58 +139,13 @@ export function ProtocolSetupModulesAndDeck({
         ) : null}
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
           {hasModules ? (
-            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-              <Flex
-                color={COLORS.darkBlack70}
-                fontSize={TYPOGRAPHY.fontSize22}
-                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                gridGap={SPACING.spacing24}
-                lineHeight={TYPOGRAPHY.lineHeight28}
-                paddingX={SPACING.spacing24}
-              >
-                <StyledText flex="3.5 0 0">{t('module')}</StyledText>
-                <StyledText flex="2 0 0">{t('location')}</StyledText>
-                <StyledText flex="4 0 0"> {t('status')}</StyledText>
-              </Flex>
-              {attachedProtocolModuleMatches.map(module => {
-                // check for duplicate module model in list of modules for protocol
-                const isDuplicateModuleModel = protocolModulesInfo
-                  // filter out current module
-                  .filter(
-                    otherModule => otherModule.moduleId !== module.moduleId
-                  )
-                  // check for existence of another module of same model
-                  .some(
-                    otherModule =>
-                      otherModule.moduleDef.model === module.moduleDef.model
-                  )
-
-                const cutoutIdForSlotName = getCutoutIdForSlotName(
-                  module.slotName,
-                  deckDef
-                )
-
-                return (
-                  <RowModule
-                    key={module.moduleId}
-                    module={module}
-                    isDuplicateModuleModel={isDuplicateModuleModel}
-                    setShowMultipleModulesModal={setShowMultipleModulesModal}
-                    calibrationStatus={calibrationStatus}
-                    chainLiveCommands={chainLiveCommands}
-                    isLoading={isCommandMutationLoading}
-                    prepCommandErrorMessage={prepCommandErrorMessage}
-                    setPrepCommandErrorMessage={setPrepCommandErrorMessage}
-                    conflictedFixture={deckConfig?.find(
-                      fixture =>
-                        fixture.cutoutId === cutoutIdForSlotName &&
-                        fixture.cutoutFixtureId != null &&
-                        !SINGLE_SLOT_FIXTURES.includes(fixture.cutoutFixtureId)
-                    )}
-                  />
-                )
-              })}
-            </Flex>
+            <ModuleTable
+              attachedProtocolModuleMatches={attachedProtocolModuleMatches}
+              deckDef={deckDef}
+              protocolModulesInfo={protocolModulesInfo}
+              runId={runId}
+              setShowMultipleModulesModal={setShowMultipleModulesModal}
+            />
           ) : null}
           <FixtureTable
             robotType={FLEX_ROBOT_TYPE}


### PR DESCRIPTION
# Overview

fixes the logic to surface a magnetic module fixture conflict if one exists and suppress conflicts with staging area fixtures. changes the background color of the magnetic module item. splits out a ModuleTable component for readability.

closes RAUT-913

<img width="1136" alt="Screen Shot 2024-01-04 at 2 33 42 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/6aaa918a-2d48-4091-9a25-26ce8f2c42c2">
<img width="1136" alt="Screen Shot 2024-01-04 at 2 36 21 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/3c7c63e3-1907-4d93-92a5-47af1feb8717">


# Test Plan

 - manually verified existence and resolution of conflicts with magnetic module in protocol

# Changelog

 - fixes magnetic module fixture conflicts

# Review requests

check magnetic module fixture conflicts, should be able to see them only when they exist and fix them

# Risk assessment

low
