### PR TITLE
fix(app): return calibration flow even if pipette is already calibrated

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -24,29 +24,13 @@ const mockSingleMountPipetteAttached = {
 }
 
 describe('getPipetteWizardStepsForProtocol', () => {
-  it('returns an empty array of info when the attached pipette matches required pipette', () => {
-    const mockFlowSteps = [] as PipetteWizardStep[]
-    expect(
-      getPipetteWizardStepsForProtocol(
-        mockSingleMountPipetteAttached,
-        [
-          {
-            id: '123',
-            pipetteName: 'p1000_single_flex',
-            mount: 'left',
-          },
-        ],
-        LEFT
-      )
-    ).toStrictEqual(mockFlowSteps)
-  })
   it('returns an empty array when there is no pipette attached and no pipette is needed', () => {
-    const mockFlowSteps = [] as PipetteWizardStep[]
+    const mockFlowSteps = null as PipetteWizardStep[] | null
     expect(
       getPipetteWizardStepsForProtocol({ left: null, right: null }, [], LEFT)
     ).toStrictEqual(mockFlowSteps)
   })
-  it('returns the calibration flow only when correct pipette is attached but there is no pip cal data', () => {
+  it('returns the calibration flow only when correct pipette is attached even if htere is pip cal data', () => {
     const mockFlowSteps = [
       {
         section: SECTIONS.BEFORE_BEGINNING,
@@ -71,7 +55,6 @@ describe('getPipetteWizardStepsForProtocol', () => {
           left: null,
           right: {
             ...mockAttachedPipetteInformation,
-            data: { calibratedOffset: undefined as any },
           } as any,
         },
         [{ id: '123', pipetteName: 'p1000_single_flex', mount: 'right' }],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/getPipetteWizardStepsForProtocol.test.tsx
@@ -30,7 +30,7 @@ describe('getPipetteWizardStepsForProtocol', () => {
       getPipetteWizardStepsForProtocol({ left: null, right: null }, [], LEFT)
     ).toStrictEqual(mockFlowSteps)
   })
-  it('returns the calibration flow only when correct pipette is attached even if htere is pip cal data', () => {
+  it('returns the calibration flow only when correct pipette is attached even if there is pip cal data', () => {
     const mockFlowSteps = [
       {
         section: SECTIONS.BEFORE_BEGINNING,

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -12,7 +12,7 @@ export const getPipetteWizardSteps = (
   mount: PipetteMount,
   selectedPipette: SelectablePipettes,
   isGantryEmpty: boolean
-): PipetteWizardStep[] => {
+): PipetteWizardStep[] | null => {
   switch (flowType) {
     case FLOWS.CALIBRATE: {
       return [
@@ -205,5 +205,5 @@ export const getPipetteWizardSteps = (
       }
     }
   }
-  return []
+  return null
 }

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -8,23 +8,17 @@ export const getPipetteWizardStepsForProtocol = (
   attachedPipettes: AttachedPipettesFromInstrumentsQuery,
   pipetteInfo: LoadedPipette[],
   mount: Mount
-): PipetteWizardStep[] => {
+): PipetteWizardStep[] | null => {
   const requiredPipette = pipetteInfo.find(pipette => pipette.mount === mount)
   const nintySixChannelAttached =
     attachedPipettes[LEFT]?.instrumentName === 'p1000_96'
 
-  //  return empty array when correct pipette is attached && pipette cal not needed or
-  //  no pipette is required in the protocol
-  if (
-    (requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName &&
-      attachedPipettes[mount]?.data?.calibratedOffset?.last_modified != null) ||
-    requiredPipette == null
-  ) {
-    return []
-    //    return calibration flow only if correct pipette is attached and pipette cal null
+  //  return empty array if no pipette is required in the protocol
+  if (requiredPipette == null) {
+    return null
+    // return calibration flow if correct pipette is attached
   } else if (
-    requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName &&
-    attachedPipettes[mount]?.data?.calibratedOffset?.last_modified == null
+    requiredPipette?.pipetteName === attachedPipettes[mount]?.instrumentName
   ) {
     return [
       {

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -86,7 +86,7 @@ export const PipetteWizardFlows = (
   )
   const host = useHost()
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
-  const totalStepCount = pipetteWizardSteps.length - 1
+  const totalStepCount = pipetteWizardSteps ? pipetteWizardSteps.length - 1 : 0
   const currentStep = pipetteWizardSteps?.[currentStepIndex] ?? null
   const [isFetchingPipettes, setIsFetchingPipettes] = React.useState<boolean>(
     false

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -87,7 +87,7 @@ export const PipetteWizardFlows = (
   const host = useHost()
   const [currentStepIndex, setCurrentStepIndex] = React.useState<number>(0)
   const totalStepCount = pipetteWizardSteps.length - 1
-  const currentStep = pipetteWizardSteps?.[currentStepIndex]
+  const currentStep = pipetteWizardSteps?.[currentStepIndex] ?? null
   const [isFetchingPipettes, setIsFetchingPipettes] = React.useState<boolean>(
     false
   )
@@ -253,10 +253,10 @@ export const PipetteWizardFlows = (
     isOnDevice,
   }
   const is96ChannelUnskippableStep =
-    currentStep.section === SECTIONS.CARRIAGE ||
-    currentStep.section === SECTIONS.MOUNTING_PLATE ||
+    currentStep?.section === SECTIONS.CARRIAGE ||
+    currentStep?.section === SECTIONS.MOUNTING_PLATE ||
     (selectedPipette === NINETY_SIX_CHANNEL &&
-      currentStep.section === SECTIONS.DETACH_PIPETTE)
+      currentStep?.section === SECTIONS.DETACH_PIPETTE)
 
   const exitModal = is96ChannelUnskippableStep ? (
     <UnskippableModal


### PR DESCRIPTION
fix RQA-2357

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In setup to run when a pipette is correctly attached and calibrated, we should still open the calibration flow when the user presses "recalibrate"
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
On ODD, with a pipette attached and calibrated, go to run setup and press "Recalibrate" - the calibration flow should launch as expected
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Return calibration steps from `getPipetteWizardStepsForProtocol` if a pipette is properly attached, regardless of whether it is already calibrated
2. Return `null` instead of `[]` for both `getPipetteWizardStepsForProtocol` and `getPipetteWizardSteps` to take advantage of null handling in the `PipetteWizardFlows` component
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over code - I've already tested this
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
