### PR TITLE
fix(app-shell, app-shell-odd): Fix intermittently dropped notifications

### DIFF
--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -184,30 +184,38 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   }
 }
 
+// Because subscription logic is directly tied to the component lifecycle, it is possible
+// for a component to trigger an unsubscribe event on dismount while a new component mounts and
+// triggers a subscribe event. For the connection store and MQTT to reflect correct topic subscriptions,
+// do not unsubscribe and close connections before newly mounted components have had time to update the connection store.
+const RENDER_TIMEOUT = 250
+
 function unsubscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic } = notifyParams
   return new Promise<void>(() => {
     if (hostname in connectionStore) {
-      const { client } = connectionStore[hostname]
-      const subscriptions = connectionStore[hostname]?.subscriptions
-      const isLastSubscription = subscriptions[topic] <= 1
+      setTimeout(() => {
+        const { client } = connectionStore[hostname]
+        const subscriptions = connectionStore[hostname]?.subscriptions
+        const isLastSubscription = subscriptions[topic] <= 1
 
-      if (isLastSubscription) {
-        client?.unsubscribe(topic, {}, (error, result) => {
-          if (error != null) {
-            log.warn(
-              `Failed to unsubscribe on ${hostname} from topic: ${topic}`
-            )
-          } else {
-            log.info(
-              `Successfully unsubscribed on ${hostname} from topic: ${topic}`
-            )
-            handleDecrementSubscriptionCount(hostname, topic)
-          }
-        })
-      } else {
-        subscriptions[topic] -= 1
-      }
+        if (isLastSubscription) {
+          client?.unsubscribe(topic, {}, (error, result) => {
+            if (error != null) {
+              log.warn(
+                `Failed to unsubscribe on ${hostname} from topic: ${topic}`
+              )
+            } else {
+              log.info(
+                `Successfully unsubscribed on ${hostname} from topic: ${topic}`
+              )
+              handleDecrementSubscriptionCount(hostname, topic)
+            }
+          })
+        } else {
+          subscriptions[topic] -= 1
+        }
+      }, RENDER_TIMEOUT)
     } else {
       log.info(
         `Attempted to unsubscribe from unconnected hostname: ${hostname}`

--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -188,7 +188,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
 // for a component to trigger an unsubscribe event on dismount while a new component mounts and
 // triggers a subscribe event. For the connection store and MQTT to reflect correct topic subscriptions,
 // do not unsubscribe and close connections before newly mounted components have had time to update the connection store.
-const RENDER_TIMEOUT = 250
+const RENDER_TIMEOUT = 10000 // 10 seconds
 
 function unsubscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic } = notifyParams

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -180,30 +180,38 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   }
 }
 
+// Because subscription logic is directly tied to the component lifecycle, it is possible
+// for a component to trigger an unsubscribe event on dismount while a new component mounts and
+// triggers a subscribe event. For the connection store and MQTT to reflect correct topic subscriptions,
+// do not unsubscribe and close connections before newly mounted components have had time to update the connection store.
+const RENDER_TIMEOUT = 250
+
 function unsubscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic } = notifyParams
   return new Promise<void>(() => {
     if (hostname in connectionStore) {
-      const { client } = connectionStore[hostname]
-      const subscriptions = connectionStore[hostname]?.subscriptions
-      const isLastSubscription = subscriptions[topic] <= 1
+      setTimeout(() => {
+        const { client } = connectionStore[hostname]
+        const subscriptions = connectionStore[hostname]?.subscriptions
+        const isLastSubscription = subscriptions[topic] <= 1
 
-      if (isLastSubscription) {
-        client?.unsubscribe(topic, {}, (error, result) => {
-          if (error != null) {
-            log.warn(
-              `Failed to unsubscribe on ${hostname} from topic: ${topic}`
-            )
-          } else {
-            log.info(
-              `Successfully unsubscribed on ${hostname} from topic: ${topic}`
-            )
-            handleDecrementSubscriptionCount(hostname, topic)
-          }
-        })
-      } else {
-        subscriptions[topic] -= 1
-      }
+        if (isLastSubscription) {
+          client?.unsubscribe(topic, {}, (error, result) => {
+            if (error != null) {
+              log.warn(
+                `Failed to unsubscribe on ${hostname} from topic: ${topic}`
+              )
+            } else {
+              log.info(
+                `Successfully unsubscribed on ${hostname} from topic: ${topic}`
+              )
+              handleDecrementSubscriptionCount(hostname, topic)
+            }
+          })
+        } else {
+          subscriptions[topic] -= 1
+        }
+      }, RENDER_TIMEOUT)
     } else {
       log.info(
         `Attempted to unsubscribe from unconnected hostname: ${hostname}`

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -184,7 +184,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
 // for a component to trigger an unsubscribe event on dismount while a new component mounts and
 // triggers a subscribe event. For the connection store and MQTT to reflect correct topic subscriptions,
 // do not unsubscribe and close connections before newly mounted components have had time to update the connection store.
-const RENDER_TIMEOUT = 250
+const RENDER_TIMEOUT = 10000 // 10 seconds
 
 function unsubscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic } = notifyParams


### PR DESCRIPTION
Closes [RQA-2339](https://opentrons.atlassian.net/browse/RQA-2339), [RQA-2321](https://opentrons.atlassian.net/browse/RQA-2321), [RQA-2319](https://opentrons.atlassian.net/browse/RQA-2319), [RAUT-962](https://opentrons.atlassian.net/browse/RAUT-962)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Our subscribe/unsubscribe logic is directly tied to the component lifecycle. If a component dismounts and unsubscribes to a given topic while a new component mounts and subscribes to the same topic, a race condition occurs in which the shell layer often thinks the subscribing component is subscribed when it is in fact not. This race condition occurs when switching pages that contain components on each page interested in the same topic. 

The most straightforward fix is to set a small timeout any time an unsubscribe request goes through to accommodate any additional rendering that might occur. After the timeout, then check to see if the connection manager really wants to unsubscribe. 

I think this solution makes the most sense, but I'm open to alternatives. 

Some things I considered:
1) We could in theory never unsubscribe to topics, but that means the MQTT broker holds more subscriptions in memory until the robot is power cycled (or the broker is restarted). 
2) Alternatively, we could somehow not handle subscriptions within components. This sounds great in theory, but our routes are not always entirely static (ex, we subscribe to runs/abc123, which we may not need 5 minutes from now). 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Push this branch to the ODD.
- On the desktop app, navigate to the DeviceDetails page.
- Launch a protocol. The desktop app should display the run status in the upper right corner.
- On the ODD, pause/play a protocol repeatedly. The desktop app run status should update. 
- The ODD buttons should update as expected. 
- Cancelling a protocol on the ODD should cause the "cancelling" modal to eventually unrender. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed an issue in which the app and ODD did not correctly reflect the current protocol run status.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2339]: https://opentrons.atlassian.net/browse/RQA-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2321]: https://opentrons.atlassian.net/browse/RQA-2321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2319]: https://opentrons.atlassian.net/browse/RQA-2319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RAUT-962]: https://opentrons.atlassian.net/browse/RAUT-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RQA-2346]: https://opentrons.atlassian.net/browse/RQA-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ