### PR TITLE
fix(components): make labware info typography styles explicit

### DIFF
--- a/components/src/hardware-sim/ProtocolDeck/LabwareInfo.tsx
+++ b/components/src/hardware-sim/ProtocolDeck/LabwareInfo.tsx
@@ -16,6 +16,7 @@ import { TYPOGRAPHY, SPACING } from '../../ui-style-constants'
 import { COLORS } from '../../helix-design-system'
 
 const labwareDisplayNameStyle = css`
+  ${TYPOGRAPHY.labelSemiBold}
   overflow: hidden;
   white-space: initial;
   text-overflow: ellipsis;


### PR DESCRIPTION
# Overview

In order to prevent wonky rendering in environments with differing global css, be explicit about the font size, weight, and line-height of the text within the labware infor of the Protocol Deck

# Risk assessment

low