### PR TITLE
fix(app-shell, app-shell-odd): Fix notification fallback for multiple subscriptions

### DIFF
--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -71,6 +71,8 @@ export function registerNotify(
   }
 }
 
+const CHECK_CONNECTION_INTERVAL = 500
+
 interface NotifyParams {
   browserWindow: BrowserWindow
   hostname: string
@@ -178,7 +180,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
             )
           )
         }
-      }, 500)
+      }, CHECK_CONNECTION_INTERVAL)
     })
   }
 }

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -67,6 +67,8 @@ export function registerNotify(
   }
 }
 
+const CHECK_CONNECTION_INTERVAL = 500
+
 interface NotifyParams {
   browserWindow: BrowserWindow
   hostname: string
@@ -174,7 +176,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
             )
           )
         }
-      }, 500)
+      }, CHECK_CONNECTION_INTERVAL)
     })
   }
 }

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -111,24 +111,21 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   // true if the connection store has an entry for the hostname.
   else {
     const subscriptions = connectionStore[hostname]?.subscriptions
-    if (subscriptions && subscriptions[topic] > 0) {
-      subscriptions[topic] += 1
-      return Promise.resolve()
-    } else {
-      if (subscriptions) {
-        subscriptions[topic] = 1
-      }
-      return new Promise<void>(() => checkIfClientConnected()).catch(() => {
-        log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
-        sendToBrowserDeserialized({
-          browserWindow,
-          hostname,
-          topic,
-          message: 'ECONNFAILED',
-        })
-        handleDecrementSubscriptionCount(hostname, topic)
-      })
+    if (subscriptions) {
+      if (subscriptions[topic] > 0) subscriptions[topic] += 1
+      else subscriptions[topic] = 1
     }
+
+    return checkIfClientConnected().catch(() => {
+      log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
+      sendToBrowserDeserialized({
+        browserWindow,
+        hostname,
+        topic,
+        message: 'ECONNFAILED',
+      })
+      handleDecrementSubscriptionCount(hostname, topic)
+    })
   }
 
   function subscribeCb(error: Error, result: mqtt.ISubscriptionGrant[]): void {
@@ -147,36 +144,38 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   }
 
   // Check every 500ms for 2 seconds before failing.
-  function checkIfClientConnected(): void {
-    const MAX_RETRIES = 4
-    let counter = 0
-    const intervalId = setInterval(() => {
-      const client = connectionStore[hostname]?.client
-      if (client != null) {
-        clearInterval(intervalId)
-        new Promise<void>(() =>
-          client.subscribe(topic, subscribeOptions, subscribeCb)
-        )
-          .then(() => Promise.resolve())
-          .catch(() =>
-            Promise.reject(
-              new Error(
-                `Maximum number of subscription retries reached for hostname: ${hostname}`
+  function checkIfClientConnected(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const MAX_RETRIES = 4
+      let counter = 0
+      const intervalId = setInterval(() => {
+        const client = connectionStore[hostname]?.client
+        if (client != null) {
+          clearInterval(intervalId)
+          new Promise<void>(() =>
+            client.subscribe(topic, subscribeOptions, subscribeCb)
+          )
+            .then(() => resolve())
+            .catch(() =>
+              reject(
+                new Error(
+                  `Maximum number of subscription retries reached for hostname: ${hostname}`
+                )
               )
             )
-          )
-      }
+        }
 
-      counter++
-      if (counter === MAX_RETRIES) {
-        clearInterval(intervalId)
-        Promise.reject(
-          new Error(
-            `Maximum number of subscription retries reached for hostname: ${hostname}`
+        counter++
+        if (counter === MAX_RETRIES) {
+          clearInterval(intervalId)
+          reject(
+            new Error(
+              `Maximum number of subscription retries reached for hostname: ${hostname}`
+            )
           )
-        )
-      }
-    }, 500)
+        }
+      }, 500)
+    })
   }
 }
 


### PR DESCRIPTION
Closes [RQA-2376](https://opentrons.atlassian.net/browse/RQA-2376)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a bug in which the notification connection manager assumes that a subscription request to a topic is successful if a previous request to the same topic has already been made. This assumption does not hold when multiple subscription requests to the same topic occur at the same time or when a subsequent request is made but before the first subscription request receives a response. 

This was causing the "fallback to HTTP polling" logic to break noticeably during protocol runs - the current run step was not properly updating. This impacts the ODD and the desktop app (for the Flexes without MQTT running and all OT-2s). 


### Current Behavior

![IMG_3778](https://github.com/Opentrons/opentrons/assets/64858653/029c8a2f-f8bf-4fb8-8639-c33541c2e3ae)

### With Fix

<img width="850" alt="Screenshot 2024-02-23 at 3 56 49 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/31c237b3-3869-4e4c-b3ad-2ae4ce3ad854">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run a protocol on a Flex with the mosquitto service stopped. Alternatively, run a protocol on the OT-2. 
- Notice that in the app, the run step will still properly update. You can confirm this by observing the network requests to `commands?pageLength=1` every 3 seconds.
- If you'd like, you can push app-shell-odd to a Flex and note that the proper run command is displayed as well. Again, make sure the mosquitto service is stopped.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a bug causing the current run step not to display when the MQTT server is not functioning. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->


# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2376]: https://opentrons.atlassian.net/browse/RQA-2376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ