### PR TITLE
fix(app): fix RecentRunProtocolCard redirecting to /protocols before /runs/:runId/setup

### DIFF
--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -2,7 +2,6 @@ import * as React from 'react'
 import difference from 'lodash/difference'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
-import { useRouteMatch } from 'react-router-dom'
 import { useDispatch } from 'react-redux'
 
 import { useInterval, truncateString } from '@opentrons/components'
@@ -145,9 +144,6 @@ export function useCurrentRunRoute(): string | null {
     staleTime: Infinity,
     enabled: currentRunId != null,
   })
-
-  const isRunSetupRoute = useRouteMatch('/runs/:runId/setup')
-  if (isRunSetupRoute != null && runRecord == null) return '/protocols'
 
   const runStatus = runRecord?.data.status
   const runActions = runRecord?.data.actions

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -269,6 +269,11 @@ function PrepareToRun({
     }
   )
 
+  const runStatus = useRunStatus(runId)
+  if (runStatus === RUN_STATUS_STOPPED) {
+    history.push('/protocols')
+  }
+
   React.useEffect(() => {
     if (mostRecentAnalysis?.status === 'completed') {
       setIsPollingForCompletedAnalysis(false)
@@ -305,7 +310,6 @@ function PrepareToRun({
 
   const protocolHasFixtures = requiredFixtures.length > 0
 
-  const runStatus = useRunStatus(runId)
   const isHeaterShakerInProtocol = useIsHeaterShakerInProtocol()
 
   const deckDef = getDeckDefFromRobotType(robotType)
@@ -450,7 +454,7 @@ function PrepareToRun({
       if (
         isHeaterShakerInProtocol &&
         isReadyToRun &&
-        (runStatus === RUN_STATUS_IDLE || runStatus === RUN_STATUS_STOPPED)
+        runStatus === RUN_STATUS_IDLE
       ) {
         confirmAttachment()
       } else {


### PR DESCRIPTION
Closes [RQA-2290](https://opentrons.atlassian.net/browse/RQA-2290)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Notification changes uncovered a bug in which a RecentRunProtocolCard caused redirection to the /runs/:runId/setup page before the actual run had loaded, which caused the TopLevelRedirect hook to bounce back to the /protocols page until the run loads. Instead of relying on run within TopLevelRedirect for this one off route case, move the redirect within ProtocolSetup and redirect if run status is stopped. This creates the same end behavior without the temporary redirect to /protocols.


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Click a recent protocol card. You shouldn't see a redirect to /protocols before the /setup route.
- Usually requires testing on a physical ODD to repro the issue.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a bug in which clicking a protocol card would temporarily redirect to the Protocol Dashboard.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2290]: https://opentrons.atlassian.net/browse/RQA-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ