### PR TITLE
fix(app): direct Protocol Library link to new URL

### DIFF
--- a/app/src/organisms/ProtocolsLanding/EmptyStateLinks.tsx
+++ b/app/src/organisms/ProtocolsLanding/EmptyStateLinks.tsx
@@ -14,7 +14,7 @@ import {
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 
-const PROTOCOL_LIBRARY_URL = 'https://protocols.opentrons.com'
+const PROTOCOL_LIBRARY_URL = 'https://library.opentrons.com'
 const PROTOCOL_DESIGNER_URL = 'https://designer.opentrons.com'
 const API_DOCS_URL = 'https://docs.opentrons.com/v2/'
 


### PR DESCRIPTION
closes [RQA-2414](https://opentrons.atlassian.net/browse/RQA-2414)

# Overview

In protocols page, there is a help link to open the Protocol Library. Here, I update the link to direct to PL reborn's URL at library.opentrons.com

# Test Plan

- open Desktop App
- scroll to bottom of protocols screen
- click 'Open Protocol Library' and verify that link directs to [library.opentrons.com](library.opentrons.com)

# Risk assessment

low

[RQA-2414]: https://opentrons.atlassian.net/browse/RQA-2414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ