### PR TITLE
fix(protocol-designer): more space between wasteChute and slotLabel

### DIFF
--- a/protocol-designer/src/components/DeckSetup/SlotLabels.tsx
+++ b/protocol-designer/src/components/DeckSetup/SlotLabels.tsx
@@ -61,7 +61,7 @@ export const SlotLabels = ({
         height="2.5rem"
         width={hasStagingAreas ? '40.5rem' : '30.375rem'}
         x="-15"
-        y={hasWasteChute ? '-90' : '-65'}
+        y={hasWasteChute ? '-100' : '-65'}
       >
         <Flex
           alignItems={ALIGN_CENTER}

--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -618,7 +618,7 @@ export const DeckSetup = (): JSX.Element => {
                               robotType={robotType}
                               trashIconColor={lightFill}
                               trashCutoutId={cutoutId as TrashCutoutId}
-                              backgroundColor={darkFill}
+                              backgroundColor={COLORS.grey2}
                             />
                           </React.Fragment>
                         ) : null


### PR DESCRIPTION
# Overview

A quick style change to leave more space between `wasteChute` and `slotLabel`. The `slotLabels` increased in `fontSize` last minute before 8.0 was cut, leaving barely any room between the `wasteChute` and `slotLabel`. This adds some space

Also the waste chute and trash bin have been different colors for 8.0 which is sort of ugly/annoying. So i fixed it up here. This change i think also happened last minute before 8.0 was cut.

# Test Plan

Create a flex protocol and add a waste chute. See that the slot label and waste chute space is big enough. See that the waste chute and trash bin are the same color

# Changelog

- increase the `Y` prop positioning
- change trash bin color fill to `grey.2` to match the waste chute

# Review requests

see test plan

# Risk assessment

low