### PR TITLE
docs(api): overhaul `ProtocolContext` docstrings

### DIFF
--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -31,6 +31,7 @@ When the move step is complete, the API updates the labware's location, so you c
     
 For the first move, the API knows to find the plate in its initial load location, slot D1. For the second move, the API knows to find the plate in D2.
 
+.. _automatic-manual-moves:
 
 Automatic vs Manual Moves
 =========================

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -119,6 +119,8 @@ Whether you need a ``requirements`` block depends on your robot model and API ve
 
 With the metadata and requirements defined, you can move on to creating the ``run()`` function for your protocol.
 
+.. _run-function:
+
 The ``run()`` function
 ----------------------
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -59,6 +59,8 @@ When choosing an API level, consider what features you need and how widely you p
 
 On the one hand, using the highest available version will give your protocol access to all the latest :ref:`features and fixes <version-notes>`. On the other hand, using the lowest possible version lets the protocol work on a wider range of robot software versions. For example, a protocol that uses the Heater-Shaker and specifies version 2.13 of the API should work equally well on a robot running version 6.1.0 or 6.2.0 of the robot software. Specifying version 2.14 would limit the protocol to robots running 6.2.0 or higher.
 
+.. _max-version:
+
 Maximum Supported Versions
 ==========================
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -180,14 +180,17 @@ class ProtocolContext(CommandPublisher):
 
         This value is set when the protocol context
         is initialized. 
-        
-          - When the context is the argument of ``run()``, the ``"apiLevel"`` key of the metadata or requirements dictionary determines ``api_version``. 
-          - When the context is instantiated with :py:meth:`opentrons.execute.get_protocol_api` or :py:meth:`opentrons.simulate.get_protocol_api`, the value of its ``version`` argument determines ``api_version``.
-        
-        
-        It may be lower than the highest version supported
-        by the robot software. For the highest version supported by the
-        robot software, see ``protocol_api.MAX_SUPPORTED_VERSION``.
+
+          - When the context is the argument of ``run()``, the ``"apiLevel"`` key of the
+            metadata or requirements dictionary determines ``api_version``.
+          - When the context is instantiated with
+            :py:meth:`opentrons.execute.get_protocol_api` or
+            :py:meth:`opentrons.simulate.get_protocol_api`, the value of its ``version``
+            argument determines ``api_version``.
+
+        It may be lower than the :ref:`maximum version <max-version>` supported by the
+        robot software, which is accessible via the
+        ``protocol_api.MAX_SUPPORTED_VERSION`` constant.
         """
         return self._api_version
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -99,9 +99,9 @@ class ProtocolContext(CommandPublisher):
       - They can control the flow of a running protocol, such as pausing, displaying
         messages, or controlling built-in robot hardware like the ambient lighting.
 
-    Do not instantiate a ``ProtocolContext`` directly for protocols that you plan to run
-    via the Opentrons App or touchscreen. The ``run()`` function of your protocol does
-    that for you. See the :ref:`Tutorial <run-function>` for more information.
+    Do not instantiate a ``ProtocolContext`` directly.
+    The ``run()`` function of your protocol does that for you.
+    See the :ref:`Tutorial <run-function>` for more information.
 
     Use :py:meth:`opentrons.execute.get_protocol_api` to instantiate a ``ProtocolContext`` when
     using Jupyter Notebook. See :ref:`advanced-control`.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -244,7 +244,7 @@ class ProtocolContext(CommandPublisher):
 
         See :ref:`axis_speed_limits` for examples.
 
-        .. caution::
+        .. note::
             This property is not yet supported in API version 2.14 or higher.
         """
         if self._api_version >= ENGINE_CORE_API_VERSION:
@@ -557,7 +557,7 @@ class ProtocolContext(CommandPublisher):
         :type location: int or str or :py:obj:`OFF_DECK`
 
         :param str namespace: The namespace that the labware definition belongs to.
-            If unspecified, will search both:
+            If unspecified, the API will automatically search two namespaces:
 
               * ``"opentrons"``, to load standard Opentrons labware definitions.
               * ``"custom_beta"``, to load custom labware definitions created with the
@@ -612,7 +612,7 @@ class ProtocolContext(CommandPublisher):
             be no entry for that slot in this value. That means you should not
             use ``loaded_labwares`` to determine if a slot is available or not,
             only to get a list of labwares. If you want a data structure of all
-            objects on the deck regardless of type, see :py:attr:`deck`.
+            objects on the deck regardless of type, use :py:attr:`deck`.
 
 
         :returns: Dict mapping deck slot number to labware, sorted in order of
@@ -659,7 +659,7 @@ class ProtocolContext(CommandPublisher):
         :param use_gripper: Whether to use the Flex Gripper for this movement.
 
                 * If ``True``, use the gripper to perform an automatic
-                  movement. This will raise an error on an OT-2 protocol.
+                  movement. This will raise an error in an OT-2 protocol.
                 * If ``False``, pause protocol execution until the user
                   performs the movement. Protocol execution remains paused until
                   the user presses **Confirm and resume**.
@@ -1048,9 +1048,9 @@ class ProtocolContext(CommandPublisher):
         """An interface to provide information about what's currently loaded on the deck.
         This object is useful for determining if a slot on the deck is free.
 
-        This object behaves like a dictionary whose keys are the deck slot names.
+        This object behaves like a dictionary whose keys are the :ref:`deck slot <deck-slots>` names.
         For instance, ``deck[1]``, ``deck["1"]``, and ``deck["D1"]``
-        will all return the object loaded in the front-left slot. (See :ref:`deck-slots`.)
+        will all return the object loaded in the front-left slot.
 
         The value will be a :py:obj:`~opentrons.protocol_api.Labware` if the slot contains a
         labware, a module context if the slot contains a hardware
@@ -1062,7 +1062,7 @@ class ProtocolContext(CommandPublisher):
 
         For :ref:`advanced-control` *only*, you can delete an element of the ``deck`` dict.
         This only works for deck slots that contain labware objects. For example, if slot
-        1 contains a labware, ``del protocol.deck['1']`` will free the slot so you can
+        1 contains a labware, ``del protocol.deck["1"]`` will free the slot so you can
         load another labware there.
 
         .. warning::
@@ -1081,7 +1081,7 @@ class ProtocolContext(CommandPublisher):
     def fixed_trash(self) -> Union[Labware, TrashBin]:
         """The trash fixed to slot 12 of an OT-2's deck.
 
-        In API version 2.15 and earlier, the fixed trash is a :py:class:`.Labware` object with one well. Access it like labware in your protocol. For example, ``protocol.fixed_trash['A1']``.
+        In API version 2.15 and earlier, the fixed trash is a :py:class:`.Labware` object with one well. Access it like labware in your protocol. For example, ``protocol.fixed_trash["A1"]``.
 
         In API version 2.15 only, Flex protocols have a fixed trash in slot A3.
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -88,17 +88,17 @@ class HardwareManager(NamedTuple):
 
 class ProtocolContext(CommandPublisher):
     """A context for the state of a protocol.
-    
+
     The ``ProtocolContext`` class provides the objects, attributes, and methods that
-    allow you to configure and control the protocol. 
-    
+    allow you to configure and control the protocol.
+
     Methods generally fall into one of two categories.
-    
+
       - They can change the state of the ``ProtocolContext`` object, such as adding
         pipettes, hardware modules, or labware to your protocol.
       - They can control the flow of a running protocol, such as pausing, displaying
         messages, or controlling built-in robot hardware like the ambient lighting.
-      
+
     Do not instantiate a ``ProtocolContext`` directly for protocols that you plan to run
     via the Opentrons App or touchscreen. The ``run()`` function of your protocol does
     that for you. See the :ref:`Tutorial <run-function>` for more information.
@@ -179,7 +179,7 @@ class ProtocolContext(CommandPublisher):
         """Return the API version specified for this protocol context.
 
         This value is set when the protocol context
-        is initialized. 
+        is initialized.
 
           - When the context is the argument of ``run()``, the ``"apiLevel"`` key of the
             :ref:`metadata <tutorial-metadata>` or :ref:`requirements
@@ -296,14 +296,14 @@ class ProtocolContext(CommandPublisher):
     @requires_version(2, 0)
     def is_simulating(self) -> bool:
         """Returns ``True`` if the protocol is running in simulation.
-        
+
         Returns ``False`` if the protocol is running on actual hardware.
-        
+
         You can evaluate the result of this method in an ``if`` statement to make your
         protocol behave differently in different environments. For example, you could
         refer to a data file on your computer when simulating and refer to a data file
         stored on the robot when not simulating.
-        
+
         You can also use it to skip time-consuming aspects of your protocol. Most Python
         Protocol API methods, like :py:meth:`.delay`, are designed to evaluate
         instantaneously in simulation. But external methods, like those from the
@@ -639,8 +639,8 @@ class ProtocolContext(CommandPublisher):
         pick_up_offset: Optional[Mapping[str, float]] = None,
         drop_offset: Optional[Mapping[str, float]] = None,
     ) -> None:
-        """Move a loaded labware to a new location. 
-        
+        """Move a loaded labware to a new location.
+
         See :ref:`moving-labware` for more details.
 
         :param labware: The labware to move. It should be a labware already loaded
@@ -851,7 +851,7 @@ class ProtocolContext(CommandPublisher):
         When analyzing the protocol on the robot, instruments loaded with this method
         are compared against the instruments attached to the robot. You won't be able to
         start the protocol until the correct instruments are attached and calibrated.
-        
+
         Currently, this method only loads pipettes. You do not need to load the Flex
         Gripper to use it in protocols. See :ref:`automatic-manual-moves`.
 
@@ -998,11 +998,11 @@ class ProtocolContext(CommandPublisher):
     def comment(self, msg: str) -> None:
         """
         Add a user-readable message to the run log.
-        
+
         The message is visible anywhere you can view the run log, including the Opentrons App and the touchscreen on Flex.
 
         .. note::
-        
+
             The value of the message is computed during protocol analysis,
             so ``comment()`` can't communicate real-time information during the
             actual protocol run.

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -234,8 +234,8 @@ class ProtocolContext(CommandPublisher):
         """Per-axis speed limits for moving instruments.
 
         Changing values within this property sets the speed limit for each non-plunger
-        axis of the robot. Note that this property only sets upper limits on movement
-        speed.
+        axis of the robot. Note that this property only sets upper limits and can't
+        exceed the physical speed limits of the movement system.
 
         This property is a dict mapping string names of axes to float values
         of maximum speeds in mm/s. To change a speed, set that axis's value. To

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -87,17 +87,24 @@ class HardwareManager(NamedTuple):
 
 
 class ProtocolContext(CommandPublisher):
-    """The Context class is a container for the state of a protocol.
+    """A context for the state of a protocol.
+    
+    The ``ProtocolContext`` class provides the objects, attributes, and methods that
+    allow you to configure and control the protocol. 
+    
+    Methods generally fall into one of two categories.
+    
+      - They can change the state of the ``ProtocolContext`` object, such as adding
+        pipettes, hardware modules, or labware to your protocol.
+      - They can control the flow of a running protocol, such as pausing, displaying
+        messages, or controlling built-in robot hardware like the ambient lighting.
+      
+    Do not instantiate a ``ProtocolContext`` directly for protocols that you plan to run
+    via the Opentrons App or touchscreen. The ``run()`` function of your protocol does
+    that for you. See the :ref:`Tutorial <run-function>` for more information.
 
-    It encapsulates many of the methods formerly found in the Robot class,
-    including labware, instrument, and module loading, as well as core
-    functions like pause and resume.
-
-    Unlike the old robot class, it is designed to be ephemeral. The lifetime
-    of a particular instance should be about the same as the lifetime of a
-    protocol. The only exception is the one stored in
-    ``.legacy_api.api.robot``, which is provided only for back
-    compatibility and should be used less and less as time goes by.
+    Use :py:meth:`opentrons.execute.get_protocol_api` to instantiate a ``ProtocolContext`` when
+    using Jupyter Notebook. See :ref:`advanced-control`.
 
     .. versionadded:: 2.0
 
@@ -169,10 +176,16 @@ class ProtocolContext(CommandPublisher):
     @property
     @requires_version(2, 0)
     def api_version(self) -> APIVersion:
-        """Return the API version supported by this protocol context.
+        """Return the API version specified for this protocol context.
 
-        The supported API version was specified when the protocol context
-        was initialized. It may be lower than the highest version supported
+        This value is set when the protocol context
+        is initialized. 
+        
+          - When the context is the argument of ``run()``, the ``"apiLevel"`` key of the metadata or requirements dictionary determines ``api_version``. 
+          - When the context is instantiated with :py:meth:`opentrons.execute.get_protocol_api` or :py:meth:`opentrons.simulate.get_protocol_api`, the value of its ``version`` argument determines ``api_version``.
+        
+        
+        It may be lower than the highest version supported
         by the robot software. For the highest version supported by the
         robot software, see ``protocol_api.MAX_SUPPORTED_VERSION``.
         """

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -210,10 +210,11 @@ class ProtocolContext(CommandPublisher):
     def bundled_data(self) -> Dict[str, bytes]:
         """Accessor for data files bundled with this protocol, if any.
 
-        This is a dictionary mapping the filenames of bundled datafiles to the bytes
-        contents of the files. The filename keys are formatted with extensions but
-        without paths. For example, a file stored in the bundle as
-        ``data/mydata/aspirations.csv`` will have the key ``"aspirations.csv"``.
+        This is a dictionary mapping the filenames of bundled datafiles to their
+        contents. The filename keys are formatted with extensions but without paths. For
+        example, a file stored in the bundle as ``data/mydata/aspirations.csv`` will
+        have the key ``"aspirations.csv"``. The values are :py:class:`bytes` objects
+        representing the contents of the files.
         """
         return self._bundled_data
 


### PR DESCRIPTION

# Overview

Fresh coat of paint on all the docstrings for `ProtocolContext` and its children.

Addresses RTC-203.

# Test Plan

Check the [sandbox](http://sandbox.docs.opentrons.com/docstrings-protocolcontext/v2/new_protocol_api.html#module-opentrons.protocol_api).
No warnings anymore! 🥳 

# Changelog

- Prose changes to nearly all docstrings.
- Added some cross-reference anchors.
- Pedantic change to an error string.

# Review requests

- A close read of the prose.
- A sanity check that I haven't restated something in a way that incorrectly captures real API behavior.

# Risk assessment

nil, docstrings