### PR TITLE
fix(app): fix pause icon alignment in ODD command icon

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
@@ -236,7 +236,7 @@ export function RunningProtocolCommandList({
                     borderRadius={BORDERS.borderRadiusSize2}
                     gridGap="0.875rem"
                   >
-                    <CommandIcon command={command} svgWidth="2rem" />
+                    <CommandIcon command={command} size="2rem" />
                     <CommandText
                       command={command}
                       robotSideAnalysis={robotSideAnalysis}

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
@@ -234,8 +234,9 @@ export function RunningProtocolCommandList({
                     lineHeight="1.75rem"
                     fontWeight={TYPOGRAPHY.fontWeightRegular}
                     borderRadius={BORDERS.borderRadiusSize2}
+                    gridGap="0.875rem"
                   >
-                    <CommandIcon command={command} />
+                    <CommandIcon command={command} svgWidth="2rem" />
                     <CommandText
                       command={command}
                       robotSideAnalysis={robotSideAnalysis}

--- a/app/src/organisms/RunPreview/CommandIcon.tsx
+++ b/app/src/organisms/RunPreview/CommandIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { SPACING, Icon, IconName } from '@opentrons/components'
+import { Icon, IconName } from '@opentrons/components'
 import { RunTimeCommand } from '@opentrons/shared-data'
 import type { StyleProps } from '@opentrons/components'
 
@@ -14,7 +14,7 @@ interface CommandIconProps extends StyleProps {
   svgWidth?: string | number
 }
 export function CommandIcon(props: CommandIconProps): JSX.Element | null {
-  const { command, svgWidth, ...styleProps } = props
+  const { command, svgWidth = '1rem', ...styleProps } = props
   let iconName = null
   if (
     command.commandType === 'moveLabware' &&

--- a/app/src/organisms/RunPreview/CommandIcon.tsx
+++ b/app/src/organisms/RunPreview/CommandIcon.tsx
@@ -31,6 +31,6 @@ export function CommandIcon(props: CommandIconProps): JSX.Element | null {
   }
 
   return iconName != null ? (
-    <Icon {...styleProps} svgWidth={svgWidth} name={iconName} flex="0 0 auto" />
+    <Icon {...styleProps} size={svgWidth} name={iconName} flex="0 0 auto" />
   ) : null
 }

--- a/app/src/organisms/RunPreview/CommandIcon.tsx
+++ b/app/src/organisms/RunPreview/CommandIcon.tsx
@@ -11,10 +11,10 @@ const ICON_BY_COMMAND_TYPE: { [commandType: string]: IconName } = {
 }
 interface CommandIconProps extends StyleProps {
   command: RunTimeCommand
-  svgWidth?: string | number
+  size?: string | number
 }
 export function CommandIcon(props: CommandIconProps): JSX.Element | null {
-  const { command, svgWidth = '1rem', ...styleProps } = props
+  const { command, size = '1rem', ...styleProps } = props
   let iconName = null
   if (
     command.commandType === 'moveLabware' &&
@@ -31,6 +31,6 @@ export function CommandIcon(props: CommandIconProps): JSX.Element | null {
   }
 
   return iconName != null ? (
-    <Icon {...styleProps} size={svgWidth} name={iconName} flex="0 0 auto" />
+    <Icon {...styleProps} size={size} name={iconName} flex="0 0 auto" />
   ) : null
 }

--- a/app/src/organisms/RunPreview/CommandIcon.tsx
+++ b/app/src/organisms/RunPreview/CommandIcon.tsx
@@ -11,9 +11,10 @@ const ICON_BY_COMMAND_TYPE: { [commandType: string]: IconName } = {
 }
 interface CommandIconProps extends StyleProps {
   command: RunTimeCommand
+  svgWidth?: string | number
 }
 export function CommandIcon(props: CommandIconProps): JSX.Element | null {
-  const { command, ...styleProps } = props
+  const { command, svgWidth, ...styleProps } = props
   let iconName = null
   if (
     command.commandType === 'moveLabware' &&
@@ -30,11 +31,6 @@ export function CommandIcon(props: CommandIconProps): JSX.Element | null {
   }
 
   return iconName != null ? (
-    <Icon
-      {...styleProps}
-      name={iconName}
-      size={SPACING.spacing20}
-      flex="0 0 auto"
-    />
+    <Icon {...styleProps} svgWidth={svgWidth} name={iconName} flex="0 0 auto" />
   ) : null
 }

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -131,11 +131,7 @@ export const RunPreviewComponent = (
                 `}
               >
                 <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-                  <CommandIcon
-                    command={command}
-                    color={contentColor}
-                    size="1rem"
-                  />
+                  <CommandIcon command={command} color={contentColor} />
                   <CommandText
                     command={command}
                     robotSideAnalysis={robotSideAnalysis}

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -131,7 +131,11 @@ export const RunPreviewComponent = (
                 `}
               >
                 <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-                  <CommandIcon command={command} color={contentColor} />
+                  <CommandIcon
+                    command={command}
+                    color={contentColor}
+                    svgWidth="1rem"
+                  />
                   <CommandText
                     command={command}
                     robotSideAnalysis={robotSideAnalysis}

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -134,7 +134,7 @@ export const RunPreviewComponent = (
                   <CommandIcon
                     command={command}
                     color={contentColor}
-                    svgWidth="1rem"
+                    size="1rem"
                   />
                   <CommandText
                     command={command}


### PR DESCRIPTION
close [RQA-2030](https://opentrons.atlassian.net/browse/RQA-2030)

# Overview

Fix the ODD pause icon alignment in commands with text that span more than 1 line.

# Test Plan

1. Run a Flex protocol with a mult-line pause command (example)
2. Observe runlog on desktop and ODD
<img width="985" alt="Screen Shot 2024-01-16 at 2 31 29 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/eca6607a-6c50-4038-b597-3991a283cbde">
<img width="861" alt="Screen Shot 2024-01-16 at 2 19 47 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/3370abdc-ecd2-4da8-895b-33e49863c370">

# Changelog

- add `svgWidth` prop to CommandIcon component
- pass proper `svgWidth` for desktop and ODD with respect to designs, accounting for possible multi-line CommandText 

# Risk assessment
low

[RQA-2030]: https://opentrons.atlassian.net/browse/RQA-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ