### PR TITLE
fix(app): update useIsRobot busy hook to check for firmware update

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/organisms/Devices/hooks/__tests__/useIsRobotBusy.test.ts
@@ -16,12 +16,7 @@ import { useIsFlex } from '../useIsFlex'
 import { useNotifyCurrentMaintenanceRun } from '../../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
 import { useNotifyAllRunsQuery } from '../../../../resources/runs/useNotifyAllRunsQuery'
 
-import type {
-  Sessions,
-  Runs,
-  Subsystem,
-  CurrentSubsystemUpdates,
-} from '@opentrons/api-client'
+import type { Sessions, Runs } from '@opentrons/api-client'
 import type { AxiosError } from 'axios'
 
 jest.mock('@opentrons/react-api-client')

--- a/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
+++ b/app/src/organisms/Devices/hooks/useIsRobotBusy.ts
@@ -2,6 +2,7 @@ import {
   useAllSessionsQuery,
   useEstopQuery,
   useHost,
+  useCurrentAllSubsystemUpdatesQuery,
 } from '@opentrons/react-api-client'
 
 import { useNotifyCurrentMaintenanceRun } from '../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
@@ -33,12 +34,23 @@ export function useIsRobotBusy(
     ...queryOptions,
     enabled: isFlex,
   })
+  const {
+    data: currentSubsystemsUpdatesData,
+  } = useCurrentAllSubsystemUpdatesQuery({
+    refetchInterval: ROBOT_STATUS_POLL_MS,
+  })
+  const isSubsystemUpdating =
+    currentSubsystemsUpdatesData?.data.some(
+      update =>
+        update.updateStatus === 'queued' || update.updateStatus === 'updating'
+    ) ?? false
 
   return (
     robotHasCurrentRun ||
     isMaintenanceRunExisting ||
     (allSessionsQueryResponse?.data?.data != null &&
       allSessionsQueryResponse?.data?.data?.length !== 0) ||
-    (isFlex && estopStatus?.data.status !== DISENGAGED && estopError == null)
+    (isFlex && estopStatus?.data.status !== DISENGAGED && estopError == null) ||
+    isSubsystemUpdating
   )
 }


### PR DESCRIPTION
closes [RQA-2293](https://opentrons.atlassian.net/browse/RQA-2293)

# Overview

Query subsystem updates in useIsRobotBusy hook to check for in-progress firmware updates as discovered in erroneously enabled robot overflow menu during firmware update.

# Test Plan

- launch firmware update from ODD
- observe that robot overflow menu is disabled

# Changelog

- add subsystem update query to `usIsRobotBusy`
- audit uses of `useIsRobotBusy` to ensure we aren't accidentally disabling other areas of the app during a firmware update

# Review Requests

The polling interval in `useIsRobotBusy` is set to 30s. This was previously only used in the hook conditionally with `useNotifyCurrentMaintenanceRun` if we are using polling instead of notifications. Is this long of a polling interval not useful with `useCurrentAllSubsystemUpdatesQuery`?

# Risk assessment

medium

[RQA-2293]: https://opentrons.atlassian.net/browse/RQA-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ