### PR TITLE
 fix(api): associate thermocycler with all slots it occupies

### DIFF
--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -34,7 +34,6 @@ from ..types import (
     LabwareOffsetVector,
     ModuleOffsetVector,
     ModuleOffsetData,
-    DeckType,
     CurrentWell,
     CurrentPipetteLocation,
     TipGeometry,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -138,13 +138,13 @@ class ModuleState:
 
     additional_slots_occupied_by_module_id: Dict[str, List[DeckSlotName]]
     """List of additional slots occupied by each module.
-    
+
     The thermocycler (both GENs), occupies multiple slots on both OT-2 and the Flex
-    but only one slot is associated with the location of the thermocycler. 
-    In order to check for deck conflicts with other items, we will keep track of any 
+    but only one slot is associated with the location of the thermocycler.
+    In order to check for deck conflicts with other items, we will keep track of any
     additional slots occupied by a module here.
-      
-    This will be None when a module occupies only one slot. 
+
+    This will be None when a module occupies only one slot.
     """
 
     requested_model_by_id: Dict[str, Optional[ModuleModel]]

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -174,7 +174,8 @@ class StateStore(StateView, ActionHandler):
             deck_definition=deck_definition,
         )
         self._module_store = ModuleStore(
-            module_calibration_offsets=module_calibration_offsets
+            config=config,
+            module_calibration_offsets=module_calibration_offsets,
         )
         self._liquid_store = LiquidStore()
         self._tip_store = TipStore()

--- a/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
+++ b/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
@@ -16,7 +16,6 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration() -> None:
     trash_labware = protocol_context.load_labware(
         "opentrons_1_trash_3200ml_fixed", "A3"
     )
-
     badly_placed_tiprack = protocol_context.load_labware(
         "opentrons_flex_96_tiprack_50ul", "C2"
     )
@@ -30,7 +29,7 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration() -> None:
     )
 
     thermocycler = protocol_context.load_module("thermocyclerModuleV2")
-    partially_accessible_plate = thermocycler.load_labware(
+    accessible_plate = thermocycler.load_labware(
         "opentrons_96_wellplate_200ul_pcr_full_skirt"
     )
 
@@ -75,7 +74,7 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration() -> None:
 
     # Will NOT raise error since first column of TC labware is accessible
     # (it is just a few mm away from the left bound)
-    instrument.dispense(25, partially_accessible_plate.wells_by_name()["A1"])
+    instrument.dispense(25, accessible_plate.wells_by_name()["A1"])
 
     instrument.drop_tip()
 
@@ -88,8 +87,8 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration() -> None:
     # No error NOW because of full config
     instrument.aspirate(50, badly_placed_labware.wells_by_name()["A1"])
 
-    # No error NOW because of full config
-    instrument.dispense(50, partially_accessible_plate.wells_by_name()["A1"])
+    # No error
+    instrument.dispense(50, accessible_plate.wells_by_name()["A1"])
 
 
 @pytest.mark.ot3_only

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -178,9 +178,7 @@ def test_get_labware_parent_position_on_module(
     ).then_return(Point(1, 2, 3))
     decoy.when(labware_view.get_deck_definition()).then_return(ot2_standard_deck_def)
     decoy.when(
-        module_view.get_nominal_module_offset(
-            module_id="module-id", deck_type=DeckType.OT2_STANDARD
-        )
+        module_view.get_nominal_module_offset(module_id="module-id")
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
     decoy.when(module_view.get_connected_model("module-id")).then_return(
         ModuleModel.THERMOCYCLER_MODULE_V2
@@ -242,9 +240,7 @@ def test_get_labware_parent_position_on_labware(
 
     decoy.when(labware_view.get_deck_definition()).then_return(ot2_standard_deck_def)
     decoy.when(
-        module_view.get_nominal_module_offset(
-            module_id="module-id", deck_type=DeckType.OT2_STANDARD
-        )
+        module_view.get_nominal_module_offset(module_id="module-id")
     ).then_return(LabwareOffsetVector(x=1, y=2, z=3))
 
     decoy.when(module_view.get_connected_model("module-id")).then_return(
@@ -424,9 +420,7 @@ def test_get_module_labware_highest_z(
     )
     decoy.when(labware_view.get_deck_definition()).then_return(ot2_standard_deck_def)
     decoy.when(
-        module_view.get_nominal_module_offset(
-            module_id="module-id", deck_type=DeckType.OT2_STANDARD
-        )
+        module_view.get_nominal_module_offset(module_id="module-id")
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
     decoy.when(module_view.get_height_over_labware("module-id")).then_return(0.5)
     decoy.when(module_view.get_module_calibration_offset("module-id")).then_return(
@@ -711,11 +705,9 @@ def test_get_highest_z_in_slot_with_single_module(
         errors.LabwareNotLoadedOnModuleError("only module")
     )
     decoy.when(labware_view.get_deck_definition()).then_return(ot2_standard_deck_def)
-    decoy.when(
-        module_view.get_module_highest_z(
-            module_id="only-module", deck_type=DeckType("ot2_standard")
-        )
-    ).then_return(12345)
+    decoy.when(module_view.get_module_highest_z(module_id="only-module")).then_return(
+        12345
+    )
 
     assert (
         subject.get_highest_z_in_slot(DeckSlotLocation(slotName=DeckSlotName.SLOT_3))
@@ -889,9 +881,7 @@ def test_get_highest_z_in_slot_with_labware_stack_on_module(
         DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
     )
     decoy.when(
-        module_view.get_nominal_module_offset(
-            module_id="module-id", deck_type=DeckType("ot2_standard")
-        )
+        module_view.get_nominal_module_offset(module_id="module-id")
     ).then_return(LabwareOffsetVector(x=40, y=50, z=60))
     decoy.when(module_view.get_connected_model("module-id")).then_return(
         ModuleModel.TEMPERATURE_MODULE_V2
@@ -1095,9 +1085,7 @@ def test_get_module_labware_well_position(
     )
     decoy.when(labware_view.get_deck_definition()).then_return(ot2_standard_deck_def)
     decoy.when(
-        module_view.get_nominal_module_offset(
-            module_id="module-id", deck_type=DeckType.OT2_STANDARD
-        )
+        module_view.get_nominal_module_offset(module_id="module-id")
     ).then_return(LabwareOffsetVector(x=4, y=5, z=6))
     decoy.when(module_view.get_module_calibration_offset("module-id")).then_return(
         ModuleOffsetData(
@@ -1636,9 +1624,7 @@ def test_get_labware_grip_point_for_labware_on_module(
     )
     decoy.when(labware_view.get_deck_definition()).then_return(ot2_standard_deck_def)
     decoy.when(
-        module_view.get_nominal_module_offset(
-            module_id="module-id", deck_type=DeckType.OT2_STANDARD
-        )
+        module_view.get_nominal_module_offset(module_id="module-id")
     ).then_return(LabwareOffsetVector(x=1, y=2, z=3))
     decoy.when(module_view.get_connected_model("module-id")).then_return(
         ModuleModel.MAGNETIC_MODULE_V2
@@ -1741,6 +1727,22 @@ def test_get_slot_item(
         is None
     )
     assert subject.get_slot_item(DeckSlotName.SLOT_2) == labware
+    assert subject.get_slot_item(DeckSlotName.SLOT_3) == module
+
+
+def test_get_slot_item_that_is_overflowed_module(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    module_view: ModuleView,
+    subject: GeometryView,
+) -> None:
+    """It should return the module that occupies the slot, even if not loaded on it."""
+    module = LoadedModule.construct(id="cool-module")  # type: ignore[call-arg]
+    decoy.when(labware_view.get_by_slot(DeckSlotName.SLOT_3)).then_return(None)
+    decoy.when(module_view.get_by_slot(DeckSlotName.SLOT_3)).then_return(None)
+    decoy.when(
+        module_view.get_overflowed_module_in_slot(DeckSlotName.SLOT_3)
+    ).then_return(module)
     assert subject.get_slot_item(DeckSlotName.SLOT_3) == module
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -4,7 +4,7 @@ from math import isclose
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from contextlib import nullcontext as does_not_raise
-from typing import ContextManager, Dict, NamedTuple, Optional, Type, Union, Any
+from typing import ContextManager, Dict, NamedTuple, Optional, Type, Union, Any, List
 
 from opentrons_shared_data import load_shared_data
 from opentrons.types import DeckSlotName, MountType
@@ -40,19 +40,26 @@ from opentrons.protocol_engine.state.module_substates import (
 
 
 def make_module_view(
+    deck_type: Optional[DeckType] = None,
     slot_by_module_id: Optional[Dict[str, Optional[DeckSlotName]]] = None,
     requested_model_by_module_id: Optional[Dict[str, Optional[ModuleModel]]] = None,
     hardware_by_module_id: Optional[Dict[str, HardwareModule]] = None,
     substate_by_module_id: Optional[Dict[str, ModuleSubStateType]] = None,
     module_offset_by_serial: Optional[Dict[str, ModuleOffsetData]] = None,
+    additional_slots_occupied_by_module_id: Optional[
+        Dict[str, List[DeckSlotName]]
+    ] = None,
 ) -> ModuleView:
     """Get a module view test subject with the specified state."""
     state = ModuleState(
+        deck_type=deck_type or DeckType.OT2_STANDARD,
         slot_by_module_id=slot_by_module_id or {},
         requested_model_by_id=requested_model_by_module_id or {},
         hardware_by_module_id=hardware_by_module_id or {},
         substate_by_module_id=substate_by_module_id or {},
         module_offset_by_serial=module_offset_by_serial or {},
+        additional_slots_occupied_by_module_id=additional_slots_occupied_by_module_id
+        or {},
     )
 
     return ModuleView(state=state)
@@ -316,6 +323,7 @@ def test_get_module_offset_for_ot2_standard(
 ) -> None:
     """It should return the correct labware offset for module in specified slot."""
     subject = make_module_view(
+        deck_type=DeckType.OT2_STANDARD,
         slot_by_module_id={"module-id": slot},
         hardware_by_module_id={
             "module-id": HardwareModule(
@@ -324,10 +332,7 @@ def test_get_module_offset_for_ot2_standard(
             )
         },
     )
-    assert (
-        subject.get_nominal_module_offset("module-id", DeckType.OT2_STANDARD)
-        == expected_offset
-    )
+    assert subject.get_nominal_module_offset("module-id") == expected_offset
 
 
 @pytest.mark.parametrize(
@@ -372,6 +377,7 @@ def test_get_module_offset_for_ot3_standard(
 ) -> None:
     """It should return the correct labware offset for module in specified slot."""
     subject = make_module_view(
+        deck_type=DeckType.OT3_STANDARD,
         slot_by_module_id={"module-id": slot},
         hardware_by_module_id={
             "module-id": HardwareModule(
@@ -380,9 +386,7 @@ def test_get_module_offset_for_ot3_standard(
             )
         },
     )
-    result_offset = subject.get_nominal_module_offset(
-        "module-id", DeckType.OT3_STANDARD
-    )
+    result_offset = subject.get_nominal_module_offset("module-id")
     assert (result_offset.x, result_offset.y, result_offset.z) == pytest.approx(
         (expected_offset.x, expected_offset.y, expected_offset.z)
     )
@@ -1777,6 +1781,7 @@ def test_get_module_highest_z(
 ) -> None:
     """It should get the highest z point of the module."""
     subject = make_module_view(
+        deck_type=deck_type,
         slot_by_module_id={"module-id": slot_name},
         requested_model_by_module_id={
             "module-id": ModuleModel.TEMPERATURE_MODULE_V2,
@@ -1789,6 +1794,28 @@ def test_get_module_highest_z(
         },
     )
     assert isclose(
-        subject.get_module_highest_z(module_id="module-id", deck_type=deck_type),
+        subject.get_module_highest_z(module_id="module-id"),
         expected_highest_z,
+    )
+
+
+def test_get_overflowed_module_in_slot(tempdeck_v1_def: ModuleDefinition) -> None:
+    """It should return the module occupying but not loaded in the given slot."""
+    subject = make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=tempdeck_v1_def,
+            )
+        },
+        additional_slots_occupied_by_module_id={
+            "module-id": [DeckSlotName.SLOT_6, DeckSlotName.SLOT_A1],
+        },
+    )
+    assert subject.get_overflowed_module_in_slot(DeckSlotName.SLOT_6) == LoadedModule(
+        id="module-id",
+        model=ModuleModel.TEMPERATURE_MODULE_V1,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_1),
+        serialNumber="serial-number",
     )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->
Addresses RQA-2311

# Overview

This PR fixes a long-standing issue that the thermocycler is associated only with the slot it was loaded, even though it occupies more than one slot on both OT-2 & Flex. This marks the first step in making our backend aware of multiple slots used by any module.

The observable change of this PR is that `protocol_context.deck` in API 2.14 & above now returns the thermocycler module for items of slot 8, 10, 11 on OT-2 & A1 on Flex, when there is a thermocycler loaded in slot 7/ B1

Currently non-observable changes (due to practical use cases and non-public API features):
- when moving a 96-channel pipette to slot A2 in a way that the pipette partially moves over thermocycler in slot A1, the deck conflict checker will do conflict checking with thermocycler. Practically, since the thermocycler sits under the deck on the Flex, we will most likely run into an out-of-bounds issue before the 96 ch nozzles collide with the thermocycler.
- when moving an 8-channel in partial config on an OT-2 with thermocycler, moving to a slot such that the pipette is at least partially over 5/8/11 will raise a deck conflict error. Currently we don't have public API available to partially configure an 8-channel so this won't happen to existing protocols.

# Test Plan

The changes in this PR can be tested with analysis. Change API levels to make sure analysis passes for all versions >= 2.14.

```
requirements = {
	"robotType": "OT-2",
	"apiLevel": "2.14",
}

def run(protocol: protocol_api.ProtocolContext):
	thermocycler        = protocol.load_module('thermocycler module gen2')
	
	assert protocol.loaded_modules == {7: thermocycler}
	assert protocol.deck["7"] ==  thermocycler
	assert protocol.deck["8"] == thermocycler
	assert protocol.deck["10"] == thermocycler
	assert protocol.deck["11"] == thermocycler

```

- Protocol analysis snapshot tests would be very useful for this.

- Other than that, we just need to make sure that protocols run fine and as usual with these changes.

# Changelog

- module state store now also stores any additional slots occupied by a module
- `state.geometry.get_slot_item(slot)` now returns the module that has the given slot in its 'additional slots occupied' list
- `state.geometry.get_highest_z_in_slot` now returns height of module occupying the slot (regardless of if it was loaded in it)

# Review requests

- Is it okay to not put this behind a new version change? 
  - we discussed on slack and the consensus is that this fixes a bug and hence, should be applied to all versions. It won't be applied to older, non-engine protocols, though.
- Are we okay merging this into release? Or should this go into edge for thorough testing?

# Risk assessment

Low-medium. 
For suggested use of our API, this changes actually fixes a long-standing bug and is an improvement over the current API at a low risk. But for any protocols that might have been using loop-holes in the deck class, this change would break the behavior.
