### PR TITLE
App update modal background colors

### DIFF
--- a/app/src/molecules/BackgroundOverlay/index.tsx
+++ b/app/src/molecules/BackgroundOverlay/index.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react'
 import { css } from 'styled-components'
 
-import {
-  COLORS,
-  Flex,
-  POSITION_FIXED,
-  RESPONSIVENESS,
-} from '@opentrons/components'
+import { COLORS, Flex, POSITION_FIXED } from '@opentrons/components'
 
 const BACKGROUND_OVERLAY_STYLE = css`
   position: ${POSITION_FIXED};

--- a/app/src/molecules/BackgroundOverlay/index.tsx
+++ b/app/src/molecules/BackgroundOverlay/index.tsx
@@ -12,11 +12,7 @@ const BACKGROUND_OVERLAY_STYLE = css`
   position: ${POSITION_FIXED};
   inset: 0;
   z-index: 3;
-  background-color: ${COLORS.black90}${COLORS.opacity40HexCode};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
-  }
+  background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
 `
 
 export interface BackgroundOverlayProps

--- a/app/src/molecules/BackgroundOverlay/index.tsx
+++ b/app/src/molecules/BackgroundOverlay/index.tsx
@@ -19,7 +19,7 @@ export function BackgroundOverlay(props: BackgroundOverlayProps): JSX.Element {
       top="0"
       bottom="0"
       zIndex="3"
-      backgroundColor={COLORS.grey50}
+      backgroundColor={`${COLORS.black90}${COLORS.opacity60HexCode}`}
       onClick={onClick}
       {...flexProps}
     />

--- a/app/src/molecules/BackgroundOverlay/index.tsx
+++ b/app/src/molecules/BackgroundOverlay/index.tsx
@@ -12,7 +12,6 @@ const BACKGROUND_OVERLAY_STYLE = css`
   position: ${POSITION_FIXED};
   inset: 0;
   z-index: 3;
-  aria-label: 'BackgroundOverlay';
   background-color: ${COLORS.black90}${COLORS.opacity40HexCode};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
@@ -30,6 +29,11 @@ export function BackgroundOverlay(props: BackgroundOverlayProps): JSX.Element {
   const { onClick, ...flexProps } = props
 
   return (
-    <Flex css={BACKGROUND_OVERLAY_STYLE} onClick={onClick} {...flexProps} />
+    <Flex
+      aria-label="BackgroundOverlay"
+      css={BACKGROUND_OVERLAY_STYLE}
+      onClick={onClick}
+      {...flexProps}
+    />
   )
 }

--- a/app/src/molecules/BackgroundOverlay/index.tsx
+++ b/app/src/molecules/BackgroundOverlay/index.tsx
@@ -1,5 +1,24 @@
 import * as React from 'react'
-import { COLORS, Flex, POSITION_FIXED } from '@opentrons/components'
+import { css } from 'styled-components'
+
+import {
+  COLORS,
+  Flex,
+  POSITION_FIXED,
+  RESPONSIVENESS,
+} from '@opentrons/components'
+
+const BACKGROUND_OVERLAY_STYLE = css`
+  position: ${POSITION_FIXED};
+  inset: 0;
+  z-index: 3;
+  aria-label: 'BackgroundOverlay';
+  background-color: ${COLORS.black90}${COLORS.opacity40HexCode};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
+  }
+`
 
 export interface BackgroundOverlayProps
   extends React.ComponentProps<typeof Flex> {
@@ -11,17 +30,6 @@ export function BackgroundOverlay(props: BackgroundOverlayProps): JSX.Element {
   const { onClick, ...flexProps } = props
 
   return (
-    <Flex
-      aria-label="BackgroundOverlay"
-      position={POSITION_FIXED}
-      left="0"
-      right="0"
-      top="0"
-      bottom="0"
-      zIndex="3"
-      backgroundColor={`${COLORS.black90}${COLORS.opacity60HexCode}`}
-      onClick={onClick}
-      {...flexProps}
-    />
+    <Flex css={BACKGROUND_OVERLAY_STYLE} onClick={onClick} {...flexProps} />
   )
 }

--- a/app/src/molecules/LegacyModal/LegacyModalShell.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalShell.tsx
@@ -86,7 +86,7 @@ const Overlay = styled.div`
   cursor: default;
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    background-color: ${COLORS.grey50};
+    background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
   }
 `
 const ContentArea = styled.div<{ zIndex: string | number }>`

--- a/app/src/molecules/LegacyModal/LegacyModalShell.tsx
+++ b/app/src/molecules/LegacyModal/LegacyModalShell.tsx
@@ -84,10 +84,6 @@ const Overlay = styled.div`
   z-index: 1;
   background-color: ${COLORS.black90}${COLORS.opacity40HexCode};
   cursor: default;
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
-  }
 `
 const ContentArea = styled.div<{ zIndex: string | number }>`
   display: flex;

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -19,6 +19,9 @@ export interface LegacyModalProps extends StyleProps {
   footer?: React.ReactNode
 }
 
+/**
+ * For Desktop app use only.
+ */
 export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
   const {
     type = 'info',

--- a/app/src/molecules/Modal/Modal.tsx
+++ b/app/src/molecules/Modal/Modal.tsx
@@ -24,6 +24,9 @@ interface ModalProps extends StyleProps {
   /** see ModalHeader component for more details */
   header?: ModalHeaderBaseProps
 }
+/**
+ * For ODD use only.
+ */
 export function Modal(props: ModalProps): JSX.Element {
   const {
     modalSize = 'medium',

--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -78,13 +78,10 @@ const Overlay = styled.div`
   top: 0;
   bottom: 0;
   z-index: 1;
-  background-color: ${COLORS.black90}${COLORS.opacity40HexCode};
+  background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
   cursor: default;
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
-  }
 `
+
 const ContentArea = styled.div<{ zIndex: string | number }>`
   display: flex;
   position: ${POSITION_ABSOLUTE};

--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -82,7 +82,7 @@ const Overlay = styled.div`
   cursor: default;
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    background-color: ${COLORS.grey50};
+    background-color: ${COLORS.black90}${COLORS.opacity60HexCode};
   }
 `
 const ContentArea = styled.div<{ zIndex: string | number }>`

--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import styled from 'styled-components'
-import { BORDERS, RESPONSIVENESS, SPACING } from '../ui-style-constants'
+import { BORDERS, SPACING } from '../ui-style-constants'
 import { COLORS } from '../helix-design-system'
 import { StyleProps, styleProps } from '../primitives'
 import {


### PR DESCRIPTION
Closes [RAUT-928](https://opentrons.atlassian.net/browse/RAUT-928) and [RQA-2282](https://opentrons.atlassian.net/browse/RQA-2282)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

[See Figma. ](https://www.figma.com/file/1ot18My22DALIcjdLl5LJh/Helix-Design-System?type=design&node-id=1069-50330&mode=design&t=0UHCNmXSdDV53iJJ-0)

Update modal background colors to designs. 

### Before

<img width="1017" alt="Screenshot 2024-02-15 at 1 52 08 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/de789e7c-696e-4445-aee8-1cc8da582753">

### After
<img width="1012" alt="Screenshot 2024-02-15 at 1 51 40 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/918c13ea-e72a-48cd-89cc-5af18cd2f1ee">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Confirmed ODD/desktop modal backgrounds are of appropriate color & transparency.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed the background color on certain modals.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-928]: https://opentrons.atlassian.net/browse/RAUT-928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2282]: https://opentrons.atlassian.net/browse/RQA-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ