### PR TITLE
fix(app,components): include moved labware in deck config conflict check

### DIFF
--- a/app/src/resources/deck_configuration/hooks.ts
+++ b/app/src/resources/deck_configuration/hooks.ts
@@ -1,4 +1,4 @@
-import { getTopMostLabwareInSlots } from '@opentrons/components'
+import { getInitialAndMovedLabwareInSlots } from '@opentrons/components'
 import { useDeckConfigurationQuery } from '@opentrons/react-api-client'
 import {
   FLEX_ROBOT_TYPE,
@@ -43,7 +43,9 @@ export function useDeckConfigurationCompatibility(
       ? getAddressableAreasInProtocol(protocolAnalysis, deckDef)
       : []
   const labwareInSlots =
-    protocolAnalysis != null ? getTopMostLabwareInSlots(protocolAnalysis) : []
+    protocolAnalysis != null
+      ? getInitialAndMovedLabwareInSlots(protocolAnalysis)
+      : []
 
   const protocolModulesInfo =
     protocolAnalysis != null

--- a/components/src/hardware-sim/ProtocolDeck/utils/getLabwareInSlots.ts
+++ b/components/src/hardware-sim/ProtocolDeck/utils/getLabwareInSlots.ts
@@ -2,6 +2,7 @@ import { getInitialLoadedLabwareByAdapter } from './getInitiallyLoadedLabwareByA
 import type {
   CompletedProtocolAnalysis,
   LoadLabwareRunTimeCommand,
+  MoveLabwareRunTimeCommand,
   ProtocolAnalysisOutput,
   LabwareDefinition2,
 } from '@opentrons/shared-data'
@@ -11,6 +12,82 @@ interface LabwareInSlot {
   labwareDef: LabwareDefinition2
   labwareNickName: string | null
   location: { slotName: string }
+}
+
+export const getInitialAndMovedLabwareInSlots = (
+  protocolAnalysis: CompletedProtocolAnalysis | ProtocolAnalysisOutput
+): LabwareInSlot[] => {
+  const { commands } = protocolAnalysis
+  const initialLoadedLabwareByAdapter = getInitialLoadedLabwareByAdapter(
+    commands
+  )
+  const topMostLabwareInSlots = getTopMostLabwareInSlots(protocolAnalysis)
+
+  return commands
+    .filter(
+      (command): command is MoveLabwareRunTimeCommand =>
+        command.commandType === 'moveLabware'
+    )
+    .reduce<LabwareInSlot[]>((acc, command) => {
+      const labwareId = command.params.labwareId
+      const location = command.params.newLocation
+
+      const originalLabware = topMostLabwareInSlots.find(
+        labware => labware.labwareId === labwareId
+      )
+      const labwareDef = originalLabware?.labwareDef
+
+      if (
+        location === 'offDeck' ||
+        'moduleId' in location ||
+        'labwareId' in location
+      )
+        return acc
+      if (labwareId == null) {
+        console.warn('expected to find labware id but could not')
+        return acc
+      }
+      if (labwareDef == null) {
+        console.warn(
+          `expected to find labware def for labware id ${String(
+            labwareId
+          )} but could not`
+        )
+        return acc
+      }
+
+      const slotName =
+        'addressableAreaName' in location
+          ? location.addressableAreaName
+          : location.slotName
+
+      // if list of labware already includes slotName, return acc
+      if (acc.find(labware => labware.location.slotName === slotName) != null) {
+        return acc
+      }
+
+      const labwareInAdapter = initialLoadedLabwareByAdapter[labwareId]
+
+      //  NOTE: only grabbing the labware on top most layer so
+      //  either the adapter or the labware but not both
+      const topLabwareDefinition =
+        labwareInAdapter?.result?.definition ?? labwareDef
+      const topLabwareId = labwareInAdapter?.result?.labwareId ?? labwareId
+      const topLabwareNickName =
+        labwareInAdapter?.params?.displayName ??
+        originalLabware?.labwareNickName ??
+        null
+
+      return [
+        ...acc,
+        {
+          labwareId: topLabwareId,
+          labwareDef: topLabwareDefinition,
+          labwareNickName: topLabwareNickName,
+          location: { slotName },
+        },
+      ]
+    }, topMostLabwareInSlots)
 }
 
 export const getTopMostLabwareInSlots = (


### PR DESCRIPTION


# Overview

adds a helper to check for moveLabware commands that use a new slot. use the helper in determining compatibility with the existing deck config. this fixes a bug where the app wasn't surfacing a conflict with a moveLabware command moving to a slot occupied by a trash.

closes RAUT-967

<img width="1136" alt="Screen Shot 2024-02-16 at 11 07 45 AM" src="https://github.com/Opentrons/opentrons/assets/29845468/08618fbb-4c24-414f-b5df-62406b73f727">
<img width="1136" alt="Screen Shot 2024-02-16 at 11 07 49 AM" src="https://github.com/Opentrons/opentrons/assets/29845468/dcba1a27-ae48-4825-9a2a-36103da072e5">
<img width="1136" alt="Screen Shot 2024-02-16 at 11 07 56 AM" src="https://github.com/Opentrons/opentrons/assets/29845468/febff438-be6e-461c-97e9-097a571aded3">


# Test Plan

Verified that conflict generated and resolvable via location conflict modal using the protocol in RAUT-967

# Changelog

 - Includes moved labware in deck config conflict check

# Review requests

check that move labware commands generate conflicts in the new location

# Risk assessment

low
