### PR TITLE
refactor(robot-server): Add a placeholder migration for schema 3

### DIFF
--- a/robot-server/robot_server/persistence/__init__.py
+++ b/robot-server/robot_server/persistence/__init__.py
@@ -1,7 +1,7 @@
 """Support for persisting data across device reboots."""
 
 
-from ._database import create_sql_engine, sqlite_rowid
+from ._database import create_schema_3_sql_engine, sqlite_rowid
 from ._fastapi_dependencies import (
     start_initializing_persistence,
     clean_up_persistence,
@@ -21,7 +21,7 @@ from ._tables import (
 
 __all__ = [
     # database utilities and helpers
-    "create_sql_engine",
+    "create_schema_3_sql_engine",
     "sqlite_rowid",
     # database tables
     "migration_table",

--- a/robot-server/robot_server/persistence/__init__.py
+++ b/robot-server/robot_server/persistence/__init__.py
@@ -11,7 +11,6 @@ from ._fastapi_dependencies import (
 )
 from ._persistence_directory import PersistenceResetter
 from ._tables import (
-    migration_table,
     protocol_table,
     analysis_table,
     run_table,
@@ -24,7 +23,6 @@ __all__ = [
     "create_schema_3_sql_engine",
     "sqlite_rowid",
     # database tables
-    "migration_table",
     "protocol_table",
     "analysis_table",
     "run_table",

--- a/robot-server/robot_server/persistence/_database.py
+++ b/robot-server/robot_server/persistence/_database.py
@@ -5,7 +5,7 @@ import sqlalchemy
 
 from server_utils import sql_utils
 
-from ._tables import add_tables_to_db
+from ._tables import schema_2, schema_3
 from ._migrations.up_to_2 import migrate
 
 
@@ -24,8 +24,10 @@ from ._migrations.up_to_2 import migrate
 sqlite_rowid = sqlalchemy.column("_ROWID_")
 
 
-def create_sql_engine(path: Path) -> sqlalchemy.engine.Engine:
-    """Create a SQL engine with tables and migrations.
+def create_schema_2_sql_engine(path: Path) -> sqlalchemy.engine.Engine:
+    """Create a SQL engine for a schema 2 database.
+
+    If provided a schema 0 or 1 database, this will migrate it in-place to schema 2.
 
     Warning:
         Migrations can take several minutes. If calling this from an async function,
@@ -36,8 +38,29 @@ def create_sql_engine(path: Path) -> sqlalchemy.engine.Engine:
     try:
         sql_utils.enable_foreign_key_constraints(sql_engine)
         sql_utils.fix_transactions(sql_engine)
-        add_tables_to_db(sql_engine)
+        schema_2.metadata.create_all(sql_engine)
+
         migrate(sql_engine)
+
+    except Exception:
+        sql_engine.dispose()
+        raise
+
+    return sql_engine
+
+
+def create_schema_3_sql_engine(path: Path) -> sqlalchemy.engine.Engine:
+    """Create a SQL engine for a schema 3 database.
+
+    Unlike `create_schema_2_sql_engine()`, this assumes the database is already
+    at schema 3. Migration is done through other mechanisms.
+    """
+    sql_engine = sqlalchemy.create_engine(sql_utils.get_connection_url(path))
+
+    try:
+        sql_utils.enable_foreign_key_constraints(sql_engine)
+        sql_utils.fix_transactions(sql_engine)
+        schema_3.metadata.create_all(sql_engine)
 
     except Exception:
         sql_engine.dispose()

--- a/robot-server/robot_server/persistence/_database.py
+++ b/robot-server/robot_server/persistence/_database.py
@@ -6,7 +6,7 @@ import sqlalchemy
 from server_utils import sql_utils
 
 from ._tables import add_tables_to_db
-from ._migrations import migrate
+from ._migrations.up_to_2 import migrate
 
 
 # A reference to SQLite's built-in ROWID column.

--- a/robot-server/robot_server/persistence/_migrations.py
+++ b/robot-server/robot_server/persistence/_migrations.py
@@ -42,7 +42,7 @@ from typing_extensions import Final
 
 import sqlalchemy
 
-from ._tables import analysis_table, migration_table, run_table
+from ._tables.schema_2 import analysis_table, migration_table, run_table
 from . import legacy_pickle
 
 

--- a/robot-server/robot_server/persistence/_migrations/_util.py
+++ b/robot-server/robot_server/persistence/_migrations/_util.py
@@ -1,0 +1,56 @@
+"""Shared helpers for migrations."""
+
+import sqlalchemy
+
+import shutil
+from pathlib import Path
+
+from .._database import sqlite_rowid
+
+
+def copy_rows_unmodified(
+    source_table: sqlalchemy.Table,
+    dest_table: sqlalchemy.Table,
+    source_connection: sqlalchemy.engine.Connection,
+    dest_connection: sqlalchemy.engine.Connection,
+    order_by_rowid: bool,
+) -> None:
+    """Copy the contents of a table between databases.
+
+    The column names must be identical.
+
+    `order_by_rowid` preserves the relative ordering in SQLite's implicit `ROWID`
+    column by inserting records in the same order they were in the source.
+    This is only necessary if the table relies on SQLite's implicit `ROWID` column for
+    row ordering; it should be `False` if the table has an explicit sequence number
+    column instead.
+    """
+    select = sqlalchemy.select(source_table).order_by(
+        sqlite_rowid if order_by_rowid else None
+    )
+    insert = sqlalchemy.insert(dest_table)
+    # TODO: SQLAlchemy or its underlying dbapi are probably paging the entire
+    # collection of source rows into memory. This is probably fine--it will probably
+    # not be much worse than how Protocol Engine keeps every command in memory--
+    # but it's not great.
+    #
+    # SQLAlchemy 1.4.40 might make this easier to fix, with yield_per.
+    # https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection.execution_options.params.yield_per
+    for row in source_connection.execute(select).mappings():
+        dest_connection.execute(insert, row)
+
+
+def copy_if_exists(src: Path, dst: Path) -> None:
+    """Like `shutil.copy()`, but no-op if `src` doesn't exist."""
+    try:
+        shutil.copy(src=src, dst=dst)
+    except FileNotFoundError:
+        pass
+
+
+def copytree_if_exists(src: Path, dst: Path) -> None:
+    """Like `shutil.copytree()`, but no-op if `src` doesn't exist."""
+    try:
+        shutil.copytree(src=src, dst=dst)
+    except FileNotFoundError:
+        pass

--- a/robot-server/robot_server/persistence/_migrations/up_to_2.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_2.py
@@ -42,8 +42,8 @@ from typing_extensions import Final
 
 import sqlalchemy
 
-from ._tables.schema_2 import analysis_table, migration_table, run_table
-from . import legacy_pickle
+from .._tables.schema_2 import analysis_table, migration_table, run_table
+from .. import legacy_pickle
 
 
 _LATEST_SCHEMA_VERSION: Final = 2

--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -41,20 +41,6 @@ def _migrate_db(
     source_transaction: sqlalchemy.engine.Connection,
     dest_transaction: sqlalchemy.engine.Connection,
 ) -> None:
-    # TODO: This migration table is what we used to use to keep track of what schema
-    # the database is at. It's not needed anymore now that we have this
-    # subdirectory-based migration infrastructure.
-    #
-    # We should either drop this table entirely from schema 3 and up, or, if we
-    # want to keep it, we should add a row here to stamp it with schema "3".
-    copy_rows_unmodified(
-        schema_2.migration_table,
-        schema_3.migration_table,
-        source_transaction,
-        dest_transaction,
-        order_by_rowid=False,
-    )
-
     copy_rows_unmodified(
         schema_2.protocol_table,
         schema_3.protocol_table,

--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -1,0 +1,88 @@
+from contextlib import ExitStack
+from pathlib import Path
+
+import sqlalchemy
+
+from .._database import create_schema_2_sql_engine, create_schema_3_sql_engine
+from .._folder_migrator import Migration
+from .._tables import schema_2, schema_3
+from ._util import copy_rows_unmodified, copy_if_exists, copytree_if_exists
+
+
+# TODO: Define a single source of truth somewhere for these paths.
+_DECK_CONFIGURATION_FILE = "deck_configuration.json"
+_PROTOCOLS_DIRECTORY = "protocols"
+_DB_FILE = "robot_server.db"
+
+
+class MigrationUpTo3(Migration):  # noqa: D101
+    def migrate(self, source_dir: Path, dest_dir: Path) -> None:
+        """Migrate the persistence directory from schema 2 to 3."""
+        copy_if_exists(
+            source_dir / _DECK_CONFIGURATION_FILE, dest_dir / _DECK_CONFIGURATION_FILE
+        )
+        copytree_if_exists(
+            source_dir / _PROTOCOLS_DIRECTORY, dest_dir / _PROTOCOLS_DIRECTORY
+        )
+
+        with ExitStack() as exit_stack:
+            # If the source is schema 0 or 1, this will migrate it to 2 in-place.
+            source_db = create_schema_2_sql_engine(source_dir / _DB_FILE)
+            exit_stack.callback(source_db.dispose)
+
+            dest_db = create_schema_3_sql_engine(dest_dir / _DB_FILE)
+            exit_stack.callback(dest_db.dispose)
+
+            with source_db.begin() as source_transaction, dest_db.begin() as dest_transaction:
+                _migrate_db(source_transaction, dest_transaction)
+
+
+def _migrate_db(
+    source_transaction: sqlalchemy.engine.Connection,
+    dest_transaction: sqlalchemy.engine.Connection,
+) -> None:
+    # TODO: This migration table is what we used to use to keep track of what schema
+    # the database is at. It's not needed anymore now that we have this
+    # subdirectory-based migration infrastructure.
+    #
+    # We should either drop this table entirely from schema 3 and up, or, if we
+    # want to keep it, we should add a row here to stamp it with schema "3".
+    copy_rows_unmodified(
+        schema_2.migration_table,
+        schema_3.migration_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=False,
+    )
+
+    copy_rows_unmodified(
+        schema_2.protocol_table,
+        schema_3.protocol_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+
+    copy_rows_unmodified(
+        schema_2.analysis_table,
+        schema_3.analysis_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+
+    copy_rows_unmodified(
+        schema_2.run_table,
+        schema_3.run_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+
+    copy_rows_unmodified(
+        schema_2.action_table,
+        schema_3.action_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )

--- a/robot-server/robot_server/persistence/_persistence_directory.py
+++ b/robot-server/robot_server/persistence/_persistence_directory.py
@@ -8,6 +8,7 @@ from typing_extensions import Final
 from anyio import Path as AsyncPath, to_thread
 
 from ._folder_migrator import MigrationOrchestrator
+from ._migrations import up_to_3
 
 
 _TEMP_PERSISTENCE_DIR_PREFIX: Final = "opentrons-robot-server-"
@@ -44,7 +45,7 @@ async def prepare_active_subdirectory(prepared_root: Path) -> Path:
     """Return the active persistence subdirectory after preparing it, if necessary."""
     migration_orchestrator = MigrationOrchestrator(
         root=prepared_root,
-        migrations=[],
+        migrations=[up_to_3.MigrationUpTo3(subdirectory="3")],
         temp_file_prefix="temp-",
     )
 

--- a/robot-server/robot_server/persistence/_tables/__init__.py
+++ b/robot-server/robot_server/persistence/_tables/__init__.py
@@ -3,7 +3,6 @@
 # Re-export the latest schema.
 from .schema_3 import (
     metadata,
-    migration_table,
     protocol_table,
     analysis_table,
     run_table,
@@ -13,7 +12,6 @@ from .schema_3 import (
 
 __all__ = [
     "metadata",
-    "migration_table",
     "protocol_table",
     "analysis_table",
     "run_table",

--- a/robot-server/robot_server/persistence/_tables/__init__.py
+++ b/robot-server/robot_server/persistence/_tables/__init__.py
@@ -1,7 +1,5 @@
 """SQL database schemas."""
 
-import sqlalchemy.engine
-
 # Re-export the latest schema.
 from .schema_3 import (
     metadata,
@@ -11,15 +9,6 @@ from .schema_3 import (
     run_table,
     action_table,
 )
-
-
-def add_tables_to_db(sql_engine: sqlalchemy.engine.Engine) -> None:
-    """Create the necessary database tables to back all data stores.
-
-    Params:
-        sql_engine: An engine for a blank SQL database, to put the tables in.
-    """
-    metadata.create_all(sql_engine)
 
 
 __all__ = [

--- a/robot-server/robot_server/persistence/_tables/__init__.py
+++ b/robot-server/robot_server/persistence/_tables/__init__.py
@@ -1,0 +1,32 @@
+"""SQL database schemas."""
+
+import sqlalchemy.engine
+
+# Re-export the latest schema.
+from .schema_2 import (
+    metadata,
+    migration_table,
+    protocol_table,
+    analysis_table,
+    run_table,
+    action_table,
+)
+
+
+def add_tables_to_db(sql_engine: sqlalchemy.engine.Engine) -> None:
+    """Create the necessary database tables to back all data stores.
+
+    Params:
+        sql_engine: An engine for a blank SQL database, to put the tables in.
+    """
+    metadata.create_all(sql_engine)
+
+
+__all__ = [
+    "metadata",
+    "migration_table",
+    "protocol_table",
+    "analysis_table",
+    "run_table",
+    "action_table",
+]

--- a/robot-server/robot_server/persistence/_tables/__init__.py
+++ b/robot-server/robot_server/persistence/_tables/__init__.py
@@ -3,7 +3,7 @@
 import sqlalchemy.engine
 
 # Re-export the latest schema.
-from .schema_2 import (
+from .schema_3 import (
     metadata,
     migration_table,
     protocol_table,

--- a/robot-server/robot_server/persistence/_tables/schema_2.py
+++ b/robot-server/robot_server/persistence/_tables/schema_2.py
@@ -1,15 +1,15 @@
 """SQLite table schemas."""
 import sqlalchemy
 
-from . import legacy_pickle
-from .pickle_protocol_version import PICKLE_PROTOCOL_VERSION
-from ._utc_datetime import UTCDateTime
+from robot_server.persistence import legacy_pickle
+from robot_server.persistence.pickle_protocol_version import PICKLE_PROTOCOL_VERSION
+from robot_server.persistence._utc_datetime import UTCDateTime
 
-_metadata = sqlalchemy.MetaData()
+metadata = sqlalchemy.MetaData()
 
 migration_table = sqlalchemy.Table(
     "migration",
-    _metadata,
+    metadata,
     sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
     sqlalchemy.Column(
@@ -21,7 +21,7 @@ migration_table = sqlalchemy.Table(
 
 protocol_table = sqlalchemy.Table(
     "protocol",
-    _metadata,
+    metadata,
     sqlalchemy.Column(
         "id",
         sqlalchemy.String,
@@ -37,7 +37,7 @@ protocol_table = sqlalchemy.Table(
 
 analysis_table = sqlalchemy.Table(
     "analysis",
-    _metadata,
+    metadata,
     sqlalchemy.Column(
         "id",
         sqlalchemy.String,
@@ -72,10 +72,9 @@ analysis_table = sqlalchemy.Table(
     ),
 )
 
-
 run_table = sqlalchemy.Table(
     "run",
-    _metadata,
+    metadata,
     sqlalchemy.Column(
         "id",
         sqlalchemy.String,
@@ -112,7 +111,7 @@ run_table = sqlalchemy.Table(
 
 action_table = sqlalchemy.Table(
     "action",
-    _metadata,
+    metadata,
     sqlalchemy.Column(
         "id",
         sqlalchemy.String,
@@ -127,12 +126,3 @@ action_table = sqlalchemy.Table(
         nullable=False,
     ),
 )
-
-
-def add_tables_to_db(sql_engine: sqlalchemy.engine.Engine) -> None:
-    """Create the necessary database tables to back all data stores.
-
-    Params:
-        sql_engine: An engine for a blank SQL database, to put the tables in.
-    """
-    _metadata.create_all(sql_engine)

--- a/robot-server/robot_server/persistence/_tables/schema_2.py
+++ b/robot-server/robot_server/persistence/_tables/schema_2.py
@@ -1,4 +1,9 @@
-"""SQLite table schemas."""
+"""v2 of our SQLite schema.
+
+v0 and v1 are subsets of this, missing certain tables and columns.
+See our migration code for details.
+"""
+
 import sqlalchemy
 
 from robot_server.persistence import legacy_pickle

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -1,0 +1,129 @@
+"""v3 of our SQLite schema."""
+
+import sqlalchemy
+
+from robot_server.persistence import legacy_pickle
+from robot_server.persistence.pickle_protocol_version import PICKLE_PROTOCOL_VERSION
+from robot_server.persistence._utc_datetime import UTCDateTime
+
+metadata = sqlalchemy.MetaData()
+
+migration_table = sqlalchemy.Table(
+    "migration",
+    metadata,
+    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
+    sqlalchemy.Column(
+        "version",
+        sqlalchemy.Integer,
+        nullable=False,
+    ),
+)
+
+protocol_table = sqlalchemy.Table(
+    "protocol",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
+)
+
+analysis_table = sqlalchemy.Table(
+    "analysis",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "protocol_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("protocol.id"),
+        index=True,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "analyzer_version",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "completed_analysis",
+        # Stores a pickled dict. See CompletedAnalysisStore.
+        # TODO(mm, 2023-08-30): Remove this. See https://opentrons.atlassian.net/browse/RSS-98.
+        sqlalchemy.LargeBinary,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "completed_analysis_as_document",
+        # Stores the same data as completed_analysis, but serialized as a JSON string.
+        sqlalchemy.String,
+        # This column should never be NULL in practice.
+        # It needs to be nullable=True because of limitations in SQLite and our migration code.
+        nullable=True,
+    ),
+)
+
+run_table = sqlalchemy.Table(
+    "run",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "protocol_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("protocol.id"),
+        nullable=True,
+    ),
+    # column added in schema v1
+    sqlalchemy.Column(
+        "state_summary",
+        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
+        nullable=True,
+    ),
+    # column added in schema v1
+    sqlalchemy.Column(
+        "commands",
+        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
+        nullable=True,
+    ),
+    # column added in schema v1
+    sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
+    # column added in schema v1
+    sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
+)
+
+action_table = sqlalchemy.Table(
+    "action",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
+    sqlalchemy.Column("action_type", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+)

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -8,18 +8,6 @@ from robot_server.persistence._utc_datetime import UTCDateTime
 
 metadata = sqlalchemy.MetaData()
 
-migration_table = sqlalchemy.Table(
-    "migration",
-    metadata,
-    sqlalchemy.Column("id", sqlalchemy.Integer, primary_key=True),
-    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
-    sqlalchemy.Column(
-        "version",
-        sqlalchemy.Integer,
-        nullable=False,
-    ),
-)
-
 protocol_table = sqlalchemy.Table(
     "protocol",
     metadata,

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -40,7 +40,7 @@ from robot_server import app
 from robot_server.hardware import get_hardware, get_ot2_hardware
 from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
 from robot_server.service.session.manager import SessionManager
-from robot_server.persistence import get_sql_engine, create_sql_engine
+from robot_server.persistence import get_sql_engine, create_schema_3_sql_engine
 from robot_server.health.router import ComponentVersions, get_versions
 
 test_router = routing.APIRouter()
@@ -389,6 +389,6 @@ def clear_custom_tiprack_def_dir() -> Iterator[None]:
 def sql_engine(tmp_path: Path) -> Generator[SQLEngine, None, None]:
     """Return a set-up database to back the store."""
     db_file_path = tmp_path / "test.db"
-    sql_engine = create_sql_engine(db_file_path)
+    sql_engine = create_schema_3_sql_engine(db_file_path)
     yield sql_engine
     sql_engine.dispose()

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -42,6 +42,8 @@ async def _assert_reset_was_successful(
     expected_files_and_directories = {
         persistence_directory / "robot_server.db",
         persistence_directory / "protocols",
+        persistence_directory / "3",
+        persistence_directory / "3" / "robot_server.db",
     }
     assert all_files_and_directories == expected_files_and_directories
 

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -84,7 +84,61 @@ EXPECTED_STATEMENTS_LATEST = [
 EXPECTED_STATEMENTS_V3 = EXPECTED_STATEMENTS_LATEST
 
 
-EXPECTED_STATEMENTS_V2 = EXPECTED_STATEMENTS_V3
+EXPECTED_STATEMENTS_V2 = [
+    """
+    CREATE TABLE migration (
+        id INTEGER NOT NULL,
+        created_at DATETIME NOT NULL,
+        version INTEGER NOT NULL,
+        PRIMARY KEY (id)
+    )
+    """,
+    """
+    CREATE TABLE protocol (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_key VARCHAR,
+        PRIMARY KEY (id)
+    )
+    """,
+    """
+    CREATE TABLE analysis (
+        id VARCHAR NOT NULL,
+        protocol_id VARCHAR NOT NULL,
+        analyzer_version VARCHAR NOT NULL,
+        completed_analysis BLOB NOT NULL,
+        completed_analysis_as_document VARCHAR,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_analysis_protocol_id ON analysis (protocol_id)
+    """,
+    """
+    CREATE TABLE run (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_id VARCHAR,
+        state_summary BLOB,
+        commands BLOB,
+        engine_status VARCHAR,
+        _updated_at DATETIME,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE TABLE action (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        action_type VARCHAR NOT NULL,
+        run_id VARCHAR NOT NULL,
+        PRIMARY KEY (id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+]
 
 
 def _normalize_statement(statement: str) -> str:

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -26,14 +26,6 @@ from robot_server.persistence._tables import (
 # Whitespace and formatting changes, on the other hand, are allowed.
 EXPECTED_STATEMENTS_LATEST = [
     """
-    CREATE TABLE migration (
-        id INTEGER NOT NULL,
-        created_at DATETIME NOT NULL,
-        version INTEGER NOT NULL,
-        PRIMARY KEY (id)
-    )
-    """,
-    """
     CREATE TABLE protocol (
         id VARCHAR NOT NULL,
         created_at DATETIME NOT NULL,


### PR DESCRIPTION
# Overview

This is a step towards the database improvement work that we have planned for this release (RSS-98 and RSS-132). It also happens to close RSS-190.

# Test plan

We're well-covered by automated tests, so far.

We'll do further manual testing after follow-up PRs merge, so we can test the changes together.

# Changelog

PR #14329 added a new versioning and migration system for robot-server's persisted data, but it didn't put it into use yet.

This PR adds the first migration under the new system. It's currently a no-op migration that just copies files.

Before:

```
/data/opentrons_robot_server/
    protocols/
    deck_configuration.json
    robot_server.db
```

After:

```
/data/opentrons_robot_server/
    protocols/
    deck_configuration.json
    robot_server.db
    3/
        protocols/
        deck_configuration.json
        robot_server.db
```

Follow-up PRs will edit this migration in-place to add their actual migration work. We will batch them up in the integration branch and release them as one migration.

# Review requests

* Am I forgetting about any files?
* Are the names understandable? Is the organization understandable?

# Risk assessment

Low.
