### PR TITLE
chore(app): add robot serial number to mixpanel tracked events

### DIFF
--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -31,12 +31,12 @@ export function OnDeviceDisplayAppFallback({
   const trackEvent = useTrackEvent()
   const dispatch = useDispatch<Dispatch>()
   const localRobot = useSelector(getLocalRobot)
-  const serialNumber =
+  const robotSerialNumber =
     localRobot?.status != null ? getRobotSerialNumber(localRobot) : null
   const handleRestartClick = (): void => {
     trackEvent({
       name: ANALYTICS_ODD_APP_ERROR,
-      properties: { errorMessage: error.message, serialNumber },
+      properties: { errorMessage: error.message, robotSerialNumber },
     })
     dispatch(appRestart(error.message))
   }

--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 
 import { useTrackEvent, ANALYTICS_ODD_APP_ERROR } from '../redux/analytics'
+import { getLocalRobot, getRobotSerialNumber } from '../redux/discovery'
 
 import type { FallbackProps } from 'react-error-boundary'
 
@@ -29,10 +30,13 @@ export function OnDeviceDisplayAppFallback({
   const { t } = useTranslation('app_settings')
   const trackEvent = useTrackEvent()
   const dispatch = useDispatch<Dispatch>()
+  const localRobot = useSelector(getLocalRobot)
+  const serialNumber =
+    localRobot?.status != null ? getRobotSerialNumber(localRobot) : null
   const handleRestartClick = (): void => {
     trackEvent({
       name: ANALYTICS_ODD_APP_ERROR,
-      properties: { errorMessage: error.message },
+      properties: { errorMessage: error.message, serialNumber },
     })
     dispatch(appRestart(error.message))
   }

--- a/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
@@ -14,7 +14,13 @@ import { mockConnectableRobot } from '../../redux/discovery/__fixtures__'
 
 jest.mock('../../redux/shell')
 jest.mock('../../redux/analytics')
-jest.mock('../../redux/discovery')
+jest.mock('../../redux/discovery', () => {
+  const actual = jest.requireActual('../../redux/discovery')
+  return {
+    ...actual,
+    getLocalRobot: jest.fn(),
+  }
+})
 
 const mockError = {
   message: 'mock error',
@@ -70,7 +76,10 @@ describe('OnDeviceDisplayAppFallback', () => {
     fireEvent.click(screen.getByText('Restart touchscreen'))
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_ODD_APP_ERROR,
-      properties: { errorMessage: 'mock error' },
+      properties: {
+        errorMessage: 'mock error',
+        robotSerialNumber: MOCK_ROBOT_SERIAL_NUMBER,
+      },
     })
     expect(mockAppRestart).toHaveBeenCalled()
   })

--- a/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
@@ -3,15 +3,18 @@ import { when } from 'jest-when'
 import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 
+import { getLocalRobot } from '../../redux/discovery'
 import { i18n } from '../../i18n'
 import { appRestart } from '../../redux/shell'
 import { useTrackEvent, ANALYTICS_ODD_APP_ERROR } from '../../redux/analytics'
 import { OnDeviceDisplayAppFallback } from '../OnDeviceDisplayAppFallback'
 
 import type { FallbackProps } from 'react-error-boundary'
+import { mockConnectableRobot } from '../../redux/discovery/__fixtures__'
 
 jest.mock('../../redux/shell')
 jest.mock('../../redux/analytics')
+jest.mock('../../redux/discovery')
 
 const mockError = {
   message: 'mock error',
@@ -19,6 +22,9 @@ const mockError = {
 const mockAppRestart = appRestart as jest.MockedFunction<typeof appRestart>
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
+>
+const mockGetLocalRobot = getLocalRobot as jest.MockedFunction<
+  typeof getLocalRobot
 >
 
 const render = (props: FallbackProps) => {
@@ -28,6 +34,8 @@ const render = (props: FallbackProps) => {
 }
 
 let mockTrackEvent: jest.Mock
+
+const MOCK_ROBOT_SERIAL_NUMBER = 'OT123'
 
 describe('OnDeviceDisplayAppFallback', () => {
   let props: FallbackProps
@@ -39,6 +47,13 @@ describe('OnDeviceDisplayAppFallback', () => {
     } as FallbackProps
     mockTrackEvent = jest.fn()
     when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
+    when(mockGetLocalRobot).mockReturnValue({
+      ...mockConnectableRobot,
+      health: {
+        ...mockConnectableRobot.health,
+        robot_serial: MOCK_ROBOT_SERIAL_NUMBER,
+      },
+    })
   })
 
   it('should render text and button', () => {

--- a/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayAppFallback.test.tsx
@@ -4,13 +4,13 @@ import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@opentrons/components'
 
 import { getLocalRobot } from '../../redux/discovery'
+import { mockConnectableRobot } from '../../redux/discovery/__fixtures__'
 import { i18n } from '../../i18n'
 import { appRestart } from '../../redux/shell'
 import { useTrackEvent, ANALYTICS_ODD_APP_ERROR } from '../../redux/analytics'
 import { OnDeviceDisplayAppFallback } from '../OnDeviceDisplayAppFallback'
 
 import type { FallbackProps } from 'react-error-boundary'
-import { mockConnectableRobot } from '../../redux/discovery/__fixtures__'
 
 jest.mock('../../redux/shell')
 jest.mock('../../redux/analytics')

--- a/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-
+import { useRobot } from '../hooks'
+import { getRobotSerialNumber } from '../../../redux/discovery'
 import { SecondaryButton } from '@opentrons/components'
 
 import {
@@ -24,14 +25,16 @@ export function BackToTopButton({
 }: BackToTopButtonProps): JSX.Element | null {
   const { t } = useTranslation('protocol_setup')
   const trackEvent = useTrackEvent()
-
+  const robot = useRobot(robotName)
+  const serialNumber =
+    robot?.status != null ? getRobotSerialNumber(robot) : null ?? ''
   return (
     <Link
       to={`/devices/${robotName}/protocol-runs/${runId}/setup`}
       onClick={() => {
         trackEvent({
           name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-          properties: { sourceLocation },
+          properties: { sourceLocation, serialNumber },
         })
         protocolRunHeaderRef?.current?.scrollIntoView({
           behavior: 'smooth',

--- a/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
@@ -26,7 +26,7 @@ export function BackToTopButton({
   const { t } = useTranslation('protocol_setup')
   const trackEvent = useTrackEvent()
   const robot = useRobot(robotName)
-  const serialNumber =
+  const robotSerialNumber =
     robot?.status != null ? getRobotSerialNumber(robot) : null ?? ''
   return (
     <Link
@@ -34,7 +34,7 @@ export function BackToTopButton({
       onClick={() => {
         trackEvent({
           name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-          properties: { sourceLocation, serialNumber },
+          properties: { sourceLocation, robotSerialNumber },
         })
         protocolRunHeaderRef?.current?.scrollIntoView({
           behavior: 'smooth',

--- a/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/BackToTopButton.tsx
@@ -27,7 +27,7 @@ export function BackToTopButton({
   const trackEvent = useTrackEvent()
   const robot = useRobot(robotName)
   const robotSerialNumber =
-    robot?.status != null ? getRobotSerialNumber(robot) : null ?? ''
+    robot?.status != null ? getRobotSerialNumber(robot) : null
   return (
     <Link
       to={`/devices/${robotName}/protocol-runs/${runId}/setup`}

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -93,6 +93,7 @@ import {
   useRobotAnalyticsData,
   useIsFlex,
   useModuleCalibrationStatus,
+  useRobot,
 } from '../hooks'
 import { getPipettesWithTipAttached } from '../../DropTipWizard/getPipettesWithTipAttached'
 import { formatTimestamp } from '../utils'
@@ -111,6 +112,7 @@ import type { Run, RunError } from '@opentrons/api-client'
 import type { State } from '../../../redux/types'
 import type { HeaterShakerModule } from '../../../redux/modules/types'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
+import { getRobotSerialNumber } from '../../../redux/discovery'
 
 interface PipettesWithTip {
   mount: 'left' | 'right'
@@ -638,8 +640,14 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       runStatus !== RUN_STATUS_BLOCKED_BY_OPEN_DOOR &&
       runStatus != null &&
       CANCELLABLE_STATUSES.includes(runStatus))
+  const robot = useRobot(robotName)
+  const serialNumber =
+    robot?.status != null ? getRobotSerialNumber(robot) : null ?? ''
   const handleProceedToRunClick = (): void => {
-    trackEvent({ name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN, properties: {} })
+    trackEvent({
+      name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+      properties: { serialNumber },
+    })
     play()
   }
   const configBypassHeaterShakerAttachmentConfirmation = useSelector(
@@ -735,9 +743,11 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       reset()
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-        properties: { sourceLocation: 'RunRecordDetail' },
+        properties: { sourceLocation: 'RunRecordDetail', serialNumber },
       })
-      trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_AGAIN })
+      trackProtocolRunEvent({
+        name: ANALYTICS_PROTOCOL_RUN_AGAIN,
+      })
     }
   }
 

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -641,12 +641,12 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       runStatus != null &&
       CANCELLABLE_STATUSES.includes(runStatus))
   const robot = useRobot(robotName)
-  const serialNumber =
+  const robotSerialNumber =
     robot?.status != null ? getRobotSerialNumber(robot) : null ?? ''
   const handleProceedToRunClick = (): void => {
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-      properties: { serialNumber },
+      properties: { robotSerialNumber },
     })
     play()
   }
@@ -743,7 +743,7 @@ function ActionButton(props: ActionButtonProps): JSX.Element {
       reset()
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-        properties: { sourceLocation: 'RunRecordDetail', serialNumber },
+        properties: { sourceLocation: 'RunRecordDetail', robotSerialNumber },
       })
       trackProtocolRunEvent({
         name: ANALYTICS_PROTOCOL_RUN_AGAIN,

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -52,6 +52,7 @@ import {
 
 import { getRobotUpdateDisplayInfo } from '../../../redux/robot-update'
 import { getRobotSettings } from '../../../redux/robot-settings'
+import { getRobotSerialNumber } from '../../../redux/discovery'
 import { ProtocolAnalysisErrorBanner } from './ProtocolAnalysisErrorBanner'
 import { ProtocolDropTipBanner } from './ProtocolDropTipBanner'
 import { DropTipWizard } from '../../DropTipWizard'
@@ -112,7 +113,6 @@ import type { Run, RunError } from '@opentrons/api-client'
 import type { State } from '../../../redux/types'
 import type { HeaterShakerModule } from '../../../redux/modules/types'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
-import { getRobotSerialNumber } from '../../../redux/discovery'
 
 interface PipettesWithTip {
   mount: 'left' | 'right'

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/BackToTopButton.test.tsx
@@ -2,6 +2,8 @@ import * as React from 'react'
 import { fireEvent } from '@testing-library/react'
 import { when, resetAllWhenMocks } from 'jest-when'
 import { StaticRouter } from 'react-router-dom'
+import { useRobot } from '../../hooks'
+import { mockConnectableRobot } from '../../../../redux/discovery/__fixtures__'
 
 import { renderWithProviders } from '@opentrons/components'
 
@@ -20,13 +22,16 @@ jest.mock('@opentrons/components', () => {
   }
 })
 jest.mock('../../../../redux/analytics')
+jest.mock('../../hooks')
 
 const mockUseTrackEvent = useTrackEvent as jest.MockedFunction<
   typeof useTrackEvent
 >
+const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
+const ROBOT_SERIAL_NUMBER = 'OT123'
 
 const render = () => {
   return renderWithProviders(
@@ -50,6 +55,13 @@ describe('BackToTopButton', () => {
   beforeEach(() => {
     mockTrackEvent = jest.fn()
     when(mockUseTrackEvent).calledWith().mockReturnValue(mockTrackEvent)
+    when(mockUseRobot).mockReturnValue({
+      ...mockConnectableRobot,
+      health: {
+        ...mockConnectableRobot.health,
+        robot_serial: ROBOT_SERIAL_NUMBER,
+      },
+    })
   })
   afterEach(() => {
     resetAllWhenMocks()
@@ -70,7 +82,10 @@ describe('BackToTopButton', () => {
     fireEvent.click(button)
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-      properties: { sourceLocation: 'test run button' },
+      properties: {
+        sourceLocation: 'test run button',
+        robotSerialNumber: ROBOT_SERIAL_NUMBER,
+      },
     })
   })
 

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -63,6 +63,7 @@ import {
   ANALYTICS_PROTOCOL_RUN_START,
   ANALYTICS_PROTOCOL_RUN_RESUME,
 } from '../../../../redux/analytics'
+import { mockConnectableRobot } from '../../../../redux/discovery/__fixtures__'
 import { getRobotUpdateDisplayInfo } from '../../../../redux/robot-update'
 import { getIsHeaterShakerAttached } from '../../../../redux/config'
 import { getRobotSettings } from '../../../../redux/robot-settings'
@@ -77,6 +78,7 @@ import {
   useUnmatchedModulesForProtocol,
   useIsRobotViewable,
   useIsFlex,
+  useRobot,
 } from '../../hooks'
 import { useIsHeaterShakerInProtocol } from '../../../ModuleCard/hooks'
 import { ConfirmAttachmentModal } from '../../../ModuleCard/ConfirmAttachmentModal'
@@ -92,7 +94,6 @@ import { useDeckConfigurationCompatibility } from '../../../../resources/deck_co
 import { useMostRecentCompletedAnalysis } from '../../../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useMostRecentRunId } from '../../../ProtocolUpload/hooks/useMostRecentRunId'
 import { useNotifyRunQuery } from '../../../../resources/runs/useNotifyRunQuery'
-
 import type { UseQueryResult } from 'react-query'
 import type { Run } from '@opentrons/api-client'
 import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
@@ -253,6 +254,7 @@ const mockUseMostRecentCompletedAnalysis = useMostRecentCompletedAnalysis as jes
 const mockUseMostRecentRunId = useMostRecentRunId as jest.MockedFunction<
   typeof useMostRecentRunId
 >
+const mockUseRobot = useRobot as jest.MockedFunction<typeof useRobot>
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -268,6 +270,7 @@ const mockSettings = {
   restart_required: false,
 }
 const MOCK_ROTOCOL_LIQUID_KEY = { liquids: [] }
+const MOCK_ROBOT_SERIAL_NUMBER = 'OT123'
 
 const simpleV6Protocol = (_uncastedSimpleV6Protocol as unknown) as CompletedProtocolAnalysis
 
@@ -448,6 +451,13 @@ describe('ProtocolRunHeader', () => {
     mockUseDeckConfigurationCompatibility.mockReturnValue([])
     when(mockGetIsFixtureMismatch).mockReturnValue(false)
     when(mockUseMostRecentRunId).mockReturnValue(RUN_ID)
+    when(mockUseRobot).mockReturnValue({
+      ...mockConnectableRobot,
+      health: {
+        ...mockConnectableRobot.health,
+        robot_serial: MOCK_ROBOT_SERIAL_NUMBER,
+      },
+    })
   })
 
   afterEach(() => {
@@ -795,7 +805,10 @@ describe('ProtocolRunHeader', () => {
     fireEvent.click(button)
     expect(mockTrackEvent).toBeCalledWith({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-      properties: { sourceLocation: 'RunRecordDetail' },
+      properties: {
+        sourceLocation: 'RunRecordDetail',
+        robotSerialNumber: MOCK_ROBOT_SERIAL_NUMBER,
+      },
     })
     expect(mockTrackProtocolRunEvent).toBeCalledWith({
       name: ANALYTICS_PROTOCOL_RUN_AGAIN,

--- a/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -52,6 +52,7 @@ import { useDeckConfigurationCompatibility } from '../../../resources/deck_confi
 import { ConfirmAttachedModal } from '../../../pages/ProtocolSetup/ConfirmAttachedModal'
 import { ProtocolSetup } from '../../../pages/ProtocolSetup'
 import { useNotifyRunQuery } from '../../../resources/runs/useNotifyRunQuery'
+import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 
 import type { UseQueryResult } from 'react-query'
 import type {
@@ -88,7 +89,7 @@ jest.mock('../../../organisms/OnDeviceDisplay/RunningProtocol')
 jest.mock('../../../organisms/RunTimeControl/hooks')
 jest.mock('../../../organisms/ProtocolSetupLiquids')
 jest.mock('../../../organisms/ModuleCard/hooks')
-jest.mock('../../../redux/discovery/selectors')
+jest.mock('../../../redux/discovery')
 jest.mock('../ConfirmAttachedModal')
 jest.mock('../../../organisms/ToasterOven')
 jest.mock('../../../resources/deck_configuration/hooks')
@@ -198,6 +199,7 @@ const render = (path = '/') => {
 
 const ROBOT_NAME = 'fake-robot-name'
 const RUN_ID = 'my-run-id'
+const ROBOT_SERIAL_NUMBER = 'OT123'
 const PROTOCOL_ID = 'my-protocol-id'
 const PROTOCOL_NAME = 'Mock Protocol Name'
 const CREATED_AT = 'top of the hour'
@@ -273,7 +275,14 @@ describe('ProtocolSetup', () => {
       <div>Mock ConfirmCancelRunModal</div>
     )
     mockUseModuleCalibrationStatus.mockReturnValue({ complete: true })
-    mockGetLocalRobot.mockReturnValue({ name: ROBOT_NAME } as any)
+    mockGetLocalRobot.mockReturnValue({
+      ...mockConnectableRobot,
+      name: ROBOT_NAME,
+      health: {
+        ...mockConnectableRobot.health,
+        robot_serial: ROBOT_SERIAL_NUMBER,
+      },
+    } as any)
     when(mockUseRobotType)
       .calledWith(ROBOT_NAME)
       .mockReturnValue(FLEX_ROBOT_TYPE)

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -784,7 +784,7 @@ export function ProtocolSetup(): JSX.Element {
         setSetupScreen={setSetupScreen}
         confirmAttachment={confirmAttachment}
         play={play}
-        robotName={localRobot?.displayName ?? ''}
+        robotName={localRobot?.name != null ? localRobot.name : 'no name'}
       />
     ),
     instruments: (

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -784,6 +784,7 @@ export function ProtocolSetup(): JSX.Element {
         setSetupScreen={setSetupScreen}
         confirmAttachment={confirmAttachment}
         play={play}
+        robotName={localRobot?.displayName ?? ''}
       />
     ),
     instruments: (

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -745,7 +745,7 @@ export type SetupScreens =
 export function ProtocolSetup(): JSX.Element {
   const { runId } = useParams<OnDeviceRouteParams>()
   const localRobot = useSelector(getLocalRobot)
-  const serialNumber =
+  const robotSerialNumber =
     localRobot?.status != null ? getRobotSerialNumber(localRobot) : null
   const trackEvent = useTrackEvent()
   const { play } = useRunControls(runId)
@@ -753,7 +753,7 @@ export function ProtocolSetup(): JSX.Element {
   const handleProceedToRunClick = (): void => {
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-      properties: { serialNumber },
+      properties: { robotSerialNumber },
     })
     play()
   }

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -75,7 +75,7 @@ import {
 import { useToaster } from '../../organisms/ToasterOven'
 import { useIsHeaterShakerInProtocol } from '../../organisms/ModuleCard/hooks'
 import { getLabwareSetupItemGroups } from '../../pages/Protocols/utils'
-import { getLocalRobot } from '../../redux/discovery'
+import { getLocalRobot, getRobotSerialNumber } from '../../redux/discovery'
 import {
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
   ANALYTICS_PROTOCOL_RUN_START,
@@ -216,6 +216,7 @@ interface PrepareToRunProps {
   setSetupScreen: React.Dispatch<React.SetStateAction<SetupScreens>>
   confirmAttachment: () => void
   play: () => void
+  robotName: string
 }
 
 function PrepareToRun({
@@ -223,12 +224,11 @@ function PrepareToRun({
   setSetupScreen,
   confirmAttachment,
   play,
+  robotName,
 }: PrepareToRunProps): JSX.Element {
   const { t, i18n } = useTranslation(['protocol_setup', 'shared'])
   const history = useHistory()
   const { makeSnackbar } = useToaster()
-  const localRobot = useSelector(getLocalRobot)
-  const robotName = localRobot?.name != null ? localRobot.name : 'no name'
 
   // Watch for scrolling to toggle dropshadow
   const scrollRef = React.useRef<HTMLDivElement>(null)
@@ -744,10 +744,17 @@ export type SetupScreens =
 
 export function ProtocolSetup(): JSX.Element {
   const { runId } = useParams<OnDeviceRouteParams>()
+  const localRobot = useSelector(getLocalRobot)
+  const serialNumber =
+    localRobot?.status != null ? getRobotSerialNumber(localRobot) : null
   const trackEvent = useTrackEvent()
   const { play } = useRunControls(runId)
+
   const handleProceedToRunClick = (): void => {
-    trackEvent({ name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN, properties: {} })
+    trackEvent({
+      name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+      properties: { serialNumber },
+    })
     play()
   }
   const configBypassHeaterShakerAttachmentConfirmation = useSelector(


### PR DESCRIPTION
closes [RQA-2386](https://opentrons.atlassian.net/jira/software/c/projects/RQA/issues/RQA-2386)

# Overview

Previous work to include robot serial number property in relevant tracked events audited usage of trackEvent wrappers useTrackProtocolRunEvent, useRobotAnalyticsData, and useProtocolRunAnalyticsData, but did not cover events using bare `trackEvent`. This PR adds serial number as a property in tracking for to the following event types:
- proceedToRun
- runAgain
- runFinish
- runPause
- runStart
- runResume
- runCancel
- sendToFlex
- oddError

[RQA-2386]: https://opentrons.atlassian.net/browse/RQA-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ