### PR TITLE
fix(step-generation): getNextTiprack now accounts for 4th column tips…

### DIFF
--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -1,7 +1,6 @@
 import assert from 'assert'
 // TODO: Ian 2019-04-18 move orderWells somewhere more general -- shared-data util?
 import min from 'lodash/min'
-import sortBy from 'lodash/sortBy'
 import {
   getTiprackVolume,
   THERMOCYCLER_MODULE_TYPE,
@@ -10,20 +9,40 @@ import {
   COLUMN,
   ALL,
 } from '@opentrons/shared-data'
+import { COLUMN_4_SLOTS } from './constants'
 import type {
   InvariantContext,
   ModuleTemporalProperties,
   RobotState,
   ThermocyclerModuleState,
-} from './'
-import { COLUMN_4_SLOTS } from './constants'
+} from './types'
+
 export function sortLabwareBySlot(
   labwareState: RobotState['labware']
 ): string[] {
-  return sortBy<string>(Object.keys(labwareState), (id: string) =>
-    parseInt(labwareState[id].slot)
+  const sortedLabware = Object.keys(labwareState).sort(
+    (idA: string, idB: string) => {
+      const slotA = parseInt(labwareState[idA].slot)
+      const slotB = parseInt(labwareState[idB].slot)
+      if (
+        COLUMN_4_SLOTS.includes(labwareState[idA].slot) &&
+        COLUMN_4_SLOTS.includes(labwareState[idB].slot)
+      ) {
+        return idA.localeCompare(idB)
+      }
+      if (COLUMN_4_SLOTS.includes(labwareState[idA].slot)) {
+        return 1
+      }
+      if (COLUMN_4_SLOTS.includes(labwareState[idB].slot)) {
+        return -1
+      }
+      return slotA - slotB
+    }
   )
+
+  return sortedLabware
 }
+
 export function _getNextTip(args: {
   pipetteId: string
   tiprackId: string
@@ -94,12 +113,8 @@ export function getNextTiprack(
         `cannot getNextTiprack, no labware entity for "${labwareId}"`
       )
       const isOnDeck = robotState.labware[labwareId].slot != null
-      const isIn4thColumn = COLUMN_4_SLOTS.includes(
-        robotState.labware[labwareId].slot
-      )
       return (
         isOnDeck &&
-        !isIn4thColumn &&
         pipetteEntity.tiprackDefURI ===
           invariantContext.labwareEntities[labwareId]?.labwareDefURI
       )

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -16,6 +16,7 @@ import type {
   RobotState,
   ThermocyclerModuleState,
 } from './'
+import { COLUMN_4_SLOTS } from './constants'
 export function sortLabwareBySlot(
   labwareState: RobotState['labware']
 ): string[] {
@@ -93,8 +94,12 @@ export function getNextTiprack(
         `cannot getNextTiprack, no labware entity for "${labwareId}"`
       )
       const isOnDeck = robotState.labware[labwareId].slot != null
+      const isIn4thColumn = COLUMN_4_SLOTS.includes(
+        robotState.labware[labwareId].slot
+      )
       return (
         isOnDeck &&
+        !isIn4thColumn &&
         pipetteEntity.tiprackDefURI ===
           invariantContext.labwareEntities[labwareId]?.labwareDefURI
       )


### PR DESCRIPTION
… correctly

closes RQA-2491

# Overview

`sortLabwareBySlot`  previously wasn't listing the 4th column slots last. Kinda weird that a customer hasn't reported this yet since it seems like a bug that would commonly occur. But anyway this PR fixes it.

# Test Plan

Upload the protocol in the bug ticket and see that you don't run into a timeline error for the last step. Then delete a tiprack in the 2nd or 3rd column. See that the timeline error says that tipracks in the 4th column can't be pipetted into.

# Changelog

- change the sortLabwareBySlot logic to list the 4th column slots last

# Review requests

see test plan

# Risk assessment

low