### PR TITLE
chore(docs): touch up trash bin line on docs homepage

### DIFF
--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -81,7 +81,7 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
                 tiprack = protocol.load_labware(
                     "opentrons_flex_96_tiprack_200ul", location="D2"
                 )
-                trash = protocol.load_trash_bin("A3")
+                trash = protocol.load_trash_bin(location="A3")
             
                 # pipettes
                 left_pipette = protocol.load_instrument(

--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -75,13 +75,13 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
             # protocol run function
             def run(protocol: protocol_api.ProtocolContext):
                 # labware
-		trash = protocol.load_trash_bin("A3")
                 plate = protocol.load_labware(
                     "corning_96_wellplate_360ul_flat", location="D1"
                 )
                 tiprack = protocol.load_labware(
                     "opentrons_flex_96_tiprack_200ul", location="D2"
                 )
+                trash = protocol.load_trash_bin("A3")
             
                 # pipettes
                 left_pipette = protocol.load_instrument(

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -92,7 +92,7 @@ This code only loads the instruments and labware listed above, and performs no o
                     load_name="usascientific_12_reservoir_22ml", location="D1"
                 )
                 # load trash bin in deck slot A3
-                trash = protocol.load_trash_bin("A3")
+                trash = protocol.load_trash_bin(location="A3")
                 # Put protocol commands here
     
     .. tab:: OT-2 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -126,11 +126,6 @@ This table lists the correspondence between Protocol API versions and robot soft
 Changes in API Versions
 =======================
 
-Version 2.17
-------------
-
-- :py:meth:`.dispense` will now raise an error if you try to dispense more than is available.
-
 Version 2.16
 ------------
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -345,10 +345,6 @@ class InstrumentContext(publisher.CommandPublisher):
 
         .. versionchanged:: 2.15
             Added the ``push_out`` parameter.
-
-        .. versionchanged:: 2.17
-            Now raises an exception if you try to dispense more than is available.
-            Previously, it would silently clamp.
         """
         if self.api_version < APIVersion(2, 15) and push_out:
             raise APIVersionError(


### PR DESCRIPTION
# Overview

Follow up to #14455. Fixes syntax and makes the code match the order on the Protocol Examples page.

Also does some housekeeping to set up a [feature branch for docs content](https://github.com/Opentrons/opentrons/pull/14493) tied to the PAPI 2.17 release. That will also allow for this change to be deployed immediately.

# Test Plan

- [x] visually inspect [sandbox](http://sandbox.docs.opentrons.com/docs-trashbin-example/v2/)
- [x] simulate code snippet on PAPI 2.16 / robot stack 7.1.1

# Changelog

- move down `trash` line and properly indent.
- remove 2.17 content in versioning.rst and docstring.

# Review requests

the whole branch management plan seems sound?

# Risk assessment

v low. deleting some docs content but it should be preserved in other branches.