### PR TITLE
docs(api): fix typo on Moving Labware page

### DIFF
--- a/api/docs/v2/moving_labware.rst
+++ b/api/docs/v2/moving_labware.rst
@@ -61,7 +61,7 @@ The ``use_gripper`` parameter of :py:meth:`~.ProtocolContext.move_labware` deter
 .. note::
     Don't add a ``pause()`` command before ``move_labware()``. When ``use_gripper`` is unset or ``False``, the protocol pauses when it reaches the movement step. The Opentrons App or the touchscreen on Flex shows an animation of the labware movement that you need to perform manually. The protocol only resumes when you press **Confirm and resume**.
 
-The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_labware=True``.
+The above example is a complete and valid ``run()`` function. You don't have to load the gripper as an instrument, and there is no ``InstrumentContext`` for the gripper. All you have to do to specify that a protocol requires the gripper is to include at least one ``move_labware()`` command with ``use_gripper=True``.
 
 If you attempt to use the gripper to move labware in an OT-2 protocol, the API will raise an error.
 


### PR DESCRIPTION


# Overview

We wrote `use_labware` (which does not exist) instead of `use_gripper`.

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-moving-labware-typo/v2/moving_labware.html#automatic-vs-manual-moves).

# Changelog

One-word fix.

# Review requests

👀 

# Risk assessment

nil