### PR TITLE
fix(api): use old TC Gen2 labwareOffset values in legacy core

### DIFF
--- a/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from opentrons_shared_data import module
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
+from opentrons_shared_data.module import OLD_TC_GEN2_LABWARE_OFFSET
 
 from opentrons.types import Location, Point, LocationLabware
 from opentrons.motion_planning.adjacent_slots_getters import (
@@ -29,6 +30,7 @@ from opentrons.hardware_control.modules.types import (
     ModuleModel,
     ModuleType,
     module_model_from_string,
+    ThermocyclerModuleModel,
 )
 
 
@@ -431,14 +433,30 @@ def create_geometry(
     The definition should be schema checked before being passed to this
     function; all definitions passed here are assumed to be valid.
     """
-    pre_transform = np.array(
-        (
-            definition["labwareOffset"]["x"],
-            definition["labwareOffset"]["y"],
-            definition["labwareOffset"]["z"],
-            1,
+    module_type = ModuleType(definition["moduleType"])
+    module_model = module_model_from_string(definition["model"])
+    overall_height = definition["dimensions"]["bareOverallHeight"]
+    height_over_labware = definition["dimensions"]["overLabwareHeight"]
+    display_name = definition["displayName"]
+
+    if module_model == ThermocyclerModuleModel.THERMOCYCLER_V2:
+        pre_transform = np.array(
+            (
+                OLD_TC_GEN2_LABWARE_OFFSET["x"],
+                OLD_TC_GEN2_LABWARE_OFFSET["y"],
+                OLD_TC_GEN2_LABWARE_OFFSET["z"],
+                1,
+            )
         )
-    )
+    else:
+        pre_transform = np.array(
+            (
+                definition["labwareOffset"]["x"],
+                definition["labwareOffset"]["y"],
+                definition["labwareOffset"]["z"],
+                1,
+            )
+        )
     if not parent.labware.is_slot:
         par = ""
         _log.warning(
@@ -464,27 +482,27 @@ def create_geometry(
     # apply the slot transform if any
     xform = np.array(xform_ser)
     xformed = np.dot(xform, pre_transform)
-    module_type = ModuleType(definition["moduleType"])
+    labware_offset = Point(xformed[0], xformed[1], xformed[2])
 
     if module_type == ModuleType.MAGNETIC or module_type == ModuleType.TEMPERATURE:
         return ModuleGeometry(
             parent=parent,
-            offset=Point(xformed[0], xformed[1], xformed[2]),
-            overall_height=definition["dimensions"]["bareOverallHeight"],
-            height_over_labware=definition["dimensions"]["overLabwareHeight"],
-            model=module_model_from_string(definition["model"]),
-            module_type=ModuleType(definition["moduleType"]),
-            display_name=definition["displayName"],
+            offset=labware_offset,
+            overall_height=overall_height,
+            height_over_labware=height_over_labware,
+            model=module_model,
+            module_type=module_type,
+            display_name=display_name,
         )
     elif module_type == ModuleType.THERMOCYCLER:
         return ThermocyclerGeometry(
             parent=parent,
-            offset=Point(xformed[0], xformed[1], xformed[2]),
-            overall_height=definition["dimensions"]["bareOverallHeight"],
-            height_over_labware=definition["dimensions"]["overLabwareHeight"],
-            model=module_model_from_string(definition["model"]),
-            module_type=ModuleType(definition["moduleType"]),
-            display_name=definition["displayName"],
+            offset=labware_offset,
+            overall_height=overall_height,
+            height_over_labware=height_over_labware,
+            model=module_model,
+            module_type=module_type,
+            display_name=display_name,
             lid_height=definition["dimensions"]["lidHeight"],
             configuration=(
                 ThermocyclerConfiguration(configuration)
@@ -495,14 +513,13 @@ def create_geometry(
     elif module_type == ModuleType.HEATER_SHAKER:
         return HeaterShakerGeometry(
             parent=parent,
-            offset=Point(xformed[0], xformed[1], xformed[2]),
-            overall_height=definition["dimensions"]["bareOverallHeight"],
-            height_over_labware=definition["dimensions"]["overLabwareHeight"],
-            model=module_model_from_string(definition["model"]),
-            module_type=ModuleType(definition["moduleType"]),
-            display_name=definition["displayName"],
+            offset=labware_offset,
+            overall_height=overall_height,
+            height_over_labware=height_over_labware,
+            model=module_model,
+            module_type=module_type,
+            display_name=display_name,
         )
-
     else:
         raise AssertionError(f"Module type {module_type} is invalid")
 

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -16,6 +16,7 @@ from .dev_types import (
 
 OLD_TC_GEN2_LABWARE_OFFSET = {"x": 0, "y": 68.06, "z": 98.26}
 
+
 # TODO (spp, 2022-05-12): Python has a built-in error called `ModuleNotFoundError` so,
 #                         maybe rename this one?
 class ModuleNotFoundError(KeyError):

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -14,6 +14,7 @@ from .dev_types import (
     ModuleModel,
 )
 
+OLD_TC_GEN2_LABWARE_OFFSET = {"x": 0, "y": 68.06, "z": 98.26}
 
 # TODO (spp, 2022-05-12): Python has a built-in error called `ModuleNotFoundError` so,
 #                         maybe rename this one?


### PR DESCRIPTION
Fixes issue in RESC-196

# Overview

[In this PR](https://github.com/Opentrons/opentrons/pull/13567), we changed how we calculate the final origin of any labware placed on a TC gen2. Previously we assumed that all labware sit 98.26mm above the OT2 slot; we call it the TC labware offset. This offset was correct for the Armadillo plate; while other pcr plates would sit +/-0.1mm differently. In 7.0.1, we updated this labware offset to be the top plane of metal cylinders of the thermocycler (108.96mm), and introduced a `stackingOffsetWithModule` parameter in the labware definitions to inform us of the distance a labware actually rests at from top of those cylinders. For labware that didn’t have these offsets, we [added a fallback](https://github.com/Opentrons/opentrons/pull/13630) of using the previous labware offset of 98.26.

Issue is, we forgot to add that fallback in v2.13, which is a legacy core based API so now the backend assumes all labware sit at 108.96mm on TC Gen2, ignoring any `stackingOffsetWithModule` because the legacy core has no concept of stacking offsets.

[I compiled all this, with options for solutions in this spreadsheet](https://docs.google.com/spreadsheets/d/1WrQNtfWEtFBqY7iKXv0lUZ_sutG1KYjYZb5C6k5Tiac/edit?usp=sharing) and we decided to go with option 1- revert the behavior of API v2.13 to what it was prior to the change in 7.0.1.

# Test Plan

- Load a TC Gen2 protocol on the OT2 without loading any previous LPC offsets and verify that pipettes go to the correct z height for the labware on the thermocycler, rather than moving 1cm above the labware.
- Also verify that TC gen1 nor any other modules are affected.

# Changelog

- when loading module labware offsets in module geometry, it will now load separate, older offset values for TC gen2
- other minor code refactoring

# Review requests

- Is it enough to save the older offsets in shared-data like that or do we want to have a better system for it?

# Risk assessment

Medium. This adds/ reverts a change in positioning such that previous LPC offsets should not used or they'll result in pipettes crashing into labware bottom. We should also convey this to users.
