### PR TITLE
fix(app): open external links in browser

### DIFF
--- a/app-shell/src/ui.ts
+++ b/app-shell/src/ui.ts
@@ -57,14 +57,10 @@ export function createUi(): BrowserWindow {
   mainWindow.loadURL(url, { extraHeaders: 'pragma: no-cache\n' })
 
   // open new windows (<a target="_blank" ...) in browser windows
-  mainWindow.webContents.setWindowOpenHandler(({ url, disposition }) => {
-    if (disposition === 'new-window' && url === 'about:blank') {
-      // eslint-disable-next-line no-void
-      void shell.openExternal(url)
-      return { action: 'deny' }
-    } else {
-      return { action: 'allow' }
-    }
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    // eslint-disable-next-line no-void
+    void shell.openExternal(url)
+    return { action: 'deny' }
   })
 
   return mainWindow


### PR DESCRIPTION
# Overview

This PR fixes a bug introduced by [updating electron](https://github.com/Opentrons/opentrons/pull/14314) where we were opening up external links in the electron window rather than an external browser window. 

As per the (poorly worded) [docs](https://www.electronjs.org/docs/latest/api/web-contents#contentssetwindowopenhandlerhandler), `contents.setWindowOpenHandler` is...

> Called before creating a window a new window is requested by the renderer, e.g. by window.open(), a link with target="_blank", shift+clicking on a link, or submitting a form with <form target="_blank">

So the checks we were doing before are unnecessary.

closes RQA-2309

# Test Plan

Verified internal links do not open in the browser, and verified external links do.

# Changelog

- Open external links in the browser (outside of electron)

# Review requests

Click around the app and make sure internal/external links work as expected.
# Risk assessment
Low