### PR TITLE
refactor(robot-server): Utilize unsubscribe flags for dynamic topics

### DIFF
--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -411,7 +411,7 @@ class RunStore:
             raise RunNotFoundError(run_id)
 
         self._clear_caches()
-        self._runs_publisher.publish_runs(run_id=run_id)
+        self._runs_publisher.publish_runs(run_id=run_id, should_unsubscribe=True)
 
     def _run_exists(
         self, run_id: str, connection: sqlalchemy.engine.Connection

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -129,7 +129,7 @@ class RunStore:
             action_rows = transaction.execute(select_actions).all()
 
         self._clear_caches()
-        self._runs_publisher.publish_runs(run_id=run_id)
+        self._runs_publisher.publish_runs_advise_refetch(run_id=run_id)
         return _convert_row_to_run(row=run_row, action_rows=action_rows)
 
     def insert_action(self, run_id: str, action: RunAction) -> None:
@@ -152,7 +152,7 @@ class RunStore:
             transaction.execute(insert)
 
         self._clear_caches()
-        self._runs_publisher.publish_runs(run_id=run_id)
+        self._runs_publisher.publish_runs_advise_refetch(run_id=run_id)
 
     def insert(
         self,
@@ -194,7 +194,7 @@ class RunStore:
                 raise ProtocolNotFoundError(protocol_id=run.protocol_id)
 
         self._clear_caches()
-        self._runs_publisher.publish_runs(run_id=run_id)
+        self._runs_publisher.publish_runs_advise_refetch(run_id=run_id)
         return run
 
     @lru_cache(maxsize=_CACHE_ENTRIES)
@@ -411,7 +411,7 @@ class RunStore:
             raise RunNotFoundError(run_id)
 
         self._clear_caches()
-        self._runs_publisher.publish_runs(run_id=run_id, should_unsubscribe=True)
+        self._runs_publisher.publish_runs_advise_unsubscribe(run_id=run_id)
 
     def _run_exists(
         self, run_id: str, connection: sqlalchemy.engine.Connection

--- a/robot-server/robot_server/service/json_api/__init__.py
+++ b/robot-server/robot_server/service/json_api/__init__.py
@@ -16,6 +16,7 @@ from .response import (
     PydanticResponse,
     ResponseList,
     NotifyRefetchBody,
+    NotifyUnsubscribeBody,
 )
 
 
@@ -46,4 +47,5 @@ __all__ = [
     "ResponseList",
     # notify models
     "NotifyRefetchBody",
+    "NotifyUnsubscribeBody",
 ]

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -293,7 +293,7 @@ class NotifyRefetchBody(BaseResponseBody):
 class NotifyUnsubscribeBody(BaseResponseBody):
     """A notification response.
 
-    Returns flags for refetching via HTTP and unsubscribing from a topic.
+    Returns flags for unsubscribing from a topic.
     """
 
-    refetchAndUnsubscribe: bool = True
+    unsubscribe: bool = True

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -288,3 +288,13 @@ class NotifyRefetchBody(BaseResponseBody):
     """A notification response that returns a flag for refetching via HTTP."""
 
     refetchUsingHTTP: bool = True
+
+
+class NotifyUnsubscribeBody(BaseResponseBody):
+    """A notification response.
+
+    Returns flags for refetching via HTTP and unsubscribing from a topic.
+    """
+
+    refetchUsingHTTP: bool = True
+    unsubscribe: bool = True

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -296,5 +296,4 @@ class NotifyUnsubscribeBody(BaseResponseBody):
     Returns flags for refetching via HTTP and unsubscribing from a topic.
     """
 
-    refetchUsingHTTP: bool = True
-    unsubscribe: bool = True
+    refetchAndUnsubscribe: bool = True

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -285,5 +285,6 @@ class ResponseList(BaseModel, Generic[ResponseDataT]):
 
 
 class NotifyRefetchBody(BaseResponseBody):
-    "A notification response that returns a flag for refetching via HTTP."
+    """A notification response that returns a flag for refetching via HTTP."""
+
     refetchUsingHTTP: bool = True

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -78,7 +78,7 @@ class NotificationClient:
         await to_thread.run_sync(self.client.disconnect)
 
     async def publish_async(
-        self, topic: str, message: NotifyRefetchBody = NotifyRefetchBody()
+        self, topic: str, message: NotifyRefetchBody = NotifyRefetchBody.construct()
     ) -> None:
         """Asynchronously Publish a message on a specific topic to the MQTT broker.
 
@@ -89,7 +89,7 @@ class NotificationClient:
         await to_thread.run_sync(self.publish, topic, message)
 
     def publish(
-        self, topic: str, message: NotifyRefetchBody = NotifyRefetchBody()
+        self, topic: str, message: NotifyRefetchBody = NotifyRefetchBody.construct()
     ) -> None:
         """Publish a message on a specific topic to the MQTT broker.
 

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -3,7 +3,7 @@ import logging
 import paho.mqtt.client as mqtt
 from anyio import to_thread
 from fastapi import Depends
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 from enum import Enum
 
 from ..json_api import NotifyRefetchBody, NotifyUnsubscribeBody

--- a/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
@@ -20,7 +20,9 @@ class MaintenanceRunsPublisher:
         self,
     ) -> None:
         """Publishes the equivalent of GET /maintenance_run/current_run"""
-        await self._client.publish_async(topic=Topics.MAINTENANCE_RUNS_CURRENT_RUN)
+        await self._client.publish_advise_refetch_async(
+            topic=Topics.MAINTENANCE_RUNS_CURRENT_RUN
+        )
 
 
 _maintenance_runs_publisher_accessor: AppStateAccessor[

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -1,5 +1,6 @@
 from fastapi import Depends
 import asyncio
+import logging
 from typing import Union, Callable, Optional
 
 from opentrons.protocol_engine import CurrentCommand, StateSummary, EngineStatus
@@ -11,6 +12,9 @@ from server_utils.fastapi_utils.app_state import (
 )
 from ..notification_client import NotificationClient, get_notification_client
 from ..topics import Topics
+
+
+log: logging.Logger = logging.getLogger(__name__)
 
 
 class RunsPublisher:
@@ -106,6 +110,8 @@ class RunsPublisher:
             self._clean_up_poller()
             await self._publish_runs_async(run_id=run_id, should_unsubscribe=True)
             await self._client.publish_async(topic=Topics.RUNS_CURRENT_COMMAND)
+        except Exception as e:
+            log.error(f"Error within run data manager poller: {e}")
 
     async def _publish_current_command(
         self,

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -66,14 +66,17 @@ class RunsPublisher:
             self._previous_state_summary_status = None
             await self._client.publish_async(topic=Topics.RUNS_CURRENT_COMMAND)
 
-    def publish_runs(self, run_id: str) -> None:
+    def publish_runs(self, run_id: str, should_unsubscribe: bool = False) -> None:
         """Publishes the equivalent of GET /runs and GET /runs/:runId.
 
         Args:
             run_id: ID of the current run.
+            should_unsubscribe: Whether the client should unsubscribe from the run_id topic.
         """
         self._client.publish(topic=Topics.RUNS)
-        self._client.publish(topic=f"{Topics.RUNS}/{run_id}")
+        self._client.publish(
+            topic=f"{Topics.RUNS}/{run_id}", should_unsubscribe=should_unsubscribe
+        )
 
     async def _poll_engine_store(
         self,

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -34,7 +34,8 @@ class RunsPublisher:
         """Continuously poll the engine store for the current_command.
 
         Args:
-            current_command: The currently executing command, if any.
+            get_current_command: Callback to get the currently executing command, if any.
+            get_state_summary: Callback to get the current run's state summary, if any.
             run_id: ID of the current run.
         """
         if self._poller is None:

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -16,6 +16,8 @@ from ..topics import Topics
 
 log: logging.Logger = logging.getLogger(__name__)
 
+POLL_INTERVAL = 1
+
 
 class RunsPublisher:
     """Publishes protocol runs topics."""
@@ -111,7 +113,7 @@ class RunsPublisher:
                 if self._previous_state_summary_status != current_state_summary_status:
                     await self._publish_runs_async(run_id=run_id)
                     self._previous_state_summary_status = current_state_summary_status
-                await asyncio.sleep(1)
+                await asyncio.sleep(POLL_INTERVAL)
         except asyncio.CancelledError:
             self._clean_up_poller()
             await self._publish_runs_advise_unsubscribe_async(run_id=run_id)

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -199,7 +199,9 @@ def test_update_run_state(
     )
     assert run_summary_result == state_summary
     assert commands_result.commands == protocol_commands
-    mock_runs_publisher.publish_runs.assert_called_once_with(run_id="run-id")
+    mock_runs_publisher.publish_runs_advise_refetch.assert_called_once_with(
+        run_id="run-id"
+    )
 
 
 def test_update_state_run_not_found(
@@ -392,8 +394,8 @@ def test_remove_run(subject: RunStore, mock_runs_publisher: mock.Mock) -> None:
     subject.remove(run_id="run-id")
 
     assert subject.get_all(length=20) == []
-    mock_runs_publisher.publish_runs.assert_called_once_with(
-        run_id="run-id", shouldUnsubscribe=True
+    mock_runs_publisher.publish_runs_advise_unsubscribe.assert_called_once_with(
+        run_id="run-id"
     )
 
 
@@ -427,7 +429,9 @@ def test_get_state_summary(
     subject.update_run_state(run_id="run-id", summary=state_summary, commands=[])
     result = subject.get_state_summary(run_id="run-id")
     assert result == state_summary
-    mock_runs_publisher.publish_runs.assert_called_once_with(run_id="run-id")
+    mock_runs_publisher.publish_runs_advise_refetch.assert_called_once_with(
+        run_id="run-id"
+    )
 
 
 def test_get_state_summary_failure(

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Type
 import pytest
 from decoy import Decoy
 from sqlalchemy.engine import Engine
+from unittest import mock
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 
@@ -162,6 +163,7 @@ def test_update_run_state(
     subject: RunStore,
     state_summary: StateSummary,
     protocol_commands: List[pe_commands.Command],
+    mock_runs_publisher: mock.Mock,
 ) -> None:
     """It should be able to update a run state to the store."""
     action = RunAction(
@@ -197,6 +199,7 @@ def test_update_run_state(
     )
     assert run_summary_result == state_summary
     assert commands_result.commands == protocol_commands
+    mock_runs_publisher.publish_runs.assert_called_once_with(run_id="run-id")
 
 
 def test_update_state_run_not_found(
@@ -372,7 +375,7 @@ def test_get_all_runs(
     assert result == expected_result
 
 
-def test_remove_run(subject: RunStore) -> None:
+def test_remove_run(subject: RunStore, mock_runs_publisher: mock.Mock) -> None:
     """It can remove a previously stored run entry."""
     action = RunAction(
         actionType=RunActionType.PLAY,
@@ -389,6 +392,9 @@ def test_remove_run(subject: RunStore) -> None:
     subject.remove(run_id="run-id")
 
     assert subject.get_all(length=20) == []
+    mock_runs_publisher.publish_runs.assert_called_once_with(
+        run_id="run-id", shouldUnsubscribe=True
+    )
 
 
 def test_remove_run_missing_id(subject: RunStore) -> None:
@@ -409,7 +415,9 @@ def test_insert_actions_no_run(subject: RunStore) -> None:
         subject.insert_action(run_id="run-id-996", action=action)
 
 
-def test_get_state_summary(subject: RunStore, state_summary: StateSummary) -> None:
+def test_get_state_summary(
+    subject: RunStore, state_summary: StateSummary, mock_runs_publisher: mock.Mock
+) -> None:
     """It should be able to get store run data."""
     subject.insert(
         run_id="run-id",
@@ -419,6 +427,7 @@ def test_get_state_summary(subject: RunStore, state_summary: StateSummary) -> No
     subject.update_run_state(run_id="run-id", summary=state_summary, commands=[])
     result = subject.get_state_summary(run_id="run-id")
     assert result == state_summary
+    mock_runs_publisher.publish_runs.assert_called_once_with(run_id="run-id")
 
 
 def test_get_state_summary_failure(

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -13,6 +13,7 @@ from robot_server.service.json_api.response import (
     MultiBody,
     MultiBodyMeta,
     NotifyRefetchBody,
+    NotifyUnsubscribeBody,
     DeprecatedResponseModel,
     DeprecatedMultiResponseModel,
 )
@@ -115,8 +116,10 @@ RESPONSE_SPECS = [
             "links": {"sibling": {"href": "/bar", "meta": None}},
         },
     ),
+    ResponseSpec(subject=NotifyRefetchBody(), expected={"refetchUsingHTTP": True}),
     ResponseSpec(
-        subject=NotifyRefetchBody.construct(), expected={"refetchUsingHTTP": True}
+        subject=NotifyUnsubscribeBody(),
+        expected={"refetchUsingHTTP": True, "unsubscribe": True},
     ),
 ]
 

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -119,7 +119,7 @@ RESPONSE_SPECS = [
     ResponseSpec(subject=NotifyRefetchBody(), expected={"refetchUsingHTTP": True}),
     ResponseSpec(
         subject=NotifyUnsubscribeBody(),
-        expected={"refetchUsingHTTP": True, "unsubscribe": True},
+        expected={"unsubscribe": True},
     ),
 ]
 

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -115,7 +115,9 @@ RESPONSE_SPECS = [
             "links": {"sibling": {"href": "/bar", "meta": None}},
         },
     ),
-    ResponseSpec(subject=NotifyRefetchBody(), expected={"refetchUsingHTTP": True}),
+    ResponseSpec(
+        subject=NotifyRefetchBody.construct(), expected={"refetchUsingHTTP": True}
+    ),
 ]
 
 


### PR DESCRIPTION
Closes [EXEC-305](https://opentrons.atlassian.net/browse/EXEC-305)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR adds unsubscribe flags for dynamic notification topics, e.g. "/runs/:runId". 

Now that the dust has settled around what our push notification can (and can’t) do, it’s clear that the burden of unsubscribing should be on the robot-server, specifically for dynamic topics. 

In other words, it’s ok for the app to connect to a broker and remain subscribed to topics that will never change, ex. “/maintenance_runs/current_run” (and be subscribed to those topics as long as the app is connected). Dynamic topics, such as “/runs/:runId”, should tell the app to unsubscribe however, as requiring the broker to stores these topics unnecessarily increases memory load on the robot server during long-lived sessions. 

This model is much easier to reason about as opposed to the component interest model that we use now. Bug surface is reduced, too.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Start up postman and start a protocol run using the desktop app's dev mode. You'll notice in the app-shell logs a lot of subscribe requests to a /run/:runId. Make note of that runId and in postman, subscribe to /runs/<that run Id>.
- After the run concludes, start another protocol run. Verify that the previous run (the run you're subscribed to in Postman), receives a message containing `unsubscribe: true`. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-305]: https://opentrons.atlassian.net/browse/EXEC-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ