### PR TITLE
fix(app): fix terminal run banner not dismissing on close button click

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -171,6 +171,7 @@ export function ProtocolRunHeader({
   const [pipettesWithTip, setPipettesWithTip] = React.useState<
     PipettesWithTip[]
   >([])
+  const [closeTerminalBanner, setCloseTerminalBanner] = React.useState(false)
   const isResetRunLoadingRef = React.useRef(false)
   const { data: runRecord } = useNotifyRunQuery(runId, { staleTime: Infinity })
   const highestPriorityError =
@@ -256,6 +257,12 @@ export function ProtocolRunHeader({
     }
   }, [runStatus, isRunCurrent, runId, closeCurrentRun])
 
+  React.useEffect(() => {
+    if (runStatus === RUN_STATUS_IDLE) {
+      setCloseTerminalBanner(false)
+    }
+  }, [runStatus])
+
   const startedAtTimestamp =
     startedAt != null ? formatTimestamp(startedAt) : EMPTY_TIMESTAMP
 
@@ -300,6 +307,7 @@ export function ProtocolRunHeader({
       properties: robotAnalyticsData ?? undefined,
     })
     closeCurrentRun()
+    setCloseTerminalBanner(true)
   }
 
   return (
@@ -364,7 +372,7 @@ export function ProtocolRunHeader({
         CANCELLABLE_STATUSES.includes(runStatus) ? (
           <Banner type="warning">{t('shared:close_robot_door')}</Banner>
         ) : null}
-        {mostRecentRunId === runId ? (
+        {mostRecentRunId === runId && !closeTerminalBanner ? (
           <TerminalRunBanner
             {...{
               runStatus,

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -883,7 +883,7 @@ describe('ProtocolRunHeader', () => {
     expect(screen.queryByTestId('Banner_close-button')).not.toBeInTheDocument()
   })
 
-  it('renders a clear protocol banner when run has succeeded', () => {
+  it('renders a clear protocol banner when run has succeeded', async () => {
     when(mockUseNotifyRunQuery)
       .calledWith(RUN_ID)
       .mockReturnValue({
@@ -895,8 +895,24 @@ describe('ProtocolRunHeader', () => {
     render()
 
     screen.getByText('Run completed.')
+  })
+
+  it('clicking close on a terminal run banner closes the run context and dismisses the banner', async () => {
+    when(mockUseNotifyRunQuery)
+      .calledWith(RUN_ID)
+      .mockReturnValue({
+        data: { data: mockSucceededRun },
+      } as UseQueryResult<Run>)
+    when(mockUseRunStatus)
+      .calledWith(RUN_ID)
+      .mockReturnValue(RUN_STATUS_SUCCEEDED)
+    render()
+
     fireEvent.click(screen.getByTestId('Banner_close-button'))
     expect(mockCloseCurrentRun).toBeCalled()
+    await waitFor(() => {
+      expect(screen.queryByText('Run completed.')).not.toBeInTheDocument()
+    })
   })
 
   it('if a heater shaker is shaking, clicking on start run should render HeaterShakerIsRunningModal', async () => {


### PR DESCRIPTION
Closes [RQA-2422](https://opentrons.atlassian.net/browse/RQA-2422)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes a UI bug in which clicking close on the terminal run banner wasn't properly closing the banner. 

PR #14394 updated the conditional rendering of the banner but did not account for the unrendering of the banner. 


### Current Behavior 

https://github.com/Opentrons/opentrons/assets/64858653/a763b856-969d-46f8-b156-a7449cef42e7

### PR Behavior

https://github.com/Opentrons/opentrons/assets/64858653/110a4339-f07c-4a07-9874-5628f4439ac9

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run any protocol on any robot. Verify that the terminal run banner properly closes when clicking X.
- Rerunning the protocol should cause the banner to re-render. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Clicking close on the terminal run banner properly closes the banner. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2422]: https://opentrons.atlassian.net/browse/RQA-2422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ