### PR TITLE
fix(app-shell, app-shell-odd): Handle HTTP fallback during active subscription

### DIFF
--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -293,7 +293,6 @@ function handleDecrementSubscriptionCount(
 interface ListenerParams {
   client: mqtt.MqttClient
   browserWindow: BrowserWindow
-  topic: NotifyTopic
   hostname: string
 }
 
@@ -301,7 +300,6 @@ function establishListeners({
   client,
   browserWindow,
   hostname,
-  topic,
 }: ListenerParams): void {
   client.on(
     'message',
@@ -324,7 +322,7 @@ function establishListeners({
     sendToBrowserDeserialized({
       browserWindow,
       hostname,
-      topic,
+      topic: 'ALL_TOPICS',
       message: FAILURE_STATUSES.ECONNFAILED,
     })
     client.end()
@@ -335,13 +333,19 @@ function establishListeners({
     if (hostname in connectionStore) delete connectionStore[hostname]
   })
 
-  client.on('disconnect', packet =>
+  client.on('disconnect', packet => {
     log.warn(
       `Disconnected from ${hostname} with code ${
         packet.reasonCode ?? 'undefined'
       }`
     )
-  )
+    sendToBrowserDeserialized({
+      browserWindow,
+      hostname,
+      topic: 'ALL_TOPICS',
+      message: FAILURE_STATUSES.ECONNFAILED,
+    })
+  })
 }
 
 export function closeAllNotifyConnections(): Promise<unknown[]> {

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -45,7 +45,10 @@ export function appShellListener(
   remote.ipcRenderer.on(
     'notify',
     (_, shellHostname, shellTopic, shellMessage) => {
-      if (hostname === shellHostname && topic === shellTopic) {
+      if (
+        hostname === shellHostname &&
+        (topic === shellTopic || shellTopic === 'ALL_TOPICS')
+      ) {
         callback(shellMessage)
       }
     }

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -132,6 +132,7 @@ export interface RobotMassStorageDeviceRemoved {
 }
 
 export type NotifyTopic =
+  | 'ALL_TOPICS'
   | 'robot-server/maintenance_runs/current_run'
   | 'robot-server/runs/current_command'
   | 'robot-server/runs'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Currently, components know to fallback to HTTP if the broker is unresponsive during the initial connection/subscription request to the MQTT broker. However, there is no logic to handle the edge case of falling back to HTTP during an active subscription (the component successfully subscribes to a topic, but during the active subscription, the broker becomes unresponsive).

This PR implements the appropriate fallback logic by notifying all components subscribed to any topic that they should fallback to HTTP if the broker becomes unresponsive after successfully subscribing. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Start a protocol run on the Flex. [Here is my favorite protocol.](https://github.com/Opentrons/opentrons/files/14484080/GripperMoveTesting.py.zip)
- During the run ssh into the robot and verify the broker is running via `systemctl status mosquitto`.
- After confirming the broker is working, `systemctl stop mosquitto`.
- Verify that the current run step still successfully tracks steps on both the desktop app and ODD. (You can also verify this via the network tab -- polling for the active run command should occur). 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Notification fallback logic after successfully subscribing to the MQTT broker works properly. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->


# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
