### PR TITLE
fix(app): disable pipette settings during active run

### DIFF
--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -108,6 +108,7 @@ export const PipetteOverflowMenu = (
               <MenuItem
                 key={`${pipetteDisplayName}_${mount}_view_settings`}
                 onClick={() => handleSettingsSlideout()}
+                disabled={isRunActive}
               >
                 {t('view_pipette_setting')}
               </MenuItem>

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -138,7 +138,7 @@ describe('PipetteOverflowMenu', () => {
     expect(settings).not.toBeInTheDocument()
   })
 
-  it('should disable certain menu items if a run is active', () => {
+  it('should disable certain menu items if a run is active for Flex pipette', () => {
     mockisFlexPipette.mockReturnValue(true)
     props = {
       ...props,
@@ -158,6 +158,30 @@ describe('PipetteOverflowMenu', () => {
     expect(
       screen.getByRole('button', {
         name: 'Drop tips',
+      })
+    ).toBeDisabled()
+  })
+
+  it('should disable certain menu items if a run is active for OT-2 pipette', () => {
+    mockisFlexPipette.mockReturnValue(false)
+    props = {
+      ...props,
+      isRunActive: true,
+    }
+    render(props)
+    expect(
+      screen.getByRole('button', {
+        name: 'Detach pipette',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', {
+        name: 'Drop tips',
+      })
+    ).toBeDisabled()
+    expect(
+      screen.getByRole('button', {
+        name: 'Pipette Settings',
       })
     ).toBeDisabled()
   })


### PR DESCRIPTION
closes [RQA-2427](https://opentrons.atlassian.net/browse/RQA-2427)

# Overview

In pipette overflow menu for OT-2 pipettes, the 'Pipette settings' menu item should be disabled during an active run.

# Test Plan

- begin protocol run on OT-2
- navigate to running OT-2's device details page
- select any pipette overflow menu
- observe that settings item is disabled during run

# Changelog

- check for active run in pipette settings menu item

[RQA-2427]: https://opentrons.atlassian.net/browse/RQA-2427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ