### PR TITLE
perf(robot-server): Store one command per row

### DIFF
--- a/robot-server/robot_server/persistence/__init__.py
+++ b/robot-server/robot_server/persistence/__init__.py
@@ -14,6 +14,7 @@ from ._tables import (
     protocol_table,
     analysis_table,
     run_table,
+    run_command_table,
     action_table,
 )
 
@@ -26,6 +27,7 @@ __all__ = [
     "protocol_table",
     "analysis_table",
     "run_table",
+    "run_command_table",
     "action_table",
     # initialization and teardown
     "start_initializing_persistence",

--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -4,11 +4,7 @@ from typing import Any, Dict, List
 
 import sqlalchemy
 
-from .._database import (
-    create_schema_2_sql_engine,
-    create_schema_3_sql_engine,
-    sqlite_rowid,
-)
+from .._database import create_schema_2_sql_engine, create_schema_3_sql_engine
 from .._folder_migrator import Migration
 from .._tables import schema_2, schema_3
 from ._util import copy_rows_unmodified, copy_if_exists, copytree_if_exists
@@ -80,44 +76,34 @@ def _migrate_run_table(
     source_transaction: sqlalchemy.engine.Connection,
     dest_transaction: sqlalchemy.engine.Connection,
 ) -> None:
-    select_everything_except_commands = sqlalchemy.select(
-        schema_2.run_table.c.id,
-        schema_2.run_table.c.created_at,
-        schema_2.run_table.c.protocol_id,
-        schema_2.run_table.c.state_summary,
-        schema_2.run_table.c.engine_status,
-        schema_2.run_table.c._updated_at,
-    ).order_by(sqlite_rowid)
+    select_old_run = sqlalchemy.select(schema_2.run_table)
     insert_new_run = sqlalchemy.insert(schema_3.run_table)
-
-    for old_run_row in (
-        source_transaction.execute(select_everything_except_commands).mappings().all()
-    ):
-        # Insert one at a time to retain sqlite rowid ordering.
-        # Providing many rows at once to execute() may not preserve order.
-        # https://www.mail-archive.com/db-sig@python.org/msg02071.html
-        dest_transaction.execute(insert_new_run, old_run_row)
-
-    select_commands = sqlalchemy.select(
-        schema_2.run_table.c.id, schema_2.run_table.c.commands
-    )
     insert_new_command = sqlalchemy.insert(schema_3.run_command_table)
 
-    for old_command_row in source_transaction.execute(select_commands).all():
-        run_id = old_command_row.id
-        commands: List[Dict[str, Any]] = old_command_row.commands or []
+    for old_run_row in source_transaction.execute(select_old_run).all():
+        dest_transaction.execute(
+            insert_new_run,
+            id=old_run_row.id,
+            created_at=old_run_row.created_at,
+            protocol_id=old_run_row.protocol_id,
+            state_summary=old_run_row.state_summary,
+            engine_status=old_run_row.engine_status,
+            _updated_at=old_run_row._updated_at,
+        )
+
+        commands: List[Dict[str, Any]] = old_run_row.commands or []
         new_command_rows = [
             {
-                "run_id": run_id,
+                "run_id": old_run_row.id,
                 "index_in_run": index_in_run,
                 "command_id": command["id"],
                 "command": command,
             }
             for index_in_run, command in enumerate(commands)
         ]
-        # Insert all the commands in one go, to avoid the overhead of separate
-        # statements, and since we had to bring them all into memory at once in order to
-        # parse them anyway.
+        # Insert all the commands for this run in one go, to avoid the overhead of
+        # separate statements, and since we had to bring them all into memory at once
+        # in order to parse them anyway.
         if len(new_command_rows) > 0:
             # This needs to be guarded by a len>0 check because if the list is empty,
             # SQLAlchemy misinterprets this as inserting a single row with all default

--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List
 
 import sqlalchemy
 
-from .._database import create_schema_2_sql_engine, create_schema_3_sql_engine
+from .._database import (
+    create_schema_2_sql_engine,
+    create_schema_3_sql_engine,
+    sqlite_rowid,
+)
 from .._folder_migrator import Migration
 from .._tables import schema_2, schema_3
 from ._util import copy_rows_unmodified, copy_if_exists, copytree_if_exists
@@ -76,11 +80,11 @@ def _migrate_run_table(
     source_transaction: sqlalchemy.engine.Connection,
     dest_transaction: sqlalchemy.engine.Connection,
 ) -> None:
-    select_old_run = sqlalchemy.select(schema_2.run_table)
+    select_old_runs = sqlalchemy.select(schema_2.run_table).order_by(sqlite_rowid)
     insert_new_run = sqlalchemy.insert(schema_3.run_table)
     insert_new_command = sqlalchemy.insert(schema_3.run_command_table)
 
-    for old_run_row in source_transaction.execute(select_old_run).all():
+    for old_run_row in source_transaction.execute(select_old_runs).all():
         dest_transaction.execute(
             insert_new_run,
             id=old_run_row.id,

--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -1,3 +1,13 @@
+"""Migrate the persistence directory from schema 2 to 3.
+
+Summary of changes from schema 2:
+
+- Run commands were formerly stored as monolithic blobs in the run table,
+  with each row storing an entire list. This has been split out into a new
+  run_command table, where each individual command gets its own row.
+"""
+
+
 from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, Dict, List

--- a/robot-server/robot_server/persistence/_tables/__init__.py
+++ b/robot-server/robot_server/persistence/_tables/__init__.py
@@ -6,6 +6,7 @@ from .schema_3 import (
     protocol_table,
     analysis_table,
     run_table,
+    run_command_table,
     action_table,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "protocol_table",
     "analysis_table",
     "run_table",
+    "run_command_table",
     "action_table",
 ]

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -87,12 +87,6 @@ run_table = sqlalchemy.Table(
         nullable=True,
     ),
     # column added in schema v1
-    sqlalchemy.Column(
-        "commands",
-        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
-        nullable=True,
-    ),
-    # column added in schema v1
     sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
     # column added in schema v1
     sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
@@ -113,5 +107,28 @@ action_table = sqlalchemy.Table(
         sqlalchemy.String,
         sqlalchemy.ForeignKey("run.id"),
         nullable=False,
+    ),
+)
+
+run_command_table = sqlalchemy.Table(
+    "run_command",
+    metadata,
+    sqlalchemy.Column(
+        "run_id", sqlalchemy.String, sqlalchemy.ForeignKey("run.id"), nullable=False
+    ),
+    sqlalchemy.Column("index_in_run", sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "command",
+        # TODO: Should be JSON.
+        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
+        nullable=False,
+    ),
+    sqlalchemy.PrimaryKeyConstraint("run_id", "command_id"),
+    sqlalchemy.Index(
+        "ix_run_run_id_index_in_run",  # An arbitrary name for the index.
+        "run_id",
+        "index_in_run",
+        unique=True,
     ),
 )

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -113,6 +113,7 @@ action_table = sqlalchemy.Table(
 run_command_table = sqlalchemy.Table(
     "run_command",
     metadata,
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
     sqlalchemy.Column(
         "run_id", sqlalchemy.String, sqlalchemy.ForeignKey("run.id"), nullable=False
     ),
@@ -125,7 +126,12 @@ run_command_table = sqlalchemy.Table(
         sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
         nullable=False,
     ),
-    sqlalchemy.PrimaryKeyConstraint("run_id", "command_id"),
+    sqlalchemy.Index(
+        "ix_run_run_id_command_id",  # An arbitrary name for the index.
+        "run_id",
+        "command_id",
+        unique=True,
+    ),
     sqlalchemy.Index(
         "ix_run_run_id_index_in_run",  # An arbitrary name for the index.
         "run_id",

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -120,7 +120,8 @@ run_command_table = sqlalchemy.Table(
     sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
     sqlalchemy.Column(
         "command",
-        # TODO: Should be JSON.
+        # TODO(mm, 2024-01-25): This should be JSON instead of a pickle. See:
+        # https://opentrons.atlassian.net/browse/RSS-98.
         sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
         nullable=False,
     ),

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
-from typing import Any, Dict, List, Optional, cast
+from typing import Dict, List, Optional
 
 import sqlalchemy
 from pydantic import parse_obj_as, ValidationError
@@ -13,7 +13,12 @@ from opentrons.util.helpers import utc_now
 from opentrons.protocol_engine import StateSummary, CommandSlice
 from opentrons.protocol_engine.commands import Command
 
-from robot_server.persistence import run_table, action_table, sqlite_rowid
+from robot_server.persistence import (
+    run_table,
+    run_command_table,
+    action_table,
+    sqlite_rowid,
+)
 from robot_server.protocols import ProtocolNotFoundError
 
 from .action_models import RunAction, RunActionType
@@ -78,28 +83,42 @@ class RunStore:
             .values(
                 _convert_state_to_sql_values(
                     run_id=run_id,
-                    commands=commands,
                     state_summary=summary,
                     engine_status=summary.status,
                 )
             )
         )
+
+        delete_existing_commands = sqlalchemy.delete(run_command_table).where(
+            run_command_table.c.run_id == run_id
+        )
+        insert_command = sqlalchemy.insert(run_command_table)
+
         select_run_resource = sqlalchemy.select(_run_columns).where(
             run_table.c.id == run_id
         )
-
         select_actions = sqlalchemy.select(action_table).where(
             action_table.c.run_id == run_id
         )
 
         with self._sql_engine.begin() as transaction:
-            transaction.execute(update_run)
-
-            try:
-                run_row = transaction.execute(select_run_resource).one()
-            except sqlalchemy.exc.NoResultFound:
+            if not self._run_exists(run_id, transaction):
                 raise RunNotFoundError(run_id=run_id)
 
+            transaction.execute(update_run)
+            transaction.execute(delete_existing_commands)
+            for command_index, command in enumerate(commands):
+                transaction.execute(
+                    insert_command,
+                    {
+                        "run_id": run_id,
+                        "index_in_run": command_index,
+                        "command_id": command.id,
+                        "command": command.dict(),
+                    },
+                )
+
+            run_row = transaction.execute(select_run_resource).one()
             action_rows = transaction.execute(select_actions).all()
 
         self._clear_caches()
@@ -120,10 +139,9 @@ class RunStore:
         )
 
         with self._sql_engine.begin() as transaction:
-            try:
-                transaction.execute(insert)
-            except sqlalchemy.exc.IntegrityError as e:
-                raise RunNotFoundError(run_id=run_id) from e
+            if not self._run_exists(run_id, transaction):
+                raise RunNotFoundError(run_id=run_id)
+            transaction.execute(insert)
 
         self._clear_caches()
 
@@ -172,9 +190,8 @@ class RunStore:
     @lru_cache(maxsize=_CACHE_ENTRIES)
     def has(self, run_id: str) -> bool:
         """Whether a given run exists in the store."""
-        statement = sqlalchemy.select(run_table.c.id).where(run_table.c.id == run_id)
         with self._sql_engine.begin() as transaction:
-            return transaction.execute(statement).first() is not None
+            return self._run_exists(run_id, transaction)
 
     @lru_cache(maxsize=_CACHE_ENTRIES)
     def get(self, run_id: str) -> RunResource:
@@ -269,22 +286,6 @@ class RunStore:
             log.warning(f"Error retrieving state summary for {run_id}: {e}")
             return None
 
-    @lru_cache(maxsize=_CACHE_ENTRIES)
-    def _get_all_unparsed_commands(self, run_id: str) -> List[Dict[str, Any]]:
-        select_run_commands = sqlalchemy.select(run_table.c.commands).where(
-            run_table.c.id == run_id
-        )
-
-        with self._sql_engine.begin() as transaction:
-            try:
-                row = transaction.execute(select_run_commands).one()
-            except sqlalchemy.exc.NoResultFound:
-                raise RunNotFoundError(run_id=run_id)
-
-        return (
-            cast(List[Dict[str, Any]], row.commands) if row.commands is not None else []
-        )
-
     def get_commands_slice(
         self,
         run_id: str,
@@ -297,6 +298,8 @@ class RunStore:
             run_id: Run ID to pull commands from.
             length: Number of commands to return.
             cursor: The starting index of the slice in the whole collection.
+                If `None`, up to `length` elements at the end of the collection will
+                be returned.
 
         Returns:
             A collection of commands as well as the actual cursor used and
@@ -305,22 +308,41 @@ class RunStore:
         Raises:
             RunNotFoundError: The given run ID was not found.
         """
-        command_intent_dicts = self._get_all_unparsed_commands(run_id)
-        commands_length = len(command_intent_dicts)
-        if cursor is None:
-            cursor = commands_length - length
+        with self._sql_engine.begin() as transaction:
+            if not self._run_exists(run_id, transaction):
+                raise RunNotFoundError(run_id=run_id)
 
-        # start is inclusive, stop is exclusive
-        actual_cursor = max(0, min(cursor, commands_length - 1))
-        stop = min(commands_length, actual_cursor + length)
+            select_count = sqlalchemy.select(sqlalchemy.func.count()).where(
+                run_command_table.c.run_id == run_id
+            )
+            count_result: int = transaction.execute(select_count).scalar_one()
+
+            actual_cursor = cursor if cursor is not None else count_result - length
+            # Clamp to [0, count_result).
+            actual_cursor = max(0, min(actual_cursor, count_result - 1))
+
+            select_slice = (
+                sqlalchemy.select(
+                    run_command_table.c.index_in_run, run_command_table.c.command
+                )
+                .where(
+                    run_command_table.c.run_id == run_id,
+                    run_command_table.c.index_in_run >= actual_cursor,
+                    run_command_table.c.index_in_run < actual_cursor + length,
+                )
+                .order_by(run_command_table.c.index_in_run)
+            )
+
+            slice_result = transaction.execute(select_slice).all()
+
         sliced_commands: List[Command] = [
-            parse_obj_as(Command, command)  # type: ignore[arg-type]
-            for command in command_intent_dicts[actual_cursor:stop]
+            parse_obj_as(Command, row.command)  # type: ignore[arg-type]
+            for row in slice_result
         ]
 
         return CommandSlice(
             cursor=actual_cursor,
-            total_length=commands_length,
+            total_length=count_result,
             commands=sliced_commands,
         )
 
@@ -339,19 +361,18 @@ class RunStore:
             RunNotFoundError: The given run ID was not found in the store.
             CommandNotFoundError: The given command ID was not found in the store.
         """
-        select_run_commands = sqlalchemy.select(run_table.c.commands).where(
-            run_table.c.id == run_id
+        select_command = sqlalchemy.select(run_command_table.c.command).where(
+            run_command_table.c.run_id == run_id,
+            run_command_table.c.command_id == command_id,
         )
-        with self._sql_engine.begin() as transaction:
-            try:
-                row = transaction.execute(select_run_commands).one()
-            except sqlalchemy.exc.NoResultFound as e:
-                raise RunNotFoundError(run_id=run_id) from e
 
-        try:
-            command = next(c for c in row.commands if c["id"] == command_id)
-        except StopIteration as e:
-            raise CommandNotFoundError(command_id=command_id) from e
+        with self._sql_engine.begin() as transaction:
+            if not self._run_exists(run_id, transaction):
+                raise RunNotFoundError(run_id=run_id)
+
+            command = transaction.execute(select_command).scalar_one_or_none()
+            if command is None:
+                raise CommandNotFoundError(command_id=command_id)
 
         return parse_obj_as(Command, command)  # type: ignore[arg-type]
 
@@ -368,8 +389,12 @@ class RunStore:
         delete_actions = sqlalchemy.delete(action_table).where(
             action_table.c.run_id == run_id
         )
+        delete_commands = sqlalchemy.delete(run_command_table).where(
+            run_command_table.c.run_id == run_id
+        )
         with self._sql_engine.begin() as transaction:
             transaction.execute(delete_actions)
+            transaction.execute(delete_commands)
             result = transaction.execute(delete_run)
 
         if result.rowcount < 1:
@@ -377,13 +402,20 @@ class RunStore:
 
         self._clear_caches()
 
+    def _run_exists(
+        self, run_id: str, connection: sqlalchemy.engine.Connection
+    ) -> bool:
+        result: bool = connection.execute(
+            sqlalchemy.select(sqlalchemy.exists().where(run_table.c.id == run_id))
+        ).scalar_one()
+        return result
+
     def _clear_caches(self) -> None:
         self.has.cache_clear()
         self.get.cache_clear()
         self.get_all.cache_clear()
         self.get_state_summary.cache_clear()
         self.get_command.cache_clear()
-        self._get_all_unparsed_commands.cache_clear()
 
 
 # The columns that must be present in a row passed to _convert_row_to_run().
@@ -438,12 +470,10 @@ def _convert_action_to_sql_values(action: RunAction, run_id: str) -> Dict[str, o
 def _convert_state_to_sql_values(
     run_id: str,
     state_summary: StateSummary,
-    commands: List[Command],
     engine_status: str,
 ) -> Dict[str, object]:
     return {
         "state_summary": state_summary.dict(),
         "engine_status": engine_status,
-        "commands": [command.dict() for command in commands],
         "_updated_at": utc_now(),
     }

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -71,13 +71,17 @@ EXPECTED_STATEMENTS_LATEST = [
     """,
     """
     CREATE TABLE run_command (
+        row_id INTEGER NOT NULL,
         run_id VARCHAR NOT NULL,
         index_in_run INTEGER NOT NULL,
         command_id VARCHAR NOT NULL,
         command BLOB NOT NULL,
-        PRIMARY KEY (run_id, command_id),
+        PRIMARY KEY (row_id),
         FOREIGN KEY(run_id) REFERENCES run (id)
     )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_command_id ON run_command (run_id, command_id)
     """,
     """
     CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
@@ -190,4 +194,7 @@ def test_creating_tables_emits_expected_statements(
     normalized_actual = [_normalize_statement(s) for s in actual_statements]
     normalized_expected = [_normalize_statement(s) for s in expected_statements]
 
-    assert normalized_actual == normalized_expected
+    # Compare ignoring order. SQLAlchemy appears to emit CREATE INDEX statements in a
+    # nondeterministic order that varies across runs. Although statement order
+    # theoretically matters, it's unlikely to matter in practice for our purposes here.
+    assert set(normalized_actual) == set(normalized_expected)

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -53,7 +53,6 @@ EXPECTED_STATEMENTS_LATEST = [
         created_at DATETIME NOT NULL,
         protocol_id VARCHAR,
         state_summary BLOB,
-        commands BLOB,
         engine_status VARCHAR,
         _updated_at DATETIME,
         PRIMARY KEY (id),
@@ -69,6 +68,19 @@ EXPECTED_STATEMENTS_LATEST = [
         PRIMARY KEY (id),
         FOREIGN KEY(run_id) REFERENCES run (id)
     )
+    """,
+    """
+    CREATE TABLE run_command (
+        run_id VARCHAR NOT NULL,
+        index_in_run INTEGER NOT NULL,
+        command_id VARCHAR NOT NULL,
+        command BLOB NOT NULL,
+        PRIMARY KEY (run_id, command_id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
     """,
 ]
 


### PR DESCRIPTION
# Overview

Closes RSS-132. See that ticket for background.

# Test Plan

I think we're sufficiently covered by existing automated integration tests.

[I've reviewed some of the new queries with SQLite's `EXPLAIN QUERY PLAN`](https://gist.github.com/SyntaxColoring/0207c40f82a6ad5b16fb269e37927a0f). They look like they're all using fast index-based searches instead of slow full table scans.

# Changelog

* Remove the `run.commands` column, where each value was a large list of commands.
* In its place, add a `run_commands` table, where each row holds just a single command.

  | **run_id** | **index_in_run** | **command_id** | **command** |
  |------------|------------------|----------------|-------------|
  | run1       | 0                | abcd           | [blob]      |
  | run1       | 1                | efgh           | [blob]      |
  | run2       | 0                | ijkl           | [blob]      |
  | run2       | 1                | mnop           | [blob]      |
  | ...        | ...              | ...            | ...         |

* Update `RunStore` to use the new table.
* Add a migration.

# Review requests

This new table will be our biggest, by far. Tens of thousands of records, as opposed to ~20 in our existing tables. One of SQL's traps is that it's easy to accidentally write a very inefficient query. If the right indexes aren't set up, SQLite will degrade to a full O(n) table scan. So scrutinize my queries to make sure we're not doing that.

Also see my inline review comments.

# Risk assessment

Medium. See review requests above.