### PR TITLE
fix(api): temporarily increase Z_L hold current to prevent 96-channel from falling when motor is re-engaged

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -266,6 +266,14 @@ class FlexBackend(Protocol):
         """
         ...
 
+    @asynccontextmanager
+    def increase_z_l_hold_current(self) -> AsyncIterator[None]:
+        """
+        Temporarily increase the hold current when engaging the Z_L axis
+        while the 96-channel is attached
+        """
+        ...
+
     async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         ...
 

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1088,6 +1088,24 @@ class OT3Controller(FlexBackend):
                 {Axis.Z_R: high_throughput_settings[Axis.Z_R].run_current}
             )
 
+    @asynccontextmanager
+    async def increase_z_l_hold_current(self) -> AsyncIterator[None]:
+        """
+        Temporarily increase the hold current when engaging the Z_L axis
+        while the 96-channel is attached
+        """
+        assert self._current_settings
+        high_throughput_settings = deepcopy(self._current_settings)
+        await self.set_hold_current(
+            {Axis.Z_L: high_throughput_settings[Axis.Z_L].run_current}
+        )
+        try:
+            yield
+        finally:
+            await self.set_hold_current(
+                {Axis.Z_L: high_throughput_settings[Axis.Z_L].hold_current}
+            )
+
     @staticmethod
     def _build_event_watcher() -> aionotify.Watcher:
         watcher = aionotify.Watcher()

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -575,6 +575,14 @@ class OT3Simulator(FlexBackend):
         """
         yield
 
+    @asynccontextmanager
+    async def increase_z_l_hold_current(self) -> AsyncIterator[None]:
+        """
+        Temporarily increase the hold current when engaging the Z_L axis
+        while the 96-channel is attached
+        """
+        yield
+
     @ensure_yield
     async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         new_mods_at_ports = [


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The 96-channel pipette sometimes fall immediately when the Z motor is re-engaged from being held by the ebrake. 

We're theorizing that increasing the hold current temporarily when we re-engage the motor could help it overcome the detent torque asserted when the ebrake was applied, so that the motor would have a chance to maintain its position. 
