### PR TITLE
feat(api,hardware): add hepa/uv config/control commands to api.

### DIFF
--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -427,8 +427,8 @@ class FlexBackend(Protocol):
     async def get_hepa_fan_state(self) -> Optional[HepaFanState]:
         ...
 
-    async def set_hepa_uv_state(self, light_on: bool, timeout_s: int) -> bool:
-        """Sets the state and timeout in seconds of the Hepa/UV module."""
+    async def set_hepa_uv_state(self, light_on: bool, uv_duration_s: int) -> bool:
+        """Sets the state and duration (seconds) of the UV light for the Hepa/UV module."""
         ...
 
     async def get_hepa_uv_state(self) -> Optional[HepaUVState]:

--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -33,10 +33,12 @@ from opentrons.hardware_control.types import (
     EstopState,
     HardwareEventHandler,
     HardwareEventUnsubscriber,
+    HepaFanState,
+    HepaUVState,
+    StatusBarState,
 )
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from ..dev_types import OT3AttachedInstruments
-from ..types import StatusBarState
 from .types import HWStopCondition
 
 Cls = TypeVar("Cls")
@@ -416,4 +418,18 @@ class FlexBackend(Protocol):
         hard_limit_lower: float,
         hard_limit_upper: float,
     ) -> None:
+        ...
+
+    async def set_hepa_fan_state(self, fan_on: bool, duty_cycle: int) -> bool:
+        """Sets the state and duty cycle of the Hepa/UV module."""
+        ...
+
+    async def get_hepa_fan_state(self) -> Optional[HepaFanState]:
+        ...
+
+    async def set_hepa_uv_state(self, light_on: bool, timeout_s: int) -> bool:
+        """Sets the state and timeout in seconds of the Hepa/UV module."""
+        ...
+
+    async def get_hepa_uv_state(self) -> Optional[HepaUVState]:
         ...

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1591,15 +1591,15 @@ class OT3Controller(FlexBackend):
             else None
         )
 
-    async def set_hepa_uv_state(self, light_on: bool, timeout_s: int) -> bool:
-        return await set_hepa_uv_state_fw(self._messenger, light_on, timeout_s)
+    async def set_hepa_uv_state(self, light_on: bool, uv_duration_s: int) -> bool:
+        return await set_hepa_uv_state_fw(self._messenger, light_on, uv_duration_s)
 
     async def get_hepa_uv_state(self) -> Optional[HepaUVState]:
         res = await get_hepa_uv_state_fw(self._messenger)
         return (
             HepaUVState(
                 light_on=res.uv_light_on,
-                config_timeout=res.timeout_s,
+                uv_duration_s=res.uv_duration_s,
                 remaining_time_s=res.remaining_time_s,
             )
             if res

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -169,6 +169,12 @@ from opentrons_hardware.hardware_control.rear_panel_settings import (
 from opentrons_hardware.hardware_control.gripper_settings import (
     get_gripper_jaw_state,
 )
+from opentrons_hardware.hardware_control.hepa_uv_settings import (
+    set_hepa_fan_state as set_hepa_fan_state_fw,
+    get_hepa_fan_state as get_hepa_fan_state_fw,
+    set_hepa_uv_state as set_hepa_uv_state_fw,
+    get_hepa_uv_state as get_hepa_uv_state_fw,
+)
 
 from opentrons_hardware.drivers.gpio import OT3GPIO, RemoteOT3GPIO
 from opentrons_shared_data.pipette.dev_types import PipetteName
@@ -193,7 +199,7 @@ from ..dev_types import (
     AttachedGripper,
     OT3AttachedInstruments,
 )
-from ..types import StatusBarState
+from ..types import HepaFanState, HepaUVState, StatusBarState
 
 from .types import HWStopCondition
 from .flex_protocol import FlexBackend
@@ -1570,3 +1576,32 @@ class OT3Controller(FlexBackend):
                     "actual-jaw-width": current_gripper_position,
                 },
             )
+
+    async def set_hepa_fan_state(self, fan_on: bool, duty_cycle: int) -> bool:
+        return await set_hepa_fan_state_fw(self._messenger, fan_on, duty_cycle)
+
+    async def get_hepa_fan_state(self) -> Optional[HepaFanState]:
+        res = await get_hepa_fan_state_fw(self._messenger)
+        return (
+            HepaFanState(
+                fan_on=res.fan_on,
+                duty_cycle=res.duty_cycle,
+            )
+            if res
+            else None
+        )
+
+    async def set_hepa_uv_state(self, light_on: bool, timeout_s: int) -> bool:
+        return await set_hepa_uv_state_fw(self._messenger, light_on, timeout_s)
+
+    async def get_hepa_uv_state(self) -> Optional[HepaUVState]:
+        res = await get_hepa_uv_state_fw(self._messenger)
+        return (
+            HepaUVState(
+                light_on=res.uv_light_on,
+                config_timeout=res.timeout_s,
+                remaining_time_s=res.remaining_time_s,
+            )
+            if res
+            else None
+        )

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -25,6 +25,8 @@ from opentrons.hardware_control import modules
 from opentrons.hardware_control.types import (
     BoardRevision,
     Axis,
+    HepaFanState,
+    HepaUVState,
     OT3Mount,
     OT3AxisMap,
     CurrentConfig,
@@ -803,3 +805,15 @@ class OT3Simulator(FlexBackend):
         # This is a (pretty bad) simulation of the gripper actually gripping something,
         # but it should work.
         self._encoder_position[Axis.G] = (hard_limit_upper - jaw_width) / 2
+
+    async def set_hepa_fan_state(self, fan_on: bool, duty_cycle: int) -> bool:
+        return False
+
+    async def get_hepa_fan_state(self) -> Optional[HepaFanState]:
+        return None
+
+    async def set_hepa_uv_state(self, light_on: bool, timeout_s: int) -> bool:
+        return False
+
+    async def get_hepa_uv_state(self) -> Optional[HepaUVState]:
+        return None

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -79,6 +79,8 @@ from .types import (
     HardwareEvent,
     HardwareEventHandler,
     HardwareAction,
+    HepaFanState,
+    HepaUVState,
     MotionChecks,
     SubSystem,
     PauseType,
@@ -2685,3 +2687,21 @@ class OT3API(
 
     def get_estop_state(self) -> EstopState:
         return self._backend.get_estop_state()
+
+    async def set_hepa_fan_state(
+        self, turn_on: bool = False, duty_cycle: int = 75
+    ) -> bool:
+        """Sets the state and duty cycle of the Hepa/UV module."""
+        return await self._backend.set_hepa_fan_state(turn_on, duty_cycle)
+
+    async def get_hepa_fan_state(self) -> Optional[HepaFanState]:
+        return await self._backend.get_hepa_fan_state()
+
+    async def set_hepa_uv_state(
+        self, turn_on: bool = False, timeout_s: int = 900
+    ) -> bool:
+        """Sets the state and timeout in seconds of the Hepa/UV module."""
+        return await self._backend.set_hepa_uv_state(turn_on, timeout_s)
+
+    async def get_hepa_uv_state(self) -> Optional[HepaUVState]:
+        return await self._backend.get_hepa_uv_state()

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2698,10 +2698,10 @@ class OT3API(
         return await self._backend.get_hepa_fan_state()
 
     async def set_hepa_uv_state(
-        self, turn_on: bool = False, timeout_s: int = 900
+        self, turn_on: bool = False, uv_duration_s: int = 900
     ) -> bool:
-        """Sets the state and timeout in seconds of the Hepa/UV module."""
-        return await self._backend.set_hepa_uv_state(turn_on, timeout_s)
+        """Sets the state and duration (seconds) of the UV light for the Hepa/UV module."""
+        return await self._backend.set_hepa_uv_state(turn_on, uv_duration_s)
 
     async def get_hepa_uv_state(self) -> Optional[HepaUVState]:
         return await self._backend.get_hepa_uv_state()

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -401,7 +401,7 @@ class HepaFanState:
 @dataclass
 class HepaUVState:
     light_on: bool
-    config_timeout: int
+    uv_duration_s: int
     remaining_time_s: int
 
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -392,6 +392,19 @@ class EstopOverallStatus:
     right_physical_state: EstopPhysicalStatus
 
 
+@dataclass
+class HepaFanState:
+    fan_on: bool
+    duty_cycle: int
+
+
+@dataclass
+class HepaUVState:
+    light_on: bool
+    config_timeout: int
+    remaining_time_s: int
+
+
 @dataclass(frozen=True)
 class DoorStateNotification:
     event: Literal[

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -655,16 +655,16 @@ class GetHepaFanStatePayloadResponse(EmptyPayload):
 
 @dataclass(eq=False)
 class SetHepaUVStateRequestPayload(EmptyPayload):
-    """A request to set the state and timeout in seconds of the hepa uv light."""
+    """A request to set the state and duration in seconds of the hepa uv light."""
 
-    timeout_s: utils.UInt32Field
+    uv_duration_s: utils.UInt32Field
     uv_light_on: utils.UInt8Field
 
 
 @dataclass(eq=False)
 class GetHepaUVStatePayloadResponse(EmptyPayload):
-    """A response with the state and timeout in seconds of the hepa uv light."""
+    """A response with the state and duration in seconds of the hepa uv light."""
 
-    timeout_s: utils.UInt32Field
+    uv_duration_s: utils.UInt32Field
     uv_light_on: utils.UInt8Field
     remaining_time_s: utils.UInt32Field

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -642,7 +642,7 @@ class SetHepaFanStateRequestPayload(EmptyPayload):
     """A request to set the state and pwm of a the hepa fan."""
 
     duty_cycle: utils.UInt32Field
-    fan_on: utils.Int8Field
+    fan_on: utils.UInt8Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
@@ -1,0 +1,149 @@
+"""Utilities for controlling the hepa/uv extension module."""
+import logging
+import asyncio
+from typing import Optional
+from dataclasses import dataclass
+from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
+from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
+
+from opentrons_hardware.firmware_bindings.messages import payloads
+from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
+from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    SetHepaFanStateRequest,
+    GetHepaFanStateRequest,
+    GetHepaFanStateResponse,
+    SetHepaUVStateRequest,
+    GetHepaUVStateRequest,
+    GetHepaUVStateResponse,
+)
+from opentrons_hardware.firmware_bindings.utils import (
+    UInt8Field,
+    UInt32Field,
+)
+from opentrons_hardware.firmware_bindings.constants import (
+    MessageId,
+    NodeId,
+    ErrorCode,
+)
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HepaFanState:
+    """Hepa Fan Config."""
+
+    fan_on: bool
+    duty_cycle: int
+
+
+@dataclass(frozen=True)
+class HepaUVState:
+    """Hepa UV Light Config."""
+
+    uv_light_on: bool
+    timeout_s: int
+    remaining_time_s: int
+
+
+async def set_hepa_fan_state(
+    can_messenger: CanMessenger,
+    fan_on: bool,
+    duty_cycle: int,
+) -> bool:
+    """Set the Hepa fan state and duty cycle."""
+    error = await can_messenger.ensure_send(
+        node_id=NodeId.hepa_uv,
+        message=SetHepaFanStateRequest(
+            payload=payloads.SetHepaFanStateRequestPayload(
+                duty_cycle=UInt32Field(duty_cycle), fan_on=UInt8Field(fan_on)
+            ),
+        ),
+        expected_nodes=[NodeId.hepa_uv],
+    )
+    if error != ErrorCode.ok:
+        log.error(f"recieved error trying to set hepa fan state {str(error)}")
+    return error == ErrorCode.ok
+
+
+async def get_hepa_fan_state(can_messenger: CanMessenger) -> Optional[HepaFanState]:
+    """Gets the state of the Hepa fan."""
+    fan_state: Optional[HepaFanState] = None
+
+    event = asyncio.Event()
+
+    def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
+        nonlocal fan_state
+        if isinstance(message, GetHepaFanStateResponse):
+            event.set()
+            fan_state = HepaFanState(
+                fan_on=bool(message.payload.fan_on.value),
+                duty_cycle=int(message.payload.duty_cycle.value),
+            )
+
+    def _filter(arb_id: ArbitrationId) -> bool:
+        return (NodeId(arb_id.parts.originating_node_id) == NodeId.hepa_uv) and (
+            MessageId(arb_id.parts.message_id) == MessageId.get_hepa_fan_state_response
+        )
+
+    can_messenger.add_listener(_listener, _filter)
+    await can_messenger.send(node_id=NodeId.hepa_uv, message=GetHepaFanStateRequest())
+    try:
+        await asyncio.wait_for(event.wait(), 1.0)
+    except asyncio.TimeoutError:
+        log.warning("hepa fan state request timed out")
+    finally:
+        can_messenger.remove_listener(_listener)
+        return fan_state
+
+
+async def set_hepa_uv_state(
+    can_messenger: CanMessenger,
+    uv_light_on: bool,
+    timeout_s: int,
+) -> bool:
+    """Set the Hepa UV state and timeout in seconds."""
+    error = await can_messenger.ensure_send(
+        node_id=NodeId.hepa_uv,
+        message=SetHepaUVStateRequest(
+            payload=payloads.SetHepaUVStateRequestPayload(
+                timeout_s=UInt32Field(timeout_s), uv_light_on=UInt8Field(uv_light_on)
+            ),
+        ),
+        expected_nodes=[NodeId.hepa_uv],
+    )
+    if error != ErrorCode.ok:
+        log.error(f"recieved error trying to set hepa uv light state {str(error)}")
+    return error == ErrorCode.ok
+
+
+async def get_hepa_uv_state(can_messenger: CanMessenger) -> Optional[HepaUVState]:
+    """Gets the state of the Hepa uv light."""
+    uv_state: Optional[HepaUVState] = None
+
+    event = asyncio.Event()
+
+    def _listener(message: MessageDefinition, arb_id: ArbitrationId) -> None:
+        nonlocal uv_state
+        if isinstance(message, GetHepaUVStateResponse):
+            event.set()
+            uv_state = HepaUVState(
+                uv_light_on=bool(message.payload.uv_light_on.value),
+                timeout_s=int(message.payload.timeout_s.value),
+                remaining_time_s=int(message.payload.remaining_time_s.value),
+            )
+
+    def _filter(arb_id: ArbitrationId) -> bool:
+        return (NodeId(arb_id.parts.originating_node_id) == NodeId.hepa_uv) and (
+            MessageId(arb_id.parts.message_id) == MessageId.get_hepa_uv_state_response
+        )
+
+    can_messenger.add_listener(_listener, _filter)
+    await can_messenger.send(node_id=NodeId.hepa_uv, message=GetHepaUVStateRequest())
+    try:
+        await asyncio.wait_for(event.wait(), 1.0)
+    except asyncio.TimeoutError:
+        log.warning("hepa uv light state request timed out")
+    finally:
+        can_messenger.remove_listener(_listener)
+        return uv_state

--- a/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
@@ -42,7 +42,7 @@ class HepaUVState:
     """Hepa UV Light Config."""
 
     uv_light_on: bool
-    timeout_s: int
+    uv_duration_s: int
     remaining_time_s: int
 
 
@@ -100,14 +100,15 @@ async def get_hepa_fan_state(can_messenger: CanMessenger) -> Optional[HepaFanSta
 async def set_hepa_uv_state(
     can_messenger: CanMessenger,
     uv_light_on: bool,
-    timeout_s: int,
+    uv_duration_s: int,
 ) -> bool:
-    """Set the Hepa UV state and timeout in seconds."""
+    """Sets the Hepa UV light state and duration in seconds."""
     error = await can_messenger.ensure_send(
         node_id=NodeId.hepa_uv,
         message=SetHepaUVStateRequest(
             payload=payloads.SetHepaUVStateRequestPayload(
-                timeout_s=UInt32Field(timeout_s), uv_light_on=UInt8Field(uv_light_on)
+                uv_duration_s=UInt32Field(uv_duration_s),
+                uv_light_on=UInt8Field(uv_light_on),
             ),
         ),
         expected_nodes=[NodeId.hepa_uv],
@@ -129,7 +130,7 @@ async def get_hepa_uv_state(can_messenger: CanMessenger) -> Optional[HepaUVState
             event.set()
             uv_state = HepaUVState(
                 uv_light_on=bool(message.payload.uv_light_on.value),
-                timeout_s=int(message.payload.timeout_s.value),
+                uv_duration_s=int(message.payload.uv_duration_s.value),
                 remaining_time_s=int(message.payload.remaining_time_s.value),
             )
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
@@ -1,0 +1,191 @@
+"""Tests for hepa/uv settings."""
+from opentrons_hardware.firmware_bindings.messages.messages import MessageDefinition
+import pytest
+from mock import AsyncMock
+from typing import List, Tuple, cast
+
+from opentrons_hardware.firmware_bindings.constants import NodeId
+from opentrons_hardware.firmware_bindings.messages import (
+    message_definitions as md,
+)
+from opentrons_hardware.firmware_bindings.messages.payloads import (
+    SetHepaFanStateRequestPayload,
+    GetHepaFanStatePayloadResponse,
+    SetHepaUVStateRequestPayload,
+    GetHepaUVStatePayloadResponse,
+)
+from opentrons_hardware.hardware_control.hepa_uv_settings import (
+    set_hepa_fan_state,
+    set_hepa_uv_state,
+    get_hepa_fan_state,
+    get_hepa_uv_state,
+    HepaFanState,
+    HepaUVState,
+)
+from opentrons_hardware.firmware_bindings.utils import (
+    UInt8Field,
+    UInt32Field,
+)
+from tests.conftest import CanLoopback
+
+
+@pytest.fixture
+def mock_can_messenger() -> AsyncMock:
+    """Mock communication."""
+    return AsyncMock()
+
+
+def create_hepa_fan_state_response(fan_on: bool, duty_cycle: int) -> MessageDefinition:
+    """Create a GetHepaFanStateResponse."""
+    return md.GetHepaFanStateResponse(
+        payload=GetHepaFanStatePayloadResponse(
+            fan_on=UInt8Field(fan_on),
+            duty_cycle=UInt32Field(duty_cycle),
+        )
+    )
+
+
+def create_hepa_uv_state_response(
+    light_on: bool, config_timeout: int, remaining_time: int
+) -> MessageDefinition:
+    """Create a GetHepaUVStateResponse."""
+    return md.GetHepaUVStateResponse(
+        payload=GetHepaUVStatePayloadResponse(
+            uv_light_on=UInt8Field(light_on),
+            timeout_s=UInt32Field(config_timeout),
+            remaining_time_s=UInt32Field(remaining_time),
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("fan_on", "duty_cycle"), [[True, 0], [True, 75], [False, 0], [False, 75]]
+)
+async def test_set_hepa_fan_state(
+    mock_can_messenger: AsyncMock,
+    fan_on: bool,
+    duty_cycle: int,
+) -> None:
+    """We should set the fan state and duty cycle for the hepa/uv node."""
+    await set_hepa_fan_state(mock_can_messenger, fan_on, duty_cycle)
+    mock_can_messenger.ensure_send.assert_any_call(
+        node_id=NodeId.hepa_uv,
+        message=md.SetHepaFanStateRequest(
+            payload=SetHepaFanStateRequestPayload(
+                fan_on=UInt8Field(fan_on),
+                duty_cycle=UInt32Field(duty_cycle),
+            )
+        ),
+        expected_nodes=[NodeId.hepa_uv],
+    )
+
+
+@pytest.mark.parametrize(
+    ("light_on", "timeout"), [[True, 0], [True, 900], [False, 3600], [False, 7200]]
+)
+async def test_set_hepa_uv_state(
+    mock_can_messenger: AsyncMock,
+    light_on: bool,
+    timeout: int,
+) -> None:
+    """We should set the uv light state and timeout for the hepa/uv node."""
+    await set_hepa_uv_state(mock_can_messenger, light_on, timeout)
+    mock_can_messenger.ensure_send.assert_any_call(
+        node_id=NodeId.hepa_uv,
+        message=md.SetHepaUVStateRequest(
+            payload=SetHepaUVStateRequestPayload(
+                uv_light_on=UInt8Field(light_on),
+                timeout_s=UInt32Field(timeout),
+            )
+        ),
+        expected_nodes=[NodeId.hepa_uv],
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        (NodeId.host, create_hepa_fan_state_response(True, 75), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(True, 0), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(False, 75), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(False, 100), NodeId.hepa_uv),
+    ],
+)
+async def test_get_hepa_fan_state(
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+    response: Tuple[NodeId, MessageDefinition, NodeId],
+) -> None:
+    """We should get the fan state and duty cycle for the hepa/uv node."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, md.GetHepaFanStateRequest):
+            return [response]
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    res = await get_hepa_fan_state(mock_messenger)
+
+    # Make sure we send out the request
+    mock_messenger.send.assert_any_call(
+        node_id=NodeId.hepa_uv,
+        message=md.GetHepaFanStateRequest(),
+    )
+
+    # Make sure the result matches the payload response
+    payload = cast(GetHepaFanStatePayloadResponse, response[1].payload)
+    assert (
+        HepaFanState(
+            bool(payload.fan_on.value),
+            int(payload.duty_cycle.value),
+        )
+        == res
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        (NodeId.host, create_hepa_uv_state_response(True, 900, 300), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_uv_state_response(True, 0, 0), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_uv_state_response(False, 0, 0), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_uv_state_response(False, 900, 0), NodeId.hepa_uv),
+    ],
+)
+async def test_get_hepa_uv_state(
+    mock_messenger: AsyncMock,
+    message_send_loopback: CanLoopback,
+    response: Tuple[NodeId, MessageDefinition, NodeId],
+) -> None:
+    """We should get the uv light state and timeout for the hepa/uv node."""
+
+    def responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        if isinstance(message, md.GetHepaUVStateRequest):
+            return [response]
+        return []
+
+    message_send_loopback.add_responder(responder)
+
+    res = await get_hepa_uv_state(mock_messenger)
+
+    # Make sure we send out the request
+    mock_messenger.send.assert_any_call(
+        node_id=NodeId.hepa_uv,
+        message=md.GetHepaUVStateRequest(),
+    )
+
+    # Make sure the result matches the payload response
+    payload = cast(GetHepaUVStatePayloadResponse, response[1].payload)
+    assert (
+        HepaUVState(
+            bool(payload.uv_light_on.value),
+            int(payload.timeout_s.value),
+            int(payload.remaining_time_s.value),
+        )
+        == res
+    )


### PR DESCRIPTION
# Overview

We added can messages to control the hepa/uv in this pr [(Opentrons/opentrons:#14452)](https://github.com/Opentrons/opentrons/pull/14452), now we want to use those messages from the hardware controller and API. This pr adds the hooks to these can messages so they can be used from repl.

Closes: [RET-1424](https://opentrons.atlassian.net/browse/RET-1424)

# Test Plan

- [x] Make sure we can control the hepa/uv module using ot3api from repl
- [x] Make sure we can query the hepa/uv module using ot3api from repl

# Changelog

- Added hooks to OT3API and OT3Controller to enable control/query of Hepa/UV state.

# Review requests


# Risk assessment

low, unreleased

# Todo

- [x] Add unit tests

[RET-1424]: https://opentrons.atlassian.net/browse/RET-1424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ