### PR TITLE
fix(robot-server): fix infinite cancelling protocol bug on ODD

### DIFF
--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -112,11 +112,6 @@ class RunDataManager:
             EngineConflictError: There is a currently active run that cannot
                 be superceded by this new run.
         """
-        await self._runs_publisher.begin_polling_engine_store(
-            get_current_command=self.get_current_command,
-            get_state_summary=self._get_state_summary,
-            run_id=run_id,
-        )
         prev_run_id = self._engine_store.current_run_id
         if prev_run_id is not None:
             prev_run_result = await self._engine_store.clear()
@@ -135,6 +130,11 @@ class RunDataManager:
             run_id=run_id,
             created_at=created_at,
             protocol_id=protocol.protocol_id if protocol is not None else None,
+        )
+        await self._runs_publisher.begin_polling_engine_store(
+            get_current_command=self.get_current_command,
+            get_state_summary=self._get_state_summary,
+            run_id=run_id,
         )
 
         return _build_run(

--- a/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
@@ -20,9 +20,7 @@ class MaintenanceRunsPublisher:
         self,
     ) -> None:
         """Publishes the equivalent of GET /maintenance_run/current_run"""
-        await self._client.publish_async(
-            topic=Topics.MAINTENANCE_RUNS_CURRENT_RUN.value
-        )
+        await self._client.publish_async(topic=Topics.MAINTENANCE_RUNS_CURRENT_RUN)
 
 
 _maintenance_runs_publisher_accessor: AppStateAccessor[

--- a/robot-server/robot_server/service/notifications/topics.py
+++ b/robot-server/robot_server/service/notifications/topics.py
@@ -4,7 +4,7 @@ from enum import Enum
 _TOPIC_BASE = "robot-server"
 
 
-class Topics(Enum):
+class Topics(str, Enum):
     """Notification Topics
 
     MQTT functional equivalent of endpoints.


### PR DESCRIPTION
Closes [RQA-2346](https://opentrons.atlassian.net/browse/RQA-2346)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an infinite cancelling bug on the ODD caused by incorrect ordering of polling logic. The protocol engine poller used by notifications initializes before the protocol run is created, causing the poller to fail silently. The fix is simply to start the poller after the protocol run is created.

More sanity checks are added to the PE poller - we now stop the current poller, clear it, and then create a new poller if a new run is created before the old run is deleted. The polling flag is properly reset now, too.

There's also a small refactor for the Topic Enum!

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Smoke tested all the major flows and a protocol run.
- Confirmed that cancelling a protocol run on the ODD actually cancels the run.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed an infinitely cancelling protocol run bug on the ODD.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low


[RQA-2346]: https://opentrons.atlassian.net/browse/RQA-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ