### PR TITLE
chore(release): Add release notes for v7.2.0 database migrations

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -12,10 +12,17 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 - In the `/runs/commands`, `/maintenance_runs/commands`, and `/protocols` endpoints, the `dispense` command will now return an error if you try to dispense more than you've aspirated, instead of silently clamping.
 - The `/notifications/subscribe` WebSocket endpoint has been removed. See https://github.com/Opentrons/opentrons/pull/14280 for details.
+- The `/runs/commands` endpoints are significantly faster when you request a small number of commands from a stored run.
 
 ### Other Changes
 
 - The `notify_server` Python package has been removed. See https://github.com/Opentrons/opentrons/pull/14280 for details.
+
+### Upgrade Notes
+
+This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow **approximately 25 minutes** for your robot to restart. This delay will only happen once.
+
+If you don't care about preserving your labware offsets and run history, you can avoid the delay. Clear your runs and protocols before starting this update. Go to **Robot Settings** > **Device Reset** and select **Clear protocol run history**.
 
 ---
 


### PR DESCRIPTION
# Changelog

Explain that the `/runs/commands` endpoints should be faster now. This covers #14348.

Explain that there will be a slow migration upon first boot. This covers #14348 and #14355. See RSS-451 for the math behind my estimate of 25 minutes.

# Review requests

Do we want to be more nuanced about the expected update time? It's likely to be much faster if you only ever run short protocols. See RSS-451.

Is suggesting a device reset to avoid the migration delay a good idea? Note that the device reset incurs its own reboot, so it will eat up a few minutes on its own.