### PR TITLE
RDEVOPS-62 Node 18 needs --openssl-legacy-provider on yarn webpack for shared data

### DIFF
--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -28,7 +28,7 @@ clean: clean-py
 .PHONY: lib-js
 lib-js: export NODE_ENV := production
 lib-js:
-	yarn webpack
+	NODE_OPTIONS=--openssl-legacy-provider yarn webpack
 
 
 


### PR DESCRIPTION
# Overview
[RDEVOPS-62](https://opentrons.atlassian.net/browse/RDEVOPS-62)
This is a temporary fix for the 7.2.0 release so we may publish shared-data.  The real fix is in the work being done to move to Vite. 

## Test Plan

Works locally

```shell
make -C shared-data lib-js
make: Entering directory '/root/github/opentrons/shared-data'
NODE_OPTIONS=--openssl-legacy-provider yarn webpack
yarn run v1.22.10
$ /root/github/opentrons/node_modules/.bin/webpack
Hash: 4c23879d2c6e65c2d53a
Version: webpack 4.46.0
Time: 3645ms
Built at: 02/29/2024 6:57:56 AM
                               Asset      Size  Chunks                          Chunk Names
            opentrons-shared-data.js   653 KiB       0  [emitted]        [big]  index
opentrons-shared-data.js.LICENSE.txt  95 bytes          [emitted]
        opentrons-shared-data.js.map   713 KiB       0  [emitted] [dev]         index
Entrypoint index [big] = opentrons-shared-data.js opentrons-shared-data.js.map
 [12] ./errors/definitions/1/errors.json 5.72 KiB {0} [built]
 [21] ./labware/schemas/2.json 12.3 KiB {0} [built]
 [22] ./deck/definitions/4/ot2_standard.json 10.1 KiB {0} [built]
 [39] ./pipette/definitions/1/pipetteNameSpecs.json 16 KiB {0} [built]
 [40] ./gripper/definitions/1/gripperV1.1.json 689 bytes {0} [built]
 [75] ./deck/definitions/4/ot3_standard.json 16 KiB {0} [built]
 [85] ./pipette/definitions/1/pipetteModelSpecs.json 262 KiB {0} [built]
 [86] ./module/definitions/3/magneticModuleV1.json 13.4 KiB {0} [built]
 [87] ./module/definitions/3/magneticModuleV2.json 14.4 KiB {0} [built]
 [88] ./module/definitions/3/temperatureModuleV1.json 4.84 KiB {0} [built]
 [89] ./module/definitions/3/temperatureModuleV2.json 7.36 KiB {0} [built]
 [90] ./module/definitions/3/thermocyclerModuleV1.json 54.3 KiB {0} [built]
 [91] ./module/definitions/3/thermocyclerModuleV2.json 150 KiB {0} [built]
 [92] ./module/definitions/3/heaterShakerModuleV1.json 16.1 KiB {0} [built]
[230] ./js/index.ts + 40 modules 98 KiB {0} [built]
      | ./js/index.ts 389 bytes [built]
      | ./js/constants.ts 11 KiB [built]
      | ./js/getLabware.ts 6.15 KiB [built]
      | ./js/fixtures.ts 4.1 KiB [built]
      | ./js/helpers/index.ts 12.5 KiB [built]
      | ./js/pipettes.ts 5.2 KiB [built]
      | ./js/types.ts 21 bytes [built]
      | ./js/labwareTools/index.ts 12.8 KiB [built]
      | ./js/modules.ts 2.47 KiB [built]
      | ./js/gripper.ts 810 bytes [built]
      | ./protocol/index.ts 55 bytes [built]
      | ./deck/index.ts 33 bytes [built]
      | ./js/titleCase.ts 913 bytes [built]
      | ./js/errors.ts 302 bytes [built]
      | ./js/helpers/get96Channel384WellPlateWells.ts 1.29 KiB [built]
      |     + 26 hidden modules
    + 216 hidden modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets:
  opentrons-shared-data.js (653 KiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  index (653 KiB)
      opentrons-shared-data.js


WARNING in webpack performance recommendations:
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
Done in 4.23s.
make: Leaving directory '/root/github/opentrons/shared-data'
```

## Changelog

- add `--openssl-legacy-provider` so that yarn webpack builds shared-data

# Risk assessment

Would not want in permanently, Vite work in edge will solve.

[RDEVOPS-62]: https://opentrons.atlassian.net/browse/RDEVOPS-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ