### PR TITLE
feat(hardware, api): check motor engaged status

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -309,6 +309,14 @@ class FlexBackend(Protocol):
         """Get engaged axes."""
         ...
 
+    async def update_engaged_axes(self) -> None:
+        """Update engaged axes."""
+        ...
+
+    async def is_motor_engaged(self, axis: Axis) -> bool:
+        """Check if axis is enabled."""
+        ...
+
     async def disengage_axes(self, axes: List[Axis]) -> None:
         """Disengage axes."""
         ...

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1161,16 +1161,15 @@ class OT3Controller(FlexBackend):
     def axis_bounds(self) -> OT3AxisMap[Tuple[float, float]]:
         """Get the axis bounds."""
         # TODO (AL, 2021-11-18): The bounds need to be defined
-        phony_bounds = (0, 300)
         return {
-            Axis.Z_L: phony_bounds,
-            Axis.Z_R: phony_bounds,
-            Axis.P_L: phony_bounds,
-            Axis.P_R: phony_bounds,
-            Axis.X: phony_bounds,
-            Axis.Y: phony_bounds,
-            Axis.Z_G: phony_bounds,
-            Axis.Q: phony_bounds,
+            Axis.Z_L: (0, 300),
+            Axis.Z_R: (0, 300),
+            Axis.P_L: (0, 200),
+            Axis.P_R: (0, 200),
+            Axis.X: (0, 550),
+            Axis.Y: (0, 550),
+            Axis.Z_G: (0, 300),
+            Axis.Q: (0, 200),
         }
 
     def engaged_axes(self) -> OT3AxisMap[bool]:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -97,6 +97,7 @@ class OT3Simulator(FlexBackend):
     _position: Dict[Axis, float]
     _encoder_position: Dict[Axis, float]
     _motor_status: Dict[Axis, MotorStatus]
+    _engaged_axes: Dict[Axis, bool]
 
     @classmethod
     async def build(

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -149,6 +149,7 @@ class OT3Simulator(FlexBackend):
         self._initialized = False
         self._lights = {"button": False, "rails": False}
         self._gear_motor_position: Dict[Axis, float] = {}
+        self._engaged_axes: Dict[Axis, bool] = {}
         self._feature_flags = feature_flags or HardwareFeatureFlags()
 
         def _sanitize_attached_instrument(

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -376,6 +376,8 @@ class OT3Simulator(FlexBackend):
         Returns:
             None
         """
+        for ax in origin:
+            self._engaged_axes[ax] = True
         self._position.update(target)
         self._encoder_position.update(target)
 
@@ -398,6 +400,7 @@ class OT3Simulator(FlexBackend):
         for h in homed:
             self._position[h] = self._get_home_position()[h]
             self._motor_status[h] = MotorStatus(True, True)
+            self._engaged_axes[h] = True
         return axis_pad(self._position, 0.0)
 
     @ensure_yield
@@ -652,6 +655,8 @@ class OT3Simulator(FlexBackend):
         return None
 
     async def is_motor_engaged(self, axis: Axis) -> bool:
+        if not axis in self._engaged_axes.keys():
+            return False
         return self._engaged_axes[axis]
 
     @ensure_yield

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -643,16 +643,27 @@ class OT3Simulator(FlexBackend):
 
     def engaged_axes(self) -> OT3AxisMap[bool]:
         """Get engaged axes."""
-        return {}
+        return self._engaged_axes
+
+    async def update_engaged_axes(self) -> None:
+        """Update engaged axes."""
+        return None
+
+    async def is_motor_engaged(self, axis: Axis) -> bool:
+        return self._engaged_axes[axis]
 
     @ensure_yield
     async def disengage_axes(self, axes: List[Axis]) -> None:
         """Disengage axes."""
+        for ax in axes:
+            self._engaged_axes.update({ax: False})
         return None
 
     @ensure_yield
     async def engage_axes(self, axes: List[Axis]) -> None:
         """Engage axes."""
+        for ax in axes:
+            self._engaged_axes.update({ax: True})
         return None
 
     @ensure_yield

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -655,7 +655,7 @@ class OT3Simulator(FlexBackend):
         return None
 
     async def is_motor_engaged(self, axis: Axis) -> bool:
-        if not axis in self._engaged_axes.keys():
+        if axis not in self._engaged_axes.keys():
             return False
         return self._engaged_axes[axis]
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -263,7 +263,9 @@ class OT3API(
             realmount == OT3Mount.LEFT
             and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
         ):
-            return not self.engaged_axes[Axis.by_mount(realmount)]
+            ax = Axis.by_mount(realmount)
+            if ax in self.engage_axes.keys():
+                return not self.engaged_axes[ax]
 
         return False
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -264,7 +264,7 @@ class OT3API(
             and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
         ):
             ax = Axis.by_mount(realmount)
-            if ax in self.engage_axes.keys():
+            if ax in self.engaged_axes.keys():
                 return not self.engaged_axes[ax]
 
         return False

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -155,6 +155,7 @@ class MessageId(int, Enum):
     error_message = 0x02
 
     get_status_request = 0x01
+    get_gear_status_response = 0x4
     get_status_response = 0x05
 
     enable_motor_request = 0x06

--- a/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/message_definitions.py
@@ -157,6 +157,17 @@ class GetStatusResponse(BaseMessage):  # noqa: D101
 
 
 @dataclass
+class GearStatusResponse(BaseMessage):  # noqa: D101
+    payload: payloads.GetStatusResponsePayload
+    payload_type: Type[
+        payloads.GetStatusResponsePayload
+    ] = payloads.GetStatusResponsePayload
+    message_id: Literal[
+        MessageId.get_gear_status_response
+    ] = MessageId.get_gear_status_response
+
+
+@dataclass
 class MoveRequest(BaseMessage):  # noqa: D101
     payload: payloads.MoveRequestPayload
     payload_type: Type[payloads.MoveRequestPayload] = payloads.MoveRequestPayload

--- a/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/messages.py
@@ -19,6 +19,7 @@ MessageDefinition = Union[
     defs.StopRequest,
     defs.GetStatusRequest,
     defs.GetStatusResponse,
+    defs.GearStatusResponse,
     defs.EnableMotorRequest,
     defs.DisableMotorRequest,
     defs.MoveRequest,

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -128,7 +128,6 @@ class GetStatusResponsePayload(EmptyPayload):
     """Get status response."""
 
     status: utils.UInt8Field
-    data: utils.UInt32Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
@@ -1,14 +1,26 @@
 """Utilities for updating the enable/disable state of an OT3 axis."""
 from typing import Set
 import logging
-from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+import asyncio
+from opentrons_hardware.drivers.can_bus.can_messenger import (
+    CanMessenger,
+    WaitableCallback,
+)
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     EnableMotorRequest,
     DisableMotorRequest,
     GearEnableMotorRequest,
     GearDisableMotorRequest,
+    GetStatusRequest,
+    GetStatusResponse,
+    GearStatusResponse,
 )
-from opentrons_hardware.firmware_bindings.constants import NodeId, ErrorCode
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+from opentrons_hardware.firmware_bindings.constants import (
+    NodeId,
+    ErrorCode,
+    MessageId,
+)
 
 log = logging.getLogger(__name__)
 
@@ -71,3 +83,59 @@ async def set_disable_tip_motor(
         )
         if error != ErrorCode.ok:
             log.error(f"recieved error {str(error)} trying to disable {str(node)} ")
+
+
+async def get_motor_enabled(
+    can_messenger: CanMessenger,
+    node: NodeId,
+    timeout: float = 0.5,
+) -> bool:
+    """Get motor status of a node."""
+
+    def _filter(arbitration_id: ArbitrationId) -> bool:
+        return (NodeId(arbitration_id.parts.originating_node_id) == node) and (
+            MessageId(arbitration_id.parts.message_id) == GetStatusResponse.message_id
+        )
+
+    async def _wait_for_response(reader: WaitableCallback) -> bool:
+        """Listener for receving motor status messages."""
+        async for response, _ in reader:
+            if isinstance(response, GetStatusResponse):
+                return bool(response.payload.status.value)
+        raise StopAsyncIteration
+
+    with WaitableCallback(can_messenger, _filter) as reader:
+        await can_messenger.send(node_id=node, message=GetStatusRequest())
+        try:
+            return await asyncio.wait_for(_wait_for_response(reader), timeout)
+        except asyncio.TimeoutError:
+            log.warning("Read motor status timed out")
+            raise StopAsyncIteration
+
+
+async def get_tip_motor_enabled(
+    can_messenger: CanMessenger,
+    node: NodeId,
+    timeout: float = 0.5,
+) -> bool:
+    """Get motor status of a node."""
+
+    def _filter(arbitration_id: ArbitrationId) -> bool:
+        return (NodeId(arbitration_id.parts.originating_node_id) == node) and (
+            MessageId(arbitration_id.parts.message_id) == GetStatusResponse.message_id
+        )
+
+    async def _wait_for_response(reader: WaitableCallback) -> bool:
+        """Listener for receving motor status messages."""
+        async for response, _ in reader:
+            if isinstance(response, GearStatusResponse):
+                return bool(response.payload.status.value)
+        raise StopAsyncIteration
+
+    with WaitableCallback(can_messenger, _filter) as reader:
+        await can_messenger.send(node_id=node, message=GetStatusRequest())
+        try:
+            return await asyncio.wait_for(_wait_for_response(reader), timeout)
+        except asyncio.TimeoutError:
+            log.warning("Read tip motor status timed out")
+            raise StopAsyncIteration

--- a/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
@@ -1,5 +1,5 @@
 """Utilities for updating the enable/disable state of an OT3 axis."""
-from typing import Set
+from typing import Dict, Set
 import logging
 import asyncio
 from opentrons_hardware.drivers.can_bus.can_messenger import (
@@ -21,6 +21,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     ErrorCode,
     MessageId,
 )
+from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
 
 log = logging.getLogger(__name__)
 
@@ -87,30 +88,41 @@ async def set_disable_tip_motor(
 
 async def get_motor_enabled(
     can_messenger: CanMessenger,
-    node: NodeId,
-    timeout: float = 0.5,
-) -> bool:
-    """Get motor status of a node."""
+    nodes: Set[NodeId],
+    timeout: float = 1.0,
+) -> Dict[NodeId, bool]:
+    """Get motor status of a set of nodes."""
+    expected = nodes or set()
+    reported: Dict[NodeId, bool] = {}
+    event = asyncio.Event()
 
-    def _filter(arbitration_id: ArbitrationId) -> bool:
-        return (NodeId(arbitration_id.parts.originating_node_id) == node) and (
-            MessageId(arbitration_id.parts.message_id) == GetStatusResponse.message_id
-        )
+    def _filter(arb_id: ArbitrationId) -> bool:
+        return MessageId(arb_id.parts.message_id) == GetStatusResponse.message_id
 
-    async def _wait_for_response(reader: WaitableCallback) -> bool:
+    def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
         """Listener for receving motor status messages."""
-        async for response, _ in reader:
-            if isinstance(response, GetStatusResponse):
-                return bool(response.payload.status.value)
-        raise StopAsyncIteration
+        if isinstance(message, GetStatusResponse):
+            reported[NodeId(arb_id.parts.originating_node_id)] = bool(
+                message.payload.status.value
+            )
 
-    with WaitableCallback(can_messenger, _filter) as reader:
-        await can_messenger.send(node_id=node, message=GetStatusRequest())
-        try:
-            return await asyncio.wait_for(_wait_for_response(reader), timeout)
-        except asyncio.TimeoutError:
-            log.warning("Read motor status timed out")
-            raise StopAsyncIteration
+        # found all expected nodes
+        if expected.issubset(reported):
+            event.set()
+
+    can_messenger.add_listener(_listener, _filter)
+    await can_messenger.send(node_id=NodeId.broadcast, message=GetStatusRequest())
+    try:
+        await asyncio.wait_for(event.wait(), timeout)
+    except asyncio.TimeoutError:
+        if expected:
+            log.warning(
+                "Read motor status timed out, missing nodes: "
+                f"{expected.difference(reported)}"
+            )
+        else:
+            log.debug("Read motor status terminated, no missing nodes.")
+    return reported
 
 
 async def get_tip_motor_enabled(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Up until now, the hardware controller doesn't actually know if a motor has been engaged. We've been assuming a motor has been disengaged by checking the stepper position status, which doesn't provide the full story and causes us to engage the motor when it's already enabled (while homing the 96-channel pipette mount). 

This PR enables the hardware controller to prompt for the motor enabled status and allows us to finally implement the `OT3controller.engaged_axes` method.

This PR also updated the phony axis bound to values that are closer to reality; this prevents us from getting stuck in a extremely long homing move (like > 33 minutes) that never times out if a limit switch malfunctions. 