### PR TITLE
fix(app): add body to gripper calibration in progress modal

### DIFF
--- a/app/src/assets/localization/en/gripper_wizard_flows.json
+++ b/app/src/assets/localization/en/gripper_wizard_flows.json
@@ -6,6 +6,7 @@
   "begin_calibration": "Begin calibration",
   "calibrate_gripper": "Calibrate Gripper",
   "calibration_pin": "Calibration Pin",
+  "calibration_pin_touching": "The calibration pin will touch the calibration square in slot {{slot}} to determine its exact position.",
   "complete_calibration": "Complete calibration",
   "connect_and_screw_in_gripper": "Connect and secure Flex Gripper",
   "continue": "Continue",

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -19,6 +19,7 @@ interface Props {
   //  optional override of the spinner
   alternativeSpinner?: React.ReactNode
   description?: string
+  body?: string
   children?: JSX.Element
 }
 
@@ -38,6 +39,14 @@ const DESCRIPTION_STYLE = css`
     line-height: ${TYPOGRAPHY.lineHeight42};
   }
 `
+const BODY_STYLE = css`
+  ${TYPOGRAPHY.pRegular}
+  text-align: ${TYPOGRAPHY.textAlignCenter};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    ${TYPOGRAPHY.level4HeaderRegular}
+    color: ${COLORS.grey60}
+    `
 const MODAL_STYLE = css`
   align-items: ${ALIGN_CENTER};
   flex-direction: ${DIRECTION_COLUMN};
@@ -58,7 +67,7 @@ const SPINNER_STYLE = css`
 `
 
 export function InProgressModal(props: Props): JSX.Element {
-  const { alternativeSpinner, children, description } = props
+  const { alternativeSpinner, children, description, body } = props
   const isOnDevice = useSelector(getIsOnDevice)
 
   return (
@@ -72,9 +81,17 @@ export function InProgressModal(props: Props): JSX.Element {
           spin
         />
       )}
-      {description != null && (
-        <StyledText css={DESCRIPTION_STYLE}>{description}</StyledText>
-      )}
+      <Flex
+        paddingX={isOnDevice ? SPACING.spacing40 : '6.5625rem'}
+        gridGap={isOnDevice ? SPACING.spacing4 : SPACING.spacing8}
+        flexDirection={DIRECTION_COLUMN}
+        alignItems={ALIGN_CENTER}
+      >
+        {description != null && (
+          <StyledText css={DESCRIPTION_STYLE}>{description}</StyledText>
+        )}
+        {body != null && <StyledText css={BODY_STYLE}>{body}</StyledText>}
+      </Flex>
       {children}
     </Flex>
   )

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -238,6 +238,11 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
             ? inProgressText
             : t('shared:stand_back_robot_is_in_motion')
         }
+        body={
+          errorMessage == null && !isExiting
+            ? t('calibration_pin_touching', { slot: 'C2' })
+            : null
+        }
         alternativeSpinner={
           errorMessage == null && !isExiting ? inProgressImage : undefined
         }


### PR DESCRIPTION
closes [RQA-2252](https://opentrons.atlassian.net/browse/RQA-2252)

# Overview

Add description to in progress modal during gripper calibration pin touching calibration square.

# Test Plan

- observe gripper calibration in progress step on both ODD and Desktop
- smoke tested instances of `InProgressModal` that use `children` to ensure they weren't affected

# Changelog

- add translation text for calibration pin touching square
- conditionally pass calibration body to in progress modal at `MovePin` step in gripper wizard flows
- handle an optional `body` prop paassed to InProgressModal and style depending on ODD or Desktop

# Risk assessment

low

[RQA-2252]: https://opentrons.atlassian.net/browse/RQA-2252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ