### PR TITLE
fix(api): Check for possible collision between lifted labware and attached tips

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, Type, List
+from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
 from opentrons.types import Point

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from pydantic import BaseModel, Field
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, List
 from typing_extensions import Literal
 
 from opentrons.types import Point
@@ -199,6 +199,7 @@ class MoveLabwareImplementation(
                 pickUpOffset=params.pickUpOffset or LabwareOffsetVector(x=0, y=0, z=0),
                 dropOffset=params.dropOffset or LabwareOffsetVector(x=0, y=0, z=0),
             )
+
             # Skips gripper moves when using virtual gripper
             await self._labware_movement.move_labware_with_gripper(
                 labware_id=params.labwareId,

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -98,9 +98,8 @@ class LabwareMovementHandler:
                 for pipette_id, tip in attached_tips:
                     if not self._state_store.geometry.validate_gripper_labware_tip_collision(
                         gripper_homed_position_z=166.125,
-                        pipettes_homed_position_z=248.0,
-                        pipette_id=pipette_id,
                         tip=tip,
+                        pipette_id=pipette_id,
                         labware_id=labware_id,
                         current_location=current_location,
                     ):
@@ -133,18 +132,10 @@ class LabwareMovementHandler:
         attached_tips = self._state_store.pipettes.get_all_attached_tips()
         if attached_tips:
             for pipette_id, tip in attached_tips:
-                pipette_mount = self._state_store.pipettes.get_mount(
-                    pipette_id
-                ).to_hw_mount()
-                pipetted_homed_position = await ot3api.gantry_position(
-                    mount=pipette_mount
-                )
-
                 if not self._state_store.geometry.validate_gripper_labware_tip_collision(
                     gripper_homed_position_z=gripper_homed_position.z,
-                    pipettes_homed_position_z=pipetted_homed_position.z,
-                    pipette_id=pipette_id,
                     tip=tip,
+                    pipette_id=pipette_id,
                     labware_id=labware_id,
                     current_location=current_location,
                 ):

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -91,8 +91,8 @@ class LabwareMovementHandler:
         use_virtual_gripper = self._state_store.config.use_virtual_gripper
 
         if use_virtual_gripper:
-            # During Analysis we will pass in hard coded estimates for certain positions on accessible during execution
-            # Estimated gripper homed position Z: 253.575 + 93.85 - 94.825 - 86.475 = 166.125 mm
+            # During Analysis we will pass in hard coded estimates for certain positions only accessible during execution
+            # Estimated gripper homed Z position: 166.125 mm
             attached_tips = self._state_store.pipettes.get_all_attached_tips()
             if attached_tips:
                 for pipette_id, tip in attached_tips:
@@ -132,7 +132,12 @@ class LabwareMovementHandler:
         attached_tips = self._state_store.pipettes.get_all_attached_tips()
         if attached_tips:
             for pipette_id, tip in attached_tips:
-                pipetted_homed_position = await ot3api.gantry_position(mount=self._state_store.pipettes.get_mount(pipette_id))
+                pipette_mount = self._state_store.pipettes.get_mount(
+                    pipette_id
+                ).to_hw_mount()
+                pipetted_homed_position = await ot3api.gantry_position(
+                    mount=pipette_mount
+                )
 
                 if not self._state_store.geometry.validate_gripper_labware_tip_collision(
                     gripper_homed_position_z=gripper_homed_position.z,

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -99,6 +99,7 @@ class LabwareMovementHandler:
                     if not self._state_store.geometry.validate_gripper_labware_tip_collision(
                         gripper_homed_position_z=166.125,
                         pipettes_homed_position_z=248.0,
+                        pipette_id=pipette_id,
                         tip=tip,
                         labware_id=labware_id,
                         current_location=current_location,
@@ -142,6 +143,7 @@ class LabwareMovementHandler:
                 if not self._state_store.geometry.validate_gripper_labware_tip_collision(
                     gripper_homed_position_z=gripper_homed_position.z,
                     pipettes_homed_position_z=pipetted_homed_position.z,
+                    pipette_id=pipette_id,
                     tip=tip,
                     labware_id=labware_id,
                     current_location=current_location,

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -8,7 +8,11 @@ from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
 
 
 from .. import errors
-from ..errors import LabwareNotLoadedOnLabwareError, LabwareNotLoadedOnModuleError
+from ..errors import (
+    LabwareNotLoadedOnLabwareError,
+    LabwareNotLoadedOnModuleError,
+    LabwareMovementNotAllowedError,
+)
 from ..resources import fixture_validation
 from ..types import (
     OFF_DECK_LOCATION,
@@ -46,6 +50,9 @@ from opentrons_shared_data.pipette.dev_types import ChannelCount
 
 
 SLOT_WIDTH = 128
+_PIPETTE_HOMED_POSITION_Z = (
+    248.0  # Height of the bottom of the nozzle without the tip attached when homed
+)
 
 
 class _TipDropSection(enum.Enum):
@@ -978,30 +985,35 @@ class GeometryView:
                     ).dropOffset
                 )
 
-    def validate_gripper_labware_tip_collision(
+    def check_gripper_labware_tip_collision(
         self,
         gripper_homed_position_z: float,
-        tip: TipGeometry,
-        pipette_id: str,
         labware_id: str,
         current_location: OnDeckLabwareLocation,
-    ) -> bool:
+    ) -> None:
         """Check for potential collision of tips against labware to be lifted."""
-        pipette_home_z = 248.0
-        # TODO(mm, 2024-01-22): Remove the 1 and 8 channel special case once we are doing X axis validation
-        if self._pipettes.get_channels(pipette_id) in [1, 8]:
-            return True
+        # TODO(cb, 2024-01-22): Remove the 1 and 8 channel special case once we are doing X axis validation
+        pipettes = self._pipettes.get_all()
+        for pipette in pipettes:
+            if self._pipettes.get_channels(pipette.id) in [1, 8]:
+                return
 
-        labware_top_z_when_gripped = gripper_homed_position_z + (
-            self.get_labware_highest_z(labware_id=labware_id)
-            - self.get_labware_grip_point(
-                labware_id=labware_id, location=current_location
-            ).z
-        )
-        # TODO(mm, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
-        if (pipette_home_z - tip.length) < labware_top_z_when_gripped:
-            return False
-        return True
+            tip = self._pipettes.get_attached_tip(pipette.id)
+            if tip:
+                labware_top_z_when_gripped = gripper_homed_position_z + (
+                    self.get_labware_highest_z(labware_id=labware_id)
+                    - self.get_labware_grip_point(
+                        labware_id=labware_id, location=current_location
+                    ).z
+                )
+                # TODO(cb, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
+                if (
+                    _PIPETTE_HOMED_POSITION_Z - tip.length
+                ) < labware_top_z_when_gripped:
+                    raise LabwareMovementNotAllowedError(
+                        f"Cannot move labware '{self._labware.get(labware_id).loadName}' when {int(tip.volume)} ul tips are attached."
+                    )
+        return
 
     def _nominal_gripper_offsets_for_location(
         self, location: OnDeckLabwareLocation

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -981,18 +981,16 @@ class GeometryView:
     def validate_gripper_labware_tip_collision(
         self,
         gripper_homed_position_z: float,
-        pipettes_homed_position_z: float,
-        pipette_id: str,
         tip: TipGeometry,
+        pipette_id: str,
         labware_id: str,
         current_location: OnDeckLabwareLocation,
     ) -> bool:
         """Check for potential collision of tips against labware to be lifted."""
-        # TODO(mm, 2024-01-22): Remove the Left mount 1 and 8 channel special case once we are doing X axis validation
-        mount = self._pipettes.get_mount(pipette_id)
-        if mount == MountType.LEFT:
-            if self._pipettes.get_channels(pipette_id) in [1, 8]:
-                return True
+        pipette_home_z = 248.0
+        # TODO(mm, 2024-01-22): Remove the 1 and 8 channel special case once we are doing X axis validation
+        if self._pipettes.get_channels(pipette_id) in [1, 8]:
+            return True
 
         labware_top_z_when_gripped = gripper_homed_position_z + (
             self.get_labware_highest_z(labware_id=labware_id)
@@ -1001,9 +999,7 @@ class GeometryView:
             ).z
         )
         # TODO(mm, 2024-01-18): Utilizing the nozzle map and labware X coordinates verify if collisions will occur on the X axis (analysis will use hard coded data to measure from the gripper critical point to the pipette mount)
-
-        tip_bottom_z = pipettes_homed_position_z - tip.length
-        if tip_bottom_z < labware_top_z_when_gripped:
+        if (pipette_home_z - tip.length) < labware_top_z_when_gripped:
             return False
         return True
 

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1011,7 +1011,7 @@ class GeometryView:
                     _PIPETTE_HOMED_POSITION_Z - tip.length
                 ) < labware_top_z_when_gripped:
                     raise LabwareMovementNotAllowedError(
-                        f"Cannot move labware '{self._labware.get(labware_id).loadName}' when {int(tip.volume)} ul tips are attached."
+                        f"Cannot move labware '{self._labware.get(labware_id).loadName}' when {int(tip.volume)} µL tips are attached."
                     )
         return
 

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -982,11 +982,18 @@ class GeometryView:
         self,
         gripper_homed_position_z: float,
         pipettes_homed_position_z: float,
+        pipette_id: str,
         tip: TipGeometry,
         labware_id: str,
         current_location: OnDeckLabwareLocation,
     ) -> bool:
         """Check for potential collision of tips against labware to be lifted."""
+        # TODO(mm, 2024-01-22): Remove the Left mount 1 and 8 channel special case once we are doing X axis validation
+        mount = self._pipettes.get_mount(pipette_id)
+        if mount == MountType.LEFT:
+            if self._pipettes.get_channels(pipette_id) in [1, 8]:
+                return True
+
         labware_top_z_when_gripped = gripper_homed_position_z + (
             self.get_labware_highest_z(labware_id=labware_id)
             - self.get_labware_grip_point(


### PR DESCRIPTION
Fixes RSS-425

In general, catch all cases where the z height of the bottom of attached tips would be lower than the top of gripped labware. We have special cased the left mount when single and 8 channel pipettes are attached.

Because of restrictions on the amount of information that analysis has access to, it was necessary to pass some hardcoded position information about the gantry when using the virtual gripper. This is part of a larger issue with the division between analysis and simulation. In truth, we do not have enough information during analysis to properly analyze the X axis status of the tips mid air against the incoming labware the gripper will attempt to lift. Because of this, we cannot validate X axis overlap without either passing in even more hard coded information about distance between the gripper and various pipette configurations, or by modifying analysis to query more in depth information form the hardware controller (and in turn creating a hardware controller delegate which could operate during both client and robot side analysis. 

**For the time being the solution is instituting behavior as follows:**

- If a single or eight channel pipette is installed in the left or right column, we pass validation as collision is unlikely based on in dev testing. 
- Otherwise, we check the Z height of the top of the labware from the deck once gripped and lifted to the gripper home height against the Z height of the bottom of a given tip from the deck
- If the height of the bottom of the tip from the deck is lower than the height of the top of the labware once lifted, we raise a labware movement error and return information about the labware that was lifted and the tip type it would have conflicted with

# Tests
The following protocol should be executed, with commented code enabled and disabled to cause pass and fail cases four the four test cases.
It must be CONFIRMED using Flex hardware that under no PASS case a robot actively encounters a collision mid air.
The four test cases are as follows:

1. 96 channel tip pickup and tiprack lift with 1000ul tips - Expected to FAIL
2. 1 channel left mount tip pickup and tiprack lift with 1000ul tips - Expected to PASS
3. 8 channel right mount tip pickup and tiprack lift with 1000ul tips - Expected to PASS
4. 8 channel right mount tip pickup and 384 wellplate lift with 50ul tips - Expected to PASS

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16"
}

def run(protocol_context):
    small_labware = protocol_context.load_labware("appliedbiosystemsmicroamp_384_wellplate_40ul", "D2")

    adapter = protocol_context.load_adapter("opentrons_flex_96_tiprack_adapter", "C3")
    # Test 1-3 tip racks
    tip_rack = adapter.load_labware("opentrons_flex_96_tiprack_1000ul")
    # Test 4 tiprack
    #tip_rack = adapter.load_labware("opentrons_flex_96_tiprack_50ul")
    

    #Test 1 instrument - should fail analysis
    instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack])

    #Test 2 instrument
    #instrument = protocol_context.load_instrument('flex_1channel_1000', mount="left", tip_racks=[tip_rack])

    #test 3 and 4 instrument
    #instrument = protocol_context.load_instrument('flex_8channel_1000', mount="right", tip_racks=[tip_rack])

    # Always command all instruments to pick up tips first, refresh tips between tests
    instrument.pick_up_tip(tip_rack)
    
    # Test 1-3 move labware:
    # Test 1 expected: Will fail analysis
    # Test 2 expected: Will pass analysis
    # Test 3 expected: Will pass analysis
    protocol_context.move_labware(tip_rack, new_location="C2", use_gripper=True)

    # Test 4 move labware:
    # Test 4 expected: Will pass analysis
    #protocol_context.move_labware(small_labware, new_location="C2", use_gripper=True)
```

# Risks
Low risk for OT-2 because this section of code only executes on OT-3 hardware.

Potential risk to customers who have built Protocols where they already engage in behavior where they lift labware with the gripper in potentially dangerous ways. This change would cause those protocols to now fail analysis and execution. Attempts have been made to mitigate this by restricting checks to only the most at-risk of configurations.

