### PR TITLE
chore: 7.2.0 known issue for losing calibration data when downgrading OT-2

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -33,7 +33,7 @@ If you don't care about preserving your labware offsets and run history, you can
 
 ### Known Issues
 
-- Downgrading an OT-2 to an earlier software version will delete tip length calibrations created with version 7.2.0. If you need to downgrade, re-run all calibrations afterward.
+- Downgrading an OT-2 to an earlier software version will delete tip length calibrations created with version 7.2.0. If you need to downgrade, re-run all pipette calibrations afterward.
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -31,6 +31,10 @@ If you don't care about preserving your labware offsets and run history, you can
 
 - Removed the `notify_server` Python package and `/notifications/subscribe` WebSocket endpoint, as they were never fully used. (See pull request [#14280](https://github.com/Opentrons/opentrons/pull/14280) for details.)
 
+### Known Issues
+
+- Downgrading an OT-2 to an earlier software version will delete tip length calibrations created with version 7.2.0. If you need to downgrade, re-run all calibrations afterward.
+
 ---
 
 ## Opentrons Robot Software Changes in 7.1.1


### PR DESCRIPTION
# Overview

Add known issue to 7.2.0 release notes, following from discussion on RQA-2425.

# Test Plan

it's markdown.

# Changelog

one header, one bullet

# Review requests

do we need to give any more specific guidance? i've erred on the side of _broad and simple_.

# Risk assessment

niente