### PR TITLE
feat(app): disable external links from opening in ODD

### DIFF
--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -58,14 +58,9 @@ export function createUi(dispatch: Dispatch): BrowserWindow {
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   mainWindow.loadURL(url, { extraHeaders: 'pragma: no-cache\n' })
 
-  // open new windows (<a target="_blank" ...) in browser windows
-  mainWindow.webContents.setWindowOpenHandler(({ url, disposition }) => {
-    if (disposition === 'new-window' && url === 'about:blank') {
-      shell.openExternal(url)
+  // never allow external links to open
+  mainWindow.webContents.setWindowOpenHandler(() => {
       return { action: 'deny' }
-    } else {
-      return { action: 'allow' }
-    }
   })
 
   return mainWindow

--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -1,5 +1,5 @@
 // sets up the main window ui
-import { app, shell, BrowserWindow } from 'electron'
+import { app, BrowserWindow } from 'electron'
 import path from 'path'
 import { sendReadyStatus } from '@opentrons/app/src/redux/shell'
 import { getConfig } from './config'
@@ -60,7 +60,7 @@ export function createUi(dispatch: Dispatch): BrowserWindow {
 
   // never allow external links to open
   mainWindow.webContents.setWindowOpenHandler(() => {
-      return { action: 'deny' }
+    return { action: 'deny' }
   })
 
   return mainWindow


### PR DESCRIPTION
# Overview

This PR disables the browser layer from opening up new windows on the ODD. 

closes RQA-2318


# Changelog

- Disable external links from opening in ODD


# Review requests

Open up release notes on the ODD and press one of the links. Nothing should happen.

# Risk assessment

Low