### PR TITLE
fix(api): analysis and simulation of OT-2 protocols no longer hang

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -132,7 +132,9 @@ class ProtocolCore(
                 )
 
     def append_disposal_location(
-        self, disposal_location: Union[Labware, TrashBin, WasteChute]
+        self,
+        disposal_location: Union[Labware, TrashBin, WasteChute],
+        skip_add_to_engine: bool = False,
     ) -> None:
         """Append a disposal location object to the core"""
         if isinstance(disposal_location, TrashBin):
@@ -150,7 +152,8 @@ class ProtocolCore(
                 existing_labware_ids=list(self._labware_cores_by_id.keys()),
                 existing_module_ids=list(self._module_cores_by_id.keys()),
             )
-            self._engine_client.add_addressable_area(disposal_location.area_name)
+            if not skip_add_to_engine:
+                self._engine_client.add_addressable_area(disposal_location.area_name)
         elif isinstance(disposal_location, WasteChute):
             # TODO(jbl 2024-01-25) hardcoding this specific addressable area should be refactored
             #   when analysis is fixed up
@@ -163,7 +166,8 @@ class ProtocolCore(
             self._engine_client.state.addressable_areas.raise_if_area_not_in_deck_configuration(
                 "1ChannelWasteChute"
             )
-            self._engine_client.add_addressable_area("1ChannelWasteChute")
+            if not skip_add_to_engine:
+                self._engine_client.add_addressable_area("1ChannelWasteChute")
         self._disposal_locations.append(disposal_location)
 
     def get_disposal_locations(self) -> List[Union[Labware, TrashBin, WasteChute]]:

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -134,7 +134,9 @@ class LegacyProtocolCore(
         return self._sync_hardware.is_simulator  # type: ignore[no-any-return]
 
     def append_disposal_location(
-        self, disposal_location: Union[Labware, TrashBin, WasteChute]
+        self,
+        disposal_location: Union[Labware, TrashBin, WasteChute],
+        skip_add_to_engine: bool = False,
     ) -> None:
         if isinstance(disposal_location, (TrashBin, WasteChute)):
             raise APIVersionError(

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -63,7 +63,9 @@ class AbstractProtocol(
 
     @abstractmethod
     def append_disposal_location(
-        self, disposal_location: Union[Labware, TrashBin, WasteChute]
+        self,
+        disposal_location: Union[Labware, TrashBin, WasteChute],
+        skip_add_to_engine: bool = False,
     ) -> None:
         """Append a disposal location object to the core"""
         ...

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -150,10 +150,10 @@ class ProtocolContext(CommandPublisher):
         }
         self._bundled_data: Dict[str, bytes] = bundled_data or {}
 
-        # With the addition of Moveable Trashes and Waste Chute support, it is not necessary
+        # With the addition of Movable Trashes and Waste Chute support, it is not necessary
         # to ensure that the list of "disposal locations", essentially the list of trashes,
         # is initialized correctly on protocols utilizing former API versions prior to 2.16
-        # and also to ensure that any protocols after 2.16 intialize a Fixed Trash for OT-2
+        # and also to ensure that any protocols after 2.16 initialize a Fixed Trash for OT-2
         # protocols so that no load trash bin behavior is required within the protocol itself.
         # Protocols prior to 2.16 expect the Fixed Trash to exist as a Labware object, while
         # protocols after 2.16 expect trash to exist as either a TrashBin or WasteChute object.
@@ -168,7 +168,13 @@ class ProtocolContext(CommandPublisher):
             _fixed_trash_trashbin = TrashBin(
                 location=DeckSlotName.FIXED_TRASH, addressable_area_name="fixedTrash"
             )
-            self._core.append_disposal_location(_fixed_trash_trashbin)
+            # We have to skip adding this fixed trash bin to engine because this __init__ is called in the main thread
+            # and any calls to sync client will cause a deadlock. This means that OT-2 fixed trashes are not added to
+            # the engine store until one is first referenced. This should have minimal consequences for OT-2 given that
+            # we do not need to worry about the 96 channel pipette and partial tip configuration with that pipette.
+            self._core.append_disposal_location(
+                _fixed_trash_trashbin, skip_add_to_engine=True
+            )
 
         self._commands: List[str] = []
         self._unsubscribe_commands: Optional[Callable[[], None]] = None

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -123,6 +123,16 @@ def test_trash_search() -> None:
             "2.16",
             "OT-2",
             False,
+            # This should ideally raise, matching OT-2 behavior on prior Protocol API versions.
+            # It currently does not because Protocol API v2.15's trashes are implemented as
+            # addressable areas, not labware--and they're only brought into existence
+            # *on first use,* not at the beginning of a protocol.
+            #
+            # The good news is that even though the conflicting load will not raise like we want,
+            # something in the protocol will eventually raise, e.g. when a pipette goes to drop a
+            # tip in the fixed trash and finds that a fixed trash can't exist there because there's
+            # a labware.
+            marks=pytest.mark.xfail(strict=True, raises=pytest.fail.Exception),
         ),
         pytest.param(
             "2.16",


### PR DESCRIPTION
# Overview

Fixes RSS-462 and RQA-2277.

In a previous PR (#14358) we added having trash bins and waste chutes immediately added to the addressable area store when they are loaded in a python protocol. Previously they'd only be added to the engine store when they were first referenced, which could cause confusing line numbers in error messages and didn't allow any deck conflict related checks to rely on them being in the store during analysis.

Unfortunately, the method used to add it to the store relied on the `SyncClient`, and since this was being called in the `__init__` of the `ProtocolContext` for OT-2s for api levels 2.16 and above, this was causing a deadlock since this was being called from the main thread and not the thread running the PAPI protocol.

This PR fixes this in the most simple and straightforward way, which is introducing a new, optional boolean argument to `append_disposal_location` that skips this call. This is now used in the call in the `__init__` and only there, so Flex trashes and the waste chute will still be added to the engine store immediately. The OT-2 fixed trash will now be added to the store when it is first referenced (either by a `drop_tip`, `dispense`, `blow_out` or a `move_to` call), which is how it acted before #14358.

This does have the consequence that the OT-2 fixed trash, unlike any other trash bin, will behave slightly differently and inconsistently. In practice, this shouldn't lead to any issues or false positives in analysis. The only checks using the addressable area store for trashes involve the 96 channel pipette, which is Flex only, and all other checks don't rely on the addressable area store.

# Test Plan

This empty OT-2 protocol does not hang during analysis or simulation but instead passes/completes.

```
requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.16"
}


def run(context):
    pass
```

# Changelog

- added boolean argument to protocol core `append_disposal_location` to allow skipping adding the area to the engine store
- OT-2 fixed trashes no longer automatically get added to the engine store at start of protocol

# Risk assessment

Low.