### PR TITLE
fix(shared-data): load pick up current properly

### DIFF
--- a/shared-data/python/opentrons_shared_data/pipette/model_constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/model_constants.py
@@ -60,7 +60,12 @@ _MAP_KEY_TO_V2: Dict[str, List[str]] = {
     "bottom": ["plungerPositionsConfigurations", "default", "bottom"],
     "blowout": ["plungerPositionsConfigurations", "default", "blowout"],
     "dropTip": ["plungerPositionsConfigurations", "default", "drop"],
-    "pickUpCurrent": ["pickUpTipConfigurations", "pressFit", "currentByTipCount"],
+    "pickUpCurrent": [
+        "pickUpTipConfigurations",
+        "pressFit",
+        "currentByTipCount",
+        "##EACHTIP##",
+    ],
     "pickUpDistance": ["pickUpTipConfigurations", "pressFit", "distance"],
     "pickUpIncrement": ["pickUpTipConfigurations", "pressFit", "increment"],
     "pickUpPresses": ["pickUpTipConfigurations", "pressFit", "presses"],

--- a/shared-data/python/tests/pipette/test_mutable_configurations.py
+++ b/shared-data/python/tests/pipette/test_mutable_configurations.py
@@ -58,6 +58,34 @@ def overrides_fixture(
     return types.MutableConfig.build(**TMPFILE_DATA["pickUpSpeed"], name="pickUpSpeed")
 
 
+def test_load_old_overrides_regression(
+    TMPFILE_DATA: Dict[str, Any], override_configuration_path: Path
+) -> None:
+    TMPFILE_DATA["pickUpCurrent"] = {
+        "value": 0.15,
+        "min": 0.08,
+        "max": 0.2,
+        "units": "amps",
+        "type": "float",
+        "default": 0.1,
+    }
+    json.dump(
+        TMPFILE_DATA, open(override_configuration_path / "P20SV222021040709.json", "w")
+    )
+    configs = mutable_configurations.load_with_mutable_configurations(
+        pipette_definition.PipetteModelVersionType(
+            pipette_type=types.PipetteModelType.p20,
+            pipette_channels=types.PipetteChannelType.SINGLE_CHANNEL,
+            pipette_version=types.PipetteVersionType(2, 2),
+        ),
+        override_configuration_path,
+        "P20SV222021040709",
+    )
+    assert configs.pick_up_tip_configurations.press_fit.current_by_tip_count == {
+        1: 0.15
+    }
+
+
 def test_list_mutable_configs_unknown_pipette_id(
     override_configuration_path: Path,
 ) -> None:


### PR DESCRIPTION
While we properly handled _most_ kinds of pipette config, there's one we didn't: pick up current. It gets special treatment now because we can properly set different currents for different numbers of tips, rather than being a value. So, we need to mark it as a setting that needs to be iterated over a dictionary in its leaf value rather than directly set.

This also fixes an issue that caused the OT-2 to not boot when loading a pipette configuration that had a pick up current customization, since this code is called when loading a pipette.

It may be closing the barn after the horse escapes, but to prevent similar issues preventing boot, I also tossed in a catch all except that logs a loud message but won't prevent starting the server.

## Testing
- [x] With this PR, modify a pipette's pick up current and check that the system reboots properly and the values are preserved across reboots
- [x] Downgrade an OT-2 to 6.3.0, modify a pipette's pick-up current, and then update to something with this PR
   - [x] note that this isn't really necessary because 6.3.0, 7.0.1, 7.1.0, and edge all produce exactly the same config override file

Closes RESC-187
