### PR TITLE
chore: current version numbers in Python API docs

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -99,7 +99,7 @@ extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 # use rst_prolog to hold the subsitution
 # update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: 2.16
+.. |apiLevel| replace:: 2.17
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -68,7 +68,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software (7.1.0) support the following version ranges: 
+Opentrons robots running the latest software (7.2.0) support the following version ranges: 
 
     * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.


### PR DESCRIPTION
# Overview

Well, we deliberately [changed our setup](https://github.com/Opentrons/opentrons/pull/13991) so we'd err on the side of caution and have to update the `|apiLevel|` substitution value manually.

So naturally, I erred and forgot to bump it to 2.17 before publishing `docs@2.17`. This fixes that and a mention of the latest robot system version.

# Test Plan

[box of sand](http://sandbox.docs.opentrons.com/docs-go-to-2.17-for-real/v2/versioning.html#maximum-supported-versions)

# Changelog

🆙 

# Review requests

While we're at it, do we want to validate the tutorial scripts against 2.17 and bump all those numbers as well? Or happy to leave them on 2.16 for the time being?

# Risk assessment

zippo