### PR TITLE
fix(app, app-shell, app-shell-odd): Fix host context for notifications

### DIFF
--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -193,8 +193,8 @@ const RENDER_TIMEOUT = 10000 // 10 seconds
 function unsubscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic } = notifyParams
   return new Promise<void>(() => {
-    if (hostname in connectionStore) {
-      setTimeout(() => {
+    setTimeout(() => {
+      if (hostname in connectionStore) {
         const { client } = connectionStore[hostname]
         const subscriptions = connectionStore[hostname]?.subscriptions
         const isLastSubscription = subscriptions[topic] <= 1
@@ -215,12 +215,12 @@ function unsubscribe(notifyParams: NotifyParams): Promise<void> {
         } else {
           subscriptions[topic] -= 1
         }
-      }, RENDER_TIMEOUT)
-    } else {
-      log.info(
-        `Attempted to unsubscribe from unconnected hostname: ${hostname}`
-      )
-    }
+      } else {
+        log.info(
+          `Attempted to unsubscribe from unconnected hostname: ${hostname}`
+        )
+      }
+    }, RENDER_TIMEOUT)
   })
 }
 

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -189,8 +189,8 @@ const RENDER_TIMEOUT = 10000 // 10 seconds
 function unsubscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic } = notifyParams
   return new Promise<void>(() => {
-    if (hostname in connectionStore) {
-      setTimeout(() => {
+    setTimeout(() => {
+      if (hostname in connectionStore) {
         const { client } = connectionStore[hostname]
         const subscriptions = connectionStore[hostname]?.subscriptions
         const isLastSubscription = subscriptions[topic] <= 1
@@ -211,12 +211,12 @@ function unsubscribe(notifyParams: NotifyParams): Promise<void> {
         } else {
           subscriptions[topic] -= 1
         }
-      }, RENDER_TIMEOUT)
-    } else {
-      log.info(
-        `Attempted to unsubscribe from unconnected hostname: ${hostname}`
-      )
-    }
+      } else {
+        log.info(
+          `Attempted to unsubscribe from unconnected hostname: ${hostname}`
+        )
+      }
+    }, RENDER_TIMEOUT)
   })
 }
 

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -9,11 +9,13 @@ import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/
 import { useTrackCreateProtocolRunEvent } from '../../../organisms/Devices/hooks'
 import { useCreateRunFromProtocol } from '../../ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol'
 import { ChooseProtocolSlideout } from '../'
+import { useNotifyService } from '../../../resources/useNotifyService'
 
 jest.mock('../../ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol')
 jest.mock('../../../redux/protocol-storage')
 jest.mock('../../../organisms/Devices/hooks')
 jest.mock('../../../redux/config')
+jest.mock('../../../resources/useNotifyService')
 
 const mockGetStoredProtocols = getStoredProtocols as jest.MockedFunction<
   typeof getStoredProtocols
@@ -23,6 +25,9 @@ const mockUseCreateRunFromProtocol = useCreateRunFromProtocol as jest.MockedFunc
 >
 const mockUseTrackCreateProtocolRunEvent = useTrackCreateProtocolRunEvent as jest.MockedFunction<
   typeof useTrackCreateProtocolRunEvent
+>
+const mockUseNotifyService = useNotifyService as jest.MockedFunction<
+  typeof useNotifyService
 >
 
 const render = (props: React.ComponentProps<typeof ChooseProtocolSlideout>) => {
@@ -52,6 +57,7 @@ describe('ChooseProtocolSlideout', () => {
     mockUseTrackCreateProtocolRunEvent.mockReturnValue({
       trackCreateProtocolRunEvent: mockTrackCreateProtocolRunEvent,
     })
+    mockUseNotifyService.mockReturnValue({} as any)
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -18,10 +18,12 @@ import {
 } from '../../../redux/discovery/__fixtures__'
 import { getNetworkInterfaces } from '../../../redux/networking'
 import { ChooseRobotSlideout } from '..'
+import { useNotifyService } from '../../../resources/useNotifyService'
 
 jest.mock('../../../redux/discovery')
 jest.mock('../../../redux/robot-update')
 jest.mock('../../../redux/networking')
+jest.mock('../../../resources/useNotifyService')
 
 const mockGetConnectableRobots = getConnectableRobots as jest.MockedFunction<
   typeof getConnectableRobots
@@ -38,6 +40,9 @@ const mockStartDiscovery = startDiscovery as jest.MockedFunction<
 >
 const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
   typeof getNetworkInterfaces
+>
+const mockUseNotifyService = useNotifyService as jest.MockedFunction<
+  typeof useNotifyService
 >
 
 const render = (props: React.ComponentProps<typeof ChooseRobotSlideout>) => {
@@ -61,6 +66,7 @@ describe('ChooseRobotSlideout', () => {
     mockGetScanning.mockReturnValue(false)
     mockStartDiscovery.mockReturnValue({ type: 'mockStartDiscovery' } as any)
     mockGetNetworkInterfaces.mockReturnValue({ wifi: null, ethernet: null })
+    mockUseNotifyService.mockReturnValue({} as any)
   })
   afterEach(() => {
     jest.resetAllMocks()

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -29,6 +29,7 @@ import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/
 import { useCreateRunFromProtocol } from '../useCreateRunFromProtocol'
 import { useOffsetCandidatesForAnalysis } from '../../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { ChooseRobotToRunProtocolSlideout } from '../'
+import { useNotifyService } from '../../../resources/useNotifyService'
 
 import type { State } from '../../../redux/types'
 
@@ -41,6 +42,7 @@ jest.mock('../../../redux/networking')
 jest.mock('../../../redux/config')
 jest.mock('../useCreateRunFromProtocol')
 jest.mock('../../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis')
+jest.mock('../../../resources/useNotifyService')
 
 const mockUseOffsetCandidatesForAnalysis = useOffsetCandidatesForAnalysis as jest.MockedFunction<
   typeof useOffsetCandidatesForAnalysis
@@ -81,6 +83,9 @@ const mockUseTrackCreateProtocolRunEvent = useTrackCreateProtocolRunEvent as jes
 >
 const mockGetNetworkInterfaces = getNetworkInterfaces as jest.MockedFunction<
   typeof getNetworkInterfaces
+>
+const mockUseNotifyService = useNotifyService as jest.MockedFunction<
+  typeof useNotifyService
 >
 
 const render = (
@@ -125,6 +130,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     })
     mockUseCurrentRunId.mockReturnValue(null)
     mockUseCurrentRunStatus.mockReturnValue(null)
+    mockUseNotifyService.mockReturnValue({} as any)
     when(mockUseCreateRunFromProtocol)
       .calledWith(
         expect.any(Object),

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
@@ -18,6 +18,7 @@ import {
 import { SetupLabwareList } from '../SetupLabwareList'
 import { SetupLabwareMap } from '../SetupLabwareMap'
 import { SetupLabware } from '..'
+import { useNotifyRunQuery } from '../../../../../resources/runs/useNotifyRunQuery'
 
 jest.mock('../SetupLabwareList')
 jest.mock('../SetupLabwareMap')
@@ -27,6 +28,7 @@ jest.mock('../../../../RunTimeControl/hooks')
 jest.mock('../../../../../redux/config')
 jest.mock('../../../hooks')
 jest.mock('../../../hooks/useLPCSuccessToast')
+jest.mock('../../../../../resources/runs/useNotifyRunQuery')
 
 const mockGetModuleTypesThatRequireExtraAttention = getModuleTypesThatRequireExtraAttention as jest.MockedFunction<
   typeof getModuleTypesThatRequireExtraAttention
@@ -57,6 +59,9 @@ const mockSetupLabwareMap = SetupLabwareMap as jest.MockedFunction<
 >
 const mockUseLPCDisabledReason = useLPCDisabledReason as jest.MockedFunction<
   typeof useLPCDisabledReason
+>
+const mockUseNotifyRunQuery = useNotifyRunQuery as jest.MockedFunction<
+  typeof useNotifyRunQuery
 >
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
@@ -110,6 +115,7 @@ describe('SetupLabware', () => {
       <div> mock setup labware list</div>
     )
     when(mockUseLPCDisabledReason).mockReturnValue(null)
+    mockUseNotifyRunQuery.mockReturnValue({} as any)
   })
 
   afterEach(() => {

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsList.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/__tests__/SetupLiquidsList.test.tsx
@@ -23,6 +23,7 @@ import {
   getTotalVolumePerLiquidLabwarePair,
 } from '../utils'
 import { LiquidsLabwareDetailsModal } from '../LiquidsLabwareDetailsModal'
+import { useNotifyRunQuery } from '../../../../../resources/runs/useNotifyRunQuery'
 
 const MOCK_LIQUIDS_IN_LOAD_ORDER = [
   {
@@ -56,6 +57,7 @@ jest.mock('../../utils/getLocationInfoNames')
 jest.mock('../LiquidsLabwareDetailsModal')
 jest.mock('@opentrons/api-client')
 jest.mock('../../../../../redux/analytics')
+jest.mock('../../../../../resources/runs/useNotifyRunQuery')
 
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
@@ -77,6 +79,9 @@ const mockParseLabwareInfoByLiquidId = parseLabwareInfoByLiquidId as jest.Mocked
 >
 const mockLiquidsLabwareDetailsModal = LiquidsLabwareDetailsModal as jest.MockedFunction<
   typeof LiquidsLabwareDetailsModal
+>
+const mockUseNotifyRunQuery = useNotifyRunQuery as jest.MockedFunction<
+  typeof useNotifyRunQuery
 >
 
 const render = (props: React.ComponentProps<typeof SetupLiquidsList>) => {
@@ -107,6 +112,7 @@ describe('SetupLiquidsList', () => {
         partialComponentPropsMatcher({ labwareId: '123', liquidId: '0' })
       )
       .mockReturnValue(<div>Mock liquids labwaqre details modal</div>)
+    mockUseNotifyRunQuery.mockReturnValue({} as any)
   })
 
   it('renders the total volume of the liquid, sample display name, and description', () => {

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -42,6 +42,7 @@ import { SetupLiquids } from '../SetupLiquids'
 import { SetupModuleAndDeck } from '../SetupModuleAndDeck'
 import { EmptySetupStep } from '../EmptySetupStep'
 import { ProtocolRunSetup } from '../ProtocolRunSetup'
+import { useNotifyRunQuery } from '../../../../resources/runs/useNotifyRunQuery'
 
 jest.mock('@opentrons/api-client')
 jest.mock('../../hooks')
@@ -56,6 +57,7 @@ jest.mock('@opentrons/shared-data/js/helpers/getSimplestFlexDeckConfig')
 jest.mock('../../../../redux/config')
 jest.mock('../../../../resources/deck_configuration/utils')
 jest.mock('../../../../resources/deck_configuration/hooks')
+jest.mock('../../../../resources/runs/useNotifyRunQuery')
 
 const mockUseIsFlex = useIsFlex as jest.MockedFunction<typeof useIsFlex>
 const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jest.MockedFunction<
@@ -112,6 +114,9 @@ const mockUseDeckConfigurationCompatibility = useDeckConfigurationCompatibility 
 >
 const mockGetIsFixtureMismatch = getIsFixtureMismatch as jest.MockedFunction<
   typeof getIsFixtureMismatch
+>
+const mockUseNotifyRunQuery = useNotifyRunQuery as jest.MockedFunction<
+  typeof useNotifyRunQuery
 >
 
 const ROBOT_NAME = 'otie'
@@ -184,6 +189,7 @@ describe('ProtocolRunSetup', () => {
       .calledWith(ROBOT_NAME, RUN_ID)
       .mockReturnValue({ missingModuleIds: [], remainingAttachedModules: [] })
     when(mockGetIsFixtureMismatch).mockReturnValue(false)
+    mockUseNotifyRunQuery.mockReturnValue({} as any)
   })
   afterEach(() => {
     resetAllWhenMocks()

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibration.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/SetupPipetteCalibration.test.tsx
@@ -8,16 +8,22 @@ import { mockTipRackDefinition } from '../../../../redux/custom-labware/__fixtur
 import { useRunPipetteInfoByMount } from '../../hooks'
 import { SetupPipetteCalibrationItem } from '../SetupPipetteCalibrationItem'
 import { SetupInstrumentCalibration } from '../SetupInstrumentCalibration'
+import { useNotifyRunQuery } from '../../../../resources/runs/useNotifyRunQuery'
+
 import type { PipetteInfo } from '../../hooks'
 
 jest.mock('../../hooks')
 jest.mock('../SetupPipetteCalibrationItem')
+jest.mock('../../../../resources/runs/useNotifyRunQuery')
 
 const mockUseRunPipetteInfoByMount = useRunPipetteInfoByMount as jest.MockedFunction<
   typeof useRunPipetteInfoByMount
 >
 const mockSetupPipetteCalibrationItem = SetupPipetteCalibrationItem as jest.MockedFunction<
   typeof SetupPipetteCalibrationItem
+>
+const mockUseNotifyRunQuery = useNotifyRunQuery as jest.MockedFunction<
+  typeof useNotifyRunQuery
 >
 
 const ROBOT_NAME = 'otie'
@@ -56,6 +62,7 @@ describe('SetupPipetteCalibration', () => {
     when(mockSetupPipetteCalibrationItem).mockReturnValue(
       <div>Mock SetupPipetteCalibrationItem</div>
     )
+    mockUseNotifyRunQuery.mockReturnValue({} as any)
   })
   afterEach(() => {
     resetAllWhenMocks()

--- a/app/src/organisms/DropTipWizard/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizard/TipsAttachedModal.tsx
@@ -11,14 +11,16 @@ import { StyledText } from '../../atoms/text'
 import { Modal } from '../../molecules/Modal'
 import { DropTipWizard } from '.'
 
-import type { PipetteData } from '@opentrons/api-client'
+import type { HostConfig, PipetteData } from '@opentrons/api-client'
 import type { PipetteModelSpecs, RobotType } from '@opentrons/shared-data'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
+import { ApiHostProvider } from '@opentrons/react-api-client'
 
 interface TipsAttachedModalProps {
   mount: PipetteData['mount']
   instrumentModelSpecs: PipetteModelSpecs
   robotType: RobotType
+  host: HostConfig | null
   onCloseClick?: (arg0: any) => void
 }
 
@@ -26,19 +28,21 @@ export const handleTipsAttachedModal = (
   mount: TipsAttachedModalProps['mount'],
   instrumentModelSpecs: TipsAttachedModalProps['instrumentModelSpecs'],
   robotType: TipsAttachedModalProps['robotType'],
+  host: TipsAttachedModalProps['host'],
   onCloseClick: TipsAttachedModalProps['onCloseClick']
 ): Promise<unknown> => {
   return NiceModal.show(TipsAttachedModal, {
     mount,
     instrumentModelSpecs,
     robotType,
+    host,
     onCloseClick,
   })
 }
 
 const TipsAttachedModal = NiceModal.create(
   (props: TipsAttachedModalProps): JSX.Element => {
-    const { mount, onCloseClick, instrumentModelSpecs } = props
+    const { mount, onCloseClick, host, instrumentModelSpecs } = props
     const { t } = useTranslation(['drop_tip_wizard'])
     const modal = useModal()
     const [showWizard, setShowWizard] = React.useState(false)
@@ -55,7 +59,7 @@ const TipsAttachedModal = NiceModal.create(
     const displayMountText = is96Channel ? '96-Channel' : capitalize(mount)
 
     return (
-      <>
+      <ApiHostProvider {...host} hostname={host?.hostname ?? null}>
         <Modal header={tipsAttachedHeader}>
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
             <StyledText as="p">
@@ -104,7 +108,7 @@ const TipsAttachedModal = NiceModal.create(
             }}
           />
         ) : null}
-      </>
+      </ApiHostProvider>
     )
   }
 )

--- a/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
@@ -12,6 +12,7 @@ import { ROBOT_MODEL_OT3 } from '../../../redux/discovery'
 import { useNotifyCurrentMaintenanceRun } from '../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
 
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
+import type { HostConfig } from '@opentrons/api-client'
 
 jest.mock('../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun')
 
@@ -27,6 +28,7 @@ const mockOnClose = jest.fn()
 const mockUseNotifyCurrentMaintenanceRun = useNotifyCurrentMaintenanceRun as jest.MockedFunction<
   typeof useNotifyCurrentMaintenanceRun
 >
+const MOCK_HOST: HostConfig = { hostname: 'MOCK_HOST' }
 
 const render = (pipetteSpecs: PipetteModelSpecs) => {
   return renderWithProviders(
@@ -37,6 +39,7 @@ const render = (pipetteSpecs: PipetteModelSpecs) => {
             LEFT,
             pipetteSpecs,
             ROBOT_MODEL_OT3,
+            MOCK_HOST,
             mockOnClose
           )
         }

--- a/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizard/__tests__/TipsAttachedModal.test.tsx
@@ -9,12 +9,12 @@ import { handleTipsAttachedModal } from '../TipsAttachedModal'
 import { LEFT } from '@opentrons/shared-data'
 import { mockPipetteInfo } from '../../../redux/pipettes/__fixtures__'
 import { ROBOT_MODEL_OT3 } from '../../../redux/discovery'
-import { useNotifyCurrentMaintenanceRun } from '../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
+import { useNotifyService } from '../../../resources/useNotifyService'
 
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { HostConfig } from '@opentrons/api-client'
 
-jest.mock('../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun')
+jest.mock('../../../resources/useNotifyService')
 
 const MOCK_ACTUAL_PIPETTE = {
   ...mockPipetteInfo.pipetteSpecs,
@@ -25,8 +25,8 @@ const MOCK_ACTUAL_PIPETTE = {
 } as PipetteModelSpecs
 
 const mockOnClose = jest.fn()
-const mockUseNotifyCurrentMaintenanceRun = useNotifyCurrentMaintenanceRun as jest.MockedFunction<
-  typeof useNotifyCurrentMaintenanceRun
+const mockUseNotifyService = useNotifyService as jest.MockedFunction<
+  typeof useNotifyService
 >
 const MOCK_HOST: HostConfig = { hostname: 'MOCK_HOST' }
 
@@ -54,7 +54,7 @@ const render = (pipetteSpecs: PipetteModelSpecs) => {
 
 describe('TipsAttachedModal', () => {
   beforeEach(() => {
-    mockUseNotifyCurrentMaintenanceRun.mockReturnValue({
+    mockUseNotifyService.mockReturnValue({
       data: {
         data: {
           id: 'test',

--- a/app/src/pages/Devices/CalibrationDashboard/__tests__/CalibrationDashboard.test.tsx
+++ b/app/src/pages/Devices/CalibrationDashboard/__tests__/CalibrationDashboard.test.tsx
@@ -15,11 +15,13 @@ import { useDashboardCalibrateTipLength } from '../hooks/useDashboardCalibrateTi
 import { useDashboardCalibrateDeck } from '../hooks/useDashboardCalibrateDeck'
 import { expectedTaskList } from '../../../../organisms/Devices/hooks/__fixtures__/taskListFixtures'
 import { mockLeftProtoPipette } from '../../../../redux/pipettes/__fixtures__'
+import { useNotifyAllRunsQuery } from '../../../../resources/runs/useNotifyAllRunsQuery'
 
 jest.mock('../../../../organisms/Devices/hooks')
 jest.mock('../hooks/useDashboardCalibratePipOffset')
 jest.mock('../hooks/useDashboardCalibrateTipLength')
 jest.mock('../hooks/useDashboardCalibrateDeck')
+jest.mock('../../../../resources/runs/useNotifyAllRunsQuery')
 
 const mockUseCalibrationTaskList = useCalibrationTaskList as jest.MockedFunction<
   typeof useCalibrationTaskList
@@ -35,6 +37,9 @@ const mockUseDashboardCalibrateDeck = useDashboardCalibrateDeck as jest.MockedFu
 >
 const mockUseAttachedPipettes = useAttachedPipettes as jest.MockedFunction<
   typeof useAttachedPipettes
+>
+const mockUseNotifyAllRunsQuery = useNotifyAllRunsQuery as jest.MockedFunction<
+  typeof useNotifyAllRunsQuery
 >
 
 const render = (path = '/') => {
@@ -60,6 +65,7 @@ describe('CalibrationDashboard', () => {
       left: mockLeftProtoPipette,
       right: null,
     })
+    mockUseNotifyAllRunsQuery.mockReturnValue({} as any)
   })
 
   it('renders a robot calibration dashboard title', () => {

--- a/app/src/pages/InstrumentDetail/InstrumentDetailOverflowMenu.tsx
+++ b/app/src/pages/InstrumentDetail/InstrumentDetailOverflowMenu.tsx
@@ -15,6 +15,7 @@ import {
   FLEX_ROBOT_TYPE,
   getPipetteModelSpecs,
 } from '@opentrons/shared-data'
+import { ApiHostProvider } from '@opentrons/react-api-client'
 
 import { StyledText } from '../../atoms/text'
 import { MenuList } from '../../atoms/MenuList'
@@ -25,21 +26,27 @@ import { DropTipWizard } from '../../organisms/DropTipWizard'
 import { FLOWS } from '../../organisms/PipetteWizardFlows/constants'
 import { GRIPPER_FLOW_TYPES } from '../../organisms/GripperWizardFlows/constants'
 
-import type { PipetteData, GripperData } from '@opentrons/api-client'
+import type {
+  PipetteData,
+  GripperData,
+  HostConfig,
+} from '@opentrons/api-client'
 
 interface InstrumentDetailsOverflowMenuProps {
   instrument: PipetteData | GripperData
+  host: HostConfig | null
 }
 
 export const handleInstrumentDetailOverflowMenu = (
-  instrument: InstrumentDetailsOverflowMenuProps['instrument']
+  instrument: InstrumentDetailsOverflowMenuProps['instrument'],
+  host: InstrumentDetailsOverflowMenuProps['host']
 ): void => {
   NiceModal.show(InstrumentDetailsOverflowMenu, { instrument })
 }
 
 const InstrumentDetailsOverflowMenu = NiceModal.create(
   (props: InstrumentDetailsOverflowMenuProps): JSX.Element => {
-    const { instrument } = props
+    const { instrument, host } = props
     const { t } = useTranslation('robot_controls')
     const modal = useModal()
     const [showDropTipWizard, setShowDropTipWizard] = React.useState(false)
@@ -88,7 +95,7 @@ const InstrumentDetailsOverflowMenu = NiceModal.create(
     }
 
     return (
-      <>
+      <ApiHostProvider {...host} hostname={host?.hostname ?? null}>
         <MenuList onClick={modal.remove} isOnDevice={true}>
           {instrument.data.calibratedOffset?.last_modified != null ? (
             <MenuItem key="recalibrate" onClick={handleRecalibrate}>
@@ -147,7 +154,7 @@ const InstrumentDetailsOverflowMenu = NiceModal.create(
             closeFlow={modal.remove}
           />
         ) : null}
-      </>
+      </ApiHostProvider>
     )
   }
 )

--- a/app/src/pages/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
+++ b/app/src/pages/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
@@ -9,7 +9,11 @@ import { i18n } from '../../../i18n'
 import { handleInstrumentDetailOverflowMenu } from '../InstrumentDetailOverflowMenu'
 import { useNotifyCurrentMaintenanceRun } from '../../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
 
-import type { PipetteData, GripperData } from '@opentrons/api-client'
+import type {
+  PipetteData,
+  GripperData,
+  HostConfig,
+} from '@opentrons/api-client'
 
 jest.mock('@opentrons/shared-data', () => ({
   getAllPipetteNames: jest.fn(
@@ -98,11 +102,15 @@ const MOCK_GRIPPER = {
   instrumentName: 'p1000_single_flex',
 } as GripperData
 
+const MOCK_HOST: HostConfig = { hostname: 'TEST_HOST' }
+
 const render = (pipetteOrGripper: PipetteData | GripperData) => {
   return renderWithProviders(
     <NiceModal.Provider>
       <button
-        onClick={() => handleInstrumentDetailOverflowMenu(pipetteOrGripper)}
+        onClick={() =>
+          handleInstrumentDetailOverflowMenu(pipetteOrGripper, MOCK_HOST)
+        }
         data-testid="testButton"
       />
     </NiceModal.Provider>,

--- a/app/src/pages/InstrumentDetail/index.tsx
+++ b/app/src/pages/InstrumentDetail/index.tsx
@@ -8,7 +8,7 @@ import {
   GripperModel,
   PipetteModel,
 } from '@opentrons/shared-data'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import { useInstrumentsQuery, useHost } from '@opentrons/react-api-client'
 import {
   Icon,
   DIRECTION_COLUMN,
@@ -28,6 +28,7 @@ import { ODD_FOCUS_VISIBLE } from '../../atoms/buttons/constants'
 import type { GripperData, PipetteData } from '@opentrons/api-client'
 
 export const InstrumentDetail = (): JSX.Element => {
+  const host = useHost()
   const { mount } = useParams<{ mount: PipetteData['mount'] }>()
   const { data: attachedInstruments } = useInstrumentsQuery()
   const instrument =
@@ -57,7 +58,9 @@ export const InstrumentDetail = (): JSX.Element => {
             <Flex marginTop={`-${SPACING.spacing16}`}>
               <IconButton
                 aria-label="overflow menu button"
-                onClick={() => handleInstrumentDetailOverflowMenu(instrument)}
+                onClick={() =>
+                  handleInstrumentDetailOverflowMenu(instrument, host)
+                }
               >
                 <Icon
                   name="overflow-btn-touchscreen"

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -142,6 +142,7 @@ export function RunSummary(): JSX.Element {
         mount,
         specs,
         FLEX_ROBOT_TYPE,
+        host,
         setPipettesWithTip
       ).catch(e => console.log(`Error launching Tip Attachment Modal: ${e}`))
     } else {
@@ -157,6 +158,7 @@ export function RunSummary(): JSX.Element {
         mount,
         specs,
         FLEX_ROBOT_TYPE,
+        host,
         setPipettesWithTip
       ).catch(e => console.log(`Error launching Tip Attachment Modal: ${e}`))
     } else {

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -10,6 +10,7 @@ import {
   notifySubscribeAction,
   notifyUnsubscribeAction,
 } from '../../redux/shell'
+import { useIsFlex } from '../../organisms/Devices/hooks/useIsFlex'
 
 import type { HostConfig } from '@opentrons/api-client'
 import type { QueryOptionsWithPolling } from '../useNotifyService'
@@ -20,6 +21,7 @@ jest.mock('../../redux/analytics')
 jest.mock('../../redux/shell/remote', () => ({
   appShellListener: jest.fn(),
 }))
+jest.mock('../../organisms/Devices/hooks/useIsFlex')
 
 const MOCK_HOST_CONFIG: HostConfig = { hostname: 'MOCK_HOST' }
 const MOCK_TOPIC = '/test/topic' as any
@@ -35,6 +37,7 @@ const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
 const mockAppShellListener = appShellListener as jest.MockedFunction<
   typeof appShellListener
 >
+const mockUseIsFlex = useIsFlex as jest.MockedFunction<typeof useIsFlex>
 
 describe('useNotifyService', () => {
   let mockDispatch: jest.Mock
@@ -48,6 +51,7 @@ describe('useNotifyService', () => {
     mockUseTrackEvent.mockReturnValue(mockTrackEvent)
     mockUseDispatch.mockReturnValue(mockDispatch)
     mockUseHost.mockReturnValue(MOCK_HOST_CONFIG)
+    mockUseIsFlex.mockReturnValue(true)
   })
 
   afterEach(() => {

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -24,6 +24,7 @@ export function useNotifyAllRunsQuery(
     topic: 'robot-server/runs',
     refetchUsingHTTP: () => setRefetchUsingHTTP(true),
     options,
+    hostOverride,
   })
 
   const isNotifyEnabled =

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -12,6 +12,7 @@ import {
 } from '../redux/analytics'
 
 import type { UseQueryOptions } from 'react-query'
+import type { HostConfig } from '@opentrons/api-client'
 import type { NotifyTopic, NotifyResponseData } from '../redux/shell/types'
 
 export interface QueryOptionsWithPolling<TData, TError = Error>
@@ -23,19 +24,22 @@ interface UseNotifyServiceProps<TData, TError = Error> {
   topic: NotifyTopic
   refetchUsingHTTP: () => void
   options: QueryOptionsWithPolling<TData, TError>
+  hostOverride?: HostConfig | null
 }
 
 export function useNotifyService<TData, TError = Error>({
   topic,
   refetchUsingHTTP,
   options,
+  hostOverride,
 }: UseNotifyServiceProps<TData, TError>): { isNotifyError: boolean } {
   const dispatch = useDispatch()
-  const host = useHost()
-  const isNotifyError = React.useRef(false)
-  const doTrackEvent = useTrackEvent()
-  const { enabled, staleTime, forceHttpPolling } = options
+  const hostFromProvider = useHost()
+  const host = hostOverride ?? hostFromProvider
   const hostname = host?.hostname ?? null
+  const doTrackEvent = useTrackEvent()
+  const isNotifyError = React.useRef(false)
+  const { enabled, staleTime, forceHttpPolling } = options
 
   React.useEffect(() => {
     // Always fetch on initial mount.

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -10,6 +10,7 @@ import {
   useTrackEvent,
   ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
 } from '../redux/analytics'
+import { useIsFlex } from '../organisms/Devices/hooks/useIsFlex'
 
 import type { UseQueryOptions } from 'react-query'
 import type { HostConfig } from '@opentrons/api-client'
@@ -38,6 +39,7 @@ export function useNotifyService<TData, TError = Error>({
   const host = hostOverride ?? hostFromProvider
   const hostname = host?.hostname ?? null
   const doTrackEvent = useTrackEvent()
+  const isFlex = useIsFlex(host?.robotName ?? '')
   const isNotifyError = React.useRef(false)
   const { enabled, staleTime, forceHttpPolling } = options
 
@@ -74,7 +76,8 @@ export function useNotifyService<TData, TError = Error>({
     if (!isNotifyError.current) {
       if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
         isNotifyError.current = true
-        if (data === 'ECONNREFUSED') {
+        // TODO(jh 2023-02-23): remove the robot type check once OT-2s support MQTT.
+        if (data === 'ECONNREFUSED' && isFlex) {
           doTrackEvent({
             name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
             properties: {},


### PR DESCRIPTION
Closes [RAUT-1018](https://opentrons.atlassian.net/browse/RAUT-1018)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR contains a few fixes for a few spots in the app that did not properly pass a host object to the notification utility, therefore causing the app to use polling instead of MQTT. 

Also, this updates MQTT analytics reporting - it's necessary to only report Flexes, because currently all OT-2s will report that MQTT is blocked (there's no MQTT on OT-2s). Filtering out false positives for the 7.2 release would be nice!

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verified that maintenance runs flows are still accessible on the ODD under the InstrumentDetails page (and utilizing MQTT). 
- Verified slideouts use MQTT as well when possible. 
- Verified via Mixpanel that OT-2s are no longer reporting. 
- Verified that an annoying shell message no longer displays. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-1018]: https://opentrons.atlassian.net/browse/RAUT-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ