### PR TITLE
docs: update docs to reflect node v18 is current

### DIFF
--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -13,7 +13,7 @@ You will need the following tools installed to develop on the Opentrons platform
 - curl
 - ssh
 - Python v3.10
-- Node.js v16
+- Node.js v18
 
 ### macOS
 
@@ -82,10 +82,9 @@ Close and re-open your terminal to confirm `nvs` is installed.
 nvs --version
 ```
 
-Now we can use nvs to install Node.js v16 and switch on `auto` mode, which will make sure Node.js v16 is used any time we're in the `opentrons` project directory.
+Now we can use `nvs` to install the currently required Node.js version set in `.nvmrc`. We think it's easiest if you switch on `auto` mode which will make sure the correct version of Node.js is used any time we're in the `opentrons` project directory. ^[If you don't want to use `nvs` auto mode you'll have to manually run `use` or `install` when you want to work on the project.]
 
 ```shell
-nvs add 16
 nvs auto on
 ```
 
@@ -202,7 +201,7 @@ Once you are inside the repository for the first time, you should do two things:
 3. Run `python --version` to confirm your chosen version. If you get the incorrect version and you're using an Apple silicon Mac, try running `eval "$(pyenv init --path)"` and then `pyenv local 3.10.13`. Then check `python --version` again.
 
 ```shell
-# confirm Node v16
+# confirm Node v18
 node --version
 
 # set Python version, and confirm


### PR DESCRIPTION
# Overview

There's already a .nvmrc file but if someone is just manually following the docs, there are references to node v16 and then either `make setup` will fail if you forced the current node version to be v16 or the setup docs will be confusing.

# Test Plan
Ran locally with both `nvm` and `nvs` in both auto mode and manual mode
- nvs auto changes to v18 when I cd into the dirrectory
- `nvm install` and `nvm use` also work as expected.

# Changelog
- Updated dev setup docs to reflect that the project depends on Node v18

# Review requests

n/a

# Risk assessment
n/a