### PR TITLE
fix(api): do not include HEPA-UV in motor nodes

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -351,13 +351,13 @@ def motor_nodes(devices: Set[FirmwareTarget]) -> Set[NodeId]:
         NodeId.head_bootloader,
         NodeId.gripper_bootloader,
     }
-    hepa_nv_nodes = {
+    hepa_uv_nodes = {
         NodeId.hepa_uv,
         NodeId.hepa_uv_bootloader,
     }
     # remove any bootloader nodes
     motor_nodes -= bootloader_nodes
-    motor_nodes -= hepa_nv_nodes
+    motor_nodes -= hepa_uv_nodes
     # filter out usb nodes
     return {NodeId(target) for target in motor_nodes if target in NodeId}
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -351,8 +351,13 @@ def motor_nodes(devices: Set[FirmwareTarget]) -> Set[NodeId]:
         NodeId.head_bootloader,
         NodeId.gripper_bootloader,
     }
+    hepa_nv_nodes = {
+        NodeId.hepa_uv,
+        NodeId.hepa_uv_bootloader,
+    }
     # remove any bootloader nodes
     motor_nodes -= bootloader_nodes
+    motor_nodes -= hepa_nv_nodes
     # filter out usb nodes
     return {NodeId(target) for target in motor_nodes if target in NodeId}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We should exclude hepa uv and its bootloader node from the motor nodes, so we don't get a timeout response fetching motor position from them.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
