### PR TITLE
fix(ci): no js source only types `shared-data/.npmignore`

### DIFF
--- a/shared-data/.npmignore
+++ b/shared-data/.npmignore
@@ -1,3 +1,5 @@
 dist
 python
 *.tgz
+js/
+!lib/js


### PR DESCRIPTION
### Overview

> The wiring up in webpack when js/ is included does not work and tries to point at the included *.ts files which I am guessing is why this was ignored in `shared-data/.npmignore` in the first place.

- [shared-data](https://www.npmjs.com/package/@opentrons/shared-data)
- [components](https://www.npmjs.com/package/@opentrons/components)

#### `0.1.2-alpha.1`

```
Import trace for requested module:
./node_modules/@opentrons/shared-data/js/constants.ts
./node_modules/@opentrons/shared-data/js/index.ts

./node_modules/@opentrons/shared-data/js/errors.ts
Module parse failed: Unexpected token (3:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| import errorDefinitions from '../errors/definitions/1/errors.json'
|
> export type ErrorCodes = keyof typeof errorDefinitions.codes
| export type ErrorCategories = keyof typeof errorDefinitions.categories
|
```

### Test Plan

- [x] Tag an alpha on this branch and see if it works.

### Changelog

- ignore source js/ in `shared-data/.npmignore`
- do not ignore lib/js/ in `shared-data/.npmignore`

### Risk assessment

None to any functional code.  CI only change to what webpack uses and what gets packed and pushed to npm.