### PR TITLE
chore(release): Add release notes for RSS-468

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -23,6 +23,7 @@ If you don't care about preserving your labware offsets and run history, you can
 ### Bug Fixes
 
 - The OT-2 now consistently applies tip length calibration. There used to be a height discrepancy between Labware Position Check and protocol runs. If you previously compensated for the inconsistent pipette height with labware offsets, re-run Labware Position Check to avoid pipette crashes.
+- The OT-2 now accurately calculates the position of the Thermocycler. If you previously compensated for the incorrect position with labware offsets, re-run Labware Position Check to avoid pipette crashes.
 - The Flex Gripper will no longer pick up large labware that could collide with tips held by an adjoining pipette.
 - Flex now properly configures itself when connected by Ethernet directly to a computer.
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -22,7 +22,7 @@ If you don't care about preserving your labware offsets and run history, you can
 
 ### Bug Fixes
 
-- OT-2 will now consistently apply Tip Length Calibration across Labware Position Check and actual protocol runs. This fixes a cause of systematic errors in pipette height. To make sure your pipette height will be good after this fix, run Labware Position Check. You may have to undo labware offsets that were previously trying to compensate for the error.
+- The OT-2 now consistently applies tip length calibration. There used to be a height discrepancy between Labware Position Check and protocol runs. If you previously compensated for the inconsistent pipette height with labware offsets, re-run Labware Position Check to avoid pipette crashes.
 - The Flex Gripper will no longer pick up large labware that could collide with tips held by an adjoining pipette.
 - Flex now properly configures itself when connected by Ethernet directly to a computer.
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -22,6 +22,7 @@ If you don't care about preserving your labware offsets and run history, you can
 
 ### Bug Fixes
 
+- OT-2 will now consistently apply Tip Length Calibration across Labware Position Check and actual protocol runs. This fixes a cause of systematic errors in pipette height. To make sure your pipette height will be good after this fix, run Labware Position Check. You may have to undo labware offsets that were previously trying to compensate for the error.
 - The Flex Gripper will no longer pick up large labware that could collide with tips held by an adjoining pipette.
 - Flex now properly configures itself when connected by Ethernet directly to a computer.
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -23,6 +23,7 @@ The Linux version of the Opentrons App now requires Ubuntu 20.04 or newer.
 
 ### Bug Fixes
 
+- The OT-2 now consistently applies tip length calibration. There used to be a height discrepancy between Labware Position Check and protocol runs. If you previously compensated for the inconsistent pipette height with labware offsets, re-run Labware Position Check to avoid pipette crashes.
 - The OT-2 now accurately calculates the position of the Thermocycler. If you previously compensated for the incorrect position with labware offsets, re-run Labware Position Check to avoid pipette crashes.
 
 ---


### PR DESCRIPTION
# Overview

Add a release note for RSS-468 / PR #14512.

# Review requests

* Can this be made less wordy?
* Do we say "OT-2" or "The OT-2" or "OT-2 robots" these days?
* Is the Capitalization of "Labware Position Check" and "Tip Length Calibration" Appropriate?

# Risk assessment

No risk.
