### PR TITLE
refactor(protocol-designer): prevent zombie children in stepEditForm

### DIFF
--- a/protocol-designer/src/components/StepEditForm/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
+import { connect } from 'react-redux'
 import { useConditionalConfirm } from '@opentrons/components'
 import { actions } from '../../steplist'
 import { actions as stepsActions } from '../../ui/steps'
@@ -23,39 +23,48 @@ import { makeSingleEditFieldProps } from './fields/makeSingleEditFieldProps'
 import { StepEditFormComponent } from './StepEditFormComponent'
 import { getDirtyFields } from './utils'
 
-import type { ThunkDispatch } from '../../types'
-import type { StepFieldName, StepIdType } from '../../form-types'
+import type { InvariantContext } from '@opentrons/step-generation'
+import type { BaseState, ThunkDispatch } from '../../types'
+import type { FormData, StepFieldName, StepIdType } from '../../form-types'
 
-export const StepEditForm = (): JSX.Element | null => {
+interface SP {
+  canSave: boolean
+  formData?: FormData | null
+  formHasChanges: boolean
+  isNewStep: boolean
+  isPristineSetTempForm: boolean
+  isPristineSetHeaterShakerTempForm: boolean
+  invariantContext: InvariantContext
+}
+interface DP {
+  deleteStep: (stepId: string) => unknown
+  handleClose: () => unknown
+  saveSetTempFormWithAddedPauseUntilTemp: () => unknown
+  saveHeaterShakerFormWithAddedPauseUntilTemp: () => unknown
+  saveStepForm: () => unknown
+  handleChangeFormInput: (name: string, value: unknown) => void
+}
+type StepEditFormManagerProps = SP & DP
+
+const StepEditFormManager = (
+  props: StepEditFormManagerProps
+): JSX.Element | null => {
+  const {
+    canSave,
+    deleteStep,
+    formData,
+    formHasChanges,
+    handleChangeFormInput,
+    handleClose,
+    isNewStep,
+    isPristineSetTempForm,
+    isPristineSetHeaterShakerTempForm,
+    saveSetTempFormWithAddedPauseUntilTemp,
+    saveHeaterShakerFormWithAddedPauseUntilTemp,
+    saveStepForm,
+    invariantContext,
+  } = props
   const { t } = useTranslation('tooltip')
-  const dispatch = useDispatch<ThunkDispatch<any>>()
-  const canSave = useSelector(stepFormSelectors.getCurrentFormCanBeSaved)
-  const formData = useSelector(stepFormSelectors.getUnsavedForm)
-  const formHasChanges = useSelector(
-    stepFormSelectors.getCurrentFormHasUnsavedChanges
-  )
-  const isNewStep = useSelector(stepFormSelectors.getCurrentFormIsPresaved)
-  const isPristineSetHeaterShakerTempForm = useSelector(
-    stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm
-  )
-  const isPristineSetTempForm = useSelector(
-    stepFormSelectors.getUnsavedFormIsPristineSetTempForm
-  )
-  const invariantContext = useSelector(getInvariantContext)
-  const deleteStep = (stepId: StepIdType): void =>
-    dispatch(actions.deleteStep(stepId))
-  const handleClose = (): void => dispatch(actions.cancelStepForm())
-  const saveHeaterShakerFormWithAddedPauseUntilTemp = (): void =>
-    dispatch(stepsActions.saveHeaterShakerFormWithAddedPauseUntilTemp())
-  const saveSetTempFormWithAddedPauseUntilTemp = (): void =>
-    dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilTemp())
-  const saveStepForm = (): void => dispatch(stepsActions.saveStepForm())
-
-  const handleChangeFormInput = (name: string, value: unknown): void => {
-    const maskedValue = maskField(name, value)
-    dispatch(actions.changeFormInput({ update: { [name]: maskedValue } }))
-  }
-
   const [
     showMoreOptionsModal,
     setShowMoreOptionsModal,
@@ -64,14 +73,11 @@ export const StepEditForm = (): JSX.Element | null => {
   const [dirtyFields, setDirtyFields] = React.useState<StepFieldName[]>(
     getDirtyFields(isNewStep, formData)
   )
-
   const toggleMoreOptionsModal = (): void => {
     resetScrollElements()
     setShowMoreOptionsModal(!showMoreOptionsModal)
   }
-
   const focus = setFocusedField
-
   const blur = (fieldName: StepFieldName): void => {
     if (fieldName === focusedField) {
       setFocusedField(null)
@@ -80,7 +86,6 @@ export const StepEditForm = (): JSX.Element | null => {
       setDirtyFields([...dirtyFields, fieldName])
     }
   }
-
   const stepId = formData?.id
   const handleDelete = (): void => {
     if (stepId != null) {
@@ -91,19 +96,16 @@ export const StepEditForm = (): JSX.Element | null => {
       )
     }
   }
-
   const {
     confirm: confirmDelete,
     showConfirmation: showConfirmDeleteModal,
     cancel: cancelDelete,
   } = useConditionalConfirm(handleDelete, true)
-
   const {
     confirm: confirmClose,
     showConfirmation: showConfirmCancelModal,
     cancel: cancelClose,
   } = useConditionalConfirm(handleClose, isNewStep || formHasChanges)
-
   const {
     confirm: confirmAddPauseUntilTempStep,
     showConfirmation: showAddPauseUntilTempStepModal,
@@ -111,7 +113,6 @@ export const StepEditForm = (): JSX.Element | null => {
     saveSetTempFormWithAddedPauseUntilTemp,
     isPristineSetTempForm
   )
-
   const {
     confirm: confirmAddPauseUntilHeaterShakerTempStep,
     showConfirmation: showAddPauseUntilHeaterShakerTempStepModal,
@@ -119,21 +120,17 @@ export const StepEditForm = (): JSX.Element | null => {
     saveHeaterShakerFormWithAddedPauseUntilTemp,
     isPristineSetHeaterShakerTempForm
   )
-
   // no form selected
   if (formData == null) {
     return null
   }
-
   const hydratedForm = getHydratedForm(formData, invariantContext)
-
   const focusHandlers = {
     focusedField,
     dirtyFields,
     focus,
     blur,
   }
-
   const propsForFields = makeSingleEditFieldProps(
     focusHandlers,
     formData,
@@ -152,7 +149,7 @@ export const StepEditForm = (): JSX.Element | null => {
   }
 
   return (
-    <React.Fragment key={formData.id}>
+    <>
       {showConfirmDeleteModal && (
         <ConfirmDeleteModal
           modalType={DELETE_STEP_FORM}
@@ -198,6 +195,62 @@ export const StepEditForm = (): JSX.Element | null => {
           toggleMoreOptionsModal,
         }}
       />
-    </React.Fragment>
+    </>
   )
 }
+
+const mapStateToProps = (state: BaseState): SP => {
+  return {
+    canSave: stepFormSelectors.getCurrentFormCanBeSaved(state),
+    formData: stepFormSelectors.getUnsavedForm(state),
+    formHasChanges: stepFormSelectors.getCurrentFormHasUnsavedChanges(state),
+    isNewStep: stepFormSelectors.getCurrentFormIsPresaved(state),
+    isPristineSetHeaterShakerTempForm: stepFormSelectors.getUnsavedFormIsPristineHeaterShakerForm(
+      state
+    ),
+    isPristineSetTempForm: stepFormSelectors.getUnsavedFormIsPristineSetTempForm(
+      state
+    ),
+    invariantContext: getInvariantContext(state),
+  }
+}
+
+const mapDispatchToProps = (dispatch: ThunkDispatch<any>): DP => {
+  const deleteStep = (stepId: StepIdType): void =>
+    dispatch(actions.deleteStep(stepId))
+  const handleClose = (): void => dispatch(actions.cancelStepForm())
+  const saveHeaterShakerFormWithAddedPauseUntilTemp = (): void =>
+    dispatch(stepsActions.saveHeaterShakerFormWithAddedPauseUntilTemp())
+  const saveSetTempFormWithAddedPauseUntilTemp = (): void =>
+    dispatch(stepsActions.saveSetTempFormWithAddedPauseUntilTemp())
+  const saveStepForm = (): void => dispatch(stepsActions.saveStepForm())
+
+  const handleChangeFormInput = (name: string, value: unknown): void => {
+    const maskedValue = maskField(name, value)
+    dispatch(actions.changeFormInput({ update: { [name]: maskedValue } }))
+  }
+
+  return {
+    deleteStep,
+    handleChangeFormInput,
+    handleClose,
+    saveSetTempFormWithAddedPauseUntilTemp,
+    saveStepForm,
+    saveHeaterShakerFormWithAddedPauseUntilTemp,
+  }
+}
+
+// NOTE(IL, 2020-04-22): This is using connect instead of useSelector in order to
+// avoid zombie children in the many connected field components.
+// (Children of a useSelector parent must always be written to use selectors defensively
+// if their parent (StepEditForm) is NOT using connect.
+// It doesn't matter if the children are using connect or useSelector,
+// only the parent matters.)
+// https://react-redux.js.org/api/hooks#stale-props-and-zombie-children
+export const StepEditForm = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)((props: StepEditFormManagerProps) => (
+  // key by ID so manager state doesn't persist across different forms
+  <StepEditFormManager key={props.formData?.id ?? 'empty'} {...props} />
+))


### PR DESCRIPTION
# Overview

🧟🧟‍♂️🧟‍♀️
 
I was running into stale props issues with adding multiple step forms and could not figure out why! Turns out, it is because of this edge case in redux: https://react-redux.js.org/api/hooks#stale-props-and-zombie-children. I thought that it would no longer be an issue for some reason since this was listed as an issue 2 years ago, but it is def still an issue haha. So this PR just reverts the component back to how it used to be before i refactored it.

# Test Plan

Create a flex or ot-2 protocol. Add a transfer step. Then add a mix step, see that the fields (in particular the mix volume field) aren't erroring before they were dirty.

# Changelog

revert the `StepEditForm` component back to using the connect function.

# Review requests

see test plan

# Risk assessment

low