### PR TITLE
refactor(app): Clean up notify hooks

### DIFF
--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -276,16 +276,19 @@ function handleDecrementSubscriptionCount(
   hostname: string,
   topic: NotifyTopic
 ): void {
-  const { client, subscriptions } = connectionStore[hostname]
-  if (topic in subscriptions) {
-    subscriptions[topic] -= 1
-    if (subscriptions[topic] <= 0) {
-      delete subscriptions[topic]
+  const host = connectionStore[hostname]
+  if (host) {
+    const { client, subscriptions } = host
+    if (topic in subscriptions) {
+      subscriptions[topic] -= 1
+      if (subscriptions[topic] <= 0) {
+        delete subscriptions[topic]
+      }
     }
-  }
 
-  if (Object.keys(subscriptions).length <= 0) {
-    client?.end()
+    if (Object.keys(subscriptions).length <= 0) {
+      client?.end()
+    }
   }
 }
 

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -272,16 +272,19 @@ function handleDecrementSubscriptionCount(
   hostname: string,
   topic: NotifyTopic
 ): void {
-  const { client, subscriptions } = connectionStore[hostname]
-  if (topic in subscriptions) {
-    subscriptions[topic] -= 1
-    if (subscriptions[topic] <= 0) {
-      delete subscriptions[topic]
+  const host = connectionStore[hostname]
+  if (host) {
+    const { client, subscriptions } = host
+    if (topic in subscriptions) {
+      subscriptions[topic] -= 1
+      if (subscriptions[topic] <= 0) {
+        delete subscriptions[topic]
+      }
     }
-  }
 
-  if (Object.keys(subscriptions).length <= 0) {
-    client?.end()
+    if (Object.keys(subscriptions).length <= 0) {
+      client?.end()
+    }
   }
 }
 

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -130,25 +130,6 @@ describe('useNotifyService', () => {
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should log an error if hostname is null', () => {
-    mockUseHost.mockReturnValue({ hostname: null } as any)
-    const errorSpy = jest.spyOn(console, 'error')
-    errorSpy.mockImplementation(() => {})
-
-    renderHook(() =>
-      useNotifyService({
-        topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
-        options: MOCK_OPTIONS,
-      } as any)
-    )
-    expect(errorSpy).toHaveBeenCalledWith(
-      'NotifyService expected hostname, received null for topic:',
-      MOCK_TOPIC
-    )
-    errorSpy.mockRestore()
-  })
-
   it('should set HTTP refetch to always if there is an error', () => {
     mockUseHost.mockReturnValue({ hostname: null } as any)
 

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -59,15 +59,15 @@ describe('useNotifyService', () => {
     jest.clearAllMocks()
   })
 
-  it('should trigger an HTTP refetch and subscribe action on initial mount', () => {
+  it('should trigger an HTTP refetch and subscribe action on a successful initial mount', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
-    expect(mockHTTPRefetch).toHaveBeenCalled()
+    expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
     expect(mockDispatch).toHaveBeenCalledWith(
       notifySubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
     )
@@ -81,7 +81,7 @@ describe('useNotifyService', () => {
     const { unmount } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -91,22 +91,11 @@ describe('useNotifyService', () => {
     )
   })
 
-  it('should return no notify error if there was a successful topic subscription', () => {
-    const { result } = renderHook(() =>
-      useNotifyService({
-        topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
-        options: MOCK_OPTIONS,
-      } as any)
-    )
-    expect(result.current.isNotifyError).toBe(false)
-  })
-
   it('should not subscribe to notifications if forceHttpPolling is true', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: { ...MOCK_OPTIONS, forceHttpPolling: true },
       } as any)
     )
@@ -119,7 +108,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: { ...MOCK_OPTIONS, enabled: false },
       } as any)
     )
@@ -132,7 +121,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: { ...MOCK_OPTIONS, staleTime: Infinity },
       } as any)
     )
@@ -149,7 +138,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -160,49 +149,47 @@ describe('useNotifyService', () => {
     errorSpy.mockRestore()
   })
 
-  it('should return a notify error and fire an analytics reporting event if the connection was refused', () => {
+  it('should set HTTP refetch to always if there is an error', () => {
+    mockUseHost.mockReturnValue({ hostname: null } as any)
+
+    renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        setRefetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    expect(mockHTTPRefetch).toHaveBeenCalledWith('always')
+  })
+
+  it('should return set HTTP refetch to always and fire an analytics reporting event if the connection was refused', () => {
     mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
       mockCb('ECONNREFUSED')
     })
-    const { result, rerender } = renderHook(() =>
+    const { rerender } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
     expect(mockTrackEvent).toHaveBeenCalled()
     rerender()
-    expect(result.current.isNotifyError).toBe(true)
+    expect(mockHTTPRefetch).toHaveBeenCalledWith('always')
   })
 
-  it('should return a notify error if the connection failed', () => {
-    mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
-      mockCb('ECONNFAILED')
-    })
-    const { result, rerender } = renderHook(() =>
-      useNotifyService({
-        topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
-        options: MOCK_OPTIONS,
-      } as any)
-    )
-    rerender()
-    expect(result.current.isNotifyError).toBe(true)
-  })
-
-  it('should trigger an HTTP refetch if the refetch flag was returned', () => {
+  it('should trigger a single HTTP refetch if the refetch flag was returned', () => {
     mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
       mockCb({ refetchUsingHTTP: true })
     })
     const { rerender } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        refetchUsingHTTP: mockHTTPRefetch,
+        setRefetchUsingHTTP: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
     rerender()
-    expect(mockHTTPRefetch).toHaveBeenCalled()
+    expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
   })
 })

--- a/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
@@ -1,41 +1,37 @@
 import * as React from 'react'
 
-import { useHost, useCurrentMaintenanceRun } from '@opentrons/react-api-client'
+import { useCurrentMaintenanceRun } from '@opentrons/react-api-client'
 
 import { useNotifyService } from '../useNotifyService'
 
 import type { UseQueryResult } from 'react-query'
 import type { MaintenanceRun } from '@opentrons/api-client'
-import type { QueryOptionsWithPolling } from '../useNotifyService'
+import type {
+  QueryOptionsWithPolling,
+  HTTPRefetchFrequency,
+} from '../useNotifyService'
 
 export function useNotifyCurrentMaintenanceRun(
-  options?: QueryOptionsWithPolling<MaintenanceRun, Error>
+  options: QueryOptionsWithPolling<MaintenanceRun, Error> = {}
 ): UseQueryResult<MaintenanceRun> | UseQueryResult<MaintenanceRun, Error> {
-  const host = useHost()
-  const [refetchUsingHTTP, setRefetchUsingHTTP] = React.useState(false)
+  const [
+    refetchUsingHTTP,
+    setRefetchUsingHTTP,
+  ] = React.useState<HTTPRefetchFrequency>(null)
 
-  const { isNotifyError } = useNotifyService<MaintenanceRun, Error>({
+  useNotifyService<MaintenanceRun, Error>({
     topic: 'robot-server/maintenance_runs/current_run',
-    refetchUsingHTTP: () => setRefetchUsingHTTP(true),
-    options: {
-      ...options,
-      enabled: host !== null && options?.enabled !== false,
-    },
+    setRefetchUsingHTTP,
+    options,
   })
-
-  const isNotifyEnabled =
-    !isNotifyError &&
-    !options?.forceHttpPolling &&
-    options?.staleTime !== Infinity
-
-  if (!isNotifyEnabled && !refetchUsingHTTP) setRefetchUsingHTTP(true)
-  const isHTTPEnabled =
-    host !== null && options?.enabled !== false && refetchUsingHTTP
 
   const httpQueryResult = useCurrentMaintenanceRun({
     ...options,
-    enabled: isHTTPEnabled,
-    onSettled: isNotifyEnabled ? () => setRefetchUsingHTTP(false) : undefined,
+    enabled: options?.enabled !== false && refetchUsingHTTP != null,
+    onSettled:
+      refetchUsingHTTP === 'once'
+        ? () => setRefetchUsingHTTP(null)
+        : () => null,
   })
 
   return httpQueryResult

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -8,39 +8,37 @@ import type { UseQueryResult } from 'react-query'
 import type { AxiosError } from 'axios'
 import type { HostConfig, GetRunsParams, Runs } from '@opentrons/api-client'
 import type { UseAllRunsQueryOptions } from '@opentrons/react-api-client/src/runs/useAllRunsQuery'
-import type { QueryOptionsWithPolling } from '../useNotifyService'
+import type {
+  QueryOptionsWithPolling,
+  HTTPRefetchFrequency,
+} from '../useNotifyService'
 
 export function useNotifyAllRunsQuery(
   params: GetRunsParams = {},
   options: QueryOptionsWithPolling<UseAllRunsQueryOptions, AxiosError> = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Runs, AxiosError> {
-  const [refetchUsingHTTP, setRefetchUsingHTTP] = React.useState(false)
+  const [
+    refetchUsingHTTP,
+    setRefetchUsingHTTP,
+  ] = React.useState<HTTPRefetchFrequency>(null)
 
-  const { isNotifyError } = useNotifyService<
-    UseAllRunsQueryOptions,
-    AxiosError
-  >({
+  useNotifyService<UseAllRunsQueryOptions, AxiosError>({
     topic: 'robot-server/runs',
-    refetchUsingHTTP: () => setRefetchUsingHTTP(true),
+    setRefetchUsingHTTP,
     options,
     hostOverride,
   })
-
-  const isNotifyEnabled =
-    !isNotifyError &&
-    !options?.forceHttpPolling &&
-    options?.staleTime !== Infinity
-
-  if (!isNotifyEnabled && !refetchUsingHTTP) setRefetchUsingHTTP(true)
-  const isHTTPEnabled = options?.enabled !== false && refetchUsingHTTP
 
   const httpResponse = useAllRunsQuery(
     params,
     {
       ...(options as UseAllRunsQueryOptions),
-      enabled: isHTTPEnabled,
-      onSettled: isNotifyEnabled ? () => setRefetchUsingHTTP(false) : undefined,
+      enabled: options?.enabled !== false && refetchUsingHTTP != null,
+      onSettled:
+        refetchUsingHTTP === 'once'
+          ? () => setRefetchUsingHTTP(null)
+          : () => null,
     },
     hostOverride
   )

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -1,43 +1,39 @@
 import * as React from 'react'
 
-import { useRunQuery, useHost } from '@opentrons/react-api-client'
+import { useRunQuery } from '@opentrons/react-api-client'
 
 import { useNotifyService } from '../useNotifyService'
 
 import type { UseQueryResult } from 'react-query'
 import type { Run } from '@opentrons/api-client'
-import type { QueryOptionsWithPolling } from '../useNotifyService'
+import type {
+  QueryOptionsWithPolling,
+  HTTPRefetchFrequency,
+} from '../useNotifyService'
 import type { NotifyTopic } from '../../redux/shell/types'
 
 export function useNotifyRunQuery<TError = Error>(
   runId: string | null,
   options: QueryOptionsWithPolling<Run, TError> = {}
 ): UseQueryResult<Run, TError> {
-  const host = useHost()
-  const [refetchUsingHTTP, setRefetchUsingHTTP] = React.useState(false)
+  const [
+    refetchUsingHTTP,
+    setRefetchUsingHTTP,
+  ] = React.useState<HTTPRefetchFrequency>(null)
 
-  const { isNotifyError } = useNotifyService({
+  useNotifyService({
     topic: `robot-server/runs/${runId}` as NotifyTopic,
-    refetchUsingHTTP: () => setRefetchUsingHTTP(true),
+    setRefetchUsingHTTP,
     options: { ...options, enabled: options.enabled && runId != null },
   })
 
-  const isNotifyEnabled =
-    !isNotifyError &&
-    !options?.forceHttpPolling &&
-    options?.staleTime !== Infinity
-
-  if (!isNotifyEnabled && !refetchUsingHTTP) setRefetchUsingHTTP(true)
-  const isHTTPEnabled =
-    options?.enabled !== false &&
-    refetchUsingHTTP &&
-    host !== null &&
-    runId != null
-
   const httpResponse = useRunQuery(runId, {
     ...options,
-    enabled: isHTTPEnabled,
-    onSettled: isNotifyEnabled ? () => setRefetchUsingHTTP(false) : undefined,
+    enabled: options?.enabled !== false && refetchUsingHTTP != null,
+    onSettled:
+      refetchUsingHTTP === 'once'
+        ? () => setRefetchUsingHTTP(null)
+        : () => null,
   })
 
   return httpResponse

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -16,6 +16,8 @@ import type { UseQueryOptions } from 'react-query'
 import type { HostConfig } from '@opentrons/api-client'
 import type { NotifyTopic, NotifyResponseData } from '../redux/shell/types'
 
+export type HTTPRefetchFrequency = 'once' | 'always' | null
+
 export interface QueryOptionsWithPolling<TData, TError = Error>
   extends UseQueryOptions<TData, TError> {
   forceHttpPolling?: boolean
@@ -23,71 +25,60 @@ export interface QueryOptionsWithPolling<TData, TError = Error>
 
 interface UseNotifyServiceProps<TData, TError = Error> {
   topic: NotifyTopic
-  refetchUsingHTTP: () => void
+  setRefetchUsingHTTP: (refetch: HTTPRefetchFrequency) => void
   options: QueryOptionsWithPolling<TData, TError>
   hostOverride?: HostConfig | null
 }
 
 export function useNotifyService<TData, TError = Error>({
   topic,
-  refetchUsingHTTP,
+  setRefetchUsingHTTP,
   options,
   hostOverride,
-}: UseNotifyServiceProps<TData, TError>): { isNotifyError: boolean } {
+}: UseNotifyServiceProps<TData, TError>): void {
   const dispatch = useDispatch()
   const hostFromProvider = useHost()
   const host = hostOverride ?? hostFromProvider
   const hostname = host?.hostname ?? null
   const doTrackEvent = useTrackEvent()
   const isFlex = useIsFlex(host?.robotName ?? '')
-  const isNotifyError = React.useRef(false)
+  const hasUsedNotifyService = React.useRef(false)
   const { enabled, staleTime, forceHttpPolling } = options
 
+  const shouldUseNotifications =
+    !forceHttpPolling &&
+    enabled !== false &&
+    hostname != null &&
+    staleTime !== Infinity
+
   React.useEffect(() => {
-    // Always fetch on initial mount.
-    refetchUsingHTTP()
-    if (
-      !forceHttpPolling &&
-      enabled !== false &&
-      hostname != null &&
-      staleTime !== Infinity
-    ) {
+    if (shouldUseNotifications) {
+      // Always fetch on initial mount.
+      setRefetchUsingHTTP('once')
       appShellListener(hostname, topic, onDataEvent)
       dispatch(notifySubscribeAction(hostname, topic))
+      hasUsedNotifyService.current = true
+    } else setRefetchUsingHTTP('always')
 
-      return () => {
-        if (hostname != null) {
-          dispatch(notifyUnsubscribeAction(hostname, topic))
-        }
-      }
-    } else {
-      if (hostname == null) {
-        console.error(
-          'NotifyService expected hostname, received null for topic:',
-          topic
-        )
+    return () => {
+      if (hasUsedNotifyService.current && hostname != null) {
+        dispatch(notifyUnsubscribeAction(hostname, topic))
       }
     }
-  }, [topic, host])
-
-  return { isNotifyError: isNotifyError.current }
+  }, [topic, host, shouldUseNotifications])
 
   function onDataEvent(data: NotifyResponseData): void {
-    if (!isNotifyError.current) {
-      if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
-        isNotifyError.current = true
-        // TODO(jh 2023-02-23): remove the robot type check once OT-2s support MQTT.
-        if (data === 'ECONNREFUSED' && isFlex) {
-          doTrackEvent({
-            name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
-            properties: {},
-          })
-        }
-      } else if ('refetchUsingHTTP' in data) {
-        refetchUsingHTTP()
-      } else {
-        console.log('Unexpected data received from notify service.')
+    if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
+      setRefetchUsingHTTP('always')
+      // TODO(jh 2023-02-23): remove the robot type check once OT-2s support MQTT.
+      if (data === 'ECONNREFUSED' && isFlex) {
+        doTrackEvent({
+          name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
+          properties: {},
+        })
       }
+    } else if ('refetchUsingHTTP' in data) {
+      setRefetchUsingHTTP('once')
     }
   }
 }


### PR DESCRIPTION
Partially closes [RAUT-990](https://opentrons.atlassian.net/browse/RAUT-990)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR serves to clean a lot of the cruft created during the development of the notification hooks. Between pivoting architectural strategies plus building things out, there was quite a bit created. 

Nothing is really new here - the only "new" thing is the addition of `shouldUseNotifications` to the useEffect dependency array in `useNotifyService`. For example, it's possible for the React Query `enable` option to change after mount, and we have to account for that. This wasn't causing any serious issue, but it was causing unnecessary polling to occur in the pipette recalibration flows. 

I also do a undefined check in the app-shell/app-shell-odd to prevent any annoying uncaught error message. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- On a physical robot, start a reattachment flow. Observe in the Network tab that the `current_run` network requests don't happen on a 3 second interval anymore. 
- I've already done it, but feel free to smoke test a protocol run (checking pausing/resuming updating the app/ODD appropriately, the current step displays correctly) and a maintenance run (the ODD takeover modal should appear as soon as the maintenance run begins and should disappear as soon as the desktop app maintenance run modal closes).  
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RAUT-990]: https://opentrons.atlassian.net/browse/RAUT-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ