### PR TITLE
docs(api): Hide `TrashBin.__init__()` signature and clarify it's for both robots

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -444,6 +444,5 @@ nitpick_ignore_regex = [
     ("py:class", r".*protocol_api\.deck.*"),
     ("py:class", r".*protocol_api\.config.*"),
     ("py:class", r".*opentrons_shared_data.*"),
-    ("py:class", r".*types\.DeckSlotName.*"),  # TODO: RTC-386
     ("py:class", r'.*AbstractLabware|APIVersion|LabwareLike|LoadedCoreMap|ModuleTypes|NoneType|OffDeckType|ProtocolCore|WellCore'),  # laundry list of not fully qualified things
 ]

--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -30,9 +30,13 @@ Labware
    :members:
    :exclude-members: next_tip, use_tips, previous_tip, return_tips
 
-.. autoclass:: opentrons.protocol_api.TrashBin
+..
+   The trailing ()s at the end of TrashBin and WasteChute here hide the __init__()
+   signatures, since users should never construct these directly.
 
-.. autoclass:: opentrons.protocol_api.WasteChute
+.. autoclass:: opentrons.protocol_api.TrashBin()
+
+.. autoclass:: opentrons.protocol_api.WasteChute()
 
 
 Wells and Liquids

--- a/api/src/opentrons/protocol_api/_trash_bin.py
+++ b/api/src/opentrons/protocol_api/_trash_bin.py
@@ -2,7 +2,7 @@ from opentrons.types import DeckSlotName
 
 
 class TrashBin:
-    """Represents a Flex trash bin.
+    """Represents a Flex or OT-2 trash bin.
 
     See :py:meth:`.ProtocolContext.load_trash_bin`.
     """

--- a/api/src/opentrons/protocol_api/_trash_bin.py
+++ b/api/src/opentrons/protocol_api/_trash_bin.py
@@ -17,7 +17,7 @@ class TrashBin:
 
         :meta private:
 
-        This is intended for Opentrons internal use only and is not a guarenteed API.
+        This is intended for Opentrons internal use only and is not a guaranteed API.
         """
         return self._location
 
@@ -27,6 +27,6 @@ class TrashBin:
 
         :meta private:
 
-        This is intended for Opentrons internal use only and is not a guarenteed API.
+        This is intended for Opentrons internal use only and is not a guaranteed API.
         """
         return self._addressable_area_name


### PR DESCRIPTION
Users are never meant to construct `TrashBin`s directly. They're supposed to get them from `ProtocolContext.load_trash_bin()`. Our docs were showing `TrashBin`'s `__init__()` signature, so let's hide it to clean things up and avoid misleading people.

`TrashBin` also said it was only for Flexes, but it's returned for OT-2s also. (See `ProtocolContext.fixed_trash`.)

## Before

![Screenshot 2024-01-29 at 11 17 26 AM](https://github.com/Opentrons/opentrons/assets/3236864/34b7946f-249d-4954-93b8-30652748f50b)

## After

![Screenshot 2024-01-29 at 11 19 03 AM](https://github.com/Opentrons/opentrons/assets/3236864/d1971bd1-5452-41da-a1e6-dc29ce269253)
