### PR TITLE
refactor(app-shell, app-shell-odd): reduce superfluous MQTT traffic

### DIFF
--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -30,6 +30,7 @@ interface ConnectionStore {
 }
 
 const connectionStore: ConnectionStore = {}
+const unreachableHosts = new Set<string>()
 const log = createLogger('notify')
 // MQTT is somewhat particular about the clientId format and will connect erratically if an unexpected string is supplied.
 // This clientId is derived from the mqttjs library.
@@ -87,10 +88,18 @@ interface NotifyParams {
   topic: NotifyTopic
 }
 
-function subscribe(notifyParams: NotifyParams): Promise<void> {
+function subscribe(notifyParams: NotifyParams): Promise<void> | void {
   const { hostname, topic, browserWindow } = notifyParams
+  if (unreachableHosts.has(hostname)) {
+    sendToBrowserDeserialized({
+      browserWindow,
+      hostname,
+      topic,
+      message: FAILURE_STATUSES.ECONNFAILED,
+    })
+  }
   // true if no subscription (and therefore connection) to host exists
-  if (connectionStore[hostname] == null) {
+  else if (connectionStore[hostname] == null) {
     connectionStore[hostname] = {
       client: null,
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -113,14 +122,16 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         log.warn(
           `Failed to connect to ${hostname} - ${error.name}: ${error.message} `
         )
-
         let failureMessage: string = FAILURE_STATUSES.ECONNFAILED
-        if (
-          error.message.includes(FAILURE_STATUSES.ECONNREFUSED) &&
-          !hasReportedAPortBlockEvent
-        ) {
-          failureMessage = FAILURE_STATUSES.ECONNREFUSED
-          hasReportedAPortBlockEvent = true
+        if (connectionStore[hostname]?.client == null) {
+          unreachableHosts.add(hostname)
+          if (
+            error.message.includes(FAILURE_STATUSES.ECONNREFUSED) &&
+            !hasReportedAPortBlockEvent
+          ) {
+            failureMessage = FAILURE_STATUSES.ECONNREFUSED
+            hasReportedAPortBlockEvent = true
+          }
         }
 
         sendToBrowserDeserialized({
@@ -136,17 +147,19 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   else {
     return waitUntilActiveOrErrored('client').then(() => {
       const { client, subscriptions, pendingSubs } = connectionStore[hostname]
+      const activeClient = client as mqtt.Client
       const isNotActiveSubscription = (subscriptions[topic] ?? 0) <= 0
       if (!pendingSubs.has(topic) && isNotActiveSubscription) {
         pendingSubs.add(topic)
         return new Promise<void>(() => {
-          client?.subscribe(topic, subscribeOptions, subscribeCb)
+          activeClient.subscribe(topic, subscribeOptions, subscribeCb)
           pendingSubs.delete(topic)
         })
-      } else
+      } else {
         void waitUntilActiveOrErrored('subscription').then(() => {
           subscriptions[topic] += 1
         })
+      }
     })
   }
   function subscribeCb(error: Error, result: mqtt.ISubscriptionGrant[]): void {

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -85,7 +85,7 @@ interface NotifyParams {
   topic: NotifyTopic
 }
 
-function subscribe(notifyParams: NotifyParams): Promise<void> | void {
+function subscribe(notifyParams: NotifyParams): Promise<void> {
   const { hostname, topic, browserWindow } = notifyParams
   if (unreachableHosts.has(hostname)) {
     sendToBrowserDeserialized({
@@ -94,6 +94,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> | void {
       topic,
       message: FAILURE_STATUSES.ECONNFAILED,
     })
+    return Promise.resolve()
   }
   // true if no subscription (and therefore connection) to host exists
   else if (connectionStore[hostname] == null) {
@@ -142,22 +143,40 @@ function subscribe(notifyParams: NotifyParams): Promise<void> | void {
   }
   // true if the connection store has an entry for the hostname.
   else {
-    return waitUntilActiveOrErrored('client').then(() => {
-      const { client, subscriptions, pendingSubs } = connectionStore[hostname]
-      const activeClient = client as mqtt.Client
-      const isNotActiveSubscription = (subscriptions[topic] ?? 0) <= 0
-      if (!pendingSubs.has(topic) && isNotActiveSubscription) {
-        pendingSubs.add(topic)
-        return new Promise<void>(() => {
-          activeClient.subscribe(topic, subscribeOptions, subscribeCb)
-          pendingSubs.delete(topic)
+    return waitUntilActiveOrErrored('client')
+      .then(() => {
+        const { client, subscriptions, pendingSubs } = connectionStore[hostname]
+        const activeClient = client as mqtt.Client
+        const isNotActiveSubscription = (subscriptions[topic] ?? 0) <= 0
+        if (!pendingSubs.has(topic) && isNotActiveSubscription) {
+          pendingSubs.add(topic)
+          return new Promise<void>(() => {
+            activeClient.subscribe(topic, subscribeOptions, subscribeCb)
+            pendingSubs.delete(topic)
+          })
+        } else {
+          void waitUntilActiveOrErrored('subscription')
+            .then(() => {
+              subscriptions[topic] += 1
+            })
+            .catch(() => {
+              sendToBrowserDeserialized({
+                browserWindow,
+                hostname,
+                topic,
+                message: FAILURE_STATUSES.ECONNFAILED,
+              })
+            })
+        }
+      })
+      .catch(() => {
+        sendToBrowserDeserialized({
+          browserWindow,
+          hostname,
+          topic,
+          message: FAILURE_STATUSES.ECONNFAILED,
         })
-      } else {
-        void waitUntilActiveOrErrored('subscription').then(() => {
-          subscriptions[topic] += 1
-        })
-      }
-    })
+      })
   }
   function subscribeCb(error: Error, result: mqtt.ISubscriptionGrant[]): void {
     const { subscriptions } = connectionStore[hostname]
@@ -176,8 +195,11 @@ function subscribe(notifyParams: NotifyParams): Promise<void> | void {
       }, RENDER_TIMEOUT)
     } else {
       // log.info(`Successfully subscribed on ${hostname} to topic: ${topic}`)
-      if (subscriptions[topic] > 0) subscriptions[topic] += 1
-      else subscriptions[topic] = 1
+      if (subscriptions[topic] > 0) {
+        subscriptions[topic] += 1
+      } else {
+        subscriptions[topic] = 1
+      }
     }
   }
 
@@ -203,15 +225,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> | void {
         if (counter === MAX_RETRIES) {
           clearInterval(intervalId)
           // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
-          sendToBrowserDeserialized({
-            browserWindow,
-            hostname,
-            topic,
-            message: FAILURE_STATUSES.ECONNFAILED,
-          })
-          reject(
-            new Error(`Maximum subscription retries exceeded for ${hostname}.`)
-          )
+          reject(new Error('Maximum subscription retries exceeded.'))
         }
       }, CHECK_CONNECTION_INTERVAL)
     })

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -24,6 +24,7 @@ interface ConnectionStore {
   [hostname: string]: {
     client: mqtt.MqttClient | null
     subscriptions: Record<NotifyTopic, number>
+    pendingSubs: Set<NotifyTopic>
   }
 }
 
@@ -46,8 +47,8 @@ const connectOptions: mqtt.IClientOptions = {
 
 /**
  * @property {number} qos: "Quality of Service", "at least once". Because we use React Query, which does not trigger
-  a render update event if duplicate data is received, we can avoid the additional overhead 
-  to guarantee "exactly once" delivery. 
+  a render update event if duplicate data is received, we can avoid the additional overhead
+  to guarantee "exactly once" delivery.
  */
 const subscribeOptions: mqtt.IClientSubscribeOptions = {
   qos: 1,
@@ -91,15 +92,19 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
       client: null,
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       subscriptions: { [topic]: 1 } as Record<NotifyTopic, number>,
+      pendingSubs: new Set(),
     }
     return connectAsync(`mqtt://${hostname}`)
       .then(client => {
+        const { pendingSubs } = connectionStore[hostname]
         log.info(`Successfully connected to ${hostname}`)
         connectionStore[hostname].client = client
+        pendingSubs.add(topic)
         establishListeners({ ...notifyParams, client })
-        return new Promise<void>(() =>
+        return new Promise<void>(() => {
           client.subscribe(topic, subscribeOptions, subscribeCb)
-        )
+          pendingSubs.delete(topic)
+        })
       })
       .catch((error: Error) => {
         log.warn(
@@ -126,25 +131,23 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   }
   // true if the connection store has an entry for the hostname.
   else {
-    const subscriptions = connectionStore[hostname]?.subscriptions
-    if (subscriptions) {
-      if (subscriptions[topic] > 0) subscriptions[topic] += 1
-      else subscriptions[topic] = 1
-    }
-
-    return checkIfClientConnected().catch(() => {
-      // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
-      sendToBrowserDeserialized({
-        browserWindow,
-        hostname,
-        topic,
-        message: FAILURE_STATUSES.ECONNFAILED,
-      })
-      handleDecrementSubscriptionCount(hostname, topic)
+    return waitUntilActiveOrErrored('client').then(() => {
+      const { client, subscriptions, pendingSubs } = connectionStore[hostname]
+      const isNotActiveSubscription = (subscriptions[topic] ?? 0) <= 0
+      if (!pendingSubs.has(topic) && isNotActiveSubscription) {
+        pendingSubs.add(topic)
+        return new Promise<void>(() => {
+          client?.subscribe(topic, subscribeOptions, subscribeCb)
+          pendingSubs.delete(topic)
+        })
+      } else
+        void waitUntilActiveOrErrored('subscription').then(() => {
+          subscriptions[topic] += 1
+        })
     })
   }
-
   function subscribeCb(error: Error, result: mqtt.ISubscriptionGrant[]): void {
+    const { subscriptions } = connectionStore[hostname]
     if (error != null) {
       // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
       sendToBrowserDeserialized({
@@ -153,41 +156,48 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         topic,
         message: FAILURE_STATUSES.ECONNFAILED,
       })
-      handleDecrementSubscriptionCount(hostname, topic)
+      setTimeout(() => {
+        if (Object.keys(connectionStore[hostname].subscriptions).length <= 0) {
+          connectionStore[hostname].client?.end()
+        }
+      }, RENDER_TIMEOUT)
     } else {
       // log.info(`Successfully subscribed on ${hostname} to topic: ${topic}`)
+      if (subscriptions[topic] > 0) subscriptions[topic] += 1
+      else subscriptions[topic] = 1
     }
   }
 
   // Check every 500ms for 2 seconds before failing.
-  function checkIfClientConnected(): Promise<void> {
+  function waitUntilActiveOrErrored(
+    connection: 'client' | 'subscription'
+  ): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       const MAX_RETRIES = 4
       let counter = 0
       const intervalId = setInterval(() => {
-        const client = connectionStore[hostname]?.client
-        if (client != null) {
+        const host = connectionStore[hostname]
+        const hasReceivedAck =
+          connection === 'client'
+            ? host?.client != null
+            : host?.subscriptions[topic] > 0
+        if (hasReceivedAck) {
           clearInterval(intervalId)
-          new Promise<void>(() =>
-            client.subscribe(topic, subscribeOptions, subscribeCb)
-          )
-            .then(() => resolve())
-            .catch(() =>
-              reject(
-                new Error(
-                  `Maximum number of subscription retries reached for hostname: ${hostname}`
-                )
-              )
-            )
+          resolve()
         }
 
         counter++
         if (counter === MAX_RETRIES) {
           clearInterval(intervalId)
+          // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
+          sendToBrowserDeserialized({
+            browserWindow,
+            hostname,
+            topic,
+            message: FAILURE_STATUSES.ECONNFAILED,
+          })
           reject(
-            new Error(
-              `Maximum number of subscription retries reached for hostname: ${hostname}`
-            )
+            new Error(`Maximum subscription retries exceeded for ${hostname}.`)
           )
         }
       }, CHECK_CONNECTION_INTERVAL)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR reduces superfluous MQTT network traffic on the app side by keeping track of robots that have known blocked MQTT ports (or have an offline message broker). Currently, any time a new component wants to attempt subscription to a blocked host, a new MQTT connection handshake will occur or the component will wait for the handshake to complete if one is already in progress. This creates unnecessary network traffic and latency. 

Instead, keep track of blocked hosts for the app session, and if a host is known to be blocked, immediately tell the component attempting subscription to fallback to the old HTTP polling. This does not account for the edge case when an MQTT server that is blocked and becomes unblocked during the same app session, but the effort to make this work isn't worth the effort considering the connectivity logic will soon be shifted to discovery-client. Forcing the app to use HTTP polling for the remainder of the session is fine.

Although MQTT elegantly handles repeated subscriptions for the same topic, this outcome is not ideal, since it implies that we are sending unneeded traffic over the network. As we do for connection attempts, where we only let the first component that wants to use notifications to initiate a connection to the broker, let's do the exact same thing for subscriptions: only the first component that expresses interest in a topic initiates a subscription request. As with the connection logic, this means that all other components that want to subscribe to a topic while the connection manager is still negotiating the subscription will simply wait for the subscription to complete or timeout after 2 seconds.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- [x] Verified via Wireshark that the app isn't sending connection packets to known port blocked hosts. You can also search the logs for `Failed to connect to <hostname>` and confirm there's only one entry for the robot, even after you navigate away and back to that robot's device details page.
- [x] Successfully smoke tested all notification flows on the desktop app for the Flex (maintenance run flows and running a protocol with pauses, plays, etc). 
- [x] Successfully smoke tested all notification flows on the ODD for the Flex (maintenance run flows and running a protocol with pauses, plays, etc). 
- [x] Successfully smoke tested all notification flows on the desktop app for the OT-2 (maintenance run flows and running a protocol with pauses, plays, etc). 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
