### PR TITLE
fix(shared-data): Fix whitespace in UnmatchedTipPresenceStates message

### DIFF
--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -558,11 +558,9 @@ class UnmatchedTipPresenceStates(RoboticsControlError):
         """Build an UnmatchedTipPresenceStatesError."""
         format_tip_state = {0: "not detected", 1: "detected"}
         msg = (
-            "Received two differing tip presence statuses:"
-            "\nRear Sensor tips"
-            + format_tip_state[states[0]]
-            + "\nFront Sensor tips"
-            + format_tip_state[states[1]]
+            f"Received two differing tip presence statuses."
+            f" Rear Sensor tips: {format_tip_state[states[0]]}."
+            f" Front Sensor tips: {format_tip_state[states[1]]}."
         )
         if detail:
             msg += str(detail)


### PR DESCRIPTION
# Overview

Improves the formatting of this error message reported by @ramifarawi and @ecormany.

![IMG_8953](https://github.com/Opentrons/opentrons/assets/3236864/5f28af05-9b04-4dab-9491-0e69c4b59f7f)

# Changelog

* Insert the missing space in `tipsdetected` and `tipsnot detected`.
* Refactor punctuation so the message doesn't depend on its `\n`s being rendered as line breaks to be readable. The app is rendering them as spaces, as shown in the picture. Arguably, that's the app's fault, but it doesn't seem like there's any harm in working around it here.

# Test Plan

Not tested. I think this change is simple enough.

# Review requests

None in particular.

# Risk assessment

Low.
