### PR TITLE
feat(api): publish commands for trash bins, waste chutes, and moving labware for Opentrons Simulate

### DIFF
--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List, Union, overload
 
 
-from .helpers import stringify_location, listify
+from .helpers import stringify_location, stringify_disposal_location, listify
 from . import types as command_types
 
 from opentrons.types import Location
+from opentrons.protocol_api._trash_bin import TrashBin
+from opentrons.protocol_api._waste_chute import WasteChute
 
 if TYPE_CHECKING:
     from opentrons.protocol_api import InstrumentContext
@@ -227,6 +229,17 @@ def drop_tip(
     text = "Dropping tip into {location}".format(location=location_text)
     return {
         "name": command_types.DROP_TIP,
+        "payload": {"instrument": instrument, "location": location, "text": text},
+    }
+
+
+def drop_tip_in_disposal_location(
+    instrument: InstrumentContext, location: Union[TrashBin, WasteChute]
+) -> command_types.DropTipInDisposalLocationCommand:
+    location_text = stringify_disposal_location(location)
+    text = f"Dropping tip into {location_text}"
+    return {
+        "name": command_types.DROP_TIP_IN_DISPOSAL_LOCATION,
         "payload": {"instrument": instrument, "location": location, "text": text},
     }
 

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -192,6 +192,18 @@ def blow_out(
     }
 
 
+def blow_out_in_disposal_location(
+    instrument: InstrumentContext, location: Union[TrashBin, WasteChute]
+) -> command_types.BlowOutInDisposalLocationCommand:
+    location_text = stringify_disposal_location(location)
+    text = f"Blowing out into {location_text}"
+
+    return {
+        "name": command_types.BLOW_OUT_IN_DISPOSAL_LOCATION,
+        "payload": {"instrument": instrument, "location": location, "text": text},
+    }
+
+
 def touch_tip(instrument: InstrumentContext) -> command_types.TouchTipCommand:
     text = "Touching tip"
 

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -288,3 +288,15 @@ def move_to(
         "name": command_types.MOVE_TO,
         "payload": {"instrument": instrument, "location": location, "text": text},
     }
+
+
+def move_to_disposal_location(
+    instrument: InstrumentContext,
+    location: Union[TrashBin, WasteChute],
+) -> command_types.MoveToDisposalLocationCommand:
+    location_text = stringify_disposal_location(location)
+    text = f"Moving to {location_text}"
+    return {
+        "name": command_types.MOVE_TO_DISPOSAL_LOCATION,
+        "payload": {"instrument": instrument, "location": location, "text": text},
+    }

--- a/api/src/opentrons/commands/commands.py
+++ b/api/src/opentrons/commands/commands.py
@@ -65,6 +65,28 @@ def dispense(
     }
 
 
+def dispense_in_disposal_location(
+    instrument: InstrumentContext,
+    volume: float,
+    location: Union[TrashBin, WasteChute],
+    flow_rate: float,
+    rate: float,
+) -> command_types.DispenseInDisposalLocationCommand:
+    location_text = stringify_disposal_location(location)
+    text = f"Dispensing {float(volume)} uL into {location_text} at {flow_rate} uL/sec"
+
+    return {
+        "name": command_types.DISPENSE_IN_DISPOSAL_LOCATION,
+        "payload": {
+            "instrument": instrument,
+            "volume": volume,
+            "location": location,
+            "rate": rate,
+            "text": text,
+        },
+    }
+
+
 def consolidate(
     instrument: InstrumentContext,
     volume: Union[float, List[float]],

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -53,7 +53,7 @@ def _stringify_labware_movement_location(
     location: Union[DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute]
 ) -> str:
     if isinstance(location, (int, str)):
-        return f"Slot {location}"
+        return f"slot {location}"
     elif isinstance(location, OffDeckType):
         return "off-deck"
     elif isinstance(location, Labware):

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -1,9 +1,11 @@
 from typing import List, Union
 
-from opentrons.protocol_api.labware import Well
-from opentrons.types import Location
+from opentrons.protocol_api.labware import Well, Labware
+from opentrons.protocol_api.module_contexts import ModuleContext
 from opentrons.protocol_api._trash_bin import TrashBin
 from opentrons.protocol_api._waste_chute import WasteChute
+from opentrons.protocol_api._types import OffDeckType
+from opentrons.types import Location, DeckLocation
 
 
 CommandLocation = Union[Location, Well]
@@ -43,5 +45,31 @@ def stringify_location(location: Union[CommandLocation, List[CommandLocation]]) 
 def stringify_disposal_location(location: Union[TrashBin, WasteChute]) -> str:
     if isinstance(location, TrashBin):
         return f"Trash Bin on slot {location.location.id}"
-    else:
+    elif isinstance(location, WasteChute):
         return "Waste Chute"
+
+
+def _stringify_labware_movement_location(
+    location: Union[DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute]
+) -> str:
+    if isinstance(location, (int, str)):
+        return f"Slot {location}"
+    elif isinstance(location, OffDeckType):
+        return "off-deck"
+    elif isinstance(location, Labware):
+        return location.name
+    elif isinstance(location, ModuleContext):
+        return str(location)
+    elif isinstance(location, WasteChute):
+        return "Waste Chute"
+
+
+def stringify_labware_movement_command(
+    source_labware: Labware,
+    destination: Union[DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute],
+    use_gripper: bool,
+) -> str:
+    source_labware_text = _stringify_labware_movement_location(source_labware)
+    destination_text = _stringify_labware_movement_location(destination)
+    gripper_text = " with gripper" if use_gripper else ""
+    return f"Moving {source_labware_text} to {destination_text}{gripper_text}"

--- a/api/src/opentrons/commands/helpers.py
+++ b/api/src/opentrons/commands/helpers.py
@@ -2,6 +2,8 @@ from typing import List, Union
 
 from opentrons.protocol_api.labware import Well
 from opentrons.types import Location
+from opentrons.protocol_api._trash_bin import TrashBin
+from opentrons.protocol_api._waste_chute import WasteChute
 
 
 CommandLocation = Union[Location, Well]
@@ -36,3 +38,10 @@ def _stringify_new_loc(loc: CommandLocation) -> str:
 def stringify_location(location: Union[CommandLocation, List[CommandLocation]]) -> str:
     loc_str_list = [_stringify_new_loc(loc) for loc in listify(location)]
     return ", ".join(loc_str_list)
+
+
+def stringify_disposal_location(location: Union[TrashBin, WasteChute]) -> str:
+    if isinstance(location, TrashBin):
+        return f"Trash Bin on slot {location.location.id}"
+    else:
+        return "Waste Chute"

--- a/api/src/opentrons/commands/protocol_commands.py
+++ b/api/src/opentrons/commands/protocol_commands.py
@@ -45,3 +45,10 @@ def resume() -> command_types.ResumeCommand:
         "name": command_types.RESUME,
         "payload": {"text": "Resuming robot operation"},
     }
+
+
+def move_labware(text: str) -> command_types.MoveLabwareCommand:
+    return {
+        "name": command_types.MOVE_LABWARE,
+        "payload": {"text": text},
+    }

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing_extensions import Literal, Final, TypedDict
 from typing import Optional, List, Sequence, TYPE_CHECKING, Union
 from opentrons.hardware_control.modules import ThermocyclerStep
+from opentrons.protocol_api._trash_bin import TrashBin
+from opentrons.protocol_api._waste_chute import WasteChute
 
 if TYPE_CHECKING:
     from opentrons.protocol_api import InstrumentContext
@@ -32,6 +34,7 @@ DISTRIBUTE: Final = "command.DISTRIBUTE"
 TRANSFER: Final = "command.TRANSFER"
 PICK_UP_TIP: Final = "command.PICK_UP_TIP"
 DROP_TIP: Final = "command.DROP_TIP"
+DROP_TIP_IN_DISPOSAL_LOCATION: Final = "command.DROP_TIP_IN_DISPOSAL_LOCATION"
 BLOW_OUT: Final = "command.BLOW_OUT"
 AIR_GAP: Final = "command.AIR_GAP"
 TOUCH_TIP: Final = "command.TOUCH_TIP"
@@ -476,6 +479,15 @@ class DropTipCommand(TypedDict):
     payload: DropTipCommandPayload
 
 
+class DropTipInDisposalLocationCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
+    location: Union[TrashBin, WasteChute]
+
+
+class DropTipInDisposalLocationCommand(TypedDict):
+    name: Literal["command.DROP_TIP_IN_DISPOSAL_LOCATION"]
+    payload: DropTipInDisposalLocationCommandPayload
+
+
 class MoveToCommand(TypedDict):
     name: Literal["command.MOVE_TO"]
     payload: MoveToCommandPayload
@@ -487,6 +499,7 @@ class MoveToCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
 
 Command = Union[
     DropTipCommand,
+    DropTipInDisposalLocationCommand,
     PickUpTipCommand,
     ReturnTipCommand,
     AirGapCommand,
@@ -556,6 +569,7 @@ CommandPayload = Union[
     AirGapCommandPayload,
     ReturnTipCommandPayload,
     DropTipCommandPayload,
+    DropTipInDisposalLocationCommandPayload,
     PickUpTipCommandPayload,
     TouchTipCommandPayload,
     BlowOutCommandPayload,
@@ -589,6 +603,10 @@ class MoveToMessage(CommandMessageFields, MoveToCommand):
 
 
 class DropTipMessage(CommandMessageFields, DropTipCommand):
+    pass
+
+
+class DropTipInDisposalLocationMessage(CommandMessageFields, DropTipInDisposalLocationCommand):
     pass
 
 
@@ -786,6 +804,7 @@ class CommentMessage(CommandMessageFields, CommentCommand):
 
 CommandMessage = Union[
     DropTipMessage,
+    DropTipInDisposalLocationMessage,
     PickUpTipMessage,
     ReturnTipMessage,
     AirGapMessage,

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -42,6 +42,7 @@ AIR_GAP: Final = "command.AIR_GAP"
 TOUCH_TIP: Final = "command.TOUCH_TIP"
 RETURN_TIP: Final = "command.RETURN_TIP"
 MOVE_TO: Final = "command.MOVE_TO"
+MOVE_TO_DISPOSAL_LOCATION: Final = "command.MOVE_TO_DISPOSAL_LOCATION"
 
 # Modules #
 
@@ -512,13 +513,22 @@ class DropTipInDisposalLocationCommand(TypedDict):
     payload: DropTipInDisposalLocationCommandPayload
 
 
+class MoveToCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
+    location: Location
+
+
 class MoveToCommand(TypedDict):
     name: Literal["command.MOVE_TO"]
     payload: MoveToCommandPayload
 
 
-class MoveToCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
-    location: Location
+class MoveToDisposalLocationCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
+    location: Union[TrashBin, WasteChute]
+
+
+class MoveToDisposalLocationCommand(TypedDict):
+    name: Literal["command.MOVE_TO_DISPOSAL_LOCATION"]
+    payload: MoveToDisposalLocationCommandPayload
 
 
 Command = Union[
@@ -567,6 +577,7 @@ Command = Union[
     DelayCommand,
     CommentCommand,
     MoveToCommand,
+    MoveToDisposalLocationCommand,
 ]
 
 
@@ -614,6 +625,7 @@ CommandPayload = Union[
     PauseCommandPayload,
     DelayCommandPayload,
     MoveToCommandPayload,
+    MoveToDisposalLocationCommandPayload,
 ]
 
 
@@ -627,6 +639,12 @@ CommandMessageFields = TypedDict(
 
 
 class MoveToMessage(CommandMessageFields, MoveToCommand):
+    pass
+
+
+class MoveToDisposalLocationMessage(
+    CommandMessageFields, MoveToDisposalLocationCommand
+):
     pass
 
 
@@ -889,4 +907,5 @@ CommandMessage = Union[
     PauseMessage,
     ResumeMessage,
     MoveToMessage,
+    MoveToDisposalLocationMessage,
 ]

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -36,6 +36,7 @@ PICK_UP_TIP: Final = "command.PICK_UP_TIP"
 DROP_TIP: Final = "command.DROP_TIP"
 DROP_TIP_IN_DISPOSAL_LOCATION: Final = "command.DROP_TIP_IN_DISPOSAL_LOCATION"
 BLOW_OUT: Final = "command.BLOW_OUT"
+BLOW_OUT_IN_DISPOSAL_LOCATION: Final = "command.BLOW_OUT_IN_DISPOSAL_LOCATION"
 AIR_GAP: Final = "command.AIR_GAP"
 TOUCH_TIP: Final = "command.TOUCH_TIP"
 RETURN_TIP: Final = "command.RETURN_TIP"
@@ -434,6 +435,15 @@ class BlowOutCommand(TypedDict):
     payload: BlowOutCommandPayload
 
 
+class BlowOutInDisposalLocationCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
+    location: Union[TrashBin, WasteChute]
+
+
+class BlowOutInDisposalLocationCommand(TypedDict):
+    name: Literal["command.BLOW_OUT_IN_DISPOSAL_LOCATION"]
+    payload: BlowOutInDisposalLocationCommandPayload
+
+
 class TouchTipCommandPayload(TextOnlyPayload, SingleInstrumentPayload):
     pass
 
@@ -505,6 +515,7 @@ Command = Union[
     AirGapCommand,
     TouchTipCommand,
     BlowOutCommand,
+    BlowOutInDisposalLocationCommand,
     MixCommand,
     TransferCommand,
     DistributeCommand,
@@ -573,6 +584,7 @@ CommandPayload = Union[
     PickUpTipCommandPayload,
     TouchTipCommandPayload,
     BlowOutCommandPayload,
+    BlowOutInDisposalLocationCommandPayload,
     MixCommandPayload,
     TransferCommandPayload,
     DistributeCommandPayload,
@@ -606,7 +618,9 @@ class DropTipMessage(CommandMessageFields, DropTipCommand):
     pass
 
 
-class DropTipInDisposalLocationMessage(CommandMessageFields, DropTipInDisposalLocationCommand):
+class DropTipInDisposalLocationMessage(
+    CommandMessageFields, DropTipInDisposalLocationCommand
+):
     pass
 
 
@@ -627,6 +641,12 @@ class TouchTipMessage(CommandMessageFields, TouchTipCommand):
 
 
 class BlowOutMessage(CommandMessageFields, BlowOutCommand):
+    pass
+
+
+class BlowOutInDisposalLocationMessage(
+    CommandMessageFields, BlowOutInDisposalLocationCommand
+):
     pass
 
 
@@ -810,6 +830,7 @@ CommandMessage = Union[
     AirGapMessage,
     TouchTipMessage,
     BlowOutMessage,
+    BlowOutInDisposalLocationMessage,
     MixMessage,
     TransferMessage,
     DistributeMessage,

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing_extensions import Literal, Final, TypedDict
 from typing import Optional, List, Sequence, TYPE_CHECKING, Union
 from opentrons.hardware_control.modules import ThermocyclerStep
-from opentrons.protocol_api._trash_bin import TrashBin
-from opentrons.protocol_api._waste_chute import WasteChute
 
 if TYPE_CHECKING:
     from opentrons.protocol_api import InstrumentContext
     from opentrons.protocol_api.labware import Well
+    from opentrons.protocol_api._trash_bin import TrashBin
+    from opentrons.protocol_api._waste_chute import WasteChute
 
 from opentrons.types import Location
 

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -28,6 +28,7 @@ COMMENT: Final = "command.COMMENT"
 
 ASPIRATE: Final = "command.ASPIRATE"
 DISPENSE: Final = "command.DISPENSE"
+DISPENSE_IN_DISPOSAL_LOCATION: Final = "command.DISPENSE_IN_DISPOSAL_LOCATION"
 MIX: Final = "command.MIX"
 CONSOLIDATE: Final = "command.CONSOLIDATE"
 DISTRIBUTE: Final = "command.DISTRIBUTE"
@@ -376,6 +377,19 @@ class DispenseCommand(TypedDict):
     payload: AspirateDispenseCommandPayload
 
 
+class DispenseInDisposalLocationCommandPayload(
+    TextOnlyPayload, SingleInstrumentPayload
+):
+    location: Union[TrashBin, WasteChute]
+    volume: float
+    rate: float
+
+
+class DispenseInDisposalLocationCommand(TypedDict):
+    name: Literal["command.DISPENSE_IN_DISPOSAL_LOCATION"]
+    payload: DispenseInDisposalLocationCommandPayload
+
+
 class ConsolidateCommandPayload(
     TextOnlyPayload, MultiLocationPayload, SingleInstrumentPayload
 ):
@@ -521,6 +535,7 @@ Command = Union[
     DistributeCommand,
     ConsolidateCommand,
     DispenseCommand,
+    DispenseInDisposalLocationCommand,
     AspirateCommand,
     HomeCommand,
     HeaterShakerSetTargetTemperatureCommand,
@@ -590,6 +605,7 @@ CommandPayload = Union[
     DistributeCommandPayload,
     ConsolidateCommandPayload,
     AspirateDispenseCommandPayload,
+    DispenseInDisposalLocationCommandPayload,
     HomeCommandPayload,
     ThermocyclerExecuteProfileCommandPayload,
     ThermocyclerSetBlockTempCommandPayload,
@@ -667,6 +683,12 @@ class ConsolidateMessage(CommandMessageFields, ConsolidateCommand):
 
 
 class DispenseMessage(CommandMessageFields, DispenseCommand):
+    pass
+
+
+class DispenseInDisposalLocationMessage(
+    CommandMessageFields, DispenseInDisposalLocationCommand
+):
     pass
 
 
@@ -836,6 +858,7 @@ CommandMessage = Union[
     DistributeMessage,
     ConsolidateMessage,
     DispenseMessage,
+    DispenseInDisposalLocationMessage,
     AspirateMessage,
     HomeMessage,
     HeaterShakerSetTargetTemperatureMessage,

--- a/api/src/opentrons/commands/types.py
+++ b/api/src/opentrons/commands/types.py
@@ -23,6 +23,7 @@ HOME: Final = "command.HOME"
 PAUSE: Final = "command.PAUSE"
 RESUME: Final = "command.RESUME"
 COMMENT: Final = "command.COMMENT"
+MOVE_LABWARE: Final = "command.MOVE_LABWARE"
 
 # Pipette #
 
@@ -531,6 +532,15 @@ class MoveToDisposalLocationCommand(TypedDict):
     payload: MoveToDisposalLocationCommandPayload
 
 
+class MoveLabwareCommandPayload(TextOnlyPayload):
+    pass
+
+
+class MoveLabwareCommand(TypedDict):
+    name: Literal["command.MOVE_LABWARE"]
+    payload: MoveLabwareCommandPayload
+
+
 Command = Union[
     DropTipCommand,
     DropTipInDisposalLocationCommand,
@@ -578,6 +588,7 @@ Command = Union[
     CommentCommand,
     MoveToCommand,
     MoveToDisposalLocationCommand,
+    MoveLabwareCommand,
 ]
 
 
@@ -626,6 +637,7 @@ CommandPayload = Union[
     DelayCommandPayload,
     MoveToCommandPayload,
     MoveToDisposalLocationCommandPayload,
+    MoveLabwareCommandPayload,
 ]
 
 
@@ -862,6 +874,10 @@ class CommentMessage(CommandMessageFields, CommentCommand):
     pass
 
 
+class MoveLabwareMessage(CommandMessageFields, MoveLabwareCommand):
+    pass
+
+
 CommandMessage = Union[
     DropTipMessage,
     DropTipInDisposalLocationMessage,
@@ -908,4 +924,5 @@ CommandMessage = Union[
     ResumeMessage,
     MoveToMessage,
     MoveToDisposalLocationMessage,
+    MoveLabwareMessage,
 ]

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -568,12 +568,17 @@ class InstrumentContext(publisher.CommandPublisher):
         elif isinstance(target, validation.PointTarget):
             move_to_location = target.location
         elif isinstance(target, (TrashBin, WasteChute)):
-            # TODO handle publish info
-            self._core.blow_out(
-                location=target,
-                well_core=None,
-                in_place=False,
-            )
+            with publisher.publish_context(
+                broker=self.broker,
+                command=cmds.blow_out_in_disposal_location(
+                    instrument=self, location=target
+                ),
+            ):
+                self._core.blow_out(
+                    location=target,
+                    well_core=None,
+                    in_place=False,
+                )
             return self
 
         with publisher.publish_context(

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1458,25 +1458,24 @@ class InstrumentContext(publisher.CommandPublisher):
                     minimum_z_height=minimum_z_height,
                     speed=speed,
                 )
-                return self
-
-            if publish:
-                contexts.enter_context(
-                    publisher.publish_context(
-                        broker=self.broker,
-                        command=cmds.move_to(instrument=self, location=location),
+            else:
+                if publish:
+                    contexts.enter_context(
+                        publisher.publish_context(
+                            broker=self.broker,
+                            command=cmds.move_to(instrument=self, location=location),
+                        )
                     )
+
+                _, well = location.labware.get_parent_labware_and_well()
+
+                self._core.move_to(
+                    location=location,
+                    well_core=well._core if well is not None else None,
+                    force_direct=force_direct,
+                    minimum_z_height=minimum_z_height,
+                    speed=speed,
                 )
-
-            _, well = location.labware.get_parent_labware_and_well()
-
-            self._core.move_to(
-                location=location,
-                well_core=well._core if well is not None else None,
-                force_direct=force_direct,
-                minimum_z_height=minimum_z_height,
-                speed=speed,
-            )
 
         return self
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1033,8 +1033,15 @@ class InstrumentContext(publisher.CommandPublisher):
             well = maybe_well
 
         elif isinstance(location, (TrashBin, WasteChute)):
-            # TODO: Publish to run log.
-            self._core.drop_tip_in_disposal_location(location, home_after=home_after)
+            with publisher.publish_context(
+                broker=self.broker,
+                command=cmds.drop_tip_in_disposal_location(
+                    instrument=self, location=location
+                ),
+            ):
+                self._core.drop_tip_in_disposal_location(
+                    location, home_after=home_after
+                )
             self._last_tip_picked_up_from = None
             return self
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -404,17 +404,25 @@ class InstrumentContext(publisher.CommandPublisher):
         flow_rate = self._core.get_dispense_flow_rate(rate)
 
         if isinstance(target, (TrashBin, WasteChute)):
-            # HANDLE THE MOVETOADDDRESSABLEAREA
-            self._core.dispense(
-                volume=c_vol,
-                rate=rate,
-                location=target,
-                well_core=None,
-                flow_rate=flow_rate,
-                in_place=False,
-                push_out=push_out,
-            )
-            # TODO publish this info
+            with publisher.publish_context(
+                broker=self.broker,
+                command=cmds.dispense_in_disposal_location(
+                    instrument=self,
+                    volume=c_vol,
+                    location=target,
+                    rate=rate,
+                    flow_rate=flow_rate,
+                ),
+            ):
+                self._core.dispense(
+                    volume=c_vol,
+                    rate=rate,
+                    location=target,
+                    well_core=None,
+                    flow_rate=flow_rate,
+                    in_place=False,
+                    push_out=push_out,
+                )
             return self
 
         with publisher.publish_context(

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -687,6 +687,7 @@ class ProtocolContext(CommandPublisher):
         with publish_context(
             broker=self.broker,
             command=cmds.move_labware(
+                # This needs to be called from protocol context and not the command for import loop reasons
                 text=stringify_labware_movement_command(
                     labware, new_location, use_gripper
                 )

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -754,6 +754,9 @@ def test_move_labware_to_module(
     mock_broker = decoy.mock(cls=LegacyBroker)
 
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
+    decoy.when(mock_module_core.get_deck_slot()).then_return(DeckSlotName.SLOT_A1)
+    decoy.when(mock_core.get_labware_on_module(mock_module_core)).then_return(None)
+    decoy.when(mock_core_map.get(None)).then_return(None)
 
     movable_labware = Labware(
         core=mock_labware_core,


### PR DESCRIPTION
# Overview

Closes RSS-416 and RSS-377

This PR adds the `publish_context` context manager and associated infrastructure to cover `drop_tip`, `dispense`, `blow_out`, `move_to` for waste chutes and 2.16 and above trash bins, as well as `move_labware` in general.

The most practical and immediate effect of this is that Opentrons Simulate will now correctly log these commands when run in CLI. This will allow a better representation of the simulated protocol. These are _not_ hooked up to the `LegacyCommandMapper`, as these commands are not legacy commands and don't need to go through that class.

# Test Plan

Running the following protocols produces the following logs when run with opentrons simulate (`pipenv run python -m opentrons.simulate`)

```
metadata = {
    'protocolName': 'Trash Bin and Waste Chute Methods',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.16"
}


def run(context):
    trash_bin_A1 = context.load_trash_bin('A1')
    trash_bin_D1 = context.load_trash_bin('D1')
    waste_chute = context.load_waste_chute()

    tiprack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'A3')
    plate = context.load_labware('opentrons_96_wellplate_200ul_pcr_full_skirt', 'C2')

    pipette = context.load_instrument('flex_1channel_50', 'left', tip_racks=[tiprack])

    pipette.pick_up_tip()
    pipette.move_to(trash_bin_A1)
    pipette.aspirate(20, plate['A1'].top())
    pipette.dispense(20, trash_bin_A1)
    pipette.blow_out(trash_bin_A1)
    pipette.drop_tip(trash_bin_A1)

    pipette.pick_up_tip()
    pipette.move_to(trash_bin_D1)
    pipette.aspirate(20, plate['A1'].top())
    pipette.dispense(20, trash_bin_D1)
    pipette.blow_out(trash_bin_D1)
    pipette.drop_tip(trash_bin_D1)

    pipette.pick_up_tip()
    pipette.move_to(waste_chute)
    pipette.aspirate(20, plate['A1'].top())
    pipette.dispense(20, waste_chute)
    pipette.blow_out(waste_chute)
    pipette.drop_tip(waste_chute)

    context.move_labware(plate, waste_chute, use_gripper=True)
```

produces

```
Belt calibration not found.
Picking up tip from A1 of Opentrons Flex 96 Tip Rack 50 µL on slot A3
Moving to Trash Bin on slot A1
Aspirating 20.0 uL from A1 of Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt on slot C2 at 8.0 uL/sec
Dispensing 20.0 uL into Trash Bin on slot A1 at 8.0 uL/sec
Blowing out into Trash Bin on slot A1
Dropping tip into Trash Bin on slot A1
Picking up tip from B1 of Opentrons Flex 96 Tip Rack 50 µL on slot A3
Moving to Trash Bin on slot D1
Aspirating 20.0 uL from A1 of Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt on slot C2 at 8.0 uL/sec
Dispensing 20.0 uL into Trash Bin on slot D1 at 8.0 uL/sec
Blowing out into Trash Bin on slot D1
Dropping tip into Trash Bin on slot D1
Picking up tip from C1 of Opentrons Flex 96 Tip Rack 50 µL on slot A3
Moving to Waste Chute
Aspirating 20.0 uL from A1 of Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt on slot C2 at 8.0 uL/sec
Dispensing 20.0 uL into Waste Chute at 8.0 uL/sec
Blowing out into Waste Chute
Dropping tip into Waste Chute
Moving opentrons_96_wellplate_200ul_pcr_full_skirt to Waste Chute with gripper
```

and

```
metadata = {
    'protocolName': 'Labware Movement',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.16"
}


def run(context):
    thermocycler = context.load_module("thermocyclerModuleV2")
    heater_shaker = context.load_module("heaterShakerModuleV1", 'D1')
    pcr_adapter = heater_shaker.load_adapter('opentrons_96_pcr_adapter')

    plate = context.load_labware('opentrons_96_wellplate_200ul_pcr_full_skirt', 'C2')

    thermocycler.open_lid()
    heater_shaker.open_labware_latch()

    context.move_labware(plate, thermocycler)
    context.move_labware(plate, 'D4')
    context.move_labware(plate, pcr_adapter)
    context.move_labware(plate, 'C2')
```

produces

```
Belt calibration not found.
Opening Thermocycler lid
Unlatching labware on Heater-Shaker
Moving opentrons_96_wellplate_200ul_pcr_full_skirt to ThermocyclerContext at Thermocycler Module GEN2 on B1 lw None
Moving opentrons_96_wellplate_200ul_pcr_full_skirt to slot D4
Moving opentrons_96_wellplate_200ul_pcr_full_skirt to opentrons_96_pcr_adapter
Moving opentrons_96_wellplate_200ul_pcr_full_skirt to slot C2
```

# Changelog

- Added publisher commands for `drop_tip`, `dispense`, `blow_out`, and `move_to` when targeting `TrashBin` and `WasteChute`
- Added publisher command for `move_labware`

# Review requests

If the text generated for trash bins and waste chutes looks good as far as format and capitalization. Module text isn't perfect right now since it uses the pre-existing `__repr__` method rather than adding a new property that would have to be gated behind a version and then not allow older protocols to be simulated without errors. If anybody has an idea to improve this or make this better, that can be added here or for a future PR.

# Risk assessment

Low.