### PR TITLE
feat(api): add pipette outer dimensions when checking movement conflict

### DIFF
--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -19,6 +19,7 @@ from opentrons_shared_data.pipette.types import PipetteTipType
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteConfigurations,
     SupportedTipsDefinition,
+    PipetteBoundingBoxOffsetDefinition,
 )
 from opentrons_shared_data.gripper import (
     GripperModel,
@@ -95,7 +96,8 @@ class PipetteDict(InstrumentDict):
     has_tip: bool
     default_push_out_volume: Optional[float]
     supported_tips: Dict[PipetteTipType, SupportedTipsDefinition]
-    current_nozzle_map: NozzleMap  # spp: why was this Optional?
+    pipette_bounding_box_offsets: PipetteBoundingBoxOffsetDefinition
+    current_nozzle_map: NozzleMap
 
 
 class PipetteStateDict(TypedDict):

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -75,7 +75,9 @@ class Pipette(AbstractInstrument[PipetteConfigurations]):
     control API. Its only purpose is to gather state.
     """
 
-    DictType = Dict[str, Union[str, float, bool]]
+    DictType = Dict[
+        str, Union[str, float, bool]
+    ]  # spp: as_dict() has value items that aren't Union[str, float, bool]..
     #: The type of this data class as a dict
 
     def __init__(

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -242,8 +242,6 @@ class PipetteHandlerProvider(Generic[MountType]):
                 instr, instr.blow_out_flow_rate, "dispense"
             )
             result["ready_to_aspirate"] = instr.ready_to_aspirate
-            # TODO (12-5-2022) figure out why this is using default aspirate flow rate
-            # rather than default dispense flow rate.
             result["default_blow_out_speeds"] = {
                 alvl: self.plunger_speed(instr, fr, "blowout")
                 for alvl, fr in instr.blow_out_flow_rates_lookup.items()
@@ -257,6 +255,9 @@ class PipetteHandlerProvider(Generic[MountType]):
                 alvl: self.plunger_speed(instr, fr, "aspirate")
                 for alvl, fr in instr.aspirate_flow_rates_lookup.items()
             }
+            result[
+                "pipette_bounding_box_offsets"
+            ] = instr.config.pipette_bounding_box_offsets
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -276,6 +276,9 @@ class OT3PipetteHandler:
             result[
                 "default_push_out_volume"
             ] = instr.active_tip_settings.default_push_out_volume
+            result[
+                "pipette_bounding_box_offsets"
+            ] = instr.config.pipette_bounding_box_offsets
         return cast(PipetteDict, result)
 
     @property

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -246,9 +246,8 @@ def check_safe_for_pipette_movement(
 
     labware_slot = engine_state.geometry.get_ancestor_slot_name(labware_id)
     pipette_bounds_at_well_location = (
-        engine_state.pipettes.get_nozzle_bounds_at_specified_move_to_position(
-            pipette_id=pipette_id,
-            destination_position=well_location_point,
+        engine_state.pipettes.get_pipette_bounds_at_specified_move_to_position(
+            pipette_id=pipette_id, destination_position=well_location_point
         )
     )
     surrounding_slots = adjacent_slots_getters.get_surrounding_slots(

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -342,6 +342,11 @@ def _will_collide_with_thermocycler_lid(
     between a complicated check involving accurate positions of all entities involved
     and a crude check that disallows all partial tip movements around the thermocycler.
     """
+    # TODO (spp, 2024-02-27): Improvements:
+    #  - create a complete no-go zone that includes the lid itself
+    #  - make the check dynamic according to lid state:
+    #     - if lid is open, check if pipette is in no-go zone
+    #     - if lid is closed, use the closed lid height to check for conflict
     if (
         DeckSlotName.SLOT_A1 in surrounding_regular_slots
         and engine_state.modules.is_flex_deck_with_thermocycler()

--- a/api/src/opentrons/protocol_api/core/engine/point_calculations.py
+++ b/api/src/opentrons/protocol_api/core/engine/point_calculations.py
@@ -22,3 +22,43 @@ def get_relative_offset(
         y=point.y + y_offset,
         z=point.z + z_offset,
     )
+
+
+def are_overlapping_rectangles(
+    rectangle1: Tuple[Point, Point],
+    rectangle2: Tuple[Point, Point],
+) -> bool:
+    """Return whether the two provided rectangles are overlapping in 2D space.
+
+    The rectangles are assumed to be coplanar and represented by tuples of
+    the back-left and front right vertices (in that order) of the respective rectangles.
+    The z-coordinate of each point will be ignored.
+
+    We determine if the rectangles overlap by comparing projections of the sides of
+    the rectangles on each of the 2 axes (x & y). If the projections on each axis overlap,
+    then we can conclude that the rectangles overlap.
+
+    The projection on an axis overlaps if the distance between the first projected point
+    and the last projected point is less than the sum of the lengths of the projected sides
+    of the two rectangles. For example, if we have two rectangles with vertices:
+    Rect1 -> BL: (x1, y1), FR: (x2, y2)
+    Rect2 -> BL: (x3, y3), FR: (x4, y4)
+
+    Then for the two rectangles to be overlapping, they should satisfy:
+    max(x1, x2, x3, x4) - min(x1, x2, x3, x4) < (x2 - x1) + (x4 - x3)
+    AND
+    max(y1, y2, y3, y4) - min(y1, y2, y3, y4) < (y2 - y1) + (y4 - y3)
+    """
+    x_coordinates = [rectangle1[0].x, rectangle1[1].x, rectangle2[0].x, rectangle2[1].x]
+    x_length_rect1 = abs(rectangle1[1].x - rectangle1[0].x)
+    x_length_rect2 = abs(rectangle2[1].x - rectangle2[0].x)
+    overlapping_in_x = (
+        abs(max(x_coordinates) - min(x_coordinates)) < x_length_rect1 + x_length_rect2
+    )
+    y_coordinates = [rectangle1[0].y, rectangle1[1].y, rectangle2[0].y, rectangle2[1].y]
+    y_length_rect1 = abs(rectangle1[1].y - rectangle1[0].y)
+    y_length_rect2 = abs(rectangle2[1].y - rectangle2[0].y)
+    overlapping_in_y = (
+        abs(max(y_coordinates) - min(y_coordinates)) < y_length_rect1 + y_length_rect2
+    )
+    return overlapping_in_x and overlapping_in_y

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -37,6 +37,8 @@ class LoadedStaticPipetteData:
         float, pipette_definition.SupportedTipsDefinition
     ]
     nominal_tip_overlap: Dict[str, float]
+    back_left_corner_offset: Point
+    front_right_corner_offset: Point
     back_left_nozzle_offset: Point
     front_right_nozzle_offset: Point
 
@@ -151,6 +153,8 @@ class VirtualPipetteDataProvider:
         ]
 
         nozzle_manager = NozzleConfigurationManager.build_from_config(config)
+        pip_back_left = config.pipette_bounding_box_offsets.back_left_corner
+        pip_front_right = config.pipette_bounding_box_offsets.front_right_corner
         return LoadedStaticPipetteData(
             model=str(pipette_model),
             display_name=config.display_name,
@@ -173,6 +177,12 @@ class VirtualPipetteDataProvider:
             nominal_tip_overlap=config.liquid_properties[
                 liquid_class
             ].tip_overlap_dictionary,
+            back_left_corner_offset=Point(
+                pip_back_left[0], pip_back_left[1], pip_back_left[2]
+            ),
+            front_right_corner_offset=Point(
+                pip_front_right[0], pip_front_right[1], pip_front_right[2]
+            ),
             back_left_nozzle_offset=nozzle_manager.current_configuration.back_left_nozzle_offset,
             front_right_nozzle_offset=nozzle_manager.current_configuration.front_right_nozzle_offset,
         )
@@ -189,6 +199,8 @@ class VirtualPipetteDataProvider:
 
 def get_pipette_static_config(pipette_dict: PipetteDict) -> LoadedStaticPipetteData:
     """Get the config for a pipette, given the state/config object from the HW API."""
+    back_left_offset = pipette_dict["pipette_bounding_box_offsets"].back_left_corner
+    front_right_offset = pipette_dict["pipette_bounding_box_offsets"].front_right_corner
     return LoadedStaticPipetteData(
         model=pipette_dict["model"],
         display_name=pipette_dict["display_name"],
@@ -215,4 +227,10 @@ def get_pipette_static_config(pipette_dict: PipetteDict) -> LoadedStaticPipetteD
         front_right_nozzle_offset=pipette_dict[
             "current_nozzle_map"
         ].front_right_nozzle_offset,
+        back_left_corner_offset=Point(
+            back_left_offset[0], back_left_offset[1], back_left_offset[2]
+        ),
+        front_right_corner_offset=Point(
+            front_right_offset[0], front_right_offset[1], front_right_offset[2]
+        ),
     )

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -725,6 +725,8 @@ class PipetteView(HasState[PipetteState]):
             - primary_nozzle_offset
             + pipette_bounds_offsets.front_right_corner
         )
+        # TODO (spp, 2024-02-27): remove back right & front left;
+        #  return only back left and front right points.
         pip_back_right_bound = Point(
             pip_front_right_bound.x, pip_back_left_bound.y, pip_front_right_bound.z
         )

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -703,7 +703,7 @@ class PipetteView(HasState[PipetteState]):
         pipette_id: str,
         destination_position: Point,
     ) -> Tuple[Point, Point, Point, Point]:
-        """Get the given pipette's bounding nozzles' positions when primary nozzle is at the given destination position."""
+        """Get the pipette's bounding offsets when primary nozzle is at the given position."""
         primary_nozzle_offset = self.get_primary_nozzle_offset(pipette_id)
         tip = self.get_attached_tip(pipette_id)
         # Primary nozzle position at destination, in deck coordinates

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -715,7 +715,6 @@ class PipetteView(HasState[PipetteState]):
         pipette_bounds_offsets = self.get_config(
             pipette_id
         ).pipette_bounding_box_offsets
-        # TODO (spp): add a margin to these bounds
         pip_back_left_bound = (
             primary_nozzle_position
             - primary_nozzle_offset

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -87,7 +87,7 @@ class BoundingNozzlesOffsets:
 
 @dataclass(frozen=True)
 class PipetteBoundingBoxOffsets:
-    """Offsets of the bounding nozzles of the pipette."""
+    """Offsets of the corners of the pipette's bounding box."""
 
     back_left_corner: Point
     front_right_corner: Point

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -379,7 +379,7 @@ module = LoadedModule(
     [("OT-3 Standard", DeckType.OT3_STANDARD)],
 )
 @pytest.mark.parametrize(
-    ["nozzle_bounds", "expected_raise"],
+    ["pipette_bounds", "expected_raise"],
     [
         (  # nozzles above highest Z
             (
@@ -432,7 +432,7 @@ module = LoadedModule(
 def test_deck_conflict_raises_for_bad_pipette_move(
     decoy: Decoy,
     mock_state_view: StateView,
-    nozzle_bounds: Tuple[Point, Point, Point, Point],
+    pipette_bounds: Tuple[Point, Point, Point, Point],
     expected_raise: ContextManager[Any],
 ) -> None:
     """It should raise errors when moving to locations with restrictions for partial pipette movement.
@@ -443,6 +443,10 @@ def test_deck_conflict_raises_for_bad_pipette_move(
     - we are checking for conflicts when moving to a labware in C2.
       For each test case, we are moving to a different point in the destination labware,
       with the same pipette and tip
+
+    Note: this test does not stub out the slot overlap checker function
+          in order to preserve readability of the test. That means the test does
+          actual slot overlap checks.
     """
     destination_well_point = Point(x=123, y=123, z=123)
     decoy.when(
@@ -466,7 +470,7 @@ def test_deck_conflict_raises_for_bad_pipette_move(
         mock_state_view.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id="pipette-id", destination_position=destination_well_point
         )
-    ).then_return(nozzle_bounds)
+    ).then_return(pipette_bounds)
 
     decoy.when(
         adjacent_slots_getters.get_surrounding_slots(5, robot_type="OT-3 Standard")
@@ -546,7 +550,7 @@ def test_deck_conflict_raises_for_collision_with_tc_lid(
 ) -> None:
     """It should raise an error if pipette might collide with thermocycler lid on the Flex."""
     destination_well_point = Point(x=123, y=123, z=123)
-    nozzle_bounds_at_destination = (
+    pipette_bounds_at_destination = (
         Point(x=50, y=150, z=60),
         Point(x=150, y=50, z=60),
         Point(x=97, y=403, z=204.5),
@@ -574,7 +578,7 @@ def test_deck_conflict_raises_for_collision_with_tc_lid(
         mock_state_view.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id="pipette-id", destination_position=destination_well_point
         )
-    ).then_return(nozzle_bounds_at_destination)
+    ).then_return(pipette_bounds_at_destination)
 
     decoy.when(
         adjacent_slots_getters.get_surrounding_slots(5, robot_type="OT-3 Standard")

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -463,7 +463,7 @@ def test_deck_conflict_raises_for_bad_pipette_move(
         )
     ).then_return(destination_well_point)
     decoy.when(
-        mock_state_view.pipettes.get_nozzle_bounds_at_specified_move_to_position(
+        mock_state_view.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id="pipette-id", destination_position=destination_well_point
         )
     ).then_return(nozzle_bounds)
@@ -571,7 +571,7 @@ def test_deck_conflict_raises_for_collision_with_tc_lid(
         )
     ).then_return(destination_well_point)
     decoy.when(
-        mock_state_view.pipettes.get_nozzle_bounds_at_specified_move_to_position(
+        mock_state_view.pipettes.get_pipette_bounds_at_specified_move_to_position(
             pipette_id="pipette-id", destination_position=destination_well_point
         )
     ).then_return(nozzle_bounds_at_destination)

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -551,10 +551,10 @@ def test_deck_conflict_raises_for_collision_with_tc_lid(
     """It should raise an error if pipette might collide with thermocycler lid on the Flex."""
     destination_well_point = Point(x=123, y=123, z=123)
     pipette_bounds_at_destination = (
-        Point(x=50, y=150, z=60),
-        Point(x=150, y=50, z=60),
-        Point(x=97, y=403, z=204.5),
-        Point(x=50, y=50, z=60),
+        Point(x=50, y=350, z=204.5),
+        Point(x=150, y=450, z=204.5),
+        Point(x=150, y=400, z=204.5),
+        Point(x=50, y=300, z=204.5),
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_api/core/engine/test_point_calculations.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_point_calculations.py
@@ -1,4 +1,8 @@
 """Tests for Protocol API point calculation."""
+from typing import Tuple
+
+import pytest
+
 from opentrons.types import Point
 
 from opentrons.protocol_api.core.engine import point_calculations as subject
@@ -15,3 +19,51 @@ def test_get_relative_offset() -> None:
     )
 
     assert result == Point(2.0, 3.0, 4.0)
+
+
+@pytest.mark.parametrize(
+    argnames=["rect1", "rect2", "expected_result"],
+    argvalues=[
+        (  # One rectangle inside the other
+            (Point(236, 170, 0), Point(391, 375, 0)),
+            (Point(237, 250, 0), Point(388, 294, 0)),
+            True,
+        ),
+        (  # One rectangle inside the other
+            (Point(237, 250, 0), Point(388, 294, 0)),
+            (Point(236, 170, 0), Point(391, 375, 0)),
+            True,
+        ),
+        (  # Two non-overlapping rectangles
+            (Point(236, 170, 0), Point(391, 375, 0)),
+            (Point(438, 216, 100), Point(937, 306, 200)),
+            False,
+        ),
+        (  # Two non-overlapping rectangles in 2nd quadrant
+            (Point(-438, 216, 100), Point(-937, 306, 200)),
+            (Point(-236, 170, 0), Point(-391, 375, 0)),
+            False,
+        ),
+        (  # Overlapping rectangles with one corner of each rectangle overlapping
+            (Point(719, 304, 20), Point(970, 370, 20)),
+            (Point(438, 216, 100), Point(937, 306, 200)),
+            True,
+        ),
+        (  # Overlapping rectangles with no overlapping corners
+            # (think two rectangles making a '+' sign)
+            (Point(630, 94, 20), Point(800, 500, 20)),
+            (Point(438, 216, 100), Point(937, 306, 200)),
+            True,
+        ),
+    ],
+)
+def test_are_overlapping_rectangles(
+    rect1: Tuple[Point, Point],
+    rect2: Tuple[Point, Point],
+    expected_result: bool,
+) -> None:
+    """It should calculate correctly whether the rectangles are overlapping."""
+    assert (
+        subject.are_overlapping_rectangles(rectangle1=rect1, rectangle2=rect2)
+        == expected_result
+    )

--- a/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
+++ b/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
@@ -70,10 +70,10 @@ def test_deck_conflicts_for_96_ch_a12_column_configuration() -> None:
     ):
         instrument.dispense(50, badly_placed_labware.wells()[0])
 
-    # Currently does not raise a 'collision with thermocycler lid' error`
-    # because it's the pipette outer cover that hits the lid, but we don't include
-    # the cover in pipette dimensions yet.
-    instrument.dispense(10, tc_adjacent_plate.wells_by_name()["A1"])
+    with pytest.raises(
+        PartialTipMovementNotAllowedError, match="collision with thermocycler lid"
+    ):
+        instrument.dispense(10, tc_adjacent_plate.wells_by_name()["A1"])
 
     # No error cuz dispensing from high above plate, so it clears tuberack in west slot
     instrument.dispense(15, badly_placed_labware.wells_by_name()["A1"].top(150))

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -46,6 +46,8 @@ async def test_configure_for_volume_implementation(
         nominal_tip_overlap={},
         back_left_nozzle_offset=Point(x=1, y=2, z=3),
         front_right_nozzle_offset=Point(x=4, y=5, z=6),
+        back_left_corner_offset=Point(10, 20, 30),
+        front_right_corner_offset=Point(40, 50, 60),
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -43,6 +43,8 @@ async def test_load_pipette_implementation(
         nominal_tip_overlap={},
         back_left_nozzle_offset=Point(x=1, y=2, z=3),
         front_right_nozzle_offset=Point(x=4, y=5, z=6),
+        back_left_corner_offset=Point(x=1, y=2, z=3),
+        front_right_corner_offset=Point(x=4, y=5, z=6),
     )
     data = LoadPipetteParams(
         pipetteName=PipetteNameType.P300_SINGLE,
@@ -100,6 +102,8 @@ async def test_load_pipette_implementation_96_channel(
         nominal_tip_overlap={},
         back_left_nozzle_offset=Point(x=1, y=2, z=3),
         front_right_nozzle_offset=Point(x=4, y=5, z=6),
+        back_left_corner_offset=Point(x=1, y=2, z=3),
+        front_right_corner_offset=Point(x=4, y=5, z=6),
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -149,6 +149,8 @@ def loaded_static_pipette_data(
         nozzle_offset_z=12.13,
         back_left_nozzle_offset=Point(x=1, y=2, z=3),
         front_right_nozzle_offset=Point(x=4, y=5, z=6),
+        back_left_corner_offset=Point(x=1, y=2, z=3),
+        front_right_corner_offset=Point(x=4, y=5, z=6),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -4,6 +4,9 @@ from collections import OrderedDict
 import pytest
 from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
 from opentrons_shared_data.pipette import pipette_definition, types as pip_types
+from opentrons_shared_data.pipette.pipette_definition import (
+    PipetteBoundingBoxOffsetDefinition,
+)
 
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.nozzle_manager import NozzleMap
@@ -214,6 +217,10 @@ def test_get_pipette_static_config(
         "default_aspirate_speeds": {"2.0": 5.021202, "2.6": 10.042404},
         "default_push_out_volume": 3,
         "supported_tips": {pip_types.PipetteTipType.t300: supported_tip_fixture},
+        "pipette_bounding_box_offsets": PipetteBoundingBoxOffsetDefinition(
+            backLeftCorner=[10, 20, 30],
+            frontRightCorner=[40, 50, 60],
+        ),
         "current_nozzle_map": NozzleMap.build(
             physical_nozzles=OrderedDict({"A1": Point(1, 2, 3), "B1": Point(4, 5, 6)}),
             physical_rows=OrderedDict({"A": ["A1"], "B": ["B1"]}),

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -59,6 +59,8 @@ def test_get_virtual_pipette_static_config(
         },
         back_left_nozzle_offset=Point(x=0.0, y=0.0, z=10.45),
         front_right_nozzle_offset=Point(x=0.0, y=0.0, z=10.45),
+        back_left_corner_offset=Point(0, 0, 10.45),
+        front_right_corner_offset=Point(0, 0, 10.45),
     )
 
 
@@ -86,6 +88,8 @@ def test_configure_virtual_pipette_for_volume(
         nominal_tip_overlap=result1.nominal_tip_overlap,
         back_left_nozzle_offset=Point(x=-8.0, y=-22.0, z=-259.15),
         front_right_nozzle_offset=Point(x=-8.0, y=-22.0, z=-259.15),
+        back_left_corner_offset=Point(-8.0, -22.0, -259.15),
+        front_right_corner_offset=Point(-8.0, -22.0, -259.15),
     )
     subject_instance.configure_virtual_pipette_for_volume(
         "my-pipette", 1, result1.model
@@ -110,6 +114,8 @@ def test_configure_virtual_pipette_for_volume(
         nominal_tip_overlap=result2.nominal_tip_overlap,
         back_left_nozzle_offset=Point(x=-8.0, y=-22.0, z=-259.15),
         front_right_nozzle_offset=Point(x=-8.0, y=-22.0, z=-259.15),
+        back_left_corner_offset=Point(-8.0, -22.0, -259.15),
+        front_right_corner_offset=Point(-8.0, -22.0, -259.15),
     )
 
 
@@ -137,6 +143,8 @@ def test_load_virtual_pipette_by_model_string(
         nominal_tip_overlap=result.nominal_tip_overlap,
         back_left_nozzle_offset=Point(x=0.0, y=31.5, z=35.52),
         front_right_nozzle_offset=Point(x=0.0, y=-31.5, z=35.52),
+        back_left_corner_offset=Point(-16.0, 43.15, 35.52),
+        front_right_corner_offset=Point(16.0, -43.15, 35.52),
     )
 
 
@@ -256,4 +264,6 @@ def test_get_pipette_static_config(
         home_position=0,
         back_left_nozzle_offset=Point(x=1, y=2, z=3),
         front_right_nozzle_offset=Point(x=4, y=5, z=6),
+        back_left_corner_offset=Point(10, 20, 30),
+        front_right_corner_offset=Point(40, 50, 60),
     )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -54,6 +54,7 @@ from opentrons.protocol_engine.state.pipettes import (
     PipetteView,
     StaticPipetteConfig,
     BoundingNozzlesOffsets,
+    PipetteBoundingBoxOffsets,
 )
 from opentrons.protocol_engine.state.addressable_areas import AddressableAreaView
 from opentrons.protocol_engine.state.geometry import GeometryView, _GripperMoveType
@@ -1856,6 +1857,10 @@ def test_get_next_drop_tip_location(
             bounding_nozzle_offsets=BoundingNozzlesOffsets(
                 back_left_offset=Point(x=10, y=20, z=30),
                 front_right_offset=Point(x=40, y=50, z=60),
+            ),
+            pipette_bounding_box_offsets=PipetteBoundingBoxOffsets(
+                back_left_corner=Point(x=10, y=20, z=30),
+                front_right_corner=Point(x=40, y=50, z=60),
             ),
         )
     )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -28,6 +28,7 @@ from opentrons.protocol_engine.state.pipettes import (
     CurrentDeckPoint,
     StaticPipetteConfig,
     BoundingNozzlesOffsets,
+    PipetteBoundingBoxOffsets,
 )
 from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
@@ -684,6 +685,8 @@ def test_add_pipette_config(
             nozzle_offset_z=10.11,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
     subject.handle_action(
@@ -704,6 +707,10 @@ def test_add_pipette_config(
         bounding_nozzle_offsets=BoundingNozzlesOffsets(
             back_left_offset=Point(x=1, y=2, z=3),
             front_right_offset=Point(x=4, y=5, z=6),
+        ),
+        pipette_bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(x=1, y=2, z=3),
+            front_right_corner=Point(x=4, y=5, z=6),
         ),
     )
     assert subject.state.flow_rates_by_id["pipette-id"].default_aspirate == {"a": 1.0}

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -26,6 +26,7 @@ from opentrons.protocol_engine.state.pipettes import (
     HardwarePipette,
     StaticPipetteConfig,
     BoundingNozzlesOffsets,
+    PipetteBoundingBoxOffsets,
 )
 from opentrons.hardware_control.nozzle_manager import NozzleMap, NozzleConfigurationType
 from opentrons.protocol_engine.errors import TipNotAttachedError, PipetteNotLoadedError
@@ -41,6 +42,9 @@ from ..pipette_fixtures import (
 
 _SAMPLE_NOZZLE_BOUNDS_OFFSETS = BoundingNozzlesOffsets(
     back_left_offset=Point(x=10, y=20, z=30), front_right_offset=Point(x=40, y=50, z=60)
+)
+_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS = PipetteBoundingBoxOffsets(
+    back_left_corner=Point(x=10, y=20, z=30), front_right_corner=Point(x=40, y=50, z=60)
 )
 
 
@@ -268,6 +272,7 @@ def test_get_pipette_working_volume(
                 home_position=0,
                 nozzle_offset_z=0,
                 bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+                pipette_bounding_box_offsets=_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS,
             )
         },
     )
@@ -296,6 +301,7 @@ def test_get_pipette_working_volume_raises_if_tip_volume_is_none(
                 home_position=0,
                 nozzle_offset_z=0,
                 bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+                pipette_bounding_box_offsets=_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS,
             )
         },
     )
@@ -333,6 +339,7 @@ def test_get_pipette_available_volume(
                 home_position=0,
                 nozzle_offset_z=0,
                 bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+                pipette_bounding_box_offsets=_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS,
             ),
             "pipette-id-none": StaticPipetteConfig(
                 min_volume=1,
@@ -346,6 +353,7 @@ def test_get_pipette_available_volume(
                 home_position=0,
                 nozzle_offset_z=0,
                 bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+                pipette_bounding_box_offsets=_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS,
             ),
         },
     )
@@ -455,6 +463,7 @@ def test_get_static_config(
         home_position=10.12,
         nozzle_offset_z=12.13,
         bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+        pipette_bounding_box_offsets=_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS,
     )
 
     subject = get_pipette_view(
@@ -503,6 +512,7 @@ def test_get_nominal_tip_overlap(
         home_position=0,
         nozzle_offset_z=0,
         bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+        pipette_bounding_box_offsets=_SAMPLE_PIPETTE_BOUNDING_BOX_OFFSETS,
     )
 
     subject = get_pipette_view(static_config_by_id={"pipette-id": config})
@@ -554,7 +564,7 @@ def test_nozzle_configuration_getters() -> None:
 
 class _PipetteSpecs(NamedTuple):
     tip_length: float
-    bounding_nozzle_offsets: BoundingNozzlesOffsets
+    bounding_box_offsets: PipetteBoundingBoxOffsets
     nozzle_map: NozzleMap
     destination_position: Point
     nozzle_bounds_result: Tuple[Point, Point, Point, Point]
@@ -564,9 +574,9 @@ _pipette_spec_cases = [
     _PipetteSpecs(
         # 8-channel P300, full configuration
         tip_length=42,
-        bounding_nozzle_offsets=BoundingNozzlesOffsets(
-            back_left_offset=Point(0.0, 31.5, 35.52),
-            front_right_offset=Point(0.0, -31.5, 35.52),
+        bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(0.0, 31.5, 35.52),
+            front_right_corner=Point(0.0, -31.5, 35.52),
         ),
         nozzle_map=NozzleMap.build(
             physical_nozzles=EIGHT_CHANNEL_MAP,
@@ -589,9 +599,9 @@ _pipette_spec_cases = [
     _PipetteSpecs(
         # 8-channel P300, single configuration
         tip_length=42,
-        bounding_nozzle_offsets=BoundingNozzlesOffsets(
-            back_left_offset=Point(0.0, 31.5, 35.52),
-            front_right_offset=Point(0.0, -31.5, 35.52),
+        bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(0.0, 31.5, 35.52),
+            front_right_corner=Point(0.0, -31.5, 35.52),
         ),
         nozzle_map=NozzleMap.build(
             physical_nozzles=EIGHT_CHANNEL_MAP,
@@ -614,9 +624,9 @@ _pipette_spec_cases = [
     _PipetteSpecs(
         # 96-channel P1000, full configuration
         tip_length=42,
-        bounding_nozzle_offsets=BoundingNozzlesOffsets(
-            back_left_offset=Point(-36.0, -25.5, -259.15),
-            front_right_offset=Point(63.0, -88.5, -259.15),
+        bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(-36.0, -25.5, -259.15),
+            front_right_corner=Point(63.0, -88.5, -259.15),
         ),
         nozzle_map=NozzleMap.build(
             physical_nozzles=NINETY_SIX_MAP,
@@ -639,9 +649,9 @@ _pipette_spec_cases = [
     _PipetteSpecs(
         # 96-channel P1000, A1 COLUMN configuration
         tip_length=42,
-        bounding_nozzle_offsets=BoundingNozzlesOffsets(
-            back_left_offset=Point(-36.0, -25.5, -259.15),
-            front_right_offset=Point(63.0, -88.5, -259.15),
+        bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(-36.0, -25.5, -259.15),
+            front_right_corner=Point(63.0, -88.5, -259.15),
         ),
         nozzle_map=NozzleMap.build(
             physical_nozzles=NINETY_SIX_MAP,
@@ -662,9 +672,9 @@ _pipette_spec_cases = [
     _PipetteSpecs(
         # 96-channel P1000, A12 COLUMN configuration
         tip_length=42,
-        bounding_nozzle_offsets=BoundingNozzlesOffsets(
-            back_left_offset=Point(-36.0, -25.5, -259.15),
-            front_right_offset=Point(63.0, -88.5, -259.15),
+        bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(-36.0, -25.5, -259.15),
+            front_right_corner=Point(63.0, -88.5, -259.15),
         ),
         nozzle_map=NozzleMap.build(
             physical_nozzles=NINETY_SIX_MAP,
@@ -685,9 +695,9 @@ _pipette_spec_cases = [
     _PipetteSpecs(
         # 96-channel P1000, ROW configuration
         tip_length=42,
-        bounding_nozzle_offsets=BoundingNozzlesOffsets(
-            back_left_offset=Point(-36.0, -25.5, -259.15),
-            front_right_offset=Point(63.0, -88.5, -259.15),
+        bounding_box_offsets=PipetteBoundingBoxOffsets(
+            back_left_corner=Point(-36.0, -25.5, -259.15),
+            front_right_corner=Point(63.0, -88.5, -259.15),
         ),
         nozzle_map=NozzleMap.build(
             physical_nozzles=NINETY_SIX_MAP,
@@ -714,7 +724,7 @@ _pipette_spec_cases = [
 )
 def test_get_nozzle_bounds_at_location(
     tip_length: float,
-    bounding_nozzle_offsets: BoundingNozzlesOffsets,
+    bounding_box_offsets: PipetteBoundingBoxOffsets,
     nozzle_map: NozzleMap,
     destination_position: Point,
     nozzle_bounds_result: Tuple[Point, Point, Point, Point],
@@ -737,14 +747,14 @@ def test_get_nozzle_bounds_at_location(
                 nominal_tip_overlap={},
                 home_position=0,
                 nozzle_offset_z=0,
-                bounding_nozzle_offsets=bounding_nozzle_offsets,
+                bounding_nozzle_offsets=_SAMPLE_NOZZLE_BOUNDS_OFFSETS,
+                pipette_bounding_box_offsets=bounding_box_offsets,
             )
         },
     )
     assert (
-        subject.get_nozzle_bounds_at_specified_move_to_position(
-            pipette_id="pipette-id",
-            destination_position=destination_position,
+        subject.get_pipette_bounds_at_specified_move_to_position(
+            pipette_id="pipette-id", destination_position=destination_position
         )
         == nozzle_bounds_result
     )

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -220,6 +220,8 @@ def test_get_next_tip_skips_picked_up_tip(
             home_position=4.56,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
     subject.handle_action(
@@ -414,6 +416,8 @@ def test_reset_tips(
             home_position=4.56,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
 
@@ -464,6 +468,8 @@ def test_handle_pipette_config_action(
             home_position=4.56,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
     subject.handle_action(
@@ -546,6 +552,8 @@ def test_drop_tip(
             home_position=4.56,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
     subject.handle_action(
@@ -651,6 +659,8 @@ def test_active_channels(
             home_position=4.56,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
     subject.handle_action(
@@ -715,6 +725,8 @@ def test_next_tip_uses_active_channels(
             home_position=4.56,
             back_left_nozzle_offset=Point(x=1, y=2, z=3),
             front_right_nozzle_offset=Point(x=4, y=5, z=6),
+            back_left_corner_offset=Point(x=1, y=2, z=3),
+            front_right_corner_offset=Point(x=4, y=5, z=6),
         ),
     )
     subject.handle_action(

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p10/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p10/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p10/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p10/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_6.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p10/1_6.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p10/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/1_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_3.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_4.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p1000/3_5.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p20/2_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 19.4],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 43.15, 19.4],
+    "frontRightCorner": [16.0, -43.15, 19.4]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p20/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p20/2_1.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 19.4],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 43.15, 19.4],
+    "frontRightCorner": [16.0, -43.15, 19.4]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p20/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p300/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p300/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p300/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p300/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 44.49, 0.8],
+    "frontRightCorner": [16.0, -44.49, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p300/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p300/2_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 35.52],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 43.15, 35.52],
+    "frontRightCorner": [16.0, -43.15, 35.52]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p300/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p300/2_1.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 35.52],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-16.0, 43.15, 35.52],
+    "frontRightCorner": [16.0, -43.15, 35.52]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p300/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-30.5, 47.5, 0.8],
+    "frontRightCorner": [19.5, -47.5, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-30.5, 47.5, 0.8],
+    "frontRightCorner": [19.5, -47.5, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-30.5, 47.5, 0.8],
+    "frontRightCorner": [19.5, -47.5, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 31.5, 0.8],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-30.5, 47.5, 0.8],
+    "frontRightCorner": [19.5, -47.5, 0.8]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p50/placeholder.gltf",
   "orderedRows": [
     {

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_3.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_4.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/eight_channel/p50/3_5.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/eight_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -16.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-38.5, 0.0, -259.15],
+    "frontRightCorner": [11.5, -95.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/1_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-67.0, -3.5, -259.15],
+    "frontRightCorner": [94.0, -113.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-67.0, -3.5, -259.15],
+    "frontRightCorner": [94.0, -113.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_3.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-67.0, -3.5, -259.15],
+    "frontRightCorner": [94.0, -113.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_4.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-67.0, -3.5, -259.15],
+    "frontRightCorner": [94.0, -113.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/ninety_six_channel/p1000/3_5.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/ninety_six_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-36.0, -25.5, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-67.0, -3.5, -259.15],
+    "frontRightCorner": [94.0, -113.0, -259.15]
+  },
   "orderedRows": [
     {
       "key": "A",

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 12.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 12.0],
+    "frontRightCorner": [0, 0, 12.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p10/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 12.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 12.0],
+    "frontRightCorner": [0, 0, 12.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p10/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 12.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 12.0],
+    "frontRightCorner": [0, 0, 12.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p10/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p10/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 12.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 12.0],
+    "frontRightCorner": [0, 0, 12.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p10/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 45.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 45.0],
+    "frontRightCorner": [0.0, 0.0, 45.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 45.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 45.0],
+    "frontRightCorner": [0.0, 0.0, 45.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 45.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 45.0],
+    "frontRightCorner": [0.0, 0.0, 45.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 45.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 45.0],
+    "frontRightCorner": [0.0, 0.0, 45.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/2_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/2_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 50.14],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 50.14],
+    "frontRightCorner": [0.0, 0.0, 50.14]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/2_1.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/2_1.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 50.14],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 50.14],
+    "frontRightCorner": [0.0, 0.0, 50.14]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/2_2.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/2_2.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 50.14],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 50.14],
+    "frontRightCorner": [0.0, 0.0, 50.14]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_3.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_4.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_5.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_6.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p1000/3_6.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p20/2_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p20/2_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 10.45],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 10.45],
+    "frontRightCorner": [0, 0, 10.45]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p20/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p20/2_1.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p20/2_1.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 10.45],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 10.45],
+    "frontRightCorner": [0, 0, 10.45]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p20/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p20/2_2.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p20/2_2.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 10.45],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0, 0, 10.45],
+    "frontRightCorner": [0, 0, 10.45]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p20/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p300/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p300/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p300/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p300/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p300/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p300/2_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p300/2_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 29.45],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 29.45],
+    "frontRightCorner": [0.0, 0.0, 29.45]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p300/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p300/2_1.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p300/2_1.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 29.45],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 29.45],
+    "frontRightCorner": [0.0, 0.0, 29.45]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p300/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_0.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_3.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_4.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/1_5.json
@@ -1,6 +1,10 @@
 {
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "nozzleOffset": [0.0, 0.0, 25.0],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [0.0, 0.0, 25.0],
+    "frontRightCorner": [0.0, 0.0, 25.0]
+  },
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_0.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_0.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_3.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_3.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_4.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_4.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_5.json
@@ -2,6 +2,10 @@
   "$otSharedSchema": "#/pipette/schemas/2/pipetteGeometrySchema.json",
   "pathTo3D": "pipette/definitions/2/geometry/single_channel/p50/placeholder.gltf",
   "nozzleOffset": [-8.0, -22.0, -259.15],
+  "pipetteBoundingBoxOffsets": {
+    "backLeftCorner": [-8.0, -22.0, -259.15],
+    "frontRightCorner": [-8.0, -22.0, -259.15]
+  },
   "orderedRows": [{ "key": "A", "orderedNozzles": ["A1"] }],
   "orderedColumns": [{ "key": "1", "orderedNozzles": ["A1"] }],
   "nozzleMap": {

--- a/shared-data/pipette/schemas/2/pipetteGeometrySchema.json
+++ b/shared-data/pipette/schemas/2/pipetteGeometrySchema.json
@@ -32,6 +32,14 @@
       "description": "The path to a valid Opentrons shared schema relative to the shared-data directory, without its extension. For instance, #/pipette/schemas/2/pipetteGeometrySchema.json is a reference to this schema."
     },
     "nozzleOffset": { "$ref": "#/definitions/xyzArray" },
+    "pipetteBoundingBoxOffsets": {
+      "description": "Offsets from the pipette mount position to the back-left & front-right corners of the pipette's casing around the nozzles.",
+      "type": "object",
+      "properties": {
+        "backLeftCorner": { "$ref": "#/definitions/xyzArray" },
+        "frontRightCorner": { "$ref": "#/definitions/xyzArray" }
+      }
+    },
     "pathTo3D": {
       "description": "path to the gltf file representing the 3D pipette model",
       "type": "string",

--- a/shared-data/pipette/schemas/2/pipetteGeometrySchema.json
+++ b/shared-data/pipette/schemas/2/pipetteGeometrySchema.json
@@ -33,7 +33,7 @@
     },
     "nozzleOffset": { "$ref": "#/definitions/xyzArray" },
     "pipetteBoundingBoxOffsets": {
-      "description": "Offsets from the pipette mount position to the back-left & front-right corners of the pipette's casing around the nozzles.",
+      "description": "Offsets from the pipette mount position to the back-left & front-right corners of the pipette's bounding box which includes the outer casing and all nozzles.",
       "type": "object",
       "properties": {
         "backLeftCorner": { "$ref": "#/definitions/xyzArray" },

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -23,6 +23,15 @@ FLEX_TC_LID_CLIP_POSITIONS_IN_DECK_COORDINATES = {
     "left_clip": {"x": -3.25, "y": 402, "z": 205},
     "right_clip": {"x": 97.75, "y": 402, "z": 205},
 }
+FLEX_TC_LID_COLLISION_ZONE = {
+    "back_left": {"x": -43.25, "y": 454.9, "z": 211.91},
+    "front_right": {"x": 128.75, "y": 402, "z": 211.91},
+}
+"""
+Deck co-ordinates of the top plane of TC lid + lid clips
+of a thermocycler on a Flex.
+"""
+
 
 # TODO (spp, 2022-05-12): Python has a built-in error called `ModuleNotFoundError` so,
 #                         maybe rename this one?

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -386,6 +386,11 @@ class PipetteColumnDefinition(BaseModel):
         return v
 
 
+class PipetteBoundingBoxOffsetDefinition(BaseModel):
+    back_left_corner: List[float]
+    front_right_corner: List[float]
+
+
 class PipetteGeometryDefinition(BaseModel):
     """The geometry properties definition of a pipette."""
 
@@ -396,6 +401,9 @@ class PipetteGeometryDefinition(BaseModel):
         alias="pathTo3D",
     )
     nozzle_map: Dict[str, List[float]] = Field(..., alias="nozzleMap")
+    pipette_bounding_box_offsets: PipetteBoundingBoxOffsetDefinition = Field(
+        ..., alias="pipetteBoundingBoxOffsets"
+    )
     ordered_columns: List[PipetteColumnDefinition] = Field(..., alias="orderedColumns")
     ordered_rows: List[PipetteRowDefinition] = Field(..., alias="orderedRows")
 

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -387,8 +387,8 @@ class PipetteColumnDefinition(BaseModel):
 
 
 class PipetteBoundingBoxOffsetDefinition(BaseModel):
-    back_left_corner: List[float]
-    front_right_corner: List[float]
+    back_left_corner: List[float] = Field(..., alias="backLeftCorner")
+    front_right_corner: List[float] = Field(..., alias="frontRightCorner")
 
 
 class PipetteGeometryDefinition(BaseModel):


### PR DESCRIPTION
Closes RQA-2311
Closes RSS-490

# Overview

Does two things-
1. shared-data: adds (to pipette definitions) the offsets of back left and front right corners of all pipettes' outer casing from their respective mount position
2. api: updates the pipette movement conflict checker to use the above mentioned pipette bounds that include the outer casing of pipettes, instead of just the bounding nozzles.

# Test Plan

Main objective of this PR is to make sure a conflict with thermocycler lid is caught in analysis. 

On top of that, since this PR also updates the logic for checking potential collisions, make sure that previously failing cases aren't passing now and vice versa. Good news is that previous integration tests for pipette movement conflict are still passing as expected.

Test protocol:

```
from opentrons.protocol_api import COLUMN, ALL

requirements = {
	"robotType": "Flex",
	"apiLevel": "2.16"
}

def run(ctx):
  tip_rack1 = ctx.load_labware("opentrons_flex_96_tiprack_50ul", "B3", adapter="opentrons_flex_96_tiprack_adapter")
  tip_rack2 = ctx.load_labware("opentrons_flex_96_tiprack_50ul", "D3")
  instrument = ctx.load_instrument('flex_96channel_1000', mount="left")
  
  my_pcr_plate = ctx.load_labware('nest_96_wellplate_200ul_flat', "C2")
  my_other_plate = ctx.load_labware('nest_96_wellplate_200ul_flat', "C1")

  thermocycler = ctx.load_module('thermocyclerModuleV2')
  tc_adjacent_plate = ctx.load_labware("nest_96_wellplate_200ul_flat", "A2")
  ctx.load_trash_bin("A3")
  
  instrument.configure_nozzle_layout(style=COLUMN, start="A12", tip_racks=[tip_rack2])
  
  instrument.pick_up_tip()  
  instrument.aspirate(50, my_pcr_plate.wells_by_name()["A4"])
  instrument.dispense(20, my_other_plate.wells_by_name()["A2"])
  
  # Should error out because conflict with thermocycler lid
  instrument.dispense(20, tc_adjacent_plate.wells_by_name()["A1"])

  instrument.drop_tip()
```

# Changelog

Shared-data:
- added `pipetteBoundingBoxOffsets` to pipette definitions

api:
- updated `PipetteDict` to include pipette bounding box offsets
- added pipette bounding box offsets to engine pipette state's config data
- replaced bounding nozzles fetchers with pipette bounding box fetchers
- updated the logic that checks whether a pipette is over/ overlapping with a certain slot. 

# Review requests

- any objections to this addition of `pipetteBoundingBoxOffsets` to the definitions?
- anything I'm missing with the changes in hardware controller?

# Risk assessment

Medium. Changes a pretty central part of the pipette movement conflict checker but it's well-tested and only used during 96 channel partial config.
