### PR TITLE
feat(hardware-testing): add life-time testing script for the Hepa/UV Module.

### DIFF
--- a/hardware-testing/hardware_testing/scripts/hepa_uv_lifetime_test.py
+++ b/hardware-testing/hardware_testing/scripts/hepa_uv_lifetime_test.py
@@ -1,0 +1,247 @@
+"""This is the life-time testing script for the Hepa/UV module."""
+
+import asyncio
+import argparse
+import datetime
+
+from typing import Optional
+
+from hardware_testing.opentrons_api import helpers_ot3
+from opentrons.hardware_control.backends.ot3controller import OT3Controller
+from opentrons.hardware_control.ot3api import OT3API
+from opentrons.hardware_control.types import (
+    SubSystem,
+    HepaFanState,
+    HepaUVState,
+)
+
+
+# Default constants
+DEFAULT_DUTY_CYCLE: int = 75
+MAX_DUTY_CYCLE: int = 100
+DEFAULT_UV_DOSAGE_DURATION: int = 900  # 15m
+MAX_UV_DOSAGE = 60 * 60  # 1hr max dosage
+DEFAULT_CYCLES = 1
+
+
+async def _turn_off_hepa_uv(api: OT3API) -> None:
+    """Set and Make sure that the Hepa fan and UV light are off."""
+
+    print("Turning off Hepa fan.")
+    await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
+    hepa_fan_state: Optional[HepaFanState] = await api.get_hepa_fan_state()
+    if hepa_fan_state:
+        assert hepa_fan_state.fan_on == False, "Hepa Fan did not turn OFF!"
+        assert hepa_fan_state.duty_cycle == 0, "Hepa Fan Duty cycle is not 0!"
+
+    print("Turning off UV light.")
+    await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
+    hepa_uv_state: Optional[HepaUVState] = await api.get_hepa_uv_state()
+    if hepa_uv_state:
+        assert hepa_uv_state.light_on == False, "Hepa UV did not turn OFF!"
+        assert hepa_uv_state.uv_duration_s == 0, "Hepa UV dosage duration is not 0!"
+        assert (
+            hepa_uv_state.remaining_time_s == 0
+        ), "Hepa UV remaining on time is not 0!"
+
+
+async def run_hepa_fan(
+    event: asyncio.Event, api, duty_cycle: int, on_time: int, off_time: int, cycles: int
+) -> None:
+    """Coroutine that will run the hepa fan."""
+
+    fan_duty_cycle = max(min(0, duty_cycle), MAX_DUTY_CYCLE)
+    fan_on_time = on_time * 60 if on_time > 0 else 0
+    fan_off_time = off_time * 60 if off_time > 0 else 0
+    run_forever = on_time == -1
+    start_time = datetime.datetime.now()
+
+    print(
+        f"Hepa Task: Starting - duty_cycle={fan_duty_cycle}, "
+        f"on_time={fan_on_time}(s), off_time={fan_off_time}(s), cycles={cycles}"
+        f"run_forever: {run_forever}, start={start_time}"
+    )
+
+    fan_on: bool = False
+    cycle: int = 0
+    while not event.is_set():
+        if not run_forever and cycle >= cycles:
+            print(f"Fan Task: Reached target cycles={cycles}.")
+            break
+
+        # on time
+        if not fan_on:
+            fan_on = True
+            print(f"Hepa Task: cycle number={cycle}")
+            msg = "forever" if run_forever else f"for {fan_on_time} seconds"
+            print(f"Hepa Fan Task: Turning on fan {msg}.")
+            await api.set_hepa_fan_state(turn_on=True, duty_cycle=fan_duty_cycle)
+            await asyncio.sleep(fan_on_time)
+
+        # off time
+        if fan_off_time:
+            print(f"Hepa Task: Turning off fan for {fan_off_time} seconds.")
+            await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
+            fan_on = False
+
+        # sleep and increment the cycle
+        await asyncio.sleep(fan_off_time or 1)
+        if not run_forever:
+            cycles += 1
+
+    print("Hepa Task: Finished - Turning off Fan ")
+    await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
+
+    elapsed_time = start_time - datetime.datetime.now()
+    print(f"Hepa Task: Elapsed time={elapsed_time}")
+
+
+async def run_hepa_uv(
+    event: asyncio.Event, api: OT3API, on_time: int, off_time: int, cycles: int
+) -> None:
+    """Coroutine that will run the hepa uv light."""
+
+    on_time_s = max(min(0, on_time), MAX_UV_DOSAGE) * 60
+    off_time_s = off_time * 60
+    start_time = datetime.datetime.now()
+
+    print(
+        f"Hepa UV Task: Starting - on_time={on_time_s}(s), "
+        f"off_time={off_time_s}(s), cycles={cycles}, start={start_time}"
+    )
+
+    uv_light_on: bool = False
+    cycle: int = 0
+    while not event.is_set():
+        if cycle >= cycles:
+            print(f"Hepa UV Task: Reached target cycles={cycles}.")
+            break
+
+        # on time
+        if not uv_light_on:
+            uv_light_on = True
+            print(f"Hepa UV Task: cycle number={cycle}")
+            print(f"Turning on the UV Light for {on_time_s} seconds.")
+            await api.set_hepa_uv_state(turn_on=True, uv_duration_s=on_time_s)
+            await asyncio.sleep(on_time)
+
+        # off time
+        if off_time_s:
+            print(f"Turning off the UV Light for {off_time_s} seconds.")
+            await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
+
+        # Sleep and increment the cycle
+        await asyncio.sleep(off_time or 1)
+        cycles += 1
+
+    print("UV Task: Finished - Turning off UV Light ")
+    await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
+
+    elapsed_time = start_time - datetime.datetime.now()
+    print(f"UV Task: Elapsed time={elapsed_time}")
+
+
+async def _control_task(event: asyncio.Event) -> None:
+    """This task is responsible for handling keyboard interrupts and such."""
+    while True:
+        try:
+            await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            print("User keyboard interrupt!")
+        except Exception:
+            print("Unhandled exception!")
+        finally:
+            print("Setting control event True")
+            event.set()
+            break
+
+
+async def _main(args: argparse.Namespace) -> None:
+    api = await helpers_ot3.build_async_ot3_hardware_api(
+        is_simulating=args.is_simulating
+    )
+
+    # scan for subsystems
+    await cast(OT3Controller, api._backend).probe_network()
+
+    # Make sure we have a hepa/uv module
+    assert SubSystem.hepa_uv in api.attached_subsystems, "No Hepa/UV module detected!"
+
+    # Lets default the settings and make sure everything is off before we start testing
+    await _turn_off_hepa_uv(api)
+
+    # synchronization event
+    event = asyncio.Event()
+
+    # create coroutines
+    control_coroutine = _control_task(event)
+    hepa_fan_coroutine = run_hepa_fan(
+        event, api, args.duty_cycle, args.fan_on_time, args.fan_off_time, args.cycles
+    )
+    hepa_uv_coroutine = run_hepa_uv(
+        event, api, args.uv_on_time, args.uv_off_time, args.cycles
+    )
+
+    # start the tasks
+    await asyncio.gather(control_coroutine, hepa_fan_coroutine, hepa_uv_coroutine)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="Hepa/UV Life-Time Test",
+        description="Program to test the lifetime of the Hepa/UV module.",
+    )
+    parser.add_argument(
+        "--is_simulating",
+        action="store_true",
+        help="Whether this is a simulation or not.",
+    )
+    parser.add_argument(
+        "--fan-duty-cycle",
+        type=int,
+        default=DEFAULT_DUTY_CYCLE,
+        help="What the duty cycle of the hepa fan should be.",
+    )
+    parser.add_argument(
+        "--fan-on-time",
+        type=int,
+        default=0,
+        help="The time in minutes the fan should stay on for. "
+        "0 turns off fan (default), -1 stays on indefinitely.",
+    )
+    parser.add_argument(
+        "--fan-off-time",
+        type=int,
+        default=0,
+        help="The time in minutes the fan should stay on for. " "ignored if not set",
+    )
+    parser.add_argument(
+        "--uv-on-time",
+        type=int,
+        default=0,
+        help="The time in minutes the UV light will be turned on for. "
+        "0 turns off uv light (default), "
+        f"The max value is {MAX_UV_DOSAGE} minutes.",
+    )
+    parser.add_argument(
+        "--uv-off-time",
+        type=int,
+        default=0,
+        help="The time in minutes the UV light will be turned off for. "
+        "if 0 DONT turn off the uv light explictly but wait for "
+        "the hepa/uv to turn off on its on based on --uv-on-time.",
+    )
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=DEFAULT_CYCLES,
+        help="The number of cycles to run.",
+    )
+
+    args = parser.parse_args()
+    try:
+        asyncio.run(_main(args))
+    except Exception as e:
+        print(e)
+    finally:
+        print("Exiting.")

--- a/hardware-testing/hardware_testing/scripts/hepa_uv_lifetime_test.py
+++ b/hardware-testing/hardware_testing/scripts/hepa_uv_lifetime_test.py
@@ -4,7 +4,7 @@ import asyncio
 import argparse
 import datetime
 
-from typing import Optional
+from typing import Optional, cast
 
 from hardware_testing.opentrons_api import helpers_ot3
 from opentrons.hardware_control.backends.ot3controller import OT3Controller

--- a/hardware-testing/hardware_testing/scripts/hepa_uv_lifetime_test.py
+++ b/hardware-testing/hardware_testing/scripts/hepa_uv_lifetime_test.py
@@ -3,8 +3,10 @@
 import asyncio
 import argparse
 import datetime
+import logging
+import logging.config
 
-from typing import Optional, cast
+from typing import Optional, cast, Dict
 
 from hardware_testing.opentrons_api import helpers_ot3
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
@@ -13,6 +15,7 @@ from opentrons.hardware_control.types import (
     SubSystem,
     HepaFanState,
     HepaUVState,
+    DoorState,
 )
 
 
@@ -20,140 +23,163 @@ from opentrons.hardware_control.types import (
 DEFAULT_DUTY_CYCLE: int = 75
 MAX_DUTY_CYCLE: int = 100
 DEFAULT_UV_DOSAGE_DURATION: int = 900  # 15m
-MAX_UV_DOSAGE = 60 * 60  # 1hr max dosage
-DEFAULT_CYCLES = 1
+MAX_UV_DOSAGE: int = 60 * 60  # 1hr max dosage
+DEFAULT_CYCLES: int = 1
+
+log = logging.getLogger(__name__)
 
 
 async def _turn_off_hepa_uv(api: OT3API) -> None:
     """Set and Make sure that the Hepa fan and UV light are off."""
+    log.info("Turning off Hepa Fan and UV Light.")
+    await api.set_hepa_uv_state(turn_on=False)
+    await api.set_hepa_fan_state(turn_on=False)
 
-    print("Turning off Hepa fan.")
-    await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
-    hepa_fan_state: Optional[HepaFanState] = await api.get_hepa_fan_state()
-    if hepa_fan_state:
-        assert hepa_fan_state.fan_on == False, "Hepa Fan did not turn OFF!"
-        assert hepa_fan_state.duty_cycle == 0, "Hepa Fan Duty cycle is not 0!"
-
-    print("Turning off UV light.")
-    await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
+    # Confirm that they are off
     hepa_uv_state: Optional[HepaUVState] = await api.get_hepa_uv_state()
     if hepa_uv_state:
-        assert hepa_uv_state.light_on == False, "Hepa UV did not turn OFF!"
-        assert hepa_uv_state.uv_duration_s == 0, "Hepa UV dosage duration is not 0!"
-        assert (
-            hepa_uv_state.remaining_time_s == 0
-        ), "Hepa UV remaining on time is not 0!"
+        assert not hepa_uv_state.light_on, "Hepa UV did not turn OFF!"
+
+    hepa_fan_state: Optional[HepaFanState] = await api.get_hepa_fan_state()
+    if hepa_fan_state:
+        assert not hepa_fan_state.fan_on, "Hepa Fan did not turn OFF!"
 
 
 async def run_hepa_fan(
-    event: asyncio.Event, api, duty_cycle: int, on_time: int, off_time: int, cycles: int
+    api: OT3API,
+    duty_cycle: int,
+    on_time: int,
+    off_time: int,
+    cycles: int,
 ) -> None:
     """Coroutine that will run the hepa fan."""
-
-    fan_duty_cycle = max(min(0, duty_cycle), MAX_DUTY_CYCLE)
-    fan_on_time = on_time * 60 if on_time > 0 else 0
-    fan_off_time = off_time * 60 if off_time > 0 else 0
+    fan_duty_cycle = max(0, min(duty_cycle, MAX_DUTY_CYCLE))
+    fan_on_time = on_time if on_time > 0 else 0
+    fan_off_time = off_time if off_time > 0 else 0
     run_forever = on_time == -1
     start_time = datetime.datetime.now()
 
-    print(
+    # Dont run task if there are no valid parameters
+    if not fan_on_time and not fan_off_time:
+        return
+
+    log.info(
         f"Hepa Task: Starting - duty_cycle={fan_duty_cycle}, "
-        f"on_time={fan_on_time}(s), off_time={fan_off_time}(s), cycles={cycles}"
-        f"run_forever: {run_forever}, start={start_time}"
+        f"on_time={fan_on_time}s, off_time={fan_off_time}s, cycles={cycles}, "
+        f"run_forever: {run_forever}"
     )
 
     fan_on: bool = False
-    cycle: int = 0
-    while not event.is_set():
-        if not run_forever and cycle >= cycles:
-            print(f"Fan Task: Reached target cycles={cycles}.")
-            break
-
-        # on time
-        if not fan_on:
-            fan_on = True
-            print(f"Hepa Task: cycle number={cycle}")
-            msg = "forever" if run_forever else f"for {fan_on_time} seconds"
-            print(f"Hepa Fan Task: Turning on fan {msg}.")
-            await api.set_hepa_fan_state(turn_on=True, duty_cycle=fan_duty_cycle)
-            await asyncio.sleep(fan_on_time)
-
-        # off time
-        if fan_off_time:
-            print(f"Hepa Task: Turning off fan for {fan_off_time} seconds.")
-            await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
-            fan_on = False
-
-        # sleep and increment the cycle
-        await asyncio.sleep(fan_off_time or 1)
-        if not run_forever:
-            cycles += 1
-
-    print("Hepa Task: Finished - Turning off Fan ")
-    await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
-
-    elapsed_time = start_time - datetime.datetime.now()
-    print(f"Hepa Task: Elapsed time={elapsed_time}")
-
-
-async def run_hepa_uv(
-    event: asyncio.Event, api: OT3API, on_time: int, off_time: int, cycles: int
-) -> None:
-    """Coroutine that will run the hepa uv light."""
-
-    on_time_s = max(min(0, on_time), MAX_UV_DOSAGE) * 60
-    off_time_s = off_time * 60
-    start_time = datetime.datetime.now()
-
-    print(
-        f"Hepa UV Task: Starting - on_time={on_time_s}(s), "
-        f"off_time={off_time_s}(s), cycles={cycles}, start={start_time}"
-    )
-
-    uv_light_on: bool = False
-    cycle: int = 0
-    while not event.is_set():
-        if cycle >= cycles:
-            print(f"Hepa UV Task: Reached target cycles={cycles}.")
-            break
-
-        # on time
-        if not uv_light_on:
-            uv_light_on = True
-            print(f"Hepa UV Task: cycle number={cycle}")
-            print(f"Turning on the UV Light for {on_time_s} seconds.")
-            await api.set_hepa_uv_state(turn_on=True, uv_duration_s=on_time_s)
-            await asyncio.sleep(on_time)
-
-        # off time
-        if off_time_s:
-            print(f"Turning off the UV Light for {off_time_s} seconds.")
-            await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
-
-        # Sleep and increment the cycle
-        await asyncio.sleep(off_time or 1)
-        cycles += 1
-
-    print("UV Task: Finished - Turning off UV Light ")
-    await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
-
-    elapsed_time = start_time - datetime.datetime.now()
-    print(f"UV Task: Elapsed time={elapsed_time}")
-
-
-async def _control_task(event: asyncio.Event) -> None:
-    """This task is responsible for handling keyboard interrupts and such."""
+    cycle: int = 1
     while True:
         try:
-            await asyncio.sleep(1)
-        except KeyboardInterrupt:
-            print("User keyboard interrupt!")
-        except Exception:
-            print("Unhandled exception!")
-        finally:
-            print("Setting control event True")
-            event.set()
+            if not run_forever and cycle > cycles:
+                log.info(f"Hepa Task: Reached target cycles={cycles}")
+                break
+
+            # on time
+            if not fan_on:
+                fan_on = True
+                log.info(f"Hepa Task: cycle {cycle}")
+                msg = "forever" if run_forever else f"for {fan_on_time} seconds"
+                log.info(f"Hepa Task: Turning on fan {msg}")
+                await api.set_hepa_fan_state(turn_on=True, duty_cycle=fan_duty_cycle)
+                await asyncio.sleep(fan_on_time)
+
+            # off time
+            if fan_off_time:
+                log.info(f"Hepa Task: Turning off fan for {fan_off_time} seconds")
+                await api.set_hepa_fan_state(turn_on=False, duty_cycle=0)
+                fan_on = False
+
+            # sleep and increment the cycle
+            await asyncio.sleep(fan_off_time or 1)
+            if not run_forever:
+                cycle += 1
+        except asyncio.CancelledError:
             break
+
+    log.info("Hepa Task: Finished - Turning off Fan")
+    await api.set_hepa_fan_state(turn_on=False, duty_cycle=DEFAULT_DUTY_CYCLE)
+
+    elapsed_time = datetime.datetime.now() - start_time
+    log.info(f"Hepa Task: Elapsed time={elapsed_time}")
+
+
+async def run_hepa_uv(api: OT3API, on_time: int, off_time: int, cycles: int) -> None:
+    """Coroutine that will run the hepa uv light."""
+    light_on_time = max(0, min(on_time, MAX_UV_DOSAGE))
+    light_off_time = off_time if off_time > 0 else 0
+    start_time = datetime.datetime.now()
+
+    # Dont run task if there are no valid parameters
+    if not light_on_time and not light_off_time:
+        return
+
+    if api.door_state == DoorState.OPEN:
+        log.warning("UV Task: Flex Door must be closed to operate the UV light")
+        return
+
+    log.info(
+        f"Hepa UV Task: Starting - on_time={light_on_time}s, "
+        f"off_time={light_off_time}s, cycles={cycles}"
+    )
+    log.info("===========================================")
+
+    uv_light_on: bool = False
+    cycle: int = 1
+    while True:
+        try:
+            if cycle > cycles:
+                log.info(f"UV Task: Reached target cycles={cycles}")
+                break
+
+            # on time
+            if not uv_light_on:
+                uv_light_on = True
+                log.info(f"UV Task: cycle number={cycle}")
+                log.info(
+                    f"UV Task: Turning on the UV Light for {light_on_time} seconds"
+                )
+                await api.set_hepa_uv_state(turn_on=True, uv_duration_s=light_on_time)
+                await asyncio.sleep(light_on_time)
+
+            # off time
+            if light_off_time:
+                log.info(
+                    f"UV Task: Turning off the UV Light for {light_off_time} seconds"
+                )
+                await api.set_hepa_uv_state(turn_on=False, uv_duration_s=0)
+                uv_light_on = False
+
+            # Sleep and increment the cycle
+            await asyncio.sleep(light_off_time or 1)
+            cycle += 1
+        except asyncio.CancelledError:
+            break
+
+    log.info("UV Task: Finished - Turning off UV Light ")
+    await api.set_hepa_uv_state(turn_on=False, uv_duration_s=DEFAULT_UV_DOSAGE_DURATION)
+
+    elapsed_time = datetime.datetime.now() - start_time
+    log.info(f"UV Task: Elapsed time={elapsed_time}")
+
+
+async def _control_task(
+    api: OT3API, hepa_task: asyncio.Task, uv_task: asyncio.Task
+) -> None:
+    """Checks robot status and cancels tasks."""
+    while True:
+        # Make sure the door is closed
+        if api.door_state == DoorState.OPEN:
+            if not uv_task.done():
+                log.warning("Control Task: Flex Door Opened, stopping UV task")
+                uv_task.cancel()
+
+        if uv_task.done() and hepa_task.done():
+            break
+
+        await asyncio.sleep(1)
 
 
 async def _main(args: argparse.Namespace) -> None:
@@ -167,29 +193,80 @@ async def _main(args: argparse.Namespace) -> None:
     # Make sure we have a hepa/uv module
     assert SubSystem.hepa_uv in api.attached_subsystems, "No Hepa/UV module detected!"
 
-    # Lets default the settings and make sure everything is off before we start testing
+    # Make sure everything is off before we start testing
     await _turn_off_hepa_uv(api)
 
-    # synchronization event
-    event = asyncio.Event()
-
-    # create coroutines
-    control_coroutine = _control_task(event)
-    hepa_fan_coroutine = run_hepa_fan(
-        event, api, args.duty_cycle, args.fan_on_time, args.fan_off_time, args.cycles
+    # create tasks
+    hepa_fan_task = asyncio.create_task(
+        run_hepa_fan(
+            api, args.fan_duty_cycle, args.fan_on_time, args.fan_off_time, args.cycles
+        )
     )
-    hepa_uv_coroutine = run_hepa_uv(
-        event, api, args.uv_on_time, args.uv_off_time, args.cycles
+    hepa_uv_task = asyncio.create_task(
+        run_hepa_uv(api, args.uv_on_time, args.uv_off_time, args.cycles)
     )
+    control_task = asyncio.create_task(_control_task(api, hepa_fan_task, hepa_uv_task))
 
     # start the tasks
-    await asyncio.gather(control_coroutine, hepa_fan_coroutine, hepa_uv_coroutine)
+    try:
+        await asyncio.gather(control_task, hepa_fan_task, hepa_uv_task)
+    finally:
+        # Make sure we always turn OFF everything!
+        await _turn_off_hepa_uv(api)
+
+
+def log_config(log_level: int) -> Dict:
+    """Configure logging."""
+    return {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "basic": {"format": "%(asctime)s %(name)s %(levelname)s %(message)s"},
+            "production_trace": {"format": "%(asctime)s %(message)s"},
+        },
+        "handlers": {
+            "main_log_handler": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "formatter": "basic",
+                "filename": "/var/log/hepauv_lifetime_debug.log",
+                "maxBytes": 5000000,
+                "level": log_level,
+                "backupCount": 3,
+            },
+            "stream_handler": {
+                "class": "logging.StreamHandler",
+                "formatter": "basic",
+                "level": log_level,
+            },
+        },
+        "loggers": {
+            "": {
+                "handlers": (
+                    ["main_log_handler"]
+                    if log_level > logging.INFO
+                    else ["stream_handler"]
+                ),
+                "level": log_level,
+            },
+        },
+    }
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="Hepa/UV Life-Time Test",
         description="Program to test the lifetime of the Hepa/UV module.",
+    )
+    parser.add_argument(
+        "--log-level",
+        help=(
+            "Developer logging level. At DEBUG or below, logs are written "
+            "to console; at INFO or above, logs are only written to "
+            "/var/log/hepauv_lifetime_debug.log"
+        ),
+        type=str,
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="WARNING",
     )
     parser.add_argument(
         "--is_simulating",
@@ -200,34 +277,34 @@ if __name__ == "__main__":
         "--fan-duty-cycle",
         type=int,
         default=DEFAULT_DUTY_CYCLE,
-        help="What the duty cycle of the hepa fan should be.",
+        help="The duty cycle of the hepa fan 0-100%.",
     )
     parser.add_argument(
         "--fan-on-time",
         type=int,
         default=0,
-        help="The time in minutes the fan should stay on for. "
-        "0 turns off fan (default), -1 stays on indefinitely.",
+        help="The time in seconds the fan should stay on for. "
+        "0 turns off fan (default), -1 stays on until program is stopped",
     )
     parser.add_argument(
         "--fan-off-time",
         type=int,
         default=0,
-        help="The time in minutes the fan should stay on for. " "ignored if not set",
+        help="The time in seconds the fan should stay on for. ignored if not set",
     )
     parser.add_argument(
         "--uv-on-time",
         type=int,
         default=0,
-        help="The time in minutes the UV light will be turned on for. "
+        help="The time in seconds the UV light will be turned on for. "
         "0 turns off uv light (default), "
-        f"The max value is {MAX_UV_DOSAGE} minutes.",
+        f"The max value is {MAX_UV_DOSAGE} seconds.",
     )
     parser.add_argument(
         "--uv-off-time",
         type=int,
         default=0,
-        help="The time in minutes the UV light will be turned off for. "
+        help="The time in seconds the UV light will be turned off for. "
         "if 0 DONT turn off the uv light explictly but wait for "
         "the hepa/uv to turn off on its on based on --uv-on-time.",
     )
@@ -237,11 +314,10 @@ if __name__ == "__main__":
         default=DEFAULT_CYCLES,
         help="The number of cycles to run.",
     )
-
     args = parser.parse_args()
+    logging.config.dictConfig(log_config(getattr(logging, args.log_level)))
+
     try:
         asyncio.run(_main(args))
-    except Exception as e:
-        print(e)
-    finally:
-        print("Exiting.")
+    except KeyboardInterrupt:
+        log.warning("KeyBoard Interrupt")


### PR DESCRIPTION
# Overview

We will start lifetime testing of the Hepa/UV module soon, this PR adds a script to enable that.

Closes: [RET-1426](https://opentrons.atlassian.net/browse/RET-1426)

# Test Plan

- [x] Make sure the hepa fan is turned on/off for the given time
- [x] Make sure the uv light is turned on/off for the given time (assuming the flex door is closed, etc)
- [x] Make sure the uv light is turned OFF whenever the script finishes or terminates

# Changelog

- add a script for lifetime testing of the Hepa/UV module

# Review requests

# Risk assessment

low, unreleased


[RET-1426]: https://opentrons.atlassian.net/browse/RET-1426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ