### PR TITLE
fix(api): use move flags in aionotify for modules

### DIFF
--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -111,7 +111,12 @@ class Controller:
         watcher.watch(
             alias="modules",
             path="/dev",
-            flags=(aionotify.Flags.CREATE | aionotify.Flags.DELETE),
+            flags=(
+                aionotify.Flags.CREATE
+                | aionotify.Flags.DELETE
+                | aionotify.Flags.MOVED_FROM
+                | aionotify.Flags.MOVED_TO
+            ),
         )
         return watcher
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1094,7 +1094,12 @@ class OT3Controller(FlexBackend):
         watcher.watch(
             alias="modules",
             path="/dev",
-            flags=(aionotify.Flags.CREATE | aionotify.Flags.DELETE),
+            flags=(
+                aionotify.Flags.CREATE
+                | aionotify.Flags.DELETE
+                | aionotify.Flags.MOVED_FROM
+                | aionotify.Flags.MOVED_TO
+            ),
         )
         return watcher
 
@@ -1105,9 +1110,10 @@ class OT3Controller(FlexBackend):
             log.debug("incomplete read error when quitting watcher")
             return
         if event is not None:
+            flags = aionotify.Flags.parse(event.flags)
+            log.debug(f"aionotify: {flags} {event.name}")
             if "ot_module" in event.name:
                 event_name = event.name
-                flags = aionotify.Flags.parse(event.flags)
                 event_description = AionotifyEvent.build(event_name, flags)
                 await self.module_controls.handle_module_appearance(event_description)
 

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -26,7 +26,13 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-MODULE_PORT_REGEX = re.compile("|".join(modules.MODULE_TYPE_BY_NAME.keys()), re.I)
+MODULE_PORT_REGEX = re.compile(
+    # capture all modules by name using alternation
+    "(" + "|".join(modules.MODULE_TYPE_BY_NAME.keys()) + ")"
+    # add a negative lookahead to suppress matches on tempfiles udev creates
+    + r"\d+(?!\.tmp-c\d+:\d+)",
+    re.I,
+)
 
 
 class AttachedModulesControl:
@@ -183,7 +189,7 @@ class AttachedModulesControl:
         """
         match = MODULE_PORT_REGEX.search(port)
         if match:
-            name = match.group().lower()
+            name = match.group(1).lower()
             if name not in modules.MODULE_TYPE_BY_NAME:
                 log.warning(f"Unexpected module connected: {name} on {port}")
                 return None
@@ -205,10 +211,10 @@ class AttachedModulesControl:
         new_modules = None
         removed_modules = None
         if maybe_module_at_port is not None:
-            if hasattr(event.flags, "DELETE"):
+            if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
                 removed_modules = [maybe_module_at_port]
                 log.info(f"Module Removed: {maybe_module_at_port}")
-            elif hasattr(event.flags, "CREATE"):
+            elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
                 new_modules = [maybe_module_at_port]
                 log.info(f"Module Added: {maybe_module_at_port}")
             try:


### PR DESCRIPTION
After updating openembedded and buildroot, their udevs will actually create temporary files for module serial port symlinks and then rename the tempfiles to the real thing. This wouldn't get noticed because they were moves, rather than creates or deletes. Getting aionotify to tell us about moves too and plumbing those events through the add/delete paths fixes the issue.

Closes RQA-2240
