### PR TITLE
fix(app): Tolerate old tip length calibration records without a `uri` field

### DIFF
--- a/api/src/opentrons/calibration_storage/ot2/deck_attitude.py
+++ b/api/src/opentrons/calibration_storage/ot2/deck_attitude.py
@@ -79,7 +79,7 @@ def get_robot_deck_attitude() -> Optional[v1.DeckCalibrationModel]:
         pass
     except (json.JSONDecodeError, ValidationError):
         log.warning(
-            "Deck calibration is malformed. Please factory reset your calibrations."
+            "Deck calibration is malformed. Please factory reset your calibrations.",
+            exc_info=True,
         )
-        pass
     return None

--- a/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot2/pipette_offset.py
@@ -92,7 +92,8 @@ def get_pipette_offset(
         return None
     except (json.JSONDecodeError, ValidationError):
         log.warning(
-            f"Malformed calibrations for {pipette_id} on {mount}. Please factory reset your calibrations."
+            f"Malformed calibrations for {pipette_id} on {mount}. Please factory reset your calibrations.",
+            exc_info=True,
         )
         # TODO: Delete the bad calibration here maybe?
         return None

--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -52,9 +52,9 @@ def tip_lengths_for_pipette(
                 tip_lengths[LabwareUri(tiprack_identifier)] = v1.TipLengthModel(**data)
             except (json.JSONDecodeError, ValidationError):
                 log.warning(
-                    f"Tip length calibration is malformed for {tiprack_identifier} on {pipette_id}"
+                    f"Tip length calibration is malformed for {tiprack_identifier} on {pipette_id}",
+                    exc_info=True,
                 )
-                pass
         return tip_lengths
     except FileNotFoundError:
         log.debug(f"Tip length calibrations not found for {pipette_id}")

--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -43,6 +43,11 @@ def tip_lengths_for_pipette(
     except FileNotFoundError:
         log.debug(f"Tip length calibrations not found for {pipette_id}")
         return {}
+    except json.JSONDecodeError:
+        log.warning(
+            f"Tip length calibration is malformed for {pipette_id}", exc_info=True
+        )
+        return {}
 
     tip_lengths: typing.Dict[LabwareUri, v1.TipLengthModel] = {}
 
@@ -55,7 +60,7 @@ def tip_lengths_for_pipette(
             tiprack_identifier = data.pop("uri")
         try:
             tip_lengths[LabwareUri(tiprack_identifier)] = v1.TipLengthModel(**data)
-        except (json.JSONDecodeError, ValidationError):
+        except ValidationError:
             log.warning(
                 f"Tip length calibration is malformed for {tiprack_identifier} on {pipette_id}",
                 exc_info=True,

--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -55,9 +55,17 @@ def tip_lengths_for_pipette(
         # We normally key these calibrations by their tip rack URI,
         # but older software had them keyed by their tip rack hash.
         # Migrate from the old format, if necessary.
-        if "/" not in tiprack_identifier:
+        tiprack_identifier_is_uri = "/" in tiprack_identifier
+        if not tiprack_identifier_is_uri:
             data["definitionHash"] = tiprack_identifier
-            tiprack_identifier = data.pop("uri")
+            uri = data.pop("uri", None)
+            if uri is None:
+                # We don't have a way to migrate old records without a URI,
+                # so skip over them.
+                continue
+            else:
+                tiprack_identifier = uri
+
         try:
             tip_lengths[LabwareUri(tiprack_identifier)] = v1.TipLengthModel(**data)
         except ValidationError:

--- a/api/src/opentrons/calibration_storage/ot3/deck_attitude.py
+++ b/api/src/opentrons/calibration_storage/ot3/deck_attitude.py
@@ -77,7 +77,7 @@ def get_robot_belt_attitude() -> Optional[v1.BeltCalibrationModel]:
         pass
     except (json.JSONDecodeError, ValidationError):
         log.warning(
-            "Belt calibration is malformed. Please factory reset your calibrations."
+            "Belt calibration is malformed. Please factory reset your calibrations.",
+            exc_info=True,
         )
-        pass
     return None

--- a/api/src/opentrons/calibration_storage/ot3/module_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/module_offset.py
@@ -108,7 +108,8 @@ def get_module_offset(
         return None
     except (json.JSONDecodeError, ValidationError):
         log.warning(
-            f"Malformed calibrations for {module_id} on slot {slot}. Please factory reset your calibrations."
+            f"Malformed calibrations for {module_id} on slot {slot}. Please factory reset your calibrations.",
+            exc_info=True,
         )
         return None
 
@@ -130,7 +131,8 @@ def load_all_module_offsets() -> List[v1.ModuleOffsetModel]:
             )
         except (json.JSONDecodeError, ValidationError):
             log.warning(
-                f"Malformed module calibrations for {file}. Please factory reset your calibrations."
+                f"Malformed module calibrations for {file}. Please factory reset your calibrations.",
+                exc_info=True,
             )
             continue
     return calibrations

--- a/api/src/opentrons/calibration_storage/ot3/pipette_offset.py
+++ b/api/src/opentrons/calibration_storage/ot3/pipette_offset.py
@@ -89,6 +89,7 @@ def get_pipette_offset(
         return None
     except (json.JSONDecodeError, ValidationError):
         log.warning(
-            f"Malformed calibrations for {pipette_id} on {mount}. Please factory reset your calibrations."
+            f"Malformed calibrations for {pipette_id} on {mount}. Please factory reset your calibrations.",
+            exc_info=True,
         )
         return None

--- a/api/src/opentrons/config/robot_configs.py
+++ b/api/src/opentrons/config/robot_configs.py
@@ -148,7 +148,7 @@ def _load_json(filename: Union[str, Path]) -> Dict[str, Any]:
         log.warning("{0} not found. Loading defaults".format(filename))
         res = {}
     except json.decoder.JSONDecodeError:
-        log.warning("{0} is corrupt. Loading defaults".format(filename))
+        log.warning("{0} is corrupt. Loading defaults".format(filename), exc_info=True)
         res = {}
     return cast(Dict[str, Any], res)
 

--- a/api/tests/opentrons/calibration_storage/test_tip_length_ot2.py
+++ b/api/tests/opentrons/calibration_storage/test_tip_length_ot2.py
@@ -113,3 +113,31 @@ def test_delete_all_tip_calibration(starting_calibration_data: Any) -> None:
     clear_tip_length_calibration()
     assert tip_lengths_for_pipette("pip1") == {}
     assert tip_lengths_for_pipette("pip2") == {}
+
+
+def test_uriless_calibrations_are_dropped(ot_config_tempdir: object) -> None:
+    """Legacy records without a `uri` field should be silently ignored."""
+
+    data = {
+        "ed323db6ca1ddf197aeb20667c1a7a91c89cfb2f931f45079d483928da056812": {
+            "tipLength": 123,
+            "lastModified": "2021-01-11T00:34:29.291073+00:00",
+            "source": "user",
+            "status": {"markedBad": False},
+        },
+        "130e17bb7b2f0c0472dcc01c1ff6f600ca1a6f9f86a90982df56c4bf43776824": {
+            "tipLength": 456,
+            "lastModified": "2021-05-12T22:16:14.249567+00:00",
+            "source": "user",
+            "status": {"markedBad": False},
+            "uri": "opentrons/opentrons_96_filtertiprack_200ul/1",
+        },
+    }
+
+    io.save_to_file(config.get_tip_length_cal_path(), "pipette1234", data)
+    result = tip_lengths_for_pipette("pipette1234")
+    assert len(result) == 1
+    assert (
+        result[LabwareUri("opentrons/opentrons_96_filtertiprack_200ul/1")].tipLength
+        == 456
+    )


### PR DESCRIPTION
# Overview

This fixes RESC-215.

Apparently, old tip length calibration records don't have a `uri` field. (It looks like `uri` was introduced in #7136, v4.1.0.) We used to safely drop these records via [this `except ValidationError` block](https://github.com/Opentrons/opentrons/blob/a1cde96c41b8cbd065fe17057e3c6119b6b252f0/api/src/opentrons/calibration_storage/ot2/tip_length.py#L46-L50). But PR #14512 started [accessing the `uri` field manually](https://github.com/Opentrons/opentrons/blob/1556c1c442d4de3619a38a56b07d20b42b60c0fc/api/src/opentrons/calibration_storage/ot2/tip_length.py#L50), accidentally bringing it outside the coverage of the `except` block and turning it into an HTTP 500 error.

# Test Plan

To reproduce this manually, you can download the `data/` directory from RESC-215 and run this in the `api` project directory:

```shell
OT_API_TIP_LENGTH_CALIBRATION_DIR=/path/to/downloaded/data/tip_lengths \
  pipenv run python -c \
  'from opentrons import calibration_storage; print(calibration_storage.get_all_tip_length_calibrations())'
```

On v7.1.1, it will work. On v7.2.0, it will raise an error. On this branch, it will work again.

I've also added a unit test.

# Changelog

* If `uri` is missing from an old tip length calibration record, silently ignore that record.
* Fix a misplaced `JSONDecodeError` catch. (This turned out to not be the problem, but it's still probably a good idea to fix.)
* Add exception info to a bunch of parsing warnings to make these problems easier to debug. (These warnings turned out to not cover this problem, but it's still probably a good idea to fix.)

# Review requests

* Is there a better way to handle these records than skipping over them entirely?

# Risk assessment

Low.