### PR TITLE
fix(app, components): fix useScrolling hook for scrollbar issue

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -235,8 +235,12 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   }
   const dispatch = useDispatch<Dispatch>()
   const isIdle = useIdle(sleepTime, options)
-  const scrollRef = React.useRef(null)
-  const isScrolling = useScrolling(scrollRef)
+  const [currentNode, setCurrentNode] = React.useState<null | HTMLElement>(null)
+  const scrollRef = React.useCallback(
+    (node: HTMLElement | null) => setCurrentNode(node),
+    []
+  )
+  const isScrolling = useScrolling(currentNode)
 
   const TOUCH_SCREEN_STYLE = css`
     position: ${POSITION_RELATIVE};
@@ -246,13 +250,8 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
     overflow-y: ${OVERFLOW_AUTO};
 
     &::-webkit-scrollbar {
-      display: ${isScrolling ? undefined : 'none'};
+      display: ${isScrolling ? 'block' : 'none'};
       width: 0.75rem;
-    }
-
-    &::-webkit-scrollbar-track {
-      margin-top: 170px;
-      margin-bottom: 170px;
     }
 
     &::-webkit-scrollbar-thumb {

--- a/components/src/hooks/__tests__/useScrolling.test.tsx
+++ b/components/src/hooks/__tests__/useScrolling.test.tsx
@@ -13,27 +13,27 @@ describe('useScrolling', () => {
   })
 
   it('returns false when there is no scrolling', () => {
-    const ref = { current: document.createElement('div') }
+    const ref = document.createElement('div')
     const { result } = renderHook(() => useScrolling(ref))
     expect(result.current).toBe(false)
   })
 
   it('returns true when scrolling', () => {
-    const ref = { current: document.createElement('div') }
+    const ref = document.createElement('div')
     const { result } = renderHook(() => useScrolling(ref))
-    ref.current.scrollTop = 10
+    ref.scrollTop = 10
     act(() => {
-      ref.current.dispatchEvent(new Event('scroll'))
+      ref.dispatchEvent(new Event('scroll'))
     })
     expect(result.current).toBe(true)
   })
 
   it('returns false after scrolling stops', () => {
-    const ref = { current: document.createElement('div') }
+    const ref = document.createElement('div')
     const { result } = renderHook(() => useScrolling(ref))
-    ref.current.scrollTop = 10
+    ref.scrollTop = 10
     act(() => {
-      ref.current.dispatchEvent(new Event('scroll'))
+      ref.dispatchEvent(new Event('scroll'))
     })
     expect(result.current).toBe(true)
     act(() => {

--- a/components/src/hooks/useScrolling.ts
+++ b/components/src/hooks/useScrolling.ts
@@ -1,34 +1,33 @@
 /**
  * A custom hook that detects whether an HTMLElement is being scrolled.
  *
- * @param {RefObject<HTMLElement>} ref - A ref object containing the HTMLElement to monitor for scrolling.
+ * @param {HTMLElement | null} node - HTMLElement to monitor for scrolling.
  * @returns {boolean} - A boolean indicating whether the HTMLElement is being scrolled.
  */
 import { useState, useEffect, useRef } from 'react'
-import type { RefObject } from 'react'
 
-export const useScrolling = (ref: RefObject<HTMLElement>): boolean => {
+export const useScrolling = (node: HTMLElement | null): boolean => {
   const [isScrolling, setIsScrolling] = useState<boolean>(false)
   const scrollTimeout = useRef<NodeJS.Timeout | null>(null)
 
   useEffect(() => {
-    const element = ref.current
-
-    if (element != null) {
+    if (node != null) {
       const handleScroll = (): void => {
         setIsScrolling(true)
         if (scrollTimeout.current != null) clearTimeout(scrollTimeout.current)
-        scrollTimeout.current = setTimeout(() => setIsScrolling(false), 100)
+        scrollTimeout.current = setTimeout(() => {
+          setIsScrolling(false)
+        }, 200)
       }
 
-      element.addEventListener('scroll', handleScroll)
+      node?.addEventListener('scroll', handleScroll)
 
       return () => {
         if (scrollTimeout.current != null) clearTimeout(scrollTimeout.current)
-        element.removeEventListener('scroll', handleScroll)
+        node?.removeEventListener('scroll', handleScroll)
       }
     }
-  }, [ref])
+  }, [node])
 
   return isScrolling
 }


### PR DESCRIPTION
closes [RQA-1047](https://opentrons.atlassian.net/browse/RQA-1047)

# Overview

fix useScrolling hook for scrollbar on ODD

# Test Plan

- open a route in ODD that accommodates vertical scrolling (eg: `Settings` tab)
- scroll up and down
- observe scrollbar during scrolling
- observe no scrollbar shortly after scrolling ends (2 second timeout)

# Changelog

- pass current node to `useScrolling` hook (with `useCallback` rather than `useRef` to recall the custom hook)
- update scrollbar styling in top level ODD css

# Risk assessment

medium. at top level of ODD 

[RQA-1047]: https://opentrons.atlassian.net/browse/RQA-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ