### PR TITLE
fix(api): raise errors from modules disconnecting

### DIFF
--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -3,6 +3,7 @@ import contextlib
 import logging
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Optional
+from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
 
 log = logging.getLogger(__name__)
@@ -48,6 +49,8 @@ class Poller:
         async with self._use_read_lock():
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+        for waiter in self._poll_waiters:
+            waiter.cancel(msg="Module was removed")
 
     async def wait_next_poll(self) -> None:
         """Wait for the next poll to complete.
@@ -56,6 +59,9 @@ class Poller:
         the next complete read. If a read raises an exception,
         it will be passed through to `wait_next_poll`.
         """
+        if not self._poll_forever_task or self._poll_forever_task.done():
+            raise ModuleCommunicationError(message="Module was removed")
+
         poll_future = asyncio.get_running_loop().create_future()
         self._poll_waiters.append(poll_future)
         await poll_future


### PR DESCRIPTION
When a module gets disconnected, the hardware controller cleans up the module instance, which stops the poller. What it doesn't do is cancel anything that was waiting on the next poll, or in fact prevent new things from waiting on the now-stopped poller. That means that if a module disconnects
- During a module method waiting for the next poll, that module method hangs (well, awaits) forever
- During a module method right _before_ waiting for the next poll, that module method would start waiting and continue waiting forever

This PR forwards cancellations into the registered poll waiters when the poller task is cancelled, and prevents the registration of new poll waiters on a cancelled poll task.

However, it does not fix the following issue: the protocol engine does not maintain a lifetime associated with a particular module connection, but looks up a module object on each call based on the serial number. That means that if a module is disconnected and reconnected during a protocol, as long as the engine isn't actually communicating with it at that exact time the protocol will continue as if nothing has happened - even if, for instance, the module disconnected because it was powered down, and the user-specified module state has been lost.