### PR TITLE
fix(app): properly manage the ipcRenderer notify event emitter

### DIFF
--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -6,18 +6,18 @@ export interface Remote {
   ipcRenderer: {
     invoke: (channel: string, ...args: unknown[]) => Promise<any>
     send: (channel: string, ...args: unknown[]) => void
-    on: (
-      channel: string,
-      listener: (
-        event: IpcMainEvent,
-        hostname: string,
-        topic: NotifyTopic,
-        message: NotifyResponseData | NotifyNetworkError,
-        ...args: unknown[]
-      ) => void
-    ) => void
+    on: (channel: string, listener: IpcListener) => void
+    off: (channel: string, listener: IpcListener) => void
   }
 }
+
+export type IpcListener = (
+  event: IpcMainEvent,
+  hostname: string,
+  topic: NotifyTopic,
+  message: NotifyResponseData | NotifyNetworkError,
+  ...args: unknown[]
+) => void
 
 interface NotifyRefetchData {
   refetchUsingHTTP: boolean

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -74,7 +74,7 @@ describe('useNotifyService', () => {
     expect(mockDispatch).not.toHaveBeenCalledWith(
       notifyUnsubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
     )
-    expect(appShellListener).toHaveBeenCalled()
+    expect(mockAppShellListener).toHaveBeenCalled()
   })
 
   it('should trigger an unsubscribe action on dismount', () => {
@@ -100,7 +100,7 @@ describe('useNotifyService', () => {
       } as any)
     )
     expect(mockHTTPRefetch).toHaveBeenCalled()
-    expect(appShellListener).not.toHaveBeenCalled()
+    expect(mockAppShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
@@ -113,7 +113,7 @@ describe('useNotifyService', () => {
       } as any)
     )
     expect(mockHTTPRefetch).toHaveBeenCalled()
-    expect(appShellListener).not.toHaveBeenCalled()
+    expect(mockAppShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
@@ -126,7 +126,7 @@ describe('useNotifyService', () => {
       } as any)
     )
     expect(mockHTTPRefetch).toHaveBeenCalled()
-    expect(appShellListener).not.toHaveBeenCalled()
+    expect(mockAppShellListener).not.toHaveBeenCalled()
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
@@ -144,8 +144,9 @@ describe('useNotifyService', () => {
   })
 
   it('should return set HTTP refetch to always and fire an analytics reporting event if the connection was refused', () => {
-    mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
-      mockCb('ECONNREFUSED')
+    mockAppShellListener.mockImplementation(function ({ callback }): any {
+      // eslint-disable-next-line n/no-callback-literal
+      callback('ECONNREFUSED')
     })
     const { rerender } = renderHook(() =>
       useNotifyService({
@@ -160,8 +161,9 @@ describe('useNotifyService', () => {
   })
 
   it('should trigger a single HTTP refetch if the refetch flag was returned', () => {
-    mockAppShellListener.mockImplementation((_: any, __: any, mockCb: any) => {
-      mockCb({ refetchUsingHTTP: true })
+    mockAppShellListener.mockImplementation(function ({ callback }): any {
+      // eslint-disable-next-line n/no-callback-literal
+      callback('ECONNREFUSED')
     })
     const { rerender } = renderHook(() =>
       useNotifyService({
@@ -172,5 +174,17 @@ describe('useNotifyService', () => {
     )
     rerender()
     expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
+  })
+
+  it('should clean up the listener on dismount', () => {
+    const { unmount } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        setRefetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      })
+    )
+    unmount()
+    expect(mockAppShellListener).toHaveBeenCalled()
   })
 })

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -55,14 +55,26 @@ export function useNotifyService<TData, TError = Error>({
     if (shouldUseNotifications) {
       // Always fetch on initial mount.
       setRefetchUsingHTTP('once')
-      appShellListener(hostname, topic, onDataEvent)
+      appShellListener({
+        hostname,
+        topic,
+        callback: onDataEvent,
+      })
       dispatch(notifySubscribeAction(hostname, topic))
       hasUsedNotifyService.current = true
     } else setRefetchUsingHTTP('always')
 
     return () => {
-      if (hasUsedNotifyService.current && hostname != null) {
-        dispatch(notifyUnsubscribeAction(hostname, topic))
+      if (hasUsedNotifyService.current) {
+        if (hostname != null) {
+          dispatch(notifyUnsubscribeAction(hostname, topic))
+        }
+        appShellListener({
+          hostname: hostname as string,
+          topic,
+          callback: onDataEvent,
+          isDismounting: true,
+        })
       }
     }
   }, [topic, host, shouldUseNotifications])


### PR DESCRIPTION
Closes [RQA-2459](https://opentrons.atlassian.net/browse/RQA-2459)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Do not instantiate new notification ipcRenderer event listeners for each component that intends to subscribe to the notification server. Instead re-use the same ipcRenderer listener. This not only reduces the number of emitters created, but fixes a bug in which ipcRenderer listeners were not properly disposed.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verified via Chrome console that there is no memory leak warning, which often appears after navigating to the devices page or the robot details page.
- Verified via smoke test that notifications still work as expected.
- Using [this build of the app](https://opentrons.slack.com/archives/C81CR4VCZ/p1710161213430769), update a robot on the devices tab via the robot update banner, click a lot, let the app sit on the device details page for a while, etc. etc., and verify the app doesn't whitescreen.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a memory leak.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Read the ticket if you'd like more context. I've asked QA to try and repro this as well. Regardless of whether or not this actually solves the whitescreen (although I think this does), this should make it into 7.2.1.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
medium-low. The code touches the app's ipcRenderer for notifications, but it's pretty straightforward: if notifications still work as expected, we're good. 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2459]: https://opentrons.atlassian.net/browse/RQA-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ