### PR TITLE
fix(app): Fix improper transitioning run status in protocol runs

### DIFF
--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a185c4e1c][Flex_P1000_96_GRIPPER_HS_TM_TC_MB_2_16_Smoke].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a185c4e1c][Flex_P1000_96_GRIPPER_HS_TM_TC_MB_2_16_Smoke].json
@@ -8271,6 +8271,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8373,6 +8374,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8475,6 +8477,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8577,6 +8580,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8679,6 +8683,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8781,6 +8786,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8883,6 +8889,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -8985,6 +8992,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -9087,6 +9095,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -9189,6 +9198,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -9291,6 +9301,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -9393,6 +9404,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -9641,6 +9653,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -10316,6 +10329,7 @@
         "addressableAreaName": "movableTrashB3",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a32a763f5][Flex_P1000_96_GRIPPER_HS_TM_TC_MB_2_16_DeckConfiguration1_NoModules].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a32a763f5][Flex_P1000_96_GRIPPER_HS_TM_TC_MB_2_16_DeckConfiguration1_NoModules].json
@@ -10514,6 +10514,7 @@
         "addressableAreaName": "movableTrashC1",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -10758,6 +10759,7 @@
         "addressableAreaName": "movableTrashD1",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5eb46a4f85][Flex_P1000_96_GRIPPER_2_16_AnalysisError_DropLabwareIntoTrashBin].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5eb46a4f85][Flex_P1000_96_GRIPPER_2_16_AnalysisError_DropLabwareIntoTrashBin].json
@@ -1257,6 +1257,7 @@
         "addressableAreaName": "movableTrashC3",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a23a1de3ce][OT2_P300M_P20S_TC_HS_TM_2_16_SmokeTestV3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a23a1de3ce][OT2_P300M_P20S_TC_HS_TM_2_16_SmokeTestV3].json
@@ -11102,6 +11102,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11137,6 +11138,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11216,6 +11218,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11295,6 +11298,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11374,6 +11378,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11453,6 +11458,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11532,6 +11538,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": false,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -11561,6 +11568,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -14985,6 +14993,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -15186,6 +15195,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -15263,6 +15273,7 @@
         "addressableAreaName": "fixedTrash",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afe15b729c][Flex_P1000_96_GRIPPER_HS_TM_TC_MB_2_16_DeckConfiguration1].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afe15b729c][Flex_P1000_96_GRIPPER_HS_TM_TC_MB_2_16_DeckConfiguration1].json
@@ -12283,6 +12283,7 @@
         "addressableAreaName": "movableTrashC1",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,
@@ -12527,6 +12528,7 @@
         "addressableAreaName": "movableTrashD1",
         "alternateDropLocation": true,
         "forceDirect": false,
+        "ignoreTipConfiguration": true,
         "offset": {
           "x": 0.0,
           "y": 0.0,

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -77,9 +77,11 @@ export function useRunStatus(
     refetchInterval: DEFAULT_STATUS_REFETCH_INTERVAL,
     enabled:
       lastRunStatus.current == null ||
-      !([RUN_STATUS_FAILED, RUN_STATUS_SUCCEEDED] as RunStatus[]).includes(
-        lastRunStatus.current
-      ),
+      !([
+        RUN_STATUS_FAILED,
+        RUN_STATUS_SUCCEEDED,
+        RUN_STATUS_STOP_REQUESTED,
+      ] as RunStatus[]).includes(lastRunStatus.current),
     onSuccess: data => (lastRunStatus.current = data?.data?.status ?? null),
     ...options,
   })

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -19,7 +19,7 @@ export function useNotifyRunQuery<TError = Error>(
   const { isNotifyError } = useNotifyService({
     topic: `robot-server/runs/${runId}` as NotifyTopic,
     refetchUsingHTTP: () => setRefetchUsingHTTP(true),
-    options,
+    options: { ...options, enabled: options.enabled && runId != null },
   })
 
   const isNotifyEnabled = !isNotifyError && !options?.forceHttpPolling

--- a/react-api-client/src/runs/useAllRunsQuery.ts
+++ b/react-api-client/src/runs/useAllRunsQuery.ts
@@ -13,6 +13,10 @@ export type UseAllRunsQueryOptions = UseQueryOptions<
   Array<string | HostConfig>
 >
 
+/**
+ * @property {HostConfig | null | undefined} hostOverride:
+ * When using all runs query outside of the host context provider, we must specify the host manually.
+ */
 export function useAllRunsQuery(
   params: GetRunsParams = {},
   options: UseAllRunsQueryOptions = {},

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -112,6 +112,11 @@ class RunDataManager:
             EngineConflictError: There is a currently active run that cannot
                 be superceded by this new run.
         """
+        await self._runs_publisher.begin_polling_engine_store(
+            get_current_command=self.get_current_command,
+            get_state_summary=self._get_state_summary,
+            run_id=run_id,
+        )
         prev_run_id = self._engine_store.current_run_id
         if prev_run_id is not None:
             prev_run_result = await self._engine_store.clear()
@@ -120,7 +125,6 @@ class RunDataManager:
                 summary=prev_run_result.state_summary,
                 commands=prev_run_result.commands,
             )
-
         state_summary = await self._engine_store.create(
             run_id=run_id,
             labware_offsets=labware_offsets,
@@ -131,11 +135,6 @@ class RunDataManager:
             run_id=run_id,
             created_at=created_at,
             protocol_id=protocol.protocol_id if protocol is not None else None,
-        )
-        await self._runs_publisher.begin_polling_engine_store(
-            get_current_command=self.get_current_command,
-            get_state_summary=self._get_state_summary,
-            run_id=run_id,
         )
 
         return _build_run(

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -411,6 +411,7 @@ class RunStore:
             raise RunNotFoundError(run_id)
 
         self._clear_caches()
+        self._runs_publisher.publish_runs(run_id=run_id)
 
     def _run_exists(
         self, run_id: str, connection: sqlalchemy.engine.Connection

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -12,10 +12,6 @@ from server_utils.fastapi_utils.app_state import (
 from ..notification_client import NotificationClient, get_notification_client
 from ..topics import Topics
 
-import logging
-
-log: logging.Logger = logging.getLogger(__name__)
-
 
 class RunsPublisher:
     """Publishes protocol runs topics."""


### PR DESCRIPTION
Closes [RQA-2291](https://opentrons.atlassian.net/browse/RQA-2291), [RQA-2307](https://opentrons.atlassian.net/browse/RQA-2307), [RQA-2306](https://opentrons.atlassian.net/browse/RQA-2306), [RQA-2304](https://opentrons.atlassian.net/browse/RQA-2304)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a bug on the app side in which the incorrect property React Query was used. In order to prevent _any_ refetches, staleTime is the correct choice. Certain useRunQuery and useAllRunQuery hooks that were not updating properly now update as expected. Also, the removed `RUN_STATUS_STOP_REQUESTED` is added back to useRunStatus(), since its removal was causing bug RQA-2306. 

The python side changes are all sanity check changes - nothing new here. A new push is added to the remove method, since we want to push on every new CRUD. I don't know if this was causing bugs, but it should be fixed. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run through the bug tickets and make sure they now work.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed modals/buttons not updating correctly related to protocol runs.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2291]: https://opentrons.atlassian.net/browse/RQA-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2307]: https://opentrons.atlassian.net/browse/RQA-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2306]: https://opentrons.atlassian.net/browse/RQA-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2304]: https://opentrons.atlassian.net/browse/RQA-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ