### PR TITLE
refactor(robot-server): Resolve SQLAlchemy deprecation warning

### DIFF
--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -101,7 +101,7 @@ class RunStore:
         )
         insert_command = sqlalchemy.insert(run_command_table)
 
-        select_run_resource = sqlalchemy.select(_run_columns).where(
+        select_run_resource = sqlalchemy.select(*_run_columns).where(
             run_table.c.id == run_id
         )
         select_actions = sqlalchemy.select(action_table).where(
@@ -216,7 +216,7 @@ class RunStore:
         Raises:
             RunNotFoundError: The given run ID was not found.
         """
-        select_run_resource = sqlalchemy.select(_run_columns).where(
+        select_run_resource = sqlalchemy.select(*_run_columns).where(
             run_table.c.id == run_id
         )
 
@@ -240,7 +240,7 @@ class RunStore:
         Returns:
             All stored run entries.
         """
-        select_runs = sqlalchemy.select(_run_columns)
+        select_runs = sqlalchemy.select(*_run_columns)
         select_actions = sqlalchemy.select(action_table).order_by(sqlite_rowid.asc())
         actions_by_run_id = defaultdict(list)
 


### PR DESCRIPTION
# Overview

A 3-character change to fix this warning in robot-server's tests:

> [...]run_store.py:104: RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)

# Test Plan

We're covered by automated tests.

# Changelog

Replace `sqlalchemy.select(iterable)` with `sqlalchemy.select(*args)`, as described in [the migration guide](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-core-usage).

# Review requests

None in particular.

# Risk assessment

Low.
