### PR TITLE
fix(api): fix left mount being disengaged when moving to maintenance position

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1001,6 +1001,12 @@ class OT3API(
                 detail={"axes": axes_str},
             )
 
+    def motor_status_ok(self, axis: Axis) -> bool:
+        return self._backend.check_motor_status([axis])
+
+    def encoder_status_ok(self, axis: Axis) -> bool:
+        return self._backend.check_encoder_status([axis])
+
     async def encoder_current_position(
         self,
         mount: Union[top_types.Mount, OT3Mount],

--- a/api/src/opentrons/hardware_control/protocols/__init__.py
+++ b/api/src/opentrons/hardware_control/protocols/__init__.py
@@ -1,6 +1,8 @@
 """Typing protocols describing a hardware controller."""
 from typing_extensions import Protocol, Type
 
+from opentrons.hardware_control.types import Axis
+
 from .module_provider import ModuleProvider
 from .hardware_manager import HardwareManager
 from .chassis_accessory_manager import ChassisAccessoryManager
@@ -81,6 +83,12 @@ class FlexHardwareControlInterface(
 
     def get_robot_type(self) -> Type[FlexRobotType]:
         return FlexRobotType
+
+    def motor_status_ok(self, axis: Axis) -> bool:
+        ...
+
+    def encoder_status_ok(self, axis: Axis) -> bool:
+        ...
 
 
 __all__ = [

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -80,6 +80,11 @@ class MoveToMaintenancePositionImplementation(
         ot3_api = ensure_ot3_hardware(
             self._hardware_api,
         )
+        # the 96-channel mount is disengaged during gripper calibration and
+        #  must be homed before the gantry position can be called
+        if not ot3_api.backend.check_motor_status([Axis.Z_L]) and \
+            ot3_api.backend.check_encoder_status([Axis.Z_L]):
+            await ot3_api.home([Axis.Z_L])
         current_position_mount = await ot3_api.gantry_position(
             Mount.LEFT, critical_point=CriticalPoint.MOUNT
         )

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -82,8 +82,9 @@ class MoveToMaintenancePositionImplementation(
         )
         # the 96-channel mount is disengaged during gripper calibration and
         #  must be homed before the gantry position can be called
-        if not ot3_api.backend.check_motor_status([Axis.Z_L]) and \
-            ot3_api.backend.check_encoder_status([Axis.Z_L]):
+        if ot3_api.encoder_status_ok(Axis.Z_L) and not ot3_api.motor_status_ok(
+            Axis.Z_L
+        ):
             await ot3_api.home([Axis.Z_L])
         current_position_mount = await ot3_api.gantry_position(
             Mount.LEFT, critical_point=CriticalPoint.MOUNT


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We now disengage the left z axis if a 96-channel pipette is attached but idle. This means that during gripper calibration, the left Z axis will not have a valid motor position (disengaged at the home position). We won't be able to move nor access the position of the Z_L until we first home it. This shouldn't take long because it should already be at its home position.

