### PR TITLE
refactor(app): refactor PreventRobotCaching section

### DIFF
--- a/app/src/organisms/AdvancedSettings/PreventRobotCaching.tsx
+++ b/app/src/organisms/AdvancedSettings/PreventRobotCaching.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { useDispatch, useSelector } from 'react-redux'
+
+import {
+  ALIGN_CENTER,
+  Box,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { StyledText } from '../../atoms/text'
+import { ToggleButton } from '../../atoms/buttons'
+import { getConfig, toggleConfigValue } from '../../redux/config'
+
+import type { Dispatch, State } from '../../redux/types'
+
+export function PreventRobotCaching(): JSX.Element {
+  const { t } = useTranslation('app_settings')
+  const displayUnavailRobots = useSelector((state: State) => {
+    return getConfig(state)?.discovery.disableCache ?? false
+  })
+  const dispatch = useDispatch<Dispatch>()
+
+  return (
+    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <Box width="70%">
+        <StyledText
+          css={TYPOGRAPHY.h3SemiBold}
+          paddingBottom={SPACING.spacing8}
+          id="AdvancedSettings_unavailableRobots"
+        >
+          {t('prevent_robot_caching')}
+        </StyledText>
+        <StyledText as="p">
+          <Trans
+            t={t}
+            i18nKey="prevent_robot_caching_description"
+            components={{
+              strong: (
+                <StyledText
+                  as="span"
+                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                />
+              ),
+            }}
+          />
+        </StyledText>
+      </Box>
+      <ToggleButton
+        label="display_unavailable_robots"
+        toggledOn={!displayUnavailRobots}
+        onClick={() => dispatch(toggleConfigValue('discovery.disableCache'))}
+        id="AdvancedSettings_unavailableRobotsToggleButton"
+      />
+    </Flex>
+  )
+}

--- a/app/src/organisms/AdvancedSettings/__tests__/PreventRobotCaching.test.tsx
+++ b/app/src/organisms/AdvancedSettings/__tests__/PreventRobotCaching.test.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react'
+import { when, resetAllWhenMocks } from 'jest-when'
+import { screen, fireEvent } from '@testing-library/react'
+
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+
+import { getConfig, toggleConfigValue } from '../../../redux/config'
+import { PreventRobotCaching } from '../PreventRobotCaching'
+
+import type { State } from '../../../redux/types'
+
+jest.mock('../../../redux/config')
+
+const mockGetConfig = getConfig as jest.MockedFunction<typeof getConfig>
+const mockToggleConfigValue = toggleConfigValue as jest.MockedFunction<
+  typeof toggleConfigValue
+>
+
+const MOCK_STATE: State = {
+  config: {
+    discovery: {
+      disableCache: false,
+    },
+  },
+} as any
+
+const render = () => {
+  return renderWithProviders(<PreventRobotCaching />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('PreventRobotCaching', () => {
+  beforeEach(() => {
+    when(mockGetConfig)
+      .calledWith(MOCK_STATE)
+      .mockReturnValue(MOCK_STATE.config)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    resetAllWhenMocks()
+  })
+
+  it('should render text and toggle button', () => {
+    render()
+    screen.getByText('Prevent Robot Caching')
+    screen.queryByText(
+      'The app will immediately clear unavailable robots and will not remember unavailable robots while this is enabled. On networks with many robots, preventing caching may improve network performance at the expense of slower and less reliable robot discovery on app launch.'
+    )
+    screen.getByRole('switch', { name: 'display_unavailable_robots' })
+  })
+
+  it('should call mock toggleConfigValue when clicking the toggle button', () => {
+    render()
+    const toggleButton = screen.getByRole('switch', {
+      name: 'display_unavailable_robots',
+    })
+    fireEvent.click(toggleButton)
+    expect(mockToggleConfigValue).toHaveBeenCalledWith('discovery.disableCache')
+  })
+})

--- a/app/src/organisms/AdvancedSettings/index.ts
+++ b/app/src/organisms/AdvancedSettings/index.ts
@@ -1,0 +1,1 @@
+export * from './PreventRobotCaching'

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -52,7 +52,7 @@ import { useToaster } from '../../organisms/ToasterOven'
 import {
   EnableDevTools,
   OT2AdvancedSettings,
-  PreventRobotCaching
+  PreventRobotCaching,
 } from '../../organisms/AdvancedSettings'
 
 import type { Dispatch, State } from '../../redux/types'

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import { css } from 'styled-components'
 
@@ -52,6 +52,7 @@ import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { useToaster } from '../../organisms/ToasterOven'
+import { PreventRobotCaching } from '../../organisms/AdvancedSettings'
 
 import type { Dispatch, State } from '../../redux/types'
 
@@ -164,9 +165,6 @@ export function AdvancedSettings(): JSX.Element {
   const handleChannel = (_: string, value: string): void => {
     dispatch(Config.updateConfigValue('update.channel', value))
   }
-  const displayUnavailRobots = useSelector((state: State) => {
-    return Config.getConfig(state)?.discovery.disableCache ?? false
-  })
 
   const formatOptionLabel: React.ComponentProps<
     typeof SelectField
@@ -320,39 +318,7 @@ export function AdvancedSettings(): JSX.Element {
           }
         </Flex>
         <Divider marginY={SPACING.spacing24} />
-        <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-          <Box width="70%">
-            <StyledText
-              css={TYPOGRAPHY.h3SemiBold}
-              paddingBottom={SPACING.spacing8}
-              id="AdvancedSettings_unavailableRobots"
-            >
-              {t('prevent_robot_caching')}
-            </StyledText>
-            <StyledText as="p">
-              <Trans
-                t={t}
-                i18nKey="prevent_robot_caching_description"
-                components={{
-                  strong: (
-                    <StyledText
-                      as="span"
-                      fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                    />
-                  ),
-                }}
-              />
-            </StyledText>
-          </Box>
-          <ToggleButton
-            label="display_unavailable_robots"
-            toggledOn={!displayUnavailRobots}
-            onClick={() =>
-              dispatch(Config.toggleConfigValue('discovery.disableCache'))
-            }
-            id="AdvancedSettings_unavailableRobotsToggleButton"
-          />
-        </Flex>
+        <PreventRobotCaching />
         <Divider marginY={SPACING.spacing24} />
         <Flex
           alignItems={ALIGN_CENTER}

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { resetAllWhenMocks } from 'jest-when'
-import { fireEvent } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 import {
   renderWithProviders,
   useConditionalConfirm,
@@ -26,6 +26,8 @@ import * as ProtocolAnalysis from '../../../redux/protocol-analysis'
 import * as SystemInfo from '../../../redux/system-info'
 import * as Fixtures from '../../../redux/system-info/__fixtures__'
 
+import { PreventRobotCaching } from '../../../organisms/AdvancedSettings'
+
 import { AdvancedSettings } from '../AdvancedSettings'
 
 jest.mock('../../../redux/config')
@@ -36,6 +38,7 @@ jest.mock('../../../redux/protocol-analysis')
 jest.mock('../../../redux/system-info')
 jest.mock('@opentrons/components/src/hooks')
 jest.mock('../../../redux/analytics')
+jest.mock('../../../organisms/AdvancedSettings')
 
 const render = (): ReturnType<typeof renderWithProviders> => {
   return renderWithProviders(
@@ -91,6 +94,9 @@ const mockOpenPythonInterpreterDirectory = ProtocolAnalysis.openPythonInterprete
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
+const mockPreventRobotCaching = PreventRobotCaching as jest.MockedFunction<
+  typeof PreventRobotCaching
+>
 
 let mockTrackEvent: jest.Mock
 const mockConfirm = jest.fn()
@@ -118,7 +124,9 @@ describe('AdvancedSettings', () => {
       showConfirmation: true,
       cancel: mockCancel,
     })
+    mockPreventRobotCaching.mockReturnValue(<div>mock PreventRobotCaching</div>)
   })
+
   afterEach(() => {
     jest.resetAllMocks()
     resetAllWhenMocks()
@@ -128,13 +136,13 @@ describe('AdvancedSettings', () => {
     const [{ getByText }] = render()
     getByText('Update Channel')
     getByText('Additional Custom Labware Source Folder')
-    getByText('Prevent Robot Caching')
     getByText('Clear Unavailable Robots')
     getByText('Developer Tools')
     getByText('OT-2 Advanced Settings')
     getByText('Tip Length Calibration Method')
     getByText('USB-to-Ethernet Adapter Information')
   })
+
   it('renders the update channel combobox and section', () => {
     const [{ getByText, getByRole }] = render()
     getByText(
@@ -142,6 +150,7 @@ describe('AdvancedSettings', () => {
     )
     getByRole('combobox', { name: '' })
   })
+
   it('renders the custom labware section with source folder selected', () => {
     getCustomLabwarePath.mockReturnValue('/mock/custom-labware-path')
     const [{ getByText, getByRole }] = render()
@@ -151,6 +160,7 @@ describe('AdvancedSettings', () => {
     getByText('Additional Source Folder')
     getByRole('button', { name: 'Change labware source folder' })
   })
+
   it('renders the custom labware section with no source folder selected', () => {
     const [{ getByText, getByRole }] = render()
     getByText('No additional source folder specified')
@@ -169,12 +179,10 @@ describe('AdvancedSettings', () => {
       name: 'Always show the prompt to choose calibration block or trash bin',
     })
   })
-  it('renders the robot caching section', () => {
-    const [{ queryByText, getByRole }] = render()
-    queryByText(
-      'The app will immediately clear unavailable robots and will not remember unavailable robots while this is enabled. On networks with many robots, preventing caching may improve network performance at the expense of slower and less reliable robot discovery on app launch.'
-    )
-    getByRole('switch', { name: 'display_unavailable_robots' })
+
+  it('should render mock robot caching section', () => {
+    render()
+    screen.getByText('mock PreventRobotCaching')
   })
 
   it('render the usb-to-ethernet adapter information', () => {
@@ -338,6 +346,7 @@ describe('AdvancedSettings', () => {
     fireEvent.click(proceedBtn)
     expect(mockConfirm).toHaveBeenCalled()
   })
+
   it('renders the developer tools section', () => {
     const [{ getByText, getByRole }] = render()
     getByText(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
refactor Prevent Robot Caching section

close RAUT-938  partially 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Go to Advanced Settings in App Settings
- Check Prevent Robot Caching section is rendered correctly
- The config value is updated when clicking the toggle button

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- create a new component for  Prevent Robot Caching section
- create a new test for  Prevent Robot Caching section
- update `AdvancedSettings` component and test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
