### PR TITLE
feat(hepa-uv): add HepaUVInfo can message to get serial from hepa.

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -145,6 +145,7 @@ class MessageId(int, Enum):
     instrument_info_request = 0x306
     pipette_info_response = 0x307
     gripper_info_response = 0x308
+    hepauv_info_response = 0x309
     set_serial_number = 0x30A
     get_motor_usage_request = 0x30B
     get_motor_usage_response = 0x30C

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -898,3 +898,12 @@ class GetMotorUsageResponse(BaseMessage):
     message_id: Literal[
         MessageId.get_motor_usage_response
     ] = MessageId.get_motor_usage_response
+
+
+@dataclass
+class HepaUVInfoResponse(BaseMessage):  # noqa: D101
+    payload: payloads.HepaUVInfoResponsePayload
+    payload_type: Type[
+        payloads.HepaUVInfoResponsePayload
+    ] = payloads.HepaUVInfoResponsePayload
+    message_id: Literal[MessageId.hepauv_info_response] = MessageId.hepauv_info_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -626,6 +626,8 @@ class GetMotorUsageResponsePayload(_GetMotorUsageResponsePayloadBase):
         inst.message_index = message_index
         return inst
 
+    usage_elements: List[MotorUsageTypeField]
+
 
 @dataclass(eq=False)
 class HepaUVInfoResponsePayload(EmptyPayload):
@@ -633,5 +635,3 @@ class HepaUVInfoResponsePayload(EmptyPayload):
 
     model: utils.UInt16Field
     serial: SerialDataCodeField
-
-    usage_elements: List[MotorUsageTypeField]

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -626,4 +626,12 @@ class GetMotorUsageResponsePayload(_GetMotorUsageResponsePayloadBase):
         inst.message_index = message_index
         return inst
 
+
+@dataclass(eq=False)
+class HepaUVInfoResponsePayload(EmptyPayload):
+    """A response carrying data about an attached gripper."""
+
+    model: utils.UInt16Field
+    serial: SerialDataCodeField
+
     usage_elements: List[MotorUsageTypeField]


### PR DESCRIPTION
# Overview

New can message for hepa uv filter so we can get the serial/model info

Closes: [RET-1412](https://opentrons.atlassian.net/browse/RET-1412)

# Test Plan

- [x] Make sure we get a HepaUVResponse message when we send an InstrumentInfoRequest CAN message to the hepa.

# Changelog

- Add HepaUVResponse (0x309) CAN message

# Review requests

# Risk assessment

Low

[RET-1412]: https://opentrons.atlassian.net/browse/RET-1412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ