### PR TITLE
fix(api): Do not pass loop arg to subproc

### DIFF
--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -34,7 +34,6 @@ async def update_firmware(
         kwargs: Dict[str, Any] = {
             "stdout": asyncio.subprocess.PIPE,
             "stderr": asyncio.subprocess.PIPE,
-            "loop": loop,
         }
         successful, res = await module.bootloader()(
             flash_port_or_dfu_serial, str(firmware_file), kwargs

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -240,7 +240,6 @@ async def test_module_update_integration(
     bootloader_kwargs = {
         "stdout": asyncio.subprocess.PIPE,
         "stderr": asyncio.subprocess.PIPE,
-        "loop": loop,
     }
 
     upload_via_avrdude_mock = mock.Mock(


### PR DESCRIPTION
asyncio subprocess used to need loop; now it doesn't. For a minimum-affected fix, just don't pass loop to the subprocess invocations while keeping it in the top level environment.

Closes RQA-2417
