### PR TITLE
feat(shared-data): create util so FE apps can access pip schema v2 defs 

### DIFF
--- a/shared-data/js/__tests__/pipettes.test.ts
+++ b/shared-data/js/__tests__/pipettes.test.ts
@@ -1,7 +1,11 @@
 // tests for pipette info accessors in `shared-data/js/pipettes.js`
 import { describe, expect, it } from 'vitest'
-import { getPipetteSpecsV2, PipetteV2LiquidSpecs, PipetteV2Specs } from '..'
-import { getPipetteNameSpecs, getPipetteModelSpecs } from '../pipettes'
+import {
+  getPipetteSpecsV2,
+  getPipetteNameSpecs,
+  getPipetteModelSpecs,
+} from '../pipettes'
+import type { PipetteV2LiquidSpecs, PipetteV2Specs } from '../types'
 
 const PIPETTE_NAMES = [
   'p10_single',

--- a/shared-data/js/__tests__/pipettes.test.ts
+++ b/shared-data/js/__tests__/pipettes.test.ts
@@ -1,5 +1,6 @@
 // tests for pipette info accessors in `shared-data/js/pipettes.js`
 import { describe, expect, it } from 'vitest'
+import { getPipetteSpecsV2, PipetteV2LiquidSpecs, PipetteV2Specs } from '..'
 import { getPipetteNameSpecs, getPipetteModelSpecs } from '../pipettes'
 
 const PIPETTE_NAMES = [
@@ -54,6 +55,182 @@ describe('pipette data accessors', () => {
     PIPETTE_MODELS.forEach(model =>
       it(`model ${model} snapshot`, () =>
         expect(getPipetteModelSpecs(model)).toMatchSnapshot())
+    )
+  })
+
+  describe('getPipetteSpecsV2', () => {
+    it('returns the correct info for p1000_single_flex', () => {
+      const mockP1000Specs = {
+        $otSharedSchema: '#/pipette/schemas/2/pipetteGeometrySchema.json',
+        availableSensors: {
+          sensors: ['pressure', 'capacitive', 'environment'],
+          capacitive: { count: 1 },
+          environment: { count: 1 },
+          pressure: { count: 1 },
+        },
+        backCompatNames: [],
+        backlashDistance: 0.1,
+        channels: 1,
+        displayCategory: 'FLEX',
+        displayName: 'Flex 1-Channel 1000 μL',
+        dropTipConfigurations: { plungerEject: { current: 1, speed: 10 } },
+        liquids: {
+          default: {
+            $otSharedSchema:
+              '#/pipette/schemas/2/pipetteLiquidPropertiesSchema.json',
+            defaultTipOverlapDictionary: {
+              default: 10.5,
+              'opentrons/opentrons_flex_96_tiprack_1000ul/1': 10.5,
+              'opentrons/opentrons_flex_96_tiprack_200ul/1': 10.5,
+              'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.5,
+            },
+            defaultTipracks: [
+              'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+              'opentrons/opentrons_flex_96_tiprack_200ul/1',
+              'opentrons/opentrons_flex_96_tiprack_50ul/1',
+            ],
+            minVolume: 5,
+            maxVolume: 1000,
+            supportedTips: expect.anything(),
+          },
+        },
+        model: 'p1000',
+        nozzleMap: expect.anything(),
+        pathTo3D:
+          'pipette/definitions/2/geometry/single_channel/p1000/placeholder.gltf',
+        pickUpTipConfigurations: {
+          pressFit: {
+            speedByTipCount: expect.anything(),
+            presses: 1,
+            increment: 0,
+            distanceByTipCount: expect.anything(),
+            currentByTipCount: expect.anything(),
+          },
+        },
+        partialTipConfigurations: {
+          availableConfigurations: null,
+          partialTipSupported: false,
+        },
+        plungerHomingConfigurations: { current: 1, speed: 30 },
+        plungerMotorConfigurations: { idle: 0.3, run: 1 },
+        plungerPositionsConfigurations: {
+          default: { blowout: 76.5, bottom: 71.5, drop: 90.5, top: 0.5 },
+        },
+        quirks: [],
+        shaftDiameter: 4.5,
+        shaftULperMM: 15.904,
+        nozzleOffset: [-8, -22, -259.15],
+        orderedColumns: expect.anything(),
+        orderedRows: expect.anything(),
+        pipetteBoundingBoxOffsets: {
+          backLeftCorner: [-8, -22, -259.15],
+          frontRightCorner: [-8, -22, -259.15],
+        },
+      } as PipetteV2Specs
+      expect(getPipetteSpecsV2('p1000_single_flex')).toStrictEqual(
+        mockP1000Specs
+      )
+    })
+  })
+  it('returns the correct liquid info for a p50 pipette with default and lowVolume', () => {
+    const mockLiquidDefault = {
+      $otSharedSchema: '#/pipette/schemas/2/pipetteLiquidPropertiesSchema.json',
+      defaultTipOverlapDictionary: {
+        default: 10.5,
+        'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.5,
+      },
+      defaultTipracks: ['opentrons/opentrons_flex_96_tiprack_50ul/1'],
+      maxVolume: 50,
+      minVolume: 5,
+      supportedTips: {
+        t50: {
+          aspirate: {
+            default: {
+              1: expect.anything(),
+            },
+          },
+          defaultAspirateFlowRate: {
+            default: 35,
+            valuesByApiLevel: {
+              '2.14': 35,
+            },
+          },
+          defaultBlowOutFlowRate: {
+            default: 57,
+            valuesByApiLevel: {
+              '2.14': 57,
+            },
+          },
+          defaultDispenseFlowRate: {
+            default: 57,
+            valuesByApiLevel: {
+              '2.14': 57,
+            },
+          },
+          defaultFlowAcceleration: 1200,
+          defaultPushOutVolume: 2,
+          defaultReturnTipHeight: 0.71,
+          defaultTipLength: 57.9,
+          dispense: {
+            default: {
+              1: expect.anything(),
+            },
+          },
+        },
+      },
+    } as PipetteV2LiquidSpecs
+    const mockLiquidLowVolume = {
+      $otSharedSchema: '#/pipette/schemas/2/pipetteLiquidPropertiesSchema.json',
+      defaultTipOverlapDictionary: {
+        default: 10.5,
+        'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.5,
+      },
+      defaultTipracks: ['opentrons/opentrons_flex_96_tiprack_50ul/1'],
+      maxVolume: 30,
+      minVolume: 1,
+      supportedTips: {
+        t50: {
+          aspirate: {
+            default: {
+              1: expect.anything(),
+            },
+          },
+          defaultAspirateFlowRate: {
+            default: 35,
+            valuesByApiLevel: {
+              2.14: 35,
+            },
+          },
+          defaultBlowOutFlowRate: {
+            default: 57,
+            valuesByApiLevel: {
+              2.14: 57,
+            },
+          },
+          defaultDispenseFlowRate: {
+            default: 57,
+            valuesByApiLevel: {
+              2.14: 57,
+            },
+          },
+          defaultFlowAcceleration: 1200,
+          defaultPushOutVolume: 7,
+          defaultReturnTipHeight: 0.71,
+          defaultTipLength: 57.9,
+          dispense: {
+            default: {
+              1: expect.anything(),
+            },
+          },
+        },
+      },
+    } as PipetteV2LiquidSpecs
+    const mockLiquids: Record<string, PipetteV2LiquidSpecs> = {
+      default: mockLiquidDefault,
+      lowVolumeDefault: mockLiquidLowVolume,
+    }
+    expect(getPipetteSpecsV2('p50_single_v3.5')?.liquids).toStrictEqual(
+      mockLiquids
     )
   })
 })

--- a/shared-data/js/__tests__/pipettes.test.ts
+++ b/shared-data/js/__tests__/pipettes.test.ts
@@ -137,13 +137,14 @@ describe('pipette data accessors', () => {
     })
   })
   it('returns the correct liquid info for a p50 pipette with default and lowVolume', () => {
+    const tiprack50uL = 'opentrons/opentrons_flex_96_tiprack_50ul/1'
     const mockLiquidDefault = {
       $otSharedSchema: '#/pipette/schemas/2/pipetteLiquidPropertiesSchema.json',
       defaultTipOverlapDictionary: {
         default: 10.5,
-        'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.5,
+        [tiprack50uL]: 10.5,
       },
-      defaultTipracks: ['opentrons/opentrons_flex_96_tiprack_50ul/1'],
+      defaultTipracks: [tiprack50uL],
       maxVolume: 50,
       minVolume: 5,
       supportedTips: {
@@ -187,9 +188,9 @@ describe('pipette data accessors', () => {
       $otSharedSchema: '#/pipette/schemas/2/pipetteLiquidPropertiesSchema.json',
       defaultTipOverlapDictionary: {
         default: 10.5,
-        'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.5,
+        [tiprack50uL]: 10.5,
       },
-      defaultTipracks: ['opentrons/opentrons_flex_96_tiprack_50ul/1'],
+      defaultTipracks: [tiprack50uL],
       maxVolume: 30,
       minVolume: 1,
       supportedTips: {

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -171,13 +171,19 @@ export const getPipetteSpecsV2 = (
   const gen = getVersionFromGen(nameSplit[2] as Gen)
 
   let version: string
-  if (nameSplit.length === 2) {
+  if (channels === 'ninety_six_channel' && nameSplit.length === 2) {
+    version = '3_0' //  special-casing p1000_96
+  } else if (channels !== 'ninety_six_channel' && nameSplit.length === 2) {
     version = '1_0'
   } else if (gen != null) {
     version = gen //  ex: gen1 -> 1_0
   } else {
-    const versionDot = nameSplit[2].split('v')[1]
-    version = versionDot.replace('.', '_') // ex: v1.1 -> 1_1
+    const versionNumber = nameSplit[2].split('v')[1]
+    if (versionNumber.includes('.')) {
+      version = versionNumber.replace('.', '_') // ex: v1.0 -> 1_0
+    } else {
+      version = `${versionNumber}_0` //  ex: v1 -> 1_0
+    }
   }
 
   const generalGeometricMatchingJsons = Object.entries(generalGeometric).reduce(

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -15,7 +15,7 @@ const generalGeometric = import.meta.glob(
   { eager: true }
 )
 const liquid = import.meta.glob(
-  '../pipette/definitions/2/liquid/*/*/default/*.json',
+  '../pipette/definitions/2/liquid/*/*/*/*.json',
   { eager: true }
 )
 
@@ -160,7 +160,8 @@ or PipetteModel such as 'p300_single_v1.3' and converts it to channels,
 model, and version from generation in order to return the correct pipette schema v2 json files. 
 **/
 export const getPipetteSpecsV2 = (
-  name: PipetteName | PipetteModel
+  name: PipetteName | PipetteModel,
+  lowVolume: boolean
 ): PipetteV2Specs | null => {
   const nameSplit = name.split('_')
   const pipetteModel = nameSplit[0] // ex: p300
@@ -181,6 +182,7 @@ export const getPipetteSpecsV2 = (
     ...liquid,
   }
   const allJsons = Object.keys(combinedGlobs).map(path => combinedGlobs[path])
+  const liquidPath = lowVolume ? 'lowVolumeDefault' : 'default'
 
   const matchingJsons = allJsons.reduce(
     //  NOTE: combinedModules = array of 3 jsons, module = 1 json
@@ -192,7 +194,7 @@ export const getPipetteSpecsV2 = (
             `../pipette/definitions/2/${type}/${channels}/${pipetteModel}/${version}.json` ===
               path) ||
           (type === 'liquid' &&
-            `../pipette/definitions/2/liquid/${channels}/${pipetteModel}/default/${version}.json` ===
+            `../pipette/definitions/2/liquid/${channels}/${pipetteModel}/${liquidPath}/${version}.json` ===
               path)
         ) {
           combinedModules.push(module.default)

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -171,18 +171,18 @@ export const getPipetteSpecsV2 = (
   const gen = getVersionFromGen(nameSplit[2] as Gen)
 
   let version: string
-  if (channels === 'ninety_six_channel' && nameSplit.length === 2) {
-    version = '3_0' //  special-casing p1000_96
-  } else if (channels !== 'ninety_six_channel' && nameSplit.length === 2) {
+  //  the first 2 conditions are to accommodate version from the pipetteName
+  if (nameSplit.length === 2) {
     version = '1_0'
   } else if (gen != null) {
     version = gen //  ex: gen1 -> 1_0
+    //  the 'else' is to accommodate the exact version if PipetteModel was added
   } else {
     const versionNumber = nameSplit[2].split('v')[1]
     if (versionNumber.includes('.')) {
-      version = versionNumber.replace('.', '_') // ex: v1.0 -> 1_0
+      version = versionNumber.replace('.', '_') // ex: 1.0 -> 1_0
     } else {
-      version = `${versionNumber}_0` //  ex: v1 -> 1_0
+      version = `${versionNumber}_0` //  ex: 1 -> 1_0
     }
   }
 

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -155,7 +155,6 @@ const getVersionFromGen = (gen: Gen): string | null => {
 }
 
 const V2_DEFINITION_TYPES = ['general', 'geometry']
-const LIQUID_TYPES = ['default', 'lowVolumeDefault']
 
 /* takes in pipetteName such as 'p300_single' or 'p300_single_gen1' 
 or PipetteModel such as 'p300_single_v1.3' and converts it to channels,
@@ -199,6 +198,7 @@ export const getPipetteSpecsV2 = (
     []
   )
   const generalGeometricCombined = Object.assign({}, ...matchingJsons)
+  const liquidTypes: string[] = []
 
   const liquidJsons = Object.keys(liquid).map(
     path => liquid[path]
@@ -207,7 +207,15 @@ export const getPipetteSpecsV2 = (
     //  NOTE: combinedModules = array of 2+ jsons, module = 1 json
     (combinedModules: PipetteV2LiquidSpecs[], module: LiquidSpecs, index) => {
       const path = Object.keys(liquid)[index]
-      LIQUID_TYPES.forEach(type => {
+
+      //  dynamically check the different liquid types and store unique types
+      //  into an array to parse through
+      const type = path.split('/')[7]
+      if (!liquidTypes.includes(type)) {
+        liquidTypes.push(type)
+      }
+
+      liquidTypes.forEach(type => {
         if (
           `../pipette/definitions/2/liquid/${channels}/${pipetteModel}/${type}/${version}.json` ===
           path
@@ -226,7 +234,7 @@ export const getPipetteSpecsV2 = (
 
   for (const [key, value] of Object.entries(liquidMatchingJsons)) {
     const index = Number(key)
-    const newKeyName = LIQUID_TYPES[index] || key
+    const newKeyName = liquidTypes[index] || key
     liquidMatchingJsonsGrouped.liquids[newKeyName] = value
   }
 

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -158,7 +158,7 @@ const V2_DEFINITION_TYPES = ['general', 'geometry']
 
 /* takes in pipetteName such as 'p300_single' or 'p300_single_gen1' 
 or PipetteModel such as 'p300_single_v1.3' and converts it to channels,
-model, and version from generation in order to return the correct pipette schema v2 json files. 
+model, and version in order to return the correct pipette schema v2 json files. 
 **/
 export const getPipetteSpecsV2 = (
   name: PipetteName | PipetteModel
@@ -181,8 +181,9 @@ export const getPipetteSpecsV2 = (
   const generalGeometricJsons = Object.keys(generalGeometric).map(
     path => generalGeometric[path]
   ) as ModuleSpecs[]
+
+  //  matchingJsons retuns an array of 2 jsons for general and geometric
   const matchingJsons = generalGeometricJsons.reduce(
-    //  NOTE: combinedModules = array of 2 jsons, module = 1 json
     (combinedModules: CombinedModules[], module: ModuleSpecs, index) => {
       const path = Object.keys(generalGeometric)[index]
       V2_DEFINITION_TYPES.forEach(type => {
@@ -203,8 +204,9 @@ export const getPipetteSpecsV2 = (
   const liquidJsons = Object.keys(liquid).map(
     path => liquid[path]
   ) as LiquidSpecs[]
+
+  //  liquidMatchingJsons returns an array of all liquid definition jsons
   const liquidMatchingJsons = liquidJsons.reduce(
-    //  NOTE: combinedModules = array of 2+ jsons, module = 1 json
     (combinedModules: PipetteV2LiquidSpecs[], module: LiquidSpecs, index) => {
       const path = Object.keys(liquid)[index]
 

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -196,7 +196,6 @@ export const getPipetteSpecsV2 = (
   )
 
   const liquidTypes: string[] = []
-  //  liquidMatchingJsons retuns liquid (default, lowVolume) jsons in a record
   const liquidMatchingJsons: {
     liquids: Record<string, PipetteV2LiquidSpecs>
   } = { liquids: {} }

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -22,6 +22,7 @@ const liquid = import.meta.glob(
 type PipChannelString = 'single' | 'multi' | '96'
 type Channels = 'eight_channel' | 'single_channel' | 'ninety_six_channel'
 type Gen = 'gen1' | 'gen2' | 'gen3' | 'flex'
+
 type CombinedModules =
   | PipetteV2GeneralSpecs
   | PipetteV2GeometrySpecs
@@ -160,7 +161,6 @@ model, and version from generation in order to return the correct pipette schema
 **/
 export const getPipetteSpecsV2 = (
   name: PipetteName | PipetteModel
-  //  TODO: make type, do not type as any
 ): PipetteV2Specs | null => {
   const nameSplit = name.split('_')
   const pipetteModel = nameSplit[0] // ex: p300
@@ -183,7 +183,7 @@ export const getPipetteSpecsV2 = (
   const allJsons = Object.keys(combinedGlobs).map(path => combinedGlobs[path])
 
   const matchingJsons = allJsons.reduce(
-    //  combinedModules = array of 3 jsons, module = 1 json
+    //  NOTE: combinedModules = array of 3 jsons, module = 1 json
     (combinedModules: CombinedModules[], module: ModuleSpecs, index) => {
       const path = Object.keys(combinedGlobs)[index]
       V2_DEFINITION_TYPES.forEach(type => {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -463,9 +463,11 @@ export interface PipetteV2LiquidSpecs {
   defaultTipracks: string[]
 }
 
-export type PipetteV2Specs = PipetteV2GeneralSpecs &
-  PipetteV2GeometrySpecs &
-  PipetteV2LiquidSpecs
+type GenericAndGeometry = PipetteV2GeneralSpecs & PipetteV2GeometrySpecs
+
+export interface PipetteV2Specs extends GenericAndGeometry {
+  liquids: Record<string, PipetteV2LiquidSpecs>
+}
 
 export interface PipetteNameSpecs {
   name: string

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -447,6 +447,10 @@ export interface PipetteV2GeneralSpecs {
   }
 }
 
+interface NozzleInfo {
+  key: string
+  orderedNozzles: string[]
+}
 export interface PipetteV2GeometrySpecs {
   nozzleOffset: number[]
   pipetteBoundingBoxOffsets: {
@@ -454,8 +458,8 @@ export interface PipetteV2GeometrySpecs {
     frontRightCorner: number[]
   }
   pathTo3D: string
-  orderedRows: any
-  orderedColumns: any
+  orderedRows: Record<number, NozzleInfo>
+  orderedColumns: Record<number, NozzleInfo>
   nozzleMap: Record<string, number[]>
 }
 
@@ -500,9 +504,10 @@ export interface PipetteV2LiquidSpecs {
   defaultTipracks: string[]
 }
 
-type GenericAndGeometry = PipetteV2GeneralSpecs & PipetteV2GeometrySpecs
+export type GenericAndGeometrySpecs = PipetteV2GeneralSpecs &
+  PipetteV2GeometrySpecs
 
-export interface PipetteV2Specs extends GenericAndGeometry {
+export interface PipetteV2Specs extends GenericAndGeometrySpecs {
   $otSharedSchema: string
   liquids: Record<string, PipetteV2LiquidSpecs>
 }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -394,6 +394,69 @@ export interface FlowRateSpec {
   max: number
 }
 
+export interface PipetteV2Specs {
+  displayName: string
+  model: string
+  displayCategory: PipetteDisplayCategory
+  pickUpTipConfigurations: {
+    pressFit: {
+      speedByTipCount: any
+      presses: number
+      increment: number
+      distanceByTipcount: any
+      currentByTipCount: any
+    }
+  }
+  dropTipConfigurations: {
+    plungerEject: {
+      current: number
+      speed: number
+    }
+  }
+  plungerMotorConfigurations: {
+    idle: number
+    run: number
+  }
+  plungerPositionConfigurations: {
+    default: {
+      top: number
+      bottom: number
+      blowout: number
+      drop: number
+    }
+  }
+  availableSensors: {
+    sensors: string[]
+  }
+  partialTipConfigurations: {
+    partialTipSupported: boolean
+    availableConfigurations: number[]
+  }
+  channels: number
+  shaftDiameter: number
+  shaftULperMM: number
+  backCompatNames: string[]
+  backlashDistance: number
+  quirks: string[]
+  plungerHomingConfigurations: {
+    current: number
+    speed: number
+  }
+  nozzleOffset: number[]
+  pipetteBoundingBoxOffsets: {
+    backLeftCorner: number[]
+    frontRightCorner: []
+  }
+  pathTo3D: string
+  orderedRows: any
+  orderedColumns: any
+  nozzleMap: any
+  supportedTips: any
+  defaultTipOverlapDictonary: any
+  maxVolume: number
+  minVolume: number
+  defaultTipracks: string[]
+}
 export interface PipetteNameSpecs {
   name: string
   displayName: string

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -400,11 +400,11 @@ export interface PipetteV2GeneralSpecs {
   displayCategory: PipetteDisplayCategory
   pickUpTipConfigurations: {
     pressFit: {
-      speedByTipCount: any
+      speedByTipCount: Record<number, string>
       presses: number
       increment: number
-      distanceByTipcount: any
-      currentByTipCount: any
+      distanceByTipCount: Record<number, string>
+      currentByTipCount: Record<number, string>
     }
   }
   dropTipConfigurations: {
@@ -417,7 +417,7 @@ export interface PipetteV2GeneralSpecs {
     idle: number
     run: number
   }
-  plungerPositionConfigurations: {
+  plungerPositionsConfigurations: {
     default: {
       top: number
       bottom: number
@@ -427,10 +427,13 @@ export interface PipetteV2GeneralSpecs {
   }
   availableSensors: {
     sensors: string[]
+    capacitive?: { count: number }
+    environment?: { count: number }
+    pressure?: { count: number }
   }
   partialTipConfigurations: {
     partialTipSupported: boolean
-    availableConfigurations: number[]
+    availableConfigurations: number[] | null
   }
   channels: number
   shaftDiameter: number
@@ -448,16 +451,50 @@ export interface PipetteV2GeometrySpecs {
   nozzleOffset: number[]
   pipetteBoundingBoxOffsets: {
     backLeftCorner: number[]
-    frontRightCorner: []
+    frontRightCorner: number[]
   }
   pathTo3D: string
   orderedRows: any
   orderedColumns: any
-  nozzleMap: any
+  nozzleMap: Record<string, number[]>
 }
+
+type TipData = [number, number, number][]
+interface SupportedTips {
+  [tipType: string]: {
+    aspirate: {
+      default: {
+        1: TipData
+      }
+    }
+    defaultAspirateFlowRate: {
+      default: number
+      valuesByApiLevel: Record<string, number>
+    }
+    defaultBlowOutFlowRate: {
+      default: number
+      valuesByApiLevel: Record<string, number>
+    }
+    defaultDispenseFlowRate: {
+      default: number
+      valuesByApiLevel: Record<string, number>
+    }
+    defaultFlowAcceleration: number
+    defaultPushOutVolume: number
+    defaultReturnTipHeight: number
+    defaultTipLength: number
+    dispense: {
+      default: {
+        1: TipData
+      }
+    }
+  }
+}
+
 export interface PipetteV2LiquidSpecs {
-  supportedTips: any
-  defaultTipOverlapDictonary: any
+  $otSharedSchema: string
+  supportedTips: SupportedTips
+  defaultTipOverlapDictionary: Record<string, number>
   maxVolume: number
   minVolume: number
   defaultTipracks: string[]
@@ -466,6 +503,7 @@ export interface PipetteV2LiquidSpecs {
 type GenericAndGeometry = PipetteV2GeneralSpecs & PipetteV2GeometrySpecs
 
 export interface PipetteV2Specs extends GenericAndGeometry {
+  $otSharedSchema: string
   liquids: Record<string, PipetteV2LiquidSpecs>
 }
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -394,7 +394,7 @@ export interface FlowRateSpec {
   max: number
 }
 
-export interface PipetteV2Specs {
+export interface PipetteV2GeneralSpecs {
   displayName: string
   model: string
   displayCategory: PipetteDisplayCategory
@@ -442,6 +442,9 @@ export interface PipetteV2Specs {
     current: number
     speed: number
   }
+}
+
+export interface PipetteV2GeometrySpecs {
   nozzleOffset: number[]
   pipetteBoundingBoxOffsets: {
     backLeftCorner: number[]
@@ -451,12 +454,19 @@ export interface PipetteV2Specs {
   orderedRows: any
   orderedColumns: any
   nozzleMap: any
+}
+export interface PipetteV2LiquidSpecs {
   supportedTips: any
   defaultTipOverlapDictonary: any
   maxVolume: number
   minVolume: number
   defaultTipracks: string[]
 }
+
+export type PipetteV2Specs = PipetteV2GeneralSpecs &
+  PipetteV2GeometrySpecs &
+  PipetteV2LiquidSpecs
+
 export interface PipetteNameSpecs {
   name: string
   displayName: string

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -459,7 +459,7 @@ export interface PipetteV2GeometrySpecs {
   nozzleMap: Record<string, number[]>
 }
 
-type TipData = [number, number, number][]
+type TipData = [number, number, number]
 interface SupportedTips {
   [tipType: string]: {
     aspirate: {


### PR DESCRIPTION
closes AUTH-51

# Overview

This PR creates a new util for the FE apps to grab the pipette schema v2 definitions. There are some keys in the v2 definitions that PD will need to have access to (specifically bounding box and nozzle map). 

In a follow up PR, I am going to plug this new util into every instance of `getPipetteNameSpecs` in PD

# Test Plan

Review the util and types and test. 

If you want, find a place where `getPipetteNameSpecs` is being used and plug it in the new util and test it to see that it works as expected! A component i've been testing with is `PipetteTypeTile` and plugging `    console.log('pip specs', getPipetteSpecsV2(o.value))` into line 174 and checking that it logs correctly.

# Changelog

- create new types that match the json shapes
- create a new `getPipetteSpecsV2` util. It takes in the same props as `getPipetteNameSpecs` and `getPipetteModelSpecs` and parses out the matching pipette v2 definition file paths. Then it filters through all the json files in the given paths to return 3+ json files that match the pipetteName's specs. Finally, it combines the json files into 1, including all of the liquid files (default and low volume) and the utility returns that combined object.

# Review requests

see test plan

# Risk assessment

low