### PR TITLE
refactor(app): refactor OT-2 Advanced Settings

### DIFF
--- a/app/src/organisms/AdvancedSettings/OT2AdvancedSettings.tsx
+++ b/app/src/organisms/AdvancedSettings/OT2AdvancedSettings.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
+
+import {
+  Flex,
+  TYPOGRAPHY,
+  SPACING,
+  RadioGroup,
+  DIRECTION_COLUMN,
+} from '@opentrons/components'
+import { StyledText } from '../../atoms/text'
+import {
+  resetUseTrashSurfaceForTipCal,
+  setUseTrashSurfaceForTipCal,
+} from '../../redux/calibration'
+import { getUseTrashSurfaceForTipCal } from '../../redux/config'
+
+import type { Dispatch, State } from '../../redux/types'
+
+const ALWAYS_BLOCK: 'always-block' = 'always-block'
+const ALWAYS_TRASH: 'always-trash' = 'always-trash'
+const ALWAYS_PROMPT: 'always-prompt' = 'always-prompt'
+
+type BlockSelection =
+  | typeof ALWAYS_BLOCK
+  | typeof ALWAYS_TRASH
+  | typeof ALWAYS_PROMPT
+
+export function OT2AdvancedSettings(): JSX.Element {
+  const { t } = useTranslation('app_settings')
+  const dispatch = useDispatch<Dispatch>()
+  const useTrashSurfaceForTipCal = useSelector((state: State) =>
+    getUseTrashSurfaceForTipCal(state)
+  )
+
+  const handleUseTrashSelection = (selection: BlockSelection): void => {
+    switch (selection) {
+      case ALWAYS_PROMPT:
+        dispatch(resetUseTrashSurfaceForTipCal())
+        break
+      case ALWAYS_BLOCK:
+        dispatch(setUseTrashSurfaceForTipCal(false))
+        break
+      case ALWAYS_TRASH:
+        dispatch(setUseTrashSurfaceForTipCal(true))
+        break
+    }
+  }
+
+  return (
+    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
+      <StyledText css={TYPOGRAPHY.h3SemiBold} id="OT-2_Advanced_Settings">
+        {t('ot2_advanced_settings')}
+      </StyledText>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+        <StyledText
+          css={TYPOGRAPHY.h3SemiBold}
+          id="AdvancedSettings_tipLengthCalibration"
+        >
+          {t('tip_length_cal_method')}
+        </StyledText>
+        <RadioGroup
+          useBlueChecked
+          css={css`
+            ${TYPOGRAPHY.pRegular}
+            line-height: ${TYPOGRAPHY.lineHeight20};
+          `}
+          value={
+            useTrashSurfaceForTipCal === true
+              ? ALWAYS_TRASH
+              : useTrashSurfaceForTipCal === false
+              ? ALWAYS_BLOCK
+              : ALWAYS_PROMPT
+          }
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            // you know this is a limited-selection field whose values are only
+            // the elements of BlockSelection; i know this is a limited-selection
+            // field whose values are only the elements of BlockSelection; but sadly,
+            // neither of us can get Flow to know it
+            handleUseTrashSelection(event.currentTarget.value as BlockSelection)
+          }}
+          options={[
+            { name: t('cal_block'), value: ALWAYS_BLOCK },
+            { name: t('trash_bin'), value: ALWAYS_TRASH },
+            { name: t('prompt'), value: ALWAYS_PROMPT },
+          ]}
+        />
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/organisms/AdvancedSettings/__tests__/OT2AdvancedSettings.test.tsx
+++ b/app/src/organisms/AdvancedSettings/__tests__/OT2AdvancedSettings.test.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+import { screen, fireEvent } from '@testing-library/react'
+
+import { renderWithProviders } from '@opentrons/components'
+import { i18n } from '../../../i18n'
+
+import {
+  resetUseTrashSurfaceForTipCal,
+  setUseTrashSurfaceForTipCal,
+} from '../../../redux/calibration'
+import { getUseTrashSurfaceForTipCal } from '../../../redux/config'
+import { OT2AdvancedSettings } from '../OT2AdvancedSettings'
+
+jest.mock('../../../redux/calibration')
+jest.mock('../../../redux/config')
+
+const mockResetUseTrashSurfaceForTipCal = resetUseTrashSurfaceForTipCal as jest.MockedFunction<
+  typeof resetUseTrashSurfaceForTipCal
+>
+
+const mockSetUseTrashSurfaceForTipCal = setUseTrashSurfaceForTipCal as jest.MockedFunction<
+  typeof setUseTrashSurfaceForTipCal
+>
+
+const mockGetUseTrashSurfaceForTipCal = getUseTrashSurfaceForTipCal as jest.MockedFunction<
+  typeof getUseTrashSurfaceForTipCal
+>
+
+const render = () => {
+  return renderWithProviders(<OT2AdvancedSettings />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('OT2AdvancedSettings', () => {
+  beforeEach(() => {
+    mockGetUseTrashSurfaceForTipCal.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render text and toggle button', () => {
+    render()
+    screen.getByText('OT-2 Advanced Settings')
+    screen.getByText('Tip Length Calibration Method')
+    screen.getByRole('radio', {
+      name: 'Always use calibration block to calibrate',
+    })
+    screen.getByRole('radio', { name: 'Always use trash bin to calibrate' })
+    screen.getByRole('radio', {
+      name: 'Always show the prompt to choose calibration block or trash bin',
+    })
+  })
+
+  it('should call mock setUseTrashSurfaceForTipCal with false when selecting always block', () => {
+    render()
+    const radioButton = screen.getByRole('radio', {
+      name: 'Always use calibration block to calibrate',
+    })
+    fireEvent.click(radioButton)
+    expect(mockSetUseTrashSurfaceForTipCal).toHaveBeenCalledWith(false)
+  })
+
+  it('should call mock setUseTrashSurfaceForTipCal with true when selecting always trash', () => {
+    mockGetUseTrashSurfaceForTipCal.mockReturnValue(false)
+    render()
+    const radioButton = screen.getByRole('radio', {
+      name: 'Always use trash bin to calibrate',
+    })
+    fireEvent.click(radioButton)
+    expect(mockSetUseTrashSurfaceForTipCal).toHaveBeenCalledWith(true)
+  })
+
+  it('should call mock resetUseTrashSurfaceForTipCal when selecting always prompt', () => {
+    render()
+    const radioButton = screen.getByRole('radio', {
+      name: 'Always show the prompt to choose calibration block or trash bin',
+    })
+    fireEvent.click(radioButton)
+    expect(mockResetUseTrashSurfaceForTipCal).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/AdvancedSettings/index.ts
+++ b/app/src/organisms/AdvancedSettings/index.ts
@@ -1,0 +1,1 @@
+export * from './OT2AdvancedSettings'

--- a/app/src/organisms/AdvancedSettings/index.ts
+++ b/app/src/organisms/AdvancedSettings/index.ts
@@ -1,3 +1,2 @@
 export * from './EnableDevTools'
 export * from './OT2AdvancedSettings'
-

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
-import { css } from 'styled-components'
 
 import {
   Flex,
   Box,
   Link,
   Icon,
-  RadioGroup,
   SPACING_AUTO,
   ALIGN_CENTER,
   JUSTIFY_SPACE_BETWEEN,
@@ -25,7 +23,6 @@ import {
 
 import * as Config from '../../redux/config'
 import * as ProtocolAnalysis from '../../redux/protocol-analysis'
-import * as Calibration from '../../redux/calibration'
 import * as CustomLabware from '../../redux/custom-labware'
 import {
   clearDiscoveryCache,
@@ -52,24 +49,14 @@ import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { useToaster } from '../../organisms/ToasterOven'
+import { OT2AdvancedSettings } from '../../organisms/AdvancedSettings'
 
 import type { Dispatch, State } from '../../redux/types'
 
-const ALWAYS_BLOCK: 'always-block' = 'always-block'
-const ALWAYS_TRASH: 'always-trash' = 'always-trash'
-const ALWAYS_PROMPT: 'always-prompt' = 'always-prompt'
 const REALTEK_URL = 'https://www.realtek.com/en/'
-
-type BlockSelection =
-  | typeof ALWAYS_BLOCK
-  | typeof ALWAYS_TRASH
-  | typeof ALWAYS_PROMPT
 
 export function AdvancedSettings(): JSX.Element {
   const { t } = useTranslation(['app_settings', 'shared'])
-  const useTrashSurfaceForTipCal = useSelector((state: State) =>
-    Config.getUseTrashSurfaceForTipCal(state)
-  )
   const trackEvent = useTrackEvent()
   const devToolsOn = useSelector(Config.getDevtoolsEnabled)
   const channel = useSelector(Config.getUpdateChannel)
@@ -113,20 +100,6 @@ export function AdvancedSettings(): JSX.Element {
     showConfirmation: showConfirmDeleteUnavailRobots,
     cancel: cancelExit,
   } = useConditionalConfirm(handleDeleteUnavailRobots, true)
-
-  const handleUseTrashSelection = (selection: BlockSelection): void => {
-    switch (selection) {
-      case ALWAYS_PROMPT:
-        dispatch(Calibration.resetUseTrashSurfaceForTipCal())
-        break
-      case ALWAYS_BLOCK:
-        dispatch(Calibration.setUseTrashSurfaceForTipCal(false))
-        break
-      case ALWAYS_TRASH:
-        dispatch(Calibration.setUseTrashSurfaceForTipCal(true))
-        break
-    }
-  }
 
   const device = useSelector(getU2EAdapterDevice)
   const driverOutdated = useSelector((state: State) => {
@@ -501,50 +474,7 @@ export function AdvancedSettings(): JSX.Element {
           />
         </Flex>
         <Divider marginY={SPACING.spacing24} />
-        <StyledText
-          css={TYPOGRAPHY.h3SemiBold}
-          paddingBottom={SPACING.spacing24}
-          id="OT-2_Advanced_Settings"
-        >
-          {t('ot2_advanced_settings')}
-        </StyledText>
-        <Box>
-          <StyledText
-            css={TYPOGRAPHY.h3SemiBold}
-            paddingBottom={SPACING.spacing8}
-            id="AdvancedSettings_tipLengthCalibration"
-          >
-            {t('tip_length_cal_method')}
-          </StyledText>
-          <RadioGroup
-            useBlueChecked
-            css={css`
-              ${TYPOGRAPHY.pRegular}
-              line-height: ${TYPOGRAPHY.lineHeight20};
-            `}
-            value={
-              useTrashSurfaceForTipCal === true
-                ? ALWAYS_TRASH
-                : useTrashSurfaceForTipCal === false
-                ? ALWAYS_BLOCK
-                : ALWAYS_PROMPT
-            }
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-              // you know this is a limited-selection field whose values are only
-              // the elements of BlockSelection; i know this is a limited-selection
-              // field whose values are only the elements of BlockSelection; but sadly,
-              // neither of us can get Flow to know it
-              handleUseTrashSelection(
-                event.currentTarget.value as BlockSelection
-              )
-            }}
-            options={[
-              { name: t('cal_block'), value: ALWAYS_BLOCK },
-              { name: t('trash_bin'), value: ALWAYS_TRASH },
-              { name: t('prompt'), value: ALWAYS_PROMPT },
-            ]}
-          />
-        </Box>
+        <OT2AdvancedSettings />
         <Divider marginY={SPACING.spacing24} />
         <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>
           <Box>

--- a/app/src/pages/AppSettings/AdvancedSettings.tsx
+++ b/app/src/pages/AppSettings/AdvancedSettings.tsx
@@ -49,7 +49,10 @@ import { TertiaryButton, ToggleButton } from '../../atoms/buttons'
 import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { useToaster } from '../../organisms/ToasterOven'
-import { EnableDevTools, OT2AdvancedSettings } from '../../organisms/AdvancedSettings'
+import {
+  EnableDevTools,
+  OT2AdvancedSettings,
+} from '../../organisms/AdvancedSettings'
 
 import type { Dispatch, State } from '../../redux/types'
 

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { resetAllWhenMocks } from 'jest-when'
-import { fireEvent } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import {
   renderWithProviders,
   useConditionalConfirm,
@@ -25,6 +25,7 @@ import * as Config from '../../../redux/config'
 import * as ProtocolAnalysis from '../../../redux/protocol-analysis'
 import * as SystemInfo from '../../../redux/system-info'
 import * as Fixtures from '../../../redux/system-info/__fixtures__'
+import { OT2AdvancedSettings } from '../../../organisms/AdvancedSettings'
 
 import { AdvancedSettings } from '../AdvancedSettings'
 
@@ -36,6 +37,7 @@ jest.mock('../../../redux/protocol-analysis')
 jest.mock('../../../redux/system-info')
 jest.mock('@opentrons/components/src/hooks')
 jest.mock('../../../redux/analytics')
+jest.mock('../../../organisms/AdvancedSettings')
 
 const render = (): ReturnType<typeof renderWithProviders> => {
   return renderWithProviders(
@@ -92,6 +94,10 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
 
+const mockOT2AdvancedSettings = OT2AdvancedSettings as jest.MockedFunction<
+  typeof OT2AdvancedSettings
+>
+
 let mockTrackEvent: jest.Mock
 const mockConfirm = jest.fn()
 const mockCancel = jest.fn()
@@ -118,6 +124,7 @@ describe('AdvancedSettings', () => {
       showConfirmation: true,
       cancel: mockCancel,
     })
+    mockOT2AdvancedSettings.mockReturnValue(<div>mock OT2AdvancedSettings</div>)
   })
   afterEach(() => {
     jest.resetAllMocks()
@@ -131,8 +138,6 @@ describe('AdvancedSettings', () => {
     getByText('Prevent Robot Caching')
     getByText('Clear Unavailable Robots')
     getByText('Developer Tools')
-    getByText('OT-2 Advanced Settings')
-    getByText('Tip Length Calibration Method')
     getByText('USB-to-Ethernet Adapter Information')
   })
   it('renders the update channel combobox and section', () => {
@@ -161,13 +166,9 @@ describe('AdvancedSettings', () => {
       properties: {},
     })
   })
-  it('renders the tip length cal section', () => {
-    const [{ getByRole }] = render()
-    getByRole('radio', { name: 'Always use calibration block to calibrate' })
-    getByRole('radio', { name: 'Always use trash bin to calibrate' })
-    getByRole('radio', {
-      name: 'Always show the prompt to choose calibration block or trash bin',
-    })
+  it('should render mock OT-2 Advanced Settings Tip Length Calibration Method section', () => {
+    render()
+    screen.getByText('mock OT2AdvancedSettings')
   })
   it('renders the robot caching section', () => {
     const [{ queryByText, getByRole }] = render()

--- a/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
+++ b/app/src/pages/AppSettings/__test__/AdvancedSettings.test.tsx
@@ -25,7 +25,10 @@ import * as Config from '../../../redux/config'
 import * as ProtocolAnalysis from '../../../redux/protocol-analysis'
 import * as SystemInfo from '../../../redux/system-info'
 import * as Fixtures from '../../../redux/system-info/__fixtures__'
-import { EnableDevTools, OT2AdvancedSettings } from '../../../organisms/AdvancedSettings'
+import {
+  EnableDevTools,
+  OT2AdvancedSettings,
+} from '../../../organisms/AdvancedSettings'
 
 import { AdvancedSettings } from '../AdvancedSettings'
 
@@ -96,7 +99,7 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
 
 const mockOT2AdvancedSettings = OT2AdvancedSettings as jest.MockedFunction<
   typeof OT2AdvancedSettings
- >
+>
 const mockEnableDevTools = EnableDevTools as jest.MockedFunction<
   typeof EnableDevTools
 >


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
refactor OT-2 Advanced Settings

close RAUT-938 partially
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Check  OT-2 Advanced Settings section is rendered correctly
The config value is updated when selecting a radio button
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
create a new component for OT-2 Advanced Settings section
create a new test for OT-2 Advanced Settings section
update AdvancedSettings component and test
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
