### PR TITLE
feat(app): add protocol run notes feature flag

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,6 +1,7 @@
 {
   "__dev_internal__protocolStats": "Protocol Stats",
   "__dev_internal__enableRunTimeParameters": "Enable Run Time Parameters",
+  "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
   "add_folder_button": "Add labware source folder",
   "add_ip_button": "Add",
   "add_ip_error": "Enter an IP Address or Hostname",

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -3,6 +3,7 @@ import type { DevInternalFlag } from './types'
 export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'protocolStats',
   'enableRunTimeParameters',
+  'enableRunNotes',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -7,7 +7,10 @@ export type UpdateChannel = 'latest' | 'beta' | 'alpha'
 
 export type DiscoveryCandidates = string[]
 
-export type DevInternalFlag = 'protocolStats' | 'enableRunTimeParameters'
+export type DevInternalFlag =
+  | 'protocolStats'
+  | 'enableRunTimeParameters'
+  | 'enableRunNotes'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 


### PR DESCRIPTION
Closes [EXEC-294](https://opentrons.atlassian.net/browse/EXEC-294)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds the protocol run notes feature flag! Both to the desktop app and the ODD!

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- App: Verify by going to Settings > Feature Flags. Can verify the config update toggle with Redux devtools.
- ODD: It's at the bottom of the settings page.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added the protocol run notes feature flag.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->


<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-294]: https://opentrons.atlassian.net/browse/EXEC-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ