### PR TITLE
feat(app): sort fixtures by configuration status in ODD fixture table

### DIFF
--- a/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/FixtureTable.tsx
@@ -64,7 +64,16 @@ export function FixtureTable({
     deckConfigCompatibility
   )
 
-  return requiredDeckConfigCompatibility.length > 0 ? (
+  // list not configured/conflicted fixtures first
+  const sortedDeckConfigCompatibility = requiredDeckConfigCompatibility.sort(
+    a =>
+      a.cutoutFixtureId != null &&
+      a.compatibleCutoutFixtureIds.includes(a.cutoutFixtureId)
+        ? 1
+        : -1
+  )
+
+  return sortedDeckConfigCompatibility.length > 0 ? (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
       <Flex
         color={COLORS.darkBlack70}
@@ -78,7 +87,7 @@ export function FixtureTable({
         <StyledText flex="2 0 0">{t('location')}</StyledText>
         <StyledText flex="4 0 0"> {t('status')}</StyledText>
       </Flex>
-      {requiredDeckConfigCompatibility.map((fixtureCompatibility, index) => {
+      {sortedDeckConfigCompatibility.map((fixtureCompatibility, index) => {
         return (
           <FixtureTableItem
             key={`FixtureTableItem_${index}`}


### PR DESCRIPTION
# Overview

list not configured/conflicted fixtures at the top of the ODD fixture table

closes RAUT-912

<img width="1136" alt="Screen Shot 2024-01-08 at 10 26 39 AM" src="https://github.com/Opentrons/opentrons/assets/29845468/8c01e768-d707-420c-8a90-15cc6719a1de">

# Test Plan

 - verified sorting behavior

# Changelog

 - Sorts fixtures by configuration status in ODD fixture table

# Review requests

check ODD fixture table order

# Risk assessment

low
