### PR TITLE
fix(api): use motion lock when updating firmware

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1,4 +1,3 @@
-
 import asyncio
 from concurrent.futures import Future
 import contextlib
@@ -493,7 +492,9 @@ class OT3API(
         # start the updates and yield the progress
         async with self._motion_lock:
             try:
-                async for update_status in self._backend.update_firmware(subsystems, force):
+                async for update_status in self._backend.update_firmware(
+                    subsystems, force
+                ):
                     yield update_status
             except SubsystemUpdating as e:
                 raise UpdateOngoingError(e.msg) from e


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The 96-channel pipette is reported to drop after a firmware update in testing. This is because while the update is happening, the pipette cannot respond to any other CAN requests. If the hardware controller probes the network at this time, it would not be able to detect the presence of the 96-channel pipette and mistakenly lower the Z-axis motor current required to hold the pipette in place.

This PR fixes this by making sure the update firmware call block other motion tasks until all firmware has been updated.
