### PR TITLE
fix(app): remove calibration menu item for incompatible modules

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { Flex, POSITION_RELATIVE, useHoverTooltip } from '@opentrons/components'
 
+import { MODULE_MODELS_OT2_ONLY } from '@opentrons/shared-data'
 import { MenuList } from '../../atoms/MenuList'
 import { Tooltip } from '../../atoms/Tooltip'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
@@ -81,7 +82,10 @@ export const ModuleOverflowMenu = (
   return (
     <Flex position={POSITION_RELATIVE}>
       <MenuList>
-        {isFlex ? (
+        {isFlex &&
+        !MODULE_MODELS_OT2_ONLY.some(
+          modModel => modModel === module.moduleModel
+        ) ? (
           <>
             <MenuItem
               onClick={handleCalibrateClick}

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -517,6 +517,7 @@ describe('ModuleOverflowMenu', () => {
     mockUseIsFlex.mockReturnValue(true)
     props = {
       ...props,
+      module: mockHeaterShaker,
       isPipetteReady: false,
     }
     const { getByRole } = render(props)
@@ -529,6 +530,7 @@ describe('ModuleOverflowMenu', () => {
     mockUseIsFlex.mockReturnValue(true)
     props = {
       ...props,
+      module: mockHeaterShaker,
       isTooHot: true,
     }
     const { getByRole } = render(props)
@@ -541,6 +543,7 @@ describe('ModuleOverflowMenu', () => {
     mockUseIsFlex.mockReturnValue(true)
     props = {
       ...props,
+      module: mockHeaterShaker,
       isPipetteReady: true,
     }
     const { getByRole } = render(props)


### PR DESCRIPTION
closes [RQA-1527](https://opentrons.atlassian.net/browse/RQA-1527)

# Overview

A previous fix removed a calibration banner rendering on Flex-incompatible module cards. This PR removes the calibration item from Flex-incompatible module overflow menus.

# Test Plan

- plug in Flex-incompatible modules into Flex (temperature module gen1, magnetic module gen1/gen2, thermocycler module gen1)
- open module overflow menu
- confirm that no 'calibrate/recalibrate' option is present
<img width="514" alt="Screen Shot 2024-01-26 at 10 13 41 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/125367fc-eb51-4d49-9153-5e9f18bf3485">

# Changelog

- check both robot and module type when conditionally rendering 'calibrate' option in module overflow menu
- update tests

# Risk assessment

low

[RQA-1527]: https://opentrons.atlassian.net/browse/RQA-1527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ