### PR TITLE
refactor(app): add robot type to MQTT analytics

### DIFF
--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -10,6 +10,7 @@ import {
   notifySubscribeAction,
   notifyUnsubscribeAction,
 } from '../../redux/shell'
+import { useRobotType } from '../../organisms/Devices/hooks'
 
 import type { HostConfig } from '@opentrons/api-client'
 import type { QueryOptionsWithPolling } from '../useNotifyService'
@@ -20,8 +21,12 @@ jest.mock('../../redux/analytics')
 jest.mock('../../redux/shell/remote', () => ({
   appShellListener: jest.fn(),
 }))
+jest.mock('../../organisms/Devices/hooks')
 
-const MOCK_HOST_CONFIG: HostConfig = { hostname: 'MOCK_HOST' }
+const MOCK_HOST_CONFIG: HostConfig = {
+  hostname: 'MOCK_HOST',
+  robotName: 'MOCK_NAME',
+}
 const MOCK_TOPIC = '/test/topic' as any
 const MOCK_OPTIONS: QueryOptionsWithPolling<any, any> = {
   forceHttpPolling: false,
@@ -34,6 +39,9 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
 >
 const mockAppShellListener = appShellListener as jest.MockedFunction<
   typeof appShellListener
+>
+const mockUseRobotType = useRobotType as jest.MockedFunction<
+  typeof useRobotType
 >
 
 describe('useNotifyService', () => {
@@ -48,6 +56,7 @@ describe('useNotifyService', () => {
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
     mockUseDispatch.mockReturnValue(mockDispatch)
     mockUseHost.mockReturnValue(MOCK_HOST_CONFIG)
+    mockUseRobotType.mockReturnValue('OT-3 Standard')
   })
 
   afterEach(() => {

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -33,7 +33,6 @@ export function useNotifyService<TData, TError = Error>({
 }: UseNotifyServiceProps<TData, TError>): { isNotifyError: boolean } {
   const dispatch = useDispatch()
   const host = useHost()
-  const robotType = useRobotType(host?.robotName ?? '')
   const isNotifyError = React.useRef(false)
   const doTrackEvent = useTrackEvent()
   const { enabled, staleTime, forceHttpPolling } = options
@@ -72,7 +71,8 @@ export function useNotifyService<TData, TError = Error>({
     if (!isNotifyError.current) {
       if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
         isNotifyError.current = true
-        if (data === 'ECONNREFUSED') {
+        if (data === 'ECONNREFUSED' && host?.robotName != null) {
+          const robotType = useRobotType(host.robotName)
           doTrackEvent({
             name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
             properties: { robotType },

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -10,6 +10,7 @@ import {
   useTrackEvent,
   ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
 } from '../redux/analytics'
+import { useRobotType } from '../organisms/Devices/hooks'
 
 import type { UseQueryOptions } from 'react-query'
 import type { NotifyTopic, NotifyResponseData } from '../redux/shell/types'
@@ -32,6 +33,7 @@ export function useNotifyService<TData, TError = Error>({
 }: UseNotifyServiceProps<TData, TError>): { isNotifyError: boolean } {
   const dispatch = useDispatch()
   const host = useHost()
+  const robotType = useRobotType(host?.robotName ?? '')
   const isNotifyError = React.useRef(false)
   const doTrackEvent = useTrackEvent()
   const { enabled, staleTime, forceHttpPolling } = options
@@ -73,7 +75,7 @@ export function useNotifyService<TData, TError = Error>({
         if (data === 'ECONNREFUSED') {
           doTrackEvent({
             name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
-            properties: {},
+            properties: { robotType },
           })
         }
       } else if ('refetchUsingHTTP' in data) {


### PR DESCRIPTION
Closes [RAUT-1018](https://opentrons.atlassian.net/browse/RAUT-1018)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

It's necessary to report the robot type when MQTT is blocked, because currently all OT-2s will report that MQTT is blocked (there's no MQTT on OT-2s). Filtering out false positives for the 7.2 release would be nice!
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->


# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-1018]: https://opentrons.atlassian.net/browse/RAUT-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ