### PR TITLE
refactor(app): Remove notification event emitters

### DIFF
--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -1,10 +1,9 @@
 // access main process remote modules via attachments to `global`
 import assert from 'assert'
-import { EventEmitter } from 'events'
 
 import type { AxiosRequestConfig } from 'axios'
 import type { ResponsePromise } from '@opentrons/api-client'
-import type { Remote, NotifyTopic } from './types'
+import type { Remote, NotifyTopic, NotifyResponseData } from './types'
 
 const emptyRemote: Remote = {} as any
 
@@ -40,16 +39,15 @@ export function appShellRequestor<Data>(
 
 export function appShellListener(
   hostname: string | null,
-  topic: NotifyTopic
-): EventEmitter {
-  const eventEmitter = new EventEmitter()
+  topic: NotifyTopic,
+  listenerCb: (data: NotifyResponseData) => void
+): void {
   remote.ipcRenderer.on(
     'notify',
     (_, shellHostname, shellTopic, shellMessage) => {
       if (hostname === shellHostname && topic === shellTopic) {
-        eventEmitter.emit('data', shellMessage)
+        listenerCb(shellMessage)
       }
     }
   )
-  return eventEmitter
 }

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -40,13 +40,13 @@ export function appShellRequestor<Data>(
 export function appShellListener(
   hostname: string | null,
   topic: NotifyTopic,
-  listenerCb: (data: NotifyResponseData) => void
+  callback: (data: NotifyResponseData) => void
 ): void {
   remote.ipcRenderer.on(
     'notify',
     (_, shellHostname, shellTopic, shellMessage) => {
       if (hostname === shellHostname && topic === shellTopic) {
-        listenerCb(shellMessage)
+        callback(shellMessage)
       }
     }
   )

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -12,12 +12,20 @@ export interface Remote {
         event: IpcMainEvent,
         hostname: string,
         topic: NotifyTopic,
-        message: string | Object,
+        message: NotifyResponseData | NotifyNetworkError,
         ...args: unknown[]
       ) => void
     ) => void
   }
 }
+
+interface NotifyRefetchData {
+  refetchUsingHTTP: boolean
+  statusCode: never
+}
+
+export type NotifyNetworkError = 'ECONNFAILED' | 'ECONNREFUSED'
+export type NotifyResponseData = NotifyRefetchData | NotifyNetworkError
 
 interface File {
   sha512: string

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -1,0 +1,204 @@
+import { useDispatch } from 'react-redux'
+import { renderHook } from '@testing-library/react'
+
+import { useHost } from '@opentrons/react-api-client'
+
+import { useNotifyService } from '../useNotifyService'
+import { appShellListener } from '../../redux/shell/remote'
+import { useTrackEvent } from '../../redux/analytics'
+import {
+  notifySubscribeAction,
+  notifyUnsubscribeAction,
+} from '../../redux/shell'
+
+import type { HostConfig } from '@opentrons/api-client'
+import type { QueryOptionsWithPolling } from '../useNotifyService'
+
+jest.mock('react-redux')
+jest.mock('@opentrons/react-api-client')
+jest.mock('../../redux/analytics')
+jest.mock('../../redux/shell/remote', () => ({
+  appShellListener: jest.fn(),
+}))
+
+const MOCK_HOST_CONFIG: HostConfig = { hostname: 'MOCK_HOST' }
+const MOCK_TOPIC = '/test/topic' as any
+const MOCK_OPTIONS: QueryOptionsWithPolling<any, any> = {
+  forceHttpPolling: false,
+}
+
+const mockUseHost = useHost as jest.MockedFunction<typeof useHost>
+const mockUseDispatch = useDispatch as jest.MockedFunction<typeof useDispatch>
+const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
+  typeof useTrackEvent
+>
+const mockAppShellListener = appShellListener as jest.MockedFunction<
+  typeof appShellListener
+>
+
+describe('useNotifyService', () => {
+  let mockDispatch: jest.Mock
+  let mockTrackEvent: jest.Mock
+  let mockHTTPRefetch: jest.Mock
+
+  beforeEach(() => {
+    mockDispatch = jest.fn()
+    mockHTTPRefetch = jest.fn()
+    mockTrackEvent = jest.fn()
+    mockUseTrackEvent.mockReturnValue(mockTrackEvent)
+    mockUseDispatch.mockReturnValue(mockDispatch)
+    mockUseHost.mockReturnValue(MOCK_HOST_CONFIG)
+  })
+
+  afterEach(() => {
+    mockUseDispatch.mockClear()
+    jest.clearAllMocks()
+  })
+
+  it('should trigger an HTTP refetch and subscribe action on initial mount', () => {
+    renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    expect(mockHTTPRefetch).toHaveBeenCalled()
+    expect(mockDispatch).toHaveBeenCalledWith(
+      notifySubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
+    )
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      notifyUnsubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
+    )
+    expect(appShellListener).toHaveBeenCalled()
+  })
+
+  it('should trigger an unsubscribe action on dismount', () => {
+    const { unmount } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    unmount()
+    expect(mockDispatch).toHaveBeenCalledWith(
+      notifyUnsubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
+    )
+  })
+
+  it('should return no notify error if there was a successful topic subscription', () => {
+    const { result } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    expect(result.current.isNotifyError).toBe(false)
+  })
+
+  it('should not subscribe to notifications if forceHttpPolling is true', () => {
+    renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: { ...MOCK_OPTIONS, forceHttpPolling: true },
+      } as any)
+    )
+    expect(mockHTTPRefetch).toHaveBeenCalled()
+    expect(appShellListener).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('should not subscribe to notifications if enabled is false', () => {
+    renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: { ...MOCK_OPTIONS, enabled: false },
+      } as any)
+    )
+    expect(mockHTTPRefetch).toHaveBeenCalled()
+    expect(appShellListener).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('should not subscribe to notifications if staleTime is Infinity', () => {
+    renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: { ...MOCK_OPTIONS, staleTime: Infinity },
+      } as any)
+    )
+    expect(mockHTTPRefetch).toHaveBeenCalled()
+    expect(appShellListener).not.toHaveBeenCalled()
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('should log an error if hostname is null', () => {
+    mockUseHost.mockReturnValue({ hostname: null } as any)
+    const errorSpy = jest.spyOn(console, 'error')
+    errorSpy.mockImplementation(() => {})
+
+    renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    expect(errorSpy).toHaveBeenCalledWith(
+      'NotifyService expected hostname, received null for topic:',
+      MOCK_TOPIC
+    )
+    errorSpy.mockRestore()
+  })
+
+  it('should return a notify error and fire an analytics reporting event if the connection was refused', () => {
+    mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
+      mockCb('ECONNREFUSED')
+    })
+    const { result, rerender } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    expect(mockTrackEvent).toHaveBeenCalled()
+    rerender()
+    expect(result.current.isNotifyError).toBe(true)
+  })
+
+  it('should return a notify error if the connection failed', () => {
+    mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
+      mockCb('ECONNFAILED')
+    })
+    const { result, rerender } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    rerender()
+    expect(result.current.isNotifyError).toBe(true)
+  })
+
+  it('should trigger an HTTP refetch if the refetch flag was returned', () => {
+    mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
+      mockCb({ refetchUsingHTTP: true })
+    })
+    const { rerender } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        refetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    rerender()
+    expect(mockHTTPRefetch).toHaveBeenCalled()
+  })
+})

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -12,21 +12,12 @@ import {
 } from '../redux/analytics'
 
 import type { UseQueryOptions } from 'react-query'
-import type { NotifyTopic } from '../redux/shell/types'
+import type { NotifyTopic, NotifyResponseData } from '../redux/shell/types'
 
 export interface QueryOptionsWithPolling<TData, TError = Error>
   extends UseQueryOptions<TData, TError> {
   forceHttpPolling?: boolean
 }
-
-interface NotifyRefetchData {
-  refetchUsingHTTP: boolean
-  statusCode: never
-}
-
-export type NotifyNetworkError = 'ECONNFAILED' | 'ECONNREFUSED'
-
-type NotifyResponseData = NotifyRefetchData | NotifyNetworkError
 
 interface UseNotifyServiceProps<TData, TError = Error> {
   topic: NotifyTopic
@@ -55,12 +46,11 @@ export function useNotifyService<TData, TError = Error>({
       hostname != null &&
       staleTime !== Infinity
     ) {
-      const eventEmitter = appShellListener(hostname, topic)
-      eventEmitter.on('data', onDataListener)
+      const listenerCb = (data: NotifyResponseData): void => onDataEvent(data)
+      appShellListener(hostname, topic, listenerCb)
       dispatch(notifySubscribeAction(hostname, topic))
 
       return () => {
-        eventEmitter.off('data', onDataListener)
         if (hostname != null) {
           dispatch(notifyUnsubscribeAction(hostname, topic))
         }
@@ -77,7 +67,7 @@ export function useNotifyService<TData, TError = Error>({
 
   return { isNotifyError: isNotifyError.current }
 
-  function onDataListener(data: NotifyResponseData): void {
+  function onDataEvent(data: NotifyResponseData): void {
     if (!isNotifyError.current) {
       if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
         isNotifyError.current = true

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -46,8 +46,7 @@ export function useNotifyService<TData, TError = Error>({
       hostname != null &&
       staleTime !== Infinity
     ) {
-      const listenerCb = (data: NotifyResponseData): void => onDataEvent(data)
-      appShellListener(hostname, topic, listenerCb)
+      appShellListener(hostname, topic, onDataEvent)
       dispatch(notifySubscribeAction(hostname, topic))
 
       return () => {


### PR DESCRIPTION
Partially closes [RAUT-990](https://opentrons.atlassian.net/browse/RAUT-990)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Event emitters don't provide anything that a callback doesn't. In fact, they make things worse by:

1. Making testing much more difficult. Mocking event emitters isn't fun.
2. There are all sorts of emitter leak issues that can arise.
3. The console gets spammed with warning messages.

Let's use callbacks from the IPCRenderer -> app without the unnecessary event emitter intermediary. Let's also move some of the types involving the data received from the shell layer to the proper place.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Smoke tested the app, making sure notifications work.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-990]: https://opentrons.atlassian.net/browse/RAUT-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ