### PR TITLE
fix(shared-data): allow thermocycler to be loaded on slot B1 only

### DIFF
--- a/shared-data/deck/definitions/4/ot3_standard.json
+++ b/shared-data/deck/definitions/4/ot3_standard.json
@@ -168,7 +168,6 @@
         "compatibleModuleTypes": [
           "temperatureModuleType",
           "heaterShakerModuleType",
-          "thermocyclerModuleType",
           "magneticBlockType"
         ]
       },


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/RSS-472.
shared-data deck config mistakenly allowed loading a thermocycler module in slot A1 on the flex.
on the OT-2 we allow only loading on slot 7.


# Test Plan

uploading the following protocol on the flex should fail analysis.

```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16",
}

def run(protocol):
	thermocycler  = protocol.load_module('thermocycler module gen2', "A1")
```

# Changelog

removed `thermocyclerModuleType` from slot `A1` in the deck definition. 

# Review requests

Should I add tests? 

# Risk assessment

low.
