### PR TITLE
fix(robot-server): append error to analysis error list in case an internal error occurred

### DIFF
--- a/robot-server/robot_server/errors/error_mappers.py
+++ b/robot-server/robot_server/errors/error_mappers.py
@@ -1,0 +1,10 @@
+"""Map errors to Exceptions."""
+from opentrons_shared_data.errors import EnumeratedError, PythonException
+
+
+def map_unexpected_error(error: BaseException) -> EnumeratedError:
+    """Map an unhandled Exception to a known exception."""
+    if isinstance(error, EnumeratedError):
+        return error
+    else:
+        return PythonException(error)

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -17,10 +17,30 @@ from opentrons.protocol_engine import (
 )
 import opentrons.protocol_runner as protocol_runner
 from opentrons.protocol_reader import ProtocolSource, JsonProtocolConfig
+import opentrons.util.helpers as datetime_helper
 
 from robot_server.protocols.analysis_store import AnalysisStore
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.protocols.protocol_analyzer import ProtocolAnalyzer
+import robot_server.errors.error_mappers as em
+
+from opentrons_shared_data.errors import EnumeratedError, ErrorCodes
+
+
+@pytest.fixture(autouse=True)
+def patch_mock_map_unexpected_error(
+    decoy: Decoy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replace map_unexpected_error with a mock."""
+    mock_map_unexpected_error = decoy.mock(func=em.map_unexpected_error)
+    monkeypatch.setattr(em, "map_unexpected_error", mock_map_unexpected_error)
+
+
+@pytest.fixture(autouse=True)
+def patch_mock_get_utc_datetime(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace utc_now with a mock."""
+    mock_get_utc_datetime = decoy.mock(func=datetime_helper.utc_now)
+    monkeypatch.setattr(datetime_helper, "utc_now", mock_get_utc_datetime)
 
 
 @pytest.fixture(autouse=True)
@@ -143,6 +163,85 @@ async def test_analyze(
             modules=[],
             pipettes=[analysis_pipette],
             errors=[analysis_error],
+            liquids=[],
+        ),
+    )
+
+
+async def test_analyze_updates_pending_on_error(
+    decoy: Decoy,
+    analysis_store: AnalysisStore,
+    subject: ProtocolAnalyzer,
+) -> None:
+    """It should update pending analysis with an internal error."""
+    robot_type: RobotType = "OT-3 Standard"
+
+    protocol_resource = ProtocolResource(
+        protocol_id="protocol-id",
+        created_at=datetime(year=2021, month=1, day=1),
+        source=ProtocolSource(
+            directory=Path("/dev/null"),
+            main_file=Path("/dev/null/abc.json"),
+            config=JsonProtocolConfig(schema_version=123),
+            files=[],
+            metadata={},
+            robot_type=robot_type,
+            content_hash="abc123",
+        ),
+        protocol_key="dummy-data-111",
+    )
+
+    raised_exception = Exception("You got me!!")
+
+    error_occurrence = pe_errors.ErrorOccurrence.construct(
+        id="internal-error",
+        createdAt=datetime(year=2023, month=3, day=3),
+        errorType="EnumeratedError",
+        detail="You got me!!",
+    )
+
+    enumerated_error = EnumeratedError(
+        code=ErrorCodes.GENERAL_ERROR,
+        message="You got me!!",
+    )
+
+    json_runner = decoy.mock(cls=protocol_runner.JsonRunner)
+
+    decoy.when(
+        await protocol_runner.create_simulating_runner(
+            robot_type=robot_type,
+            protocol_config=JsonProtocolConfig(schema_version=123),
+        )
+    ).then_return(json_runner)
+
+    decoy.when(
+        await json_runner.run(
+            deck_configuration=[], protocol_source=protocol_resource.source
+        )
+    ).then_raise(raised_exception)
+
+    decoy.when(em.map_unexpected_error(error=raised_exception)).then_return(
+        enumerated_error
+    )
+
+    decoy.when(datetime_helper.utc_now()).then_return(
+        datetime(year=2023, month=3, day=3)
+    )
+
+    await subject.analyze(
+        protocol_resource=protocol_resource,
+        analysis_id="analysis-id",
+    )
+
+    decoy.verify(
+        await analysis_store.update(
+            analysis_id="analysis-id",
+            robot_type=robot_type,
+            commands=[],
+            labware=[],
+            modules=[],
+            pipettes=[],
+            errors=[error_occurrence],
             liquids=[],
         ),
     )


### PR DESCRIPTION
# Overview

closes [RSS-169](https://opentrons.atlassian.net/browse/RSS-169).
append internal error to analysis errors list in case a un expected error occured. 

# Test Plan

Tested this by adding a raise in the `runner.run` method. made sure that the analysis is not stuck in a pending state. 
Can do the same test on a robot. 
Make sure analysis completed with "NOT_OK" result and that the error appears.  
```
{
    "data": [
        {
            "id": "45aeefdd-8450-470d-8289-bde0d6c17597",
            "status": "completed",
            "result": "not-ok",
            "robotType": "OT-2 Standard",
            "commands": [],
            "labware": [],
            "pipettes": [],
            "modules": [],
            "liquids": [],
            "errors": [
                {
                    "id": "internal-error",
                    "createdAt": "2024-02-16T02:24:08.423768+00:00",
                    "errorCode": "4000",
                    "errorType": "PythonException",
                    "detail": "RuntimeError: No active exception to reraise",
                    "errorInfo": {
                        "args": "('No active exception to reraise',)",
                        "traceback": "  File \"/Users/tamarzanzouri/opentrons/robot-server/robot_server/protocols/protocol_analyzer.py\", line 37, in analyze\n    result = await runner.run(\n\n  File \"/Users/tamarzanzouri/opentrons/api/src/opentrons/protocol_runner/protocol_runner.py\", line 307, in run\n    raise\n",
                        "class": "RuntimeError"
                    },
                    "wrappedErrors": []
                }
            ]
        }
    ],
    "meta": {
        "cursor": 0,
        "totalLength": 1
    }
}
```

# Changelog

- Added a "catch all" for errors that the PE does not catch internally in `analyze`.
- Create an error from the internal error and append it to the analysis error list. 


# Risk assessment

low.


[RSS-169]: https://opentrons.atlassian.net/browse/RSS-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ