### PR TITLE
fix: allow dev Dockerfile to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM ubuntu as base
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-RUN apt-get update && apt-get install --yes python3 pip pkg-config libsystemd-dev
+RUN apt-get update && apt-get install --yes python3 pip pkg-config libsystemd-dev git
 
 FROM base as builder
 COPY scripts scripts
 COPY LICENSE LICENSE
 
 COPY shared-data shared-data
+
+COPY server-utils/setup.py server-utils/setup.py
+COPY server-utils/server_utils server-utils/server_utils
 
 COPY api/MANIFEST.in api/MANIFEST.in
 COPY api/setup.py api/setup.py
@@ -18,6 +21,7 @@ COPY robot-server/setup.py robot-server/setup.py
 COPY robot-server/robot_server robot-server/robot_server
 
 RUN cd shared-data/python && python3 setup.py bdist_wheel -d /dist/
+RUN cd server-utils && python3 setup.py bdist_wheel -d /dist/
 RUN cd api && python3 setup.py bdist_wheel -d /dist/
 RUN cd robot-server && python3 setup.py bdist_wheel -d /dist/
 


### PR DESCRIPTION
# Overview

There were 2 issues that prevented this dockerfile from building: 1) The base ubuntu image doesn't have git installed. This is required by `./scripts/python_build_utils.py` when normalizing version strings in setup.py 2) robot-server depends on server-utils but that was never copied or installed in the dockerfile

# Test Plan

Verified that a standalone docker build works

```
docker buildx build -t ot-dev .
```

Verified that the dev robot stack can be brought up and connected to 127.0.0.1 with the app.

```
docker compose up
```

# Changelog
- Fixed dev robot stack Dockerfile to include git in the builder stage and install server-utils

# Risk assessment

Unclear. This isn't used in any of the github actions. Since it was broken and `server-utils` has existed for a while, it's unclear if anyone is using the local docker dev workflow