### PR TITLE
fix(app): fix banners displaying when resetting a run on the desktop app

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -170,6 +170,7 @@ export function ProtocolRunHeader({
   const [pipettesWithTip, setPipettesWithTip] = React.useState<
     PipettesWithTip[]
   >([])
+  const isResetRunLoadingRef = React.useRef(false)
   const { data: runRecord } = useRunQuery(runId, { staleTime: Infinity })
   const highestPriorityError =
     runRecord?.data.errors?.[0] != null
@@ -371,6 +372,7 @@ export function ProtocolRunHeader({
               setShowRunFailedModal,
               highestPriorityError,
             }}
+            isResetRunLoading={isResetRunLoadingRef.current}
           />
         ) : null}
         {mostRecentRunId === runId &&
@@ -406,6 +408,7 @@ export function ProtocolRunHeader({
               }
               isDoorOpen={isDoorOpen}
               isFixtureMismatch={isFixtureMismatch}
+              isResetRunLoadingRef={isResetRunLoadingRef}
             />
           </Flex>
         </Box>
@@ -550,7 +553,9 @@ interface ActionButtonProps {
   isProtocolAnalyzing: boolean
   isDoorOpen: boolean
   isFixtureMismatch: boolean
+  isResetRunLoadingRef: React.MutableRefObject<boolean>
 }
+
 function ActionButton(props: ActionButtonProps): JSX.Element {
   const {
     runId,
@@ -559,6 +564,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
     isProtocolAnalyzing,
     isDoorOpen,
     isFixtureMismatch,
+    isResetRunLoadingRef,
   } = props
   const history = useHistory()
   const { t } = useTranslation(['run_details', 'shared'])
@@ -583,6 +589,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       `/devices/${robotName}/protocol-runs/${createRunResponse.data.id}/run-preview`
     )
   )
+  isResetRunLoadingRef.current = isResetRunLoading
   const { missingModuleIds } = useUnmatchedModulesForProtocol(robotName, runId)
   const { complete: isCalibrationComplete } = useRunCalibrationStatus(
     robotName,
@@ -778,6 +785,7 @@ interface TerminalRunProps {
   handleClearClick: () => void
   isClosingCurrentRun: boolean
   setShowRunFailedModal: (showRunFailedModal: boolean) => void
+  isResetRunLoading: boolean
   highestPriorityError?: RunError | null
 }
 function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
@@ -787,6 +795,7 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
     isClosingCurrentRun,
     setShowRunFailedModal,
     highestPriorityError,
+    isResetRunLoading,
   } = props
   const { t } = useTranslation('run_details')
 
@@ -795,7 +804,10 @@ function TerminalRunBanner(props: TerminalRunProps): JSX.Element | null {
     setShowRunFailedModal(true)
   }
 
-  if (runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED) {
+  if (
+    isResetRunLoading === false &&
+    (runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED)
+  ) {
     return (
       <>
         {runStatus === RUN_STATUS_SUCCEEDED ? (

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -844,6 +844,30 @@ describe('ProtocolRunHeader', () => {
     screen.getByText('mock RunFailedModal')
   })
 
+  it('does not render banners when a run is resetting', () => {
+    when(mockUseRunQuery)
+      .calledWith(RUN_ID)
+      .mockReturnValue({
+        data: { data: mockFailedRun },
+      } as UseQueryResult<Run>)
+    when(mockUseRunStatus).calledWith(RUN_ID).mockReturnValue(RUN_STATUS_FAILED)
+    when(mockUseRunControls)
+      .calledWith(RUN_ID, expect.anything())
+      .mockReturnValue({
+        play: () => {},
+        pause: () => {},
+        stop: () => {},
+        reset: () => {},
+        isPlayRunActionLoading: false,
+        isPauseRunActionLoading: false,
+        isStopRunActionLoading: false,
+        isResetRunLoading: true,
+      })
+    render()
+
+    expect(screen.queryByText('mock RunFailedModal')).not.toBeInTheDocument()
+  })
+
   it('renders a clear protocol banner when run has been canceled', () => {
     when(mockUseRunStatus)
       .calledWith(RUN_ID)


### PR DESCRIPTION
Closes RQA-2250

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a bug in which banners from a cancelled, previous run would render while resetting the run. The problem is more noticable on the OT-2.

### Before

https://github.com/Opentrons/opentrons/assets/64858653/8562f362-7ec0-47d7-81f5-75d001b1b6ba

### With Fix

https://github.com/Opentrons/opentrons/assets/64858653/f9b8edc4-bcc0-4977-89c9-8c6382e86efb

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

You can use this protocol to test. Just follow the videos above as a guide. 
[testing_ot2api_decorated_methods.py.zip](https://github.com/Opentrons/opentrons/files/14113952/testing_ot2api_decorated_methods.py.zip)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a bug where banners would display for a cancelled run while the run is resetting.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
