### PR TITLE
refactor(protocol-designer): export button disabled before file created

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -243,7 +243,8 @@ export function v8WarningContent(t: any): JSX.Element {
 }
 export function FileSidebar(): JSX.Element {
   const fileData = useSelector(fileDataSelectors.createFile)
-  const canDownload = useSelector(selectors.getCurrentPage)
+  const currentPage = useSelector(selectors.getCurrentPage)
+  const canDownload = currentPage !== 'file-splash'
   const initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const modulesOnDeck = initialDeckSetup.modules
   const pipettesOnDeck = initialDeckSetup.pipettes


### PR DESCRIPTION
# Overview

Fix bug from when i refactored the `FileSidebar` component to not be a class component

# Test Plan

make sure the export button is disabled when you first open PD but then after you create a file, it is enabled

# Changelog

fix the oopsy. initially what i had, it made the export button always enabled.

# Review requests

see test plan

# Risk assessment
low