### PR TITLE
refactor(api): separate serial logging

### DIFF
--- a/api/src/opentrons/util/logging_config.py
+++ b/api/src/opentrons/util/logging_config.py
@@ -94,6 +94,18 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "formatter": "message_only",
                 "SYSLOG_IDENTIFIER": "opentrons-api-serial",
             },
+            "can_serial": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFIER": "opentrons-api-serial-can",
+            },
+            "usbbin_serial": {
+                "class": "systemd.journal.JournalHandler",
+                "level": logging.DEBUG,
+                "formatter": "message_only",
+                "SYSLOG_IDENTIFIER": "opentrons-api-serial-usbbin",
+            },
         },
         "loggers": {
             "opentrons.drivers.asyncio.communication.serial_connection": {
@@ -110,12 +122,12 @@ def _buildroot_config(level_value: int) -> Dict[str, Any]:
                 "level": level_value,
             },
             "opentrons_hardware.drivers.can_bus.can_messenger": {
-                "handlers": ["serial"],
+                "handlers": ["can_serial"],
                 "level": logging.DEBUG,
                 "propagate": False,
             },
             "opentrons_hardware.drivers.binary_usb.bin_serial": {
-                "handlers": ["serial"],
+                "handlers": ["usbbin_serial"],
                 "level": logging.DEBUG,
                 "propagate": False,
             },

--- a/robot-server/robot_server/service/legacy/routers/logs.py
+++ b/robot-server/robot_server/service/legacy/routers/logs.py
@@ -8,7 +8,7 @@ router = APIRouter()
 
 IDENTIFIER_TO_SYSLOG_ID: Dict[LogIdentifier, str] = {
     LogIdentifier.api: "opentrons-api",
-    LogIdentifier.serial: "opentrons-api-serial",
+    LogIdentifier.serial: log_control.SERIAL_SPECIAL,
     LogIdentifier.server: "uvicorn",
     LogIdentifier.api_server: "opentrons-robot-server",
     LogIdentifier.touchscreen: "opentrons-robot-app",

--- a/robot-server/tests/service/legacy/routers/test_logs.py
+++ b/robot-server/tests/service/legacy/routers/test_logs.py
@@ -20,9 +20,7 @@ def test_get_serial_log_with_defaults(api_client):
         body = response.text
         assert response.status_code == 200
         assert body == expected
-        m.assert_called_once_with(
-            "opentrons-api-serial", DEFAULT_RECORDS, "short-precise"
-        )
+        m.assert_called_once_with("ALL_SERIAL", DEFAULT_RECORDS, "short-precise")
 
 
 @pytest.mark.parametrize(
@@ -59,7 +57,7 @@ def test_get_serial_log_with_params(
         assert body == expected
         assert response.status_code == 200
 
-        m.assert_called_once_with("opentrons-api-serial", records_param, mode_param)
+        m.assert_called_once_with("ALL_SERIAL", records_param, mode_param)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We have serial logging for anything that involves sending commands to other hardware. On the OT-2, that meant the smoothie/cmb and any modules. On the Flex, it means modules, rear panel, and canbus. All these things can interfere with each other and they all get jammed in `opentrons-api-serial`.

Instead, we'll keep the smoothie and module logs in `opentrons-api-serial` but pipe the can logs to
`opentrons-api-serial-can` and the rear panel to
`opentrons-api-serial-usbbin`. Then we'll gather them all up when you hit the logs endpoint, but now
- If you're in an ssh or serial term session and want to see just the can logs, you finally are able to: journalctl -f -t opentrons-api-serial-canbus
- If you're reading log exports after the fact and want to look at just the can logs, you can now search for opentrons-api-serial-canbus and it will do what you want

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
