### PR TITLE
chore: verbose pypi deploys to catch errors

### DIFF
--- a/.github/actions/python/pypi-deploy/action.yaml
+++ b/.github/actions/python/pypi-deploy/action.yaml
@@ -28,7 +28,7 @@ runs:
           fi
         fi
         status=0
-        QUIET=1 BUILD_NUMBER=${OT_BUILD} make -C ${{ inputs.project }} clean deploy twine_repository_url=${{ inputs.repository_url }} pypi_username=opentrons pypi_password=${{ inputs.password }} || status=$?
+        CI=1 QUIET=1 BUILD_NUMBER=${OT_BUILD} make -C ${{ inputs.project }} clean deploy twine_repository_url=${{ inputs.repository_url }} pypi_username=opentrons pypi_password=${{ inputs.password }} || status=$?
         if [[ ${status} != 0 ]] && [[ ${{ inputs.repository_url }} =~ "test.pypi.org" ]]; then
           echo "upload failures allowed to test pypi"
           exit 0

--- a/api/Makefile
+++ b/api/Makefile
@@ -199,8 +199,8 @@ emulator:
 	-$(python) -m opentrons.hardware_control.emulation.app
 
 .PHONY: deploy
-deploy: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file))
+deploy: wheel sdist
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file),$(sdist_file))
 
 # User must currently specify host, e.g.: `make term host=169.254.202.176`
 .PHONY: term

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -144,5 +144,5 @@ emulator:
 	echo "Nothing here yet"
 
 .PHONY: deploy
-deploy: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file))
+deploy: wheel sdist
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file),$(sdist_file))

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -69,7 +69,7 @@ endef
 # parameter 2: repository url
 # parameter 3: the wheel file to upload
 define python_upload_package
-$(python) -m twine upload --repository-url $(2) $(1) $(3)
+$(python) -m twine upload $(and $(CI),--verbose) --repository-url $(2) $(1) $(3)
 endef
 
 # Get an enhanced version dict of the project

--- a/scripts/python.mk
+++ b/scripts/python.mk
@@ -68,8 +68,9 @@ endef
 # parameter 1: auth arguments for twine
 # parameter 2: repository url
 # parameter 3: the wheel file to upload
+# parameter 4: the sdist to upload
 define python_upload_package
-$(python) -m twine upload $(and $(CI),--verbose) --repository-url $(2) $(1) $(3)
+$(python) -m twine upload $(and $(CI),--verbose) --repository-url $(2) $(1) $(3) $(4)
 endef
 
 # Get an enhanced version dict of the project

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -118,8 +118,8 @@ push-ot3: push-no-restart-ot3
 	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),opentrons-robot-server)
 
 .PHONY: deploy
-deploy: wheel
-	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file))
+deploy: wheel sdist
+	$(call python_upload_package,$(twine_auth_args),$(twine_repository_url),$(wheel_file),$(sdist_file))
 
 .PHONY: test
 test:


### PR DESCRIPTION
Our pypi deploys seem to have succeeded in that the build is on pypi (https://pypi.org/project/opentrons/7.1.1a0/#files) but failed in that the action said there was an error and you should run with --verbose, so let's do that.