### PR TITLE
test(shared-data): add pressFit pickUpTipConfigurations validation test

### DIFF
--- a/shared-data/python/tests/pipette/test_validate_schema.py
+++ b/shared-data/python/tests/pipette/test_validate_schema.py
@@ -35,3 +35,36 @@ def test_check_all_models_are_valid() -> None:
                 )
 
                 assert isinstance(loaded_model, PipetteConfigurations)
+
+
+def test_pick_up_configs_tip_count_keys() -> None:
+    """Verify that speed, distance & current of pickUpTipConfigurations have same tip count keys."""
+    paths_to_validate = (
+        get_shared_data_root() / "pipette" / "definitions" / "2" / "general"
+    )
+    _channel_model_str = {
+        "single_channel": "single",
+        "ninety_six_channel": "96",
+        "eight_channel": "multi",
+    }
+    assert os.listdir(paths_to_validate), "You have a path wrong"
+    for channel_dir in os.listdir(paths_to_validate):
+        for model_dir in os.listdir(paths_to_validate / channel_dir):
+            for version_file in os.listdir(paths_to_validate / channel_dir / model_dir):
+                version_list = version_file.split(".json")[0].split("_")
+                built_model: PipetteModel = PipetteModel(
+                    f"{model_dir}_{_channel_model_str[channel_dir]}_v{version_list[0]}.{version_list[1]}"
+                )
+
+                model_version = convert_pipette_model(built_model)
+                loaded_model = load_definition(
+                    model_version.pipette_type,
+                    model_version.pipette_channels,
+                    model_version.pipette_version,
+                )
+                pick_up_tip_configs = loaded_model.pick_up_tip_configurations.press_fit
+                assert (
+                    pick_up_tip_configs.distance_by_tip_count.keys()
+                    == pick_up_tip_configs.speed_by_tip_count.keys()
+                    == pick_up_tip_configs.current_by_tip_count.keys()
+                )


### PR DESCRIPTION
# Overview

I started working towards RSS-496 and as I was updating the definitions to use `configsByTipCount`, I realized that that schema was more prone to human errors and was too verbose. Even though the current schema looks a bit redundant with three properties keyed by tip count, having a property written as: 

```
currentByTipCount: {"1": 0.1, "2": 0.2, "3": 0.3....}
```
as opposed to 
```
configByTipCount: { "1": { "current": 0.1, "speed": 12, "distance": 22}, "2": {.....}}
```

is much more readable, easy to peruse at a quick glance and less prone to human errors because you can spot an anomaly in the pattern right away.

Now the present and easily readable schema still has the problem of tip count keys being missed or out of sync. So this PR adds a test that scans all pipette definitions to verify that each definition has identical keys for `speedByTipCount`, `distanceByTipCount` & `currentByTipCount`.

# Test Plan

Checked that removing a key from any definition raises error in the added test.

# Review requests

Any opposition to not changing the schema?

# Risk assessment

None. Just a test
