### PR TITLE
fix(app): scrollbar moves ODD content left

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -257,11 +257,12 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
     overflow-y: ${OVERFLOW_AUTO};
 
     &::-webkit-scrollbar {
-      display: ${isScrolling ? 'block' : 'none'};
+      display: block;
       width: 0.75rem;
     }
 
     &::-webkit-scrollbar-thumb {
+      display: ${isScrolling ? 'block' : 'none'};
       background: ${COLORS.grey50};
       border-radius: 11px;
     }


### PR DESCRIPTION
closes [RQA-2329](https://opentrons.atlassian.net/browse/RQA-2329)

# Overview

prevent scrollbar presence from moving ODD content left

# Test Plan

- navigate to scrollable route on ODD (ex: Settings tab)
- scroll up and down
- observe that content remains fixed even with presence of scrollbar

https://github.com/Opentrons/opentrons/assets/47604184/42e3f182-d637-422f-8efc-e80f783d04b3

# Changelog

# Risk assessment

low

[RQA-2329]: https://opentrons.atlassian.net/browse/RQA-2329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ