### PR TITLE
feat(hardware): add CAN messages to control the Hepa/UV filter.

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -250,6 +250,13 @@ class MessageId(int, Enum):
     peripheral_status_response = 0x8D
     baseline_sensor_response = 0x8E
 
+    set_hepa_fan_state_request = 0x90
+    get_hepa_fan_state_request = 0x91
+    get_hepa_fan_state_response = 0x92
+    set_hepa_uv_state_request = 0x93
+    get_hepa_uv_state_request = 0x94
+    get_hepa_uv_state_response = 0x95
+
 
 @unique
 class ErrorSeverity(int, Enum):

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -907,3 +907,73 @@ class HepaUVInfoResponse(BaseMessage):  # noqa: D101
         payloads.HepaUVInfoResponsePayload
     ] = payloads.HepaUVInfoResponsePayload
     message_id: Literal[MessageId.hepauv_info_response] = MessageId.hepauv_info_response
+
+
+@dataclass
+class SetHepaFanStateRequest(BaseMessage):
+    """Request to set the state and duty cycle of the hepa fan."""
+
+    payload: payloads.SetHepaFanStateRequestPayload
+    payload_type: Type[
+        payloads.SetHepaFanStateRequestPayload
+    ] = payloads.SetHepaFanStateRequestPayload
+    message_id: Literal[
+        MessageId.set_hepa_fan_state_request
+    ] = MessageId.set_hepa_fan_state_request
+
+
+@dataclass
+class GetHepaFanStateRequest(EmptyPayloadMessage):
+    """Request the Hepa/UV to send the state and duty cycle of the fan."""
+
+    message_id: Literal[
+        MessageId.get_hepa_fan_state_request
+    ] = MessageId.get_hepa_fan_state_request
+
+
+@dataclass
+class GetHepaFanStateResponse(BaseMessage):
+    """Hepa/UV response with the state and duty cycle of the fan."""
+
+    payload: payloads.GetHepaFanStatePayloadResponse
+    payload_type: Type[
+        payloads.GetHepaFanStatePayloadResponse
+    ] = payloads.GetHepaFanStatePayloadResponse
+    message_id: Literal[
+        MessageId.get_hepa_fan_state_response
+    ] = MessageId.get_hepa_fan_state_response
+
+
+@dataclass
+class SetHepaUVStateRequest(BaseMessage):
+    """Sets the state and timeout in seconds the UV light should stay on."""
+
+    payload: payloads.SetHepaUVStateRequestPayload
+    payload_type: Type[
+        payloads.SetHepaUVStateRequestPayload
+    ] = payloads.SetHepaUVStateRequestPayload
+    message_id: Literal[
+        MessageId.set_hepa_uv_state_request
+    ] = MessageId.set_hepa_uv_state_request
+
+
+@dataclass
+class GetHepaUVStateRequest(EmptyPayloadMessage):
+    """Request the Hepa/UV send the state and timeout in seconds for the UV light."""
+
+    message_id: Literal[
+        MessageId.get_hepa_uv_state_request
+    ] = MessageId.get_hepa_uv_state_request
+
+
+@dataclass
+class GetHepaUVStateResponse(BaseMessage):
+    """Response from the Hepa/UV state and timeout in seconds for the UV light."""
+
+    payload: payloads.GetHepaUVStatePayloadResponse
+    payload_type: Type[
+        payloads.GetHepaUVStatePayloadResponse
+    ] = payloads.GetHepaUVStatePayloadResponse
+    message_id: Literal[
+        MessageId.get_hepa_uv_state_response
+    ] = MessageId.get_hepa_uv_state_response

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -100,6 +100,12 @@ MessageDefinition = Union[
     defs.SetGripperJawHoldoffRequest,
     defs.GripperJawHoldoffRequest,
     defs.GripperJawHoldoffResponse,
+    defs.SetHepaFanStateRequest,
+    defs.GetHepaFanStateRequest,
+    defs.GetHepaFanStateResponse,
+    defs.SetHepaUVStateRequest,
+    defs.GetHepaUVStateRequest,
+    defs.GetHepaUVStateResponse,
 ]
 
 

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -631,7 +631,40 @@ class GetMotorUsageResponsePayload(_GetMotorUsageResponsePayloadBase):
 
 @dataclass(eq=False)
 class HepaUVInfoResponsePayload(EmptyPayload):
-    """A response carrying data about an attached gripper."""
+    """A response carrying data about an attached hepa uv."""
 
     model: utils.UInt16Field
     serial: SerialDataCodeField
+
+
+@dataclass(eq=False)
+class SetHepaFanStateRequestPayload(EmptyPayload):
+    """A request to set the state and pwm of a the hepa fan."""
+
+    duty_cycle: utils.UInt32Field
+    fan_on: utils.Int8Field
+
+
+@dataclass(eq=False)
+class GetHepaFanStatePayloadResponse(EmptyPayload):
+    """A response with the state and pwm of the fan."""
+
+    duty_cycle: utils.UInt32Field
+    fan_on: utils.UInt8Field
+
+
+@dataclass(eq=False)
+class SetHepaUVStateRequestPayload(EmptyPayload):
+    """A request to set the state and timeout in seconds of the hepa uv light."""
+
+    timeout_s: utils.UInt32Field
+    uv_light_on: utils.UInt8Field
+
+
+@dataclass(eq=False)
+class GetHepaUVStatePayloadResponse(EmptyPayload):
+    """A response with the state and timeout in seconds of the hepa uv light."""
+
+    timeout_s: utils.UInt32Field
+    uv_light_on: utils.UInt8Field
+    remaining_time_s: utils.UInt32Field


### PR DESCRIPTION
# Overview

We need to control the Hepa/UV filter from the Flex for testing and eventual system integration, this PR adds the CAN message definition to configure and control the Hepa fan and UV light on the device. This PR coincides with [Opentrons/ot3-firmware#753](https://github.com/Opentrons/ot3-firmware/pull/753) PR.

Closes: [RET-1422](https://opentrons.atlassian.net/browse/RET-1422) [RET-1423](https://opentrons.atlassian.net/browse/RET-1423)

# Test Plan

- Test Plan in firmware pr.

# Changelog

- Added CAN messages to set/get the hepa fan state/pwm
- Added CAN messages to set/get the hepa light state/timeout

# Review requests

- Does the API make sense?

# Risk assessment

low, unreleased

[RET-1422]: https://opentrons.atlassian.net/browse/RET-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RET-1423]: https://opentrons.atlassian.net/browse/RET-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ