### PR TITLE
fix(app): update LPC labware and pipette render for labware and pipette renders

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LabwarePositionCheck/JogToWell.tsx
@@ -97,7 +97,10 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
   }, [])
 
   let wellsToHighlight: string[] = []
-  if (getPipetteNameSpecs(pipetteName)?.channels === 8) {
+  if (
+    getPipetteNameSpecs(pipetteName)?.channels === 8 &&
+    !shouldUseMetalProbe
+  ) {
     wellsToHighlight = labwareDef.ordering[0]
   } else {
     wellsToHighlight = ['A1']
@@ -150,6 +153,7 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
                 <PipetteRender
                   labwareDef={labwareDef}
                   pipetteName={pipetteName}
+                  usingMetalProbe={shouldUseMetalProbe}
                 />
               </>
             )}

--- a/components/src/hardware-sim/Pipette/PipetteRender.tsx
+++ b/components/src/hardware-sim/Pipette/PipetteRender.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import classNames from 'classnames'
 import {
   getPipetteNameSpecs,
   LabwareDefinition2,
@@ -18,7 +17,6 @@ import {
 } from './constants'
 import { EmanatingNozzle } from './EmanatingNozzle'
 import { EightEmanatingNozzles } from './EightEmanatingNozzles'
-import styles from './styles.css'
 
 interface PipetteRenderProps {
   labwareDef: LabwareDefinition2
@@ -66,7 +64,7 @@ export const PipetteRender = (props: PipetteRenderProps): JSX.Element => {
       }
       x={x - probeOffsetX}
       y={y}
-      className={classNames(styles.overflow)}
+      outerProps={{ style: { overflow: 'visible' } }}
       innerDivProps={{
         style: {
           width: '100%',

--- a/components/src/hardware-sim/Pipette/PipetteRender.tsx
+++ b/components/src/hardware-sim/Pipette/PipetteRender.tsx
@@ -38,9 +38,9 @@ export const PipetteRender = (props: PipetteRenderProps): JSX.Element => {
   const x = labwareDef.wells.A1.x - cx
   const y = channels === 1 ? labwareDef.wells.A1.y - cy : MULTI_CHANNEL_Y_OFFSET
 
-  let boxWidth
-  let probeOffsetX = 0
-  let probeOffsetY = 0
+  let boxWidth: number
+  let probeOffsetX: number = 0
+  let probeOffsetY: number = 0
   if (channels === 1) {
     boxWidth = SINGLE_CHANNEL_PIPETTE_WIDTH
   } else if (channels === 8) {

--- a/components/src/hardware-sim/Pipette/constants.ts
+++ b/components/src/hardware-sim/Pipette/constants.ts
@@ -1,8 +1,10 @@
+// These constants are used only in pipette render in LPC. The values do not necessarily reflect physical pipette dimensions.
 export const SINGLE_CHANNEL_PIPETTE_WIDTH = 18.7
 export const SINGLE_CHANNEL_PIPETTE_HEIGHT = 30.5
 
 export const MULTI_CHANNEL_PIPETTE_WIDTH = 18.7
 export const MULTI_CHANNEL_PIPETTE_HEIGHT = 90.3
+export const NINETY_SIX_CHANNEL_PIPETTE_WIDTH = 117.7
 
 export const MULTI_CHANNEL_CENTER_Y_NOZZLE = 13.3
 export const MULTI_CHANNEL_Y_OFFSET = -2.5


### PR DESCRIPTION
closes [RQA-2174](https://opentrons.atlassian.net/jira/software/c/projects/RQA/issues/RQA-2174)
closes [RQA-2097](https://opentrons.atlassian.net/browse/RQA-2097)

# Overview

Labware render highlighted wells and pipette render box and emanating nozzles position and number should reflect the number of pipette channels, the labware layout, and whether probe (Flex) or tip (OT-2) LPC is being utilized. 

See large testing matrix below for all conditions.

# Test Plan

## Probe LPC

96-channel
<img width="743" alt="96ch_1well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/1e85ccfc-d899-4686-90df-56c04b3bc726">
<img width="744" alt="96ch_12well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/2256f1a3-778a-42ab-8536-6d2d27d4b948">
<img width="746" alt="96ch_96well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/01bf83bc-1217-48e7-a424-01675e540446">

8-channel
<img width="737" alt="8ch_1well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/36c0d6b7-89b8-4eef-a644-cef28cd49014">
<img width="733" alt="8ch_12well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/6b601fa7-5bf8-45b8-a150-0c847fb73d02">
<img width="742" alt="8ch_96well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/0b4510bf-7c14-4c8d-b7f0-32c14544e83d">

1-channel
<img width="744" alt="1ch_1well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/2da7acb1-01ce-4809-8786-34fa90baa360">
<img width="738" alt="1ch_12well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/ad4a301e-3e32-4d27-a24a-3b3197d5d7ab">
<img width="735" alt="1ch_96well_probe" src="https://github.com/Opentrons/opentrons/assets/47604184/fdfbb8b9-829c-460e-ab8b-c5d13f4f7f2f">


## Tip LPC

8-channel
<img width="739" alt="Screen Shot 2024-01-02 at 5 24 59 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/840b151d-259c-4308-ba2a-e8d4a89716a6">
<img width="744" alt="8ch_12well_tip" src="https://github.com/Opentrons/opentrons/assets/47604184/06501d01-17f3-4922-a090-1ec42337340c">
<img width="745" alt="8ch_96well_tip" src="https://github.com/Opentrons/opentrons/assets/47604184/b0021716-b742-4035-b156-a401082abefb">


1-channel
<img width="741" alt="1ch_1well_tip" src="https://github.com/Opentrons/opentrons/assets/47604184/448c1366-de53-4eff-89db-617dbad0f6ab">
<img width="736" alt="1ch_12well_tip" src="https://github.com/Opentrons/opentrons/assets/47604184/a933f551-98f3-4b86-b59a-781b6df958e6">
<img width="747" alt="1ch_96well_tip" src="https://github.com/Opentrons/opentrons/assets/47604184/76fc0707-61ea-40f4-9aa0-02fd7bde67a0">


# Changelog
- provide `usingMetalProbe` prop to PipetteRender
- add constant for 96-channel projection
- determine position of emanating nozzles and pipette projection based on probe usage and labware grid

[RQA-2174]: https://opentrons.atlassian.net/browse/RQA-2174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-2097]: https://opentrons.atlassian.net/browse/RQA-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ