### PR TITLE
docs(api): section on Position Relative to Trash Containers

### DIFF
--- a/api/docs/v2/deck_slots.rst
+++ b/api/docs/v2/deck_slots.rst
@@ -149,9 +149,6 @@ Starting in API version 2.16, you must load trash bin fixtures in your protocol 
 
 .. versionadded:: 2.16
 
-.. note::
-    The :py:class:`.TrashBin` class doesn't have any callable methods, so you don't have to save the result of ``load_trash_bin()`` to a variable, especially if your protocol only loads a single trash container. Being able to reference the trash bin by name is useful when dealing with multiple trash containers.
-
 Call ``load_trash_bin()`` multiple times to add more than one bin. See :ref:`pipette-trash-containers` for more information on using pipettes with multiple trash bins.
 
 .. _configure-waste-chute:

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -123,9 +123,10 @@ You should only adjust labware offsets in your Python code if you plan to run yo
 Position Relative to Trash Containers
 =====================================
 
-In API version 2.15 and earlier, trash containers are :py:class:`.Labware` objects that have a single well. Use the above techniques for labware to adjust position relative to trash containers in protocols specifying these API versions.
+Movement to :py:class:`.TrashBin` or :py:class:`.WasteChute` objects is based on the horizontal *center* of the pipette. This is different than movement to labware, which is based on the primary channel (the back channel on 8-channel pipettes, and the back-left channel on 96-channel pipettes in default configuration). Using the center of the pipette ensures that all attached tips are over the trash container for blowing out, dropping tips, or other disposal operations.
 
-Starting in API version 2.16, trash containers are :py:class:`.TrashBin` or :py:class:`.WasteChute` objects. The API calculates movement to these objects based on the horizontal *center* of the pipette, rather than its primary channel (the back channel on 8-channel pipettes, and the back-left channel on 96-channel pipettes in default configuration). This ensures that all tips attached to the pipette are placed over the trash container for blowing out, dropping tips, or other operations.
+.. note::
+    In API version 2.15 and earlier, trash containers are :py:class:`.Labware` objects that have a single well. See :py:obj:`.fixed_trash` and :ref:`position-relative-labware` above.
 
 You can adjust the position of the pipette center with the :py:meth:`.TrashBin.top` and :py:meth:`.WasteChute.top` methods. These methods allow adjustments along the x-, y-, and z-axes. In contrast, ``Well.top()``, :ref:`covered above <well-top>`, only allows z-axis adjustment. With no adjustments, the "top" position is centered on the x- and y-axes and is just below the opening of the trash container.
 
@@ -140,8 +141,7 @@ You can adjust the position of the pipette center with the :py:meth:`.TrashBin.t
 
 .. versionadded:: 2.18
 
-.. note::
-    Another difference between the trash container ``top()`` methods and ``Well.top()`` is that they return an object of the same type, not a :py:class:`.Location`. This helps prevent performing undesired actions in trash containers. For example, you can :py:meth:`.aspirate` at a location or from a well, but not from a trash container. On the other hand, you can :py:meth:`.blow_out` at a location, well, trash bin, or waste chute.
+Another difference between the trash container ``top()`` methods and ``Well.top()`` is that they return an object of the same type, not a :py:class:`.Location`. This helps prevent performing undesired actions in trash containers. For example, you can :py:meth:`.aspirate` at a location or from a well, but not from a trash container. On the other hand, you can :py:meth:`.blow_out` at a location, well, trash bin, or waste chute.
 
 .. _protocol-api-deck-coords:
 

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -138,7 +138,7 @@ You can adjust the position of the pipette center with the :py:meth:`.TrashBin.t
     trash.top(z=10)  # 10 mm higher
     trash.top(y=10)  # 10 mm towards back, default height
 
-.. versionadded:: 2.16
+.. versionadded:: 2.18
 
 .. note::
     Another difference between the trash container ``top()`` methods and ``Well.top()`` is that they return an object of the same type, not a :py:class:`.Location`. This helps prevent performing undesired actions in trash containers. For example, you can :py:meth:`.aspirate` at a location or from a well, but not from a trash container. On the other hand, you can :py:meth:`.blow_out` at a location, well, trash bin, or waste chute.

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -140,16 +140,8 @@ You can adjust the position of the pipette center with the :py:meth:`.TrashBin.t
 
 .. versionadded:: 2.16
 
-Another difference between the trash container ``top()`` methods and ``Well.top()`` is that they return an object of the same type, not a :py:class:`.Location`. This means that you can use their output anywhere that accepts objects of those types.
-
-One example is the :py:obj:`.InstrumentContext.trash_container` property. Because this property is settable, if you always want to drop tips at an offset from the default location, you can overwrite the default for a given pipette::
-
-    chute = protocol.load_waste_chute()
-
-    pipette.trash_container = chute.top(z=-5)
-    pipette.pick_up_tip()
-    pipette.drop_tip()  # drop in waste chute, 5 mm lower than default
-
+.. note::
+    Another difference between the trash container ``top()`` methods and ``Well.top()`` is that they return an object of the same type, not a :py:class:`.Location`. This helps prevent performing undesired actions in trash containers. For example, you can :py:meth:`.aspirate` at a location or from a well, but not from a trash container. On the other hand, you can :py:meth:`.blow_out` at a location, well, trash bin, or waste chute.
 
 .. _protocol-api-deck-coords:
 

--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -21,6 +21,8 @@ Top, Bottom, and Center
 
 Every well on every piece of labware has three addressable positions: top, bottom, and center. The position is determined by the labware definition and what the labware is loaded on top of. You can use these positions as-is or calculate other positions relative to them.
 
+.. _well-top:
+
 Top
 ^^^^
 
@@ -115,6 +117,39 @@ Using Labware Position Check
 All positions relative to labware are adjusted automatically based on labware offset data. Calculate labware offsets by running Labware Position Check during protocol setup, either in the Opentrons App or on the Flex touchscreen. Version 6.0.0 and later of the robot software can apply previously calculated offsets on the same robot for the same labware type and deck slot, even across different protocols.
 
 You should only adjust labware offsets in your Python code if you plan to run your protocol in Jupyter Notebook or from the command line. See :ref:`using_lpc` in the Advanced Control article for information.
+
+.. _position-relative-trash:
+
+Position Relative to Trash Containers
+=====================================
+
+In API version 2.15 and earlier, trash containers are :py:class:`.Labware` objects that have a single well. Use the above techniques for labware to adjust position relative to trash containers in protocols specifying these API versions.
+
+Starting in API version 2.16, trash containers are :py:class:`.TrashBin` or :py:class:`.WasteChute` objects. The API calculates movement to these objects based on the horizontal *center* of the pipette, rather than its primary channel (the back channel on 8-channel pipettes, and the back-left channel on 96-channel pipettes in default configuration). This ensures that all tips attached to the pipette are placed over the trash container for blowing out, dropping tips, or other operations.
+
+You can adjust the position of the pipette center with the :py:meth:`.TrashBin.top` and :py:meth:`.WasteChute.top` methods. These methods allow adjustments along the x-, y-, and z-axes. In contrast, ``Well.top()``, :ref:`covered above <well-top>`, only allows z-axis adjustment. With no adjustments, the "top" position is centered on the x- and y-axes and is just below the opening of the trash container.
+
+.. code-block:: python
+
+    trash = protocol.load_trash_bin("A3")
+
+    trash  # pipette center just below trash top center
+    trash.top()  # same position
+    trash.top(z=10)  # 10 mm higher
+    trash.top(y=10)  # 10 mm towards back, default height
+
+.. versionadded:: 2.16
+
+Another difference between the trash container ``top()`` methods and ``Well.top()`` is that they return an object of the same type, not a :py:class:`.Location`. This means that you can use their output anywhere that accepts objects of those types.
+
+One example is the :py:obj:`.InstrumentContext.trash_container` property. Because this property is settable, if you always want to drop tips at an offset from the default location, you can overwrite the default for a given pipette::
+
+    chute = protocol.load_waste_chute()
+
+    pipette.trash_container = chute.top(z=-5)
+    pipette.pick_up_tip()
+    pipette.drop_tip()  # drop in waste chute, 5 mm lower than default
+
 
 .. _protocol-api-deck-coords:
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -327,6 +327,9 @@ class InstrumentContext(publisher.CommandPublisher):
                             liquid aspirated into the pipette will be dispensed (the
                             amount is accessible through :py:attr:`current_volume`).
 
+            .. versionchanged:: 2.18
+                Accepts ``TrashBin`` and ``WasteChute`` values.
+
         :param rate: How quickly a pipette dispenses liquid. The speed in µL/s is
                      calculated as ``rate`` multiplied by :py:attr:`flow_rate.dispense
                      <flow_rate>`. If not specified, defaults to 1.0. See
@@ -551,6 +554,9 @@ class InstrumentContext(publisher.CommandPublisher):
                               without first calling a method that takes a location, like
                               :py:meth:`.aspirate` or :py:meth:`dispense`.
         :returns: This instance.
+
+        .. versionchanged:: 2.18
+            The ``location`` parameter accepts ``TrashBin`` and ``WasteChute`` values.
         """
         well: Optional[labware.Well] = None
         move_to_location: types.Location
@@ -1015,6 +1021,9 @@ class InstrumentContext(publisher.CommandPublisher):
             position.
 
         :returns: This instance.
+
+        .. versionchanged:: 2.18
+            The ``location`` parameter accepts ``TrashBin`` and ``WasteChute`` values.
         """
         alternate_drop_location: bool = False
         if location is None:
@@ -1445,6 +1454,9 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param publish: Whether to list this function call in the run preview.
                         Default is ``True``.
+
+        .. versionchanged:: 2.18
+            The ``location`` parameter accepts ``TrashBin`` and ``WasteChute`` values.
         """
         with ExitStack() as contexts:
             if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -331,7 +331,7 @@ class InstrumentContext(publisher.CommandPublisher):
                             liquid aspirated into the pipette will be dispensed (the
                             amount is accessible through :py:attr:`current_volume`).
 
-            .. versionchanged:: 2.18
+            .. versionchanged:: 2.16
                 Accepts ``TrashBin`` and ``WasteChute`` values.
 
         :param rate: How quickly a pipette dispenses liquid. The speed in µL/s is
@@ -552,7 +552,7 @@ class InstrumentContext(publisher.CommandPublisher):
         :param location: The blowout location. If no location is specified, the pipette
             will blow out from its current position.
 
-            .. versionchanged:: 2.18
+            .. versionchanged:: 2.16
                 Accepts ``TrashBin`` and ``WasteChute`` values.
 
         :type location: :py:class:`.Well` or :py:class:`.Location` or ``None``
@@ -1444,7 +1444,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param location: Where to move to.
 
-          .. versionchanged:: 2.18
+          .. versionchanged:: 2.16
                Accepts ``TrashBin`` and ``WasteChute`` values.
 
         :type location: :py:class:`~.types.Location`

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -546,7 +546,11 @@ class InstrumentContext(publisher.CommandPublisher):
         :ref:`blow-out`.
 
         :param location: The blowout location. If no location is specified, the pipette
-                         will blow out from its current position.
+            will blow out from its current position.
+
+            .. versionchanged:: 2.18
+                Accepts ``TrashBin`` and ``WasteChute`` values.
+
         :type location: :py:class:`.Well` or :py:class:`.Location` or ``None``
 
         :raises RuntimeError: If no location is specified and the location cache is
@@ -554,9 +558,6 @@ class InstrumentContext(publisher.CommandPublisher):
                               without first calling a method that takes a location, like
                               :py:meth:`.aspirate` or :py:meth:`dispense`.
         :returns: This instance.
-
-        .. versionchanged:: 2.18
-            The ``location`` parameter accepts ``TrashBin`` and ``WasteChute`` values.
         """
         well: Optional[labware.Well] = None
         move_to_location: types.Location
@@ -1009,7 +1010,11 @@ class InstrumentContext(publisher.CommandPublisher):
               ``pipette.drop_tip(location=waste_chute)``.
 
         :param location:
-            The location to drop the tip.
+            Where to drop the tip.
+
+            .. versionchanged:: 2.16
+                Accepts ``TrashBin`` and ``WasteChute`` values.
+
         :type location:
             :py:class:`~.types.Location` or :py:class:`.Well` or ``None``
         :param home_after:
@@ -1021,9 +1026,6 @@ class InstrumentContext(publisher.CommandPublisher):
             position.
 
         :returns: This instance.
-
-        .. versionchanged:: 2.18
-            The ``location`` parameter accepts ``TrashBin`` and ``WasteChute`` values.
         """
         alternate_drop_location: bool = False
         if location is None:
@@ -1436,7 +1438,11 @@ class InstrumentContext(publisher.CommandPublisher):
 
         See :ref:`move-to` for examples.
 
-        :param location: The location to move to.
+        :param location: Where to move to.
+
+          .. versionchanged:: 2.18
+               Accepts ``TrashBin`` and ``WasteChute`` values.
+
         :type location: :py:class:`~.types.Location`
         :param force_direct: If ``True``, move directly to the destination without arc
                              motion.
@@ -1454,9 +1460,6 @@ class InstrumentContext(publisher.CommandPublisher):
 
         :param publish: Whether to list this function call in the run preview.
                         Default is ``True``.
-
-        .. versionchanged:: 2.18
-            The ``location`` parameter accepts ``TrashBin`` and ``WasteChute`` values.
         """
         with ExitStack() as contexts:
             if isinstance(location, (TrashBin, WasteChute)):

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -306,21 +306,25 @@ class InstrumentContext(publisher.CommandPublisher):
         :type volume: int or float
 
         :param location: Tells the robot where to dispense liquid held in the pipette.
-                         The location can be a :py:class:`.Well`, :py:class:`.Location`,
-                         :py:class:`.TrashBin`, or :py:class:`.WasteChute`.
+            The location can be a :py:class:`.Well`, :py:class:`.Location`,
+            :py:class:`.TrashBin`, or :py:class:`.WasteChute`.
 
-                            - If the location is a ``Well``, the pipette will dispense
+                            - If a ``Well``, the pipette will dispense
                               at or above the bottom center of the well. The distance (in
                               mm) from the well bottom is specified by
                               :py:obj:`well_bottom_clearance.dispense
                               <well_bottom_clearance>`.
 
-                            - If the location is a ``Location`` (e.g., the result of
-                              :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the robot
-                              will dispense into that specified position.
+                            - If a ``Location`` (e.g., the result of
+                              :py:meth:`.Well.top` or :py:meth:`.Well.bottom`), the pipette
+                              will dispense at that specified position.
 
-                            - If the ``location`` is unspecified, the robot will
-                              dispense into its current position.
+                            - If a trash container, the pipette will dispense at a location
+                              relative to its center and the trash container's top center.
+                              See :ref:`position-relative-trash` for details.
+
+                            - If unspecified, the pipette will
+                              dispense at its current position.
 
                             If only a ``location`` is passed (e.g.,
                             ``pipette.dispense(location=plate['A1'])``), all of the

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -306,8 +306,8 @@ class InstrumentContext(publisher.CommandPublisher):
         :type volume: int or float
 
         :param location: Tells the robot where to dispense liquid held in the pipette.
-                         The location can be a :py:class:`.Well` or a
-                         :py:class:`.Location`.
+                         The location can be a :py:class:`.Well`, :py:class:`.Location`,
+                         :py:class:`.TrashBin`, or :py:class:`.WasteChute`.
 
                             - If the location is a ``Well``, the pipette will dispense
                               at or above the bottom center of the well. The distance (in


### PR DESCRIPTION
# Overview

Follow up to further explain behavior introduced in #14560.

Addresses RTC-400.

# Test Plan

- [sandbox](http://sandbox.docs.opentrons.com/docs-trash-offsets/v2/robot_position.html#position-relative-to-trash-containers)
- simulated snippets in 2.16 / `edge`

# Changelog

- new § on Labware and Deck Positions page
- updated description and example for `move_to()` to cover new acceptable `location`s
- version added statements for `TrashBin`, `WasteChute`, and their methods in API Reference 

# Review requests

- double check code snippets. not only simulate, but do what i say they do?
- confirm version added for the methods. it feels like we may need to gate this to 2.17, because otherwise there will be a big functionality gap between robot system 7.1 (which can't do any of this) and 7.2 (which can). the classes are unambiguously _New in version 2.16._

# Risk assessment

low…but see API version gate caveat above.