### PR TITLE
refactor(api): Split CommandStore

### DIFF
--- a/api/src/opentrons/ordered_set.py
+++ b/api/src/opentrons/ordered_set.py
@@ -81,7 +81,7 @@ class OrderedSet(Generic[_SetElementT]):
     def head(
         self, default_value: Union[_DefaultValueT, _NOT_SPECIFIED] = _NOT_SPECIFIED()
     ) -> Union[_SetElementT, _DefaultValueT]:
-        """Get the head of the set.
+        """Get the head (oldest-added element) of the set.
 
         Args:
             default_value: A value to return if set is empty.
@@ -93,12 +93,44 @@ class OrderedSet(Generic[_SetElementT]):
             IndexError: set is empty and default was not specified.
         """
         try:
-            return next(iter(self))
-        except StopIteration as e:
+            return next(iter(self._elements))
+        except StopIteration:
             if isinstance(default_value, _NOT_SPECIFIED):
-                raise IndexError("Set is empty") from e
+                raise IndexError("Set is empty") from None
+            else:
+                return default_value
 
-        return default_value
+    @overload
+    def tail(self) -> _SetElementT:
+        ...
+
+    @overload
+    def tail(
+        self, default_value: _DefaultValueT
+    ) -> Union[_SetElementT, _DefaultValueT]:
+        ...
+
+    def tail(
+        self, default_value: Union[_DefaultValueT, _NOT_SPECIFIED] = _NOT_SPECIFIED()
+    ) -> Union[_SetElementT, _DefaultValueT]:
+        """Get the tail (newest-added element) of the set.
+
+        Args:
+            default_value: A value to return if set is empty.
+
+        Returns:
+            The tail of the set, or the default value, if specified.
+
+        Raises:
+            IndexError: set is empty and default was not specified.
+        """
+        try:
+            return next(reversed(self._elements))
+        except StopIteration:
+            if isinstance(default_value, _NOT_SPECIFIED):
+                raise IndexError("Set is empty") from None
+            else:
+                return default_value
 
     def __iter__(self) -> Iterator[_SetElementT]:
         """Enable iteration over all elements in the set.

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -114,14 +114,9 @@ class QueueCommandAction:
 
 @dataclass(frozen=True)
 class UpdateCommandAction:
-    """Update a command from queued->running or running->succeeded.
-
-    For other state transitions, there are more specific actions, so use those instead.
-    """
+    """Update a given command."""
 
     command: Command
-    """The command in its new state."""
-
     private_result: CommandPrivateResult
 
 

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -114,9 +114,14 @@ class QueueCommandAction:
 
 @dataclass(frozen=True)
 class UpdateCommandAction:
-    """Update a given command."""
+    """Update a command from queued->running or running->succeeded.
+
+    For other state transitions, there are more specific actions, so use those instead.
+    """
 
     command: Command
+    """The command in its new state."""
+
     private_result: CommandPrivateResult
 
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -241,6 +241,7 @@ class ProtocolEngine:
         if self._state_store.commands.get_is_stopped():
             return
         current_id = (
+            # todo
             self._state_store.commands.state.running_command_id
             or self._state_store.commands.state.queued_command_ids.head(None)
         )
@@ -256,6 +257,7 @@ class ProtocolEngine:
 
             # In the case where the running command was a setup command - check if there
             # are any pending *run* commands and, if so, clear them all
+            # todo
             current_id = self._state_store.commands.state.queued_command_ids.head(None)
             if current_id is not None:
                 fail_action = FailCommandAction(

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -242,6 +242,27 @@ class ProtocolEngine:
             return
         current_id = (
             # todo
+            #
+            ## Notes
+            # Reading:
+            # - Get single command by ID
+            # - Get all commands, ordered
+            # - Get slice of commands by integer index, potentially starting from "currently running or most recently executed" (but see confusing docs)
+            # - Get "current" (currently running, or most recently completed) command (but see confusing docs)
+            #   - May need to change for fixup commands
+            # - Get "next to execute" (first queued setup command or first queued protocol command)
+            #   - Will need to change for fixup commands
+            # == / !=, mostly for tests
+            # Writing:
+            # - Enqueue a new command
+            # - Update command for its new state
+            # Steps for this PR:
+            # 1. Naively move everything into this file
+            # ?. Resolve get_current()/get_slice() discrepancy
+            # ?. Add .tail to OrderedSet to support existing JSONv6 performance bug
+            # ?. General state deduplication and cleanup.
+            # "Most recently executed" unfortunately does not mean "most recent to have internally entered a completed state," because of mid-JSON-run failures.
+            # Resolve todo about separate actions for separate state transitions, instead of a single UpdateCommandAction
             self._state_store.commands.state.running_command_id
             or self._state_store.commands.state.queued_command_ids.head(None)
         )

--- a/api/src/opentrons/protocol_engine/state/command_structure.py
+++ b/api/src/opentrons/protocol_engine/state/command_structure.py
@@ -64,6 +64,9 @@ class CommandStructure:
     def get_all(self) -> List[Command]:
         return [self._commands_by_id[cid].command for cid in self._all_command_ids]
 
+    def get_all_ids(self) -> List[str]:
+        return [*self._all_command_ids]
+
     def get_slice(self, start: int, stop: int) -> List[Command]:
         command_ids = self._all_command_ids[start:stop]
         return [self._commands_by_id[command_id].command for command_id in command_ids]

--- a/api/src/opentrons/protocol_engine/state/command_structure.py
+++ b/api/src/opentrons/protocol_engine/state/command_structure.py
@@ -83,6 +83,9 @@ class CommandStructure:
     def get_queued_command_ids(self) -> OrderedSet[str]:
         return self._queued_command_ids
 
+    def get_queued_setup_command_ids(self) -> OrderedSet[str]:
+        return self._queued_setup_command_ids
+
     def add_queued(self, queued_command: Command) -> None:
         assert queued_command.status == CommandStatus.QUEUED
         assert not self.has(queued_command.id)

--- a/api/src/opentrons/protocol_engine/state/command_structure.py
+++ b/api/src/opentrons/protocol_engine/state/command_structure.py
@@ -1,0 +1,39 @@
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from opentrons.ordered_set import OrderedSet
+from opentrons.protocol_engine.commands.command_unions import Command
+
+
+@dataclass(frozen=True)
+class CommandEntry:
+    """An command entry in state, including its index in the list."""
+
+    command: Command
+    index: int
+
+
+@dataclass  # dataclass for __eq__() autogeneration.
+class CommandStructure:
+    _all_command_ids: List[str]
+    """All command IDs, in insertion order."""
+
+    _queued_command_ids: OrderedSet[str]
+    """The IDs of queued commands, in FIFO order"""
+
+    _queued_setup_command_ids: OrderedSet[str]
+    """The IDs of queued setup commands, in FIFO order"""
+
+    _running_command_id: Optional[str]
+    """The ID of the currently running command, if any"""
+
+    _commands_by_id: Dict[str, CommandEntry]
+    """All command resources, in insertion order, mapped by their unique IDs."""
+
+    def __init__(self) -> None:
+        self._all_command_ids = []
+        self._running_command_id = None
+        self._queued_command_ids = OrderedSet()
+        self._queued_setup_command_ids = OrderedSet()
+        self._commands_by_id = OrderedDict()

--- a/api/src/opentrons/protocol_engine/state/command_structure.py
+++ b/api/src/opentrons/protocol_engine/state/command_structure.py
@@ -140,14 +140,10 @@ class CommandStructure:
 
         self._failed_command = self._commands_by_id[command_id]
         if prev_entry.command.intent == CommandIntent.SETUP:
-            other_command_ids_to_fail = [
-                *[i for i in self._queued_setup_command_ids],
-            ]
+            other_command_ids_to_fail = self._queued_setup_command_ids
             self._queued_setup_command_ids.clear()
         else:
-            other_command_ids_to_fail = [
-                *[i for i in self._queued_command_ids],
-            ]
+            other_command_ids_to_fail = self._queued_command_ids
             self._queued_command_ids.clear()
 
         for command_id in other_command_ids_to_fail:

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -522,6 +522,16 @@ class CommandView(HasState[CommandState]):
         else:
             return run_error or finish_error
 
+    # TODO: Why is this different from get_slice()?
+    # TODO:
+    # - GET /runs/commands docs say that links.current is "currently running or NEXT QUEUED", and attempts to implement that via this.
+    # - These docs say that this implements "currently [running] or MOST RECENT TO HAVE COMPLETED"
+    # - This actual implementation returns currently running or MOST RECENT TO HAVE COMPLETED.
+    #
+    # Not to be confused with the ?cursor param to GET /runs/commands, which:
+    # - HTTP docs say "MOST RECENTLY EXECUTED"
+    # - Docs in this file say "MOST RECENTLY EXECUTED"
+    # - Implementation returns MOST RECENTLY EXECUTED
     def get_current(self) -> Optional[CurrentCommand]:
         """Return the "current" command, if any.
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -468,12 +468,18 @@ class CommandView(HasState[CommandState]):
             if running_command_id is not None:
                 cursor = commands_by_id[running_command_id].index
             elif len(queued_command_ids) > 0:
+                # Get the most recently executed command,
+                # which we can find just before the first queued command.
                 cursor = commands_by_id[queued_command_ids.head()].index - 1
             elif (
                 self._state.run_result
                 and self._state.run_result == RunResult.FAILED
                 and self._state.failed_command
             ):
+                # Currently, if the run fails, we mark all the commands we didn't
+                # reach as failed. This makes command status alone insufficient to
+                # find the most recent command that actually executed, so we need to
+                # store that separately.
                 cursor = self._state.failed_command.index
             else:
                 cursor = total_length - length

--- a/api/tests/opentrons/test_ordered_set.py
+++ b/api/tests/opentrons/test_ordered_set.py
@@ -126,17 +126,31 @@ def test_clear() -> None:
 def test_head() -> None:
     """It should return the head of the set."""
     subject = OrderedSet([1, 2])
-
     assert subject.head() == 1
+
     subject.remove(1)
-
     assert subject.head() == 2
-    subject.remove(2)
 
-    with pytest.raises(IndexError):
+    subject.remove(2)
+    with pytest.raises(IndexError, match="Set is empty"):
         subject.head()
 
     assert subject.head(default_value=42) == 42
+
+
+def test_tail() -> None:
+    """It should return the tail of the set."""
+    subject = OrderedSet([1, 2])
+    assert subject.tail() == 2
+
+    subject.remove(2)
+    assert subject.tail() == 1
+
+    subject.remove(1)
+    with pytest.raises(IndexError, match="Set is empty"):
+        subject.tail()
+
+    assert subject.tail(default_value=42) == 42
 
 
 def test_difference() -> None:


### PR DESCRIPTION
# Background

[This file](https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/protocol_engine/state/commands.py) has been a bit uncomfortably bloated for a while. It's responsible for at least two broad areas:

1. Run-level concerns, like getting "the overall run error," or choosing "the next command to execute."
2. Lower-level data organization concerns, to support stuff like O(1) retrieval of a command by its ID, or O(1) retrieval of the next queued command.

The other problem is that it uses the old test style of splitting the [store](https://github.com/Opentrons/opentrons/blob/edge/api/tests/opentrons/protocol_engine/state/test_command_store.py) from the [view](https://github.com/Opentrons/opentrons/blob/edge/api/tests/opentrons/protocol_engine/state/test_command_view.py). This creates thousands of lines of tests that don't pull their weight in catching bugs, and, I find, make it harder to work on this file.

All of this has contributed to maintenance problems (here are apparently two [different](https://github.com/Opentrons/opentrons/blob/392d83bc23d85c261b440723df8f5b3f5c9ba3c8/api/src/opentrons/protocol_engine/state/commands.py#L470-L471) [ways](https://github.com/Opentrons/opentrons/blob/392d83bc23d85c261b440723df8f5b3f5c9ba3c8/api/src/opentrons/protocol_engine/state/commands.py#L536-L544) of computing the same thing, for example), and performance problems [past](https://github.com/Opentrons/opentrons/pull/9170) and [ongoing](https://github.com/Opentrons/opentrons/blob/392d83bc23d85c261b440723df8f5b3f5c9ba3c8/api/src/opentrons/protocol_engine/state/commands.py#L534-L535).

This is going to get worse because of error recovery, which will add new run states and maybe command states.

So, the plan here is:

* Pull the lower-level data organization stuff out into its own data structure. Its responsibility will be to provide O(1) access to commands, without relying on knowledge of higher-level things like runs.
* That single type will take over for at least [these fields](https://github.com/Opentrons/opentrons/blob/392d83bc23d85c261b440723df8f5b3f5c9ba3c8/api/src/opentrons/protocol_engine/state/commands.py#L103-L116) in CommandState.
* Unit-test as a pure functional black box.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
