### PR TITLE
chore(hardware): dont ask for barcode serial with print/clear action.

### DIFF
--- a/hardware/opentrons_hardware/scripts/provision_robot.py
+++ b/hardware/opentrons_hardware/scripts/provision_robot.py
@@ -274,14 +274,12 @@ def _main(args: argparse.Namespace, eeprom_api: EEPROMDriver) -> None:
     # Check if we have properties passed in and convert them to PropId
     properties = _format_properties(args.property) if args.property else dict()
 
-    # Add serial number from barcode
-    if not properties:
-        properties = _get_property_from_barcode()
-
     # The eeprom has been setup and is ready for action
     if args.action == "clear":
         success, msg = clear_eeprom(eeprom_api)
     elif args.action == "write":
+        # Add serial number from barcode
+        properties = properties or _get_property_from_barcode()
         success, msg = write_eeprom(eeprom_api, properties)
     elif args.action == "print":
         success, msg = print_eeprom(eeprom_api)


### PR DESCRIPTION
# Overview

Change the order of operations so we don't get asked to input a serial number from barcode when printing/clearing the eeprom, we should only get the serial from barcode when we don't specify any properties to write.

# Test Plan

- [x] Make sure the default action `write` is not changed and we are asked to input a serial number if no property is given.
- [x] Make sure we are not asked to input a serial number when we use the `print` and `clear` actions

# Changelog

- Only get serial from barcode if we are doing a `write` action and there are no properties

# Review requests
# Risk assessment
