### PR TITLE
chore: 7.2 alpha release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,7 +10,7 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.2.0 release of the Opentrons robot software!
 
-This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow *approximately 25 minutes* for your robot to restart. This delay will only happen once.
+This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow *approximately 20 minutes* for your robot to restart. This delay will only happen once.
 
 If you don't care about preserving your labware offsets and run history, you can avoid the delay by clearing your runs and protocols before starting this update. Go to **Robot Settings** > **Device Reset** and select **Clear protocol run history**.
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,23 +6,26 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
-## Opentrons Robot Software Changes in [!!EDIT ME WITH THE ACTUAL NUMBER OF THE NEXT RELEASE!!]
+## Opentrons Robot Software Changes in 7.2.0
 
-### HTTP API
+Welcome to the v7.2.0 release of the Opentrons robot software!
+
+This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow *approximately 25 minutes* for your robot to restart. This delay will only happen once.
+
+If you don't care about preserving your labware offsets and run history, you can avoid the delay by clearing your runs and protocols before starting this update. Go to **Robot Settings** > **Device Reset** and select **Clear protocol run history**.
+
+### Improved Features
 
 - In the `/runs/commands`, `/maintenance_runs/commands`, and `/protocols` endpoints, the `dispense` command will now return an error if you try to dispense more than you've aspirated, instead of silently clamping.
-- The `/notifications/subscribe` WebSocket endpoint has been removed. See https://github.com/Opentrons/opentrons/pull/14280 for details.
 - The `/runs/commands` endpoints are significantly faster when you request a small number of commands from a stored run.
 
-### Other Changes
+### Bug Fixes
 
-- The `notify_server` Python package has been removed. See https://github.com/Opentrons/opentrons/pull/14280 for details.
+- The Flex Gripper will no longer pick up large labware that could collide with tips held by an adjoining pipette.
 
-### Upgrade Notes
+### Removals
 
-This update may take longer than usual if your robot has a lot of long protocols and runs stored on it. Allow **approximately 25 minutes** for your robot to restart. This delay will only happen once.
-
-If you don't care about preserving your labware offsets and run history, you can avoid the delay. Clear your runs and protocols before starting this update. Go to **Robot Settings** > **Device Reset** and select **Clear protocol run history**.
+- Removed the `notify_server` Python package and `/notifications/subscribe` WebSocket endpoint, as they were never fully used.
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -25,7 +25,7 @@ If you don't care about preserving your labware offsets and run history, you can
 
 ### Removals
 
-- Removed the `notify_server` Python package and `/notifications/subscribe` WebSocket endpoint, as they were never fully used.
+- Removed the `notify_server` Python package and `/notifications/subscribe` WebSocket endpoint, as they were never fully used. (See pull request [#14280](https://github.com/Opentrons/opentrons/pull/14280) for details.)
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -16,12 +16,14 @@ If you don't care about preserving your labware offsets and run history, you can
 
 ### Improved Features
 
-- In the `/runs/commands`, `/maintenance_runs/commands`, and `/protocols` endpoints, the `dispense` command will now return an error if you try to dispense more than you've aspirated, instead of silently clamping.
-- The `/runs/commands` endpoints are significantly faster when you request a small number of commands from a stored run.
+- The robot software now runs Python 3.10. Many built-in Python packages were updated to match. If you have installed your own Python packages on the robot, re-install them to ensure compatibility.
+- Added error handling when dispensing. The `/runs/commands`, `/maintenance_runs/commands`, and `/protocols` HTTP API endpoints now return an error if you try to dispense more than you've aspirated.
+- Improved performance of the `/runs/commands` endpoints. They are now significantly faster when requesting a small number of commands from a stored run.
 
 ### Bug Fixes
 
 - The Flex Gripper will no longer pick up large labware that could collide with tips held by an adjoining pipette.
+- Flex now properly configures itself when connected by Ethernet directly to a computer.
 
 ### Removals
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -12,6 +12,15 @@ Welcome to the v7.2.0 release of the Opentrons App!
 
 The Linux version of the Opentrons App now requires Ubuntu 20.04 or newer.
 
+### New Features
+
+- Added a warning in case you need to manually remove tips from a pipette after power cycling the robot.
+
+### Improved Features
+
+- Commands involving the trash bin or waste chute now appear in the run preview.
+- The app will prompt you to reanalyze protocols that haven't been analyzed in such a long time that intervening changes to the app could affect their behavior.
+
 ### Bug Fixes
 
 - The OT-2 now accurately calculates the position of the Thermocycler. If you previously compensated for the incorrect position with labware offsets, re-run Labware Position Check to avoid pipette crashes.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,18 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons App Changes in 7.2.0
+
+Welcome to the v7.2.0 release of the Opentrons App!
+
+The Linux version of the Opentrons App now requires Ubuntu 20.04 or newer.
+
+### Bug Fixes
+
+- The OT-2 now accurately calculates the position of the Thermocycler. If you previously compensated for the incorrect position with labware offsets, re-run Labware Position Check to avoid pipette crashes.
+
+---
+
 ## Opentrons App Changes in 7.1.1
 
 Welcome to the v7.1.1 release of the Opentrons App!


### PR DESCRIPTION
# Overview

Better late than never, here are draft release notes for 7.2.

Partially addresses RTC-384.

# Test Plan

Make sure these look good at the next alpha tag.

# Changelog

- Edited existing stub for api notes.
- Added app-shell notes.

# Review requests

The items included here are based on tickets that are closed or in QA. If there's an omission that will definitely be in the 7.2 release, comment and I'll get it added. If the feature is still in progress and isn't certain to be included in 7.2, wait and we can add it in a follow-up PR before stable release.

# Risk assessment

v low, release notes only