### PR TITLE
feat(app): detect an A1 deck config conflict for thermcycler

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -53,6 +53,7 @@
   "deck_cal_description_bullet_2": "Redo Deck Calibration if you relocate your robot.",
   "deck_cal_description": "This measures the deck X and Y values relative to the gantry. Deck Calibration is the foundation for Tip Length Calibration and Pipette Offset Calibration.",
   "deck_calibration_title": "Deck Calibration",
+  "deck_conflict_info_thermocycler": "<block>Update the deck configuration by removing the fixtures in locations <strong>A1 and B1</strong>. Either remove the fixtures from the deck configuration or update the protocol.</block>",
   "deck_conflict_info": "<block>Update the deck configuration by removing the <strong>{{currentFixture}}</strong> in location <strong>{{cutout}}</strong>. Either remove the fixture from the deck configuration or update the protocol.</block>",
   "deck_conflict": "Deck location conflict",
   "deck_map": "Deck Map",

--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/LocationConflictModal.tsx
@@ -27,6 +27,8 @@ import {
   SINGLE_RIGHT_CUTOUTS,
   SINGLE_LEFT_SLOT_FIXTURE,
   SINGLE_RIGHT_SLOT_FIXTURE,
+  THERMOCYCLER_MODULE_V1,
+  THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import { Portal } from '../../../../App/portal'
 import { LegacyModal } from '../../../../molecules/LegacyModal'
@@ -67,10 +69,25 @@ export const LocationConflictModal = (
   const deckConfigurationAtLocationFixtureId = deckConfig.find(
     (deckFixture: CutoutConfig) => deckFixture.cutoutId === cutoutId
   )?.cutoutFixtureId
+
+  const isThermocycler =
+    requiredModule === THERMOCYCLER_MODULE_V1 ||
+    requiredModule === THERMOCYCLER_MODULE_V2
+
   const currentFixtureDisplayName =
     deckConfigurationAtLocationFixtureId != null
       ? getFixtureDisplayName(deckConfigurationAtLocationFixtureId)
       : ''
+
+  // get fixture display name at A1 for themocycler if B1 is slot
+  const deckConfigurationAtA1 = deckConfig.find(
+    (deckFixture: CutoutConfig) => deckFixture.cutoutId === 'cutoutA1'
+  )?.cutoutFixtureId
+
+  const currentThermocyclerFixtureDisplayName =
+    currentFixtureDisplayName === 'Slot' && deckConfigurationAtA1 != null
+      ? getFixtureDisplayName(deckConfigurationAtA1)
+      : currentFixtureDisplayName
 
   const handleUpdateDeck = (): void => {
     if (requiredFixtureId != null) {
@@ -93,7 +110,16 @@ export const LocationConflictModal = (
           : fixture
       )
 
-      updateDeckConfiguration(newSingleSlotDeckConfig)
+      // add A1 and B1 single slot config for thermocycler
+      const newThermocyclerDeckConfig = isThermocycler
+        ? newSingleSlotDeckConfig.map(fixture =>
+            fixture.cutoutId === 'cutoutA1' || fixture.cutoutId === 'cutoutB1'
+              ? { ...fixture, cutoutFixtureId: SINGLE_LEFT_SLOT_FIXTURE }
+              : fixture
+          )
+        : newSingleSlotDeckConfig
+
+      updateDeckConfiguration(newThermocyclerDeckConfig)
     }
     onCloseClick()
   }
@@ -123,7 +149,11 @@ export const LocationConflictModal = (
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
             <Trans
               t={t}
-              i18nKey="deck_conflict_info"
+              i18nKey={
+                isThermocycler
+                  ? 'deck_conflict_info_thermocycler'
+                  : 'deck_conflict_info'
+              }
               values={{
                 currentFixture: currentFixtureDisplayName,
                 cutout: getCutoutDisplayName(cutoutId),
@@ -140,7 +170,9 @@ export const LocationConflictModal = (
                 paddingBottom={SPACING.spacing8}
               >
                 {t('slot_location', {
-                  slotName: getCutoutDisplayName(cutoutId),
+                  slotName: isThermocycler
+                    ? 'A1 + B1'
+                    : getCutoutDisplayName(cutoutId),
                 })}
               </StyledText>
               <Flex
@@ -217,7 +249,11 @@ export const LocationConflictModal = (
           <Flex flexDirection={DIRECTION_COLUMN}>
             <Trans
               t={t}
-              i18nKey="deck_conflict_info"
+              i18nKey={
+                isThermocycler
+                  ? 'deck_conflict_info_thermocycler'
+                  : 'deck_conflict_info'
+              }
               values={{
                 currentFixture: currentFixtureDisplayName,
                 cutout: getCutoutDisplayName(cutoutId),
@@ -233,7 +269,9 @@ export const LocationConflictModal = (
                 fontWeight={TYPOGRAPHY.fontWeightBold}
               >
                 {t('slot_location', {
-                  slotName: getCutoutDisplayName(cutoutId),
+                  slotName: isThermocycler
+                    ? 'A1 + B1'
+                    : getCutoutDisplayName(cutoutId),
                 })}
               </StyledText>
               <Flex
@@ -270,7 +308,9 @@ export const LocationConflictModal = (
                     </StyledText>
                   </Box>
                   <StyledText as="label">
-                    {currentFixtureDisplayName}
+                    {isThermocycler
+                      ? currentThermocyclerFixtureDisplayName
+                      : currentFixtureDisplayName}
                   </StyledText>
                 </Flex>
               </Flex>

--- a/app/src/organisms/Devices/hooks/useModuleRenderInfoForProtocolById.ts
+++ b/app/src/organisms/Devices/hooks/useModuleRenderInfoForProtocolById.ts
@@ -6,6 +6,7 @@ import {
   MAGNETIC_BLOCK_TYPE,
   SINGLE_SLOT_FIXTURES,
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client/src/deck_configuration'
 
@@ -70,10 +71,15 @@ export function useModuleRenderInfoForProtocolById(
       const isMagneticBlockModule =
         protocolMod.moduleDef.moduleType === MAGNETIC_BLOCK_TYPE
 
+      const isThermocycler =
+        protocolMod.moduleDef.moduleType === THERMOCYCLER_MODULE_TYPE
+
       const conflictedFixture =
         deckConfig?.find(
           fixture =>
-            fixture.cutoutId === cutoutIdForSlotName &&
+            (fixture.cutoutId === cutoutIdForSlotName ||
+              // special-case A1 for the thermocycler to require a single slot fixture
+              (isThermocycler && fixture.cutoutId === 'cutoutA1')) &&
             fixture.cutoutFixtureId != null &&
             // do not generate a conflict for single slot fixtures, because modules are not yet fixtures
             !SINGLE_SLOT_FIXTURES.includes(fixture.cutoutFixtureId) &&

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/ModuleTable.tsx
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/ModuleTable.tsx
@@ -113,10 +113,15 @@ export function ModuleTable(props: ModuleTableProps): JSX.Element {
         const isMagneticBlockModule =
           module.moduleDef.moduleType === MAGNETIC_BLOCK_TYPE
 
+        const isThermocycler =
+          module.moduleDef.moduleType === THERMOCYCLER_MODULE_TYPE
+
         const conflictedFixture =
           deckConfig?.find(
             fixture =>
-              fixture.cutoutId === cutoutIdForSlotName &&
+              (fixture.cutoutId === cutoutIdForSlotName ||
+                // special-case A1 for the thermocycler to require a single slot fixture
+                (fixture.cutoutId === 'cutoutA1' && isThermocycler)) &&
               fixture.cutoutFixtureId != null &&
               // do not generate a conflict for single slot fixtures, because modules are not yet fixtures
               !SINGLE_SLOT_FIXTURES.includes(fixture.cutoutFixtureId) &&


### PR DESCRIPTION
# Overview

provides special-case logic to generate a conflict if a protocol uses a therocycler and the robot has a trash bin configured in A1. special-casing is needed because A1 is not directly referenced in the protocol. in a future where modules are fixtures, we won't need this.

Updates the location conflict modal for the thermocycler to reference both slots, and update both slots.

closes RQA-2029

<img width="1136" alt="Screen Shot 2024-02-05 at 1 44 40 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/a63754e7-2e9e-4fd1-8e15-e8c2385bb655">
<img width="1136" alt="Screen Shot 2024-02-05 at 3 18 16 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/fd8ec174-67e0-4781-b4b3-228e1d418ffd">


# Test Plan

 - verified that a conflict is generated when protocol requires a thermocycler and trash bin is configured in A1. verified that conflict is resolved by location conflict modal

# Changelog

 - Detects an A1 deck config conflict for thermcycler

# Review requests

load a thermocycler protocol, add a trash bin in A1 and look for conflict

# Risk assessment

low
