### PR TITLE
fix(app): restrict add fixture modal options when provided

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -71,7 +71,7 @@ export function AddFixtureModal({
     title: t('add_to_slot', {
       slotName: getCutoutDisplayName(cutoutId),
     }),
-    hasExitIcon: true,
+    hasExitIcon: providedFixtureOptions == null,
     onClick: () => setShowAddFixtureModal(false),
   }
 
@@ -109,15 +109,18 @@ export function AddFixtureModal({
     [CutoutFixtureId | 'WASTE_CHUTE', string]
   > = fixtureOptions.map(fixture => [fixture, getFixtureDisplayName(fixture)])
 
-  const showSelectWasteChuteOptions = cutoutId === WASTE_CHUTE_CUTOUT
-  if (showSelectWasteChuteOptions) {
-    fixtureOptionsWithDisplayNames.push([
-      GENERIC_WASTE_CHUTE_OPTION,
-      t('waste_chute'),
-    ])
-  }
+  const showSelectWasteChuteOptions =
+    cutoutId === WASTE_CHUTE_CUTOUT && providedFixtureOptions == null
 
-  fixtureOptionsWithDisplayNames.sort((a, b) => a[1].localeCompare(b[1]))
+  const fixtureOptionsWithDisplayNamesAndGenericWasteChute = fixtureOptionsWithDisplayNames.concat(
+    showSelectWasteChuteOptions
+      ? [[GENERIC_WASTE_CHUTE_OPTION, t('waste_chute')]]
+      : []
+  )
+
+  fixtureOptionsWithDisplayNamesAndGenericWasteChute.sort((a, b) =>
+    a[1].localeCompare(b[1])
+  )
 
   const wasteChuteOptionsWithDisplayNames = WASTE_CHUTE_FIXTURES.map(
     fixture => [fixture, getFixtureDisplayName(fixture)]
@@ -125,7 +128,7 @@ export function AddFixtureModal({
 
   const displayedFixtureOptions = showWasteChuteOptions
     ? wasteChuteOptionsWithDisplayNames
-    : fixtureOptionsWithDisplayNames
+    : fixtureOptionsWithDisplayNamesAndGenericWasteChute
 
   const handleAddDesktop = (requiredFixtureId: CutoutFixtureId): void => {
     const newDeckConfig = deckConfig.map(fixture =>
@@ -143,7 +146,11 @@ export function AddFixtureModal({
       {isOnDevice ? (
         <Modal
           header={modalHeader}
-          onOutsideClick={() => setShowAddFixtureModal(false)}
+          onOutsideClick={() =>
+            providedFixtureOptions != null
+              ? null
+              : setShowAddFixtureModal(false)
+          }
         >
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
             <StyledText as="p">{t('add_to_slot_description')}</StyledText>

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
@@ -70,6 +70,23 @@ describe('Touchscreen AddFixtureModal', () => {
     fireEvent.click(screen.getAllByText('Add')[0])
     expect(mockSetCurrentDeckConfig).toHaveBeenCalled()
   })
+
+  it('when fixture options are provided, should only render those options', () => {
+    props = {
+      ...props,
+      providedFixtureOptions: ['trashBinAdapter'],
+    }
+    render(props)
+    screen.getByText('Add to slot D3')
+    screen.getByText(
+      'Choose a fixture below to add to your deck configuration. It will be referenced during protocol analysis.'
+    )
+    expect(screen.queryByText('Staging area slot')).toBeNull()
+    screen.getByText('Trash bin')
+    expect(screen.queryByText('Waste chute')).toBeNull()
+    expect(screen.getAllByText('Add').length).toBe(1)
+    expect(screen.queryByText('Select options')).toBeNull()
+  })
 })
 
 describe('Desktop AddFixtureModal', () => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/NotConfiguredModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/NotConfiguredModal.tsx
@@ -50,13 +50,9 @@ export const NotConfiguredModal = (
   return (
     <Portal level="top">
       <LegacyModal
-        title={
-          <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-            {t('add_fixture', {
-              fixtureName: getFixtureDisplayName(requiredFixtureId),
-            })}
-          </StyledText>
-        }
+        title={t('add_fixture', {
+          fixtureName: getFixtureDisplayName(requiredFixtureId),
+        })}
         onClose={onCloseClick}
         width="27.75rem"
       >
@@ -74,7 +70,7 @@ export const NotConfiguredModal = (
                 {getFixtureDisplayName(requiredFixtureId)}
               </StyledText>
               <TertiaryButton onClick={handleUpdateDeck}>
-                {i18n.format(t('add'), 'capitalize')}
+                {i18n.format(t('shared:add'), 'capitalize')}
               </TertiaryButton>
             </Flex>
           </Flex>


### PR DESCRIPTION
# Overview

when add fixture modal options are provided (during protocol setup on ODD), only show those options and do not allow the modal to close without selecting an option

closes RAUT-911

<img width="1136" alt="Screen Shot 2024-01-05 at 4 23 12 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/301dcecb-c5be-49d2-8ecb-89855d6ca1a0">


# Test Plan

 - verified and added a unit test

# Changelog

 - Restricts add fixture modal options when provided

# Review requests

check the ODD protocol setup add fixture modal for a fixture not configured in D3

# Risk assessment

low
