### PR TITLE
refactor(protocol-designer): hard code trashBin entity in for ot-2 pr…

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1532,6 +1532,19 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           }
         : {}
 
+      const hardcodedTrashBinId = `${uuid()}:fixedTrash`
+      const hardcodedTrashBin = {
+        [hardcodedTrashBinId]: {
+          name: 'trashBin' as const,
+          id: hardcodedTrashBinId,
+          location: getCutoutIdByAddressableArea(
+            'fixedTrash' as AddressableAreaName,
+            'fixedTrashSlot',
+            OT2_ROBOT_TYPE
+          ),
+        },
+      }
+
       if (isFlex) {
         return {
           ...state,
@@ -1541,7 +1554,14 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           ...stagingAreas,
         }
       } else {
-        return { ...state, ...trashBin }
+        if (trashBin != null) {
+          return { ...state, ...trashBin }
+        } else {
+          //  when importing an OT-2 protocol, ensure that there is always a trashBin
+          //  entity created even when the protocol does not have a command that involves
+          //  the trash. Since no trash for OT-2 is not supported
+          return { ...state, ...hardcodedTrashBin }
+        }
       }
     },
 


### PR DESCRIPTION
…otocols

closes RQA-2359

# Overview

In production, if you create an OT-2 protocol with no pipetting commands and you export and re-import, the trash bin entity is never created. Therefore, you can't add a pipetting step in because there is no drop tip location. This PR fixes that bug by hardcoding in a trash bin entity if there are no trash bin commands.

# Test Plan

Create an OT-2 protocol and add a step that is not pipetting, such as a pause or a move Labware. Export the protocol and import it again. The imported protocol should have no errors. Try to add a mix or transfer step, see that the drop tip dropdown has a trash bin selection available.

# Changelog

- add a hardcoded trash bin entity with a newly created UUId if there are no trash bin commands found in the imported protocol

# Review requests

see test plan

# Risk assessment

low