### PR TITLE
fix(shared-data): widen gripper error bounds

### DIFF
--- a/shared-data/gripper/definitions/1/gripperV1.1.json
+++ b/shared-data/gripper/definitions/1/gripperV1.1.json
@@ -24,6 +24,6 @@
       "min": 60.0,
       "max": 92.0
     },
-    "maxAllowedGripError": 6.0
+    "maxAllowedGripError": 12.0
   }
 }

--- a/shared-data/gripper/definitions/1/gripperV1.2.json
+++ b/shared-data/gripper/definitions/1/gripperV1.2.json
@@ -24,6 +24,6 @@
       "min": 60.0,
       "max": 92.0
     },
-    "maxAllowedGripError": 6.0
+    "maxAllowedGripError": 12.0
   }
 }


### PR DESCRIPTION
Unfortunately, the gripper assemblies vary by enough that without calibration (which we haven't yet implemented) we are not accurate (i.e., encoder position matching physical position) enough to trigger on small errors. A larger value should still catch the cases where the gripper closes on air.

The next step is to implement jaw calibration during home to bring this value down again (RET-1416)

Closes RQA-2242
