### PR TITLE
fix(api): FLEX fast home collision hangs because of deadlock

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1542,7 +1542,7 @@ class OT3API(
                     self._log.warning(
                         f"Stall on {axis} during fast home, encoder may have missed an overflow"
                     )
-                    await self.refresh_positions()
+                    await self.refresh_positions(acquire_lock=False)
 
             await self._backend.home([axis], self.gantry_load)
         else:


### PR DESCRIPTION
RQA-2312

# Overview
When a stall happens during a FLEX fast home move, it tries to acquire the motion lock while trying to refresh position - while it already has the lock and causes the robot to hang. 
