### PR TITLE
fix(ci): build-ts before push to npm

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -191,6 +191,8 @@ jobs:
           yarn config set cache-folder ./.yarn-cache
           yarn config set network-timeout 60000
           yarn
+      - name: 'build typescript'
+        run: make build-ts
       - name: 'build library'
         run: |
           make -C components lib
@@ -210,6 +212,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd ./components && echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ./.npmrc && npm publish --access public
-          
-
-      

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -240,6 +240,8 @@ jobs:
           yarn config set cache-folder ./.yarn-cache
           yarn config set network-timeout 60000
           yarn
+      - name: 'build typescript'
+        run: make build-ts
       - name: 'build library'
         run: |
           make -C shared-data lib-js

--- a/shared-data/.npmignore
+++ b/shared-data/.npmignore
@@ -1,4 +1,3 @@
 dist
-js
 python
 *.tgz


### PR DESCRIPTION
### Overview

There is no typing present in 0.1.1 of 
- [shared-data](https://www.npmjs.com/package/@opentrons/shared-data)
- [components](https://www.npmjs.com/package/@opentrons/components)

### Test Plan

If this is the correct fix, merge it then tag - or - tag this branch? to test a new deploy.

### Changelog

- add `make build-ts` in the GitHub Actions job that publishes for `shared-data`
- add `make build-ts` in the GitHub Actions job that publishes for `components`

### Review requests

- [x] Is this the correct way to get the types distributed in the package?
- [x] in https://github.com/Opentrons/opentrons/blob/4371e799ac2d43e2eba511eacd71bb1fda0b0604/components/webpack.config.js#L6 we use the `barrel.ts` but https://github.com/Opentrons/opentrons/blob/4371e799ac2d43e2eba511eacd71bb1fda0b0604/components/package.json#L6 will look for types on index.  Will that be ok?

### Risk assessment

None to any functional code.  CI only change to build types before distributing components and shared-data.