### PR TITLE
fix(robot-server): Fix error parsing persisted loadModule commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -87,7 +87,7 @@ class LoadModuleResult(BaseModel):
     )
 
     serialNumber: Optional[str] = Field(
-        ...,
+        None,
         description="Hardware serial number of the connected module. "
         "Will be `None` if a module is not electrically connected to the robot (like the Magnetic Block).",
     )


### PR DESCRIPTION
# Overview

Fixes RSS-471.

# Test Plan

The integration tests added in #14508 will cover this.

# Details

When you load a Magnetic Block, that's represented by a Protocol Engine `loadModule` command. Unlike other `loadModule` commands, it will not have a `result.serialNumber`. This is all good and correct so far.

That `serialNumber` field is defined like this:

```python
serialNumber: Optional[str] = Field(
    ...,  # This is a literal ellipsis, not me summarizing.
    description="blah blah"
)
```

This means, when parsing this model from persistent storage, `serialNumber` *must* be present, either as a string or as an explicit Python `None` / JSON `null`. It cannot be omitted; it will not default to `None`/`null`.

The bug is that this does not match how these models are *saved to* persistent storage. There, the field *is* omitted. My fix is to add a default of `None`, so they match.

We're only seeing this now because, as of #14355, we're parsing models that were saved under a different set of Pydantic options. Formerly, we were doing `.dict()` (for [analyses][oldanalyses], [runs][oldruns], and [commands][oldcommands]). Now, we're [doing][newjson] `.json(by_alias=True`, `exclude_none=True`) (for [analyses][newanalyses], [runs][newruns], and [commands][newcommands]). The "bad" part of that is `exclude_none=True`—see below.

[oldanalyses]: https://github.com/Opentrons/opentrons/blob/4b0653611a6f21d29a0cd65fe88e02cf9fc8ffe1/robot-server/robot_server/protocols/completed_analysis_store.py#L294
[oldruns]: https://github.com/Opentrons/opentrons/blob/4b0653611a6f21d29a0cd65fe88e02cf9fc8ffe1/robot-server/robot_server/runs/run_store.py#L445
[oldcommands]: https://github.com/Opentrons/opentrons/blob/4b0653611a6f21d29a0cd65fe88e02cf9fc8ffe1/robot-server/robot_server/runs/run_store.py#L447
[newjson]: https://github.com/Opentrons/opentrons/blob/1813a8a84da8e89cd6df210647565bae17701ef9/robot-server/robot_server/persistence/pydantic.py#L10-L17
[newanalyses]: https://github.com/Opentrons/opentrons/blob/1813a8a84da8e89cd6df210647565bae17701ef9/robot-server/robot_server/protocols/completed_analysis_store.py#L46
[newruns]: https://github.com/Opentrons/opentrons/blob/1813a8a84da8e89cd6df210647565bae17701ef9/robot-server/robot_server/runs/run_store.py#L487
[newcommands]: https://github.com/Opentrons/opentrons/blob/1813a8a84da8e89cd6df210647565bae17701ef9/robot-server/robot_server/runs/run_store.py#L124

# Review requests

## Is this the only place we've introduced this bug?

Theoretically, this bug can happen in any other model that's declaring a field like `field: Optional[T] = Field(default=...)`. 

I've run a global text search on the monorepo with this [Comby](https://comby.dev/) rule. Basically, look for any `Optional[X] = Field(Y)`, where `Y` contains `...`.

```
comby 'Optional[...] = :[~(pydantic\.)?]Field(:[params])' \
  '' \
  -rule 'where match :[params] { | ":[~.*\.\.\..*]" -> true}' \
  -match-only \
  .py
```

Although there are [many hits](https://gist.github.com/SyntaxColoring/fec42df5509032426d4feb1daa18347d), all except for this one seem to be false positives or models that aren't stored in the database.

But it's difficult to be confident that this search is exhaustive.

## Is `exclude_none=True` a correct way to serialize these objects in the first place?

This seems like it will take a bit of attention to untangle, but here is a spike ticket for us to figure that out: RSS-473. If you have any thoughts, drop them there.

# Risk assessment

I don't think this change can make anything worse, but the underlying hazard still remains.