### PR TITLE
fix(app): style disabled tooltip at protocol run header start run

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -757,7 +757,9 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
         <StyledText css={TYPOGRAPHY.pSemiBold}>{buttonText}</StyledText>
       </PrimaryButton>
       {disableReason != null && (
-        <Tooltip tooltipProps={tooltipProps}>{disableReason}</Tooltip>
+        <Tooltip tooltipProps={tooltipProps} width="auto" maxWidth="8rem">
+          {disableReason}
+        </Tooltip>
       )}
       {showIsShakingModal &&
         activeHeaterShaker != null &&


### PR DESCRIPTION
closes [RQA-2249](https://opentrons.atlassian.net/browse/RQA-2249)

# Overview

Removes excess whitespace surrounding disable reason on tooltip for disabled 'Start run' button

# Test Plan

- move to protocol setup screen
- open Flex door to disable `Start run button`
- hover button and observe tooltip
<img width="998" alt="Screen Shot 2024-02-05 at 12 07 02 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/ce90f387-08a6-4beb-b0e3-4b18e238184a">

# Changelog

- add `width`, `maxWidth` props to tooltip

# Risk assessment

low

[RQA-2249]: https://opentrons.atlassian.net/browse/RQA-2249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ