### PR TITLE
refactor(app): refactor enable dev tools section

### DIFF
--- a/app/src/organisms/AdvancedSettings/EnableDevTools.tsx
+++ b/app/src/organisms/AdvancedSettings/EnableDevTools.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector, useDispatch } from 'react-redux'
+
+import {
+  ALIGN_CENTER,
+  Box,
+  Flex,
+  JUSTIFY_SPACE_BETWEEN,
+  SPACING,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+
+import { StyledText } from '../../atoms/text'
+import { ToggleButton } from '../../atoms/buttons'
+import { getDevtoolsEnabled, toggleDevtools } from '../../redux/config'
+
+import type { Dispatch } from '../../redux/types'
+
+export function EnableDevTools(): JSX.Element {
+  const { t } = useTranslation('app_settings')
+  const devToolsOn = useSelector(getDevtoolsEnabled)
+  const dispatch = useDispatch<Dispatch>()
+  const toggleDevTools = (): unknown => dispatch(toggleDevtools())
+
+  return (
+    <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
+      <Box width="70%">
+        <StyledText
+          css={TYPOGRAPHY.h3SemiBold}
+          paddingBottom={SPACING.spacing8}
+          id="AdvancedSettings_devTools"
+        >
+          {t('enable_dev_tools')}
+        </StyledText>
+        <StyledText as="p">{t('enable_dev_tools_description')}</StyledText>
+      </Box>
+      <ToggleButton
+        label="enable_dev_tools"
+        toggledOn={devToolsOn}
+        onClick={toggleDevTools}
+        id="AdvancedSettings_devTooltoggle"
+      />
+    </Flex>
+  )
+}

--- a/app/src/organisms/AdvancedSettings/__tests__/EnableDevTools.test.tsx
+++ b/app/src/organisms/AdvancedSettings/__tests__/EnableDevTools.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { screen, fireEvent } from '@testing-library/react'
+
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+
+import { getDevtoolsEnabled, toggleDevtools } from '../../../redux/config'
+import { EnableDevTools } from '../EnableDevTools'
+
+jest.mock('../../../redux/config')
+
+const mockGetDevtoolsEnabled = getDevtoolsEnabled as jest.MockedFunction<
+  typeof getDevtoolsEnabled
+>
+const mockToggleDevtools = toggleDevtools as jest.MockedFunction<
+  typeof toggleDevtools
+>
+
+const render = () => {
+  return renderWithProviders(<EnableDevTools />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('EnableDevTools', () => {
+  beforeEach(() => {
+    mockGetDevtoolsEnabled.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render text and toggle button', () => {
+    render()
+    screen.getByText('Developer Tools')
+    screen.getByText(
+      'Enabling this setting opens Developer Tools on app launch, enables additional logging and gives access to feature flags.'
+    )
+    screen.getByRole('switch', { name: 'enable_dev_tools' })
+  })
+
+  it('should call mock toggleConfigValue when clicking the toggle button', () => {
+    render()
+    const toggleButton = screen.getByRole('switch', {
+      name: 'enable_dev_tools',
+    })
+    fireEvent.click(toggleButton)
+    expect(mockToggleDevtools).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/AdvancedSettings/index.ts
+++ b/app/src/organisms/AdvancedSettings/index.ts
@@ -1,0 +1,1 @@
+export * from './EnableDevTools'

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -52,6 +52,7 @@ import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { useToaster } from '../../organisms/ToasterOven'
+import { EnableDevTools } from '../../organisms/AdvancedSettings'
 
 import type { Dispatch, State } from '../../redux/types'
 
@@ -71,7 +72,6 @@ export function AdvancedSettings(): JSX.Element {
     Config.getUseTrashSurfaceForTipCal(state)
   )
   const trackEvent = useTrackEvent()
-  const devToolsOn = useSelector(Config.getDevtoolsEnabled)
   const channel = useSelector(Config.getUpdateChannel)
   const channelOptions: SelectOption[] = useSelector(
     Config.getUpdateChannelOptions
@@ -159,8 +159,6 @@ export function AdvancedSettings(): JSX.Element {
       properties: {},
     })
   }
-
-  const toggleDevtools = (): unknown => dispatch(Config.toggleDevtools())
   const handleChannel = (_: string, value: string): void => {
     dispatch(Config.updateConfigValue('update.channel', value))
   }
@@ -482,24 +480,7 @@ export function AdvancedSettings(): JSX.Element {
           )}
         </Flex>
         <Divider marginY={SPACING.spacing24} />
-        <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
-          <Box width="70%">
-            <StyledText
-              css={TYPOGRAPHY.h3SemiBold}
-              paddingBottom={SPACING.spacing8}
-              id="AdvancedSettings_devTools"
-            >
-              {t('enable_dev_tools')}
-            </StyledText>
-            <StyledText as="p">{t('enable_dev_tools_description')}</StyledText>
-          </Box>
-          <ToggleButton
-            label="enable_dev_tools"
-            toggledOn={devToolsOn}
-            onClick={toggleDevtools}
-            id="AdvancedSettings_devTooltoggle"
-          />
-        </Flex>
+        <EnableDevTools />
         <Divider marginY={SPACING.spacing24} />
         <StyledText
           css={TYPOGRAPHY.h3SemiBold}

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { resetAllWhenMocks } from 'jest-when'
-import { fireEvent } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 import {
   renderWithProviders,
   useConditionalConfirm,
@@ -25,6 +25,7 @@ import * as Config from '../../../redux/config'
 import * as ProtocolAnalysis from '../../../redux/protocol-analysis'
 import * as SystemInfo from '../../../redux/system-info'
 import * as Fixtures from '../../../redux/system-info/__fixtures__'
+import { EnableDevTools } from '../../../organisms/AdvancedSettings'
 
 import { AdvancedSettings } from '../AdvancedSettings'
 
@@ -36,6 +37,7 @@ jest.mock('../../../redux/protocol-analysis')
 jest.mock('../../../redux/system-info')
 jest.mock('@opentrons/components/src/hooks')
 jest.mock('../../../redux/analytics')
+jest.mock('../../../organisms/AdvancedSettings')
 
 const render = (): ReturnType<typeof renderWithProviders> => {
   return renderWithProviders(
@@ -92,6 +94,10 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
 
+const mockEnableDevTools = EnableDevTools as jest.MockedFunction<
+  typeof EnableDevTools
+>
+
 let mockTrackEvent: jest.Mock
 const mockConfirm = jest.fn()
 const mockCancel = jest.fn()
@@ -118,6 +124,7 @@ describe('AdvancedSettings', () => {
       showConfirmation: true,
       cancel: mockCancel,
     })
+    mockEnableDevTools.mockReturnValue(<div>mock EnableDevTools</div>)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -130,7 +137,6 @@ describe('AdvancedSettings', () => {
     getByText('Additional Custom Labware Source Folder')
     getByText('Prevent Robot Caching')
     getByText('Clear Unavailable Robots')
-    getByText('Developer Tools')
     getByText('OT-2 Advanced Settings')
     getByText('Tip Length Calibration Method')
     getByText('USB-to-Ethernet Adapter Information')
@@ -338,11 +344,8 @@ describe('AdvancedSettings', () => {
     fireEvent.click(proceedBtn)
     expect(mockConfirm).toHaveBeenCalled()
   })
-  it('renders the developer tools section', () => {
-    const [{ getByText, getByRole }] = render()
-    getByText(
-      'Enabling this setting opens Developer Tools on app launch, enables additional logging and gives access to feature flags.'
-    )
-    getByRole('switch', { name: 'enable_dev_tools' })
+  it('should render mock developer tools section', () => {
+    render()
+    screen.getByText('mock EnableDevTools')
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
refactor enable dev tools section

close [RAUT-938](https://opentrons.atlassian.net/browse/RAUT-938) partially
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Go to Advanced Settings in App Settings
- Check Enable Dev Tools section is rendered correctly
- The config value is updated when clicking the toggle button
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- create a new component for Enable Dev Tools section
- create a new test for Enable Dev Tools section
- update AdvancedSettings component and test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-938]: https://opentrons.atlassian.net/browse/RAUT-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-938]: https://opentrons.atlassian.net/browse/RAUT-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ