### PR TITLE
fix(robot-server): Fix indefinite protocol cancel state

### DIFF
--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -77,11 +77,9 @@ export function useRunStatus(
     refetchInterval: DEFAULT_STATUS_REFETCH_INTERVAL,
     enabled:
       lastRunStatus.current == null ||
-      !([
-        RUN_STATUS_STOP_REQUESTED,
-        RUN_STATUS_FAILED,
-        RUN_STATUS_SUCCEEDED,
-      ] as RunStatus[]).includes(lastRunStatus.current),
+      !([RUN_STATUS_FAILED, RUN_STATUS_SUCCEEDED] as RunStatus[]).includes(
+        lastRunStatus.current
+      ),
     onSuccess: data => (lastRunStatus.current = data?.data?.status ?? null),
     ...options,
   })

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -133,7 +133,9 @@ class RunDataManager:
             protocol_id=protocol.protocol_id if protocol is not None else None,
         )
         await self._runs_publisher.begin_polling_engine_store(
-            get_current_command=self.get_current_command, run_id=run_id
+            get_current_command=self.get_current_command,
+            get_state_summary=self._get_state_summary,
+            run_id=run_id,
         )
 
         return _build_run(

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -2,9 +2,7 @@ from fastapi import Depends
 import asyncio
 from typing import Union, Callable, Optional
 
-from opentrons.protocol_engine import (
-    CurrentCommand,
-)
+from opentrons.protocol_engine import CurrentCommand, StateSummary, EngineStatus
 
 from server_utils.fastapi_utils.app_state import (
     AppState,
@@ -23,11 +21,13 @@ class RunsPublisher:
         self._client = client
         self._run_data_manager_polling = asyncio.Event()
         self._previous_current_command: Union[CurrentCommand, None] = None
+        self._previous_state_summary_status: Union[EngineStatus, None] = None
 
     # TODO(jh, 2023-02-02): Instead of polling, emit current_commands directly from PE.
     async def begin_polling_engine_store(
         self,
         get_current_command: Callable[[str], Optional[CurrentCommand]],
+        get_state_summary: Callable[[str], Optional[StateSummary]],
         run_id: str,
     ) -> None:
         """Continuously poll the engine store for the current_command.
@@ -38,7 +38,9 @@ class RunsPublisher:
         """
         asyncio.create_task(
             self._poll_engine_store(
-                get_current_command=get_current_command, run_id=run_id
+                get_current_command=get_current_command,
+                run_id=run_id,
+                get_state_summary=get_state_summary,
             )
         )
 
@@ -59,6 +61,7 @@ class RunsPublisher:
     async def _poll_engine_store(
         self,
         get_current_command: Callable[[str], Optional[CurrentCommand]],
+        get_state_summary: Callable[[str], Optional[StateSummary]],
         run_id: str,
     ) -> None:
         """Asynchronously publish new current commands.
@@ -69,12 +72,23 @@ class RunsPublisher:
         """
         while not self._run_data_manager_polling.is_set():
             current_command = get_current_command(run_id)
+            current_state_summary = get_state_summary(run_id)
+            current_state_summary_status = (
+                current_state_summary.status if current_state_summary else None
+            )
             if (
                 current_command is not None
                 and self._previous_current_command != current_command
             ):
                 await self._publish_current_command()
                 self._previous_current_command = current_command
+
+            if (
+                current_state_summary_status is not None
+                and self._previous_state_summary_status != current_state_summary_status
+            ):
+                await self._publish_runs_async(run_id=run_id)
+                self._previous_state_summary_status = current_state_summary_status
             await asyncio.sleep(1)
 
     async def _publish_current_command(
@@ -82,6 +96,15 @@ class RunsPublisher:
     ) -> None:
         """Publishes the equivalent of GET /runs/:runId/commands?cursor=null&pageLength=1."""
         await self._client.publish_async(topic=Topics.RUNS_CURRENT_COMMAND.value)
+
+    async def _publish_runs_async(self, run_id: str) -> None:
+        """Asynchronously publishes the equivalent of GET /runs and GET /runs/:runId.
+
+        Args:
+            run_id: ID of the current run.
+        """
+        await self._client.publish_async(topic=Topics.RUNS.value)
+        await self._client.publish_async(topic=f"{Topics.RUNS.value}/{run_id}")
 
 
 _runs_publisher_accessor: AppStateAccessor[RunsPublisher] = AppStateAccessor[


### PR DESCRIPTION
Closes [RQA-2286](https://opentrons.atlassian.net/browse/RQA-2286)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

This PR fixes a bug in which cancelling a protocol from the desktop app/ODD results in an indefinite stop-requested state, which does not resolve unless the user navigates away and back to the protocol from the desktop app. Certain EngineStatus states are internal to PE and not handled by the robot-server, including stop-requested. This means that when the app requests a STOP, robot-server doesn't internally manage the transition from stop-requested->stopped. Simply emitting refetch flags whenever the robot-server updates the state is therefore insufficient. The current solution is to do what we do for current_commands, which is to poll PE and emit to the app if there's an update. In the future, we should bubble up this event to robot-server from PE (the TODO is already there).

There's a cheeky removal of the RUN_STATUS_STOP_REQUESTED as a run status that currently disables refetching on the app side. After spending some time looking at it with @shlokamin, we were unable to determine why this conditional is here, or why things appear to work even when it is here. Let's just get rid of it. 

# Test Plan
- Initiate a protocol run.
- Cancel out of said protocol run.
- The cancel modal should not be indefinite now.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed indefinite "cancelling run" desktop app/ODD state when pressing "cancel" during a protocol run.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low. This PR just adds another notification push. Worst case scenario, the app refetches more often than it should.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2286]: https://opentrons.atlassian.net/browse/RQA-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ