### PR TITLE
fix(api): ot2 subsystems is a property

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -347,6 +347,7 @@ class API(
     def board_revision(self) -> str:
         return str(self._backend.board_revision)
 
+    @property
     def attached_subsystems(self) -> Dict[SubSystem, SubSystemState]:
         return {}
 


### PR DESCRIPTION
The OT2 hardware control API actually has an attached_subsystems property, except it wasn't a property, which causes annoying error messages on OT-2.
