### PR TITLE
feat(app): add unreachable robot deck config placeholder text

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -107,6 +107,7 @@
   "no_recent_runs_description": "After you run some protocols, they will appear here.",
   "no_recent_runs": "No recent runs",
   "num_units": "{{num}} mm",
+  "offline_deck_configuration": "Robot must be on the network to see deck configuration",
   "offline_instruments_and_modules": "Robot must be on the network to see connected instruments and modules",
   "offline_recent_protocol_runs": "Robot must be on the network to see protocol runs",
   "open_lid": "Open lid",

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/DeviceDetailsDeckConfiguration.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/DeviceDetailsDeckConfiguration.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { i18n } from '../../../i18n'
-import { useRunStatuses } from '../../Devices/hooks'
+import { useIsRobotViewable, useRunStatuses } from '../../Devices/hooks'
 import { DeckFixtureSetupInstructionsModal } from '../DeckFixtureSetupInstructionsModal'
 import { useIsEstopNotDisengaged } from '../../../resources/devices/hooks/useIsEstopNotDisengaged'
 import { DeviceDetailsDeckConfiguration } from '../'
@@ -60,6 +60,9 @@ const mockUseCurrentMaintenanceRun = useCurrentMaintenanceRun as jest.MockedFunc
 const mockUseIsEstopNotDisengaged = useIsEstopNotDisengaged as jest.MockedFunction<
   typeof useIsEstopNotDisengaged
 >
+const mockUseIsRobotViewable = useIsRobotViewable as jest.MockedFunction<
+  typeof useIsRobotViewable
+>
 
 const render = (
   props: React.ComponentProps<typeof DeviceDetailsDeckConfiguration>
@@ -91,6 +94,7 @@ describe('DeviceDetailsDeckConfiguration', () => {
     when(mockUseIsEstopNotDisengaged)
       .calledWith(ROBOT_NAME)
       .mockReturnValue(false)
+    when(mockUseIsRobotViewable).calledWith(ROBOT_NAME).mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -154,7 +158,13 @@ describe('DeviceDetailsDeckConfiguration', () => {
     when(mockDeckConfigurator)
       .calledWith(partialComponentPropsMatcher({ readOnly: true }))
       .mockReturnValue(<div>disabled mock DeckConfigurator</div>)
-    const [{ getByText }] = render(props)
-    getByText('disabled mock DeckConfigurator')
+    render(props)
+    screen.getByText('disabled mock DeckConfigurator')
+  })
+
+  it('should render not viewable text when robot is not viewable', () => {
+    when(mockUseIsRobotViewable).calledWith(ROBOT_NAME).mockReturnValue(false)
+    render(props)
+    screen.getByText('Robot must be on the network to see deck configuration')
   })
 })

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -11,8 +11,10 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
+  JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   Link,
+  SIZE_4,
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -34,7 +36,7 @@ import { StyledText } from '../../atoms/text'
 import { Banner } from '../../atoms/Banner'
 import { DeckFixtureSetupInstructionsModal } from './DeckFixtureSetupInstructionsModal'
 import { AddFixtureModal } from './AddFixtureModal'
-import { useRunStatuses } from '../Devices/hooks'
+import { useIsRobotViewable, useRunStatuses } from '../Devices/hooks'
 import { useIsEstopNotDisengaged } from '../../resources/devices/hooks/useIsEstopNotDisengaged'
 
 import type { CutoutId } from '@opentrons/shared-data'
@@ -71,6 +73,7 @@ export function DeviceDetailsDeckConfiguration({
     refetchInterval: RUN_REFETCH_INTERVAL,
   })
   const isMaintenanceRunExisting = maintenanceRunData?.data?.id != null
+  const isRobotViewable = useIsRobotViewable(robotName)
 
   const handleClickAdd = (cutoutId: CutoutId): void => {
     setTargetCutoutId(cutoutId)
@@ -145,92 +148,115 @@ export function DeviceDetailsDeckConfiguration({
             {t('setup_instructions')}
           </Link>
         </Flex>
-        <Flex
-          gridGap={SPACING.spacing16}
-          paddingX={SPACING.spacing16}
-          paddingBottom={SPACING.spacing32}
-          paddingTop={
-            isRunRunning || isMaintenanceRunExisting
-              ? undefined
-              : SPACING.spacing32
-          }
-          width="100%"
-          flexDirection={DIRECTION_COLUMN}
-        >
-          {isRunRunning ? (
-            <Banner type="warning">
-              {t('deck_configuration_is_not_available_when_run_is_in_progress')}
-            </Banner>
-          ) : null}
-          {isMaintenanceRunExisting ? (
-            <Banner type="warning">
-              {t('deck_configuration_is_not_available_when_robot_is_busy')}
-            </Banner>
-          ) : null}
-          <Flex css={DECK_CONFIG_SECTION_STYLE}>
-            <Flex
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              marginLeft={`-${SPACING.spacing32}`}
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              marginTop={`-${SPACING.spacing6}`}
-              flexDirection={DIRECTION_COLUMN}
-            >
-              <DeckConfigurator
-                readOnly={
-                  isRunRunning ||
-                  isMaintenanceRunExisting ||
-                  isEstopNotDisengaged
-                }
-                deckConfig={deckConfig}
-                handleClickAdd={handleClickAdd}
-                handleClickRemove={handleClickRemove}
-              />
-            </Flex>
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              gridGap={SPACING.spacing8}
-              width="32rem"
-            >
+        {isRobotViewable ? (
+          <Flex
+            gridGap={SPACING.spacing16}
+            paddingX={SPACING.spacing16}
+            paddingBottom={SPACING.spacing32}
+            paddingTop={
+              isRunRunning || isMaintenanceRunExisting
+                ? undefined
+                : SPACING.spacing32
+            }
+            width="100%"
+            flexDirection={DIRECTION_COLUMN}
+          >
+            {isRunRunning ? (
+              <Banner type="warning">
+                {t(
+                  'deck_configuration_is_not_available_when_run_is_in_progress'
+                )}
+              </Banner>
+            ) : null}
+            {isMaintenanceRunExisting ? (
+              <Banner type="warning">
+                {t('deck_configuration_is_not_available_when_robot_is_busy')}
+              </Banner>
+            ) : null}
+            <Flex css={DECK_CONFIG_SECTION_STYLE}>
               <Flex
-                gridGap={SPACING.spacing32}
-                paddingLeft={SPACING.spacing8}
-                css={TYPOGRAPHY.labelSemiBold}
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                marginLeft={`-${SPACING.spacing32}`}
+                // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                marginTop={`-${SPACING.spacing6}`}
+                flexDirection={DIRECTION_COLUMN}
               >
-                <StyledText>{t('location')}</StyledText>
-                <StyledText>{t('fixture')}</StyledText>
+                <DeckConfigurator
+                  readOnly={
+                    isRunRunning ||
+                    isMaintenanceRunExisting ||
+                    isEstopNotDisengaged
+                  }
+                  deckConfig={deckConfig}
+                  handleClickAdd={handleClickAdd}
+                  handleClickRemove={handleClickRemove}
+                />
               </Flex>
-              {fixtureDisplayList.length > 0 ? (
-                fixtureDisplayList.map(fixture => (
+              <Flex
+                flexDirection={DIRECTION_COLUMN}
+                gridGap={SPACING.spacing8}
+                width="32rem"
+              >
+                <Flex
+                  gridGap={SPACING.spacing32}
+                  paddingLeft={SPACING.spacing8}
+                  css={TYPOGRAPHY.labelSemiBold}
+                >
+                  <StyledText>{t('location')}</StyledText>
+                  <StyledText>{t('fixture')}</StyledText>
+                </Flex>
+                {fixtureDisplayList.length > 0 ? (
+                  fixtureDisplayList.map(fixture => (
+                    <Flex
+                      key={fixture.cutoutId}
+                      backgroundColor={COLORS.grey10}
+                      gridGap={SPACING.spacing60}
+                      padding={SPACING.spacing8}
+                      width="100%"
+                      css={TYPOGRAPHY.labelRegular}
+                    >
+                      <StyledText>
+                        {getCutoutDisplayName(fixture.cutoutId)}
+                      </StyledText>
+                      <StyledText>
+                        {getFixtureDisplayName(fixture.cutoutFixtureId)}
+                      </StyledText>
+                    </Flex>
+                  ))
+                ) : (
                   <Flex
-                    key={fixture.cutoutId}
                     backgroundColor={COLORS.grey10}
                     gridGap={SPACING.spacing60}
                     padding={SPACING.spacing8}
                     width="100%"
                     css={TYPOGRAPHY.labelRegular}
                   >
-                    <StyledText>
-                      {getCutoutDisplayName(fixture.cutoutId)}
-                    </StyledText>
-                    <StyledText>
-                      {getFixtureDisplayName(fixture.cutoutFixtureId)}
-                    </StyledText>
+                    <StyledText>{t('no_deck_fixtures')}</StyledText>
                   </Flex>
-                ))
-              ) : (
-                <Flex
-                  backgroundColor={COLORS.grey10}
-                  gridGap={SPACING.spacing60}
-                  padding={SPACING.spacing8}
-                  width="100%"
-                  css={TYPOGRAPHY.labelRegular}
-                >
-                  <StyledText>{t('no_deck_fixtures')}</StyledText>
-                </Flex>
-              )}
+                )}
+              </Flex>
             </Flex>
           </Flex>
-        </Flex>
+        ) : (
+          <Flex
+            alignItems={ALIGN_CENTER}
+            flexDirection={DIRECTION_COLUMN}
+            gridGap={SPACING.spacing12}
+            justifyContent={JUSTIFY_CENTER}
+            minHeight={SIZE_4}
+            padding={SPACING.spacing12}
+            paddingBottom={SPACING.spacing24}
+            width="100%"
+          >
+            <StyledText
+              as="p"
+              color={COLORS.grey40}
+              id="InstrumentsAndModules_offline"
+            >
+              {t('offline_deck_configuration')}
+            </StyledText>
+          </Flex>
+        )}
       </Flex>
     </>
   )


### PR DESCRIPTION
# Overview

on the device details page, for unreachable robots show "Robot must be on the network" text as other sections on the page do instead of an empty deck map

<img width="1136" alt="Screen Shot 2024-01-26 at 10 57 35 AM" src="https://github.com/Opentrons/opentrons/assets/29845468/a838a2d4-dbb4-40ae-9119-626857398655">

Before:

<img width="1136" alt="Screen Shot 2024-01-26 at 11 06 22 AM" src="https://github.com/Opentrons/opentrons/assets/29845468/ca25f709-1e7d-4193-a65c-8bf9cad7f766">


# Test Plan

updated unit tests

# Changelog

 - Adds unreachable robot deck config placeholder text

# Review requests

check the unreachable robot

# Risk assessment

low
