### PR TITLE
 fix(app): remove [Object, object] tooltip from appearing on hover

### DIFF
--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -68,7 +68,7 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
       onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
       marginLeft={styleProps.marginLeft ?? '7.125rem'}
-      {...props}
+      {...styleProps}
       footer={footer}
     >
       <Box padding={childrenPadding}>{children}</Box>

--- a/app/src/organisms/AnalyticsSettingsModal/index.tsx
+++ b/app/src/organisms/AnalyticsSettingsModal/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 import {
   Flex,
   SPACING,
@@ -34,7 +35,7 @@ export function AnalyticsSettingsModal(): JSX.Element | null {
     dispatch(toggleAnalyticsOptedIn())
   }
 
-  return !seen || !hasOptedIn ? (
+  return seen || !hasOptedIn ? (
     <LegacyModal
       title={
         <StyledText css={TYPOGRAPHY.h3SemiBold}>
@@ -58,7 +59,7 @@ export function AnalyticsSettingsModal(): JSX.Element | null {
           <Flex gridGap={SPACING.spacing10} flexDirection={DIRECTION_COLUMN}>
             <Trans
               t={t}
-              i18nKey={t('privacy_body')}
+              i18nKey="privacy_body"
               components={{ block: <StyledText as="p" /> }}
             />
           </Flex>

--- a/app/src/organisms/AnalyticsSettingsModal/index.tsx
+++ b/app/src/organisms/AnalyticsSettingsModal/index.tsx
@@ -35,7 +35,7 @@ export function AnalyticsSettingsModal(): JSX.Element | null {
     dispatch(toggleAnalyticsOptedIn())
   }
 
-  return seen || !hasOptedIn ? (
+  return !seen || !hasOptedIn ? (
     <LegacyModal
       title={
         <StyledText css={TYPOGRAPHY.h3SemiBold}>

--- a/app/src/organisms/AnalyticsSettingsModal/index.tsx
+++ b/app/src/organisms/AnalyticsSettingsModal/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Trans, useTranslation } from 'react-i18next'
-import { css } from 'styled-components'
 import {
   Flex,
   SPACING,

--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -129,6 +129,8 @@ describe('UpdateAppModal', () => {
       error: { name: 'Update Error' },
     } as ShellUpdateState)
     render(props)
-    expect(screen.getByTitle('Update Error')).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: 'Update Error' })
+    ).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
closes RQA-2323

# Overview

This was a tricky bug, I narrowed down the issue occurring with the `LegacyModal` and there must have been some sort of conflict with passing down the props, so changing it from `...props` (passing down all props even the ones already written out) to `...styleProps` (passing down only styled components props) ensured that only the style props were being passed down. I also fixed a i18n bug i introduced in the modal.

Before:

https://github.com/Opentrons/opentrons/assets/66035149/f9dbadbb-cf52-4658-aa1d-1a934d42f0d3

After:

https://github.com/Opentrons/opentrons/assets/66035149/11fccfc4-6204-4755-9f4a-1cd039fd9075


# Test Plan

See the videos but also test for yourself if you want. An easy way to test is to change the `seen` boolean logic from `!seen` to `seen`.

# Changelog

- fix i18n bug with the `Trans` component
- change `LegacyModal`'s spread operator props.

# Review requests

see test plan

# Risk assessment

low