### PR TITLE
fix(robot-server): mqtt disconnect cb signature

### DIFF
--- a/robot-server/robot_server/notification_client.py
+++ b/robot-server/robot_server/notification_client.py
@@ -116,7 +116,13 @@ class NotificationClient:  # noqa: D101
         else:
             log.info(f"Failed to connect to MQTT broker with reason code: {rc}")
 
-    def _on_disconnect(self, client: mqtt.Client, userdata: Any, rc: int) -> None:
+    def _on_disconnect(
+        self,
+        client: mqtt.Client,
+        userdata: Any,
+        rc: int,
+        properties: Optional[mqtt.Properties] = None,
+    ) -> None:
         """Callback invoked when the client is disconnected from the MQTT broker.
 
         Args:


### PR DESCRIPTION
The disconnect callback is called with a properties instance if we're running mqtt 5, as with the connect callback. I don't think we're running mqtt 5, but it doesn't matter because it looks like we call with this property during shutdown anyway so this prevents an annoying log message.
