### PR TITLE
fix(app): capitalize "attach gripper" button in protocol setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupGripperCalibrationItem.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupGripperCalibrationItem.tsx
@@ -26,7 +26,7 @@ export function SetupGripperCalibrationItem({
   gripperData,
   runId,
 }: SetupGripperCalibrationItemProps): JSX.Element | null {
-  const { t } = useTranslation('protocol_setup')
+  const { t, i18n } = useTranslation('protocol_setup')
   const [
     openWizardFlowType,
     setOpenWizardFlowType,
@@ -47,7 +47,7 @@ export function SetupGripperCalibrationItem({
             setOpenWizardFlowType(GRIPPER_FLOW_TYPES.ATTACH)
           }}
         >
-          {t('attach_gripper')}
+          {i18n.format(t('attach_gripper'), 'capitalize')}
         </TertiaryButton>
       </Flex>
     )


### PR DESCRIPTION
# Overview
RQA-2496
This "attach gripper" button text wasn't capitalized.

![attach gripper lowercase](https://github.com/Opentrons/opentrons/assets/1958332/58ac2f28-716f-4ec4-b248-d4c6e1fe5d6a)

Now it is.

![attach gripper capitalized](https://github.com/Opentrons/opentrons/assets/1958332/349eefb4-2e90-4942-ba50-a4a37504d76c)

# Test Plan

1. `make -C app dev`
2. start a protocol run (on dev robot or HW with no gripper attached)
3. go to setup and expand Instruments accordion

- no unit tests for this component, it seems.

# Changelog

apply capitalization to the one string

# Review requests

should this go into the 7.2.1 branch? i can rebase and retarget.

# Risk assessment

v v low, it's a button