### PR TITLE
fix(app-shell): detect usb devices after update

### DIFF
--- a/app-shell/src/system-info/__tests__/usb-devices.test.ts
+++ b/app-shell/src/system-info/__tests__/usb-devices.test.ts
@@ -3,6 +3,7 @@ import { usb } from 'usb'
 
 import * as Fixtures from '@opentrons/app/src/redux/system-info/__fixtures__'
 import { createUsbDeviceMonitor, getWindowsDriverVersion } from '../usb-devices'
+import { isWindows } from '../../os'
 
 jest.mock('execa')
 jest.mock('usb')
@@ -76,7 +77,9 @@ const mockUSBDevice = {
   close: usbDeviceClose,
 }
 
-describe('app-shell::system-info::usb-devices', () => {
+const describeIfNotWindows = isWindows() ? describe.skip : describe
+
+describeIfNotWindows('app-shell::system-info::usb-devices::detection', () => {
   const { windowsDriverVersion: _, ...mockDevice } = Fixtures.mockUsbDevice
   afterEach(() => {
     jest.resetAllMocks()
@@ -194,6 +197,13 @@ describe('app-shell::system-info::usb-devices', () => {
         reject(new Error('detachListener was not created'))
       }
     }))
+})
+
+describe('app-shell::system-info::usb-devices', () => {
+  const { windowsDriverVersion: _, ...mockDevice } = Fixtures.mockUsbDevice
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
 
   it('can get the Windows driver version of a device', () => {
     execaCommand.mockResolvedValue({ stdout: '1.2.3' } as any)

--- a/app-shell/src/system-info/__tests__/usb-devices.test.ts
+++ b/app-shell/src/system-info/__tests__/usb-devices.test.ts
@@ -25,7 +25,14 @@ const usbOn = usb.on as jest.MockedFunction<typeof usb.on>
 
 const execaCommand = execa.command as jest.MockedFunction<typeof execa.command>
 
+const mockFixtureDevice = {
+  ...Fixtures.mockUsbDevice,
+  identifier: 'ec2c23ab245e0424059c3ad99e626cdb',
+}
+
 const mockDescriptor = {
+  busNumber: 3,
+  deviceAddress: 10,
   deviceDescriptor: {
     idVendor: Fixtures.mockUsbDevice.vendorId,
     idProduct: Fixtures.mockUsbDevice.productId,
@@ -94,19 +101,19 @@ describe('app-shell::system-info::usb-devices', () => {
 
     expect(devices).toEqual([
       {
-        ...Fixtures.mockUsbDevice,
+        ...mockFixtureDevice,
         manufacturerName: 'mfr1',
         serialNumber: 'sn1',
         productName: 'pr1',
       },
       {
-        ...Fixtures.mockUsbDevice,
+        ...mockFixtureDevice,
         manufacturerName: 'mfr2',
         serialNumber: 'sn2',
         productName: 'pr2',
       },
       {
-        ...Fixtures.mockUsbDevice,
+        ...mockFixtureDevice,
         manufacturerName: 'mfr3',
         serialNumber: 'sn3',
         productName: 'pr3',
@@ -120,7 +127,7 @@ describe('app-shell::system-info::usb-devices', () => {
       onDeviceAdd.mockImplementation(device => {
         try {
           expect(device).toEqual({
-            ...Fixtures.mockUsbDevice,
+            ...mockFixtureDevice,
             manufacturerName: 'mfr1',
             serialNumber: 'sn1',
             productName: 'pn1',
@@ -157,6 +164,11 @@ describe('app-shell::system-info::usb-devices', () => {
           expect(device).toEqual({
             vendorId: mockDevice.vendorId,
             productId: mockDevice.productId,
+            identifier: 'ec2c23ab245e0424059c3ad99e626cdb',
+            manufacturerName: undefined,
+            productName: undefined,
+            serialNumber: undefined,
+            systemIdentifier: undefined,
           })
           resolve()
         } catch (error) {

--- a/app-shell/src/system-info/index.ts
+++ b/app-shell/src/system-info/index.ts
@@ -26,23 +26,6 @@ const IFACE_POLL_INTERVAL_MS = 30000
 
 const log = createLogger('system-info')
 
-// format USBDevice to UsbDevice type
-const createUsbDevice = (device: USBDevice): UsbDevice => {
-  return {
-    vendorId: device.vendorId,
-    productId: device.productId,
-    productName: device.productName != null ? device.productName : 'no name',
-    manufacturerName:
-      device.manufacturerName != null
-        ? device.manufacturerName
-        : 'no manufacture',
-    serialNumber:
-      device.serialNumber != null ? device.serialNumber : 'no serial',
-  }
-}
-const createUsbDevices = (devices: USBDevice[]): UsbDevice[] =>
-  devices.map((device: USBDevice) => createUsbDevice(device))
-
 const addDriverVersion = (device: UsbDevice): Promise<UsbDevice> => {
   if (
     isWindows() &&
@@ -110,9 +93,7 @@ export function registerSystemInfo(
 
         usbMonitor
           .getAllDevices()
-          .then(devices =>
-            Promise.all(createUsbDevices(devices).map(addDriverVersion))
-          )
+          .then(devices => Promise.all(devices.map(addDriverVersion)))
           .then(devices => {
             dispatch(SystemInfo.initialized(devices, getActiveInterfaces()))
           })

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -19,23 +19,30 @@ export interface UsbDeviceMonitor {
 
 const log = createLogger('usb-devices')
 
+const decToHex = (number: number): string =>
+  number.toString(16).toUpperCase().padStart(4, '0')
+const idVendor = (device: usb.Device): string =>
+  decToHex(device.deviceDescriptor.idVendor)
+const idProduct = (device: usb.Device): string =>
+  decToHex(device.deviceDescriptor.idProduct)
+
 const descriptorToDevice = (
   descriptors: usb.Device,
   manufacturerName?: string,
   serialNumber?: string,
-  productName?: string
+  productName?: string,
+  systemIdentifier?: string
 ): UsbDevice => ({
   vendorId: descriptors.deviceDescriptor.idVendor,
   productId: descriptors.deviceDescriptor.idProduct,
-  // yes this arbitrary string could be something other than an hmac but then
-  // it might be different lengths. it was this or install leftPad, I tell you
   identifier: createHmac('md5', '')
-    .update(descriptors.busNumber.toString(16))
-    .update(descriptors.deviceAddress.toString(16))
+    .update(decToHex(descriptors.busNumber))
+    .update(decToHex(descriptors.deviceAddress))
     .digest('hex'),
   serialNumber,
   manufacturerName,
   productName,
+  systemIdentifier,
 })
 
 const getStringDescriptorPromise = (
@@ -52,11 +59,6 @@ const getStringDescriptorPromise = (
     })
   })
 
-const idVendor = (device: usb.Device): string =>
-  device.deviceDescriptor.idVendor.toString(16)
-const idProduct = (device: usb.Device): string =>
-  device.deviceDescriptor.idProduct.toString(16)
-
 const orDefault = <T, U>(
   promise: Promise<T>,
   defaulter: (err: any) => U
@@ -70,7 +72,100 @@ const orDefault = <T, U>(
         })
     )
 
-function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
+const doUpstreamDeviceFromUsbDevice = (
+  device: usb.Device
+): Promise<UsbDevice[]> =>
+  isWindows()
+    ? upstreamDeviceFromUsbDeviceWinAPI(device)
+    : upstreamDeviceFromUsbDeviceLibUSB(device)
+
+function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice[]> {
+  return doUpstreamDeviceFromUsbDevice(device).catch(err => {
+    log.error(
+      `Failed to get device information for vid=${idVendor(
+        device
+      )} pid=${idProduct(device)}: ${err}: friendly names unavailable`
+    )
+    return [descriptorToDevice(device)]
+  })
+}
+
+interface WmiObject {
+  Present: boolean
+  Manufacturer: string
+  Name: string
+  DeviceID: string
+}
+
+function upstreamDeviceFromUsbDeviceWinAPI(
+  device: usb.Device
+): Promise<UsbDevice[]> {
+  // Here begins an annotated series of interesting powershell interactions!
+  // We don't know the device ID of the device. For USB devices it's typically composed of
+  // the VID, the PID, and the serial, and we don't know the serial. (Also if there's two devices
+  // with the same vid+pid+serial, as with devices that hardcode serial to 1, then you get some
+  // random something-or-other in there so even if we had the serial we couldn't rely on it.)
+
+  // We also essentially have no way of linking this uniquely identifying information to that
+  // provided by libusb. Libusb provides usb-oriented identifiers like the bus address; windows
+  // provides identifiers about hubs and ports.
+
+  // This is basically why we have everything returning lists of devices - this function needs
+  // to tell people that it found multiple devices and it doesn't know which is which.
+
+  // We can get a json-formatted dump of information about all devices with the specified vid and
+  // pid
+  return execa
+    .command(
+      `Get-WmiObject Win32_PnpEntity -Filter "DeviceId like '%\\VID_${idVendor(
+        device
+      )}&PID_${idProduct(
+        device
+      )}%'" | Select-Object -Property * | ConvertTo-JSON -Compress`,
+      { shell: 'PowerShell.exe' }
+    )
+    .then(dump => {
+      // powershell helpfully will dump a json object when there's exactly one result and a json
+      // array when there's more than one result. isn't that really cool? this is actually fixed
+      // in any at-all modern powershell version, where ConvertTo-JSON has a flag -AsArray that
+      // forces array output, but you absolutely cannot rely on anything past like powershell
+      // 5.1 being present
+      const parsePoshJsonOutputToWmiObjectArray = (
+        dump: string
+      ): WmiObject[] => {
+        if (dump[0] === '[') {
+          return JSON.parse(dump) as WmiObject[]
+        } else {
+          return [JSON.parse(dump) as WmiObject]
+        }
+      }
+      if (dump.stderr !== '') {
+        return Promise.reject(new Error(`Command failed: ${dump.stderr}`))
+      }
+      const getObjsWithCorrectPresence = (wmiDump: WmiObject[]): WmiObject[] =>
+        wmiDump.filter(obj => obj.Present)
+
+      const objsToQuery = getObjsWithCorrectPresence(
+        parsePoshJsonOutputToWmiObjectArray(dump.stdout.trim())
+      )
+      return objsToQuery.map(wmiObj =>
+        descriptorToDevice(
+          device,
+          wmiObj.Manufacturer,
+          // the serial number, or something kind of like a serial number in the case of devices
+          // with duplicate serial numbers, is the third element of the device id which is formed
+          // by concatenating stuff with \\ as a separator (and of course each \ must be escaped)
+          wmiObj.DeviceID.match(/.*\\\\.*\\\\(.*)/)?.at(1) ?? undefined,
+          wmiObj.Name,
+          wmiObj.DeviceID
+        )
+      )
+    })
+}
+
+function upstreamDeviceFromUsbDeviceLibUSB(
+  device: usb.Device
+): Promise<UsbDevice[]> {
   return new Promise<usb.Device>((resolve, reject) => {
     try {
       device.open(false)
@@ -128,18 +223,11 @@ function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
       ])
     )
     .then(([manufacturer, serialNumber, productName]) => {
-      try {
-        device.close()
-      } catch (err) {
-        log.warn(
-          `Failed to close vid=${idVendor(device)}, pid=${idProduct(
-            device
-          )}: ${err}`
-        )
-      }
-      return descriptorToDevice(device, manufacturer, serialNumber, productName)
+      return [
+        descriptorToDevice(device, manufacturer, serialNumber, productName),
+      ]
     })
-    .catch(err => {
+    .finally(() => {
       try {
         device.close()
       } catch (err) {
@@ -149,12 +237,6 @@ function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
           )} in err handler: ${err}`
         )
       }
-      log.error(
-        `Could not fetch descriptors for vid=${idVendor(
-          device
-        )}, pid=${idProduct(device)}: ${err}, string descriptors unavailable`
-      )
-      return descriptorToDevice(device)
     })
 }
 
@@ -173,29 +255,27 @@ export function createUsbDeviceMonitor(
   }
   if (typeof onDeviceAdd === 'function') {
     usb.on('attach', device => {
-      upstreamDeviceFromUsbDevice(device)
-        .then(onDeviceAdd)
-        .catch(err => {
-          log.error(
-            `Failed to format added device vid=${idVendor(
-              device
-            )} pid=${idProduct(device)} for upstream: ${err}`
-          )
-        })
+      upstreamDeviceFromUsbDevice(device).then(devices =>
+        devices.forEach(onDeviceAdd)
+      )
     })
   }
 
   if (typeof onDeviceRemove === 'function') {
-    usb.on('detach', device => onDeviceRemove(descriptorToDevice(device)))
+    usb.on('detach', device => {
+      onDeviceRemove(descriptorToDevice(device))
+    })
   }
 
   return {
     getAllDevices: () =>
       new Promise<usb.Device[]>((resolve, reject) => {
         resolve(usb.getDeviceList())
-      }).then(deviceList =>
-        Promise.all(deviceList.map(upstreamDeviceFromUsbDevice))
-      ),
+      })
+        .then(deviceList =>
+          Promise.all(deviceList.map(upstreamDeviceFromUsbDevice))
+        )
+        .then(upstreamDevices => upstreamDevices.flat()),
     stop: () => {
       if (typeof onDeviceAdd === 'function') {
         usb.removeAllListeners('attach')
@@ -209,29 +289,39 @@ export function createUsbDeviceMonitor(
   }
 }
 
-const decToHex = (number: number): string =>
-  number.toString(16).toUpperCase().padStart(4, '0')
+const deviceIdFromDetails = (device: UsbDevice): string | null => {
+  const {
+    vendorId: vidDecimal,
+    productId: pidDecimal,
+    serialNumber,
+    systemIdentifier,
+  } = device
+  if (systemIdentifier !== undefined) {
+    return systemIdentifier
+  }
+  const [vid, pid] = [decToHex(vidDecimal), decToHex(pidDecimal)]
+
+  // USBDevice serialNumber is  string | undefined
+  if (serialNumber == null) {
+    return null
+  }
+  return `USB\\VID_${vid}&PID_${pid}\\${serialNumber}`
+}
 
 export function getWindowsDriverVersion(
   device: UsbDevice
 ): Promise<string | null> {
   console.log('getWindowsDriverVersion', device)
-  const { vendorId: vidDecimal, productId: pidDecimal, serialNumber } = device
-  const [vid, pid] = [decToHex(vidDecimal), decToHex(pidDecimal)]
-
-  // USBDevice serialNumber is  string | undefined
-  if (serialNumber == null) {
-    return Promise.resolve(null)
-  }
-
   assert(
     isWindows() || process.env.NODE_ENV === 'test',
     `getWindowsDriverVersion cannot be called on ${process.platform}`
   )
 
+  const deviceId = deviceIdFromDetails(device)
+
   return execa
     .command(
-      `Get-PnpDeviceProperty -InstanceID "USB\\VID_${vid}&PID_${pid}\\${serialNumber}" -KeyName "DEVPKEY_Device_DriverVersion" | % { $_.Data }`,
+      `Get-PnpDeviceProperty -InstanceID "${deviceId}" -KeyName "DEVPKEY_Device_DriverVersion" | % { $_.Data }`,
       { shell: 'PowerShell.exe' }
     )
     .then(result => result.stdout.trim())

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -1,6 +1,6 @@
 import assert from 'assert'
 import execa from 'execa'
-import { usb, WebUSB } from 'usb'
+import { usb } from 'usb'
 import { isWindows } from '../os'
 import { createLogger } from '../log'
 
@@ -12,14 +12,69 @@ export type UsbDeviceMonitorOptions = Partial<{
 }>
 
 export interface UsbDeviceMonitor {
-  getAllDevices: () => Promise<USBDevice[]>
+  getAllDevices: () => Promise<UsbDevice[]>
   stop: () => void
 }
 
 const log = createLogger('usb-devices')
-const webusb = new WebUSB({
-  allowAllDevices: true,
+
+const descriptorToDevice = (
+  descriptors: usb.Device,
+  manufacturerName?: string,
+  serialNumber?: string
+): UsbDevice => ({
+  vendorId: descriptors.deviceDescriptor.idVendor,
+  productId: descriptors.deviceDescriptor.idProduct,
+  serialNumber,
+  manufacturerName,
 })
+
+const getStringDescriptorPromise = (
+  device: usb.Device,
+  index: number
+): Promise<string> =>
+  new Promise((resolve, reject) =>
+    device.getStringDescriptor(index, (error?, value?) =>
+      !!error || !!!value ? reject(error) : resolve(value)
+    )
+  )
+
+const orDefault = <T, U>(
+  promise: Promise<T>,
+  defaulter: (err: any) => U
+): Promise<T | U> =>
+  promise.catch((err: any) => {
+    return new Promise(resolve => resolve(defaulter(err)))
+  })
+
+function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
+  return Promise.all([
+    orDefault(
+      getStringDescriptorPromise(device, device.deviceDescriptor.iManufacturer),
+      (err: any) => {
+        log.error(
+          `Failed to get manufacturer for vid=${device.deviceDescriptor.idVendor.toString(
+            16
+          )} pid=${device.deviceDescriptor.idProduct.toString(16)}: ${err}`
+        )
+        return undefined
+      }
+    ),
+    orDefault(
+      getStringDescriptorPromise(device, device.deviceDescriptor.iSerialNumber),
+      (err: any) => {
+        log.error(
+          `Failed to get serial for vid=${device.deviceDescriptor.idVendor.toString(
+            16
+          )} pid=${device.deviceDescriptor.idProduct.toString(16)}: ${err}`
+        )
+        return undefined
+      }
+    ),
+  ]).then(([manufacturer, serialNumber]) =>
+    descriptorToDevice(device, manufacturer, serialNumber)
+  )
+}
 
 export function createUsbDeviceMonitor(
   options: UsbDeviceMonitorOptions = {}
@@ -27,15 +82,22 @@ export function createUsbDeviceMonitor(
   const { onDeviceAdd, onDeviceRemove } = options
 
   if (typeof onDeviceAdd === 'function') {
-    usb.on('attach', device => onDeviceAdd)
+    usb.on('attach', device =>
+      upstreamDeviceFromUsbDevice(device).then(onDeviceAdd)
+    )
   }
 
   if (typeof onDeviceRemove === 'function') {
-    usb.on('detach', device => onDeviceRemove)
+    usb.on('detach', device => onDeviceRemove(descriptorToDevice(device)))
   }
 
   return {
-    getAllDevices: () => Promise.resolve(webusb.getDevices()),
+    getAllDevices: () =>
+      new Promise<usb.Device[]>((resolve, reject) => {
+        resolve(usb.getDeviceList())
+      }).then(deviceList =>
+        Promise.all(deviceList.map(upstreamDeviceFromUsbDevice))
+      ),
     stop: () => {
       if (typeof onDeviceAdd === 'function') {
         usb.removeAllListeners('attach')

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -55,7 +55,7 @@ const getStringDescriptorPromise = (
 const idVendor = (device: usb.Device): string =>
   device.deviceDescriptor.idVendor.toString(16)
 const idProduct = (device: usb.Device): string =>
-  device.deviceDescriptor.idVendor.toString(16)
+  device.deviceDescriptor.idProduct.toString(16)
 
 const orDefault = <T, U>(
   promise: Promise<T>,
@@ -125,7 +125,7 @@ function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
         device.close()
       } catch (err) {
         log.warn(
-          `Failed to close pid=${idProduct(device)}, vid=${idVendor(
+          `Failed to close vid=${idVendor(device)}, pid=${idProduct(
             device
           )}: ${err}`
         )
@@ -137,15 +137,15 @@ function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
         device.close()
       } catch (err) {
         log.warn(
-          `Failed to close pid=${idProduct(device)}, vid=${idVendor(
+          `Failed to close vid=${idVendor(device)}, pid=${idProduct(
             device
           )} in err handler: ${err}`
         )
       }
       log.error(
-        `Could not fetch descriptors for pid=${idProduct(
+        `Could not fetch descriptors for vid=${idVendor(
           device
-        )}, vid=${idVendor(device)}: ${err}, string descriptors unavailable`
+        )}, pid=${idProduct(device)}: ${err}, string descriptors unavailable`
       )
       return descriptorToDevice(device)
     })

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -61,7 +61,14 @@ const orDefault = <T, U>(
   promise: Promise<T>,
   defaulter: (err: any) => U
 ): Promise<T | U> =>
-  promise.then((result: T): T => result).catch((err: any) => defaulter(err))
+  promise
+    .then((result: T): T => result)
+    .catch(
+      (err: any) =>
+        new Promise<U>(resolve => {
+          resolve(defaulter(err))
+        })
+    )
 
 function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
   return new Promise<usb.Device>((resolve, reject) => {

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -37,7 +37,9 @@ const getStringDescriptorPromise = (
 ): Promise<string> =>
   new Promise((resolve, reject) => {
     device.getStringDescriptor(index, (error?, value?) => {
-      !!error || !!!value ? reject(error ?? 'no value') : resolve(value)
+      // fyi if you do something in this callback that throws there's a good chance
+      // it will crash node
+      (!!error || !!!value) ? reject(error ?? 'no value') : resolve(value)
     })
   })
 
@@ -113,7 +115,7 @@ function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
       try {
         device.close()
       } catch (err) {
-        log.warning(
+        log.warn(
           `Failed to close pid=${idProduct(device)}, vid=${idVendor(
             device
           )}: ${err}`
@@ -125,7 +127,7 @@ function upstreamDeviceFromUsbDevice(device: usb.Device): Promise<UsbDevice> {
       try {
         device.close()
       } catch (err) {
-        log.warning(
+        log.warn(
           `Failed to close pid=${idProduct(device)}, vid=${idVendor(
             device
           )} in err handler: ${err}`

--- a/app-shell/src/system-info/usb-devices.ts
+++ b/app-shell/src/system-info/usb-devices.ts
@@ -117,7 +117,7 @@ function upstreamDeviceFromUsbDeviceWinAPI(
   // pid
   return execa
     .command(
-      `Get-WmiObject Win32_PnpEntity -Filter "DeviceId like '%\\VID_${idVendor(
+      `Get-WmiObject Win32_PnpEntity -Filter "DeviceId like '%\\\\VID_${idVendor(
         device
       )}&PID_${idProduct(
         device
@@ -228,15 +228,20 @@ function upstreamDeviceFromUsbDeviceLibUSB(
       ]
     })
     .finally(() => {
-      try {
-        device.close()
-      } catch (err) {
-        log.warn(
-          `Failed to close vid=${idVendor(device)}, pid=${idProduct(
-            device
-          )} in err handler: ${err}`
-        )
-      }
+      setImmediate(() => {
+        try {
+          device.close()
+          log.info(
+            `closed vid=${idVendor(device)}, pid=${idProduct(device)} ok`
+          )
+        } catch (err) {
+          log.info(
+            `failed to close vid=${idVendor(device)}, pid=${idProduct(
+              device
+            )}: ${err}`
+          )
+        }
+      })
     })
 }
 

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -110,6 +110,8 @@
   "usb_to_ethernet_adapter_no_driver_version": "Unknown",
   "usb_to_ethernet_adapter_toast_message": "An update is available for Realtek USB-to-Ethernet adapter driver",
   "usb_to_ethernet_not_connected": "No USB-to-Ethernet adapter connected",
+  "usb_to_ethernet_unknown_manufacturer": "Unknown Manufacturer",
+  "usb_to_ethernet_unknown_product": "Unknown Adapter",
   "versions_sync": "Learn more about keeping the Opentrons App and robot software in sync",
   "view_change_log": "View Opentrons technical change log",
   "view_issue_tracker": "View Opentrons issue tracker",

--- a/app/src/organisms/AdvancedSettings/U2EInformation.tsx
+++ b/app/src/organisms/AdvancedSettings/U2EInformation.tsx
@@ -82,7 +82,7 @@ export function U2EInformation(): JSX.Element {
               <StyledText css={TYPOGRAPHY.pSemiBold}>
                 {t('usb_to_ethernet_adapter_description')}
               </StyledText>
-              <StyledText as="p">{device?.productName}</StyledText>
+              <StyledText as="p">{device?.productName ?? t('usb_to_ethernet_unknown_product')}</StyledText>
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}
@@ -91,7 +91,7 @@ export function U2EInformation(): JSX.Element {
               <StyledText css={TYPOGRAPHY.pSemiBold}>
                 {t('usb_to_ethernet_adapter_manufacturer')}
               </StyledText>
-              <StyledText as="p">{device?.manufacturerName}</StyledText>
+              <StyledText as="p">{device?.manufacturerName ?? t('usb_to_ethernet_unknown_manufacturer')}</StyledText>
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/AdvancedSettings/U2EInformation.tsx
+++ b/app/src/organisms/AdvancedSettings/U2EInformation.tsx
@@ -82,7 +82,9 @@ export function U2EInformation(): JSX.Element {
               <StyledText css={TYPOGRAPHY.pSemiBold}>
                 {t('usb_to_ethernet_adapter_description')}
               </StyledText>
-              <StyledText as="p">{device?.productName ?? t('usb_to_ethernet_unknown_product')}</StyledText>
+              <StyledText as="p">
+                {device?.productName ?? t('usb_to_ethernet_unknown_product')}
+              </StyledText>
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}
@@ -91,7 +93,10 @@ export function U2EInformation(): JSX.Element {
               <StyledText css={TYPOGRAPHY.pSemiBold}>
                 {t('usb_to_ethernet_adapter_manufacturer')}
               </StyledText>
-              <StyledText as="p">{device?.manufacturerName ?? t('usb_to_ethernet_unknown_manufacturer')}</StyledText>
+              <StyledText as="p">
+                {device?.manufacturerName ??
+                  t('usb_to_ethernet_unknown_manufacturer')}
+              </StyledText>
             </Flex>
             <Flex
               flexDirection={DIRECTION_COLUMN}

--- a/app/src/redux/system-info/__fixtures__/index.ts
+++ b/app/src/redux/system-info/__fixtures__/index.ts
@@ -8,6 +8,7 @@ export const mockUsbDevice: UsbDevice = {
   productName: 'USB Device',
   manufacturerName: 'Manufacturer Name',
   serialNumber: 'Serial Number',
+  identifier: 'aasdhasdasd',
 }
 
 export const mockRealtekDevice: UsbDevice = {
@@ -18,6 +19,7 @@ export const mockRealtekDevice: UsbDevice = {
   productName: 'USB 10/100 LAN',
   manufacturerName: 'Realtek',
   serialNumber: 'Serial Number',
+  identifier: 'kjhgkjhdf',
 }
 
 export const mockWindowsRealtekDevice: UsbDevice = {
@@ -28,6 +30,7 @@ export const mockWindowsRealtekDevice: UsbDevice = {
   productName: 'Realtek USB FE Family Controller',
   manufacturerName: 'Realtek',
   serialNumber: 'Serial Number',
+  identifier: '0tgewu0dfasd',
   windowsDriverVersion: '1.2.3',
 }
 

--- a/app/src/redux/system-info/reducer.ts
+++ b/app/src/redux/system-info/reducer.ts
@@ -29,16 +29,10 @@ export const systemInfoReducer: Reducer<SystemInfoState, Action> = (
     }
 
     case Constants.USB_DEVICE_REMOVED: {
-      const { vendorId, productId, serialNumber } = action.payload.usbDevice
+      const { identifier } = action.payload.usbDevice
       return {
         ...state,
-        usbDevices: state.usbDevices.filter(d => {
-          return (
-            d.vendorId !== vendorId ||
-            d.productId !== productId ||
-            d.serialNumber !== serialNumber
-          )
-        }),
+        usbDevices: state.usbDevices.filter(d => d.identifier !== identifier),
       }
     }
 

--- a/app/src/redux/system-info/types.ts
+++ b/app/src/redux/system-info/types.ts
@@ -19,6 +19,7 @@ export interface UsbDevice {
   manufacturerName?: string
   serialNumber?: string
   windowsDriverVersion?: string | null
+  systemIdentifier?: string
 }
 
 // based on built-in type os$NetIFAddr

--- a/app/src/redux/system-info/types.ts
+++ b/app/src/redux/system-info/types.ts
@@ -14,6 +14,7 @@ import {
 export interface UsbDevice {
   vendorId: number
   productId: number
+  identifier: string
   productName?: string
   manufacturerName?: string
   serialNumber?: string


### PR DESCRIPTION
When we updated to electron 27, our old package for detecting devices didn't work anymore. Instead we now use the npm package `usb`, which is a reimplementation of node-usb that also provides a WebUSB frontend.

The integration here had a couple small problems; the webusb just straight up doesn't seem to work with these devices, and we were doing the callback glue slightly wrong.

With both those problems fixed, we should once again detected device add and removal basically instantly, which fixes some issues with robot detection and removal.

Closes RQA-2324
