### PR TITLE
fix(app): ensure firmware takeover modal won't open uneccessarily

### DIFF
--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -81,10 +81,19 @@ export function FirmwareUpdateTakeover(): JSX.Element {
     ) {
       setShowUpdateNeededModal(true)
     }
+    // close modal if update is no longer needed
+    else if (
+      instrumentsData?.find(instrument => !instrument.ok) == null &&
+      initiatedSubsystemUpdate == null &&
+      showUpdateNeededModal
+    ) {
+      setShowUpdateNeededModal(false)
+    }
   }, [
     externalSubsystemUpdate,
     indexToUpdate,
     instrumentsToUpdate,
+    initiatedSubsystemUpdate,
     instrumentsData,
     isUnboxingFlowOngoing,
     maintenanceRunData,

--- a/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/FirmwareUpdateTakeover.tsx
@@ -63,7 +63,16 @@ export function FirmwareUpdateTakeover(): JSX.Element {
   )
 
   React.useEffect(() => {
+    // in case instruments are updated elsewhere in the app, clear update needed list
+    // when all instruments are ok but array has elements
     if (
+      instrumentsData?.find(instrument => !instrument.ok) == null &&
+      !showUpdateNeededModal &&
+      instrumentsToUpdate.length > 0
+    ) {
+      setInstrumentsToUpdate([])
+      setIndexToUpdate(0)
+    } else if (
       instrumentsToUpdate.length > indexToUpdate &&
       instrumentsToUpdate[indexToUpdate]?.subsystem != null &&
       maintenanceRunData == null &&
@@ -73,11 +82,13 @@ export function FirmwareUpdateTakeover(): JSX.Element {
       setShowUpdateNeededModal(true)
     }
   }, [
-    instrumentsToUpdate,
-    indexToUpdate,
-    maintenanceRunData,
-    isUnboxingFlowOngoing,
     externalSubsystemUpdate,
+    indexToUpdate,
+    instrumentsToUpdate,
+    instrumentsData,
+    isUnboxingFlowOngoing,
+    maintenanceRunData,
+    showUpdateNeededModal,
   ])
 
   return (
@@ -88,10 +99,12 @@ export function FirmwareUpdateTakeover(): JSX.Element {
         <UpdateNeededModal
           subsystem={instrumentsToUpdate[indexToUpdate]?.subsystem}
           onClose={() => {
-            // if no more instruments need updating, close the modal
+            // if no more instruments need updating, close the modal and clear data
             // otherwise start over with next instrument
             if (instrumentsToUpdate.length <= indexToUpdate + 1) {
               setShowUpdateNeededModal(false)
+              setInstrumentsToUpdate([])
+              setIndexToUpdate(0)
             } else {
               setIndexToUpdate(prevIndexToUpdate => prevIndexToUpdate + 1)
             }


### PR DESCRIPTION
fix RQA-2236

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds a few layers of protection against opening the ODD Firmware Update Takeover modal unnecessarily.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Poke around on the ODD after having updated an instrument, ensure the modal doesn't pop up again
2. If you attach an instrument that needs an update, see the modal but don't interact with it before removing the instrument, the pop up should close

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Add logic to the use effect that will wipe the `instrumentsToUpdate` array if the modal isn't open and there are currently no instruments that need updating. This will ensure that if an instrument is updated elsewhere in the app, it won't remain in this array.
3. Reset the `instrumentsToUpdate` array and `indexToUpdate` field when closing the takeover modal

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
With this branch on an ODD, play around with different scenarios that have been producing this bug
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
