### PR TITLE
refactor(protocol-designer): add text to i18n

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -376,7 +376,7 @@ export function FileSidebar(): JSX.Element {
             onCloseClick={cancelModal}
             buttons={[
               {
-                children: t('Cancel'),
+                children: t('cancel'),
                 onClick: cancelModal,
               },
               {

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -282,7 +282,7 @@ export function FileSidebar(): JSX.Element {
   const loadFile = (
     fileChangeEvent: React.ChangeEvent<HTMLInputElement>
   ): void => {
-    if (!hasUnsavedChanges || window.confirm(t('window.confirm_import'))) {
+    if (!hasUnsavedChanges || window.confirm(t('confirm_import'))) {
       dispatch(loadFileActions.loadProtocolFile(fileChangeEvent))
     }
   }

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -376,11 +376,11 @@ export function FileSidebar(): JSX.Element {
             onCloseClick={cancelModal}
             buttons={[
               {
-                children: 'CANCEL',
+                children: t('Cancel'),
                 onClick: cancelModal,
               },
               {
-                children: 'CONTINUE WITH EXPORT',
+                children: t('continue_with_export'),
                 className: modalStyles.long_button,
                 onClick: () => {
                   setShowExportWarningModal(false)
@@ -396,11 +396,11 @@ export function FileSidebar(): JSX.Element {
       <SidePanel title="Protocol File">
         <div className={styles.file_sidebar}>
           <OutlineButton onClick={createNewFile} className={styles.button}>
-            Create New
+            {t('create_new')}
           </OutlineButton>
 
           <OutlineButton Component="label" className={cx(styles.upload_button)}>
-            Import
+            {t('import')}
             <input type="file" onChange={loadFile} />
           </OutlineButton>
 
@@ -417,7 +417,7 @@ export function FileSidebar(): JSX.Element {
               }}
               disabled={!canDownload}
             >
-              Export
+              {t('export')}
             </DeprecatedPrimaryButton>
           </div>
         </div>

--- a/protocol-designer/src/components/IngredientsList/index.tsx
+++ b/protocol-designer/src/components/IngredientsList/index.tsx
@@ -143,9 +143,7 @@ function IngredIndividual(props: IndividProps): JSX.Element {
           className={styles.close_icon}
           name="close"
           onClick={() =>
-            window.confirm(
-              `Are you sure you want to delete well ${wellName} ?`
-            ) &&
+            window.confirm(t('are_you_sure_delete_well', { well: wellName })) &&
             removeWellsContents({ liquidGroupId: groupId, wells: [wellName] })
           }
         />

--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
@@ -111,12 +111,7 @@ export const LiquidPlacementForm = (): JSX.Element | null => {
 
   const handleClearWells: () => void = () => {
     if (labwareId && selectedWells && selectionHasLiquids) {
-      // TODO: Ian 2018-10-22 replace with modal later on if we like this UX
-      if (
-        global.confirm(
-          'Are you sure you want to remove liquids from all selected wells?'
-        )
-      ) {
+      if (global.confirm(t('application:are_you_sure'))) {
         dispatch(
           removeWellsContents({
             labwareId: labwareId,

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 import {
   Flex,
@@ -17,10 +17,6 @@ export interface Announcement {
   message: React.ReactNode
 }
 
-interface AnnouncementProps {
-  t: any
-}
-
 const batchEditStyles = css`
   justify-content: ${JUSTIFY_SPACE_AROUND};
   padding: ${SPACING.spacing16};
@@ -34,8 +30,8 @@ const PD = 'Protocol Designer'
 const APP = 'Opentrons App'
 const OPENTRONS_PD = 'Opentrons Protocol Designer'
 
-export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
-  const { t } = props
+export const useAnnouncements = (): Announcement[] => {
+  const { t } = useTranslation('modal')
 
   return [
     {

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -48,14 +48,16 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </div>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('modulesRequireRunAppUpdate.body1', { pd: PD })}</p>
+          <p>
+            {t('announcements.modulesRequireRunAppUpdate.body1', { pd: PD })}
+          </p>
           <p>
             <Trans
               t={t}
-              i18nKey={'modulesRequireRunAppUpdate.body2'}
+              i18nKey={'announcements.modulesRequireRunAppUpdate.body2'}
               components={{ bold: <strong /> }}
               values={{ app: APP }}
             />
@@ -73,14 +75,14 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </div>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('thermocyclerSupport.body1', { pd: PD })}</p>
+          <p>{t('announcements.thermocyclerSupport.body1', { pd: PD })}</p>
           <p>
             <Trans
               t={t}
-              i18nKey={'thermocyclerSupport.body2'}
+              i18nKey={'announcements.thermocyclerSupport.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />
@@ -90,15 +92,15 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
     },
     {
       announcementKey: 'airGapDelaySettings',
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       image: null,
       message: (
         <>
-          <p>{t('airGapDelaySettings.body1', { pd: PD })}</p>
+          <p>{t('announcements.airGapDelaySettings.body1', { pd: PD })}</p>
           <p>
             <Trans
               t={t}
-              i18nKey={'airGapDelaySettings.body2'}
+              i18nKey={'announcements.airGapDelaySettings.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />
@@ -117,24 +119,24 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           <img src={require('../../../images/announcements/batch_edit.gif')} />
         </Flex>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('batchEditTransfer.body1')}</p>
+          <p>{t('announcements.batchEditTransfer.body1')}</p>
           <ul>
-            <li>{t('batchEditTransfer.body2')}</li>
-            <li>{t('batchEditTransfer.body3')}</li>
+            <li>{t('announcements.batchEditTransfer.body2')}</li>
+            <li>{t('announcements.batchEditTransfer.body3')}</li>
           </ul>
 
           <p>
             <Trans
               t={t}
-              i18nKey={'batchEditTransfer.body4'}
+              i18nKey={'announcements.batchEditTransfer.body4'}
               components={{ strong: <strong /> }}
             />
           </p>
 
-          <p>{t('batchEditTransfer.body5')}</p>
+          <p>{t('announcements.batchEditTransfer.body5')}</p>
         </>
       ),
     },
@@ -148,14 +150,18 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </div>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('heaterShakerSupport.body1', { opd: OPENTRONS_PD })}</p>
+          <p>
+            {t('announcements.heaterShakerSupport.body1', {
+              opd: OPENTRONS_PD,
+            })}
+          </p>
           <p>
             <Trans
               t={t}
-              i18nKey={'heaterShakerSupport.body2'}
+              i18nKey={'announcements.heaterShakerSupport.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />
@@ -173,14 +179,18 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </div>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('thermocyclerGen2Support.body1', { opd: OPENTRONS_PD })}</p>
+          <p>
+            {t('announcements.thermocyclerGen2Support.body1', {
+              opd: OPENTRONS_PD,
+            })}
+          </p>
           <p>
             <Trans
               t={t}
-              i18nKey={'thermocyclerGen2Support.body2'}
+              i18nKey={'announcements.thermocyclerGen2Support.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />
@@ -198,14 +208,18 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </div>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('liquidColorEnhancements.body1', { opd: OPENTRONS_PD })}</p>
+          <p>
+            {t('announcements.liquidColorEnhancements.body1', {
+              opd: OPENTRONS_PD,
+            })}
+          </p>
           <p>
             <Trans
               t={t}
-              i18nKey={'liquidColorEnhancements.body2'}
+              i18nKey={'announcements.liquidColorEnhancements.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />
@@ -224,14 +238,19 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </Flex>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('flexSupport7.0.body1', { pd: PD, flex: 'Opentrons Flex' })}</p>
+          <p>
+            {t('announcements.flexSupport.body1', {
+              pd: PD,
+              flex: 'Opentrons Flex',
+            })}
+          </p>
           <p>
             <Trans
               t={t}
-              i18nKey={'flexSupport7.0.body2'}
+              i18nKey={'announcements.flexSupport.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />
@@ -249,14 +268,14 @@ export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
           />
         </Flex>
       ),
-      heading: t('header', { pd: PD }),
+      heading: t('announcements.header', { pd: PD }),
       message: (
         <>
-          <p>{t('deckConfigAnd96Channel8.0.body1', { pd: PD })}</p>
+          <p>{t('announcements.deckConfigAnd96Channel.body1', { pd: PD })}</p>
           <p>
             <Trans
               t={t}
-              i18nKey={'deckConfigAnd96Channel8.0.body2'}
+              i18nKey={'announcements.deckConfigAnd96Channel.body2'}
               components={{ strong: <strong /> }}
               values={{ app: APP }}
             />

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Trans } from 'react-i18next'
 import { css } from 'styled-components'
 import {
   Flex,
@@ -16,6 +17,10 @@ export interface Announcement {
   message: React.ReactNode
 }
 
+interface AnnouncementProps {
+  t: any
+}
+
 const batchEditStyles = css`
   justify-content: ${JUSTIFY_SPACE_AROUND};
   padding: ${SPACING.spacing16};
@@ -25,223 +30,239 @@ const batchEditStyles = css`
   }
 `
 
-export const announcements: Announcement[] = [
-  {
-    announcementKey: 'modulesRequireRunAppUpdate',
-    image: (
-      <div className={styles.modules_diagrams_row}>
-        <img
-          className={styles.modules_diagram}
-          src={require('../../../images/modules/magdeck_tempdeck_combined.png')}
-        />
-      </div>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>
-          Protocol Designer Beta now includes support for Temperature and
-          Magnetic modules.
-        </p>
-        <p>
-          Note: Protocols with modules{' '}
-          <strong>may require an app and robot update to run</strong>. You will
-          need to have the OT-2 app and robot on the latest versions (
-          <strong>3.17 or higher</strong>).
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'thermocyclerSupport',
-    image: (
-      <div className={styles.thermocycler_diagram_row}>
-        <img
-          className={styles.modules_diagram}
-          src={require('../../../images/modules/thermocycler.jpg')}
-        />
-      </div>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>Protocol Designer Beta now includes support for the Thermocycler!</p>
-        <p>
-          Note: Protocols with modules{' '}
-          <strong>may require an app and robot update to run</strong>. You will
-          need to have the OT-2 app and robot on the latest versions (
-          <strong>3.18 or higher</strong>).
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'airGapDelaySettings',
-    heading: "We've updated the Protocol Designer",
-    image: null,
-    message: (
-      <>
-        <p>
-          Protocol Designer Beta now includes support for more pipetting
-          settings: Air gap and Delay.{' '}
-        </p>
-        <p>
-          Note: Protocols using new features{' '}
-          <strong>may require an app and robot update to run.</strong> You will
-          need to have the OT-2 app and orbot on the latest versions (
-          <strong>3.20 or higher</strong>).{' '}
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'batchEditTransfer',
-    image: (
-      <Flex css={batchEditStyles}>
-        <img src={require('../../../images/announcements/multi_select.gif')} />
+const PD = 'Protocol Designer'
+const APP = 'Opentrons App'
+const OPENTRONS_PD = 'Opentrons Protocol Designer'
 
-        <img src={require('../../../images/announcements/batch_edit.gif')} />
-      </Flex>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>Starting today, you’ll be able to:</p>
-        <ul>
-          <li>Select, delete, and duplicate multiple steps at once</li>
-          <li>
-            Edit advanced settings for multiple Transfer or Mix steps at once
-          </li>
-        </ul>
+export const getAnnouncements = (props: AnnouncementProps): Announcement[] => {
+  const { t } = props
 
-        <p>
-          To enter multi-select mode, simply hold <strong>SHIFT</strong> or{' '}
-          <strong>CTRL/CMND</strong> and click on a step.
-        </p>
+  return [
+    {
+      announcementKey: 'modulesRequireRunAppUpdate',
+      image: (
+        <div className={styles.modules_diagrams_row}>
+          <img
+            className={styles.modules_diagram}
+            src={require('../../../images/modules/magdeck_tempdeck_combined.png')}
+          />
+        </div>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('modulesRequireRunAppUpdate.body1', { pd: PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'modulesRequireRunAppUpdate.body2'}
+              components={{ bold: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'thermocyclerSupport',
+      image: (
+        <div className={styles.thermocycler_diagram_row}>
+          <img
+            className={styles.modules_diagram}
+            src={require('../../../images/modules/thermocycler.jpg')}
+          />
+        </div>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('thermocyclerSupport.body1', { pd: PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'thermocyclerSupport.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'airGapDelaySettings',
+      heading: t('header', { pd: PD }),
+      image: null,
+      message: (
+        <>
+          <p>{t('airGapDelaySettings.body1', { pd: PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'airGapDelaySettings.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'batchEditTransfer',
+      image: (
+        <Flex css={batchEditStyles}>
+          <img
+            src={require('../../../images/announcements/multi_select.gif')}
+          />
 
-        <p>
-          From here, you can access the control bar at the top of the protocol
-          timeline, or edit advanced settings for Transfer or Mix steps!
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'heaterShakerSupport',
-    image: (
-      <div className={styles.modules_diagrams_row}>
-        <img
-          className={styles.modules_diagram}
-          src={require('../../../images/modules/heatershaker.png')}
-        />
-      </div>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>
-          The Opentrons Protocol Designer now supports our Heater-Shaker Module!
-        </p>
-        <p>
-          All protocols now require Opentrons App version
-          <strong> 6.1+ </strong> to run.
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'thermocyclerGen2Support',
-    image: (
-      <div className={styles.modules_diagrams_row}>
-        <img
-          className={styles.modules_diagram}
-          src={require('../../../images/modules/thermocycler_gen2.png')}
-        />
-      </div>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>
-          The Opentrons Protocol Designer now supports our Thermocycler Module
-          GEN2!
-        </p>
-        <p>
-          All protocols now require Opentrons App version
-          <strong> 6.2+ </strong> to run.
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'liquidColorEnhancements',
-    image: (
-      <div className={styles.modules_diagrams_color_enhancements}>
-        <img
-          className={styles.modules_diagram}
-          src={require('../../../images/announcements/liquid-enhancements.gif')}
-        />
-      </div>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>
-          The Opentrons Protocol Designer now lets you customize liquid colors!
-        </p>
-        <p>
-          All protocols now require Opentrons App version
-          <strong> 6.2+ </strong> to run.
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'flexSupport7.0',
-    image: (
-      <Flex justifyContent={JUSTIFY_CENTER}>
-        <img
-          height="240"
-          width="240"
-          src={require('../../../images/OpentronsFlex.png')}
-        />
-      </Flex>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>
-          Introducing the Protocol Designer 7.0 with Opentrons Flex support!
-        </p>
-        <p>
-          All protocols now require Opentrons App version
-          <strong> 7.0+ </strong> to run.
-        </p>
-      </>
-    ),
-  },
-  {
-    announcementKey: 'deckConfigAnd96Channel8.0',
-    image: (
-      <Flex justifyContent={JUSTIFY_CENTER} paddingTop={SPACING.spacing8}>
-        <img
-          width="340"
-          src={require('../../../images/deck_configuration.png')}
-        />
-      </Flex>
-    ),
-    heading: "We've updated the Protocol Designer",
-    message: (
-      <>
-        <p>
-          Introducing the Protocol Designer 8.0 with deck configuration and
-          96-channel pipette support!
-        </p>
-        <p>
-          All protocols now require Opentrons App version
-          <strong> 7.1+ </strong> to run.
-        </p>
-      </>
-    ),
-  },
-]
+          <img src={require('../../../images/announcements/batch_edit.gif')} />
+        </Flex>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('batchEditTransfer.body1')}</p>
+          <ul>
+            <li>{t('batchEditTransfer.body2')}</li>
+            <li>{t('batchEditTransfer.body3')}</li>
+          </ul>
+
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'batchEditTransfer.body4'}
+              components={{ strong: <strong /> }}
+            />
+          </p>
+
+          <p>{t('batchEditTransfer.body5')}</p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'heaterShakerSupport',
+      image: (
+        <div className={styles.modules_diagrams_row}>
+          <img
+            className={styles.modules_diagram}
+            src={require('../../../images/modules/heatershaker.png')}
+          />
+        </div>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('heaterShakerSupport.body1', { opd: OPENTRONS_PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'heaterShakerSupport.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'thermocyclerGen2Support',
+      image: (
+        <div className={styles.modules_diagrams_row}>
+          <img
+            className={styles.modules_diagram}
+            src={require('../../../images/modules/thermocycler_gen2.png')}
+          />
+        </div>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('thermocyclerGen2Support.body1', { opd: OPENTRONS_PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'thermocyclerGen2Support.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'liquidColorEnhancements',
+      image: (
+        <div className={styles.modules_diagrams_color_enhancements}>
+          <img
+            className={styles.modules_diagram}
+            src={require('../../../images/announcements/liquid-enhancements.gif')}
+          />
+        </div>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('liquidColorEnhancements.body1', { opd: OPENTRONS_PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'liquidColorEnhancements.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'flexSupport7.0',
+      image: (
+        <Flex justifyContent={JUSTIFY_CENTER}>
+          <img
+            height="240"
+            width="240"
+            src={require('../../../images/OpentronsFlex.png')}
+          />
+        </Flex>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('flexSupport7.0.body1', { pd: PD, flex: 'Opentrons Flex' })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'flexSupport7.0.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+    {
+      announcementKey: 'deckConfigAnd96Channel8.0',
+      image: (
+        <Flex justifyContent={JUSTIFY_CENTER} paddingTop={SPACING.spacing8}>
+          <img
+            width="340"
+            src={require('../../../images/deck_configuration.png')}
+          />
+        </Flex>
+      ),
+      heading: t('header', { pd: PD }),
+      message: (
+        <>
+          <p>{t('deckConfigAnd96Channel8.0.body1', { pd: PD })}</p>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'deckConfigAnd96Channel8.0.body2'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
+  ]
+}

--- a/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
@@ -13,7 +13,7 @@ import styles from './AnnouncementModal.css'
 
 export const AnnouncementModal = (): JSX.Element => {
   const { t } = useTranslation(['modal', 'button'])
-  const announcements = getAnnouncements(t)
+  const announcements = getAnnouncements({ t })
 
   const { announcementKey, message, heading, image } = announcements[
     announcements.length - 1

--- a/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
@@ -7,13 +7,13 @@ import {
   getLocalStorageItem,
   localStorageAnnouncementKey,
 } from '../../../persist'
-import { getAnnouncements } from './announcements'
+import { useAnnouncements } from './announcements'
 import modalStyles from '../modal.css'
 import styles from './AnnouncementModal.css'
 
 export const AnnouncementModal = (): JSX.Element => {
   const { t } = useTranslation(['modal', 'button'])
-  const announcements = getAnnouncements({ t })
+  const announcements = useAnnouncements()
 
   const { announcementKey, message, heading, image } = announcements[
     announcements.length - 1

--- a/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/index.tsx
@@ -7,12 +7,14 @@ import {
   getLocalStorageItem,
   localStorageAnnouncementKey,
 } from '../../../persist'
+import { getAnnouncements } from './announcements'
 import modalStyles from '../modal.css'
-import { announcements } from './announcements'
 import styles from './AnnouncementModal.css'
 
 export const AnnouncementModal = (): JSX.Element => {
-  const { t } = useTranslation('button')
+  const { t } = useTranslation(['modal', 'button'])
+  const announcements = getAnnouncements(t)
+
   const { announcementKey, message, heading, image } = announcements[
     announcements.length - 1
   ]
@@ -50,7 +52,9 @@ export const AnnouncementModal = (): JSX.Element => {
             <div className={styles.announcement_message}>{message}</div>
 
             <div className={modalStyles.button_row}>
-              <OutlineButton onClick={handleClick}>{t('got_it')}</OutlineButton>
+              <OutlineButton onClick={handleClick}>
+                {t('button:got_it')}
+              </OutlineButton>
             </div>
           </div>
         </Modal>

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
@@ -13,22 +13,25 @@ import modalStyles from '../modal.css'
 export function FileUploadMessageModal(): JSX.Element | null {
   const message = useSelector(loadFileSelectors.getFileUploadMessages)
   const dispatch = useDispatch()
-  const { t } = useTranslation('button')
+  const { t } = useTranslation(['modal', 'button'])
 
   const dismissModal = (): void => {
     dispatch(loadFileActions.dismissFileUploadMessage())
   }
   if (!message) return null
 
-  const { title, body, okButtonText } = getModalContents(message)
+  const { title, body, okButtonText } = getModalContents({
+    uploadResponse: message,
+    t,
+  })
   let buttons = [
     {
-      children: t('cancel'),
+      children: t('button:cancel'),
       onClick: () => dispatch(loadFileActions.undoLoadFile()),
       className: modalStyles.bottom_button,
     },
     {
-      children: okButtonText || 'ok',
+      children: okButtonText || t('button:ok'),
       onClick: dismissModal,
       className: modalStyles.button_medium,
     },
@@ -36,7 +39,7 @@ export function FileUploadMessageModal(): JSX.Element | null {
   if (title === 'Incorrect file type' || title === 'Invalid JSON file') {
     buttons = [
       {
-        children: okButtonText || 'ok',
+        children: okButtonText || t('button:ok'),
         onClick: dismissModal,
         className: modalStyles.button_medium,
       },

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
@@ -7,7 +7,7 @@ import {
   selectors as loadFileSelectors,
   actions as loadFileActions,
 } from '../../../load-file'
-import { getModalContents } from './modalContents'
+import { useModalContents } from './modalContents'
 import modalStyles from '../modal.css'
 
 export function FileUploadMessageModal(): JSX.Element | null {
@@ -18,12 +18,13 @@ export function FileUploadMessageModal(): JSX.Element | null {
   const dismissModal = (): void => {
     dispatch(loadFileActions.dismissFileUploadMessage())
   }
-  if (!message) return null
-
-  const { title, body, okButtonText } = getModalContents({
+  const modalContents = useModalContents({
     uploadResponse: message,
-    t,
   })
+
+  if (modalContents == null) return null
+
+  const { title, body, okButtonText } = modalContents
   let buttons = [
     {
       children: t('button:cancel'),

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/FileUploadMessageModal.tsx
@@ -36,7 +36,7 @@ export function FileUploadMessageModal(): JSX.Element | null {
       className: modalStyles.button_medium,
     },
   ]
-  if (title === 'Incorrect file type' || title === 'Invalid JSON file') {
+  if (title === t('incorrect_file.header') || title === t('invalid.header')) {
     buttons = [
       {
         children: okButtonText || t('button:ok'),

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/__tests__/modalContents.test.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/__tests__/modalContents.test.tsx
@@ -1,4 +1,17 @@
+import * as React from 'react'
 import { getMigrationMessage } from '../modalContents'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: jest.fn().mockReturnValue({
+    t: (key: string) => key,
+    Trans: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  }),
+}))
+
+const tMock = (key: string) => key
+
 describe('modalContents', () => {
   describe('getMigrationMessage', () => {
     it('should return the v3 migration message when migrating to v3', () => {
@@ -10,11 +23,11 @@ describe('modalContents', () => {
         ['3.0.0', '4.0.0', '5.0.0', '5.1.0, 5.2.0'],
       ]
       migrationsList.forEach(migrations => {
-        expect(JSON.stringify(getMigrationMessage(migrations))).toEqual(
-          expect.stringContaining(
-            'Updating your protocol to use the new labware definitions will consequently require you to re-calibrate all labware in your protocol'
+        expect(
+          JSON.stringify(
+            getMigrationMessage({ migrationsRan: migrations, t: tMock })
           )
-        )
+        ).toEqual(expect.stringContaining('migrations.toV3Migration.title'))
       })
     })
     it('should return the "no behavior change message" when migrating from v5.x to 6', () => {
@@ -24,11 +37,11 @@ describe('modalContents', () => {
         ['5.0.0', '5.1.0', '5.2.0'],
       ]
       migrationsList.forEach(migrations => {
-        expect(JSON.stringify(getMigrationMessage(migrations))).toEqual(
-          expect.stringContaining(
-            'we do not expect any changes in how the robot will execute this protocol'
+        expect(
+          JSON.stringify(
+            getMigrationMessage({ migrationsRan: migrations, t: tMock })
           )
-        )
+        ).toEqual(expect.stringContaining('migrations.noBehaviorChange.body1'))
       })
     })
     it('should return the generic migration modal when a v4 migration or v7 migration is required', () => {
@@ -40,11 +53,11 @@ describe('modalContents', () => {
         ['6.0.0', '6.1.0', '6.2.0', '6.2.1', '6.2.2'],
       ]
       migrationsList.forEach(migrations => {
-        expect(JSON.stringify(getMigrationMessage(migrations))).toEqual(
-          expect.stringContaining(
-            'Updating the file may make changes to liquid handling actions'
+        expect(
+          JSON.stringify(
+            getMigrationMessage({ migrationsRan: migrations, t: tMock })
           )
-        )
+        ).toEqual(expect.stringContaining('migrations.generic.body1'))
       })
     })
   })

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -1,149 +1,133 @@
 import * as React from 'react'
+import { Trans } from 'react-i18next'
 import assert from 'assert'
-import styles from './modalContents.css'
-import { ModalContents } from './types'
 import { FileUploadMessage } from '../../../load-file'
+import type { ModalContents } from './types'
 
-const INVALID_FILE_TYPE: ModalContents = {
-  title: 'Incorrect file type',
-  body: (
-    <>
-      <p>Only JSON files created in the Protocol Designer can be imported.</p>
-      <p>At this time Python protocol files are not supported.</p>
-    </>
-  ),
+import styles from './modalContents.css'
+
+const PD = 'Protocol Designer'
+
+interface InvalidModalProps {
+  t: any
+  errorMessage?: string | null
 }
 
-const invalidJsonModal = (errorMessage?: string | null): ModalContents => ({
-  title: 'Invalid JSON file',
-  body: (
-    <>
-      <p>
-        This file is either missing information it needs to import properly or
-        contains sections that the Protocol Designer cannot read.
-      </p>
-      <p>
-        At this time we do not support JSON files created outside of the
-        Protocol Designer.
-      </p>
-      <p>
-        If this is a Protocol Designer file that you have edited outside of this
-        tool you may have introduced errors.
-      </p>
+const getInvalidFileType = (props: InvalidModalProps): ModalContents => {
+  const { t } = props
+  return {
+    title: t('incorrect_file.header'),
+    body: (
+      <>
+        <p>{t('incorrect_file.body1', { pd: PD })}</p>
+        <p>{t('incorrect_file.body2')}.</p>
+      </>
+    ),
+  }
+}
 
-      <div className={styles.error_wrapper}>
-        <p>Error message:</p>
-        <p className={styles.error_text}>{errorMessage}</p>
+const invalidJsonModal = (props: InvalidModalProps): ModalContents => {
+  const { t, errorMessage } = props
+  return {
+    title: t('invalid.header'),
+    body: (
+      <>
+        <p>{t('invalid.body1', { pd: PD })}</p>
+        <p>{t('invalid.body2', { pd: PD })}</p>
+        <p>{t('invalid.body3', { pd: PD })}</p>
+
+        <div className={styles.error_wrapper}>
+          <p>{t('invalid.error')}</p>
+          <p className={styles.error_text}>{errorMessage}</p>
+        </div>
+      </>
+    ),
+  }
+}
+
+export const getGenericDidMigrateMessage = (t: any): ModalContents => {
+  return {
+    title: t('migrations.header', { pd: PD }),
+    body: (
+      <>
+        <p>{t('migrations.generic.body1', { pd: PD })}</p>
+        <p>{t('migrations.generic.body2', { pd: PD })}</p>
+        <p>{t('migrations.generic.body3')}</p>
+      </>
+    ),
+  }
+}
+
+export const getNoBehaviorChangeMessage = (t: any): ModalContents => {
+  return {
+    title: t('migrations.header', { pd: PD }),
+    body: (
+      <div className={styles.migration_message}>
+        <p>{t('migrations.noBehaviorChange.body1')}</p>
+        <p>{t('migrations.noBehaviorChange.body2')}</p>
+        <p>{t('migrations.noBehaviorChange.body3')}</p>
       </div>
-    </>
-  ),
-})
-
-export const genericDidMigrateMessage: ModalContents = {
-  title: 'Your protocol was made in an older version of Protocol Designer',
-  body: (
-    <>
-      <p>
-        Your protocol will be automatically updated to the latest version.
-        Please note that the updated file will be incompatible with older
-        versions of the Protocol Designer. We recommend making a separate copy
-        of the file that you just imported before continuing.
-      </p>
-      <p>
-        Updating the file may make changes to liquid handling actions. Please
-        review your file in the Protocol Designer.
-      </p>
-      <p>As always, please contact us with any questions or feedback.</p>
-    </>
-  ),
+    ),
+  }
 }
 
-export const noBehaviorChangeMessage: ModalContents = {
-  title: 'Your protocol was made in an older version of Protocol Designer',
-  body: (
-    <div className={styles.migration_message}>
-      <p>Your protocol will be automatically updated to the latest version.</p>
-      <p>
-        We have added new features since the last time this protocol was
-        updated, but have not made any changes to existing protocol behavior.
-        Because of this we do not expect any changes in how the robot will
-        execute this protocol. To be safe we will still recommend keeping a
-        separate copy of the file you just imported.
-      </p>
-      <p>As always, please contact us with any questions or feedback.</p>
-    </div>
-  ),
-}
-
-export const toV8MigrationMessage: ModalContents = {
-  title: 'Your protocol was made in an older version of Protocol Designer',
-  body: (
-    <div className={styles.migration_message}>
-      <p>Your protocol will be automatically updated to the latest version.</p>
-      <p>
-        Protocol Designer no longer supports aspirate or mix actions in a trash
-        bin. If your protocol contains these actions, an error icon will appear
-        next to them in the Protocol Timeline. To resolve the error, choose
-        another location for aspirating or mixing.
-      </p>
-      <p>
-        Additionally, we have addressed a bug where blow out speeds were slower
-        than expected. Your protocol will automatically update the flow rates
-        unless they were specifically initialized.
-      </p>
-      <p>As always, please contact us with any questions or feedback.</p>
-    </div>
-  ),
-}
-
-export const toV3MigrationMessage: ModalContents = {
-  title: 'Update protocol to use new labware definitions',
-  okButtonText: 'update protocol',
-  body: (
-    <div className={styles.migration_message}>
-      <p>
-        <strong>
-          To import your file successfully, you must update your protocol to use
-          the new labware definitions.
-        </strong>{' '}
-        Your protocol was made using an older version of Protocol Designer.
-        Since then, Protocol Designer has been improved to include new labware
-        definitions which are more accurate and reliable.
-      </p>
-
-      <div className={styles.section_header}>
-        What this means for your protocol
-      </div>
-      <p>
-        Updating your protocol to use the new labware definitions will
-        consequently require you to re-calibrate all labware in your protocol
-        prior to running it on your robot. We recommend you try a dry run or one
-        with water to ensure everything is working as expected.
-      </p>
-
-      <div className={styles.section_header}>
-        {"What happens if you don't update"}
-      </div>
-      <div>
+export const getToV8MigrationMessage = (t: any): ModalContents => {
+  return {
+    title: t('migrations.header', { pd: PD }),
+    body: (
+      <div className={styles.migration_message}>
         <p>
-          If you choose not to update, you will still be able to run your
-          protocol as usual with older labware, however you will not be able to
-          make further updates to this protocol using the Protocol Designer.
+          <p>{t('migrations.toV8Migration.body1')}</p>
         </p>
+        <p>{t('migrations.toV8Migration.body2', { pd: PD })}</p>
+        <p>{t('migrations.toV8Migration.body3')}</p>
+        <p>{t('migrations.toV8Migration.body4')}</p>
       </div>
-
-      <div className={styles.note}>
-        Please note that in order to run the updated protocol on your robot
-        successfully, the OT-2 App and robot are required to be updated to
-        version 3.10.0 or higher.
-      </div>
-    </div>
-  ),
+    ),
+  }
 }
 
-export function getMigrationMessage(migrationsRan: string[]): ModalContents {
+export const getToV3MigrationMessage = (t: any): ModalContents => {
+  return {
+    title: t('migrations.toV3Migration.title'),
+    okButtonText: t('migrations.toV3Migration.button'),
+    body: (
+      <div className={styles.migration_message}>
+        <p>
+          <Trans
+            t={t}
+            i18nKey="migrations.toV3Migration.body1"
+            components={{ strong: <strong /> }}
+          />
+        </p>
+        <div className={styles.section_header}>
+          {t('migrations.toV3Migration.body2')}
+        </div>
+        <p>{t('migrations.toV3Migration.body3')}</p>
+        <div className={styles.section_header}>
+          {t('migrations.toV3Migration.body4')}
+        </div>
+        <div>
+          <p>{t('migrations.toV3Migration.body5')}</p>
+        </div>
+        <div className={styles.note}>{t('migrations.toV3Migration.body6')}</div>
+      </div>
+    ),
+  }
+}
+
+interface MigrationMessageProps {
+  migrationsRan: string[]
+  t: any
+}
+
+export function getMigrationMessage(
+  props: MigrationMessageProps
+): ModalContents {
+  const { t, migrationsRan } = props
+
   if (migrationsRan.includes('3.0.0')) {
-    return toV3MigrationMessage
+    return getToV3MigrationMessage({ t })
   }
   const noBehaviorMigrations = [
     ['5.0.0'],
@@ -155,23 +139,29 @@ export function getMigrationMessage(migrationsRan: string[]): ModalContents {
       migrationsRan.every(migration => migrationList.includes(migration))
     )
   ) {
-    return noBehaviorChangeMessage
+    return getNoBehaviorChangeMessage({ t })
   }
   if (migrationsRan.includes('8.0.0')) {
-    return toV8MigrationMessage
+    return getToV8MigrationMessage({ t })
   }
-  return genericDidMigrateMessage
+  return getGenericDidMigrateMessage({ t })
 }
 
-export function getModalContents(
+interface ModalContentsProps {
   uploadResponse: FileUploadMessage
-): ModalContents {
+  t: any
+}
+export function getModalContents(props: ModalContentsProps): ModalContents {
+  const { t, uploadResponse } = props
   if (uploadResponse.isError) {
     switch (uploadResponse.errorType) {
       case 'INVALID_FILE_TYPE':
-        return INVALID_FILE_TYPE
+        return getInvalidFileType({ t })
       case 'INVALID_JSON_FILE':
-        return invalidJsonModal(uploadResponse.errorMessage)
+        return invalidJsonModal({
+          errorMessage: uploadResponse.errorMessage,
+          t,
+        })
       default: {
         console.warn('Invalid error type specified for modal')
         return { title: 'Error', body: 'Error' }
@@ -180,7 +170,10 @@ export function getModalContents(
   }
   switch (uploadResponse.messageKey) {
     case 'DID_MIGRATE':
-      return getMigrationMessage(uploadResponse.migrationsRan)
+      return getMigrationMessage({
+        migrationsRan: uploadResponse.migrationsRan,
+        t,
+      })
     default: {
       assert(
         false,

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -8,12 +8,12 @@ import styles from './modalContents.css'
 
 const PD = 'Protocol Designer'
 
-interface InvalidModalProps {
+interface ModalProps {
   t: any
   errorMessage?: string | null
 }
 
-const getInvalidFileType = (props: InvalidModalProps): ModalContents => {
+const getInvalidFileType = (props: ModalProps): ModalContents => {
   const { t } = props
   return {
     title: t('incorrect_file.header'),
@@ -26,7 +26,7 @@ const getInvalidFileType = (props: InvalidModalProps): ModalContents => {
   }
 }
 
-const invalidJsonModal = (props: InvalidModalProps): ModalContents => {
+const invalidJsonModal = (props: ModalProps): ModalContents => {
   const { t, errorMessage } = props
   return {
     title: t('invalid.header'),
@@ -45,7 +45,11 @@ const invalidJsonModal = (props: InvalidModalProps): ModalContents => {
   }
 }
 
-export const getGenericDidMigrateMessage = (t: any): ModalContents => {
+export const getGenericDidMigrateMessage = (
+  props: ModalProps
+): ModalContents => {
+  const { t } = props
+
   return {
     title: t('migrations.header', { pd: PD }),
     body: (
@@ -58,7 +62,11 @@ export const getGenericDidMigrateMessage = (t: any): ModalContents => {
   }
 }
 
-export const getNoBehaviorChangeMessage = (t: any): ModalContents => {
+export const getNoBehaviorChangeMessage = (
+  props: ModalProps
+): ModalContents => {
+  const { t } = props
+
   return {
     title: t('migrations.header', { pd: PD }),
     body: (
@@ -71,7 +79,9 @@ export const getNoBehaviorChangeMessage = (t: any): ModalContents => {
   }
 }
 
-export const getToV8MigrationMessage = (t: any): ModalContents => {
+export const getToV8MigrationMessage = (props: ModalProps): ModalContents => {
+  const { t } = props
+
   return {
     title: t('migrations.header', { pd: PD }),
     body: (
@@ -87,7 +97,9 @@ export const getToV8MigrationMessage = (t: any): ModalContents => {
   }
 }
 
-export const getToV3MigrationMessage = (t: any): ModalContents => {
+export const getToV3MigrationMessage = (props: ModalProps): ModalContents => {
+  const { t } = props
+
   return {
     title: t('migrations.toV3Migration.title'),
     okButtonText: t('migrations.toV3Migration.button'),

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Trans } from 'react-i18next'
+import { Trans, useTranslation } from 'react-i18next'
 import assert from 'assert'
 import { FileUploadMessage } from '../../../load-file'
 import type { ModalContents } from './types'
@@ -53,11 +53,11 @@ export const getGenericDidMigrateMessage = (
   return {
     title: t('migrations.header', { pd: PD }),
     body: (
-      <>
+      <div>
         <p>{t('migrations.generic.body1', { pd: PD })}</p>
         <p>{t('migrations.generic.body2', { pd: PD })}</p>
         <p>{t('migrations.generic.body3')}</p>
-      </>
+      </div>
     ),
   }
 }
@@ -133,9 +133,9 @@ interface MigrationMessageProps {
   t: any
 }
 
-export function getMigrationMessage(
+export const getMigrationMessage = (
   props: MigrationMessageProps
-): ModalContents {
+): ModalContents => {
   const { t, migrationsRan } = props
 
   if (migrationsRan.includes('3.0.0')) {
@@ -160,11 +160,16 @@ export function getMigrationMessage(
 }
 
 interface ModalContentsProps {
-  uploadResponse: FileUploadMessage
-  t: any
+  uploadResponse?: FileUploadMessage | null
 }
-export function getModalContents(props: ModalContentsProps): ModalContents {
-  const { t, uploadResponse } = props
+export function useModalContents(
+  props: ModalContentsProps
+): ModalContents | null {
+  const { uploadResponse } = props
+  const { t } = useTranslation('modal')
+
+  if (uploadResponse == null) return null
+
   if (uploadResponse.isError) {
     switch (uploadResponse.errorType) {
       case 'INVALID_FILE_TYPE':

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -196,10 +196,15 @@
       }
     }
   },
+  "cancel": "Cancel",
+  "continue_with_export": "Continue with export",
+  "create_new": "Create New",
   "confirm_create_new": "Are you sure you want to create a new file? Any unsaved changes will be discarded.",
   "confirm_delete_step": "Are you sure you want to delete this step?",
   "confirm_import": "Are you sure you want to import this file? You will lose any current unsaved changes.",
   "confirm_leave": "Are you sure you want to leave? You will lose any unsaved changes.",
+  "export": "Export",
+  "import": "Import",
   "module_placement": {
     "SLOT_OCCUPIED": {
       "title": "Cannot place module",

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -1,4 +1,6 @@
 {
+  "are_you_sure": "Are you sure you want to remove liquids from all selected wells?",
+  "are_you_sure_delete_well": "Are you sure you want to delete well {{well}}?",
   "exit_batch_edit": "exit batch edit",
   "go_back": "Go back",
   "labware": "labware",

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -35,11 +35,11 @@
       "body1": "The {{opd}} now lets you customize liquid colors!",
       "body2": "All protocols now require {{app}} version <strong> 6.2+ </strong> to run."
     },
-    "flexSupport7.0": {
+    "flexSupport": {
       "body1": "Introducing the {{pd}} 7.0 with {{flex}} support!",
       "body2": "All protocols now require {{app}} version <strong> 7.0+ </strong> to run."
     },
-    "deckConfigAnd96Channel8.0": {
+    "deckConfigAnd96Channel": {
       "body1": "Introducing the {{pd}} 8.0 with deck configuration and 96-channel pipette support!",
       "body2": "All protocols now require {{app}} version <strong> 7.1+ </strong> to run."
     }
@@ -230,5 +230,46 @@
   },
   "step_notes": {
     "title": "Step Notes"
+  },
+  "invalid": {
+    "header": "Invalid JSON file",
+    "body1": "This file is either missing information it needs to import properly or contains sections that the {{pd}} cannot read.",
+    "body2": "At this time we do not support JSON files created outside of the {{pd}}.",
+    "body3": "If this is a {{pd}} file that you have edited outside of this tool you may have introduced errors.",
+    "error": "Error message:"
+  },
+  "incorrect_file": {
+    "header": "Incorrect file type",
+    "body1": "Only JSON files created in the {{pd}} can be imported.",
+    "body2": "At this time Python protocol files are not supported."
+  },
+  "migrations": {
+    "header": "Your protocol was made in an older version of {{pd}}",
+    "noBehaviorChange": {
+      "body1": "Your protocol will be automatically updated to the latest version.",
+      "body2": "We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior. Because of this we do not expect any changes in how the robot will execute this protocol. To be safe we will still recommend keeping a separate copy of the file you just imported.",
+      "body3": "As always, please contact us with any questions or feedback."
+    },
+    "toV8Migration": {
+      "body1": "Your protocol will be automatically updated to the latest version.",
+      "body2": "{{pd}} no longer supports aspirate or mix actions in a trash bin. If your protocol contains these actions, an error icon will appear next to them in the Protocol Timeline. To resolve the error, choose another location for aspirating or mixing.",
+      "body3": "Additionally, we have addressed a bug where blow out speeds were slower than expected. Your protocol will automatically update the flow rates unless they were specifically initialized.",
+      "body4": "As always, please contact us with any questions or feedback."
+    },
+    "generic": {
+      "body1": "Your protocol will be automatically updated to the latest version. Please note that the updated file will be incompatible with older versions of the {{pd}}. We recommend making a separate copy of the file that you just imported before continuing.",
+      "body2": "Updating the file may make changes to liquid handling actions. Please review your file in the {{pd}}",
+      "body3": "As always, please contact us with any questions or feedback."
+    },
+    "toV3Migration": {
+      "title": "Update protocol to use new labware definitions",
+      "button": "update protocol",
+      "body1": "<strong>To import your file successfully, you must update your protocol to use the new labware definitions. </strong>Your protocol was made using an older version of Protocol Designer. Since then, Protocol Designer has been improved to include new labware definitions which are more accurate and reliable.",
+      "body2": "What this means for you protocol",
+      "body3": "Updating your protocol to use the new labware definitions will consequently require you to re-calibrate all labware in your protocol prior to running it on your robot. We recommend you try a dry run or one with water to ensure everything is working as expected.",
+      "body4": "What happens if you don't update",
+      "body5": "If you choose not to update, you will still be able to run your protocol as usual with older labware, however you will not be able to make further updates to this protocol using the Protocol Designer.",
+      "body6": "Please note that in order to run the updated protocol on your robot successfully, the OT-2 App and robot are required to be updated to version 3.10.0 or higher."
+    }
   }
 }

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -2,6 +2,48 @@
   "browse_labware": {
     "instructions": "Hover on a well to see contents"
   },
+  "announcements": {
+    "header": "We've updated the {{pd}}",
+    "modulesRequireRunAppUpdate": {
+      "body1": "{{pd}} Beta now includes support for Temperature and Magnetic modules.",
+      "body2": "Note: Protocols with modules <bold>may require an app and robot update to run</bold>. You will need to have the {{app}} and robot on the latest versions ( <bold>3.17 or higher</bold>)"
+    },
+    "thermocyclerSupport": {
+      "body1": "{{pd}} Beta now includes support for the Thermocycler!",
+      "body2": "Note: Protocols with modules <strong>may require an app and robot update to run</strong>. You will need to have the {{app}} and robot on the latest versions (<strong>3.18 or higher</strong>)."
+    },
+    "airGapDelaySettings": {
+      "body1": "{{pd}} Beta now includes support for more pipetting settings: Air gap and Delay.",
+      "body2": "Note: Protocols using new features <strong>may require an app and robot update to run.</strong> You will need to have the {{app}} and orbot on the latest versions (<strong>3.20 or higher</strong>)."
+    },
+    "batchEditTransfer": {
+      "body1": "Starting today, you’ll be able to:",
+      "body2": "Select, delete, and duplicate multiple steps at once",
+      "body3": "Edit advanced settings for multiple Transfer or Mix steps at once",
+      "body4": "To enter multi-select mode, simply hold <strong>SHIFT</strong> or <strong>CTRL/CMND</strong> and click on a step.",
+      "body5": "From here, you can access the control bar at the top of the protocol timeline, or edit advanced settings for Transfer or Mix steps!"
+    },
+    "heaterShakerSupport": {
+      "body1": "The {{opd}} now supports our Heater-Shaker Module!",
+      "body2": "All protocols now require {{app}} version <strong> 6.1+ </strong> to run."
+    },
+    "thermocyclerGen2Support": {
+      "body1": "The {{opd}} now supports our Thermocycler Module GEN2!",
+      "body2": "All protocols now require {{app}} version <strong> 6.2+ </strong> to run."
+    },
+    "liquidColorEnhancements": {
+      "body1": "The {{opd}} now lets you customize liquid colors!",
+      "body2": "All protocols now require {{app}} version <strong> 6.2+ </strong> to run."
+    },
+    "flexSupport7.0": {
+      "body1": "Introducing the {{pd}} 7.0 with {{flex}} support!",
+      "body2": "All protocols now require {{app}} version <strong> 7.0+ </strong> to run."
+    },
+    "deckConfigAnd96Channel8.0": {
+      "body1": "Introducing the {{pd}} 8.0 with deck configuration and 96-channel pipette support!",
+      "body2": "All protocols now require {{app}} version <strong> 7.1+ </strong> to run."
+    }
+  },
   "labware_selection": {
     "measurements": "Labware Measurements",
     "well_count": "# of wells",


### PR DESCRIPTION
closes RAUT-942

# Overview

Add some text to i18n in PD

# Test Plan

Smoke test in PD! In particular look at:
1. `localStorage.clear()` in dev tools console to reset the modals and refresh, look at the welcome modal
2. importing a JSON protocol that has to go through a migration (use any json file in the `Protocol-designer/fixtures/protocol` directory that isn't a v8

# Changelog

- add stuff to i18n
- refactor some consts to be utils!

# Review requests

see test plan

# Risk assessment

low