### PR TITLE
feat(hardware): Add the NodeIds for the HEPA/UV module

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -24,12 +24,14 @@ class NodeId(int, Enum):
     gripper = 0x20
     gripper_z = 0x21
     gripper_g = 0x22
+    hepa_filter = 0x80
     pipette_left_bootloader = pipette_left | 0xF
     pipette_right_bootloader = pipette_right | 0xF
     gantry_x_bootloader = gantry_x | 0xF
     gantry_y_bootloader = gantry_y | 0xF
     head_bootloader = head | 0xF
     gripper_bootloader = gripper | 0xF
+    hepa_filter_bootloader = hepa_filter | 0xF
 
     def is_bootloader(self) -> bool:
         """Whether this node ID is a bootloader."""

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -5,7 +5,7 @@ by default. Please do not unconditionally import things outside the python stand
 library.
 """
 from enum import Enum, unique
-from typing import Union
+from typing import Union, Dict, List
 
 
 @unique
@@ -24,35 +24,78 @@ class NodeId(int, Enum):
     gripper = 0x20
     gripper_z = 0x21
     gripper_g = 0x22
-    hepa_filter = 0x80
+    hepa_uv = 0x32
     pipette_left_bootloader = pipette_left | 0xF
     pipette_right_bootloader = pipette_right | 0xF
     gantry_x_bootloader = gantry_x | 0xF
     gantry_y_bootloader = gantry_y | 0xF
     head_bootloader = head | 0xF
     gripper_bootloader = gripper | 0xF
-    hepa_filter_bootloader = hepa_filter | 0xF
+    # We cant use bitwise & 0xF0 to determine the application Node because
+    # the NodeId bitmask is only 7 bits long, which means we only have
+    # 7 unique pairs of (node_id <-> bootloader_node_id). i.e,
+    # head (0x50) <-> head_bootloader (0x5f). Since we have already
+    # hit that limit we have to move away from categorizing nodes with
+    # 0xf as the bootloader node and instead use an explicit map as defined
+    # here to determine relationship between node and bootloader_node.
+    hepa_uv_bootloader = hepa_uv | 0xE
+
+    @classmethod
+    def bootloader_map(cls) -> Dict["NodeId", List["NodeId"]]:
+        """Mapping between bootloader_node and nodes.
+
+        Note: The ordering of the Node list matters as the first element
+        represents the core appliaction node for that given node. For example
+
+        NodeId.head_bootloader : [NodeId.head, NodeId.head_l, NodeId.head_r]
+
+        The core node here is NodeId.head because its the first element.
+        """
+        return {
+            NodeId.broadcast: [NodeId.broadcast],
+            NodeId.host: [NodeId.host],
+            NodeId.pipette_left_bootloader: [NodeId.pipette_left],
+            NodeId.pipette_right_bootloader: [NodeId.pipette_right],
+            NodeId.gantry_x_bootloader: [NodeId.gantry_x],
+            NodeId.gantry_y_bootloader: [NodeId.gantry_y],
+            NodeId.head_bootloader: [NodeId.head, NodeId.head_l, NodeId.head_r],
+            NodeId.gripper_bootloader: [
+                NodeId.gripper,
+                NodeId.gripper_z,
+                NodeId.gripper_g,
+            ],
+            NodeId.hepa_uv_bootloader: [NodeId.hepa_uv],
+        }
 
     def is_bootloader(self) -> bool:
         """Whether this node ID is a bootloader."""
-        return bool(self.value & 0xF == 0xF)
+        return (
+            self not in [NodeId.broadcast, NodeId.host]
+            and self in NodeId.bootloader_map()
+        )
 
     def bootloader_for(self) -> "NodeId":
-        """The associated bootloader node ID for the node.
+        """The associated bootloader node ID for the node."""
+        if self.is_bootloader():
+            return self
 
-        This is safe to call on any node id, including ones that are already bootloaders.
-        """
-        return NodeId(self.value | 0xF)
+        # Get the bootloader for the given node
+        for bootloader, nodes in self.bootloader_map().items():
+            if self in nodes:
+                return bootloader
+        raise ValueError(f"No bootloader node for {self.name}.")
 
     def application_for(self) -> "NodeId":
         """The associated core node ID for the node (i.e. head, not head_l).
 
-        This is safe to call on any node ID, including non-core application node IDs like
-        head_l. It will always give the code node ID.
+        This is safe to call on any node ID, including non-core application
+        node IDs like head_l, head_bootloader. It will always give the core node ID.
         """
-        # in c this would be & ~0xf but in python that gives 0x10 for some reason
-        # so let's write out the whole byte
-        return NodeId(self.value & 0xF0)
+        for bootloader, nodes in self.bootloader_map().items():
+            # The core application node for any node is the first item in the node list
+            if bootloader is self or self in nodes:
+                return nodes[0]
+        raise ValueError(f"No application node for {self.name}.")
 
 
 # make these negative numbers so there is no chance they overlap with NodeId

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_constants.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_constants.py
@@ -43,7 +43,6 @@ def test_is_bootloader(node_id: NodeId) -> None:
 @pytest.mark.parametrize("node_id", [n.application_for() for n in NodeId])
 def test_bootloader_for(node_id: NodeId) -> None:
     """Test application node id to bootloader node id mapping."""
-
     # There is no bootloader for these nodes, they return themselves.
     if node_id in {NodeId.broadcast, NodeId.host}:
         assert node_id.bootloader_for() == node_id
@@ -56,7 +55,6 @@ def test_bootloader_for(node_id: NodeId) -> None:
 @pytest.mark.parametrize("node_id", {n for n in NodeId})
 def test_application_for(node_id: NodeId) -> None:
     """Test bootloader node to application node mapping."""
-
     # bootloaders should produce application nodes
     if node_id.is_bootloader():
         assert node_id.application_for() == NodeId.bootloader_map()[node_id][0]

--- a/hardware/tests/opentrons_hardware/firmware_bindings/test_constants.py
+++ b/hardware/tests/opentrons_hardware/firmware_bindings/test_constants.py
@@ -4,6 +4,7 @@ from typing import Iterable
 import pytest
 
 from opentrons_hardware.firmware_bindings import constants
+from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.firmware_bindings.arbitration_id import (
     NODE_ID_BITS,
     MESSAGE_ID_BITS,
@@ -24,3 +25,49 @@ def test_range(subject: Iterable[int], bit_width: int) -> None:
     mask = (2**bit_width) - 1
     for v in subject:
         assert (v & ~mask) == 0, f"{v} must be between 0 and {mask}"
+
+
+@pytest.mark.parametrize("node_id", [n for n in NodeId if n.is_bootloader()])
+def test_is_bootloader(node_id: NodeId) -> None:
+    """Test that we correctly identify a node as bootloader or not."""
+    # broadcast and host nodes do not have a bootloader node id
+    assert node_id not in {
+        NodeId.broadcast,
+        NodeId.host,
+    }, "No bootloader for these nodes"
+
+    # Make sure we have the bootloader node in our above list
+    assert node_id in NodeId.bootloader_map(), f"bootloader node {node_id} not found"
+
+
+@pytest.mark.parametrize("node_id", [n.application_for() for n in NodeId])
+def test_bootloader_for(node_id: NodeId) -> None:
+    """Test application node id to bootloader node id mapping."""
+
+    # There is no bootloader for these nodes, they return themselves.
+    if node_id in {NodeId.broadcast, NodeId.host}:
+        assert node_id.bootloader_for() == node_id
+
+    # Make sure we have the right values between nodes
+    bootloader_node = node_id.bootloader_for()
+    assert node_id in NodeId.bootloader_map()[bootloader_node]
+
+
+@pytest.mark.parametrize("node_id", {n for n in NodeId})
+def test_application_for(node_id: NodeId) -> None:
+    """Test bootloader node to application node mapping."""
+
+    # bootloaders should produce application nodes
+    if node_id.is_bootloader():
+        assert node_id.application_for() == NodeId.bootloader_map()[node_id][0]
+
+    # get a flattened list of all the sub-nodes, which are nodes with more
+    # than one element in the NodeId.bootloader_map list.
+    sub_nodes = sum(  # type: ignore[var-annotated]
+        [n for n in NodeId.bootloader_map().values() if len(n) > 1], []
+    )
+    # Make sure that if this is a sub-node that the application node is the first
+    # element in the bootloader map list
+    if node_id in sub_nodes:
+        bootloader = node_id.bootloader_for()
+        assert node_id.application_for() == NodeId.bootloader_map()[bootloader][0]


### PR DESCRIPTION
# Overview

We are adding the HEPA/UV module, which talks to the Flex over CAN; this means we need two new NodeIds, one for the application and one for the bootloader. Unfortunately, the node id is 7 bits long in the arbitration bitmask that we use as the header for CAN messages, which means we can only have 7 unique bootloader_node_ids. This is because we perform a bitwise OR on the node_id with the value 0xF, which converts the node_id from something like 0x30 to 0x3e, which works well until you have node_ids that occupy the same 10s place as another node like 0x33, as this produces the same bootloader_node_id for more than one node_id, which is bad.

So instead of relying on this simple bitwise operation and treating the NodeId as just a 7-digit bitmask capable of only having 7 unique bootloaders, let's instead have a direct mapping between bootloader_node_ids and node_ids. This increases the number of unique NodeIds we can have to 125 ids ( 127d (1111111b) - 2 (broadcast, host) = 125). Since the firmware_binding/contants.py file is already the source of truth for NodeId values, and we don't actually do any multicasting using the 7-bit NodeId, we can just use these 7 bits as their decimal equivalent without causing issues as long as we keep the old NodeIds the same.

# Test Plan

- [x] Make sure that messages over CAN have the corresponding NodeId so there is no mixup.
- [x] Make sure that all axes still move without issues
- [x] Make sure that the head_l, head_r move up/down
- [x] Make sure the plunger for pipettes still works
- [x] Make sure the gripper_z and gripper_g still work

# Changelog

- Add node_id = 0x32 and bootloader_node_id = 0x3e for HEPA/UV module
- Add direct mapping between bootloader_node_ids and node_ids to move away from node_id 7bit limitation.
- Convert existing NodeId functions to use the new mapping mechanism.

# Review requests

Let's make sure this makes sense and that there aren't any deeper consequences from making this change, is there something obvious I'm missing, any other considerations?

# Risk assessment

High if the logic or assumptions are wrong


