### PR TITLE
docs(api): describe new `distribute()` volume clamping behavior

### DIFF
--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -76,7 +76,9 @@ To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dis
     pipette.dispense(200, plate["B1"])
 
 .. note::
-    In API version 2.16 and earlier, you could pass a ``volume`` argument to ``dispense()`` greater than what was aspirated into the pipette. The API automatically clamped this value, and the robot *would not* move the plunger lower than dispensing the exact amount. In version 2.17 and later, passing such values raises an error.
+    In API version 2.16 and earlier, you could pass a ``volume`` argument to ``dispense()`` greater than what was aspirated into the pipette. In this case, the API would ignore ``volume`` and dispense the pipette's :py:obj:`~.InstrumentContext.current_volume`. The robot *would not* move the plunger lower as a result.
+
+    In version 2.17 and later, passing such values raises an error.
 
     To move the plunger a small extra amount, add a :ref:`push out <push-out-dispense>`. Or to move it a large amount, use :ref:`blow out <blow-out>`.
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -75,6 +75,11 @@ To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dis
 
     pipette.dispense(200, plate["B1"])
 
+.. note::
+    In version 2.16 and earlier of the API, you could pass a ``volume`` argument to ``dispense()`` greater than what was aspirated into the pipette. The API automatically clamped this value, and the robot *would not* move the plunger lower than dispensing the exact amount. In version 2.17 and later, passing such values raises an error.
+
+    To move the plunger a small extra amount, add a :ref:`push out <push-out-dispense>`. Or to move it a large amount, use :ref:`blow out <blow-out>`.
+
 If the pipette doesn’t move, you can specify an additional dispense action without including a location. To demonstrate, this code snippet pauses the protocol, automatically resumes it, and dispense a second time from location B1.
 
 .. code-block:: python
@@ -128,9 +133,6 @@ For example, this dispense action moves the plunger the equivalent of an additio
     pipette.drop_tip()
 
 .. versionadded:: 2.15
-
-.. note::
-    In version 7.0.2 and earlier of the robot software, you could accomplish a similar result by dispensing a volume greater than what was aspirated into the pipette. In version 7.1.0 and later, the API will return an error. Calculate the difference between the two amounts and use that as the value of ``push_out``.
 
 .. _new-blow-out:
 

--- a/api/docs/v2/basic_commands/liquids.rst
+++ b/api/docs/v2/basic_commands/liquids.rst
@@ -76,7 +76,7 @@ To dispense liquid from a pipette tip, call the :py:meth:`.InstrumentContext.dis
     pipette.dispense(200, plate["B1"])
 
 .. note::
-    In version 2.16 and earlier of the API, you could pass a ``volume`` argument to ``dispense()`` greater than what was aspirated into the pipette. The API automatically clamped this value, and the robot *would not* move the plunger lower than dispensing the exact amount. In version 2.17 and later, passing such values raises an error.
+    In API version 2.16 and earlier, you could pass a ``volume`` argument to ``dispense()`` greater than what was aspirated into the pipette. The API automatically clamped this value, and the robot *would not* move the plunger lower than dispensing the exact amount. In version 2.17 and later, passing such values raises an error.
 
     To move the plunger a small extra amount, add a :ref:`push out <push-out-dispense>`. Or to move it a large amount, use :ref:`blow out <blow-out>`.
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -129,7 +129,7 @@ Changes in API Versions
 Version 2.17
 ------------
 
-- :py:meth:`.dispense` will now raise an error if you try to dispense more than is available.
+- :py:meth:`.dispense` now raises an error if you try to dispense more than :py:obj:`.InstrumentContext.current_volume`.
 
 Version 2.16
 ------------

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -290,8 +290,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-dispense` for more details and examples.
 
-        :param volume: The volume to dispense, measured in µL. If only a volume is
-                       passed, the pipette will dispense from its current position.
+        :param volume: The volume to dispense, measured in µL.
 
                          - If unspecified or ``None``, dispense the :py:attr:`current_volume`.
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -290,15 +290,15 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`new-dispense` for more details and examples.
 
-        :param volume: The volume to dispense, measured in µL. If unspecified,
-                       defaults to :py:attr:`current_volume`. If only a volume is
+        :param volume: The volume to dispense, measured in µL. If only a volume is
                        passed, the pipette will dispense from its current position.
 
-                       If ``dispense`` is called with a volume of precisely 0, its behavior
-                       depends on the API level of the protocol. On API levels below 2.16,
-                       it will behave the same as a volume of ``None``/unspecified: dispense
-                       all liquid in the pipette. On API levels at or above 2.16, no liquid
-                       will be dispensed.
+                         - If unspecified or ``None``, dispense the :py:attr:`current_volume`.
+
+                         - If 0, the behavior of ``dispense()`` depends on the API level
+                           of the protocol. In API version 2.16 and earlier, dispense all
+                           liquid in the pipette (same as unspecified or ``None``). In API
+                           version 2.17 and later, dispense no liquid.
         :type volume: int or float
 
         :param location: Tells the robot where to dispense liquid held in the pipette.


### PR DESCRIPTION
# Overview

Brings the docs up to date with changes in #14253.

Tagged "do not merge" because this has PAPI 2.17 features. This PR should eventually be retargeted on the feature branch for the first robot stack version that supports 2.17.

Addresses RTC-383.

# Test Plan

Check the [sandbox](http://sandbox.docs.opentrons.com/docs-dispense-note/v2/basic_commands/liquids.html#dispense).

# Changelog

- Rewrote note about dispense volumes and moved it up in the section (it's not really about `push_out` anymore)
  - Clamped down on "clamping"
- Updated bullet on Versioning page
- Cleaned up docstring for `volume` argument of `dispense()`

# Review requests

Is there anything more we'd like to say about dispense volumes vis-a-vis push out? I drafted this but I think it's not actually a good real-world example.

```
If you want to move the plunger a certain amount, regardless of how much has been
aspirated, you can calculate the values of ``volume`` and ``push_out`` based on the
:py:obj:`~InstrumentContext.current_volume` held in the pipette::

    pipette.pick_up_tip()
    plunger_amount=105
    pipette.aspirate(100, plate['A1'])
    pipette.dispense(
        volume=min(plunger_amount, pipette.current_volume), 
        location=plate['B1'], 
        push_out=max(pipette.current_volume-plunger_amount, 0)
    )   # dispense 100, push out 5
    pipette.aspirate(120, plate['A2'])
    pipette.dispense(
        volume=min(plunger_amount, pipette.current_volume), 
        location=plate['B2'], 
        push_out=max(pipette.current_volume-plunger_amount, 0)
    )   # dispense 105, push out 0, 15 left in tip
    pipette.drop_tip()
    
Note that when passing large ``push_out`` values, the plunger can't pass its physical
lower limit. For example, ``push_out=100`` will not have the effect of moving the
plunger the same distance as during a 100 µL dispense. For clearing large amounts
through the pipette, blow out instead.

```

# Risk assessment

v v low, docs and docstrings only. 