### PR TITLE
refactor(app-shell, app-shell-odd): Refactor app to use unsubscribe flags

### DIFF
--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -257,6 +257,8 @@ function unsubscribe(notifyParams: NotifyParams): Promise<void> {
           client?.unsubscribe(topic, {}, (error, result) => {
             if (error == null) {
               handleDecrementSubscriptionCount(hostname, topic)
+            } else {
+              log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
             }
           })
         } else {

--- a/app-shell-odd/src/notify.ts
+++ b/app-shell-odd/src/notify.ts
@@ -190,7 +190,6 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   function subscribeCb(error: Error, result: mqtt.ISubscriptionGrant[]): void {
     const { subscriptions } = connectionStore[hostname]
     if (error != null) {
-      // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
       sendToBrowserDeserialized({
         browserWindow,
         hostname,
@@ -203,7 +202,6 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         }
       }, RENDER_TIMEOUT)
     } else {
-      // log.info(`Successfully subscribed on ${hostname} to topic: ${topic}`)
       if (subscriptions[topic] > 0) {
         subscriptions[topic] += 1
       } else {
@@ -233,7 +231,6 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         counter++
         if (counter === MAX_RETRIES) {
           clearInterval(intervalId)
-          // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
           reject(new Error('Maximum subscription retries exceeded.'))
         }
       }, CHECK_CONNECTION_INTERVAL)
@@ -258,24 +255,13 @@ function unsubscribe(notifyParams: NotifyParams): Promise<void> {
 
         if (isLastSubscription) {
           client?.unsubscribe(topic, {}, (error, result) => {
-            if (error != null) {
-              // log.warn(
-              //   `Failed to unsubscribe on ${hostname} from topic: ${topic}`
-              // )
-            } else {
-              // log.info(
-              //   `Successfully unsubscribed on ${hostname} from topic: ${topic}`
-              // )
+            if (error == null) {
               handleDecrementSubscriptionCount(hostname, topic)
             }
           })
         } else {
           subscriptions[topic] -= 1
         }
-      } else {
-        // log.info(
-        //   `Attempted to unsubscribe from unconnected hostname: ${hostname}`
-        // )
       }
     }, RENDER_TIMEOUT)
   })

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -188,7 +188,6 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
   function subscribeCb(error: Error, result: mqtt.ISubscriptionGrant[]): void {
     const { subscriptions } = connectionStore[hostname]
     if (error != null) {
-      // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
       sendToBrowserDeserialized({
         browserWindow,
         hostname,
@@ -201,7 +200,6 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         }
       }, RENDER_TIMEOUT)
     } else {
-      // log.info(`Successfully subscribed on ${hostname} to topic: ${topic}`)
       if (subscriptions[topic] > 0) {
         subscriptions[topic] += 1
       } else {
@@ -231,7 +229,6 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         counter++
         if (counter === MAX_RETRIES) {
           clearInterval(intervalId)
-          // log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
           reject(new Error('Maximum subscription retries exceeded.'))
         }
       }, CHECK_CONNECTION_INTERVAL)
@@ -256,24 +253,13 @@ function unsubscribe(notifyParams: NotifyParams): Promise<void> {
 
         if (isLastSubscription) {
           client?.unsubscribe(topic, {}, (error, result) => {
-            if (error != null) {
-              // log.warn(
-              //   `Failed to unsubscribe on ${hostname} from topic: ${topic}`
-              // )
-            } else {
-              // log.info(
-              //   `Successfully unsubscribed on ${hostname} from topic: ${topic}`
-              // )
+            if (error == null) {
               handleDecrementSubscriptionCount(hostname, topic)
             }
           })
         } else {
           subscriptions[topic] -= 1
         }
-      } else {
-        // log.info(
-        //   `Attempted to unsubscribe from unconnected hostname: ${hostname}`
-        // )
       }
     }, RENDER_TIMEOUT)
   })

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -255,6 +255,8 @@ function unsubscribe(notifyParams: NotifyParams): Promise<void> {
           client?.unsubscribe(topic, {}, (error, result) => {
             if (error == null) {
               handleDecrementSubscriptionCount(hostname, topic)
+            } else {
+              log.warn(`Failed to subscribe on ${hostname} to topic: ${topic}`)
             }
           })
         } else {

--- a/app-shell/src/notify.ts
+++ b/app-shell/src/notify.ts
@@ -1,10 +1,17 @@
 /* eslint-disable @typescript-eslint/no-dynamic-delete */
 import mqtt from 'mqtt'
+import isEqual from 'lodash/isEqual'
 
 import { createLogger } from './log'
 
 import type { BrowserWindow } from 'electron'
-import type { NotifyTopic } from '@opentrons/app/src/redux/shell/types'
+import type {
+  NotifyTopic,
+  NotifyResponseData,
+  NotifyRefetchData,
+  NotifyUnsubscribeData,
+  NotifyNetworkError,
+} from '@opentrons/app/src/redux/shell/types'
 import type { Action, Dispatch } from './types'
 
 // TODO(jh, 2024-03-01): after refactoring notify connectivity and subscription logic, uncomment logs.
@@ -120,7 +127,7 @@ function subscribe(notifyParams: NotifyParams): Promise<void> {
         log.warn(
           `Failed to connect to ${hostname} - ${error.name}: ${error.message} `
         )
-        let failureMessage: string = FAILURE_STATUSES.ECONNFAILED
+        let failureMessage: NotifyNetworkError = FAILURE_STATUSES.ECONNFAILED
         if (connectionStore[hostname]?.client == null) {
           unreachableHosts.add(hostname)
           if (
@@ -341,12 +348,21 @@ function establishListeners({
   client.on(
     'message',
     (topic: NotifyTopic, message: Buffer, packet: mqtt.IPublishPacket) => {
-      sendToBrowserDeserialized({
-        browserWindow,
-        hostname,
-        topic,
-        message: message.toString(),
-      })
+      deserialize(message.toString())
+        .then(deserializedMessage => {
+          log.debug('Received notification data from main via IPC', {
+            hostname,
+            topic,
+          })
+
+          browserWindow.webContents.send(
+            'notify',
+            hostname,
+            topic,
+            deserializedMessage
+          )
+        })
+        .catch(error => log.debug(`${error.message}`))
     }
   )
 
@@ -407,7 +423,7 @@ interface SendToBrowserParams {
   browserWindow: BrowserWindow
   hostname: string
   topic: NotifyTopic
-  message: string
+  message: NotifyResponseData
 }
 
 function sendToBrowserDeserialized({
@@ -416,18 +432,34 @@ function sendToBrowserDeserialized({
   topic,
   message,
 }: SendToBrowserParams): void {
-  let deserializedMessage: string | Object
+  browserWindow.webContents.send('notify', hostname, topic, message)
+}
 
-  try {
-    deserializedMessage = JSON.parse(message)
-  } catch {
-    deserializedMessage = message
-  }
+const VALID_MODELS: [NotifyRefetchData, NotifyUnsubscribeData] = [
+  { refetchUsingHTTP: true },
+  { unsubscribe: true },
+]
 
-  // log.info('Received notification data from main via IPC', {
-  //   hostname,
-  //   topic,
-  // })
+function deserialize(message: string): Promise<NotifyResponseData> {
+  return new Promise((resolve, reject) => {
+    let deserializedMessage: NotifyResponseData | Record<string, unknown>
+    const error = new Error(
+      `Unexpected data received from notify broker: ${message}`
+    )
 
-  browserWindow.webContents.send('notify', hostname, topic, deserializedMessage)
+    try {
+      deserializedMessage = JSON.parse(message)
+    } catch {
+      reject(error)
+    }
+
+    const isValidNotifyResponse = VALID_MODELS.some(model =>
+      isEqual(model, deserializedMessage)
+    )
+    if (!isValidNotifyResponse) {
+      reject(error)
+    } else {
+      resolve(JSON.parse(message))
+    }
+  })
 }

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -19,13 +19,17 @@ export interface Remote {
   }
 }
 
-interface NotifyRefetchData {
+export interface NotifyRefetchData {
   refetchUsingHTTP: boolean
-  statusCode: never
 }
 
+export interface NotifyUnsubscribeData {
+  unsubscribe: boolean
+}
+
+export type NotifyBrokerResponses = NotifyRefetchData | NotifyUnsubscribeData
 export type NotifyNetworkError = 'ECONNFAILED' | 'ECONNREFUSED'
-export type NotifyResponseData = NotifyRefetchData | NotifyNetworkError
+export type NotifyResponseData = NotifyBrokerResponses | NotifyNetworkError
 
 interface File {
   sha512: string

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -171,4 +171,21 @@ describe('useNotifyService', () => {
     rerender()
     expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
   })
+
+  it('should trigger a single HTTP refetch if the unsubscribe flag was returned', () => {
+    vi.mocked(appShellListener).mockImplementation(
+      (_: any, __: any, mockCb: any) => {
+        mockCb({ unsubscribe: true })
+      }
+    )
+    const { rerender } = renderHook(() =>
+      useNotifyService({
+        topic: MOCK_TOPIC,
+        setRefetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      } as any)
+    )
+    rerender()
+    expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
+  })
 })

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -77,7 +77,7 @@ export function useNotifyService<TData, TError = Error>({
           properties: {},
         })
       }
-    } else if ('refetchUsingHTTP' in data) {
+    } else if ('refetchUsingHTTP' in data || 'unsubscribe' in data) {
       setRefetchUsingHTTP('once')
     }
   }


### PR DESCRIPTION
Closes [EXEC-306](https://opentrons.atlassian.net/browse/EXEC-306)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This is the frontend implementation of https://github.com/Opentrons/opentrons/pull/14620. See that PR and its corresponding ticket for the explanation behind this refactor. This also includes the feedback from https://github.com/Opentrons/opentrons/pull/14633.

Note: This PR does NOT implement any shell logic changes based on the new unsubscribe flag, as that would unnecessarily increase the complexity of the shell logic without any current benefit. The payoff of using unsubscribe flags is contingent upon app-shell connectivity logic being tied to discovery-client (which will happen in a follow up PR) and the ODD connectivity logic not trying to account for connecting to other hosts (again, another PR). 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Push https://github.com/Opentrons/opentrons/pull/14620 to a robot.
- Open the desktop app and smoke test running a protocol and opening/closing a maintenance run flow. 
- During a protocol run, cancel the run. The app should successfully handle the close without getting caught in an infinite loop (this is where the new "unsubscribe flag" is dispatched). 
- You can repeat the same steps on the ODD if you'd like, but the code is nearly identical. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-306]: https://opentrons.atlassian.net/browse/EXEC-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ