### PR TITLE
fix(app): fix Mixpanel empty string issue

### DIFF
--- a/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
@@ -46,7 +46,9 @@ export const parseProtocolRunAnalyticsData = (
       protocolAuthor: protocolAuthor !== '' ? protocolAuthor : '',
       protocolText: protocolText !== '' ? protocolText : '',
       robotType:
-        protocolAnalysis?.robotType != null ? protocolAnalysis?.robotType : '',
+        protocolAnalysis?.robotType != null
+          ? protocolAnalysis?.robotType
+          : storedProtocol?.mostRecentAnalysis?.robotType,
     },
     runTime:
       startedAt != null ? formatInterval(startedAt, Date()) : EMPTY_TIMESTAMP,

--- a/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -30,11 +30,13 @@ import { mockRobotSideAnalysis } from '../../../organisms/CommandText/__fixtures
 import {
   useAttachedModules,
   useLPCDisabledReason,
-  useRunCreatedAtTimestamp,
   useModuleCalibrationStatus,
   useRobotType,
+  useRunCreatedAtTimestamp,
+  useTrackProtocolRunEvent,
 } from '../../../organisms/Devices/hooks'
 import { getLocalRobot } from '../../../redux/discovery'
+import { ANALYTICS_PROTOCOL_RUN_START } from '../../../redux/analytics'
 import { ProtocolSetupLiquids } from '../../../organisms/ProtocolSetupLiquids'
 import { getProtocolModulesInfo } from '../../../organisms/Devices/ProtocolRun/utils/getProtocolModulesInfo'
 import { ProtocolSetupModulesAndDeck } from '../../../organisms/ProtocolSetupModulesAndDeck'
@@ -166,6 +168,9 @@ const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
 const mockUseDeckConfigurationCompatibility = useDeckConfigurationCompatibility as jest.MockedFunction<
   typeof useDeckConfigurationCompatibility
 >
+const mockUseTrackProtocolRunEvent = useTrackProtocolRunEvent as jest.MockedFunction<
+  typeof useTrackProtocolRunEvent
+>
 
 const render = (path = '/') => {
   return renderWithProviders(
@@ -238,6 +243,7 @@ const mockFixture = {
 }
 
 const MOCK_MAKE_SNACKBAR = jest.fn()
+const mockTrackProtocolRunEvent = jest.fn()
 
 describe('ProtocolSetup', () => {
   let mockLaunchLPC: jest.Mock
@@ -335,6 +341,9 @@ describe('ProtocolSetup', () => {
         makeSnackbar: MOCK_MAKE_SNACKBAR,
       } as unknown) as any)
     when(mockUseDeckConfigurationCompatibility).mockReturnValue([])
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID)
+      .mockReturnValue({ trackProtocolRunEvent: mockTrackProtocolRunEvent })
   })
 
   afterEach(() => {
@@ -439,5 +448,15 @@ describe('ProtocolSetup', () => {
     expect(MOCK_MAKE_SNACKBAR).toBeCalledWith(
       'Close the robot door before starting the run.'
     )
+  })
+
+  it('calls trackProtocolRunEvent when tapping play button', () => {
+    render(`/runs/${RUN_ID}/setup/`)
+    fireEvent.click(screen.getByRole('button', { name: 'play' }))
+    expect(mockTrackProtocolRunEvent).toBeCalledTimes(1)
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalledWith({
+      name: ANALYTICS_PROTOCOL_RUN_START,
+      properties: {},
+    })
   })
 })

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -47,7 +47,9 @@ import {
   useAttachedModules,
   useLPCDisabledReason,
   useModuleCalibrationStatus,
+  useRobotAnalyticsData,
   useRobotType,
+  useTrackProtocolRunEvent,
 } from '../../organisms/Devices/hooks'
 import {
   useRequiredProtocolHardwareFromAnalysis,
@@ -75,8 +77,9 @@ import { useIsHeaterShakerInProtocol } from '../../organisms/ModuleCard/hooks'
 import { getLabwareSetupItemGroups } from '../../pages/Protocols/utils'
 import { getLocalRobot } from '../../redux/discovery'
 import {
-  useTrackEvent,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+  ANALYTICS_PROTOCOL_RUN_START,
+  useTrackEvent,
 } from '../../redux/analytics'
 import { getIsHeaterShakerAttached } from '../../redux/config'
 import { ConfirmAttachedModal } from '../../pages/ProtocolSetup/ConfirmAttachedModal'
@@ -338,6 +341,10 @@ function PrepareToRun({
     robotType,
     mostRecentAnalysis
   )
+
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const robotAnalyticsData = useRobotAnalyticsData(robotName)
+
   const requiredDeckConfigCompatibility = getRequiredDeckConfig(
     deckConfigCompatibility
   )
@@ -448,6 +455,10 @@ function PrepareToRun({
       } else {
         if (isReadyToRun) {
           play()
+          trackProtocolRunEvent({
+            name: ANALYTICS_PROTOCOL_RUN_START,
+            properties: robotAnalyticsData != null ? robotAnalyticsData : {},
+          })
         } else {
           makeSnackbar(
             i18n.format(t('complete_setup_before_proceeding'), 'capitalize')


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix Mixpanel empty string issue

close RAUT-920 's `robotType` part

add trackEvent to protocol setup since there wasn't trackEvent function. (This was the reason why we couldn't see ODD when use analyze the data with `runStart`.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- pass storedProtocol's `robotType` instead of '' when protocolAnalysis `robotType` is null/undefined
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
