### PR TITLE
refactor(app): rename section text in protocold details

### DIFF
--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -591,7 +591,7 @@ export function ProtocolDetails(
                   onClick={() => setCurrentTab('robot_config')}
                 >
                   <StyledText>
-                    {i18n.format(t('robot_configuration'), 'capitalize')}
+                    {i18n.format(t('hardware'), 'capitalize')}
                   </StyledText>
                 </RoundTab>
                 <RoundTab


### PR DESCRIPTION
# Overview

This PR renames the ‘Robot Configuration’ tab to ‘Hardware’ to align with the ODD.

closes RAUT-995

# Changelog

- Rename section text in protocold details

# Risk assessment

Low
