### PR TITLE
feat(hardware-testing): Adds protocol for photometric baseline

### DIFF
--- a/hardware-testing/hardware_testing/protocols/flex_baseline_for_96ch.py
+++ b/hardware-testing/hardware_testing/protocols/flex_baseline_for_96ch.py
@@ -8,14 +8,21 @@ from opentrons.protocol_api import ProtocolContext, InstrumentContext, Labware
 #                EDIT - START                #
 ##############################################
 
+# FIXME: make these variables configurable through RUNTIME-VARIABLES
+
 metadata = {"protocolName": "Flex: Baseline for 96ch"}
 requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 RETURN_TIP = False
+FILL_MULTIPLE_PLATES = False
 
-DILUENT_VOLUME = 200
-DILUENT_PUSH_OUT = 15
-DILUENT_SOURCES = [
+LIQUID_NAME = "Baseline"
+LIQUID_DESCRIPTION = "Artel MVS Baseline"
+LIQUID_COLOR = "#00FF00"
+
+TARGET_VOLUME = 200
+TARGET_PUSH_OUT = 15
+TARGET_SOURCES = [
     {
         "source": "A1",
         "destinations": ["A1", "A2", "A3", "A4", "A5", "A6"],
@@ -146,20 +153,20 @@ def _assign_starting_volumes(
     pipette: InstrumentContext,
     reservoir: Labware,
 ) -> None:
-    diluent = ctx.define_liquid(
-        name="Diluent",
-        description="Artel MVS Diluent",
-        display_color="#0000FF",
+    liquid = ctx.define_liquid(
+        name=LIQUID_NAME,
+        description=LIQUID_DESCRIPTION,
+        display_color=LIQUID_COLOR,
     )
-    for test in DILUENT_SOURCES:
+    for test in TARGET_SOURCES:
         src_ul_per_trial = _start_volumes_per_trial(
-            DILUENT_VOLUME,
+            TARGET_VOLUME,
             reservoir.load_name,
             pipette.channels,
             len(test["destinations"]),
         )
         first_trial_ul = src_ul_per_trial[0]
-        reservoir[str(test["source"])].load_liquid(diluent, first_trial_ul)
+        reservoir[str(test["source"])].load_liquid(liquid, first_trial_ul)
 
 
 def _transfer(
@@ -214,19 +221,19 @@ def run(ctx: ProtocolContext) -> None:
     plate = ctx.load_labware("corning_96_wellplate_360ul_flat", "D2")
     pipette = ctx.load_instrument("flex_8channel_1000", "left", tip_racks=[tips])
     _assign_starting_volumes(ctx, pipette, reservoir)
-    for i in range(1):
-        pipette.configure_for_volume(DILUENT_VOLUME)
+    for i in range(12):
+        pipette.configure_for_volume(TARGET_VOLUME)
         pipette.pick_up_tip()
-        for test in DILUENT_SOURCES:
+        for test in TARGET_SOURCES:
             _transfer(
                 ctx,
-                DILUENT_VOLUME,
+                TARGET_VOLUME,
                 pipette,
                 reservoir,
                 plate,
                 test["source"],  # type: ignore[arg-type]
                 test["destinations"],  # type: ignore[arg-type]
-                push_out=DILUENT_PUSH_OUT,
+                push_out=TARGET_PUSH_OUT,
                 touch_tip=True,
                 volume_already_in_plate=0,
             )
@@ -234,5 +241,7 @@ def run(ctx: ProtocolContext) -> None:
             pipette.return_tip()
         else:
             pipette.drop_tip()
-        # if i < 11:
-        #     ctx.pause("refresh Diluent to start volumes, and add new Plate")
+        if not FILL_MULTIPLE_PLATES:
+            break
+        if i < 11:
+            ctx.pause("refresh liquid to start volumes, and add new Plate")

--- a/hardware-testing/hardware_testing/protocols/flex_baseline_for_96ch.py
+++ b/hardware-testing/hardware_testing/protocols/flex_baseline_for_96ch.py
@@ -1,4 +1,4 @@
-"""Flex: Diluent for 96ch."""
+"""Flex: Baseline for 96ch."""
 from math import pi
 from typing import List, Optional, Dict, Tuple
 
@@ -8,12 +8,12 @@ from opentrons.protocol_api import ProtocolContext, InstrumentContext, Labware
 #                EDIT - START                #
 ##############################################
 
-metadata = {"protocolName": "Flex: Diluent for 96ch"}
+metadata = {"protocolName": "Flex: Baseline for 96ch"}
 requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 RETURN_TIP = False
 
-DILUENT_VOLUME = 195
+DILUENT_VOLUME = 200
 DILUENT_PUSH_OUT = 15
 DILUENT_SOURCES = [
     {
@@ -214,7 +214,7 @@ def run(ctx: ProtocolContext) -> None:
     plate = ctx.load_labware("corning_96_wellplate_360ul_flat", "D2")
     pipette = ctx.load_instrument("flex_8channel_1000", "left", tip_racks=[tips])
     _assign_starting_volumes(ctx, pipette, reservoir)
-    for i in range(12):
+    for i in range(1):
         pipette.configure_for_volume(DILUENT_VOLUME)
         pipette.pick_up_tip()
         for test in DILUENT_SOURCES:
@@ -234,5 +234,5 @@ def run(ctx: ProtocolContext) -> None:
             pipette.return_tip()
         else:
             pipette.drop_tip()
-        if i < 11:
-            ctx.pause("refresh Diluent to start volumes, and add new Plate")
+        # if i < 11:
+        #     ctx.pause("refresh Diluent to start volumes, and add new Plate")

--- a/hardware-testing/hardware_testing/protocols/flex_diluent_for_96ch.py
+++ b/hardware-testing/hardware_testing/protocols/flex_diluent_for_96ch.py
@@ -8,14 +8,21 @@ from opentrons.protocol_api import ProtocolContext, InstrumentContext, Labware
 #                EDIT - START                #
 ##############################################
 
+# FIXME: make these variables configurable through RUNTIME-VARIABLES
+
 metadata = {"protocolName": "Flex: Diluent for 96ch"}
 requirements = {"robotType": "Flex", "apiLevel": "2.15"}
 
 RETURN_TIP = False
+FILL_MULTIPLE_PLATES = True
 
-DILUENT_VOLUME = 195
-DILUENT_PUSH_OUT = 15
-DILUENT_SOURCES = [
+LIQUID_NAME = "Diluent"
+LIQUID_DESCRIPTION = "Artel MVS Diluent"
+LIQUID_COLOR = "#0000FF"
+
+TARGET_VOLUME = 195
+TARGET_PUSH_OUT = 15
+TARGET_SOURCES = [
     {
         "source": "A1",
         "destinations": ["A1", "A2", "A3", "A4", "A5", "A6"],
@@ -146,20 +153,20 @@ def _assign_starting_volumes(
     pipette: InstrumentContext,
     reservoir: Labware,
 ) -> None:
-    diluent = ctx.define_liquid(
-        name="Diluent",
-        description="Artel MVS Diluent",
-        display_color="#0000FF",
+    liquid = ctx.define_liquid(
+        name=LIQUID_NAME,
+        description=LIQUID_DESCRIPTION,
+        display_color=LIQUID_COLOR,
     )
-    for test in DILUENT_SOURCES:
+    for test in TARGET_SOURCES:
         src_ul_per_trial = _start_volumes_per_trial(
-            DILUENT_VOLUME,
+            TARGET_VOLUME,
             reservoir.load_name,
             pipette.channels,
             len(test["destinations"]),
         )
         first_trial_ul = src_ul_per_trial[0]
-        reservoir[str(test["source"])].load_liquid(diluent, first_trial_ul)
+        reservoir[str(test["source"])].load_liquid(liquid, first_trial_ul)
 
 
 def _transfer(
@@ -215,18 +222,18 @@ def run(ctx: ProtocolContext) -> None:
     pipette = ctx.load_instrument("flex_8channel_1000", "left", tip_racks=[tips])
     _assign_starting_volumes(ctx, pipette, reservoir)
     for i in range(12):
-        pipette.configure_for_volume(DILUENT_VOLUME)
+        pipette.configure_for_volume(TARGET_VOLUME)
         pipette.pick_up_tip()
-        for test in DILUENT_SOURCES:
+        for test in TARGET_SOURCES:
             _transfer(
                 ctx,
-                DILUENT_VOLUME,
+                TARGET_VOLUME,
                 pipette,
                 reservoir,
                 plate,
                 test["source"],  # type: ignore[arg-type]
                 test["destinations"],  # type: ignore[arg-type]
-                push_out=DILUENT_PUSH_OUT,
+                push_out=TARGET_PUSH_OUT,
                 touch_tip=True,
                 volume_already_in_plate=0,
             )
@@ -234,5 +241,7 @@ def run(ctx: ProtocolContext) -> None:
             pipette.return_tip()
         else:
             pipette.drop_tip()
+        if not FILL_MULTIPLE_PLATES:
+            break
         if i < 11:
-            ctx.pause("refresh Diluent to start volumes, and add new Plate")
+            ctx.pause("refresh liquid to start volumes, and add new Plate")


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Previous PR adding the diluent protocol forgot to include a protocol for baseline, which is a required step for the photometric test. Because we don't have runtime variables yet, this needs to be an entirely separate protocol, even though it is identical to the diluent protocol except the target volume in the plate is `200` instead of `195`

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
