### PR TITLE
chore: use api tokens for pypi deploys

### DIFF
--- a/.github/actions/python/pypi-deploy/action.yaml
+++ b/.github/actions/python/pypi-deploy/action.yaml
@@ -28,7 +28,7 @@ runs:
           fi
         fi
         status=0
-        CI=1 QUIET=1 BUILD_NUMBER=${OT_BUILD} make -C ${{ inputs.project }} clean deploy twine_repository_url=${{ inputs.repository_url }} pypi_username=opentrons pypi_password=${{ inputs.password }} || status=$?
+        CI=1 QUIET=1 BUILD_NUMBER=${OT_BUILD} make -C ${{ inputs.project }} clean deploy twine_repository_url=${{ inputs.repository_url }} pypi_username=__token__ pypi_password=${{ inputs.password }} || status=$?
         if [[ ${status} != 0 ]] && [[ ${{ inputs.repository_url }} =~ "test.pypi.org" ]]; then
           echo "upload failures allowed to test pypi"
           exit 0

--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -27,6 +27,7 @@ runs:
     - shell: bash
       run: |
         npm install --global shx@0.3.3
+        $OT_PYTHON -m pip install --upgrade pip
         $OT_PYTHON -m pip install pipenv==2023.11.15
     - shell: bash
       run: 'make -C ${{ inputs.project }} setup'

--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -28,6 +28,6 @@ runs:
       run: |
         npm install --global shx@0.3.3
         $OT_PYTHON -m pip install --upgrade pip
-        $OT_PYTHON -m pip install pipenv==2023.11.15
+        $OT_PYTHON -m pip install pipenv==2023.12.1
     - shell: bash
       run: 'make -C ${{ inputs.project }} setup'

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -165,11 +165,11 @@ jobs:
         with:
           project: 'api'
           repository_url: 'https://test.pypi.org/legacy/'
-          password: '${{ secrets.OT_TEST_PYPI_PASSWORD }}'
+          password: '${{ secrets.TEST_PYPI_DEPLOY_TOKEN_OPENTRONS }}'
       - if: startsWith(env.OT_TAG, 'v')
         name: 'upload to real pypi'
         uses: './.github/actions/python/pypi-deploy'
         with:
           project: 'api'
           repository_url: 'https://upload.pypi.org/legacy/'
-          password: '${{ secrets.OT_PYPI_PASSWORD }}'
+          password: '${{ secrets.PYPI_DEPLOY_TOKEN_OPENTRONS }}'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -179,14 +179,14 @@ jobs:
         with:
           project: 'shared-data/python'
           repository_url: 'https://test.pypi.org/legacy/'
-          password: '${{ secrets.OT_TEST_PYPI_PASSWORD }}'
+          password: '${{ secrets.TEST_PYPI_DEPLOY_TOKEN_OPENTRONS_SHARED_DATA }}'
       - if: startsWith(env.OT_TAG, 'v')
         name: 'upload to pypi'
         uses: './.github/actions/python/pypi-deploy'
         with:
           project: 'shared-data/python'
           repository_url: 'https://upload.pypi.org/legacy/'
-          password: '${{ secrets.OT_PYPI_PASSWORD }}'
+          password: '${{ secrets.PYPI_DEPLOY_TOKEN_OPENTRONS_SHARED_DATA }}'
 
   publish-switch:
     runs-on: 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PYTHON_SETUP_TARGETS := $(addsuffix -py-setup, $(PYTHON_DIRS))
 .PHONY: setup-py
 setup-py:
 	$(OT_PYTHON) -m pip install --upgrade pip
-	$(OT_PYTHON) -m pip install pipenv==2023.11.15
+	$(OT_PYTHON) -m pip install pipenv==2023.12.1
 	$(MAKE) $(PYTHON_SETUP_TARGETS)
 
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ PYTHON_SETUP_TARGETS := $(addsuffix -py-setup, $(PYTHON_DIRS))
 
 .PHONY: setup-py
 setup-py:
+	$(OT_PYTHON) -m pip install --upgrade pip
 	$(OT_PYTHON) -m pip install pipenv==2023.11.15
 	$(MAKE) $(PYTHON_SETUP_TARGETS)
 


### PR DESCRIPTION
Update to using API tokens instead of passwords.