### PR TITLE
chore: fix ci setup-py

### DIFF
--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -28,6 +28,6 @@ runs:
       run: |
         npm install --global shx@0.3.3
         $OT_PYTHON -m pip install --upgrade pip
-        $OT_PYTHON -m pip install pipenv==2023.12.1
+        $OT_PYTHON -m pip install --user pipenv==2023.12.1
     - shell: bash
       run: 'make -C ${{ inputs.project }} setup'

--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -18,12 +18,17 @@ runs:
           sudo apt-get install -y --no-install-recommends libsystemd-dev
         fi
     - name: Set the OT_PYTHON env variable
+      shell: bash
       run: echo "OT_PYTHON=$(which python)" >> $GITHUB_ENV
     - name: If provided set the OT_VIRTUALENV_VERSION env variable
+      shell : bash
       if: ${{ inputs.python-version != 'false' }}
       run: echo "OT_VIRTUALENV_VERSION=${{ inputs.python-version }}" >> $GITHUB_ENV
-    - run: |
-        npm install --global shx@0.3.3
-        $OT_PYTHON -m pip install --upgrade pip
-        $OT_PYTHON -m pip install --user pipenv==2023.12.1
-    - run: 'make -C ${{ inputs.project }} setup'
+    - shell: bash
+      run: npm install --global shx@0.3.3
+    - shell: bash
+      run: $OT_PYTHON -m pip install --upgrade pip
+    - shell: bash
+      run: $OT_PYTHON -m pip install --user pipenv==2023.12.1
+    - shell: bash
+      run: 'make -C ${{ inputs.project }} setup'

--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -18,16 +18,12 @@ runs:
           sudo apt-get install -y --no-install-recommends libsystemd-dev
         fi
     - name: Set the OT_PYTHON env variable
-      shell: bash
       run: echo "OT_PYTHON=$(which python)" >> $GITHUB_ENV
     - name: If provided set the OT_VIRTUALENV_VERSION env variable
-      shell : bash
       if: ${{ inputs.python-version != 'false' }}
       run: echo "OT_VIRTUALENV_VERSION=${{ inputs.python-version }}" >> $GITHUB_ENV
-    - shell: bash
-      run: |
+    - run: |
         npm install --global shx@0.3.3
         $OT_PYTHON -m pip install --upgrade pip
         $OT_PYTHON -m pip install --user pipenv==2023.12.1
-    - shell: bash
-      run: 'make -C ${{ inputs.project }} setup'
+    - run: 'make -C ${{ inputs.project }} setup'

--- a/.github/actions/python/setup/action.yaml
+++ b/.github/actions/python/setup/action.yaml
@@ -31,4 +31,4 @@ runs:
     - shell: bash
       run: $OT_PYTHON -m pip install --user pipenv==2023.12.1
     - shell: bash
-      run: 'make -C ${{ inputs.project }} setup'
+      run: 'make -C ${{ inputs.project }} setup || make -C ${{ inputs.project }} setup'


### PR DESCRIPTION
CI's setup-py step has been failing with mysterious pipenv problems. It also only fails once. So try again if it fails. I am not proud

Also somehow an empty notify-server workflow got snuck back in, so remove it