### PR TITLE
fix(api): flex has no z retract distance

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -75,7 +75,6 @@ DEFAULT_CARRIAGE_OFFSET: Final[Offset] = (477.20, 493.8, 253.475)
 DEFAULT_LEFT_MOUNT_OFFSET: Final[Offset] = (-13.5, -60.5, 255.675)
 DEFAULT_RIGHT_MOUNT_OFFSET: Final[Offset] = (40.5, -60.5, 255.675)
 DEFAULT_GRIPPER_MOUNT_OFFSET: Final[Offset] = (84.55, -12.75, 93.85)
-DEFAULT_Z_RETRACT_DISTANCE: Final = 2
 DEFAULT_SAFE_HOME_DISTANCE: Final = 5
 DEFAULT_CALIBRATION_AXIS_MAX_SPEED: Final = 30
 
@@ -380,9 +379,6 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
                 current_settings.get("run_current", {}),
                 DEFAULT_RUN_CURRENT,
             ),
-        ),
-        z_retract_distance=robot_settings.get(
-            "z_retract_distance", DEFAULT_Z_RETRACT_DISTANCE
         ),
         safe_home_distance=robot_settings.get(
             "safe_home_distance", DEFAULT_SAFE_HOME_DISTANCE

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -174,7 +174,6 @@ class OT3Config:
     log_level: str
     motion_settings: OT3MotionSettings
     current_settings: OT3CurrentSettings
-    z_retract_distance: float
     safe_home_distance: float
     deck_transform: OT3Transform
     carriage_offset: Offset

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2379,7 +2379,7 @@ class OT3API(
             OT3Mount.from_mount(mount), carriage_pos, critical_point
         )
 
-        return pos_at_home[Axis.by_mount(mount)] - self._config.z_retract_distance
+        return pos_at_home[Axis.by_mount(mount)]
 
     async def update_nozzle_configuration_for_mount(
         self,

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -109,7 +109,6 @@ ot3_dummy_settings = {
         },
     },
     "log_level": "NADA",
-    "z_retract_distance": 10,
     "safe_home_distance": 5,
     "deck_transform": [[-0.5, 0, 1], [0.1, -2, 4], [0, 0, -1]],
     "carriage_offset": (1, 2, 3),


### PR DESCRIPTION
On the OT-2, when we home the Z axes we move up until we hit the switch; set that to the home position; and then move down 2mm. We have a corresponding config element that captures this 2mm distance called z_retract_distance, and when computing the max instrument height we subtract it from the stored home position. When we worked on the flex, because we inherited most of the code, we inherited this behavior.

However, this is actually not correct behavior on the flex. On the flex, when we home we move up until we hit the switch (well, occlude the photointerrupter, but potato potato); we move down until the switch is released; and we set _that_ to be the home position. So if we later take 2mm off the top for a retract distance, then we'll command a move above the physical home position and hit the stops, causing a stall.

Closes RQA-2256

