### PR TITLE
fix(app): Center app and robot update modals

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -301,7 +301,7 @@
   "update_robot_software_description": "Bypass the Opentrons App auto-update process and update the robot software manually.",
   "update_robot_software_link": "Launch Opentrons software update page",
   "updating": "Updating",
-  "updating_robot_system": "Updating the robot software requires restarting the robot",
+  "update_requires_restarting": "Updating the robot software requires restarting the robot",
   "usage_settings": "Usage Settings",
   "usb": "USB",
   "usb_to_ethernet_description": "Looking for USB-to-Ethernet Adapter info?",

--- a/app/src/molecules/LegacyModal/__tests__/LegacyModal.test.tsx
+++ b/app/src/molecules/LegacyModal/__tests__/LegacyModal.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { screen } from '@testing-library/react'
 
 import { COLORS, renderWithProviders } from '@opentrons/components'
 
@@ -20,33 +21,43 @@ describe('LegacyModal', () => {
   })
 
   it('should render modal without header icon when type is info', () => {
-    const [{ getByText, queryByTestId, getByTestId }] = render(props)
-    expect(queryByTestId('Modal_header_icon')).not.toBeInTheDocument()
-    getByText('mock info modal')
-    expect(getByTestId('Modal_header')).toHaveStyle(
+    render(props)
+    expect(screen.queryByTestId('Modal_header_icon')).not.toBeInTheDocument()
+    screen.getByText('mock info modal')
+    expect(screen.getByTestId('Modal_header')).toHaveStyle(
       `background-color: ${COLORS.white}`
     )
   })
 
   it('should render modal with orange header icon when type is warning', () => {
     props.type = 'warning'
-    const [{ getByTestId }] = render(props)
-    const headerIcon = getByTestId('Modal_header_icon')
+    render(props)
+    const headerIcon = screen.getByTestId('Modal_header_icon')
     expect(headerIcon).toBeInTheDocument()
     expect(headerIcon).toHaveStyle(`color: ${COLORS.yellow50}`)
-    expect(getByTestId('Modal_header')).toHaveStyle(
+    expect(screen.getByTestId('Modal_header')).toHaveStyle(
       `background-color: ${COLORS.white}`
     )
   })
 
   it('should render modal with red header icon when type is error', () => {
     props.type = 'error'
-    const [{ getByTestId }] = render(props)
-    const headerIcon = getByTestId('Modal_header_icon')
+    render(props)
+    const headerIcon = screen.getByTestId('Modal_header_icon')
     expect(headerIcon).toBeInTheDocument()
     expect(headerIcon).toHaveStyle(`color: ${COLORS.red50}`)
-    expect(getByTestId('Modal_header')).toHaveStyle(
+    expect(screen.getByTestId('Modal_header')).toHaveStyle(
       `background-color: ${COLORS.white}`
+    )
+  })
+
+  it('should supply a default margin to account for the sidebar, aligning the modal in the center of the app', () => {
+    render(props)
+    expect(screen.getByLabelText('ModalShell_ModalArea')).toHaveStyle(
+      'width: 31.25rem'
+    )
+    expect(screen.getByLabelText('ModalShell_ModalArea')).toHaveStyle(
+      'margin-left: 5.656rem'
     )
   })
 })

--- a/app/src/molecules/LegacyModal/index.tsx
+++ b/app/src/molecules/LegacyModal/index.tsx
@@ -70,7 +70,7 @@ export const LegacyModal = (props: LegacyModalProps): JSX.Element => {
       header={modalHeader}
       onOutsideClick={closeOnOutsideClick ?? false ? onClose : undefined}
       // center within viewport aside from nav
-      marginLeft={styleProps.marginLeft ?? '7.125rem'}
+      marginLeft={styleProps.marginLeft ?? '5.656rem'}
       {...styleProps}
       footer={footer}
     >

--- a/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -155,7 +155,7 @@ export function UpdateRobotModal({
     >
       <Flex flexDirection={DIRECTION_COLUMN}>
         <UpdateAppBanner type="informing" marginBottom={SPACING.spacing8}>
-          {t('updating_robot_system')}
+          {t('update_requires_restarting')}
         </UpdateAppBanner>
         <ReleaseNotes source={releaseNotes} />
       </Flex>

--- a/app/src/organisms/RobotSettingsDashboard/RobotSystemVersionModal.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/RobotSystemVersionModal.tsx
@@ -51,7 +51,7 @@ export function RobotSystemVersionModal({
         >
           <InlineNotification
             type="neutral"
-            heading={t('updating_robot_system')}
+            heading={t('update_requires_restarting')}
             hug
           />
           <ReleaseNotes source={releaseNotes} />

--- a/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
+++ b/app/src/organisms/UpdateAppModal/__tests__/UpdateAppModal.test.tsx
@@ -133,4 +133,13 @@ describe('UpdateAppModal', () => {
       screen.getByRole('heading', { name: 'Update Error' })
     ).toBeInTheDocument()
   })
+  it('uses a custom width and left margin to properly center the modal', () => {
+    render(props)
+    expect(screen.getByLabelText('ModalShell_ModalArea')).toHaveStyle(
+      'width: 40rem'
+    )
+    expect(screen.getByLabelText('ModalShell_ModalArea')).toHaveStyle(
+      'margin-left: 5.336rem'
+    )
+  })
 })

--- a/app/src/organisms/UpdateAppModal/index.tsx
+++ b/app/src/organisms/UpdateAppModal/index.tsx
@@ -85,6 +85,7 @@ const UPDATE_PROGRESS_BAR_STYLE = css`
 `
 const LEGACY_MODAL_STYLE = css`
   width: 40rem;
+  margin-left: 5.336rem;
 `
 
 const RESTART_APP_AFTER_TIME = 5000


### PR DESCRIPTION
Closes [RQA-2349](https://opentrons.atlassian.net/browse/RQA-2349)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes an issue in which the app and robot update modals are not properly centered (as a bonus, the module setup modal is also properly centered). 

There's a lot we can do to make this issue less likely to occur in the future, and I've added a note to revisit this topic in the [tech debt paydown doc](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/3917479962/App+UI+Pay+off+Tech+Debt+Improve+Codebase). Because we don't have standardized modal sizing, custom modal widths require a custom left margin offset in order to be properly centered. 

At a bare minimum, adding testing to custom width/left-margin modals is a good idea. This at least shows we've gone out of the way to center the modal properly, and anyone who tries to adjust width only will fail a test and have to re-center the modal.

A better, longer-term solution off the top of my head would be to standardize modal sizes (convo w/ design).

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Downloaded [this build of the app. ](https://opentrons.slack.com/archives/C81CR4VCZ/p1708619272432719)
- Verified that the app update modal is centered (select the alpha channel if you aren't already on it).
- Opened up a robot update modal and verify the robot update modal is centered.
- Verified that no other modals were negatively impacted by this change.
- If you'd like to try this yourself and you don't have a robot, you may have to finagle the code a bit to get the banners to show, but it is possible!
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Desktop app update modals are now properly centered.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2349]: https://opentrons.atlassian.net/browse/RQA-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ