### PR TITLE
fix(ci): analyses snapshot test timeout and dedup

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -12,10 +12,11 @@ on:
         required: true
         default: 'edge'
   schedule:
-    - cron:  '0 7-8 * * *' # Random time between 2-3 AM EST (7-8 AM UTC)
+    - cron:  '26 7 * * *' # 7:26 AM UTC
 
 jobs:
   build-and-test:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       TARGET: ${{ github.event.inputs.TARGET || 'edge' }}


### PR DESCRIPTION
## Overview

- Change the CRON to run once.
- Add a timeout on the test.

### Risk

None, CI job change only