### PR TITLE
fix(app): update protocol setup action needed status for missing pipettes and modules

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -33,6 +33,7 @@ import {
   useRobot,
   useRunCalibrationStatus,
   useRunHasStarted,
+  useRunPipetteInfoByMount,
   useStoredProtocolAnalysis,
   useUnmatchedModulesForProtocol,
 } from '../../hooks'
@@ -118,6 +119,9 @@ const mockGetIsFixtureMismatch = getIsFixtureMismatch as jest.MockedFunction<
 const mockUseNotifyRunQuery = useNotifyRunQuery as jest.MockedFunction<
   typeof useNotifyRunQuery
 >
+const mockUseRunPipetteInfoByMount = useRunPipetteInfoByMount as jest.MockedFunction<
+  typeof useRunPipetteInfoByMount
+>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
@@ -190,6 +194,9 @@ describe('ProtocolRunSetup', () => {
       .mockReturnValue({ missingModuleIds: [], remainingAttachedModules: [] })
     when(mockGetIsFixtureMismatch).mockReturnValue(false)
     mockUseNotifyRunQuery.mockReturnValue({} as any)
+    when(mockUseRunPipetteInfoByMount)
+      .calledWith(RUN_ID)
+      .mockReturnValue({ left: null, right: null })
   })
   afterEach(() => {
     resetAllWhenMocks()


### PR DESCRIPTION
# Overview

renders action needed in protocol setup step when pipette is missing (or mismatched) or module is missing for both OT-2 and Flex

closes RQA-2406, RQA-2407

OT-2:
<img width="1136" alt="Screen Shot 2024-02-29 at 3 50 25 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/775f08e7-3724-4fdf-9c7d-b794ef4a01d3">
<img width="1136" alt="Screen Shot 2024-02-29 at 3 49 25 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/198c6758-849d-451e-879f-0ba37d074b33">
<img width="1136" alt="Screen Shot 2024-02-29 at 3 54 50 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/25ba7ec0-363a-41ae-9c96-67a028182b0a">
<img width="1136" alt="Screen Shot 2024-02-29 at 3 52 23 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/d335690e-0eaf-4457-8a95-687b3582af72">

Flex:
<img width="1136" alt="Screen Shot 2024-02-29 at 3 57 14 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/90b530ff-10b2-4e67-9898-78546e228803">
<img width="1136" alt="Screen Shot 2024-02-29 at 3 56 11 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/8610613f-827f-4280-adc3-ab37f0028c06">


# Test Plan

verified behavior, updated unit test

# Changelog

 - Updates protocol setup action needed status for missing pipettes and modules

# Review requests

check various states of pipette and module attachment and setup status

# Risk assessment

low
