### PR TITLE
refactor(protocol-designer): nicknames now properly import

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -2526,7 +2526,7 @@
       "key": "d497b90e-2eaa-40ae-92ed-aa688f2b0eb5",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+        "displayName": "Opentrons 96 Tip Rack 300 µL",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
         "loadName": "opentrons_96_tiprack_300ul",
         "namespace": "opentrons",

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -2573,7 +2573,7 @@
       "key": "4d3bfc65-5b48-4891-93ba-c2daea854dff",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+        "displayName": "Opentrons 96 Tip Rack 300 µL",
         "labwareId": "0b44c760-75c7-11ea-b42f-4b64e50f43e5:opentrons/opentrons_96_tiprack_300ul/1",
         "loadName": "opentrons_96_tiprack_300ul",
         "namespace": "opentrons",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -3351,7 +3351,7 @@
       "key": "823bb056-dd22-40aa-9c97-89a2e67fcb82",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "Opentrons OT-2 96 Tip Rack 10 µL",
+        "displayName": "tiprack 10ul (1)",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
         "loadName": "opentrons_96_tiprack_10ul",
         "namespace": "opentrons",
@@ -3363,7 +3363,7 @@
       "key": "8a771523-8f41-4228-9f62-852de34df87e",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "(Retired) TipOne 96 Tip Rack 200 µL",
+        "displayName": "tiprack 200ul (1)",
         "labwareId": "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul",
         "loadName": "tipone_96_tiprack_200ul",
         "namespace": "opentrons",
@@ -3375,7 +3375,7 @@
       "key": "a545c357-1414-4500-b01b-16bc8dc87fbb",
       "commandType": "loadLabware",
       "params": {
-        "displayName": "USA Scientific 96 Deep Well Plate 2.4 mL",
+        "displayName": "96 deep well (1)",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
         "loadName": "usascientific_96_wellplate_2.4ml_deep",
         "namespace": "opentrons",

--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -167,10 +167,15 @@ export const containers: Reducer<ContainersState, any> = handleActions(
 
       return loadLabwareCommands.reduce(
         (acc: ContainersState, command, key): ContainersState => {
-          const { loadName, displayName } = command.params
+          const { labwareId, displayName } = command.params
+
+          if (labwareId == null) {
+            console.error('expected to find a labwareId but could not')
+          }
+
           return {
             ...acc,
-            [loadName]: {
+            [labwareId ?? '']: {
               nickname: displayName,
               disambiguationNumber: key,
             },


### PR DESCRIPTION
closes RQA-2358, RQA-1927

# Overview

This bug has been reported by Support numerous times so it is a high priority bug to get in with the next PD release. Looking into it, its definitely a bug I introduced 7 months ago by accidentally listing the container info via the labware's loadname instead of the labware Id. Oops. 

# Test Plan

Create a protocol either flex or ot-2. When adding a labware, add a nickname. Also add duplicate tipracks. Add a command that uses the trash. Export. Import the protocol, see that the nicknames on the labware and the tiprack (the numbering at the end of the tiprack) are preserved. 

# Changelog

- fix the reducer to list the containers via the labware Id instead of the loadname

# Review requests

see test plan

# Risk assessment

low