### PR TITLE
feat(api): remove z safety margin from pipette movement check

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -79,9 +79,6 @@ A1_column_back_right_bound = Point(
     x=A12_column_back_right_bound.x - _NOZZLE_PITCH * 11, y=506.2
 )
 
-# Arbitrary safety margin in z-direction
-Z_SAFETY_MARGIN = 10
-
 _FLEX_TC_LID_BACK_LEFT_PT = Point(
     x=FLEX_TC_LID_COLLISION_ZONE["back_left"]["x"],
     y=FLEX_TC_LID_COLLISION_ZONE["back_left"]["y"],
@@ -333,7 +330,7 @@ def _slot_has_potential_colliding_object(
             slot_highest_z = engine_state.geometry.get_highest_z_in_slot(
                 StagingSlotLocation(slotName=surrounding_slot)
             )
-        return slot_highest_z + Z_SAFETY_MARGIN > pipette_bounds[0].z
+        return slot_highest_z >= pipette_bounds[0].z
     return False
 
 

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1103,6 +1103,7 @@ class InstrumentContext(publisher.CommandPublisher):
         self._core.home_plunger()
         return self
 
+    # TODO (spp, 2024-03-08): verify if ok to & change source & dest types to AdvancedLiquidHandling
     @publisher.publish(command=cmds.distribute)
     @requires_version(2, 0)
     def distribute(
@@ -1142,6 +1143,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         return self.transfer(volume, source, dest, **kwargs)
 
+    # TODO (spp, 2024-03-08): verify if ok to & change source & dest types to AdvancedLiquidHandling
     @publisher.publish(command=cmds.consolidate)
     @requires_version(2, 0)
     def consolidate(


### PR DESCRIPTION
Closes RESC-216

# Overview

See the escalations ticket for more info.
Now that we use actual nozzle positions in movement conflict check, we shouldn't need to add such a big safety margin (10mm). We will prefer allowing the movement if it's in the realm of 'slight chance of collision'.

# Review requests

Added an integration test. Feel free to throw some tests at it that check for collisions when moving to places where a pipette goes very close to a surrounding labware but falls just short of actually touching it.

**Question: There is another way we can handle this and it's keeping the safety margin but making it low, like 2mm. Should we do that instead? See risk assessment for reason.**

# Risk assessment

Medium- low: there is a slight chance- due to equipment manufacturing tolerance that the pipette might touch/collide a deck item. 
