### PR TITLE
refactor(robot-server): Store Pydantic objects as JSON instead of pickles, take 2

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -2,9 +2,18 @@
 
 Summary of changes from schema 2:
 
-- Run commands were formerly stored as monolithic blobs in the run table,
+- Run commands were formerly stored as monolithic blobs in the `run` table,
   with each row storing an entire list. This has been split out into a new
-  run_command table, where each individual command gets its own row.
+  `run_command` table, where each individual command gets its own row.
+
+- All columns that were storing binary pickles have been converted to storing
+  JSON strings:
+  - `analysis.completed_analysis`
+  - `run.state_summary`
+  - `run_commands.command` (formerly `run.commands`; see above)
+
+- `analysis.completed_analysis_as_document` has been removed,
+  since the updated `analysis.completed_analysis` (see above) replaces it.
 """
 
 

--- a/robot-server/robot_server/persistence/_migrations/up_to_3.py
+++ b/robot-server/robot_server/persistence/_migrations/up_to_3.py
@@ -10,10 +10,13 @@ Summary of changes from schema 2:
 
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, List
 
+from opentrons.protocol_engine import Command, StateSummary
+import pydantic
 import sqlalchemy
 
+from ..pydantic import pydantic_to_json
 from .._database import (
     create_schema_2_sql_engine,
     create_schema_3_sql_engine,
@@ -95,25 +98,40 @@ def _migrate_run_table(
     insert_new_command = sqlalchemy.insert(schema_3.run_command_table)
 
     for old_run_row in source_transaction.execute(select_old_runs).all():
+        old_state_summary = old_run_row.state_summary
+        new_state_summary = (
+            None
+            if old_run_row.state_summary is None
+            else pydantic_to_json(
+                pydantic.parse_obj_as(StateSummary, old_state_summary)
+            )
+        )
         dest_transaction.execute(
             insert_new_run,
             id=old_run_row.id,
             created_at=old_run_row.created_at,
             protocol_id=old_run_row.protocol_id,
-            state_summary=old_run_row.state_summary,
+            state_summary=new_state_summary,
             engine_status=old_run_row.engine_status,
             _updated_at=old_run_row._updated_at,
         )
 
-        commands: List[Dict[str, Any]] = old_run_row.commands or []
+        old_commands: List[Dict[str, Any]] = old_run_row.commands or []
+        pydantic_old_commands: Iterable[Command] = (
+            pydantic.parse_obj_as(
+                Command,  # type: ignore[arg-type]
+                c,
+            )
+            for c in old_commands
+        )
         new_command_rows = [
             {
                 "run_id": old_run_row.id,
                 "index_in_run": index_in_run,
-                "command_id": command["id"],
-                "command": command,
+                "command_id": pydantic_command.id,
+                "command": pydantic_to_json(pydantic_command),
             }
-            for index_in_run, command in enumerate(commands)
+            for index_in_run, pydantic_command in enumerate(pydantic_old_commands)
         ]
         # Insert all the commands for this run in one go, to avoid the overhead of
         # separate statements, and since we had to bring them all into memory at once

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -2,8 +2,6 @@
 
 import sqlalchemy
 
-from robot_server.persistence import legacy_pickle
-from robot_server.persistence.pickle_protocol_version import PICKLE_PROTOCOL_VERSION
 from robot_server.persistence._utc_datetime import UTCDateTime
 
 metadata = sqlalchemy.MetaData()
@@ -83,7 +81,7 @@ run_table = sqlalchemy.Table(
     # column added in schema v1
     sqlalchemy.Column(
         "state_summary",
-        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
+        sqlalchemy.String,
         nullable=True,
     ),
     # column added in schema v1
@@ -119,13 +117,7 @@ run_command_table = sqlalchemy.Table(
     ),
     sqlalchemy.Column("index_in_run", sqlalchemy.Integer, nullable=False),
     sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
-    sqlalchemy.Column(
-        "command",
-        # TODO(mm, 2024-01-25): This should be JSON instead of a pickle. See:
-        # https://opentrons.atlassian.net/browse/RSS-98.
-        sqlalchemy.PickleType(pickler=legacy_pickle, protocol=PICKLE_PROTOCOL_VERSION),
-        nullable=False,
-    ),
+    sqlalchemy.Column("command", sqlalchemy.String, nullable=False),
     sqlalchemy.Index(
         "ix_run_run_id_command_id",  # An arbitrary name for the index.
         "run_id",

--- a/robot-server/robot_server/persistence/_tables/schema_3.py
+++ b/robot-server/robot_server/persistence/_tables/schema_3.py
@@ -44,18 +44,9 @@ analysis_table = sqlalchemy.Table(
     ),
     sqlalchemy.Column(
         "completed_analysis",
-        # Stores a pickled dict. See CompletedAnalysisStore.
-        # TODO(mm, 2023-08-30): Remove this. See https://opentrons.atlassian.net/browse/RSS-98.
-        sqlalchemy.LargeBinary,
-        nullable=False,
-    ),
-    sqlalchemy.Column(
-        "completed_analysis_as_document",
-        # Stores the same data as completed_analysis, but serialized as a JSON string.
+        # Stores a JSON string. See CompletedAnalysisStore.
         sqlalchemy.String,
-        # This column should never be NULL in practice.
-        # It needs to be nullable=True because of limitations in SQLite and our migration code.
-        nullable=True,
+        nullable=False,
     ),
 )
 

--- a/robot-server/robot_server/persistence/pydantic.py
+++ b/robot-server/robot_server/persistence/pydantic.py
@@ -1,0 +1,22 @@
+"""Store Pydantic objects in the SQL database."""
+
+from typing import Type, TypeVar
+from pydantic import BaseModel, parse_raw_as
+
+
+_BaseModelT = TypeVar("_BaseModelT", bound=BaseModel)
+
+
+def pydantic_to_json(obj: BaseModel) -> str:
+    """Serialize a Pydantic object for storing in the SQL database."""
+    return obj.json(
+        # by_alias and exclude_none should match how
+        # FastAPI + Pydantic + our customizations serialize these objects
+        by_alias=True,
+        exclude_none=True,
+    )
+
+
+def json_to_pydantic(model: Type[_BaseModelT], json: str) -> _BaseModelT:
+    """Parse a Pydantic object stored in the SQL database."""
+    return parse_raw_as(model, json)

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -38,8 +38,7 @@ EXPECTED_STATEMENTS_LATEST = [
         id VARCHAR NOT NULL,
         protocol_id VARCHAR NOT NULL,
         analyzer_version VARCHAR NOT NULL,
-        completed_analysis BLOB NOT NULL,
-        completed_analysis_as_document VARCHAR,
+        completed_analysis VARCHAR NOT NULL,
         PRIMARY KEY (id),
         FOREIGN KEY(protocol_id) REFERENCES protocol (id)
     )

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -52,7 +52,7 @@ EXPECTED_STATEMENTS_LATEST = [
         id VARCHAR NOT NULL,
         created_at DATETIME NOT NULL,
         protocol_id VARCHAR,
-        state_summary BLOB,
+        state_summary VARCHAR,
         engine_status VARCHAR,
         _updated_at DATETIME,
         PRIMARY KEY (id),
@@ -75,7 +75,7 @@ EXPECTED_STATEMENTS_LATEST = [
         run_id VARCHAR NOT NULL,
         index_in_run INTEGER NOT NULL,
         command_id VARCHAR NOT NULL,
-        command BLOB NOT NULL,
+        command VARCHAR NOT NULL,
         PRIMARY KEY (row_id),
         FOREIGN KEY(run_id) REFERENCES run (id)
     )


### PR DESCRIPTION
# Overview

Closes RSS-98. Takes over for #11561.

# Test Plan

I'm going to spend the day putting this on various robots and smoke-testing them to make sure it doesn't break any basic flows or cause any horrific performance regressions.

Other than that, we have okay automated test coverage. But see the risk assessment below.

# Changelog

* For `RunStore`, convert our storage of `Command`s and `StateSummary`s from pickled dictified Pydantic objects to JSON-serialized Pydantic objects.
* For `CompletedAnalysisStore`, we already did that conversion in #13425, in an experimental parallel column. Promote that column to be non-experimental, and delete the old one that had pickled dicts.

# Review requests

None in particular.

# Risk assessment

Medium.

## Correctness risks

Automated tests currently cover these:

* Freshly-created records can survive a round-trip in and out of the database.
* The migration doesn't outright break any endpoints—i.e., HTTP requests won't start returning HTTP 500 errors.

But they do *not* cover:

* HTTP requests will return exactly the same JSON data that they were returning before. In particular, dealing with JSON `null`/omitted fields is always a bit hazardous with Pydantic, and this migration introduces points where something can go wrong with that.

This omission is tracked as RSS-213.

Mitigating this risk is the fact that we've been running this scheme in production, experimentally, since #13425, and it apparently hasn't caused any problems there.

## Performance risks

[Prior testing](https://opentrons.atlassian.net/l/cp/iHJnoFgC) has shown parsing JSON to take about 1.7x as long as parsing our existing pickled dicts. So retrieving runs and commands may get slower. (Retrieving analyses is unaffected because of #13425).

Manual testing will have to bear out whether this is a problem in practice. I expect #14286 and #14348 to go a long way. If we need a nuclear option, we can do something like #13425 again.

The migration can take a long time. I think this is unavoidable to some extent and we just need to communicate it. I've done what I can here to mitigate this by combining this migration with #14348. RSS-217 makes this worse, but we can fix that separately.

## Risk tolerance

We should take seriously the risks listed above, and mitigate them as much as we have time for, but we also need to weigh them against the risk of *not* merging this.

* RSS-98 is really not a good thing to have around, and it gets harder to solve the longer we let it sit.
* We were previously mitigating RSS-98 by giving it ongoing manual attention (e.g. RSS-157, RSS-198). We haven't done that in a while (RSS-371) because we've been preoccupied with the Flex and with deck configuration.
* Because we don't have Datadog configured for the Flex yet, RSS-98 can be setting up Flex-specific traps that we don't know about.