### PR TITLE
fix(api): preserve last_moved in retract

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1306,24 +1306,25 @@ class OT3API(
         Disengage the 96-channel and gripper mount if retracted. Re-engage
         the 96-channel or gripper mount if it is about to move.
         """
+        last_moved = self._last_moved_mount
         if self.is_idle_mount(mount):
             # home the left/gripper mount if it is current disengaged
             await self.home_z(mount)
 
-        if mount != self._last_moved_mount and self._last_moved_mount:
-            await self.retract(self._last_moved_mount, 10)
+        if mount != last_moved and last_moved:
+            await self.retract(last_moved, 10)
 
             # disengage Axis.Z_L motor and engage the brake to lower power
             # consumption and reduce the chance of the 96-channel pipette dropping
             if (
                 self.gantry_load == GantryLoad.HIGH_THROUGHPUT
-                and self._last_moved_mount == OT3Mount.LEFT
+                and last_moved == OT3Mount.LEFT
             ):
                 await self.disengage_axes([Axis.Z_L])
 
             # disegnage Axis.Z_G when we can to reduce the chance of
             # the gripper dropping
-            if self._last_moved_mount == OT3Mount.GRIPPER:
+            if last_moved == OT3Mount.GRIPPER:
                 await self.disengage_axes([Axis.Z_G])
 
         if mount != OT3Mount.GRIPPER:


### PR DESCRIPTION
8398c83a52e2d0f60dc5814d1e5984746e44e94c made a refactor to the way the hardware controller retracts the last-moved mount to get it out of the way when you change a move. This change allowed mounts that have electronic brakes to have those brakes engaged more often, lowring current consumption and heat generation. Unfortunately, it also introduced an issue in a specific code path.

If you have a 96 channel attached and you've been moving a mount that is not the left mount, so last_moved_mount is RIGHT or GRIPPER; and then you call `_cache_and_maybe_retract_mount(LEFT)`; then
- the left mount is idle, so we home it with home_z
- home_z clears _last_moved_mount
- there is now no mount to retract, and so it is not retracted

The fix for this is to copy last_moved_mount to a local so altering the cached value won't effect the rest of the method.

This fixes an issue where we use exactly this codepath: moving to maintenance position immediately after calibrating the gripper. _last_moved_mount is GRIPPER, but we always move the left mount to the maintenance position. This hits the problem. Any other codepath of this kind would also hit it.

This change should be strictly safer than the previous behavior.

Closes RABR-45, RQA-2380, RABR-23, RABR-24, RABR-25

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
