### PR TITLE
fix(components): only show nest labware info on protocol deck when expected

### DIFF
--- a/components/src/hardware-sim/ProtocolDeck/index.tsx
+++ b/components/src/hardware-sim/ProtocolDeck/index.tsx
@@ -56,6 +56,7 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
         labwareByLiquidId
       ),
       moduleChildren:
+        showLabwareInfo &&
         nestedLabwareDef != null &&
         !(nestedLabwareDef.allowedRoles ?? []).includes('adapter') ? (
           <LabwareInfo def={nestedLabwareDef}>


### PR DESCRIPTION
# Overview

Within the Protocol Deck component, the `showLabwareInfo` prop should also manage the presence or absence of the labware info on module-nested labware.
 
# Risk assessment

Low
