### PR TITLE
chore: default all py versions to robot-stack

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -19,7 +19,7 @@ sphinx_build_allow_warnings := $(pipenv) run sphinx-build
 
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 # Find the version of the wheel from git using a helper script. We
 # use python here so we can use the same version normalization that will be
@@ -27,10 +27,10 @@ project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
 wheel_file = dist/$(call python_get_wheelname,api,$(project_rs_default),opentrons,$(BUILD_NUMBER))
 
 # Find the version of the sdist file from git using a helper script.
-sdist_file = dist/$(call python_get_sdistname,api,$(project_ot3_default),opentrons)
+sdist_file = dist/$(call python_get_sdistname,api,$(project_rs_default),opentrons)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,api,$(project_ot3_default),opentrons)
+version_file = $(call python_get_git_version,api,$(project_rs_default),opentrons)
 
 # These variables are for simulating python protocols
 sim_log_level ?= info
@@ -100,7 +100,7 @@ wheel:
 
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist:
 	$(clean_sdist_cmd)
 	$(python) setup.py sdist

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -7,15 +7,15 @@ SHX := npx shx
 
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 package_name = hardware_testing
-package_version = $(call python_package_version,hardware-testing,$(project_ot3_default))
+package_version = $(call python_package_version,hardware-testing,$(project_rs_default))
 wheel_file = dist/$(call python_get_wheelname,hardware-testing,$(project_rs_default),$(package_name),$(BUILD_NUMBER))
-sdist_file = dist/$(call python_get_sdistname,hardware-testing,$(project_ot3_default),$(package_name))
+sdist_file = dist/$(call python_get_sdistname,hardware-testing,$(project_rs_default),$(package_name))
 usb_file =   dist/$(package_name)-usb-$(package_version).tar.gz
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,hardware-testing,$(project_ot3_default),hardware-testing)
+version_file = $(call python_get_git_version,hardware-testing,$(project_rs_default),hardware-testing)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -70,7 +70,7 @@ wheel:
 	$(SHX) ls dist
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist:
 	$(clean_cmd)
 	$(python) setup.py sdist

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -7,7 +7,7 @@ SHX := npx shx
 
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 # Find the version of the wheel from git using a helper script. We
 # use python here so we can use the same version normalization that will be
@@ -18,10 +18,10 @@ wheel_file = dist/$(call python_get_wheelname,hardware,$(project_rs_default),ope
 # Find the version of the sdist from git using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the sdist.
-sdist_file = dist/$(call python_get_sdistname,hardware,$(project_ot3_default),opentrons_hardware)
+sdist_file = dist/$(call python_get_sdistname,hardware,$(project_rs_default),opentrons_hardware)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,hardware,$(project_ot3_default),opentrons_hardware)
+version_file = $(call python_get_git_version,hardware,$(project_rs_default),opentrons_hardware)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -79,7 +79,7 @@ dist/opentrons_hardware-%-py2.py3-none-any.whl: setup.py $(ot_sources)
 
 wheel: $(wheel_file)
 
-$(sdist_file): export OPENTRONS_PROJECT=$(project_ot3_default)
+$(sdist_file): export OPENTRONS_PROJECT=$(project_rs_default)
 $(sdist_file): setup.py $(ot_sources)
 	$(python) setup.py sdist
 	$(SHX) rm -rf build

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -12,7 +12,7 @@ SRC_PATH = robot_server
 # Project to get the version for
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 
 # Find the version of the wheel from git using a helper script. We
@@ -23,10 +23,10 @@ wheel_file = dist/$(call python_get_wheelname,robot-server,$(project_rs_default)
 # Find the version of the sdist from git using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the sdist.
-sdist_file = dist/$(call python_get_sdistname,robot-server,$(project_ot3_default),robot_server)
+sdist_file = dist/$(call python_get_sdistname,robot-server,$(project_rs_default),robot_server)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,robot-server,$(project_ot3_default),robot_server)
+version_file = $(call python_get_git_version,robot-server,$(project_rs_default),robot_server)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -104,7 +104,7 @@ wheel: setup.py $(ot_sources)
 	$(SHX) ls dist
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist: setup.py $(ot_sources)
 	$(clean_sdist_cmd)
 	$(python) setup.py sdist

--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -11,7 +11,7 @@ SRC_PATH = server_utils
 # Project to get the version for
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 
 # Find the version of the wheel from git using a helper script. We
@@ -22,10 +22,10 @@ wheel_file = dist/$(call python_get_wheelname,server-utils,$(project_rs_default)
 # Find the version of the sdist from git using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the sdist.
-sdist_file = dist/$(call python_get_sdistname,server-utils,$(project_ot3_default),server_utils)
+sdist_file = dist/$(call python_get_sdistname,server-utils,$(project_rs_default),server_utils)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,server-utils,$(project_ot3_default),server_utils)
+version_file = $(call python_get_git_version,server-utils,$(project_rs_default),server_utils)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -79,7 +79,7 @@ wheel: setup.py $(ot_sources)
 	$(SHX) ls dist
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist: setup.py $(ot_sources)
 	$(clean_sdist_cmd)
 	$(python) setup.py sdist

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -22,7 +22,7 @@ BUILD_NUMBER ?=
 
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 # this may be set as an environment variable to select the version of
 # python to run if pyenv is not available. it should always be set to
@@ -33,7 +33,7 @@ BUILD_DIR := dist
 
 
 wheel_file = $(BUILD_DIR)/$(call python_get_wheelname,shared-data,$(project_rs_default),opentrons_shared_data,$(BUILD_NUMBER),../../scripts/python_build_utils.py)
-sdist_file = $(BUILD_DIR)/$(call python_get_sdistname,shared-data,$(project_ot3_default),opentrons_shared_data,,../../scripts/python_build_utils.py)
+sdist_file = $(BUILD_DIR)/$(call python_get_sdistname,shared-data,$(project_rs_default),opentrons_shared_data,,../../scripts/python_build_utils.py)
 
 py_sources = $(filter %.py,$(shell $(SHX) find opentrons_shared_data)) opentrons_shared_data/py.typed
 deck_sources = $(wildcard ../deck/definitions/*/*.json) $(wildcard ../deck/schemas/*.json)
@@ -84,7 +84,7 @@ wheel: setup.py $(py_sources) $(json_sources)
 
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist: setup.py $(py_sources) $(json_sources)
 	$(SHX) mkdir -p build
 	$(python) setup.py sdist

--- a/system-server/Makefile
+++ b/system-server/Makefile
@@ -14,7 +14,7 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 # Find the version of the wheel from git using a helper script. We
 # use python here so we can use the same version normalization that will be
@@ -24,10 +24,10 @@ wheel_file = dist/$(call python_get_wheelname,system-server,$(project_rs_default
 # Find the version of the sdist from git using a helper script. We
 # use python here so we can use the same version normalization that will be
 # used to create the sdist.
-sdist_file = $(call python_get_sdistname,system-server,$(project_ot3_default),system_server)
+sdist_file = $(call python_get_sdistname,system-server,$(project_rs_default),system_server)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,system-server,$(project_ot3_default),system_server)
+version_file = $(call python_get_git_version,system-server,$(project_rs_default),system_server)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -83,7 +83,7 @@ wheel: setup.py $(ot_sources)
 	$(SHX) ls dist
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist: clean
 	$(python) setup.py sdist
 	$(SHX) rm -rf build

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -12,15 +12,15 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 
 ot_project := $(OPENTRONS_PROJECT)
 project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
 
 port ?= 34000
 tests ?= tests
 test_opts ?=
 wheel_file = $(call python_get_wheelname,update-server,$(project_rs_default),otupdate)
-sdist_file = $(call python_get_sdistname,update-server,$(project_ot3_default),otupdate)
+sdist_file = $(call python_get_sdistname,update-server,$(project_rs_default),otupdate)
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,update-server,$(project_ot3_default),update-server)
+version_file = $(call python_get_git_version,update-server,$(project_rs_default),update-server)
 # Host key location for robot
 ssh_key ?= $(default_ssh_key)
 # Other SSH args for robot
@@ -74,7 +74,7 @@ wheel: clean
 	$(SHX) ls dist
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist: clean
 	$(python) setup.py sdist
 	$(SHX) rm -rf build

--- a/usb-bridge/Makefile
+++ b/usb-bridge/Makefile
@@ -13,7 +13,8 @@ SHX := npx shx
 PATH := $(shell cd .. && yarn bin):$(PATH)
 
 ot_project := $(OPENTRONS_PROJECT)
-project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
+project_ir_default = $(if $(ot_project),$(ot_project),ot3)
+project_rs_default = $(if $(ot_project),$(ot_project),robot-stack)
 
 # These variables can be overriden when make is invoked to customize the
 # behavior of pytest. For instance,
@@ -21,10 +22,10 @@ project_ot3_default = $(if $(ot_project),$(ot_project),ot3)
 # specified test
 tests ?= tests
 test_opts ?=
-sdist_file = $(call python_get_sdistname,usb-bridge,$(project_ot3_default),ot3usb)
+sdist_file = $(call python_get_sdistname,usb-bridge,$(project_rs_default),ot3usb)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
-version_file = $(call python_get_git_version,usb-bridge,$(project_ot3_default),ot3usb)
+version_file = $(call python_get_git_version,usb-bridge,$(project_rs_default),ot3usb)
 
 # Host key location for robot
 ssh_key ?= $(default_ssh_key)
@@ -66,7 +67,7 @@ format:
 	$(python) -m black ot3usb tests
 
 .PHONY: sdist
-sdist: export OPENTRONS_PROJECT=$(project_ot3_default)
+sdist: export OPENTRONS_PROJECT=$(project_rs_default)
 sdist: clean
 	$(python) setup.py sdist
 	$(SHX) rm -rf build


### PR DESCRIPTION
We used to have different default projects (which happen, it turns out, in the deploy environment) for sdists and wheels and stuff because sdists only existed for flex dev and we hadn't released it yet. Now we have, and we should always be using our robot-stack project unless ot_project is set to something else.

Keep the other defaults around but make them ir (for internal release) instead of ot3.

This should hopefully prevent the pypi uploads from posting internal-release sdists.

Should fix this: https://github.com/Opentrons/opentrons/actions/runs/7902877476/job/21569838106