### PR TITLE
fix(app): handle error during exit from pipette wizard flow

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -182,7 +182,9 @@ export const PipetteWizardFlows = (
   }
   const handleClose = (): void => {
     if (onComplete != null) onComplete()
-    deleteMaintenanceRun(maintenanceRunData?.data.id)
+    if (maintenanceRunData != null) {
+      deleteMaintenanceRun(maintenanceRunData?.data.id)
+    }
     closeFlow()
   }
 

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
-import { useConditionalConfirm } from '@opentrons/components'
+import { useConditionalConfirm, COLORS } from '@opentrons/components'
 import {
   LEFT,
   NINETY_SIX_CHANNEL,
@@ -24,7 +24,6 @@ import {
 import { useNotifyCurrentMaintenanceRun } from '../../resources/maintenance_runs/useNotifyCurrentMaintenanceRun'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { Portal } from '../../App/portal'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { WizardHeader } from '../../molecules/WizardHeader'
 import { FirmwareUpdateModal } from '../FirmwareUpdateModal'
 import { getIsOnDevice } from '../../redux/config'
@@ -47,6 +46,7 @@ import { UnskippableModal } from './UnskippableModal'
 import type { PipetteMount } from '@opentrons/shared-data'
 import type { CommandData, HostConfig } from '@opentrons/api-client'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 
 const RUN_REFETCH_INTERVAL = 5000
 
@@ -181,18 +181,15 @@ export const PipetteWizardFlows = (
     }
   }
   const handleClose = (): void => {
-    setIsExiting(false)
-    closeFlow()
+    console.log('HANDLE CLOSE')
     if (onComplete != null) onComplete()
+    deleteMaintenanceRun(maintenanceRunData.data.id)
+    closeFlow()
   }
 
-  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
-    onSuccess: () => handleClose(),
-    onError: () => handleClose(),
-  })
+  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({})
 
   const handleCleanUpAndClose = (): void => {
-    setIsExiting(true)
     if (maintenanceRunData?.data.id == null) handleClose()
     else {
       chainRunCommands(
@@ -201,11 +198,11 @@ export const PipetteWizardFlows = (
         false
       )
         .then(() => {
-          deleteMaintenanceRun(maintenanceRunData?.data.id)
+          handleClose()
         })
         .catch(error => {
-          console.error(error.message)
-          handleClose()
+          setIsExiting(true)
+          setShowErrorMessage(error.message)
         })
     }
   }
@@ -214,16 +211,6 @@ export const PipetteWizardFlows = (
     showConfirmation: showConfirmExit,
     cancel: cancelExit,
   } = useConditionalConfirm(handleCleanUpAndClose, true)
-
-  const [isRobotMoving, setIsRobotMoving] = React.useState<boolean>(false)
-
-  React.useEffect(() => {
-    if (isCommandMutationLoading || isExiting) {
-      setIsRobotMoving(true)
-    } else {
-      setIsRobotMoving(false)
-    }
-  }, [isCommandMutationLoading, isExiting])
 
   let chainMaintenanceRunCommands
   if (maintenanceRunData?.data.id != null) {
@@ -245,7 +232,7 @@ export const PipetteWizardFlows = (
       : undefined
   const calibrateBaseProps = {
     chainRunCommands: chainMaintenanceRunCommands,
-    isRobotMoving,
+    isRobotMoving: isCommandMutationLoading,
     proceed,
     maintenanceRunId,
     goBack,
@@ -266,11 +253,11 @@ export const PipetteWizardFlows = (
       proceed={handleCleanUpAndClose}
       goBack={cancelExit}
       isOnDevice={isOnDevice}
-      isRobotMoving={isRobotMoving}
+      isRobotMoving={isCommandMutationLoading}
     />
   ) : (
     <ExitModal
-      isRobotMoving={isRobotMoving}
+      isRobotMoving={isCommandMutationLoading}
       goBack={cancelExit}
       proceed={handleCleanUpAndClose}
       flowType={flowType}
@@ -281,10 +268,16 @@ export const PipetteWizardFlows = (
   let onExit
   if (currentStep == null) return null
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
-  if (isExiting) {
-    modalContent = <InProgressModal description={t('stand_back')} />
-  }
-  if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {
+  if (isExiting && errorMessage != null) {
+    modalContent = (
+      <SimpleWizardBody
+        isSuccess={false}
+        iconColor={COLORS.red50}
+        header={t('shared:error_encountered')}
+        subHeader={errorMessage}
+      />
+    )
+  } else if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {
     onExit = handleCleanUpAndClose
     modalContent = (
       <BeforeBeginning
@@ -388,9 +381,11 @@ export const PipetteWizardFlows = (
   }
 
   let exitWizardButton = onExit
-  if (isRobotMoving) {
+  if (isCommandMutationLoading) {
     exitWizardButton = undefined
-  } else if (showConfirmExit || errorMessage != null) {
+  } else if (errorMessage != null && isExiting) {
+    exitWizardButton = handleClose
+  } else if (showConfirmExit) {
     exitWizardButton = handleCleanUpAndClose
   }
 
@@ -399,7 +394,7 @@ export const PipetteWizardFlows = (
 
   const wizardHeader = (
     <WizardHeader
-      exitDisabled={isRobotMoving || isFetchingPipettes}
+      exitDisabled={isCommandMutationLoading || isFetchingPipettes}
       title={memoizedWizardTitle}
       currentStep={
         progressBarForCalError ? currentStepIndex - 1 : currentStepIndex

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -182,7 +182,7 @@ export const PipetteWizardFlows = (
   }
   const handleClose = (): void => {
     if (onComplete != null) onComplete()
-    deleteMaintenanceRun(maintenanceRunData.data.id)
+    deleteMaintenanceRun(maintenanceRunData?.data.id)
     closeFlow()
   }
 

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -181,7 +181,6 @@ export const PipetteWizardFlows = (
     }
   }
   const handleClose = (): void => {
-    console.log('HANDLE CLOSE')
     if (onComplete != null) onComplete()
     deleteMaintenanceRun(maintenanceRunData.data.id)
     closeFlow()


### PR DESCRIPTION
closes [RQA-2340](https://opentrons.atlassian.net/browse/RQA-2340)

# Overview

Pipette wizard flows need to be able to handle errors after exiting, namely, during homing. Behavior is updated here to surface the error reason to the user and expose only the option to exit the modal, without issuing another home command. The modal immediately closes and deletes the maintenance run on this final exit click.

# Test Plan

- begin a pipette wizard flow (e.g. attach pipette)
- from any step, exit the wizard flow
- create or simulate an error as the gantry attempts to home. this can be done by copying the following into the promise `catch` block on line 201:
```
        .catch(error => {
          setIsExiting(true)
          setShowErrorMessage(error.message)
        })
```
- verify error screen
- click exit again
- verify that modal closes immediately

# RIsk Assessment
- medium


[RQA-2340]: https://opentrons.atlassian.net/browse/RQA-2340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ