### PR TITLE
fix(api): Addition of Cutout Fixtures to slot height checks

### DIFF
--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -460,6 +460,19 @@ class AddressableAreaView(HasState[AddressableAreaState]):
             z=position.z,
         )
 
+    def get_fixture_by_deck_slot_name(self, slot_name: DeckSlotName) -> (str | None):
+        """Get the Cutout Fixture ID of a fixture currently loaded into a specific Deck Slot, if one exists."""
+        for cutout in CUTOUT_TO_DECK_SLOT_MAP:
+            if CUTOUT_TO_DECK_SLOT_MAP[cutout] == slot_name:
+                deck_config = (
+                    self.state.deck_configuration
+                )  # we need to use that get cutout fixture by id thing
+                if deck_config:
+                    for deck_item in deck_config:
+                        if cutout in deck_item:
+                            return deck_item[1]
+        return None
+
     def get_fixture_height(self, cutout_fixture_name: str) -> float:
         """Get the z height of a cutout fixture."""
         cutout_fixture = deck_configuration_provider.get_cutout_fixture(

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -460,17 +460,23 @@ class AddressableAreaView(HasState[AddressableAreaState]):
             z=position.z,
         )
 
-    def get_fixture_by_deck_slot_name(self, slot_name: DeckSlotName) -> (str | None):
-        """Get the Cutout Fixture ID of a fixture currently loaded into a specific Deck Slot, if one exists."""
-        for cutout in CUTOUT_TO_DECK_SLOT_MAP:
-            if CUTOUT_TO_DECK_SLOT_MAP[cutout] == slot_name:
-                deck_config = (
-                    self.state.deck_configuration
-                )  # we need to use that get cutout fixture by id thing
-                if deck_config:
-                    for deck_item in deck_config:
-                        if cutout in deck_item:
-                            return deck_item[1]
+    def get_fixture_by_deck_slot_name(
+        self, slot_name: DeckSlotName
+    ) -> Optional[PotentialCutoutFixture]:
+        """Get the Potential Cutout Fixture of a fixture currently loaded into a specific Deck Slot."""
+        deck_config = self.state.deck_configuration
+        potential_fixtures = self.state.potential_cutout_fixtures_by_cutout_id
+        if deck_config:
+            cutout_id = list(CUTOUT_TO_DECK_SLOT_MAP.keys())[
+                list(CUTOUT_TO_DECK_SLOT_MAP.values()).index(slot_name)
+            ]
+            deck_items = {
+                deck_item for deck_item in deck_config if cutout_id in deck_item
+            }
+            for item in deck_items:
+                for fixture in potential_fixtures[cutout_id]:
+                    if fixture.cutout_fixture_id == item[1]:
+                        return fixture
         return None
 
     def get_fixture_height(self, cutout_fixture_name: str) -> float:

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -33,8 +33,6 @@ from ..types import (
     OnDeckLabwareLocation,
     AddressableAreaLocation,
     AddressableOffsetVector,
-    AddressableArea,
-    PotentialCutoutFixture,
 )
 from .config import Config
 from .labware import LabwareView

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -692,10 +692,9 @@ class GeometryView:
                 slot_name
             )
 
-            if maybe_fixture is None:
-                maybe_module = self._modules.get_by_slot(
-                    slot_name=slot_name,
-                )
+            maybe_module = self._modules.get_by_slot(
+                slot_name=slot_name,
+            )
         else:
             # Modules and fixtures can't be loaded on staging slots
             maybe_fixture = None

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -461,6 +461,83 @@ def test_deck_conflict_raises_for_bad_partial_96_channel_move(
 @pytest.mark.parametrize(
     ["destination_well_point", "expected_raise"],
     [
+        (
+            Point(x=100, y=100, z=10),
+            pytest.raises(
+                deck_conflict.PartialTipMovementNotAllowedError,
+                match="Moving to destination-labware in slot D2 with pipette column A1 nozzle configuration will result in collision with items in deck slot D3.",
+            ),
+        ),
+    ],
+)
+def test_deck_conflict_raises_for_bad_partial_96_channel_move_with_fixtures(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    destination_well_point: Point,
+    expected_raise: ContextManager[Any],
+) -> None:
+    """It should raise an error when moving to locations adjacent to fixtures with restrictions for partial tip 96-channel movement.
+
+    Test premise:
+    - we are using a pipette configured for COLUMN nozzle layout with primary nozzle A1
+    - there's a waste chute with in D3
+    - we are checking for conflicts when moving to column A12 of a labware in D2.
+    """
+    decoy.when(mock_state_view.pipettes.get_channels("pipette-id")).then_return(96)
+    decoy.when(
+        mock_state_view.labware.get_display_name("destination-labware-id")
+    ).then_return("destination-labware")
+    decoy.when(
+        mock_state_view.pipettes.get_nozzle_layout_type("pipette-id")
+    ).then_return(NozzleConfigurationType.COLUMN)
+    decoy.when(mock_state_view.pipettes.get_primary_nozzle("pipette-id")).then_return(
+        "A1"
+    )
+    decoy.when(
+        mock_state_view.geometry.get_well_position(
+            labware_id="destination-labware-id",
+            well_name="A12",
+            well_location=WellLocation(origin=WellOrigin.TOP, offset=WellOffset(z=10)),
+        )
+    ).then_return(destination_well_point)
+    decoy.when(
+        mock_state_view.geometry.get_ancestor_slot_name("destination-labware-id")
+    ).then_return(DeckSlotName.SLOT_D2)
+    decoy.when(
+        mock_state_view.addressable_areas.get_fixture_height(
+            "wasteChuteRightAdapterNoCover"
+        )
+    ).then_return(124.5)
+    decoy.when(
+        mock_state_view.geometry.get_highest_z_in_slot(
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_D3)
+        )
+    ).then_return(
+        mock_state_view.addressable_areas.get_fixture_height(
+            "wasteChuteRightAdapterNoCover"
+        )
+    )
+    decoy.when(mock_state_view.pipettes.get_attached_tip("pipette-id")).then_return(
+        TipGeometry(length=10, diameter=100, volume=0)
+    )
+
+    with expected_raise:
+        deck_conflict.check_safe_for_pipette_movement(
+            engine_state=mock_state_view,
+            pipette_id="pipette-id",
+            labware_id="destination-labware-id",
+            well_name="A12",
+            well_location=WellLocation(origin=WellOrigin.TOP, offset=WellOffset(z=10)),
+        )
+
+
+@pytest.mark.parametrize(
+    ("robot_type", "deck_type"),
+    [("OT-3 Standard", DeckType.OT3_STANDARD)],
+)
+@pytest.mark.parametrize(
+    ["destination_well_point", "expected_raise"],
+    [
         (Point(x=100, y=100, z=60), does_not_raise()),
         # Z-collisions
         (


### PR DESCRIPTION
# Overview
This seeks to fix issues related to RSS-375 and RSS-422.

Of note, this will only fix issues during runtime. Currently when in partial tip configuration the engine will attempt to check the height of object adjacent to the slot that an action (such as pickup tip) is occurring in. However, only the heigh of labware and module is checked, the system does not check for the height of fixtures loaded into the deck configuration.

To solve this, a method has been added to allow for searching of Cutout fixtures by deck slot name, and then the height of a returned fixture is then checked alongside the labware and module heights. If, for example a waste chute is loaded in D3 and a partial tip pickup is attempted in D2, the engine will raise an error.

# Test Plan
Ensure that a protocol with a waste chute loaded in D3  with a 96 channel in partial tip configuration set to pick up tips from column A12 of a tiprack in D2 using column A1 of the instrument raises an error during operation before a collision would occur.
The following protocol ought to produce the expected results:

```python
from opentrons.protocol_api import COLUMN, ALL

requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16"
}

def run(protocol_context):
	tip_rack1 = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "D2")
	instrument = protocol_context.load_instrument('flex_96channel_1000', mount="left", tip_racks=[tip_rack1])

	waste_chute = protocol_context.load_waste_chute()

	instrument.configure_nozzle_layout(style=COLUMN, start="A1")

	instrument.pick_up_tip(tip_rack1)
	instrument.drop_tip(waste_chute)
```

# Risk assessment
While the robot will prevent a collision during runtime, a protocol where a crash would occur would still pass analysis. This is in part due to the fact that we do not load a true deck configuration for analysis, so when checking the set of loaded fixtures we see that there are "None", even if that is untrue. This is yet another item that would become simpler with multipass analysis.