### PR TITLE
fix(api): reconfigure instrument cache after a firmware update

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -727,7 +727,7 @@ class OT3API(
         await self.set_gantry_load(self._gantry_load_from_instruments())
         await self.refresh_positions()
         await self.reset_tip_detectors(False)
-        self._configured_since_update = False
+        self._configured_since_update = True
 
     async def reset_tip_detectors(
         self,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -524,7 +524,8 @@ class OT3API(
                     message="Update failed because of uncaught error",
                     wrapping=[PythonException(e)],
                 ) from e
-            self._configured_since_update = False
+            finally:
+                self._configured_since_update = False
 
     # Incidentals (i.e. not motion) API
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The hardware controller sets the proper motor currents for each axis when the instruments are cached. Whenever a subsystem gets rebooted/updated, the motor current setting is lost. This means we must re-configure the instrument cache after we update a firmware, to make sure the subsystem motor is set up correctly. 

