### PR TITLE
perf(robot-server): Remove slow re-exports from __init__.py and protocols/__init__.py

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -71,7 +71,7 @@ clean_all_cmd = $(clean_cmd) dist
 #     probably POSIX-only.
 dev_port ?= "31950"
 dev_host ?= "localhost"
-run_dev ?= uvicorn "robot_server:app" --host $(dev_host) --port $(dev_port) --ws wsproto --lifespan on --reload
+run_dev ?= uvicorn "robot_server.app:app" --host $(dev_host) --port $(dev_port) --ws wsproto --lifespan on --reload
 
 .PHONY: all
 all: clean sdist wheel

--- a/robot-server/opentrons-robot-server.service
+++ b/robot-server/opentrons-robot-server.service
@@ -18,7 +18,7 @@ Type=notify
 # /run/aiohttp.sock matches where our reverse proxy expects to find us.
 # It refers to aiohttp even though this server doesn't use that framework
 # for historical reasons.
-ExecStart=uvicorn robot_server:app --uds /run/aiohttp.sock --ws wsproto --lifespan on
+ExecStart=uvicorn robot_server.app:app --uds /run/aiohttp.sock --ws wsproto --lifespan on
 
 Environment=OT_SMOOTHIE_ID=AMA
 Environment=RUNNING_ON_PI=true

--- a/robot-server/robot_server/__init__.py
+++ b/robot-server/robot_server/__init__.py
@@ -2,9 +2,3 @@
 
 This server provides the main control interface for an Opentrons robot.
 """
-
-from .app_setup import app
-
-__all__ = [
-    "app",
-]

--- a/robot-server/robot_server/app.py
+++ b/robot-server/robot_server/app.py
@@ -1,0 +1,10 @@
+"""The public export of the server's ASGI app object.
+
+For import speed, we do this from a dedicated file instead of from the top-level
+__init__.py. We want worker processes and tests to be able to import specific things
+deep in robot_server without having to import this ASGI app and all of its dependencies.
+"""
+
+from .app_setup import app
+
+__all__ = ["app"]

--- a/robot-server/robot_server/protocols/__init__.py
+++ b/robot-server/robot_server/protocols/__init__.py
@@ -1,16 +1,1 @@
 """Protocol file upload and management."""
-from .router import protocols_router, ProtocolNotFound
-from .dependencies import get_protocol_store
-from .protocol_store import ProtocolStore, ProtocolResource, ProtocolNotFoundError
-
-__all__ = [
-    # main protocols router
-    "protocols_router",
-    # common error response details
-    "ProtocolNotFound",
-    # protocol state management
-    "get_protocol_store",
-    "ProtocolStore",
-    "ProtocolResource",
-    "ProtocolNotFoundError",
-]

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -11,7 +11,7 @@ from .health import health_router
 from .instruments import instruments_router
 from .maintenance_runs.router import maintenance_runs_router
 from .modules import modules_router
-from .protocols import protocols_router
+from .protocols.router import protocols_router
 from .robot.router import robot_router
 from .runs import runs_router
 from .service.labware.router import router as labware_router

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -31,7 +31,7 @@ from opentrons.protocol_engine import (
     create_protocol_engine,
 )
 
-from robot_server.protocols import ProtocolResource
+from robot_server.protocols.protocol_store import ProtocolResource
 from opentrons.protocol_engine.types import DeckConfigurationType
 
 

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -27,12 +27,12 @@ from robot_server.service.json_api import (
     PydanticResponse,
 )
 
-from robot_server.protocols import (
+from robot_server.protocols.dependencies import get_protocol_store
+from robot_server.protocols.protocol_store import (
     ProtocolStore,
-    ProtocolNotFound,
     ProtocolNotFoundError,
-    get_protocol_store,
 )
+from robot_server.protocols.router import ProtocolNotFound
 
 from ..run_models import RunNotFoundError
 from ..run_auto_deleter import RunAutoDeleter

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -13,7 +13,7 @@ from opentrons.protocol_engine import (
     Command,
 )
 
-from robot_server.protocols import ProtocolResource
+from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.task_runner import TaskRunner
 from robot_server.service.notifications import RunsPublisher
 

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -20,7 +20,7 @@ from robot_server.persistence import (
     sqlite_rowid,
 )
 from robot_server.persistence.pydantic import json_to_pydantic, pydantic_to_json
-from robot_server.protocols import ProtocolNotFoundError
+from robot_server.protocols.protocol_store import ProtocolNotFoundError
 from robot_server.service.notifications import RunsPublisher
 
 from .action_models import RunAction, RunActionType

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -36,7 +36,7 @@ from opentrons.calibration_storage.ot2 import (
 from opentrons.protocol_api import labware
 from opentrons.types import Point, Mount
 
-from robot_server import app
+from robot_server.app import app
 from robot_server.hardware import get_hardware, get_ot2_hardware
 from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
 from robot_server.service.session.manager import SessionManager

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -79,7 +79,7 @@ class DevServer:
                 "robot_server",
                 "-m",
                 "uvicorn",
-                "robot_server:app",
+                "robot_server.app:app",
                 "--host",
                 "localhost",
                 "--port",

--- a/robot-server/tests/runs/router/conftest.py
+++ b/robot-server/tests/runs/router/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 from decoy import Decoy
 
-from robot_server.protocols import ProtocolStore
+from robot_server.protocols.protocol_store import ProtocolStore
 from robot_server.runs.run_auto_deleter import RunAutoDeleter
 from robot_server.runs.run_store import RunStore
 from robot_server.runs.engine_store import EngineStore

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -17,10 +17,10 @@ from robot_server.service.json_api import (
     ResourceLink,
 )
 
-from robot_server.protocols import (
-    ProtocolStore,
-    ProtocolResource,
+from robot_server.protocols.protocol_store import (
     ProtocolNotFoundError,
+    ProtocolResource,
+    ProtocolStore,
 )
 
 from robot_server.runs.run_auto_deleter import RunAutoDeleter

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -18,7 +18,7 @@ from opentrons.protocol_runner import (
 )
 from opentrons.protocol_reader import ProtocolReader, ProtocolSource
 
-from robot_server.protocols import ProtocolResource
+from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs.engine_store import (
     EngineStore,
     EngineConflictError,

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -21,7 +21,7 @@ from opentrons.protocol_engine import (
     LabwareOffset,
 )
 
-from robot_server.protocols import ProtocolResource
+from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs.engine_store import EngineStore, EngineConflictError
 from robot_server.runs.run_data_manager import RunDataManager, RunNotCurrentError
 from robot_server.runs.run_models import Run, RunNotFoundError

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -18,7 +18,7 @@ from opentrons.types import Mount
 from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
 
-from robot_server import app
+from robot_server.app import app
 from robot_server.deck_configuration.fastapi_dependencies import (
     get_deck_configuration_store_failsafe,
 )


### PR DESCRIPTION
# Overview

This rearranges some of robot-server's internal `import` statements to make it significantly faster to launch certain subprocesses. See https://github.com/Opentrons/opentrons/pull/14465#discussion_r1484989089 for background. This goes towards RSS-451.

This is paired with a PR in oe-core: https://github.com/Opentrons/oe-core/pull/134

# Benchmarks

This brings the startup time of #14465's worker processes down from **~74 sec to ~31 sec**. Tested on an OT-2 with this command:

```
python -m timeit -r1 -n1 'import robot_server.persistence._migrations._up_to_3_helper; import robot_server.persistence.legacy_pickle; robot_server.persistence.legacy_pickle._get_legacy_ot_types()'
```

(The call to `_get_legacy_ot_types()` is to make sure we account for the cost of its dynamic import. `_up_to_3_helper` is a thing from my work in progress for #14465 and it may not make it into the final PR, so don't be surprised if you can't import it; but it's basically just the code for that PR's worker process, extracted to a standalone file.)

# Explanation

In Python, if you have a tree like this:

```
some_package/
    __init__.py
        # re-export .module_1.foo, module_2.bar, module_3.baz, etc.
    module_1.py
    module_2.py
    module_3.py
```

And then you do this:

```python
import some_package.module_1
```

The Python interpreter will evaluate `module_1`, `module_2`, *and* `module_3`, because they were mentioned in `some_package/__init__.py`. When you factor in all the subdependencies of `module_2` and `module_3`, this can be very very slow.

In the case of #14465, worker processes for database migration code were wasting nearly 45 seconds importing things like FastAPI routers, which are irrelevant to them.



# Review requests

We will definitely regress on this performance improvement unless we deliberately guard against it.

I propose, going forward, we adopt a house rule to "very rarely" re-export things from `__init__.py` files. Acceptable re-exports are ones like [`opentrons.protocol_api.<...>`](https://github.com/Opentrons/opentrons/blob/c142da102967ea7d2f6fb13c5d72b754fdc560cb/api/src/opentrons/protocol_api/__init__.py#L39-L63), where we have a strict public interface that we want to be ergonomic for users. All other re-exports are questionable.

Then, without those re-exports, we need a way to delineate private stuff from public stuff. I propose we lean harder into prefixing the filenames with underscores. We've already done this in a few places, but it's been pretty ad-hoc so far. Underscore-prefixed filenames are a common, but not universal, Python convention. (Examples: [h11](https://github.com/python-hyper/h11/tree/master/h11), [trio](https://github.com/python-trio/trio/tree/b65afe1686e915071ac3c67ae7dbb35236736a84/src/trio), [requests](https://github.com/psf/requests/blob/4f3f189d6b7d2a19ff73dfb4a3e39713d4abe01a/src/requests/_internal_utils.py); counterexamples: [sqlalchemy](https://github.com/sqlalchemy/sqlalchemy/tree/62b3ca476e879bacb20bb0c520c7c91feca576c0/lib/sqlalchemy), [pydantic](https://github.com/pydantic/pydantic/tree/main/pydantic).)

Does all of that sound good?

Then, we could take this a lot further. `opentrons.protocol_engine`'s imports, for example, are pretty heavy. You can't just import command models without also pulling in all of the execution logic, and all of the dependencies of that execution logic, including the hardware API, etc. etc.

# Test plan

* [x] `make dev` still works
* [x] Still boots on an OT-2
* [x] Still boots on a Flex
    * Remember this needs a build with https://github.com/Opentrons/oe-core/pull/134

# Risk assessment

Pretty low.