### PR TITLE
refactor(app): update desktop special-case colors

### DIFF
--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -153,7 +153,7 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
                 >
                   {t(stepSizeTranslationKeyByStep[stepSize])}
                   <StyledText
-                    color={COLORS.grey50}
+                    color={COLORS.grey60}
                     css={TYPOGRAPHY.labelRegular}
                   >{`${stepSize} mm`}</StyledText>
                 </PrimaryButton>

--- a/app/src/molecules/WizardHeader/index.tsx
+++ b/app/src/molecules/WizardHeader/index.tsx
@@ -31,7 +31,7 @@ const EXIT_BUTTON_STYLE = css`
   color: ${COLORS.grey60};
 
   &:hover {
-    opacity: 70%;
+    color: ${COLORS.grey50};
   }
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     margin-right: 1.75rem;
@@ -41,7 +41,7 @@ const EXIT_BUTTON_STYLE = css`
       opacity: 100%;
     }
     &:active {
-      opacity: 70%;
+      color: ${COLORS.grey50};
     }
   }
 `
@@ -70,6 +70,7 @@ const HEADER_TEXT_STYLE = css`
 `
 const STEP_TEXT_STYLE = css`
   ${TYPOGRAPHY.pSemiBold}
+  color: ${COLORS.grey60};
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     font-size: 1.375rem;
     margin-left: ${SPACING.spacing16};
@@ -89,7 +90,7 @@ export const WizardHeader = (props: WizardHeaderProps): JSX.Element => {
           </StyledText>
 
           {currentStep != null && totalSteps != null && currentStep > 0 ? (
-            <StyledText css={STEP_TEXT_STYLE} color={COLORS.grey50}>
+            <StyledText css={STEP_TEXT_STYLE}>
               {t('step', { current: currentStep, max: totalSteps })}
             </StyledText>
           ) : null}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/DeviceResetSlideout.tsx
@@ -171,7 +171,6 @@ export function DeviceResetSlideout({
           backgroundColor={COLORS.yellow30}
           borderRadius={BORDERS.borderRadiusSize1}
           padding={SPACING.spacing8}
-          border={`1px solid ${COLORS.yellow60}`}
           marginBottom={SPACING.spacing24}
         >
           <Icon

--- a/app/src/organisms/LabwareDetails/StyledComponents/LabeledValue.tsx
+++ b/app/src/organisms/LabwareDetails/StyledComponents/LabeledValue.tsx
@@ -22,7 +22,7 @@ export function LabeledValue({ label, value }: LabeledValueProps): JSX.Element {
       alignItems={ALIGN_CENTER}
       paddingY={SPACING.spacing8}
     >
-      <StyledText as="h6" color={COLORS.grey50}>
+      <StyledText as="h6" color={COLORS.grey60}>
         {label}
       </StyledText>
       <StyledText as="p">{value}</StyledText>

--- a/app/src/organisms/TaskList/index.tsx
+++ b/app/src/organisms/TaskList/index.tsx
@@ -24,6 +24,8 @@ import { Tooltip } from '../../atoms/Tooltip'
 
 import type { SubTaskProps, TaskListProps, TaskProps } from './types'
 
+const TASK_CONNECTOR_STYLE = `1px solid ${COLORS.grey40}`
+
 interface ProgressTrackerItemProps {
   activeIndex: [number, number] | null
   subTasks: SubTaskProps[]
@@ -52,7 +54,7 @@ function ProgressTrackerItem({
   const taskConnector = (
     <Flex
       flex="1"
-      borderLeft={BORDERS.lineBorder}
+      borderLeft={TASK_CONNECTOR_STYLE}
       borderColor={
         isTaskListComplete || isPastTask || isActiveTaskWithSubtasks
           ? COLORS.blue50
@@ -77,7 +79,7 @@ function ProgressTrackerItem({
           margin={SPACING.spacing16}
           name="ot-check"
           color={
-            isTaskListComplete || isPastTask ? COLORS.blue50 : COLORS.grey60
+            isTaskListComplete || isPastTask ? COLORS.blue50 : COLORS.grey40
           }
         />
       ) : (
@@ -85,7 +87,7 @@ function ProgressTrackerItem({
           flex={FLEX_NONE}
           alignItems={ALIGN_CENTER}
           justifyContent={JUSTIFY_CENTER}
-          backgroundColor={isFutureTask ? COLORS.grey60 : COLORS.blue50}
+          backgroundColor={isFutureTask ? COLORS.grey40 : COLORS.blue50}
           color={COLORS.white}
           margin={SPACING.spacing16}
           height="1.25rem"
@@ -145,7 +147,7 @@ function ProgressTrackerItem({
                       ? COLORS.grey40
                       : 'initial'
                   }
-                  border={BORDERS.lineBorder}
+                  border={TASK_CONNECTOR_STYLE}
                   borderColor={isFutureSubTask ? COLORS.grey40 : COLORS.blue50}
                   borderWidth={SPACING.spacing2}
                   color={COLORS.white}
@@ -157,14 +159,14 @@ function ProgressTrackerItem({
                 {/* subtask connector component */}
                 <Flex
                   flex="1"
-                  borderLeft={BORDERS.lineBorder}
+                  borderLeft={TASK_CONNECTOR_STYLE}
                   borderColor={
                     // do not show the subtask connector if it's the final subtask of the task list
                     isFinalSubTaskOfTaskList
                       ? COLORS.transparent
                       : isTaskListComplete || isPastSubTask
                       ? COLORS.blue50
-                      : COLORS.grey30
+                      : COLORS.grey40
                   }
                   marginTop={`-${SPACING.spacing8}`}
                   marginBottom={
@@ -216,7 +218,7 @@ function SubTask({
       backgroundColor={isActiveSubTask ? COLORS.blue10 : COLORS.white}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       padding={SPACING.spacing16}
-      border={isActiveSubTask ? BORDERS.activeLineBorder : BORDERS.lineBorder}
+      border={isActiveSubTask ? BORDERS.activeLineBorder : TASK_CONNECTOR_STYLE}
       borderRadius={BORDERS.radiusSoftCorners}
       gridGap={SPACING.spacing24}
       width="100%"
@@ -237,7 +239,7 @@ function SubTask({
         </StyledText>
         <StyledText as="p">{description}</StyledText>
         {footer != null ? (
-          <StyledText as="p" color={COLORS.grey50}>
+          <StyledText as="p" color={COLORS.grey60}>
             <Flex
               alignItems={ALIGN_CENTER}
               flexDirection={DIRECTION_ROW}
@@ -358,9 +360,7 @@ function Task({
           isActiveTask && !isTaskOpen ? COLORS.blue10 : COLORS.white
         }
         border={
-          isActiveTask && !isTaskOpen
-            ? BORDERS.activeLineBorder
-            : BORDERS.lineBorder
+          isActiveTask && !isTaskOpen ? BORDERS.activeLineBorder : undefined
         }
         borderRadius={BORDERS.radiusSoftCorners}
         width="100%"

--- a/components/src/atoms/buttons/AlertPrimaryButton.tsx
+++ b/components/src/atoms/buttons/AlertPrimaryButton.tsx
@@ -16,6 +16,7 @@ export const AlertPrimaryButton = styled(NewAlertPrimaryBtn)`
 
   &:hover {
     box-shadow: 0 0 0;
+    background-color: ${COLORS.red55};
   }
 
   &:disabled {

--- a/components/src/helix-design-system/colors.ts
+++ b/components/src/helix-design-system/colors.ts
@@ -60,7 +60,7 @@ export const blue10 = '#F1F8FF'
  */
 export const grey60 = '#4A4C4E'
 export const grey55 = '#737578'
-export const grey50 = '#9C9C9C'
+export const grey50 = '#737578'
 export const grey40 = '#B7B8B9'
 export const grey35 = '#CBCCCC'
 export const grey30 = '#DEDEDE'

--- a/components/src/helix-design-system/colors.ts
+++ b/components/src/helix-design-system/colors.ts
@@ -65,7 +65,7 @@ export const grey40 = '#B7B8B9'
 export const grey35 = '#CBCCCC'
 export const grey30 = '#DEDEDE'
 export const grey20 = '#E9E9E9'
-export const grey10 = '#F8F8F8'
+export const grey10 = '#F3F3F3'
 
 /**
  * core


### PR DESCRIPTION
Closes [RAUT-970](https://opentrons.atlassian.net/browse/RAUT-970), [RAUT-997](https://opentrons.atlassian.net/browse/RAUT-997), [RAUT-998](https://opentrons.atlassian.net/browse/RAUT-998), [RAUT-999](https://opentrons.atlassian.net/browse/RAUT-999), [RAUT-1000](https://opentrons.atlassian.net/browse/RAUT-1000), [RAUT-1002](https://opentrons.atlassian.net/browse/RAUT-1002), and [RAUT-1004](https://opentrons.atlassian.net/browse/RAUT-1004)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Updates the colors for one-off desktop components. See tickets for specific changes. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Just look at the tickets and verify changes were made to appropriate components. 
- See comments within [RAUT-1004](https://opentrons.atlassian.net/browse/RAUT-1004) and [RAUT-1002](https://opentrons.atlassian.net/browse/RAUT-1002) for changes.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-970]: https://opentrons.atlassian.net/browse/RAUT-970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-997]: https://opentrons.atlassian.net/browse/RAUT-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-998]: https://opentrons.atlassian.net/browse/RAUT-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-999]: https://opentrons.atlassian.net/browse/RAUT-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-1000]: https://opentrons.atlassian.net/browse/RAUT-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-1002]: https://opentrons.atlassian.net/browse/RAUT-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-1004]: https://opentrons.atlassian.net/browse/RAUT-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RAUT-1004]: https://opentrons.atlassian.net/browse/RAUT-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ