### PR TITLE
refactor(app): add robot serial number to mixpanel analytics

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -82,7 +82,8 @@ export function ChooseProtocolSlideoutComponent(
       : []
 
   const { trackCreateProtocolRunEvent } = useTrackCreateProtocolRunEvent(
-    selectedProtocol
+    selectedProtocol,
+    name
   )
 
   const {

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -49,11 +49,12 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     mostRecentAnalysis,
   } = storedProtocolData
 
+  const [selectedRobot, setSelectedRobot] = React.useState<Robot | null>(null)
   const { trackCreateProtocolRunEvent } = useTrackCreateProtocolRunEvent(
-    storedProtocolData
+    storedProtocolData,
+    selectedRobot?.name ?? ''
   )
 
-  const [selectedRobot, setSelectedRobot] = React.useState<Robot | null>(null)
   const offsetCandidates = useOffsetCandidatesForAnalysis(
     mostRecentAnalysis,
     selectedRobot?.ip ?? null

--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -129,7 +129,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     closeOverflowMenu(e)
   }
   const trackEvent = useTrackEvent()
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const { reset } = useRunControls(runId, onResetSuccess)
   const { deleteRun } = useDeleteRunMutation()
 

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -155,7 +155,7 @@ export function ProtocolRunHeader({
     isProtocolAnalyzing,
   } = useProtocolDetailsForRun(runId)
 
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const isRobotViewable = useIsRobotViewable(robotName)
   const runStatus = useRunStatus(runId)
@@ -453,6 +453,7 @@ export function ProtocolRunHeader({
           <ConfirmCancelModal
             onClose={() => setShowConfirmCancelModal(false)}
             runId={runId}
+            robotName={robotName}
           />
         ) : null}
         {showDropTipWizard &&
@@ -575,7 +576,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       enabled: runStatus != null && START_RUN_STATUSES.includes(runStatus),
     })?.data?.data ?? []
   const trackEvent = useTrackEvent()
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const [targetProps, tooltipProps] = useHoverTooltip()
   const {
     play,

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -406,9 +406,11 @@ describe('ProtocolRunHeader', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(RUN_ID)
       .mockReturnValue(PROTOCOL_DETAILS)
-    when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
-      trackProtocolRunEvent: mockTrackProtocolRunEvent,
-    })
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        trackProtocolRunEvent: mockTrackProtocolRunEvent,
+      })
     when(mockUseDismissCurrentRunMutation)
       .calledWith()
       .mockReturnValue({

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
@@ -106,9 +106,11 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
         deleteRun: jest.fn(),
       } as any)
     )
-    when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
-      trackProtocolRunEvent: mockTrackProtocolRunEvent,
-    })
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        trackProtocolRunEvent: mockTrackProtocolRunEvent,
+      })
     when(mockUseRunControls)
       .calledWith(RUN_ID, expect.anything())
       .mockReturnValue({

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
@@ -45,6 +45,7 @@ let store: Store<any> = createStore(jest.fn(), {})
 
 const RUN_ID = '1'
 const RUN_ID_2 = '2'
+const ROBOT_NAME = 'otie'
 
 const PIPETTES = [
   { id: '1', pipetteName: 'testModelLeft' },
@@ -111,9 +112,12 @@ describe('useProtocolAnalysisErrors hook', () => {
   })
 
   it('returns getProtocolRunAnalyticsData function', () => {
-    const { result } = renderHook(() => useProtocolRunAnalyticsData(RUN_ID), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useProtocolRunAnalyticsData(RUN_ID, ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
     expect(typeof result.current.getProtocolRunAnalyticsData).toEqual(
       'function'
     )
@@ -123,9 +127,12 @@ describe('useProtocolAnalysisErrors hook', () => {
     when(mockUseProtocolDetailsForRun)
       .calledWith(RUN_ID_2)
       .mockReturnValue({ protocolData: ROBOT_PROTOCOL_ANALYSIS } as any)
-    const { result } = renderHook(() => useProtocolRunAnalyticsData(RUN_ID_2), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useProtocolRunAnalyticsData(RUN_ID_2, ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
     const protocolRunAnalyticsData = await waitFor(() =>
       result.current.getProtocolRunAnalyticsData()
     )
@@ -142,15 +149,19 @@ describe('useProtocolAnalysisErrors hook', () => {
         protocolText: 'hashedString',
         protocolType: '',
         robotType: 'OT-2 Standard',
+        robotSerialNumber: '',
       },
       runTime: '1:00:00',
     })
   })
 
   it('getProtocolRunAnalyticsData returns fallback stored data when robot data unavailable', async () => {
-    const { result } = renderHook(() => useProtocolRunAnalyticsData(RUN_ID), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useProtocolRunAnalyticsData(RUN_ID, ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
     const protocolRunAnalyticsData = await waitFor(() =>
       result.current.getProtocolRunAnalyticsData()
     )
@@ -167,6 +178,7 @@ describe('useProtocolAnalysisErrors hook', () => {
         protocolText: 'hashedString',
         protocolType: 'json',
         robotType: 'OT-2 Standard',
+        robotSerialNumber: '',
       },
       runTime: '1:00:00',
     })

--- a/app/src/organisms/Devices/hooks/__tests__/useRobotAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRobotAnalyticsData.test.tsx
@@ -12,6 +12,7 @@ import { getRobotSettings } from '../../../../redux/robot-settings'
 import {
   getRobotApiVersion,
   getRobotFirmwareVersion,
+  getRobotSerialNumber,
 } from '../../../../redux/discovery'
 
 import type { DiscoveredRobot } from '../../../../redux/discovery/types'
@@ -36,6 +37,9 @@ const mockGetRobotFirmwareVersion = getRobotFirmwareVersion as jest.MockedFuncti
 const mockGetAttachedPipettes = getAttachedPipettes as jest.MockedFunction<
   typeof getAttachedPipettes
 >
+const mockGetRobotSerialNumber = getRobotSerialNumber as jest.MockedFunction<
+  typeof getRobotSerialNumber
+>
 
 const ROBOT_SETTINGS = [
   { id: `setting1`, value: true, title: '', description: '' },
@@ -47,6 +51,7 @@ const ATTACHED_PIPETTES = {
   left: { id: '1', model: 'testModelLeft' },
   right: { id: '2', model: 'testModelRight' },
 }
+const ROBOT_SERIAL_NUMBER = 'OT123'
 
 let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
 let store: Store<any> = createStore(jest.fn(), {})
@@ -70,6 +75,7 @@ describe('useProtocolAnalysisErrors hook', () => {
     mockGetAttachedPipettes.mockReturnValue(
       ATTACHED_PIPETTES as AttachedPipettesByMount
     )
+    mockGetRobotSerialNumber.mockReturnValue(ROBOT_SERIAL_NUMBER)
   })
 
   afterEach(() => {
@@ -99,6 +105,7 @@ describe('useProtocolAnalysisErrors hook', () => {
       robotLeftPipette: 'testModelLeft',
       robotRightPipette: 'testModelRight',
       robotSmoothieVersion: ROBOT_FIRMWARE_VERSION,
+      robotSerialNumber: ROBOT_SERIAL_NUMBER,
     })
   })
 })

--- a/app/src/organisms/Devices/hooks/__tests__/useRobotAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useRobotAnalyticsData.test.tsx
@@ -9,6 +9,8 @@ import { useRobot } from '../'
 import { useRobotAnalyticsData } from '../useRobotAnalyticsData'
 import { getAttachedPipettes } from '../../../../redux/pipettes'
 import { getRobotSettings } from '../../../../redux/robot-settings'
+import { mockConnectableRobot } from '../../../../redux/discovery/__fixtures__'
+
 import {
   getRobotApiVersion,
   getRobotFirmwareVersion,
@@ -93,7 +95,13 @@ describe('useProtocolAnalysisErrors hook', () => {
   it('returns robot analytics data when robot exists', () => {
     when(mockUseRobot)
       .calledWith('otie')
-      .mockReturnValue({} as DiscoveredRobot)
+      .mockReturnValue({
+        ...mockConnectableRobot,
+        health: {
+          ...mockConnectableRobot.health,
+          robot_serial: ROBOT_SERIAL_NUMBER,
+        },
+      } as DiscoveredRobot)
 
     const { result } = renderHook(() => useRobotAnalyticsData('otie'), {
       wrapper,

--- a/app/src/organisms/Devices/hooks/__tests__/useTrackCreateProtocolRunEvent.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useTrackCreateProtocolRunEvent.test.tsx
@@ -72,7 +72,7 @@ describe('useTrackCreateProtocolRunEvent hook', () => {
 
   it('returns trackCreateProtocolRunEvent function', () => {
     const { result } = renderHook(
-      () => useTrackCreateProtocolRunEvent(storedProtocolData),
+      () => useTrackCreateProtocolRunEvent(storedProtocolData, 'otie'),
       {
         wrapper,
       }
@@ -82,7 +82,7 @@ describe('useTrackCreateProtocolRunEvent hook', () => {
 
   it('trackCreateProtocolRunEvent invokes trackEvent with correct props', async () => {
     const { result } = renderHook(
-      () => useTrackCreateProtocolRunEvent(storedProtocolData),
+      () => useTrackCreateProtocolRunEvent(storedProtocolData, 'otie'),
       {
         wrapper,
       }
@@ -107,7 +107,7 @@ describe('useTrackCreateProtocolRunEvent hook', () => {
         })
     )
     const { result } = renderHook(
-      () => useTrackCreateProtocolRunEvent(storedProtocolData),
+      () => useTrackCreateProtocolRunEvent(storedProtocolData, 'otie'),
       {
         wrapper,
       }

--- a/app/src/organisms/Devices/hooks/__tests__/useTrackProtocolRunEvent.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useTrackProtocolRunEvent.test.tsx
@@ -11,6 +11,7 @@ import {
   useTrackEvent,
   ANALYTICS_PROTOCOL_RUN_START,
 } from '../../../../redux/analytics'
+import { RobotName } from '../../../RobotSettingsDashboard'
 
 jest.mock('../../hooks')
 jest.mock('../useProtocolRunAnalyticsData')
@@ -27,6 +28,7 @@ const mockUseProtocolRunAnalyticsData = useProtocolRunAnalyticsData as jest.Mock
 >
 
 const RUN_ID = 'runId'
+const ROBOT_NAME = 'otie'
 const PROTOCOL_PROPERTIES = { protocolType: 'python' }
 
 let mockTrackEvent: jest.Mock
@@ -54,9 +56,11 @@ describe('useTrackProtocolRunEvent hook', () => {
         )
     )
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
-    when(mockUseProtocolRunAnalyticsData).calledWith(RUN_ID).mockReturnValue({
-      getProtocolRunAnalyticsData: mockGetProtocolRunAnalyticsData,
-    })
+    when(mockUseProtocolRunAnalyticsData)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        getProtocolRunAnalyticsData: mockGetProtocolRunAnalyticsData,
+      })
   })
 
   afterEach(() => {
@@ -65,16 +69,22 @@ describe('useTrackProtocolRunEvent hook', () => {
   })
 
   it('returns trackProtocolRunEvent function', () => {
-    const { result } = renderHook(() => useTrackProtocolRunEvent(RUN_ID), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useTrackProtocolRunEvent(RUN_ID, ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
     expect(typeof result.current.trackProtocolRunEvent).toBe('function')
   })
 
   it('trackProtocolRunEvent invokes trackEvent with correct props', async () => {
-    const { result } = renderHook(() => useTrackProtocolRunEvent(RUN_ID), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useTrackProtocolRunEvent(RUN_ID, ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
     await waitFor(() =>
       result.current.trackProtocolRunEvent({
         name: ANALYTICS_PROTOCOL_RUN_START,
@@ -89,16 +99,19 @@ describe('useTrackProtocolRunEvent hook', () => {
 
   it('trackProtocolRunEvent calls trackEvent without props when error is thrown in getProtocolRunAnalyticsData', async () => {
     when(mockUseProtocolRunAnalyticsData)
-      .calledWith('errorId')
+      .calledWith('errorId', ROBOT_NAME)
       .mockReturnValue({
         getProtocolRunAnalyticsData: () =>
           new Promise(() => {
             throw new Error('error')
           }),
       })
-    const { result } = renderHook(() => useTrackProtocolRunEvent('errorId'), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useTrackProtocolRunEvent('errorId', ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
     await waitFor(() =>
       result.current.trackProtocolRunEvent({
         name: ANALYTICS_PROTOCOL_RUN_START,

--- a/app/src/organisms/Devices/hooks/__tests__/useTrackProtocolRunEvent.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useTrackProtocolRunEvent.test.tsx
@@ -11,7 +11,6 @@ import {
   useTrackEvent,
   ANALYTICS_PROTOCOL_RUN_START,
 } from '../../../../redux/analytics'
-import { RobotName } from '../../../RobotSettingsDashboard'
 
 jest.mock('../../hooks')
 jest.mock('../useProtocolRunAnalyticsData')

--- a/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
@@ -1,10 +1,13 @@
 import { useSelector } from 'react-redux'
 
 import { hash } from '../../../redux/analytics/hash'
-import { useRobot } from './'
 import { getStoredProtocol } from '../../../redux/protocol-storage'
 import { getRobotSerialNumber } from '../../../redux/discovery'
-import { useStoredProtocolAnalysis, useProtocolDetailsForRun } from './'
+import {
+  useRobot,
+  useStoredProtocolAnalysis,
+  useProtocolDetailsForRun,
+} from './'
 import { useProtocolMetadata } from './useProtocolMetadata'
 import { useRunTimestamps } from '../../RunTimeControl/hooks'
 import { formatInterval } from '../../RunTimeControl/utils'

--- a/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
@@ -1,7 +1,9 @@
 import { useSelector } from 'react-redux'
 
 import { hash } from '../../../redux/analytics/hash'
+import { useRobot } from './'
 import { getStoredProtocol } from '../../../redux/protocol-storage'
+import { getRobotSerialNumber } from '../../../redux/discovery'
 import { useStoredProtocolAnalysis, useProtocolDetailsForRun } from './'
 import { useProtocolMetadata } from './useProtocolMetadata'
 import { useRunTimestamps } from '../../RunTimeControl/hooks'
@@ -16,12 +18,17 @@ import type { State } from '../../../redux/types'
 export const parseProtocolRunAnalyticsData = (
   protocolAnalysis: ProtocolAnalysisOutput | null,
   storedProtocol: StoredProtocolData | null,
-  startedAt: string | null
+  startedAt: string | null,
+  robotName: string
 ) => () => {
   const hashTasks = [
     hash(protocolAnalysis?.metadata?.author) ?? '',
     hash(storedProtocol?.srcFiles?.toString() ?? '') ?? '',
   ]
+
+  const robot = useRobot(robotName)
+  const serialNumber =
+    robot?.status != null ? getRobotSerialNumber(robot) : null
 
   return Promise.all(hashTasks).then(([protocolAuthor, protocolText]) => ({
     protocolRunAnalyticsData: {
@@ -49,6 +56,7 @@ export const parseProtocolRunAnalyticsData = (
         protocolAnalysis?.robotType != null
           ? protocolAnalysis?.robotType
           : storedProtocol?.mostRecentAnalysis?.robotType,
+      robotSerialNumber: serialNumber ?? '',
     },
     runTime:
       startedAt != null ? formatInterval(startedAt, Date()) : EMPTY_TIMESTAMP,
@@ -68,7 +76,8 @@ type GetProtocolRunAnalyticsData = () => Promise<{
  *          data properties for use in event trackEvent
  */
 export function useProtocolRunAnalyticsData(
-  runId: string | null
+  runId: string | null,
+  robotName: string
 ): {
   getProtocolRunAnalyticsData: GetProtocolRunAnalyticsData
 } {
@@ -96,7 +105,8 @@ export function useProtocolRunAnalyticsData(
   const getProtocolRunAnalyticsData = parseProtocolRunAnalyticsData(
     protocolAnalysis as ProtocolAnalysisOutput | null,
     storedProtocol,
-    startedAt
+    startedAt,
+    robotName
   )
 
   return { getProtocolRunAnalyticsData }

--- a/app/src/organisms/Devices/hooks/useRobotAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useRobotAnalyticsData.ts
@@ -7,6 +7,7 @@ import { getRobotSettings, fetchSettings } from '../../../redux/robot-settings'
 import {
   getRobotApiVersion,
   getRobotFirmwareVersion,
+  getRobotSerialNumber,
 } from '../../../redux/discovery'
 
 import type { State, Dispatch } from '../../../redux/types'
@@ -30,6 +31,8 @@ export function useRobotAnalyticsData(
   const settings = useSelector((state: State) =>
     getRobotSettings(state, robotName)
   )
+  const serialNumber =
+    robot != null ? useSelector(() => getRobotSerialNumber(robot)) : null
   const dispatch = useDispatch<Dispatch>()
 
   React.useEffect(() => {
@@ -50,6 +53,7 @@ export function useRobotAnalyticsData(
           robotSmoothieVersion: getRobotFirmwareVersion(robot) ?? '',
           robotLeftPipette: pipettes.left?.model ?? '',
           robotRightPipette: pipettes.right?.model ?? '',
+          robotSerialNumber: serialNumber ?? '',
         }
       )
     }

--- a/app/src/organisms/Devices/hooks/useRobotAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useRobotAnalyticsData.ts
@@ -32,7 +32,7 @@ export function useRobotAnalyticsData(
     getRobotSettings(state, robotName)
   )
   const serialNumber =
-    robot != null ? useSelector(() => getRobotSerialNumber(robot)) : null
+    robot?.status != null ? getRobotSerialNumber(robot) : null
   const dispatch = useDispatch<Dispatch>()
 
   React.useEffect(() => {

--- a/app/src/organisms/Devices/hooks/useTrackCreateProtocolRunEvent.ts
+++ b/app/src/organisms/Devices/hooks/useTrackCreateProtocolRunEvent.ts
@@ -18,7 +18,8 @@ type TrackCreateProtocolRunEvent = (
 ) => void
 
 export function useTrackCreateProtocolRunEvent(
-  protocol: StoredProtocolData | null
+  protocol: StoredProtocolData | null,
+  robotName: string
 ): { trackCreateProtocolRunEvent: TrackCreateProtocolRunEvent } {
   const trackEvent = useTrackEvent()
 
@@ -29,7 +30,8 @@ export function useTrackCreateProtocolRunEvent(
   const getProtocolRunAnalyticsData = parseProtocolRunAnalyticsData(
     storedProtocolAnalysis,
     protocol,
-    null
+    null,
+    robotName
   )
 
   const trackCreateProtocolRunEvent: TrackCreateProtocolRunEvent = ({

--- a/app/src/organisms/Devices/hooks/useTrackProtocolRunEvent.ts
+++ b/app/src/organisms/Devices/hooks/useTrackProtocolRunEvent.ts
@@ -11,10 +11,14 @@ export type TrackProtocolRunEvent = (
 ) => void
 
 export function useTrackProtocolRunEvent(
-  runId: string | null
+  runId: string | null,
+  robotName: string
 ): { trackProtocolRunEvent: TrackProtocolRunEvent } {
   const trackEvent = useTrackEvent()
-  const { getProtocolRunAnalyticsData } = useProtocolRunAnalyticsData(runId)
+  const { getProtocolRunAnalyticsData } = useProtocolRunAnalyticsData(
+    runId,
+    robotName
+  )
 
   const trackProtocolRunEvent: TrackProtocolRunEvent = ({
     name,

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -31,6 +31,7 @@ jest.mock('../hooks')
 jest.mock('../../../../resources/runs/useNotifyAllRunsQuery')
 
 const RUN_ID = 'mockRunId'
+const ROBOT_NAME = 'otie'
 
 const mockMissingPipette = [
   {
@@ -136,9 +137,11 @@ describe('RecentRunProtocolCard', () => {
     mockUseProtocolQuery.mockReturnValue({
       data: { data: { metadata: { protocolName: 'mockProtocol' } } },
     } as any)
-    when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
-      trackProtocolRunEvent: mockTrackProtocolRunEvent,
-    })
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        trackProtocolRunEvent: mockTrackProtocolRunEvent,
+      })
     mockCloneRun = jest.fn()
     when(mockUseCloneRun)
       .calledWith(RUN_ID, expect.anything())

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 
 import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import {
@@ -21,6 +22,7 @@ import { Modal } from '../../../molecules/Modal'
 import { useTrackProtocolRunEvent } from '../../../organisms/Devices/hooks'
 import { useRunStatus } from '../../../organisms/RunTimeControl/hooks'
 import { ANALYTICS_PROTOCOL_RUN_CANCEL } from '../../../redux/analytics'
+import { getLocalRobot } from '../../../redux/discovery'
 import { CancelingRunModal } from './CancelingRunModal'
 
 import type { ModalHeaderBaseProps } from '../../../molecules/Modal/types'
@@ -45,7 +47,9 @@ export function ConfirmCancelRunModal({
     isLoading: isDismissing,
   } = useDismissCurrentRunMutation()
   const runStatus = useRunStatus(runId)
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const localRobot = useSelector(getLocalRobot)
+  const robotName = localRobot?.name ?? ''
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const history = useHistory()
   const [isCanceling, setIsCanceling] = React.useState(false)
 

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/ConfirmCancelRunModal.test.tsx
@@ -14,6 +14,8 @@ import { i18n } from '../../../../i18n'
 import { useTrackProtocolRunEvent } from '../../../../organisms/Devices/hooks'
 import { useRunStatus } from '../../../../organisms/RunTimeControl/hooks'
 import { useTrackEvent } from '../../../../redux/analytics'
+import { getLocalRobot } from '../../../../redux/discovery'
+import { mockConnectedRobot } from '../../../../redux/discovery/__fixtures__'
 import { ConfirmCancelRunModal } from '../ConfirmCancelRunModal'
 import { CancelingRunModal } from '../CancelingRunModal'
 
@@ -23,6 +25,7 @@ jest.mock('../../../../organisms/RunTimeControl/hooks')
 jest.mock('../../../../redux/analytics')
 jest.mock('../../../ProtocolUpload/hooks')
 jest.mock('../CancelingRunModal')
+jest.mock('../../../../redux/discovery')
 
 const mockPush = jest.fn()
 let mockStopRun: jest.Mock
@@ -56,6 +59,9 @@ const mockCancelingRunModal = CancelingRunModal as jest.MockedFunction<
 const mockUseRunStatus = useRunStatus as jest.MockedFunction<
   typeof useRunStatus
 >
+const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
+  typeof getLocalRobot
+>
 
 const render = (props: React.ComponentProps<typeof ConfirmCancelRunModal>) => {
   return renderWithProviders(
@@ -69,6 +75,7 @@ const render = (props: React.ComponentProps<typeof ConfirmCancelRunModal>) => {
 }
 
 const RUN_ID = 'mock_runID'
+const ROBOT_NAME = 'otie'
 const mockFn = jest.fn()
 
 describe('ConfirmCancelRunModal', () => {
@@ -86,15 +93,21 @@ describe('ConfirmCancelRunModal', () => {
     mockTrackProtocolRunEvent = jest.fn(
       () => new Promise(resolve => resolve({}))
     )
+    mockGetLocalRobot.mockReturnValue({
+      ...mockConnectedRobot,
+      name: ROBOT_NAME,
+    })
     mockUseStopRunMutation.mockReturnValue({ stopRun: mockStopRun } as any)
     mockUseDismissCurrentRunMutation.mockReturnValue({
       dismissCurrentRun: mockDismissCurrentRun,
       isLoading: false,
     } as any)
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
-    when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
-      trackProtocolRunEvent: mockTrackProtocolRunEvent,
-    })
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        trackProtocolRunEvent: mockTrackProtocolRunEvent,
+      })
     mockCancelingRunModal.mockReturnValue(<div>mock CancelingRunModal</div>)
     when(mockUseRunStatus).calledWith(RUN_ID).mockReturnValue(RUN_STATUS_IDLE)
   })

--- a/app/src/organisms/RunDetails/ConfirmCancelModal.tsx
+++ b/app/src/organisms/RunDetails/ConfirmCancelModal.tsx
@@ -28,16 +28,17 @@ import { ANALYTICS_PROTOCOL_RUN_CANCEL } from '../../redux/analytics'
 export interface ConfirmCancelModalProps {
   onClose: () => unknown
   runId: string
+  robotName: string
 }
 
 export function ConfirmCancelModal(
   props: ConfirmCancelModalProps
 ): JSX.Element {
-  const { onClose, runId } = props
+  const { onClose, runId, robotName } = props
   const { stopRun } = useStopRunMutation()
   const [isCanceling, setIsCanceling] = React.useState(false)
   const runStatus = useRunStatus(runId)
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const { t } = useTranslation('run_details')
 
   const cancelRun: React.MouseEventHandler<HTMLButtonElement> = (e): void => {

--- a/app/src/organisms/RunDetails/__tests__/ConfirmCancelModal.test.tsx
+++ b/app/src/organisms/RunDetails/__tests__/ConfirmCancelModal.test.tsx
@@ -41,6 +41,7 @@ const render = (props: React.ComponentProps<typeof ConfirmCancelModal>) => {
 }
 
 const RUN_ID = 'mockRunId'
+const ROBOT_NAME = 'otie'
 let mockStopRun: jest.Mock
 let mockTrackEvent: jest.Mock
 let mockTrackProtocolRunEvent: jest.Mock
@@ -56,11 +57,13 @@ describe('ConfirmCancelModal', () => {
     mockUseStopRunMutation.mockReturnValue({ stopRun: mockStopRun } as any)
     mockUseRunStatus.mockReturnValue(RUN_STATUS_RUNNING)
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
-    when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
-      trackProtocolRunEvent: mockTrackProtocolRunEvent,
-    })
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        trackProtocolRunEvent: mockTrackProtocolRunEvent,
+      })
 
-    props = { onClose: jest.fn(), runId: RUN_ID }
+    props = { onClose: jest.fn(), runId: RUN_ID, robotName: ROBOT_NAME }
   })
 
   afterEach(() => {

--- a/app/src/pages/ProtocolDashboard/index.tsx
+++ b/app/src/pages/ProtocolDashboard/index.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
-  BORDERS,
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,

--- a/app/src/pages/ProtocolDashboard/index.tsx
+++ b/app/src/pages/ProtocolDashboard/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
+  BORDERS,
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,

--- a/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -345,7 +345,7 @@ describe('ProtocolSetup', () => {
       } as unknown) as any)
     when(mockUseDeckConfigurationCompatibility).mockReturnValue([])
     when(mockUseTrackProtocolRunEvent)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, ROBOT_NAME)
       .mockReturnValue({ trackProtocolRunEvent: mockTrackProtocolRunEvent })
   })
 

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -343,7 +343,7 @@ function PrepareToRun({
     mostRecentAnalysis
   )
 
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
 
   const requiredDeckConfigCompatibility = getRequiredDeckConfig(

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -107,12 +107,12 @@ export function RunSummary(): JSX.Element {
   const [showSplash, setShowSplash] = React.useState(
     runStatus === RUN_STATUS_FAILED || runStatus === RUN_STATUS_SUCCEEDED
   )
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
+  const localRobot = useSelector(getLocalRobot)
+  const robotName = localRobot?.name ?? 'no name'
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const { reset } = useRunControls(runId)
   const trackEvent = useTrackEvent()
   const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
-  const localRobot = useSelector(getLocalRobot)
-  const robotName = localRobot?.name ?? 'no name'
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const [showRunFailedModal, setShowRunFailedModal] = React.useState<boolean>(
     false

--- a/app/src/pages/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -17,6 +17,7 @@ import {
   useRunActionMutations,
 } from '@opentrons/react-api-client'
 
+import { getLocalRobot } from '../../../redux/discovery'
 import { mockRobotSideAnalysis } from '../../../organisms/CommandText/__fixtures__'
 import {
   CurrentRunningProtocolCommand,
@@ -24,6 +25,7 @@ import {
   RunningProtocolSkeleton,
 } from '../../../organisms/OnDeviceDisplay/RunningProtocol'
 import { mockUseAllCommandsResponseNonDeterministic } from '../../../organisms/RunProgressMeter/__fixtures__'
+import { mockConnectedRobot } from '../../../redux/discovery/__fixtures__'
 import {
   useRunStatus,
   useRunTimestamps,
@@ -100,8 +102,12 @@ const mockOpenDoorAlertModal = OpenDoorAlertModal as jest.MockedFunction<
 const mockUseNotifyLastRunCommandKey = useNotifyLastRunCommandKey as jest.MockedFunction<
   typeof useNotifyLastRunCommandKey
 >
+const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
+  typeof getLocalRobot
+>
 
 const RUN_ID = 'run_id'
+const ROBOT_NAME = 'otie'
 const PROTOCOL_ID = 'protocol_id'
 const PROTOCOL_KEY = 'protocol_key'
 const PROTOCOL_ANALYSIS = {
@@ -160,6 +166,10 @@ describe('RunningProtocol', () => {
       stoppedAt: '',
       completedAt: '2022-05-04T18:24:41.833862+00:00',
     })
+    mockGetLocalRobot.mockReturnValue({
+      ...mockConnectedRobot,
+      name: ROBOT_NAME,
+    })
     when(mockUseRunActionMutations).calledWith(RUN_ID).mockReturnValue({
       playRun: mockPlayRun,
       pauseRun: mockPauseRun,
@@ -168,9 +178,11 @@ describe('RunningProtocol', () => {
       isPauseRunActionLoading: false,
       isStopRunActionLoading: false,
     })
-    when(mockUseTrackProtocolRunEvent).calledWith(RUN_ID).mockReturnValue({
-      trackProtocolRunEvent: mockTrackProtocolRunEvent,
-    })
+    when(mockUseTrackProtocolRunEvent)
+      .calledWith(RUN_ID, ROBOT_NAME)
+      .mockReturnValue({
+        trackProtocolRunEvent: mockTrackProtocolRunEvent,
+      })
     when(mockUseMostRecentCompletedAnalysis)
       .calledWith(RUN_ID)
       .mockReturnValue(mockRobotSideAnalysis)

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -110,9 +110,9 @@ export function RunningProtocol(): JSX.Element {
     protocolRecord?.data.metadata.protocolName ??
     protocolRecord?.data.files[0].name
   const { playRun, pauseRun } = useRunActionMutations(runId)
-  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId)
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot != null ? localRobot.name : 'no name'
+  const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const robotType = useRobotType(robotName)
   React.useEffect(() => {

--- a/app/src/redux/analytics/types.ts
+++ b/app/src/redux/analytics/types.ts
@@ -21,6 +21,7 @@ export interface ProtocolAnalyticsData {
   protocolText: string
   pipettes: string
   modules: string
+  robotSerialNumber: string
 }
 
 export type RobotAnalyticsData = {

--- a/app/src/redux/analytics/types.ts
+++ b/app/src/redux/analytics/types.ts
@@ -28,6 +28,7 @@ export type RobotAnalyticsData = {
   robotSmoothieVersion: string
   robotLeftPipette: string
   robotRightPipette: string
+  robotSerialNumber: string
 } & {
   // feature flags
   // e.g. robotFF_settingName


### PR DESCRIPTION
closes [RAUT-899](https://opentrons.atlassian.net/browse/RAUT-899)

# Overview

Add a new robot serial number property to Mixpanel events tracked alongside existing robot analytics data.

# Test Plan


# Changelog


# Risk assessment


[RAUT-899]: https://opentrons.atlassian.net/browse/RAUT-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ