### PR TITLE
refactor(robot-server): prevent using pipette settings on flex

### DIFF
--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -150,7 +150,7 @@ def _override_version_with_mock(versions: MagicMock) -> Iterator[None]:
 def _override_ot2_hardware_with_mock(hardware: MagicMock) -> Iterator[None]:
     async def get_ot2_hardware_override() -> API:
         """Override for the get_ot2_hardware FastAPI dependency."""
-        return MagicMock(spec=API)
+        return hardware
 
     app.dependency_overrides[get_ot2_hardware] = get_ot2_hardware_override
     yield


### PR DESCRIPTION
They are fundamentally not necessary or really functional on flex pipettes, and the settings don't really work on the 96 anyway.

