### PR TITLE
fix(api): OT-2 trash bins in 2.16 get added to engine at the start of protocol

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -41,7 +41,7 @@ from opentrons.protocols import parse
 from opentrons.protocols.api_support.deck_type import (
     guess_from_global_config as guess_deck_type_from_global_config,
     should_load_fixed_trash,
-    should_load_fixed_trash_for_python_protocol,
+    should_load_fixed_trash_labware_for_python_protocol,
 )
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.execution import execute as execute_apiv2
@@ -540,7 +540,9 @@ def _create_live_context_pe(
             config=_get_protocol_engine_config(),
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
-            load_fixed_trash=should_load_fixed_trash_for_python_protocol(api_version),
+            load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
+                api_version
+            ),
         )
     )
 

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -134,9 +134,14 @@ class ProtocolCore(
     def append_disposal_location(
         self,
         disposal_location: Union[Labware, TrashBin, WasteChute],
-        skip_add_to_engine: bool = False,
     ) -> None:
-        """Append a disposal location object to the core"""
+        """Append a disposal location object to the core."""
+        self._disposal_locations.append(disposal_location)
+
+    def add_disposal_location_to_engine(
+        self, disposal_location: Union[TrashBin, WasteChute]
+    ) -> None:
+        """Verify and add disposal location to engine store and append it to the core."""
         if isinstance(disposal_location, TrashBin):
             self._engine_client.state.addressable_areas.raise_if_area_not_in_deck_configuration(
                 disposal_location.area_name
@@ -152,8 +157,7 @@ class ProtocolCore(
                 existing_labware_ids=list(self._labware_cores_by_id.keys()),
                 existing_module_ids=list(self._module_cores_by_id.keys()),
             )
-            if not skip_add_to_engine:
-                self._engine_client.add_addressable_area(disposal_location.area_name)
+            self._engine_client.add_addressable_area(disposal_location.area_name)
         elif isinstance(disposal_location, WasteChute):
             # TODO(jbl 2024-01-25) hardcoding this specific addressable area should be refactored
             #   when analysis is fixed up
@@ -166,9 +170,8 @@ class ProtocolCore(
             self._engine_client.state.addressable_areas.raise_if_area_not_in_deck_configuration(
                 "1ChannelWasteChute"
             )
-            if not skip_add_to_engine:
-                self._engine_client.add_addressable_area("1ChannelWasteChute")
-        self._disposal_locations.append(disposal_location)
+            self._engine_client.add_addressable_area("1ChannelWasteChute")
+        self.append_disposal_location(disposal_location)
 
     def get_disposal_locations(self) -> List[Union[Labware, TrashBin, WasteChute]]:
         """Get disposal locations."""

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -136,13 +136,17 @@ class LegacyProtocolCore(
     def append_disposal_location(
         self,
         disposal_location: Union[Labware, TrashBin, WasteChute],
-        skip_add_to_engine: bool = False,
     ) -> None:
         if isinstance(disposal_location, (TrashBin, WasteChute)):
             raise APIVersionError(
                 "Trash Bin and Waste Chute Disposal locations are not supported in this API Version."
             )
         self._disposal_locations.append(disposal_location)
+
+    def add_disposal_location_to_engine(
+        self, disposal_location: Union[TrashBin, WasteChute]
+    ) -> None:
+        assert False, "add_disposal_location_to_engine only supported on engine core"
 
     def add_labware_definition(
         self,

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -65,9 +65,15 @@ class AbstractProtocol(
     def append_disposal_location(
         self,
         disposal_location: Union[Labware, TrashBin, WasteChute],
-        skip_add_to_engine: bool = False,
     ) -> None:
         """Append a disposal location object to the core"""
+        ...
+
+    @abstractmethod
+    def add_disposal_location_to_engine(
+        self, disposal_location: Union[TrashBin, WasteChute]
+    ) -> None:
+        """Verify and add disposal location to engine store and append it to the core."""
         ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -15,10 +15,14 @@ from opentrons.util.broker import Broker
 from opentrons.protocol_engine import ProtocolEngine
 from opentrons.protocol_engine.clients import SyncClient, ChildThreadTransport
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.deck_type import (
+    should_load_fixed_trash_area_for_python_protocol,
+)
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 
 from .protocol_context import ProtocolContext
 from .deck import Deck
+from ._trash_bin import TrashBin
 
 from .core.common import ProtocolCore as AbstractProtocolCore
 from .core.legacy.deck import Deck as LegacyDeck
@@ -148,7 +152,7 @@ def create_protocol_context(
     # this swap may happen once `ctx.move_labware` off-deck is implemented
     deck = None if isinstance(core, ProtocolCore) else cast(Deck, core.get_deck())
 
-    return ProtocolContext(
+    context = ProtocolContext(
         api_version=api_version,
         # TODO(mm, 2023-05-11): This cast shouldn't be necessary.
         # Fix this by making the appropriate TypeVars covariant?
@@ -158,3 +162,17 @@ def create_protocol_context(
         deck=deck,
         bundled_data=bundled_data,
     )
+    # If we're loading an engine based core into the context, and we're on api level 2.16 or above, and on an OT-2
+    # we need to insert a fixed trash addressable area into the protocol engine for correctness in anything that relies
+    # on knowing what addressable areas have been loaded (and any checks involving trash geometry). Because the method
+    # that uses this in the core relies on the sync client
+    if (
+        protocol_engine is not None
+        and should_load_fixed_trash_area_for_python_protocol(
+            api_version=api_version,
+            robot_type=protocol_engine.state_view.config.robot_type,
+        )
+    ):
+        assert isinstance(context.fixed_trash, TrashBin)
+        protocol_engine.add_addressable_area(context.fixed_trash.area_name)
+    return context

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -162,10 +162,11 @@ def create_protocol_context(
         deck=deck,
         bundled_data=bundled_data,
     )
-    # If we're loading an engine based core into the context, and we're on api level 2.16 or above, and on an OT-2
-    # we need to insert a fixed trash addressable area into the protocol engine for correctness in anything that relies
-    # on knowing what addressable areas have been loaded (and any checks involving trash geometry). Because the method
-    # that uses this in the core relies on the sync client
+    # If we're loading an engine based core into the context, and we're on api level 2.16 or above, on an OT-2 we need
+    # to insert a fixed trash addressable area into the protocol engine, for correctness in anything that relies on
+    # knowing what addressable areas have been loaded (and any checks involving trash geometry). Because the method
+    # that uses this in the core relies on the sync client and this code will run in the main thread (which if called
+    # will cause a deadlock), we're directly calling the protocol engine method here where we have access to it.
     if (
         protocol_engine is not None
         and should_load_fixed_trash_area_for_python_protocol(

--- a/api/src/opentrons/protocols/api_support/deck_type.py
+++ b/api/src/opentrons/protocols/api_support/deck_type.py
@@ -45,15 +45,30 @@ class NoTrashDefinedError(EnumeratedError):
         )
 
 
-def should_load_fixed_trash_for_python_protocol(api_version: APIVersion) -> bool:
+def should_load_fixed_trash_labware_for_python_protocol(
+    api_version: APIVersion,
+) -> bool:
+    """Whether to automatically load the fixed trash as a labware for a Python protocol at protocol start."""
     return api_version <= LOAD_FIXED_TRASH_GATE_VERSION_PYTHON
 
 
+def should_load_fixed_trash_area_for_python_protocol(
+    api_version: APIVersion, robot_type: RobotType
+) -> bool:
+    """Whether to automatically load the fixed trash addressable area for OT-2 protocols on 2.16 and above."""
+    return (
+        api_version > LOAD_FIXED_TRASH_GATE_VERSION_PYTHON
+        and robot_type == "OT-2 Standard"
+    )
+
+
 def should_load_fixed_trash(protocol_config: ProtocolConfig) -> bool:
-    """Decide whether to automatically load fixed trash on the deck based on version."""
+    """Decide whether to automatically load fixed trash labware on the deck based on version."""
     load_fixed_trash = False
     if isinstance(protocol_config, PythonProtocolConfig):
-        return should_load_fixed_trash_for_python_protocol(protocol_config.api_version)
+        return should_load_fixed_trash_labware_for_python_protocol(
+            protocol_config.api_version
+        )
     # TODO(jbl 2023-10-27), when schema v8 is out, use a new deck version field to support fixed trash protocols
     elif isinstance(protocol_config, JsonProtocolConfig):
         load_fixed_trash = (

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -66,7 +66,7 @@ from opentrons.protocols.types import (
 from opentrons.protocols.api_support.deck_type import (
     for_simulation as deck_type_for_simulation,
     should_load_fixed_trash,
-    should_load_fixed_trash_for_python_protocol,
+    should_load_fixed_trash_labware_for_python_protocol,
 )
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
@@ -801,7 +801,9 @@ def _create_live_context_pe(
             config=_get_protocol_engine_config(robot_type),
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
-            load_fixed_trash=should_load_fixed_trash_for_python_protocol(api_version),
+            load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
+                api_version
+            ),
         )
     )
 

--- a/api/tests/opentrons/protocol_api_integration/test_trashes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_trashes.py
@@ -123,16 +123,6 @@ def test_trash_search() -> None:
             "2.16",
             "OT-2",
             False,
-            # This should ideally raise, matching OT-2 behavior on prior Protocol API versions.
-            # It currently does not because Protocol API v2.15's trashes are implemented as
-            # addressable areas, not labware--and they're only brought into existence
-            # *on first use,* not at the beginning of a protocol.
-            #
-            # The good news is that even though the conflicting load will not raise like we want,
-            # something in the protocol will eventually raise, e.g. when a pipette goes to drop a
-            # tip in the fixed trash and finds that a fixed trash can't exist there because there's
-            # a labware.
-            marks=pytest.mark.xfail(strict=True, raises=pytest.fail.Exception),
         ),
         pytest.param(
             "2.16",


### PR DESCRIPTION
# Overview

This PR refactors #14433 to fix a known inconsistency it introduced.

When the new `TrashBin` and `WasteChute` objects were introduced in api level 2.16 in version 7.1.0 of the robot, there was a peculiarity of how they were loaded in PAPI versus when they would actually appear in the engine during analysis. Because of the way the protocol engine commands were designed, they'd only be recognized when first used i.e. whenever the pipette would first move to the trash for a drop tip, dispense, or blow out. This caused analysis caught errors to display wrong line numbers and made relying on the addressable area store in engine during analysis more difficult.

To fix all this, in #14325 a protocol action was added to allow the addressable areas representing the trash bin and waste chute to be immediately added to engine on a load. This worked for Flex protocols, but because of a threading issue caused OT-2 protocols to hang during analysis. To fix this issue, #14433 reverted OT-2s to load the fixed trash addressable area on first reference, not at the start of the protocol.

This PR fixes that by refactoring the protocol core methods that add trash bins and waste chutes to the engine and internal list of disposal locations. Now there are two methods, one that just adds a disposal location (a `Labware`, `TrashBin` or `WasteChute` to the engine core's `self._disposal_locations` list and another one that does that _and_ adds and validates the area, only for the latter two objects. Now for OT-2s, in the `ProtocolContext.__init__` method the OT-2 fixed trash `TrashBin` is only appended to the core list. In order to fix the inconsistency, in `create_protocol_context` the protocol engine method is called directly to add that trash.

# Test Plan

Re-using test protocols from previous PRs, this protocol passes analysis/simulate without deadlocking
```
requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.16"
}


def run(context):
    pass
```

These protocols correctly fail analysis
```
metadata = {
    'protocolName': 'Thermocycler conflict 1',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.16"
}


def run(context):
    thermocycler = context.load_module("thermocyclerModuleV2")
    trash = context.load_trash_bin('A1')
```
```
metadata = {
    'protocolName': 'Heater-shaker conflict OT-2',
}

requirements = {
    "robotType": "OT-2",
    "apiLevel": "2.16"
}


def run(context):
    # Both these lines should raise
    heater_shaker = context.load_module("heaterShakerModuleV1", '11')
    heater_shaker_2 = context.load_module("heaterShakerModuleV1", '9')
```

# Changelog

- removes `skip_add_to_engine` boolean flag for `append_disposal_location` and remove adding it to engine in that method
- add core method `add_disposal_location_to_engine` to add and verify against the engine/deck conflict for new trash objects
- add a `should_load_fixed_trash_area_for_python_protocol` method to see if we should add the area in `create_protocol_context` and to make sure it stays in sync with `ProtocolContext.__init__`


# Risk assessment

Low.