### PR TITLE
feat(protocol-designer): add Opentrons Tough PCR plate as compatible …

### DIFF
--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -114,6 +114,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   [ALUMINUM_BLOCK_96_LOADNAME]: [
     'opentrons/biorad_96_wellplate_200ul_pcr/2',
     'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',
+    'opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2'
   ],
   [ALUMINUM_FLAT_BOTTOM_PLATE]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',
@@ -196,8 +197,7 @@ export const getAdapterLabwareIsAMatch = (
       draggedLabwareLoadname === 'corning_96_wellplate_360ul_flat')
   const aluminumBlock96Pairs =
     loadName === ALUMINUM_BLOCK_96_LOADNAME &&
-    (draggedLabwareLoadname === 'biorad_96_wellplate_200ul_pcr' ||
-      draggedLabwareLoadname === 'nest_96_wellplate_100ul_pcr_full_skirt')
+    pcrLabwares.includes(draggedLabwareLoadname)
   const aluminumFlatBottomPlatePairs =
     loadName === ALUMINUM_FLAT_BOTTOM_PLATE &&
     flatBottomLabwares.includes(draggedLabwareLoadname)

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -114,7 +114,7 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER: Record<
   [ALUMINUM_BLOCK_96_LOADNAME]: [
     'opentrons/biorad_96_wellplate_200ul_pcr/2',
     'opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2',
-    'opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2'
+    'opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2',
   ],
   [ALUMINUM_FLAT_BOTTOM_PLATE]: [
     'opentrons/corning_384_wellplate_112ul_flat/2',


### PR DESCRIPTION
…with aluminum block

closes [AUTH-53 ](https://opentrons.atlassian.net/browse/AUTH-53)

# Overview

A customer noticed that the 96 well aluminum block is only compatible with the biorad and NEST plates but not the Opentrons Tough 96 well plate. So this PR fixes that. Additionally, this plate is already supported in the labware definition so it should work in python already. 

<img width="448" alt="Screen Shot 2024-03-04 at 11 44 55 AM" src="https://github.com/Opentrons/opentrons/assets/66035149/cb0c5b00-8de1-493d-a1a8-2392fe012cba">

# Test Plan

Create a flex protocol. Add a temperature module and the gripper. On the temperature module, add the 96 well aluminum block under the adapter selection. Then on the deck, add the same aluminum block. Add the Opentrons tough plate on top of one of them. Then add a move labware step with the gripper to move the labware from one aluminum block to the other.

That should work as expected.

# Changelog

- add the opentrons tough plate as compatible with the 96 well aluminum block both with labware selection and moving the labware

# Review requests

see test plan

# Risk assessment

low