### PR TITLE
chore(api): bump Python API version to 2.18 and tag new trash container methods

### DIFF
--- a/api/docs/v2/new_protocol_api.rst
+++ b/api/docs/v2/new_protocol_api.rst
@@ -35,10 +35,8 @@ Labware
    signatures, since users should never construct these directly.
 
 .. autoclass:: opentrons.protocol_api.TrashBin()
-   :members:
 
 .. autoclass:: opentrons.protocol_api.WasteChute()
-   :members:
 
 Wells and Liquids
 =================

--- a/api/src/opentrons/protocol_api/disposal_locations.py
+++ b/api/src/opentrons/protocol_api/disposal_locations.py
@@ -5,6 +5,7 @@ from typing_extensions import Protocol as TypingProtocol
 
 from opentrons.types import DeckSlotName
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import requires_version
 from opentrons.protocol_engine.clients import SyncClient
 
 
@@ -98,6 +99,7 @@ class TrashBin(_DisposalLocation):
         else:
             self._cutout_fixture_name = _TRASH_BIN_CUTOUT_FIXTURE
 
+    @requires_version(2, 18)
     def top(self, x: float = 0, y: float = 0, z: float = 0) -> TrashBin:
         """Add a location offset to a trash bin.
 
@@ -174,6 +176,7 @@ class WasteChute(_DisposalLocation):
         self._api_version = api_version
         self._offset = offset
 
+    @requires_version(2, 18)
     def top(self, x: float = 0, y: float = 0, z: float = 0) -> WasteChute:
         """Add a location offset to a waste chute.
 

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 17)
+MAX_SUPPORTED_VERSION = APIVersion(2, 18)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)


### PR DESCRIPTION
# Overview

It's time for Python API version 2.18! Trash container `top()` methods are the first features included in this version-in-progress.

# Test Plan

- [sandbox](http://sandbox.docs.opentrons.com/papi-2.18-in-edge-time/v2/new_protocol_api.html#opentrons.protocol_api.TrashBin)
- automated tests

# Changelog

- bump max supported version
- decorate trash container top methods
- hide those methods from API reference, for now. they will be _shown_ in #14593 and the 2.18 docs feature branch.

# Review requests

sensible? correct? well-timed?

# Risk assessment

v low. this version bump was coming sooner or later and shouldn't affect anything up through 2.17.