### PR TITLE
fix: ensure that pipenv is installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,15 @@ usb_host=$(shell yarn run -s discovery find -i 169.254)
 .PHONY: setup
 setup: setup-js setup-py
 
+# Both the python and JS setup targets depend on a minimal python setup so they can create
+# virtual envs using pipenv.
+.PHONY: setup-py-toolchain
+setup-py-toolchain:
+	$(OT_PYTHON) -m pip install pipenv==2023.11.15
+
 # front-end dependecies handled by yarn
 .PHONY: setup-js
-setup-js:
+setup-js: setup-py-toolchain
 	yarn config set network-timeout 60000
 	yarn
 	$(MAKE) -C $(APP_SHELL_DIR) setup
@@ -64,8 +70,7 @@ setup-js:
 PYTHON_SETUP_TARGETS := $(addsuffix -py-setup, $(PYTHON_DIRS))
 
 .PHONY: setup-py
-setup-py:
-	$(OT_PYTHON) -m pip install pipenv==2023.11.15
+setup-py: setup-py-toolchain
 	$(MAKE) $(PYTHON_SETUP_TARGETS)
 
 


### PR DESCRIPTION
# Overview

The current "out-of-the-box" dev experience fails in the following way
- `make setup` first invokes
- `make setup-js` before it runs `make setup-py`
- setup-js invokes a sub-make for the app shell which requires pipenv already setup to build the python protocol analysis sandbox.

This is fine if you've already run things before and have pipenv installed locally but it means the standard experience following the dev guides fails.

This pulls out the minimal python setup as a dependency of both the setup-py and setup-js build targets

# Test Plan

Manually tested from a clean repo and then re-ran setup in a repo that was already setup.

# Changelog

- Fixed build for freshly cloned repos when pipenv isn't available on the system


# Risk assessment

n/a