### PR TITLE
refactor(protocol-designer): dropTipLocation defaulted through createPresavedStepForm

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -46,14 +46,6 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       migrationModal: 'v8',
     },
     {
-      title:
-        'mix 5.0.x (schema 3, PD version 5.0.0) -> should migrate to 8.0.x, schema 8',
-      importFixture: '../../fixtures/protocol/5/mix_5_0_x.json',
-      expectedExportFixture: '../../fixtures/protocol/8/mix_8_0_0.json',
-      migrationModal: 'v8',
-      unusedPipettes: false,
-    },
-    {
       title: '96-channel full and column schema 8 -> reimported as schema 8',
       importFixture:
         '../../fixtures/protocol/8/ninetySixChannelFullAndColumn.json',

--- a/protocol-designer/cypress/integration/mixSettings.spec.js
+++ b/protocol-designer/cypress/integration/mixSettings.spec.js
@@ -316,7 +316,7 @@ describe('Advanced Settings for Mix Form', () => {
     // Verify dest well is selected
     cy.get('[id=BlowoutLocationField_dropdown]').should($input => {
       const value = $input.val()
-      const expectedSubstring = 'dest_well'
+      const expectedSubstring = 'trashBin'
       expect(value).to.include(expectedSubstring)
     })
     // Click on step 3 to verify the batch editing
@@ -326,7 +326,7 @@ describe('Advanced Settings for Mix Form', () => {
     // Verify that dest well is selected for the blowout option
     cy.get('[id=BlowoutLocationField_dropdown]').should($input => {
       const value = $input.val()
-      const expectedSubstring = 'dest_well'
+      const expectedSubstring = 'trashBin'
       expect(value).to.include(expectedSubstring)
     })
   })

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -35,6 +35,12 @@ export function DropTipField(
   const options: DropdownOption[] = []
   if (wasteChute != null) options.push(wasteChuteOption)
   if (trashBin != null) options.push(trashOption)
+
+  React.useEffect(() => {
+    if (additionalEquipment[String(dropdownItem)] == null) {
+      updateValue(null)
+    }
+  }, [dropdownItem])
   return (
     <FormGroup
       label={i18n.t('form.step_edit_form.field.location.label')}

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -35,7 +35,6 @@ export function DropTipField(
   const options: DropdownOption[] = []
   if (wasteChute != null) options.push(wasteChuteOption)
   if (trashBin != null) options.push(trashOption)
-
   return (
     <FormGroup
       label={i18n.t('form.step_edit_form.field.location.label')}

--- a/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DropTipField/index.tsx
@@ -36,13 +36,6 @@ export function DropTipField(
   if (wasteChute != null) options.push(wasteChuteOption)
   if (trashBin != null) options.push(trashOption)
 
-  const [selectedValue, setSelectedValue] = React.useState(
-    dropdownItem || (options[0] && options[0].value)
-  )
-  React.useEffect(() => {
-    updateValue(selectedValue)
-  }, [selectedValue])
-
   return (
     <FormGroup
       label={i18n.t('form.step_edit_form.field.location.label')}
@@ -51,13 +44,11 @@ export function DropTipField(
       <DropdownField
         options={options}
         name={name}
-        value={dropdownItem ? String(dropdownItem) : options[0].value}
+        value={dropdownItem ? String(dropdownItem) : null}
         onBlur={onFieldBlur}
         onFocus={onFieldFocus}
         onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-          const newValue = e.currentTarget.value
-          setSelectedValue(newValue)
-          updateValue(newValue)
+          updateValue(e.currentTarget.value)
         }}
       />
     </FormGroup>

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -57,6 +57,7 @@ import {
   _getPipetteEntitiesRootState,
   _getLabwareEntitiesRootState,
   _getInitialDeckSetupRootState,
+  _getAdditionalEquipmentEntitiesRootState,
 } from '../selectors'
 import {
   CreateDeckFixtureAction,
@@ -190,6 +191,9 @@ export const unsavedForm = (
         orderedStepIds: rootState.orderedStepIds,
         initialDeckSetup: _getInitialDeckSetupRootState(rootState),
         robotStateTimeline: action.meta.robotStateTimeline,
+        additionalEquipmentEntities: _getAdditionalEquipmentEntitiesRootState(
+          rootState
+        ),
       })
     }
 

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1424,6 +1424,14 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
                   stepForm.blowout_location?.includes('trashBin'))
             )
           : null
+      const mixStepTrashBin =
+        savedStepForms != null
+          ? Object.values(savedStepForms).find(
+              stepForm =>
+                stepForm.stepType === 'mix' &&
+                stepForm.dropTip_location.includes('trashBin')
+            )
+          : null
 
       let trashBinId: string | null = null
       if (moveLiquidStepTrashBin != null) {
@@ -1442,6 +1450,8 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
         ) {
           trashBinId = moveLiquidStepTrashBin.blowOut_location
         }
+      } else if (mixStepTrashBin != null) {
+        trashBinId = mixStepTrashBin.dropTip_location
       }
 
       const trashCutoutId =

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -49,6 +49,9 @@ beforeEach(() => {
         labwareOnMagModule,
       },
     },
+    additionalEquipmentEntities: {
+      mockTrash: { name: 'trashBin', id: 'mockTrash', location: 'A3' },
+    },
     savedStepForms: {},
     orderedStepIds: [],
     initialDeckSetup: {
@@ -122,7 +125,7 @@ describe('createPresavedStepForm', () => {
       })
     })
   })
-  it(`should call handleFormChange with a default pipette for "moveLiquid" step`, () => {
+  it(`should call handleFormChange with a default pipette and drop tip location for "moveLiquid" step`, () => {
     const args = { ...defaultArgs, stepType: 'moveLiquid' }
     expect(createPresavedStepForm(args)).toEqual({
       id: stepId,
@@ -130,7 +133,7 @@ describe('createPresavedStepForm', () => {
       nozzles: null,
       stepType: 'moveLiquid',
       // default fields
-      dropTip_location: null,
+      dropTip_location: 'mockTrash',
       aspirate_airGap_checkbox: false,
       aspirate_airGap_volume: '1',
       aspirate_delay_checkbox: false,
@@ -177,7 +180,7 @@ describe('createPresavedStepForm', () => {
     })
   })
   describe('mix step', () => {
-    it('should call handleFormChange with a default pipette for mix step', () => {
+    it('should call handleFormChange with a default pipette and drop tip location for mix step', () => {
       const args = { ...defaultArgs, stepType: 'mix' }
       expect(createPresavedStepForm(args)).toEqual({
         id: stepId,
@@ -186,7 +189,7 @@ describe('createPresavedStepForm', () => {
         // default fields
         labware: null,
         nozzles: null,
-        dropTip_location: null,
+        dropTip_location: 'mockTrash',
         wells: [],
         aspirate_delay_checkbox: false,
         aspirate_delay_seconds: `${DEFAULT_DELAY_SECONDS}`,

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -101,7 +101,6 @@ const _patchDefaultDropTipLocation = (args: {
   } else if (trashBin != null) {
     defaultDropTipId = trashBin.id
   }
-
   const formHasDropTipField = formData && 'dropTip_location' in formData
 
   if (formHasDropTipField && defaultDropTipId !== null) {

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -23,6 +23,7 @@ import {
   LabwareEntities,
   RobotState,
   Timeline,
+  AdditionalEquipmentEntities,
 } from '@opentrons/step-generation'
 import { FormData, StepType, StepIdType } from '../../form-types'
 import { InitialDeckSetup } from '../types'
@@ -37,6 +38,7 @@ export interface CreatePresavedStepFormArgs {
   orderedStepIds: OrderedStepIdsState
   initialDeckSetup: InitialDeckSetup
   robotStateTimeline: Timeline
+  additionalEquipmentEntities: AdditionalEquipmentEntities
 }
 type FormUpdater = (arg0: FormData) => FormPatch | null
 
@@ -70,6 +72,42 @@ const _patchDefaultPipette = (args: {
     const updatedFields = handleFormChange(
       {
         pipette: defaultPipetteId,
+      },
+      formData,
+      pipetteEntities,
+      labwareEntities
+    )
+    return updatedFields
+  }
+
+  return null
+}
+
+const _patchDefaultDropTipLocation = (args: {
+  additionalEquipmentEntities: AdditionalEquipmentEntities
+  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
+}): FormUpdater => formData => {
+  const { additionalEquipmentEntities, labwareEntities, pipetteEntities } = args
+  const trashBin = Object.values(additionalEquipmentEntities).find(
+    aE => aE.name === 'trashBin'
+  )
+  const wasteChute = Object.values(additionalEquipmentEntities).find(
+    aE => aE.name === 'wasteChute'
+  )
+  let defaultDropTipId = null
+  if (wasteChute != null) {
+    defaultDropTipId = wasteChute.id
+  } else if (trashBin != null) {
+    defaultDropTipId = trashBin.id
+  }
+
+  const formHasDropTipField = formData && 'dropTip_location' in formData
+
+  if (formHasDropTipField && defaultDropTipId !== null) {
+    const updatedFields = handleFormChange(
+      {
+        dropTip_location: defaultDropTipId,
       },
       formData,
       pipetteEntities,
@@ -223,10 +261,17 @@ export const createPresavedStepForm = ({
   stepId,
   stepType,
   robotStateTimeline,
+  additionalEquipmentEntities,
 }: CreatePresavedStepFormArgs): FormData => {
   const formData = createBlankForm({
     stepId,
     stepType,
+  })
+
+  const updateDefaultDropTip = _patchDefaultDropTipLocation({
+    labwareEntities,
+    pipetteEntities,
+    additionalEquipmentEntities,
   })
 
   const updateDefaultPipette = _patchDefaultPipette({
@@ -268,6 +313,7 @@ export const createPresavedStepForm = ({
   // passing the applied result from one updater as the input of the next
   return [
     updateDefaultPipette,
+    updateDefaultDropTip,
     updateTemperatureModuleId,
     updateThermocyclerFields,
     updateHeaterShakerModuleId,

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -89,6 +89,23 @@ const getLabwareOrAdditionalEquipmentEntity = (
   } else return null
 }
 
+const getDropTipLocation = (state: InvariantContext): string | null => {
+  const { additionalEquipmentEntities } = state
+  const trashBin = Object.values(additionalEquipmentEntities).find(
+    aE => aE.name === 'trashBin'
+  )
+  const wasteChute = Object.values(additionalEquipmentEntities).find(
+    aE => aE.name === 'wasteChute'
+  )
+  let defaultDropTipId = null
+  if (wasteChute != null) {
+    defaultDropTipId = wasteChute.id
+  } else if (trashBin != null) {
+    defaultDropTipId = trashBin.id
+  }
+
+  return defaultDropTipId
+}
 const getIsAdapterLocation = (
   newLocation: string,
   labwareEntities: LabwareEntities
@@ -397,6 +414,10 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
   newLocation: {
     getErrors: composeErrors(requiredField),
     hydrate: getLabwareLocation,
+  },
+  dropTip_location: {
+    getErrors: composeErrors(requiredField),
+    hydrate: getDropTipLocation,
   },
 }
 const profileFieldHelperMap: Record<string, StepFieldHelpers> = {

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -89,23 +89,6 @@ const getLabwareOrAdditionalEquipmentEntity = (
   } else return null
 }
 
-const getDropTipLocation = (state: InvariantContext): string | null => {
-  const { additionalEquipmentEntities } = state
-  const trashBin = Object.values(additionalEquipmentEntities).find(
-    aE => aE.name === 'trashBin'
-  )
-  const wasteChute = Object.values(additionalEquipmentEntities).find(
-    aE => aE.name === 'wasteChute'
-  )
-  let defaultDropTipId = null
-  if (wasteChute != null) {
-    defaultDropTipId = wasteChute.id
-  } else if (trashBin != null) {
-    defaultDropTipId = trashBin.id
-  }
-
-  return defaultDropTipId
-}
 const getIsAdapterLocation = (
   newLocation: string,
   labwareEntities: LabwareEntities
@@ -414,10 +397,6 @@ const stepFieldHelperMap: Record<StepFieldName, StepFieldHelpers> = {
   newLocation: {
     getErrors: composeErrors(requiredField),
     hydrate: getLabwareLocation,
-  },
-  dropTip_location: {
-    getErrors: composeErrors(requiredField),
-    hydrate: getDropTipLocation,
   },
 }
 const profileFieldHelperMap: Record<string, StepFieldHelpers> = {

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -244,10 +244,6 @@ export const substepTimelineMultiChannel = (
           numChannels = 96
         } else if (nozzles === COLUMN) {
           numChannels = 8
-        } else {
-          console.error(
-            'we currently do not support other 96-channel configurations'
-          )
         }
         const wellsForTips =
           numChannels &&

--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -30,7 +30,7 @@ function _wellsForPipette(
     let channels: 8 | 96 = pipChannels
     if (nozzles === ALL) {
       channels = 96
-    } else if (nozzles === COLUMN) {
+    } else if (nozzles === COLUMN || pipChannels === 8) {
       channels = 8
     } else {
       console.error(`we don't support other 96-channel configurations yet`)


### PR DESCRIPTION
addresses RAUT-921

# Overview

There was some brittleness with how the drop tip location was being auto-populated. this is because `React.useEffect` was being used. I refactored it to get populated through the `createPresavedStepForm` which is what we are currently doing to auto-populated the pipette.

Additionally, I added what the drop tip location should hydrate to

# Test Plan

Test with either ot-2 or Flex, add a transfer and mix step and make sure the drop tip location is populated correctly. If both trash bin and waste chute are attached, it should default to `wasteChute` first.

Additionally, upload the attached protocol. Add a waste chute and delete the trash bin. Go to the timeline tab and see that each step is populated correctly.

[Ribogreen assay 24 samples in 2 plates.json](https://github.com/Opentrons/opentrons/files/13878483/Ribogreen.assay.24.samples.in.2.plates.json)

# Changelog

- clean up the `dropTipField` component by removing the `React.useEffect` and `React.useState`
- create a new function `_patchDefaultDropTipLocation` to grab the default drop tip location and plug it into the `createPresavedStepForm`
- fix the `createPresavedStepForm` test
- add a `getDropTipLocation` fn for the `dropTipLocation` to hydrate to
- BONUS: there were a few errors in console regarding the substep highlights and timeline that i fixed

# Review requests

see test plan

# Risk assessment

low
