### PR TITLE
feat(api,robot-server): export notes on commands

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -20,6 +20,7 @@ from .commands import (
     CommandStatus,
     CommandType,
     CommandIntent,
+    CommandNote,
 )
 from .state import State, StateView, StateSummary, CommandSlice, CurrentCommand, Config
 from .plugins import AbstractPlugin
@@ -79,6 +80,7 @@ __all__ = [
     "CommandStatus",
     "CommandType",
     "CommandIntent",
+    "CommandNote",
     # state interfaces and models
     "State",
     "StateView",

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -28,6 +28,7 @@ from .command import (
     BaseCommandCreate,
     CommandStatus,
     CommandIntent,
+    CommandNote,
 )
 
 from .command_unions import (
@@ -332,6 +333,7 @@ __all__ = [
     "BaseCommandCreate",
     "CommandStatus",
     "CommandIntent",
+    "CommandNote",
     # command parameter hashing
     "hash_command_params",
     # command schema generation

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -14,6 +14,7 @@ from typing import (
     Tuple,
     Union,
     Literal,
+    List,
 )
 
 from pydantic import BaseModel, Field

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -175,6 +175,13 @@ class BaseCommand(GenericModel, Generic[CommandParamsT, CommandResultT]):
             " a command that is part of a calibration procedure."
         ),
     )
+    notes: Optional[List[CommandNote]] = Field(
+        None,
+        description=(
+            "Information not critical to the execution of the command derived from either"
+            " the command's execution or the command's generation."
+        ),
+    )
 
 
 class AbstractCommandImpl(

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -296,6 +296,7 @@ async def get_run_commands(
             completedAt=c.completedAt,
             params=c.params,
             error=c.error,
+            notes=c.notes,
         )
         for c in command_slice.commands
     ]

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine import (
     LabwareOffset,
     LabwareOffsetCreate,
     Liquid,
+    CommandNote,
 )
 from opentrons_shared_data.errors import GeneralError
 from robot_server.service.json_api import ResourceModel
@@ -55,6 +56,10 @@ class RunCommandSummary(ResourceModel):
     intent: Optional[CommandIntent] = Field(
         None,
         description="Why this command was added to the run.",
+    )
+    notes: Optional[List[CommandNote]] = Field(
+        None,
+        description="Notes pertaining to this command.",
     )
 
 

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -249,6 +249,24 @@ async def test_get_run_commands(
     decoy: Decoy, mock_run_data_manager: RunDataManager
 ) -> None:
     """It should return a list of all commands in a run."""
+    long_note = pe_commands.CommandNote(
+        noteKind="warning",
+        shortMessage="this is a warning.",
+        longMessage="""
+            hello, friends. I bring a warning....
+
+
+
+            FROM THE FUTURE!
+            """,
+        source="test",
+    )
+    unenumed_note = pe_commands.CommandNote(
+        noteKind="lahsdlasd",
+        shortMessage="Oh no",
+        longMessage="its a notekind not in the enum",
+        source="test2",
+    )
     command = pe_commands.WaitForResume(
         id="command-id",
         key="command-key",
@@ -264,6 +282,7 @@ async def test_get_run_commands(
             createdAt=datetime(year=2024, month=4, day=4),
             detail="Things are not looking good.",
         ),
+        notes=[long_note, unenumed_note],
     )
 
     decoy.when(mock_run_data_manager.get_current_command("run-id")).then_return(
@@ -306,6 +325,7 @@ async def test_get_run_commands(
                 createdAt=datetime(year=2024, month=4, day=4),
                 detail="Things are not looking good.",
             ),
+            notes=[long_note, unenumed_note],
         )
     ]
     assert result.content.meta == MultiBodyMeta(cursor=1, totalLength=3)

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -47,6 +47,7 @@ export interface CommonCommandRunTimeInfo {
   startedAt: string | null
   completedAt: string | null
   intent?: 'protocol' | 'setup'
+  notes?: CommandNote[] | null
 }
 export interface CommonCommandCreateInfo {
   key?: string


### PR DESCRIPTION
Commands in runs can have notes attached to them. Each command can have zero or more notes, and zero notes can be expressed as any of (notes=None, notes is-not-present, notes is empty-list). This is to make the public models a little more robust across versions.

Closes EXEC-288
