### PR TITLE
fix(app): add remove probe prompt when LPC errors

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/FatalErrorModal.tsx
+++ b/app/src/organisms/LabwarePositionCheck/FatalErrorModal.tsx
@@ -27,6 +27,7 @@ const SUPPORT_EMAIL = 'support@opentrons.com'
 
 interface FatalErrorModalProps {
   errorMessage: string
+  shouldUseMetalProbe: boolean
   onClose: () => void
 }
 export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
@@ -58,6 +59,15 @@ export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
           <ErrorHeader>
             {i18n.format(t('shared:something_went_wrong'), 'sentenceCase')}
           </ErrorHeader>
+          {props.shouldUseMetalProbe && (
+            <StyledText
+              as="p"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              textAlign={TEXT_ALIGN_CENTER}
+            >
+              {t('remove_probe_before_exit')}
+            </StyledText>
+          )}
           <StyledText as="p" textAlign={TEXT_ALIGN_CENTER}>
             {t('shared:help_us_improve_send_error_report', {
               support_email: SUPPORT_EMAIL,

--- a/app/src/organisms/LabwarePositionCheck/FatalErrorModal.tsx
+++ b/app/src/organisms/LabwarePositionCheck/FatalErrorModal.tsx
@@ -31,6 +31,7 @@ interface FatalErrorModalProps {
   onClose: () => void
 }
 export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
+  const { errorMessage, shouldUseMetalProbe, onClose } = props
   const { t } = useTranslation(['labware_position_check', 'shared'])
   return (
     <Portal level="top">
@@ -39,7 +40,7 @@ export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
         header={
           <WizardHeader
             title={t('labware_position_check_title')}
-            onExit={props.onClose}
+            onExit={onClose}
           />
         }
       >
@@ -59,7 +60,7 @@ export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
           <ErrorHeader>
             {i18n.format(t('shared:something_went_wrong'), 'sentenceCase')}
           </ErrorHeader>
-          {props.shouldUseMetalProbe && (
+          {shouldUseMetalProbe ? (
             <StyledText
               as="p"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}
@@ -67,7 +68,7 @@ export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
             >
               {t('remove_probe_before_exit')}
             </StyledText>
-          )}
+          ) : null}
           <StyledText as="p" textAlign={TEXT_ALIGN_CENTER}>
             {t('shared:help_us_improve_send_error_report', {
               support_email: SUPPORT_EMAIL,
@@ -75,13 +76,13 @@ export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
           </StyledText>
           <ErrorTextArea
             readOnly
-            value={props.errorMessage ?? ''}
+            value={errorMessage ?? ''}
             spellCheck={false}
           />
           <PrimaryButton
             textTransform={TEXT_TRANSFORM_CAPITALIZE}
             alignSelf={ALIGN_FLEX_END}
-            onClick={props.onClose}
+            onClick={onClose}
           >
             {t('shared:exit')}
           </PrimaryButton>

--- a/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LabwarePositionCheckComponent.tsx
@@ -334,6 +334,7 @@ export const LabwarePositionCheckComponent = (
     modalContent = (
       <FatalErrorModal
         errorMessage={fatalError}
+        shouldUseMetalProbe={shouldUseMetalProbe}
         onClose={handleCleanUpAndClose}
       />
     )

--- a/app/src/organisms/LabwarePositionCheck/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/index.tsx
@@ -3,8 +3,9 @@ import { useLogger } from '../../logger'
 import { LabwarePositionCheckComponent } from './LabwarePositionCheckComponent'
 import { FatalErrorModal } from './FatalErrorModal'
 
-import type {
+import {
   CompletedProtocolAnalysis,
+  FLEX_ROBOT_TYPE,
   RobotType,
 } from '@opentrons/shared-data'
 import type { LabwareOffset } from '@opentrons/api-client'
@@ -34,6 +35,7 @@ export const LabwarePositionCheck = (
     <ErrorBoundary
       logger={logger}
       ErrorComponent={FatalErrorModal}
+      shouldUseMetalProbe={props.robotType === FLEX_ROBOT_TYPE}
       onClose={props.onCloseClick}
     >
       <LabwarePositionCheckComponent {...props} />
@@ -44,9 +46,11 @@ export const LabwarePositionCheck = (
 interface ErrorBoundaryProps {
   children: React.ReactNode
   onClose: () => void
+  shouldUseMetalProbe: boolean
   logger: ReturnType<typeof useLogger>
   ErrorComponent: (props: {
     errorMessage: string
+    shouldUseMetalProbe: boolean
     onClose: () => void
   }) => JSX.Element
 }
@@ -70,12 +74,13 @@ class ErrorBoundary extends React.Component<
   }
 
   render(): ErrorBoundaryProps['children'] | JSX.Element {
-    const { ErrorComponent, children } = this.props
+    const { ErrorComponent, children, shouldUseMetalProbe } = this.props
     const { error } = this.state
     if (error != null)
       return (
         <ErrorComponent
           errorMessage={error.message}
+          shouldUseMetalProbe={shouldUseMetalProbe}
           onClose={this.props.onClose}
         />
       )


### PR DESCRIPTION
fix RQA-2342

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When using golden tip LPC, we should have a callout on the error modal to remind the user to remove the calibration probe before exiting
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
During LPC, throw an error and see that the callout is now reflected. I tested this so don't think more testing is necessary 
<img width="827" alt="Screen Shot 2024-02-29 at 2 05 00 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/28d5a73b-1f4e-4e57-bb05-acbf02fd3f92">

<!--

Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Add probe removal callout to FatalErrorModal if `shouldUseProbe` is true
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Quick code check
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
