### PR TITLE
refactor(step-generation): openLatch should emit last in heaterShaker…

### DIFF
--- a/step-generation/src/__tests__/heaterShaker.test.ts
+++ b/step-generation/src/__tests__/heaterShaker.test.ts
@@ -127,7 +127,7 @@ describe('heaterShaker compound command creator', () => {
       },
     ])
   })
-  it('should NOT delay and deactivate the heater shaker when a user specificies a timer tthat is 0 seconds', () => {
+  it('should NOT delay and deactivate the heater shaker when a user specificies a timer that is 0 seconds', () => {
     heaterShakerArgs = {
       ...heaterShakerArgs,
       rpm: 444,
@@ -159,6 +159,73 @@ describe('heaterShaker compound command creator', () => {
         params: {
           moduleId: 'heaterShakerId',
           rpm: 444,
+        },
+      },
+    ])
+  })
+  it('should delay and emit open latch last if open latch is specified', () => {
+    heaterShakerArgs = {
+      module: HEATER_SHAKER_ID,
+      rpm: null,
+      commandCreatorFnName: 'heaterShaker',
+      targetTemperature: null,
+      latchOpen: true,
+      timerMinutes: null,
+      timerSeconds: null,
+    }
+
+    heaterShakerArgs = {
+      ...heaterShakerArgs,
+      rpm: 444,
+      targetTemperature: 80,
+      timerSeconds: 20,
+      timerMinutes: 0,
+    }
+    const result = heaterShaker(heaterShakerArgs, invariantContext, robotState)
+
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'heaterShaker/setTargetTemperature',
+        key: expect.any(String),
+        params: {
+          celsius: 80,
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/setAndWaitForShakeSpeed',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
+          rpm: 444,
+        },
+      },
+      {
+        commandType: 'waitForDuration',
+        key: expect.any(String),
+        params: {
+          seconds: 20,
+        },
+      },
+      {
+        commandType: 'heaterShaker/deactivateShaker',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/deactivateHeater',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
+        },
+      },
+      {
+        commandType: 'heaterShaker/openLabwareLatch',
+        key: expect.any(String),
+        params: {
+          moduleId: 'heaterShakerId',
         },
       },
     ])

--- a/step-generation/src/commandCreators/compound/heaterShaker.ts
+++ b/step-generation/src/commandCreators/compound/heaterShaker.ts
@@ -78,14 +78,6 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
     )
   }
 
-  if (args.latchOpen) {
-    commandCreators.push(
-      curryCommandCreator(heaterShakerOpenLatch, {
-        moduleId: args.module,
-      })
-    )
-  }
-
   if (
     (args.timerMinutes != null && args.timerMinutes !== 0) ||
     (args.timerSeconds != null && args.timerSeconds !== 0)
@@ -108,6 +100,14 @@ export const heaterShaker: CommandCreator<HeaterShakerArgs> = (
     )
     commandCreators.push(
       curryCommandCreator(heaterShakerDeactivateHeater, {
+        moduleId: args.module,
+      })
+    )
+  }
+
+  if (args.latchOpen) {
+    commandCreators.push(
+      curryCommandCreator(heaterShakerOpenLatch, {
         moduleId: args.module,
       })
     )


### PR DESCRIPTION
… compound command

closes RQA-2361, RESC-195

# Overview

Very strange that this bug was never reported until now. Basically, if a user adds a timer step in the heater-shaker form with an open latch, the open latch occurs before the heater and shaker are deactivated. This is not allowed in protocols so it would fail analysis. For the fix, i swapped the order so the open latch is emitted last.

# Test Plan

1. upload the attached protocol to the app. see that it fails analysis with an error saying the H-S can't heat or shake with the latch open
2. Upload the attached protocol to PD and then export then upload that to the app. it should pass analysis.

This is the customer's protocol
[test-1 (2).json](https://github.com/Opentrons/opentrons/files/14349054/test-1.2.json)


# Changelog

- change the command order in the H-S compound command
- add a test case

# Review requests

see test plan

# Risk assessment

low