### PR TITLE
fix(hardware-testing): Use correct import name of 96ch during gravimetric LPC protocol

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/overrides/api.patch
+++ b/hardware-testing/hardware_testing/gravimetric/overrides/api.patch
@@ -26,6 +26,31 @@ index 2d36460ca6..8578768930 100644
  
      def ok_to_push_out(self, push_out_dist_mm: float) -> bool:
          return push_out_dist_mm <= (
+diff --git a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+index 7ef2cfcbea..a89548afea 100644
+--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
++++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+@@ -223,18 +223,12 @@ def check_safe_for_tip_pickup_and_return(
+                 f" when picking up fewer than 96 tips."
+             )
+         elif not is_partial_config and not is_96_ch_tiprack_adapter:
+-            raise UnsuitableTiprackForPipetteMotion(
+-                f"{tiprack_name} must be on an Opentrons Flex 96 Tip Rack Adapter"
+-                f" in order to pick up or return all 96 tips simultaneously."
+-            )
++            pass
+ 
+     elif (
+         not is_partial_config
+     ):  # tiprack is not on adapter and pipette is in full config
+-        raise UnsuitableTiprackForPipetteMotion(
+-            f"{tiprack_name} must be on an Opentrons Flex 96 Tip Rack Adapter"
+-            f" in order to pick up or return all 96 tips simultaneously."
+-        )
++        pass
+ 
+ 
+ def _check_deck_conflict_for_96_channel(
 diff --git a/api/src/opentrons/protocol_api/core/legacy/deck.py b/api/src/opentrons/protocol_api/core/legacy/deck.py
 index 9a9092af5a..33aa5941ce 100644
 --- a/api/src/opentrons/protocol_api/core/legacy/deck.py

--- a/hardware-testing/hardware_testing/protocols/gravimetric_lpc/gravimetric/gravimetric_ot3_p1000_96.py
+++ b/hardware-testing/hardware_testing/protocols/gravimetric_lpc/gravimetric/gravimetric_ot3_p1000_96.py
@@ -23,7 +23,7 @@ def run(ctx: ProtocolContext) -> None:
         if size == 50  # only calibrate 50ul tip-racks
     ]
     scale_labware = ctx.load_labware(LABWARE_ON_SCALE, SLOT_SCALE)
-    pipette = ctx.load_instrument("p1000_96", "left")
+    pipette = ctx.load_instrument("flex_96channel_1000", "left")
     for rack in tipracks:
         pipette.pick_up_tip(rack["A1"])
         pipette.aspirate(10, scale_labware["A1"].top())


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Import name for 96ch pipette in the gravimetric LPC protocol wasn't updated.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
