### PR TITLE
fix(api): simulate not logging drop_tip with no args

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1024,11 +1024,17 @@ class InstrumentContext(publisher.CommandPublisher):
             if isinstance(trash_container, labware.Labware):
                 well = trash_container.wells()[0]
             else:  # implicit drop tip in disposal location, not well
-                self._core.drop_tip_in_disposal_location(
-                    trash_container,
-                    home_after=home_after,
-                    alternate_tip_drop=True,
-                )
+                with publisher.publish_context(
+                    broker=self.broker,
+                    command=cmds.drop_tip_in_disposal_location(
+                        instrument=self, location=trash_container
+                    ),
+                ):
+                    self._core.drop_tip_in_disposal_location(
+                        trash_container,
+                        home_after=home_after,
+                        alternate_tip_drop=True,
+                    )
                 self._last_tip_picked_up_from = None
                 return self
 

--- a/api/tests/opentrons/data/ot2_drop_tip.py
+++ b/api/tests/opentrons/data/ot2_drop_tip.py
@@ -1,0 +1,11 @@
+from opentrons import protocol_api
+
+requirements = {"robotType": "OT-2", "apiLevel": "2.16"}
+
+
+def run(ctx: protocol_api.ProtocolContext) -> None:
+    tipracks = [ctx.load_labware("opentrons_96_tiprack_300ul", "5")]
+    m300 = ctx.load_instrument("p300_multi_gen2", "right", tipracks)
+
+    m300.pick_up_tip()
+    m300.drop_tip()

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -90,6 +90,13 @@ def test_simulate_without_filename(protocol: Protocol, protocol_file: str) -> No
                 "Dropping tip into H12 of Opentrons OT-2 96 Tip Rack 1000 µL on slot 1",
             ],
         ),
+        (
+            "ot2_drop_tip.py",
+            [
+                "Picking up tip from A1 of Opentrons OT-2 96 Tip Rack 300 µL on slot 5",
+                "Dropping tip into Trash Bin on slot 12",
+            ],
+        ),
     ],
 )
 def test_simulate_function_apiv2_run_log(


### PR DESCRIPTION


# Overview

Fixes [RESC-214](https://opentrons.atlassian.net/browse/RESC-214)

# Test Plan

- [x] Add simulate test that runs a protocol using `drop_tip` with no args

# Changelog

- Add publisher.publish_context context manager when calling drop tip with no args
- Add above test case to `test_simulate.py`

# Review requests

- It seems that the simulate drop tip functionality could benefit from more robust test coverage. Should make sure that we validate all branches inside of drop_tip. But is this PR the place to do it? 

# Risk assessment

Very low. Just added a message and a test


[RESC-214]: https://opentrons.atlassian.net/browse/RESC-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ