### PR TITLE
chore(app): remove robot calibration link from labware offsets modal

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -98,7 +98,6 @@
   "learn_how_it_works": "Learn how it works",
   "learn_more_about_offset_data": "Learn more about Labware Offset Data",
   "learn_more_about_robot_cal_link": "Learn more about robot calibration",
-  "learn_more_about_robot_cal_offset": "Learn more about Robot Calibration",
   "learn_more": "Learn more",
   "liquid_setup_step_description": "View liquid starting locations and volumes",
   "liquid_setup_step_title": "Liquids",

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/HowLPCWorksModal.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/HowLPCWorksModal.tsx
@@ -14,8 +14,6 @@ import { Portal } from '../../../../App/portal'
 import { LegacyModal } from '../../../../molecules/LegacyModal'
 import { StyledText } from '../../../../atoms/text'
 
-const ROBOT_CAL_HELP_ARTICLE =
-  'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
 const OFFSET_DATA_HELP_ARTICLE =
   'https://support.opentrons.com/s/article/How-Labware-Offsets-work-on-the-OT-2'
 interface HowLPCWorksModalProps {
@@ -52,20 +50,6 @@ export const HowLPCWorksModal = (props: HowLPCWorksModalProps): JSX.Element => {
           <StyledText as="p" marginBottom={SPACING.spacing16}>
             {t('why_use_lpc')}
           </StyledText>
-          <Link
-            external
-            css={TYPOGRAPHY.linkPSemiBold}
-            href={ROBOT_CAL_HELP_ARTICLE}
-            id="HowLPCWorksModal_helpArticleLink1"
-            marginBottom={SPACING.spacing16}
-          >
-            {t('learn_more_about_robot_cal_offset')}
-            <Icon
-              name="open-in-new"
-              marginLeft={SPACING.spacing4}
-              size="0.5rem"
-            />
-          </Link>
           <PrimaryButton
             onClick={props.onCloseClick}
             textTransform={TYPOGRAPHY.textTransformCapitalize}

--- a/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/HowLPCWorksModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLabwarePositionCheck/__tests__/HowLPCWorksModal.test.tsx
@@ -30,16 +30,6 @@ describe('HowLPCWorksModal', () => {
     )
   })
 
-  it('should render a link to robot cal', () => {
-    const { getByRole } = render(props)
-    expect(
-      getByRole('link', {
-        name: 'Learn more about Robot Calibration',
-      }).getAttribute('href')
-    ).toBe(
-      'https://support.opentrons.com/s/article/How-positional-calibration-works-on-the-OT-2'
-    )
-  })
   it('should render a link to the learn more page', () => {
     const { getByRole } = render(props)
     expect(


### PR DESCRIPTION

# Overview

A link in the "How labware offsets work" modal goes to a help center page that only covers OT-2. The link is present when setting up Flex or OT-2 protocols. See comments on RQA-2411.

![labware offset modal with calibration link](https://github.com/Opentrons/opentrons/assets/1958332/b79fe13a-a872-4f59-a0bd-1da033f45601)

It would be a big lift to rewrite the help center page, and it only provides supplemental information — it won't directly help users run LPC and getting the protocol started.

We decided to remove the link for now.

# Test Plan

It's gone 🕳️ 

![labware offset modal without calibration link](https://github.com/Opentrons/opentrons/assets/1958332/f3a44812-2460-42e1-ac94-2d714e30aaee)

# Changelog

- remove `<Link>` 
- update tests
- remove unused localization string

# Review requests

I'm pretty sure everything I touched here is contained to only this modal — would love a double check though.

# Risk assessment

low.