### PR TITLE
fix(app): fix query caching issues with last run command key

### DIFF
--- a/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
@@ -14,10 +14,7 @@ export function useNotifyCurrentMaintenanceRun(
   const host = useHost()
   const [refetchUsingHTTP, setRefetchUsingHTTP] = React.useState(true)
 
-  const {
-    notifyQueryResponse,
-    isNotifyError,
-  } = useNotifyService<MaintenanceRun>({
+  const { isNotifyError } = useNotifyService<MaintenanceRun>({
     topic: 'robot-server/maintenance_runs',
     queryKey: [host, 'maintenance_runs', 'current_run'],
     refetchUsingHTTP: () => setRefetchUsingHTTP(true),
@@ -38,5 +35,5 @@ export function useNotifyCurrentMaintenanceRun(
     onSettled: isNotifyEnabled ? () => setRefetchUsingHTTP(false) : undefined,
   })
 
-  return isHTTPEnabled ? httpQueryResult : notifyQueryResponse
+  return httpQueryResult
 }

--- a/app/src/resources/runs/useNotifyLastRunCommandKey.ts
+++ b/app/src/resources/runs/useNotifyLastRunCommandKey.ts
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useQueryClient } from 'react-query'
 
 import { useHost } from '@opentrons/react-api-client'
 import { useNotifyService } from '../useNotifyService'
@@ -14,13 +13,11 @@ export function useNotifyLastRunCommandKey(
   options?: QueryOptionsWithPolling<CommandsData, Error>
 ): string | null {
   const host = useHost()
-  const queryClient = useQueryClient()
   const [refetchUsingHTTP, setRefetchUsingHTTP] = React.useState(true)
-  const queryKey = [host, 'maintenance_runs', 'current_run']
 
   const { isNotifyError } = useNotifyService<CommandsData>({
     topic: 'robot-server/runs/current_command',
-    queryKey,
+    queryKey: [host, 'runs', 'current_command'],
     refetchUsingHTTP: () => setRefetchUsingHTTP(true),
     options: options != null ? options : {},
   })
@@ -35,14 +32,5 @@ export function useNotifyLastRunCommandKey(
     onSettled: isNotifyEnabled ? () => setRefetchUsingHTTP(false) : undefined,
   })
 
-  const currentCachedResponse =
-    queryClient.getQueryData<string | null>(queryKey) ?? null
-
-  if (httpResponse !== currentCachedResponse) {
-    queryClient.setQueryData(queryKey, httpResponse)
-  }
-  const httpResponseData =
-    queryClient.getQueryData<string | null>(queryKey) ?? null
-
-  return httpResponseData
+  return httpResponse
 }


### PR DESCRIPTION
Closes RQA-2275

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Follow up to #14399. useNotify hooks do not need to support returning useable data from the MQTT broker, since the broker only ever supplies refetch flags currently. Assuming the broker could return real command data was causing strange edge cases in which last run command keys would sometimes return null. Just use HTTP response data for all notify hooks. I'll follow this up with a refactor to simplify the useNotifyService hook as well.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run a protocol, there should be no command flickering. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
