### PR TITLE
fix(robot-server): dont let /instruments block

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -431,7 +431,9 @@ class API(
         return False
 
     async def cache_instruments(
-        self, require: Optional[Dict[top_types.Mount, PipetteName]] = None
+        self,
+        require: Optional[Dict[top_types.Mount, PipetteName]] = None,
+        skip_if_would_block: bool = False,
     ) -> None:
         """
         Scan the attached instruments, take necessary configuration actions,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -653,12 +653,16 @@ class OT3API(
 
     # TODO (spp, 2023-01-31): add unit tests
     async def cache_instruments(
-        self, require: Optional[Dict[top_types.Mount, PipetteName]] = None
+        self,
+        require: Optional[Dict[top_types.Mount, PipetteName]] = None,
+        skip_if_would_block: bool = False,
     ) -> None:
         """
         Scan the attached instruments, take necessary configuration actions,
         and set up hardware controller internal state if necessary.
         """
+        if skip_if_would_block and self._motion_lock.locked():
+            return
         async with self._motion_lock:
             skip_configure = await self._cache_instruments(require)
             if not skip_configure or not self._configured_since_update:

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -28,6 +28,7 @@ class InstrumentConfigurer(Protocol[MountArgType]):
     async def cache_instruments(
         self,
         require: Optional[Dict[Mount, PipetteName]] = None,
+        skip_if_would_block: bool = False,
     ) -> None:
         """
         Scan the attached instruments, take necessary configuration actions,

--- a/robot-server/robot_server/instruments/router.py
+++ b/robot-server/robot_server/instruments/router.py
@@ -216,7 +216,7 @@ async def _get_attached_instruments_ot3(
     hardware: OT3HardwareControlAPI,
 ) -> PydanticResponse[SimpleMultiBody[AttachedItem]]:
     # OT3
-    await hardware.cache_instruments()
+    await hardware.cache_instruments(skip_if_would_block=True)
     response_data = await _get_instrument_data(hardware)
     return await PydanticResponse.create(
         content=SimpleMultiBody.construct(

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -121,7 +121,7 @@ async def test_get_all_attached_instruments(
         subsystem=SubSystem.pipette_right,
     )
 
-    async def rehearse_instrument_retrievals() -> None:
+    async def rehearse_instrument_retrievals(skip_if_would_block: bool = False) -> None:
         decoy.when(ot3_hardware_api.attached_gripper).then_return(
             cast(
                 GripperDict,
@@ -188,9 +188,9 @@ async def test_get_all_attached_instruments(
 
     # We use this convoluted way of testing to verify the important point that
     # cache_instruments is called before fetching attached pipette and gripper data.
-    decoy.when(await ot3_hardware_api.cache_instruments()).then_do(
-        rehearse_instrument_retrievals
-    )
+    decoy.when(
+        await ot3_hardware_api.cache_instruments(skip_if_would_block=True)
+    ).then_do(rehearse_instrument_retrievals)
     decoy.when(ot3_hardware_api.get_instrument_offset(mount=OT3Mount.LEFT)).then_return(
         PipetteOffsetSummary(
             offset=Point(1, 2, 3),


### PR DESCRIPTION
It calls cache_instruments and that can block because it takes the motion lock, but we really don't want that. We don't mind if cache_instruments doesn't get called on the flex because it's sort of a secondary functionality, so just bail early in this case.

## Testing
- Run on a robot and do some `GET /instruments` while things are homign and note that it instantly returns
- Do an attach flow and note that it still returns the new instruments.

Closes EXEC-298
