### PR TITLE
fix(app): fix app progress bar not displaying 100% when update downloaded

### DIFF
--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { when } from 'jest-when'
-import { fireEvent } from '@testing-library/react'
+import { screen, fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 
@@ -71,21 +71,23 @@ describe('UpdateAppModal', () => {
   })
 
   it('renders update available title and release notes when update is available', () => {
-    const [{ getByText }] = render(props)
-    expect(getByText('Opentrons App Update Available')).toBeInTheDocument()
-    expect(getByText('this is a release')).toBeInTheDocument()
+    render(props)
+    expect(
+      screen.getByText('Opentrons App Update Available')
+    ).toBeInTheDocument()
+    expect(screen.getByText('this is a release')).toBeInTheDocument()
   })
   it('closes modal when "remind me later" button is clicked', () => {
     const closeModal = jest.fn()
-    const [{ getByText }] = render({ ...props, closeModal })
-    fireEvent.click(getByText('Remind me later'))
+    render({ ...props, closeModal })
+    fireEvent.click(screen.getByText('Remind me later'))
     expect(closeModal).toHaveBeenCalled()
   })
 
   it('renders a release notes link pointing to the Github releases page', () => {
-    const [{ getByText }] = render(props)
+    render(props)
 
-    const link = getByText('Release notes')
+    const link = screen.getByText('Release notes')
     expect(link).toHaveAttribute('href', RELEASE_NOTES_URL_BASE + '7.0.0')
   })
 
@@ -96,34 +98,37 @@ describe('UpdateAppModal', () => {
         name: 'Error',
       },
     } as ShellUpdateState)
-    const [{ getByText }] = render(props)
-    expect(getByText('Update Error')).toBeInTheDocument()
+    render(props)
+    expect(screen.getByText('Update Error')).toBeInTheDocument()
   })
   it('shows a download progress bar when downloading', () => {
     getShellUpdateState.mockReturnValue({
       downloading: true,
       downloadPercentage: 50,
     } as ShellUpdateState)
-    const [{ getByText, getByRole }] = render(props)
-    expect(getByText('Downloading update...')).toBeInTheDocument()
-    expect(getByRole('progressbar')).toBeInTheDocument()
+    render(props)
+    expect(screen.getByText('Downloading update...')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
   it('renders download complete text when download is finished', () => {
     getShellUpdateState.mockReturnValue({
       downloading: false,
       downloaded: true,
     } as ShellUpdateState)
-    const [{ getByText, getByRole }] = render(props)
+    render(props)
     expect(
-      getByText('Download complete, restarting the app...')
+      screen.getByText('Download complete, restarting the app...')
     ).toBeInTheDocument()
-    expect(getByRole('progressbar')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    expect(getComputedStyle(screen.getByTestId('ProgressBar_Bar')).width).toBe(
+      '100%'
+    )
   })
   it('renders an error message when an error occurs', () => {
     getShellUpdateState.mockReturnValue({
       error: { name: 'Update Error' },
     } as ShellUpdateState)
-    const [{ getByTitle }] = render(props)
-    expect(getByTitle('Update Error')).toBeInTheDocument()
+    render(props)
+    expect(screen.getByTitle('Update Error')).toBeInTheDocument()
   })
 })

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -174,7 +174,7 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
               {downloading ? t('download_update') : t('restarting_app')}
             </StyledText>
             <ProgressBar
-              percentComplete={downloadPercentage}
+              percentComplete={downloaded ? 100 : downloadPercentage}
               outerStyles={UPDATE_PROGRESS_BAR_STYLE}
             />
           </Flex>


### PR DESCRIPTION
Closes RQA-2266
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Fixes a 1x issue where the app progress bar did not show 100% after the update was downloaded. A good cover-all solution for these update issues is to have the progress bar report 100% when the node layer emits that the update was successfully downloaded (as we do with the modal text). 

![Screenshot 2024-01-30 at 10 13 30 AM (2)](https://github.com/Opentrons/opentrons/assets/64858653/865e7d50-dfb8-4f44-9649-b773c5a56398)

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Just reason through the code. It's a 1x reported issue that I can't repro. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- App update progress bar will always be at 100% when the download is complete.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
