### PR TITLE
 fix(protocol-designer): draggable step items does not duplicate or disappear

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/AdapterControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/AdapterControls.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import assert from 'assert'
 import { useDispatch, useSelector } from 'react-redux'
 import { DropTargetMonitor, useDrop } from 'react-dnd'
 import cx from 'classnames'
@@ -15,7 +14,6 @@ import {
   moveDeckItem,
   openAddLabwareModal,
 } from '../../../labware-ingred/actions'
-import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import { selectors as labwareDefSelectors } from '../../../labware-defs'
 import { START_TERMINAL_ITEM_ID, TerminalItemId } from '../../../steplist'
 import { BlockedSlot } from './BlockedSlot'
@@ -67,7 +65,7 @@ export const AdapterControls = (
       accept: DND_TYPES.LABWARE,
       canDrop: (item: DroppedItem) => {
         const draggedDef = item.labwareOnDeck?.def
-        assert(
+        console.assert(
           draggedDef,
           'no labware def of dragged item, expected it on drop'
         )

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import assert from 'assert'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import noop from 'lodash/noop'
@@ -14,7 +15,6 @@ import {
   moveDeckItem,
   openAddLabwareModal,
 } from '../../../labware-ingred/actions'
-import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import { selectors as labwareDefSelectors } from '../../../labware-defs'
 import { START_TERMINAL_ITEM_ID, TerminalItemId } from '../../../steplist'
 import { BlockedSlot } from './BlockedSlot'
@@ -53,10 +53,7 @@ export const SlotControls = (props: SlotControlsProps): JSX.Element | null => {
   const customLabwareDefs = useSelector(
     labwareDefSelectors.getCustomLabwareDefsByURI
   )
-  const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
-  const labware = activeDeckSetup.labware
   const ref = React.useRef(null)
-  const [newSlot, setSlot] = React.useState<string | null>(null)
   const dispatch = useDispatch()
 
   const { t } = useTranslation('deck')
@@ -66,56 +63,49 @@ export const SlotControls = (props: SlotControlsProps): JSX.Element | null => {
     item: { labwareOnDeck: null },
   })
 
-  const [{ draggedItem, itemType, isOver }, drop] = useDrop({
-    accept: DND_TYPES.LABWARE,
-    canDrop: (item: DroppedItem) => {
-      const draggedDef = item?.labwareOnDeck?.def
-      console.assert(
-        draggedDef,
-        'no labware def of dragged item, expected it on drop'
-      )
-
-      if (moduleType != null && draggedDef != null) {
-        // this is a module slot, prevent drop if the dragged labware is not compatible
-        const isCustomLabware = getLabwareIsCustom(
-          customLabwareDefs,
-          item.labwareOnDeck
+  const [{ draggedItem, itemType, isOver }, drop] = useDrop(
+    () => ({
+      accept: DND_TYPES.LABWARE,
+      canDrop: (item: DroppedItem) => {
+        const draggedDef = item?.labwareOnDeck?.def
+        console.assert(
+          draggedDef,
+          'no labware def of dragged item, expected it on drop'
         )
 
-        return getLabwareIsCompatible(draggedDef, moduleType) || isCustomLabware
-      }
-      return true
-    },
-    drop: (item: DroppedItem) => {
-      const droppedLabware = item
-      if (newSlot != null) {
-        dispatch(moveDeckItem(newSlot, slotId))
-      } else if (droppedLabware.labwareOnDeck != null) {
-        const droppedSlot = droppedLabware.labwareOnDeck.slot
-        dispatch(moveDeckItem(droppedSlot, slotId))
-      }
-    },
-    hover: () => {
-      if (handleDragHover != null) {
-        handleDragHover()
-      }
-    },
-    collect: (monitor: DropTargetMonitor) => ({
-      itemType: monitor.getItemType(),
-      isOver: !!monitor.isOver(),
-      draggedItem: monitor.getItem() as DroppedItem,
+        if (moduleType != null && draggedDef != null) {
+          // this is a module slot, prevent drop if the dragged labware is not compatible
+          const isCustomLabware = getLabwareIsCustom(
+            customLabwareDefs,
+            item.labwareOnDeck
+          )
+
+          return (
+            getLabwareIsCompatible(draggedDef, moduleType) || isCustomLabware
+          )
+        }
+        return true
+      },
+      drop: (item: DroppedItem) => {
+        const droppedLabware = item
+        if (droppedLabware.labwareOnDeck != null) {
+          const droppedSlot = droppedLabware.labwareOnDeck.slot
+          dispatch(moveDeckItem(droppedSlot, slotId))
+        }
+      },
+      hover: () => {
+        if (handleDragHover != null) {
+          handleDragHover()
+        }
+      },
+      collect: (monitor: DropTargetMonitor) => ({
+        itemType: monitor.getItemType(),
+        isOver: !!monitor.isOver(),
+        draggedItem: monitor.getItem() as DroppedItem,
+      }),
     }),
-  })
-
-  const draggedLabware = Object.values(labware).find(
-    l => l.id === draggedItem?.labwareOnDeck?.id
+    []
   )
-
-  React.useEffect(() => {
-    if (draggedLabware != null) {
-      setSlot(draggedLabware.slot)
-    }
-  })
 
   if (
     selectedTerminalItemId !== START_TERMINAL_ITEM_ID ||

--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/SlotControls.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import assert from 'assert'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
 import noop from 'lodash/noop'

--- a/protocol-designer/src/components/steplist/DraggableStepItems.tsx
+++ b/protocol-designer/src/components/steplist/DraggableStepItems.tsx
@@ -21,7 +21,6 @@ import styles from './StepItem.module.css'
 
 interface DragDropStepItemProps extends ConnectedStepItemProps {
   stepId: StepIdType
-  clickDrop: () => void
   moveStep: (stepId: StepIdType, value: number) => void
   findStepIndex: (stepId: StepIdType) => number
   orderedStepIds: string[]
@@ -32,7 +31,7 @@ interface DropType {
 }
 
 const DragDropStepItem = (props: DragDropStepItemProps): JSX.Element => {
-  const { stepId, moveStep, clickDrop, findStepIndex, orderedStepIds } = props
+  const { stepId, moveStep, findStepIndex, orderedStepIds } = props
   const ref = React.useRef<HTMLDivElement>(null)
 
   const [{ isDragging }, drag] = useDrag(

--- a/protocol-designer/src/components/steplist/DraggableStepItems.tsx
+++ b/protocol-designer/src/components/steplist/DraggableStepItems.tsx
@@ -26,6 +26,7 @@ interface DragDropStepItemProps extends ConnectedStepItemProps {
   moveStep: (stepId: StepIdType, value: number) => void
   setIsOver: React.Dispatch<React.SetStateAction<boolean>>
   findStepIndex: (stepId: StepIdType) => number
+  orderedStepIds: string[]
 }
 
 interface DropType {
@@ -33,37 +34,50 @@ interface DropType {
 }
 
 const DragDropStepItem = (props: DragDropStepItemProps): JSX.Element => {
-  const { stepId, moveStep, clickDrop, setIsOver, findStepIndex } = props
+  const {
+    stepId,
+    moveStep,
+    clickDrop,
+    setIsOver,
+    findStepIndex,
+    orderedStepIds,
+  } = props
   const ref = React.useRef<HTMLDivElement>(null)
 
-  const [{ isDragging }, drag] = useDrag({
-    type: DND_TYPES.STEP_ITEM,
-    item: { stepId },
-    collect: (monitor: DragLayerMonitor) => ({
-      isDragging: monitor.isDragging(),
+  const [{ isDragging }, drag] = useDrag(
+    () => ({
+      type: DND_TYPES.STEP_ITEM,
+      item: { stepId },
+      collect: (monitor: DragLayerMonitor) => ({
+        isDragging: monitor.isDragging(),
+      }),
     }),
-  })
+    [orderedStepIds]
+  )
 
-  const [{ isOver, handlerId }, drop] = useDrop(() => ({
-    accept: DND_TYPES.STEP_ITEM,
-    canDrop: () => {
-      return true
-    },
-    drop: () => {
-      clickDrop()
-    },
-    hover: (item: DropType) => {
-      const draggedId = item.stepId
-      if (draggedId !== stepId) {
-        const overIndex = findStepIndex(stepId)
-        moveStep(draggedId, overIndex)
-      }
-    },
-    collect: (monitor: DropTargetOptions) => ({
-      isOver: monitor.isOver(),
-      handlerId: monitor.getHandlerId(),
+  const [{ isOver, handlerId }, drop] = useDrop(
+    () => ({
+      accept: DND_TYPES.STEP_ITEM,
+      canDrop: () => {
+        return true
+      },
+      drop: () => {
+        clickDrop()
+      },
+      hover: (item: DropType) => {
+        const draggedId = item.stepId
+        if (draggedId !== stepId) {
+          const overIndex = findStepIndex(stepId)
+          moveStep(draggedId, overIndex)
+        }
+      },
+      collect: (monitor: DropTargetOptions) => ({
+        isOver: monitor.isOver(),
+        handlerId: monitor.getHandlerId(),
+      }),
     }),
-  }))
+    [orderedStepIds]
+  )
 
   React.useEffect(() => {
     setIsOver(isOver)
@@ -136,6 +150,7 @@ export const DraggableStepItems = (
               clickDrop={clickDrop}
               setIsOver={setIsOver}
               findStepIndex={findStepIndex}
+              orderedStepIds={orderedStepIds}
             />
           ))
         }


### PR DESCRIPTION
closes [AUTH-18](https://opentrons.atlassian.net/browse/AUTH-18)

# Overview

fix a few bugs but mainly refactor how we are dragging and dropping items in the timeline. Plus, clean up how `slotControls`, adapterControls`, and `editLabware` are getting the current state of the item they are dragging/dropping by adding the dependency array

# Test Plan

Create a flex or ot-2 protocol

# Changelog

- add dependency array in `SlotControls`, `AdapterControls`, `EditLabware` and remove the now unneeded state variable since the dependency array updates the item to the latest state
- add a few `console.asserts`
- refactor `draggableStepItems` to not have a state

# Review requests

see test plan

# Risk assessment

low

[AUTH-18]: https://opentrons.atlassian.net/browse/AUTH-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ