### PR TITLE
feat(api,hardware,robot-server): enable firmware updates for the HEPA/UV.

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -80,6 +80,7 @@ SUBSYSTEM_NODEID: Dict[SubSystem, NodeId] = {
     SubSystem.pipette_left: NodeId.pipette_left,
     SubSystem.pipette_right: NodeId.pipette_right,
     SubSystem.gripper: NodeId.gripper,
+    SubSystem.hepa_uv: NodeId.hepa_uv,
 }
 
 NODEID_SUBSYSTEM = {node: subsystem for subsystem, node in SUBSYSTEM_NODEID.items()}

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -254,6 +254,7 @@ class SubSystem(enum.Enum):
     gripper = 5
     rear_panel = 6
     motor_controller_board = 7
+    hepa_uv = 8
 
     def __str__(self) -> str:
         return self.name

--- a/hardware/opentrons_hardware/firmware_update/utils.py
+++ b/hardware/opentrons_hardware/firmware_update/utils.py
@@ -27,6 +27,7 @@ _DEFAULT_PCBA_REVS: Final[Dict[FirmwareTarget, str]] = {
     NodeId.gantry_x: "c1",
     NodeId.gantry_y: "c1",
     NodeId.gripper: "c1",
+    NodeId.hepa_uv: "b1",
     USBTarget.rear_panel: "b1",
 }
 
@@ -50,6 +51,7 @@ class FirmwareUpdateType(Enum):
     pipettes_multi = 5
     pipettes_96 = 6
     rear_panel = 7
+    hepa_uv = 8
     unknown = -1
     unknown_no_subtype = -2
     unknown_no_revision = -3
@@ -89,6 +91,7 @@ class FirmwareUpdateType(Enum):
             NodeId.gantry_x: cls.gantry_x,
             NodeId.gantry_y: cls.gantry_y,
             NodeId.gripper: cls.gripper,
+            NodeId.hepa_uv: cls.hepa_uv,
         }
         return lookup[node.application_for()]
 

--- a/hardware/opentrons_hardware/scripts/update_fw.py
+++ b/hardware/opentrons_hardware/scripts/update_fw.py
@@ -48,6 +48,7 @@ TARGETS: Final[Dict[str, FirmwareTarget]] = {
     "pipette-left": NodeId.pipette_left,
     "pipette-right": NodeId.pipette_right,
     "gripper": NodeId.gripper,
+    "hepa-uv": NodeId.hepa_uv,
     "rear-panel": USBTarget.rear_panel,
 }
 

--- a/robot-server/robot_server/subsystems/models.py
+++ b/robot-server/robot_server/subsystems/models.py
@@ -26,6 +26,7 @@ class SubSystem(enum.Enum):
     pipette_right = "pipette_right"
     gripper = "gripper"
     rear_panel = "rear_panel"
+    hepa_uv = "hepa_uv"
     motor_controller_board = "motor_controller_board"
 
     @classmethod
@@ -46,6 +47,7 @@ _HW_SUBSYSTEM_TO_SUBSYSTEM: Dict[HWSubSystem, SubSystem] = {
     HWSubSystem.pipette_right: SubSystem.pipette_right,
     HWSubSystem.rear_panel: SubSystem.rear_panel,
     HWSubSystem.gripper: SubSystem.gripper,
+    HWSubSystem.hepa_uv: SubSystem.hepa_uv,
     HWSubSystem.motor_controller_board: SubSystem.motor_controller_board,
 }
 
@@ -57,6 +59,7 @@ _SUBSYSTEM_TO_HW_SUBSYSTEM: Dict[SubSystem, HWSubSystem] = {
     SubSystem.pipette_right: HWSubSystem.pipette_right,
     SubSystem.rear_panel: HWSubSystem.rear_panel,
     SubSystem.gripper: HWSubSystem.gripper,
+    SubSystem.hepa_uv: HWSubSystem.hepa_uv,
     SubSystem.motor_controller_board: HWSubSystem.motor_controller_board,
 }
 


### PR DESCRIPTION
# Overview

The HEPA/UV can update over CAN, this PR adds the missing defines for this to work properly.

# Test Plan

- [x] Make sure we can update the HEPA/UV fan when we power on the Flex.
- [x] Make sure the robot server starts up properly after updating the HEPA/UV
- [x] Make sure the robot server starts properly without a HEPA/UV filter.

# Changelog

- Add hepa_uv defines for SubSystem, FirmwareUpdateType, and HWSubSystem

# Review requests
# Risk assessment

- low, Flex only, unreleased device