### PR TITLE
fix(app): don't publish "Dropping tip into…" for steps that don't drop tips

### DIFF
--- a/app/src/assets/localization/en/protocol_command_text.json
+++ b/app/src/assets/localization/en/protocol_command_text.json
@@ -37,7 +37,7 @@
   "move_to_slot": "Moving to Slot {{slot_name}}",
   "move_to_well": "Moving to well {{well_name}} of {{labware}} in {{labware_location}}",
   "move_to_addressable_area": "Moving to {{addressable_area}}",
-  "move_to_addressable_area_drop_tip": "Dropping tip into {{addressable_area}}",
+  "move_to_addressable_area_drop_tip": "Moving to {{addressable_area}}",
   "notes": "notes",
   "off_deck": "off deck",
   "offdeck": "offdeck",

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -304,7 +304,7 @@ describe('CommandText', () => {
       />,
       { i18nInstance: i18n }
     )[0]
-    getByText('Dropping tip into Trash Bin in D3')
+    getByText('Moving to Trash Bin in D3')
   })
   it('renders correct text for moveToAddressableArea for slots', () => {
     const { getByText } = renderWithProviders(


### PR DESCRIPTION
# Overview

Run log entries in the Opentrons App for movement to trash bins read as "Dropping tip into" instead of "Moving to". In other words, they would say tips were being dropped even when they weren't, like when dispensing or blowing out into the trash.

This is a string fix band-aid 🩹 just to make the run log sensical and correct. We would probably like these commands to behave more like the `opentrons_simulate` output introduced in #14419 (i.e., combining the movement and action step into a single line). But that's for another day and another release.

# Test Plan

- Tested in app with sample protocol from #14419.
- Unit tests pass.

# Changelog

- Changed `move_to_addressable_area_drop_tip`  localization string and corresponding test.

# Review requests

OK solution for now? Does this break any other publishing? It shouldn't as far as I know.

# Risk assessment

low