### PR TITLE
refactor(api): Add an `enableErrorRecoveryExperiments` feature flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -219,6 +219,19 @@ settings = [
         description="When this setting is on, Flex will continue its activities regardless of pressure changes inside the pipette. Do not turn this setting on unless you are intentionally causing pressures over 8 kPa inside the pipette air channel.",
         robot_type=[RobotTypeEnum.FLEX],
     ),
+    SettingDefinition(
+        _id="enableErrorRecoveryExperiments",
+        title="Enable error recovery experiments",
+        description=(
+            "Do not enable."
+            " This is an Opentrons internal setting to experiment with"
+            " in-development error recovery features."
+            " This will interfere with your protocol runs,"
+            " corrupt your robot's storage,"
+            " bring misfortune and pestilence upon you and your livestock, etc."
+        ),
+        robot_type=[RobotTypeEnum.FLEX],
+    ),
 ]
 
 if (
@@ -668,6 +681,16 @@ def _migrate29to30(previous: SettingsMap) -> SettingsMap:
     return {k: v for k, v in previous.items() if "disableTipPresenceDetection" != k}
 
 
+def _migrate30to31(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 31 of the feature flags file.
+
+    - Adds the enableErrorRecoveryExperiments config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["enableErrorRecoveryExperiments"] = None
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -699,6 +722,7 @@ _MIGRATIONS = [
     _migrate27to28,
     _migrate28to29,
     _migrate29to30,
+    _migrate30to31,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -231,6 +231,7 @@ settings = [
             " bring misfortune and pestilence upon you and your livestock, etc."
         ),
         robot_type=[RobotTypeEnum.FLEX],
+        internal_only=True,
     ),
 ]
 

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -70,3 +70,9 @@ def require_estop() -> bool:
     return not advs.get_setting_with_env_overload(
         "estopNotRequired", RobotTypeEnum.FLEX
     )
+
+
+def enable_error_recovery_experiments() -> bool:
+    return advs.get_setting_with_env_overload(
+        "enableErrorRecoveryExperiments", RobotTypeEnum.FLEX
+    )

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -8,7 +8,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 30
+    return 31
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -29,6 +29,7 @@ def default_file_settings() -> Dict[str, Any]:
         "disableStatusBar": None,
         "disableOverpressureDetection": None,
         "estopNotRequired": None,
+        "enableErrorRecoveryExperiments": None,
     }
 
 
@@ -366,6 +367,18 @@ def v30_config(v29_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v31_config(v30_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v30_config.copy()
+    r.update(
+        {
+            "_version": 31,
+            "enableErrorRecoveryExperiments": None,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -401,6 +414,7 @@ def v30_config(v29_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v28_config"),
         lazy_fixture("v29_config"),
         lazy_fixture("v30_config"),
+        lazy_fixture("v31_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:
@@ -492,4 +506,5 @@ def test_ensures_config() -> None:
         "disableStatusBar": None,
         "estopNotRequired": None,
         "disableOverpressureDetection": None,
+        "enableErrorRecoveryExperiments": None,
     }


### PR DESCRIPTION
# Overview

Closes [EXEC-317](https://opentrons.atlassian.net/browse/EXEC-317).

# Test Plan

There's nothing meaningful to test here until further work wires stuff up to this feature flag.

# Changelog

Add an `enableErrorRecoveryExperiments` feature flag, which currently doesn't do anything, but will help with future work in EXEC-284.

# Review requests

I've left `internal_only` set to `False`, which I guess means this will show up in the Opentrons App. I figure we want to make it easy for our internal engineers to toggle this on and off.

Is the description text sufficient to turn away people who shouldn't be messing with this, or do we want to set `internal_only` to `True`?

# Risk assessment

Low.

[EXEC-317]: https://opentrons.atlassian.net/browse/EXEC-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ