### PR TITLE
fix(api): module update process bug

### DIFF
--- a/api/src/opentrons/hardware_control/modules/update.py
+++ b/api/src/opentrons/hardware_control/modules/update.py
@@ -3,7 +3,7 @@ import logging
 import os
 from pathlib import Path
 from glob import glob
-from typing import Any, AsyncGenerator, Dict, Tuple, Optional, Union
+from typing import Any, AsyncGenerator, Dict, Tuple, Union
 from .types import UpdateError
 from .mod_abc import AbstractModule
 from opentrons.hardware_control.threaded_async_lock import ThreadedAsyncLock
@@ -23,7 +23,6 @@ async def protect_update_transition() -> AsyncGenerator[None, None]:
 async def update_firmware(
     module: AbstractModule,
     firmware_file: Union[str, Path],
-    loop: Optional[asyncio.AbstractEventLoop],
 ) -> None:
     """Apply update of given firmware file to given module.
 

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -230,8 +230,6 @@ async def test_module_update_integration(
 ):
     from opentrons.hardware_control import modules
 
-    loop = asyncio.get_running_loop()
-
     def async_return(result):
         f = asyncio.Future()
         f.set_result(result)
@@ -255,14 +253,14 @@ async def test_module_update_integration(
     )
 
     # test temperature module update with avrdude bootloader
-    await modules.update_firmware(mod_tempdeck, "fake_fw_file_path", loop)
+    await modules.update_firmware(mod_tempdeck, "fake_fw_file_path")
     upload_via_avrdude_mock.assert_called_once_with(
         "ot_module_avrdude_bootloader1", "fake_fw_file_path", bootloader_kwargs
     )
     upload_via_avrdude_mock.reset_mock()
 
     # test magnetic module update with avrdude bootloader
-    await modules.update_firmware(mod_magdeck, "fake_fw_file_path", loop)
+    await modules.update_firmware(mod_magdeck, "fake_fw_file_path")
     upload_via_avrdude_mock.assert_called_once_with(
         "ot_module_avrdude_bootloader1", "fake_fw_file_path", bootloader_kwargs
     )
@@ -280,7 +278,7 @@ async def test_module_update_integration(
         modules.update, "find_bootloader_port", mock_find_bossa_bootloader_port
     )
 
-    await modules.update_firmware(mod_thermocycler, "fake_fw_file_path", loop)
+    await modules.update_firmware(mod_thermocycler, "fake_fw_file_path")
     upload_via_bossa_mock.assert_called_once_with(
         "ot_module_bossa_bootloader1", "fake_fw_file_path", bootloader_kwargs
     )
@@ -298,7 +296,7 @@ async def test_module_update_integration(
 
     monkeypatch.setattr(modules.update, "find_dfu_device", mock_find_dfu_device_hs)
 
-    await modules.update_firmware(mod_heatershaker, "fake_fw_file_path", loop)
+    await modules.update_firmware(mod_heatershaker, "fake_fw_file_path")
     upload_via_dfu_mock.assert_called_once_with(
         "df11", "fake_fw_file_path", bootloader_kwargs
     )
@@ -311,7 +309,7 @@ async def test_module_update_integration(
 
     monkeypatch.setattr(modules.update, "find_dfu_device", mock_find_dfu_device_tc2)
 
-    await modules.update_firmware(mod_thermocycler_gen2, "fake_fw_file_path", loop)
+    await modules.update_firmware(mod_thermocycler_gen2, "fake_fw_file_path")
     upload_via_dfu_mock.assert_called_once_with(
         "df11", "fake_fw_file_path", bootloader_kwargs
     )

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -158,7 +158,6 @@ async def post_serial_update(
                 modules.update_firmware(
                     matching_module,
                     matching_module.bundled_fw.path,
-                    asyncio.get_event_loop(),
                 ),
                 100,
             )

--- a/robot-server/tests/service/legacy/routers/test_modules.py
+++ b/robot-server/tests/service/legacy/routers/test_modules.py
@@ -3,7 +3,6 @@ from mock import patch, PropertyMock, MagicMock
 
 import pytest
 import asyncio
-from decoy import matchers
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import (
     ModuleType,
@@ -308,7 +307,6 @@ def test_post_serial_update(api_client, hardware, tempdeck):
         p.assert_called_once_with(
             tempdeck,
             tempdeck._bundled_fw.path,
-            matchers.IsA(asyncio.AbstractEventLoop),
         )
 
         body = resp.json()


### PR DESCRIPTION
Closes RQA-2417

# Overview

Python 3.10 removed the loop param of `create_subprocess_exec`. This instance in firmware update process got left out and was not caught by the linter because the loop was being passed as a kwarg.

# Test Plan

Test updating an arduino AVR module (temp/ mag) arduino SAMD module (thermocycler gen1) and an STM32 module (TC GEN2/ Heater-shaker).
I was able to successfully update the H/S with this change.

# Review requests

- usual stuff

