### PR TITLE
 fix(app): add prop so run setup pipette flows are strung together

### DIFF
--- a/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -19,6 +19,7 @@ import {
   NINETY_SIX_CHANNEL,
   PipetteName,
   SINGLE_MOUNT_PIPETTES,
+  LoadedPipette,
 } from '@opentrons/shared-data'
 
 import { SmallButton } from '../../atoms/buttons'
@@ -49,6 +50,7 @@ interface ProtocolInstrumentMountItemProps {
   attachedInstrument: InstrumentData | null
   speccedName: PipetteName | GripperModel
   instrumentsRefetch?: () => void
+  pipetteInfo?: LoadedPipette[]
 }
 export function ProtocolInstrumentMountItem(
   props: ProtocolInstrumentMountItemProps
@@ -172,6 +174,7 @@ export function ProtocolInstrumentMountItem(
           closeFlow={() => setShowPipetteWizardFlow(false)}
           selectedPipette={selectedPipette}
           mount={mount as Mount}
+          pipetteInfo={props.pipetteInfo}
           onComplete={props.instrumentsRefetch}
         />
       ) : null}

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -47,7 +47,7 @@ export const MountingPlate = (
         setShowErrorMessage(error.message)
       })
   }
-  console.log(isRobotMoving)
+
   if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
   return errorMessage ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -5,6 +5,7 @@ import { COLORS, SPACING } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
+import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { getPipetteAnimations96 } from './utils'
 import { BODY_STYLE, FLOWS, SECTIONS } from './constants'
 import type { PipetteWizardStepProps } from './types'
@@ -13,6 +14,7 @@ export const MountingPlate = (
   props: PipetteWizardStepProps
 ): JSX.Element | null => {
   const {
+    isRobotMoving,
     goBack,
     proceed,
     flowType,
@@ -45,7 +47,8 @@ export const MountingPlate = (
         setShowErrorMessage(error.message)
       })
   }
-
+  console.log(isRobotMoving)
+  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
   return errorMessage ? (
     <SimpleWizardBody
       iconColor={COLORS.red50}

--- a/app/src/organisms/ProtocolSetupInstruments/index.tsx
+++ b/app/src/organisms/ProtocolSetupInstruments/index.tsx
@@ -86,6 +86,7 @@ export function ProtocolSetupInstruments({
             speccedName={loadedPipette.pipetteName}
             attachedInstrument={attachedPipetteMatch}
             instrumentsRefetch={refetch}
+            pipetteInfo={mostRecentAnalysis?.pipettes}
           />
         )
       })}


### PR DESCRIPTION
Fix RQA-2305, RQA-2292, RQA-2284
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
This PR fixes a few bugs (or missing implementations) in pipette flows on the ODD and app. It ensures pipette detach -> attach flows are properly strung together for ODD instrument setup and adds a "Robot is Moving" loading screen after attaching a mounting plate during 96-channel attach

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
On ODD, 
1. From run setup with the wrong instruments attached, the ODD should now initiate a "Replace pipette" flow:
![IMG_6670](https://github.com/Opentrons/opentrons/assets/14302493/779583da-9996-4e84-bc7a-207fb59fc1d0)

2. From run setup with a single channel on the left mount for a protocol that requires an ODD, the replace pipette flow should show the correct pipette name in the detach step and lower the correct mount:
![IMG_6672](https://github.com/Opentrons/opentrons/assets/14302493/3f0e5021-a3c0-4500-83b9-a91f4c8c1b0d)
![IMG_6673](https://github.com/Opentrons/opentrons/assets/14302493/c6a30045-44e1-4fa0-8e30-dc21e2f11817)

3. When attaching a 96-channel pipette, there should be a loading screen while the gantry moves after attaching a mounting plate

# Changelog
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over code and screenshots
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
