### PR TITLE
fix(app): fix desktop app attach flow for the 96ch

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
+import NiceModal, { useModal } from '@ebay/nice-modal-react'
+
 import { useConditionalConfirm } from '@opentrons/components'
 import {
   LEFT,
@@ -12,12 +14,13 @@ import {
 import {
   useHost,
   useDeleteMaintenanceRunMutation,
+  ApiHostProvider,
 } from '@opentrons/react-api-client'
+
 import {
   useCreateTargetedMaintenanceRunMutation,
   useChainMaintenanceCommands,
 } from '../../resources/runs/hooks'
-
 import { useNotifyCurrentMaintenanceRun } from '../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
@@ -42,7 +45,7 @@ import { MountingPlate } from './MountingPlate'
 import { UnskippableModal } from './UnskippableModal'
 
 import type { PipetteMount } from '@opentrons/shared-data'
-import type { CommandData } from '@opentrons/api-client'
+import type { CommandData, HostConfig } from '@opentrons/api-client'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
 
 const RUN_REFETCH_INTERVAL = 5000
@@ -433,3 +436,29 @@ export const PipetteWizardFlows = (
     </Portal>
   )
 }
+
+type PipetteWizardFlowsPropsWithHost = PipetteWizardFlowsProps & {
+  host: HostConfig
+}
+
+export const handlePipetteWizardFlows = (
+  props: PipetteWizardFlowsPropsWithHost
+): void => {
+  NiceModal.show(NiceModalPipetteWizardFlows, props)
+}
+
+const NiceModalPipetteWizardFlows = NiceModal.create(
+  (props: PipetteWizardFlowsPropsWithHost): JSX.Element => {
+    const modal = useModal()
+    const closeFlowAndModal = (): void => {
+      props.closeFlow()
+      modal.remove()
+    }
+
+    return (
+      <ApiHostProvider {...props.host}>
+        <PipetteWizardFlows {...props} closeFlow={closeFlowAndModal} />
+      </ApiHostProvider>
+    )
+  }
+)

--- a/app/src/pages/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
+++ b/app/src/pages/InstrumentDetail/__tests__/InstrumentDetailOverflowMenu.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import NiceModal from '@ebay/nice-modal-react'
-import { fireEvent, waitFor } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 
 import { renderWithProviders } from '@opentrons/components'
 import { getPipetteModelSpecs } from '@opentrons/shared-data'
@@ -165,46 +165,6 @@ describe('UpdateBuildroot', () => {
 
     getByText('Recalibrate')
     expect(queryByText('Drop tips')).not.toBeInTheDocument()
-  })
-
-  it('renders the pipette calibration wizard  when recalibrate is clicked', () => {
-    const [{ getByTestId, getByText }] = render(MOCK_PIPETTE)
-    const btn = getByTestId('testButton')
-    fireEvent.click(btn)
-    fireEvent.click(getByText('Recalibrate'))
-
-    getByText('Calibrate Left Pipette')
-  })
-
-  it('renders the drop tip wizard  when Drop tips is clicked', () => {
-    const [{ getByTestId, getByText, getAllByText }] = render(MOCK_PIPETTE)
-    const btn = getByTestId('testButton')
-    fireEvent.click(btn)
-    fireEvent.click(getByText('Drop tips'))
-
-    expect(getAllByText('Drop tips')).toHaveLength(2)
-  })
-
-  it('renders the gripper calibration wizard when recalibrate is clicked', () => {
-    const [{ getByTestId, getByText }] = render(MOCK_GRIPPER)
-    const btn = getByTestId('testButton')
-    fireEvent.click(btn)
-    fireEvent.click(getByText('Recalibrate'))
-
-    getByText('Calibrate Gripper')
-  })
-
-  it('closes the overflow menu when a launched wizard closes', async () => {
-    const [{ getByTestId, getByText, queryByText }] = render(MOCK_GRIPPER)
-    const btn = getByTestId('testButton')
-    fireEvent.click(btn)
-    fireEvent.click(getByText('Recalibrate'))
-
-    getByText('Calibrate Gripper')
-    fireEvent.click(getByText('exit'))
-    await waitFor(() =>
-      expect(queryByText('Recalibrate')).not.toBeInTheDocument()
-    )
   })
 
   it('closes the overflow menu when a click occurs outside of the overflow menu', () => {


### PR DESCRIPTION
Closes [RQA-2408](https://opentrons.atlassian.net/browse/RQA-2408)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The right pipette card on the desktop app conditionally renders based on whether or not a 96 channel is attached. This poses an issue when a user tries to attach a 96ch from the right card, since the card will unrender as soon as the pipette is recognized, unrendering the pipette wizard as well. This is a natural spot for our Nice Modal library, which decouples the conditional logic for rendering the modal from the logic persisting the modal.

I also randomly refactored a Nice Modal test that was testing things it didn't need to test and causing issues.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run the attach flow for the 96ch on the desktop app from the _right pipette card_. Verify the flow works.
- Feel free to smoke test other pipette flows from the pipette cards as well.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Attaching the 96ch pipette from the overflow menu of the right pipette card on the desktop app will no longer cause the pipette wizard to disppear as soon as the 96ch pipette is attached.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2408]: https://opentrons.atlassian.net/browse/RQA-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ