### PR TITLE
fix(api): keep proto contents in bytes for longer

### DIFF
--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -12,7 +12,7 @@ import re
 import traceback
 from io import BytesIO
 from zipfile import ZipFile
-from typing import Any, Dict, Optional, Union, Tuple, TYPE_CHECKING, cast
+from typing import Any, Dict, Optional, Union, Tuple, TYPE_CHECKING
 
 import jsonschema  # type: ignore
 
@@ -500,17 +500,6 @@ def _has_api_v1_imports(parsed: ast.Module) -> bool:
     return bool(v1_markers.intersection(opentrons_imports))
 
 
-def _strvalue_from_str_or_byte_dict(
-    dct: Union[Dict[str, str], Dict[bytes, bytes]], key: str
-) -> Optional[str]:
-    key_bytes = key.encode("utf-8")
-    val_bytes = cast(Dict[bytes, bytes], dct).get(key_bytes, None)
-    val_str = cast(Dict[str, str], dct).get(key, None)
-    if val_bytes:
-        return val_bytes.decode("utf-8")
-    return val_str
-
-
 def _version_from_static_python_info(
     static_python_info: StaticPythonInfo,
 ) -> Optional[APIVersion]:
@@ -519,12 +508,8 @@ def _version_from_static_python_info(
     If the protocol doesn't declare apiLevel at all, return None.
     If the protocol declares apiLevel incorrectly, raise a ValueError.
     """
-    from_requirements = _strvalue_from_str_or_byte_dict(
-        static_python_info.requirements or {}, "apiLevel"
-    )
-    from_metadata = _strvalue_from_str_or_byte_dict(
-        static_python_info.metadata or {}, "apiLevel"
-    )
+    from_requirements = (static_python_info.requirements or {}).get("apiLevel", None)
+    from_metadata = (static_python_info.metadata or {}).get("apiLevel", None)
 
     requested_level = from_requirements or from_metadata
     if requested_level is None:
@@ -553,9 +538,7 @@ def robot_type_from_python_identifier(python_robot_type: str) -> RobotType:
 def _robot_type_from_static_python_info(
     static_python_info: StaticPythonInfo,
 ) -> RobotType:
-    python_robot_type = _strvalue_from_str_or_byte_dict(
-        static_python_info.requirements or {}, "robotType"
-    )
+    python_robot_type = (static_python_info.requirements or {}).get("robotType", None)
     if python_robot_type is None:
         return "OT-2 Standard"
     else:

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -369,7 +369,7 @@ def parse(
         if protocol_file and protocol_file[0] in ("{", b"{"[0]):
             return _parse_json(protocol_file, filename)
         else:
-            print(f'default assumption, file[0] is {protocol_file[0]}')
+            print(f"default assumption, file[0] is {protocol_file[0]}")
             return _parse_python(
                 protocol_contents=protocol_file,
                 python_parse_mode=python_parse_mode,

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -192,7 +192,9 @@ def version_from_string(vstr: str) -> APIVersion:
     return APIVersion(major=int(matches.group(1)), minor=int(matches.group(2)))
 
 
-def _parse_json(protocol_contents: str, filename: Optional[str] = None) -> JsonProtocol:
+def _parse_json(
+    protocol_contents: Union[str, bytes], filename: Optional[str] = None
+) -> JsonProtocol:
     """Parse a protocol known or at least suspected to be json"""
     protocol_json = json.loads(protocol_contents)
     version, validated = validate_json(protocol_json)
@@ -351,7 +353,7 @@ def parse(
 
         # our jsonschema says the top level json kind is object
         if protocol_file and protocol_file[0] in ("{", b"{"):
-            return _parse_json(protocol_str, filename)
+            return _parse_json(protocol_file, filename)
         else:
             return _parse_python(
                 protocol_contents=protocol_file,

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -208,7 +208,7 @@ def _parse_json(protocol_contents: str, filename: Optional[str] = None) -> JsonP
 
 
 def _parse_python(
-    protocol_contents: str,
+    protocol_contents: Union[str, bytes],
     python_parse_mode: PythonParseMode,
     filename: Optional[str] = None,
     bundled_labware: Optional[Dict[str, "LabwareDefinition"]] = None,
@@ -338,16 +338,11 @@ def parse(
             )
         return result
     else:
-        if isinstance(protocol_file, bytes):
-            protocol_str = protocol_file.decode("utf-8")
-        else:
-            protocol_str = protocol_file
-
         if filename and filename.endswith(".json"):
-            return _parse_json(protocol_str, filename)
+            return _parse_json(protocol_file, filename)
         elif filename and filename.endswith(".py"):
             return _parse_python(
-                protocol_contents=protocol_str,
+                protocol_contents=protocol_file,
                 python_parse_mode=python_parse_mode,
                 filename=filename,
                 extra_labware=extra_labware,
@@ -355,11 +350,11 @@ def parse(
             )
 
         # our jsonschema says the top level json kind is object
-        if protocol_str and protocol_str[0] in ("{", b"{"):
+        if protocol_file and protocol_file[0] in ("{", b"{"):
             return _parse_json(protocol_str, filename)
         else:
             return _parse_python(
-                protocol_contents=protocol_str,
+                protocol_contents=protocol_file,
                 python_parse_mode=python_parse_mode,
                 filename=filename,
                 extra_labware=extra_labware,

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -369,7 +369,6 @@ def parse(
         if protocol_file and protocol_file[0] in ("{", b"{"[0]):
             return _parse_json(protocol_file, filename)
         else:
-            print(f"default assumption, file[0] is {protocol_file[0]}")
             return _parse_python(
                 protocol_contents=protocol_file,
                 python_parse_mode=python_parse_mode,

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -31,7 +31,13 @@ class StaticPythonInfo:
 
 @dataclass(frozen=True)
 class _ProtocolCommon:
-    text: str
+    text: Union[str, bytes]
+    """The original text of the protocol file in the format it was specified with.
+
+    This leads to a wide type but it is actually quite important that we do not ever
+    str.decode('utf-8') this because it will break the interpreter's understanding of
+    line numbers for if we have to format an exception.
+    """
 
     filename: Optional[str]
     """The original name of the main protocol file, if it had a name.
@@ -74,7 +80,7 @@ Protocol = Union[JsonProtocol, PythonProtocol]
 
 
 class BundleContents(NamedTuple):
-    protocol: str
+    protocol: Union[str, bytes]
     bundled_labware: Dict[str, "LabwareDefinition"]
     bundled_data: Dict[str, bytes]
     bundled_python: Dict[str, str]

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -166,7 +166,10 @@ def adapt_protocol_source(protocol: Protocol) -> Generator[ProtocolSource, None,
         # through the filesystem. https://opentrons.atlassian.net/browse/RSS-281
 
         main_file = pathlib.Path(temporary_directory) / main_file_name
-        main_file.write_text(protocol.text, encoding="utf-8")
+        if isinstance(protocol.text, str):
+            main_file.write_text(protocol.text, encoding="utf-8")
+        else:
+            main_file.write_bytes(protocol.text)
 
         labware_files: List[pathlib.Path] = []
         if isinstance(protocol, PythonProtocol) and protocol.extra_labware is not None:

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -457,7 +457,7 @@ def test_parse_json_details(
     get_json_protocol_fixture: Callable[..., Any],
     fixture_version: str,
     fixture_name: str,
-    protocol_text_kind: Literal['str', 'bytes'],
+    protocol_text_kind: Literal["str", "bytes"],
     filename: str,
 ) -> None:
     protocol = get_json_protocol_fixture(

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -1,6 +1,6 @@
 import json
 from textwrap import dedent
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, Literal
 
 import pytest
 from opentrons_shared_data.robot.dev_types import RobotType
@@ -407,7 +407,7 @@ def test_validate_json(
 @pytest.mark.parametrize("filename", ["protocol.py", None])
 def test_parse_python_details(
     protocol_source: str,
-    protocol_text_kind: str,
+    protocol_text_kind: Literal["str", "bytes"],
     filename: Optional[str],
     expected_api_level: APIVersion,
     expected_robot_type: RobotType,
@@ -423,8 +423,11 @@ def test_parse_python_details(
     parsed = parse(text, filename)
 
     assert isinstance(parsed, PythonProtocol)
-    assert parsed.text == protocol_source
-    assert isinstance(parsed.text, str)
+    assert parsed.text == text
+    if protocol_text_kind == "str":
+        assert isinstance(parsed.text, str)
+    else:
+        assert isinstance(parsed.text, bytes)
 
     assert parsed.filename == filename
     assert parsed.contents.co_filename == (
@@ -454,13 +457,13 @@ def test_parse_json_details(
     get_json_protocol_fixture: Callable[..., Any],
     fixture_version: str,
     fixture_name: str,
-    protocol_text_kind: str,
+    protocol_text_kind: Literal['str', 'bytes'],
     filename: str,
 ) -> None:
     protocol = get_json_protocol_fixture(
         fixture_version=fixture_version, fixture_name=fixture_name, decode=False
     )
-    if protocol_text_kind == "text":
+    if protocol_text_kind == "str":
         protocol_text: Union[bytes, str] = protocol
     else:
         protocol_text = protocol.encode("utf-8")


### PR DESCRIPTION
When we parse python protocols, we were doing it by (1) making it into a string with decode('utf-8') and then (2) passing the string ast.parse(). The problem with this is that decode('utf-8') does not apply "universal newlines", which means that the code object created by compiling the ast will have line numbers that are around twice what they should be under certain circumstances (windows machine, crlf file, mercury in the seventh house, etc). Then, when we go and display a nice error message about a syntax error or whatever, the user says "why is this error message pointing to a place past the end of my protocol".

This should fix that by keeping the protocol contents in bytes form all the way through to passing ast.parse() a bytes that _has never been through str.decode('utf-8')_ which should preserve everything.

# Testing
- Use a protocol like the attached
[flex_mag_mod.py.zip](https://github.com/Opentrons/opentrons/files/14201855/flex_mag_mod.py.zip) (unzip it first) that has (1) an error and (2) crlf newlines
- On windows, simulate with `opentrons_simulate` and in the app
- check that it says the error is on the right line, and not the line*2