### PR TITLE
feat(api): Pause run after recoverable errors

### DIFF
--- a/api/src/opentrons/ordered_set.py
+++ b/api/src/opentrons/ordered_set.py
@@ -130,3 +130,9 @@ class OrderedSet(Generic[_SetElementT]):
         The elements that aren't removed retain their original relative order.
         """
         return OrderedSet(e for e in self if e not in other)
+
+    def __repr__(self) -> str:  # noqa: D105
+        # Use repr() on the keys view in case it's super long and Python is smart
+        # enough to abbreviate it.
+        elements_str = repr(self._elements.keys())
+        return f"OrderedSet({elements_str})"

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Optional, Union
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control.types import DoorState
@@ -129,18 +130,13 @@ class UpdateCommandAction:
 
 @dataclass(frozen=True)
 class FailCommandAction:
-    """Mark a given command as failed.
+    """Mark a given command as failed."""
 
-    The given command and all currently queued commands will be marked
-    as failed due to the given error.
-    """
-
-    # TODO(mc, 2021-11-12): we'll likely need to add the command params
-    # to this payload for state reaction purposes
     command_id: str
     error_id: str
     failed_at: datetime
     error: EnumeratedError
+    type: ErrorRecoveryType
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/error_recovery_policy.py
+++ b/api/src/opentrons/protocol_engine/error_recovery_policy.py
@@ -1,0 +1,76 @@
+# noqa: D100
+
+import enum
+from typing import Protocol
+
+from opentrons_shared_data.errors import EnumeratedError, ErrorCodes
+
+from opentrons.config import feature_flags as ff
+from opentrons.protocol_engine.commands import Command
+
+
+class ErrorRecoveryType(enum.Enum):
+    """Ways to handle a command failure."""
+
+    FAIL_RUN = enum.auto()
+    """Permanently fail the entire run.
+
+    TODO(mm, 2024-03-18): This might be a misnomer because failing the run is not
+    a decision that's up to Protocol Engine. It's decided by what the caller supplies
+    to `ProtocolEngine.finish()`. For example, a Python protocol can
+    theoretically swallow the exception and continue on.
+    """
+
+    WAIT_FOR_RECOVERY = enum.auto()
+    """Stop and wait for the error to be recovered from manually."""
+
+    # TODO(mm, 2023-03-18): Add something like this for
+    # https://opentrons.atlassian.net/browse/EXEC-302.
+    # CONTINUE = enum.auto()
+    # """Continue with the run, as if the command never failed."""
+
+
+class ErrorRecoveryPolicy(Protocol):
+    """An interface to decide how to handle a command failure.
+
+    This describes a function that Protocol Engine calls after each command failure,
+    with the details of that failure. The implementation should inspect those details
+    and return an appropriate `ErrorRecoveryType`.
+    """
+
+    @staticmethod
+    def __call__(  # noqa: D102
+        failed_command: Command, exception: Exception
+    ) -> ErrorRecoveryType:
+        ...
+
+
+def error_recovery_by_ff(
+    failed_command: Command, exception: Exception
+) -> ErrorRecoveryType:
+    """Use API feature flags to decide how to handle an error.
+
+    This is just for development. This should be replaced by a proper config
+    system exposed through robot-server's HTTP API.
+    """
+    # todo(mm, 2024-03-18): Do we need to do anything explicit here to disable
+    # error recovery on the OT-2?
+    if ff.enable_error_recovery_experiments() and _is_recoverable(
+        failed_command, exception
+    ):
+        return ErrorRecoveryType.WAIT_FOR_RECOVERY
+    else:
+        return ErrorRecoveryType.FAIL_RUN
+
+
+def _is_recoverable(failed_command: Command, exception: Exception) -> bool:
+    if (
+        failed_command.commandType == "pickUpTip"
+        and isinstance(exception, EnumeratedError)
+        # Hack(?): It seems like this should be ErrorCodes.TIP_PICKUP_FAILED, but that's
+        # not what gets raised in practice.
+        and exception.code == ErrorCodes.UNEXPECTED_TIP_REMOVAL
+    ):
+        return True
+    else:
+        return False

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -11,6 +11,8 @@ from opentrons_shared_data.errors.exceptions import (
     PythonException,
 )
 
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
+
 from ..state import StateStore
 from ..resources import ModelUtils
 from ..commands import (
@@ -82,6 +84,7 @@ class CommandExecutor:
         run_control: RunControlHandler,
         rail_lights: RailLightsHandler,
         status_bar: StatusBarHandler,
+        error_recovery_policy: ErrorRecoveryPolicy,
         model_utils: Optional[ModelUtils] = None,
         command_note_tracker_provider: Optional[CommandNoteTrackerProvider] = None,
     ) -> None:
@@ -102,6 +105,7 @@ class CommandExecutor:
         self._command_note_tracker_provider = (
             command_note_tracker_provider or _NoteTracker
         )
+        self._error_recovery_policy = error_recovery_policy
 
     async def execute(self, command_id: str) -> None:
         """Run a given command's execution procedure.
@@ -177,6 +181,18 @@ class CommandExecutor:
                     command_id=command_id,
                     error_id=self._model_utils.generate_id(),
                     failed_at=self._model_utils.get_timestamp(),
+                    # todo(mm, 2024-03-13):
+                    # When a command fails recoverably, and we handle it with
+                    # WAIT_FOR_RECOVERY or CONTINUE, we want to update our logical
+                    # protocol state as if the command succeeded. (e.g. if a tip
+                    # pickup failed, pretend that it succeeded and that the tip is now
+                    # on the pipette.) However, this currently does the opposite,
+                    # acting as if the command never executed.
+                    type=self._error_recovery_policy(
+                        # todo: should possibly be command_with_new_notes
+                        running_command,
+                        error,
+                    ),
                 )
             )
         else:

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -189,7 +189,6 @@ class CommandExecutor:
                     # on the pipette.) However, this currently does the opposite,
                     # acting as if the command never executed.
                     type=self._error_recovery_policy(
-                        # todo: should possibly be command_with_new_notes
                         running_command,
                         error,
                     ),

--- a/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
@@ -1,5 +1,6 @@
 """QueueWorker and dependency factory."""
 from opentrons.hardware_control import HardwareControlAPI
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 from opentrons.protocol_engine.execution.rail_lights import RailLightsHandler
 
 from ..state import StateStore
@@ -20,6 +21,7 @@ def create_queue_worker(
     hardware_api: HardwareControlAPI,
     state_store: StateStore,
     action_dispatcher: ActionDispatcher,
+    error_recovery_policy: ErrorRecoveryPolicy,
 ) -> QueueWorker:
     """Create a ready-to-use QueueWorker instance.
 
@@ -27,6 +29,7 @@ def create_queue_worker(
         hardware_api: Hardware control API to pass down to dependencies.
         state_store: StateStore to pass down to dependencies.
         action_dispatcher: ActionDispatcher to pass down to dependencies.
+        error_recovery_policy: ErrorRecoveryPolicy to pass down to dependencies.
     """
     gantry_mover = create_gantry_mover(
         hardware_api=hardware_api,
@@ -85,6 +88,7 @@ def create_queue_worker(
         run_control=run_control_handler,
         rail_lights=rail_lights_handler,
         status_bar=status_bar_handler,
+        error_recovery_policy=error_recovery_policy,
     )
 
     return QueueWorker(

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -316,12 +316,12 @@ class ProtocolEngine:
     async def wait_until_complete(self) -> None:
         """Wait until there are no more commands to execute.
 
-        Raises:
-            CommandExecutionFailedError: if any protocol command failed.
+        If a command encountered a fatal error, it's raised as an exception.
         """
         await self._state_store.wait_for(
             condition=self._state_store.commands.get_all_commands_final
         )
+        self._state_store.commands.raise_fatal_command_error()
 
     async def finish(
         self,

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -12,6 +12,7 @@ from opentrons.ordered_set import OrderedSet
 
 from opentrons.hardware_control.types import DoorState
 from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 
 from ..actions import (
     Action,

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -120,7 +120,7 @@ class CommandState:
     """Whether the engine is currently pulling new commands off the queue to execute.
 
     A command may still be executing, and the robot may still be in motion,
-    even if INACTIVE.
+    even if PAUSED.
     """
 
     run_started_at: Optional[datetime]

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -1,7 +1,8 @@
 """Protocol engine commands sub-state."""
 from __future__ import annotations
+
+import enum
 from collections import OrderedDict
-from enum import Enum
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Union
@@ -43,27 +44,43 @@ from .abstract_store import HasState, HandlesActions
 from .config import Config
 
 
-class QueueStatus(str, Enum):
-    """Execution status of the command queue.
+class QueueStatus(enum.Enum):
+    """Execution status of the command queue."""
 
-    Properties:
-        SETUP: The engine has been created, but the run has not yet started.
-            New protocol commands may be enqueued but will wait to execute.
-            New setup commands may be enqueued and will execute immediately.
-        RUNNING: The queue is running though protocol commands.
-            New protocol commands may be enqueued and will execute immediately.
-            New setup commands may not be enqueued.
-        PAUSED: Execution of protocol commands has been paused.
-            New protocol commands may be enqueued but wait to execute.
-            New setup commands may not be enqueued.
+    SETUP = enum.auto()
+    """The engine has been created, but the run has not yet started.
+
+    New protocol commands may be enqueued, but will wait to execute.
+    New setup commands may be enqueued and will execute immediately.
+    New fixup commands may not be enqueued.
     """
 
-    SETUP = "setup"
-    RUNNING = "running"
-    PAUSED = "paused"
+    RUNNING = enum.auto()
+    """The queue is running through protocol commands.
+
+    New protocol commands may be enqueued and will execute immediately.
+    New setup commands may not be enqueued.
+    New fixup commands may not be enqueued.
+    """
+
+    PAUSED = enum.auto()
+    """Execution of protocol commands has been paused.
+
+    New protocol commands may be enqueued, but will wait to execute.
+    New setup commands may not be enqueued.
+    New fixup commands may not be enqueued.
+    """
+
+    AWAITING_RECOVERY = enum.auto()
+    """A protocol command has encountered a recoverable error.
+
+    New protocol commands may be enqueued, but will wait to execute.
+    New setup commands may not be enqueued.
+    New fixup commands may be enqueued and will execute immediately.
+    """
 
 
-class RunResult(str, Enum):
+class RunResult(str, enum.Enum):
     """Result of the run."""
 
     SUCCEEDED = "succeeded"

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -618,10 +618,12 @@ class CommandView(HasState[CommandState]):
         """
         status = self.get(command_id).status
 
+        run_requested_to_stop = self._state.run_result is not None
+
         return (
             status == CommandStatus.SUCCEEDED
             or status == CommandStatus.FAILED
-            or (status == CommandStatus.QUEUED and self._state.run_result is not None)
+            or (status == CommandStatus.QUEUED and run_requested_to_stop)
         )
 
     def get_all_commands_final(self) -> bool:
@@ -634,8 +636,11 @@ class CommandView(HasState[CommandState]):
             `setup`.
         """
         no_command_running = self._state.running_command_id is None
+        run_requested_to_stop = self._state.run_result is not None
         no_command_to_execute = (
-            self._state.run_result is not None
+            run_requested_to_stop
+            # TODO(mm, 2024-03-15): This ignores queued setup commands,
+            # which seems questionable?
             or len(self._state.queued_command_ids) == 0
         )
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -173,7 +173,12 @@ class CommandState:
     """
 
     failed_command: Optional[CommandEntry]
-    """The command, if any, that made the run fail and the index in the command list."""
+    """The most recent command failure, if any."""
+    # TODO(mm, 2024-03-19): This attribute is currently only used to help robot-server
+    # with pagination, but "the failed command" is an increasingly nuanced idea, now
+    # that we're doing error recovery. See if we can implement robot-server pagination
+    # atop simpler concepts, like "the last command that ran" or "the next command that
+    # would run."
 
     finish_error: Optional[ErrorOccurrence]
     """The error that happened during the post-run finish steps (homing & dropping tips), if any."""

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -13,6 +13,7 @@ from opentrons.protocol_engine import (
     commands as pe_commands,
     types as pe_types,
 )
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 from opentrons.protocol_engine.resources import (
     ModelUtils,
     ModuleDataProvider,
@@ -248,6 +249,11 @@ class LegacyCommandMapper:
                         error_id=ModelUtils.generate_id(),
                         failed_at=now,
                         error=LegacyContextCommandError(command_error),
+                        # For legacy protocols, we don't attempt to support any kind
+                        # of error recovery at the Protocol Engine level.
+                        # These protocols only run on the OT-2, which doesn't have
+                        # any recoverable errors, anyway.
+                        type=ErrorRecoveryType.FAIL_RUN,
                     )
                 )
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store.py
@@ -629,7 +629,11 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
 
 
 def test_nonfatal_command_failure() -> None:
-    """It should clear the command queue on command failure."""
+    """Test the command queue if a command fails recoverably.
+
+    Commands that were after the failed command in the queue should be left in
+    the queue.
+    """
     queue_1 = QueueCommandAction(
         request=commands.WaitForResumeCreate(
             params=commands.WaitForResumeParams(), key="command-key-1"
@@ -646,7 +650,7 @@ def test_nonfatal_command_failure() -> None:
         created_at=datetime(year=2021, month=1, day=1),
         command_id="command-id-2",
     )
-    running_1 = UpdateCommandAction(
+    run_1 = UpdateCommandAction(
         private_result=None,
         command=commands.WaitForResume(
             id="command-id-1",
@@ -696,7 +700,7 @@ def test_nonfatal_command_failure() -> None:
 
     subject.handle_action(queue_1)
     subject.handle_action(queue_2)
-    subject.handle_action(running_1)
+    subject.handle_action(run_1)
     subject.handle_action(fail_1)
 
     assert subject.state.running_command_id is None

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -243,8 +243,8 @@ def test_get_all_commands_final() -> None:
     assert subject.get_all_commands_final() is False
 
 
-def test_get_all_complete_fatal_command_failure() -> None:
-    """It should raise an error if any protocol commands failed."""
+def test_raise_fatal_command_error() -> None:
+    """It should raise the fatal command error."""
     completed_command = create_succeeded_command(command_id="command-id-1")
     failed_command = create_failed_command(
         command_id="command-id-2",
@@ -264,10 +264,10 @@ def test_get_all_complete_fatal_command_failure() -> None:
     )
 
     with pytest.raises(ProtocolCommandFailedError):
-        subject.get_all_commands_final()
+        subject.raise_fatal_command_error()
 
 
-def test_get_all_complete_setup_not_fatal() -> None:
+def test_raise_fatal_command_error_tolerates_failed_setup_commands() -> None:
     """It should not call setup command fatal."""
     completed_command = create_succeeded_command(command_id="command-id-1")
     failed_command = create_failed_command(
@@ -288,8 +288,7 @@ def test_get_all_complete_setup_not_fatal() -> None:
         commands=[completed_command, failed_command],
     )
 
-    result = subject.get_all_commands_final()
-    assert result is True
+    subject.raise_fatal_command_error()  # Should not raise.
 
 
 def test_get_is_stopped() -> None:

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -9,6 +9,7 @@ from decoy import Decoy
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons.ordered_set import OrderedSet
 from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
@@ -695,7 +696,8 @@ async def test_wait_until_complete(
     decoy.verify(
         await state_store.wait_for(
             condition=state_store.commands.get_all_commands_final
-        )
+        ),
+        state_store.commands.raise_fatal_command_error(),
     )
 
 
@@ -778,12 +780,14 @@ async def test_estop_during_command(
         error_id=error_id,
         failed_at=timestamp,
         error=EStopActivatedError(message="Estop Activated"),
+        type=ErrorRecoveryType.FAIL_RUN,
     )
     expected_action_2 = FailCommandAction(
         command_id=fake_command_set.head(),
         error_id=error_id,
         failed_at=timestamp,
         error=EStopActivatedError(message="Estop Activated"),
+        type=ErrorRecoveryType.FAIL_RUN,
     )
 
     subject.estop(maintenance_run=maintenance_run)

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine import (
     commands as pe_commands,
     actions as pe_actions,
 )
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 from opentrons.protocol_engine.resources import (
     ModuleDataProvider,
     pipette_data_provider,
@@ -158,6 +159,7 @@ def test_map_after_with_error_command() -> None:
                 LegacyContextCommandError,
                 match="oh no",
             ),
+            type=ErrorRecoveryType.FAIL_RUN,
         )
     ]
 
@@ -251,6 +253,7 @@ def test_command_stack() -> None:
             error_id=matchers.IsA(str),
             failed_at=matchers.IsA(datetime),
             error=matchers.ErrorMatching(LegacyContextCommandError, "oh no"),
+            type=ErrorRecoveryType.FAIL_RUN,
         ),
     ]
 

--- a/api/tests/opentrons/test_ordered_set.py
+++ b/api/tests/opentrons/test_ordered_set.py
@@ -145,3 +145,13 @@ def test_difference() -> None:
     b = {1, 9}
 
     assert (a - OrderedSet(b)) == (a - b) == OrderedSet([3, 4, 5, 2, 6, 5, 3, 5, 8, 7])
+
+
+def test_repr() -> None:
+    """It should return a meaningful repr string."""
+    subject = OrderedSet([1, 2, 3])
+    result = repr(subject)
+    assert "OrderedSet" in result
+    assert "1" in result
+    assert "2" in result
+    assert "3" in result


### PR DESCRIPTION
# Overview

This closes most of EXEC-301 and closes EXEC-320.

# Changelog

## What works now (or is intended to work, anyway)

* When running a JSON protocol on a Flex, if a `pickUpTip` command fails because of a missing tip, the run pauses now, instead of homing and showing an error message.
* You can then either:
    * Cancel the run in the usual way, by issuing a `stop` action via `POST /runs/{id}/actions`.
    * Resume the run from the next command, by issuing a `resume-from-recovery` action via `POST /runs/{id}/actions`.

## What doesn't work

* After a `pickUpTip` command failure, the robot seems to simultaneously think it does not have a tip attached (a subsequent `aspirate` command will fail with a "tip not attached" error) and that it does have a tip attached (a subsequent `moveTo` will act like there's a tip). I haven't had a chance to look into this yet. So the practical usefulness of this is pretty limited so far: you can only meaningfully recover if the protocol doesn't have any aspirates or dispenses.
* After recovering from an error and proceeding through the rest of the run, the run will end as `failed` despite the recovery. I see what's causing this, I just haven't gotten to it yet.
* You can't issue any fixup commands yet.
* You can't recover from errors in Python protocols yet. EXEC-339 is the next step to accomplish that.
* This isn't remotely supported by the Opentrons App or Flex on-device display. You'll see weird things like buttons without labels.

# Test Plan

## Setup

Enable the hidden error recovery feature flag by manually issuing a `POST /settings` request with `{"id": "enableErrorRecoveryExperiments", "value": true}`.

## Test

1. Upload this test protocol to a Flex: [Recovery test.json.zip](https://github.com/Opentrons/opentrons/files/14654980/Recovery.test.json.zip). This comes from Protocol Designer, with `aspirate`s and `dispense`s hand-replaced by `moveToWell`s in order to work around the tip-attached confusion that I've described above.
2. Fill random wells in the leftmost column of the tip rack with tips.
3. Start the run.
4. When the run reaches a missing tip, it should pause. Resume it by issuing a `{"data": {"actionType": "resume-from-recovery"}}` action to `POST /runs/{id}/actions`, or cancel it by issuing a `{"data": {"actionType": "stop"}}` action.


## Cleanup

1. Delete any runs that you just created, to avoid database incompatibilities when you push a different branch. You can do this with the Opentrons App or with manually-issued `DELETE /runs/{id}` requests.
5. `POST /settings` with `{"id": "enableErrorRecoveryExperiments", "value": false}`.

# Review requests

None in particular.

The easiest way to review this might be to filter by commit. I've organized this into refactor commits vs. feature commits.

# Risk assessment

Medium. This touches core internal Protocol Engine logic. Although it's all technically well covered by unit tests, those tests are mostly too isolated and low-level to catch actual bugs.