### PR TITLE
fix(app): poll modules from protocol run module controls

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -82,7 +82,8 @@ export const ProtocolRunModuleControls = ({
   } = usePipetteIsReady()
 
   const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
-    runId
+    runId,
+    true
   )
   const attachedModules = Object.values(moduleRenderInfoForProtocolById).filter(
     module => module.attachedModuleMatch != null

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunModuleControls.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunModuleControls.test.tsx
@@ -77,7 +77,7 @@ describe('ProtocolRunModuleControls', () => {
 
   it('renders a magnetic module card', () => {
     when(mockUseModuleRenderInfoForProtocolById)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, true)
       .mockReturnValue({
         [mockMagMod.moduleId]: {
           moduleId: 'magModModuleId',
@@ -102,7 +102,7 @@ describe('ProtocolRunModuleControls', () => {
 
   it('renders a temperature module card', () => {
     when(mockUseModuleRenderInfoForProtocolById)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, true)
       .mockReturnValue({
         [mockTempMod.moduleId]: {
           moduleId: 'temperatureModuleId',
@@ -129,7 +129,7 @@ describe('ProtocolRunModuleControls', () => {
 
   it('renders a thermocycler module card', () => {
     when(mockUseModuleRenderInfoForProtocolById)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, true)
       .mockReturnValue({
         [mockTCModule.moduleId]: {
           moduleId: mockTCModule.moduleId,
@@ -158,7 +158,7 @@ describe('ProtocolRunModuleControls', () => {
 
   it('renders a heater-shaker module card', () => {
     when(mockUseModuleRenderInfoForProtocolById)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, true)
       .mockReturnValue({
         [mockHeaterShakerDef.moduleId]: {
           moduleId: 'heaterShakerModuleId',
@@ -186,7 +186,7 @@ describe('ProtocolRunModuleControls', () => {
 
   it('renders correct text when module is not attached but required for protocol', () => {
     when(mockUseModuleRenderInfoForProtocolById)
-      .calledWith(RUN_ID)
+      .calledWith(RUN_ID, true)
       .mockReturnValue({
         [mockHeaterShakerDef.moduleId]: {
           moduleId: 'heaterShakerModuleId',

--- a/app/src/organisms/Devices/hooks/__tests__/useModuleRenderInfoForProtocolById.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useModuleRenderInfoForProtocolById.test.tsx
@@ -135,13 +135,11 @@ describe('useModuleRenderInfoForProtocolById hook', () => {
     when(mockUseDeckConfigurationQuery).mockReturnValue({
       data: [mockCutoutConfig],
     } as UseQueryResult<DeckConfiguration>)
-    when(mockUseAttachedModules)
-      .calledWith()
-      .mockReturnValue([
-        mockMagneticModuleGen2,
-        mockTemperatureModuleGen2,
-        mockThermocycler,
-      ])
+    mockUseAttachedModules.mockReturnValue([
+      mockMagneticModuleGen2,
+      mockTemperatureModuleGen2,
+      mockThermocycler,
+    ])
     when(mockUseStoredProtocolAnalysis)
       .calledWith('1')
       .mockReturnValue((PROTOCOL_DETAILS as unknown) as ProtocolAnalysisOutput)
@@ -162,11 +160,15 @@ describe('useModuleRenderInfoForProtocolById hook', () => {
       .calledWith('1')
       .mockReturnValue(null)
     when(mockUseStoredProtocolAnalysis).calledWith('1').mockReturnValue(null)
-    const { result } = renderHook(() => useModuleRenderInfoForProtocolById('1'))
+    const { result } = renderHook(() =>
+      useModuleRenderInfoForProtocolById('1', true)
+    )
     expect(result.current).toStrictEqual({})
   })
   it('should return module render info', () => {
-    const { result } = renderHook(() => useModuleRenderInfoForProtocolById('1'))
+    const { result } = renderHook(() =>
+      useModuleRenderInfoForProtocolById('1', true)
+    )
     expect(result.current).toStrictEqual({
       magneticModuleId: {
         conflictedFixture: mockCutoutConfig,

--- a/app/src/organisms/Devices/hooks/useModuleRenderInfoForProtocolById.ts
+++ b/app/src/organisms/Devices/hooks/useModuleRenderInfoForProtocolById.ts
@@ -28,18 +28,21 @@ export interface ModuleRenderInfoById {
   [moduleId: string]: ModuleRenderInfoForProtocol
 }
 
-const DECK_CONFIG_REFETCH_INTERVAL = 5000
+const REFETCH_INTERVAL_5000_MS = 5000
 
 export function useModuleRenderInfoForProtocolById(
-  runId: string
+  runId: string,
+  pollModules?: boolean
 ): ModuleRenderInfoById {
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
   const { data: deckConfig } = useDeckConfigurationQuery({
-    refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
+    refetchInterval: REFETCH_INTERVAL_5000_MS,
   })
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const protocolAnalysis = robotProtocolAnalysis ?? storedProtocolAnalysis
-  const attachedModules = useAttachedModules()
+  const attachedModules = useAttachedModules({
+    refetchInterval: pollModules ? REFETCH_INTERVAL_5000_MS : false,
+  })
   if (protocolAnalysis == null) return {}
 
   const deckDef = getDeckDefFromRobotType(


### PR DESCRIPTION
fix RQA-2419

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Once a run is completed, the module cards on the controls section of the run view were not updating to reflect the most recent module information. This is because we were only polling for modules in the Setup section, which is disabled after the run begins. To fix this, I've enabled polling for modules from the Module Controls tab.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Run a protocol that uses modules - I've linked one in the ticket that I tested earlier today on app&ui bot
2. Once the run has finished, navigate to the Module Controls tab
3. Take action with one of the modules by disabling it, setting temp, etc
4. See that the module card updates with the changing information
5. In the network tab of dev tools, you should see a `/modules` response every 5 seconds. If you dismiss the run by X'ing the run completed banner, the Module Controls tab should become disabled and this poll should stop

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Add optional `pollModules` param to `useModuleRenderInfoForProtcolById` that will poll `useAttachedModules` every 5 seconds when true 
Pass this prop as `true` from `ProtocolRunModuleControls`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test this out and look over change
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
