### PR TITLE
fix(protocol-designer): cannot move trash into slot with a module

### DIFF
--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditModulesModal.test.tsx
@@ -129,9 +129,7 @@ describe('Edit Modules Modal', () => {
     render(props)
     screen.getByText('Thermocycler module')
     screen.getByText('warning')
-    screen.getByText(
-      'Slot 10 is occupied by a Heater-Shaker. Other modules cannot be placed in front of or behind a Heater-Shaker.'
-    )
+    screen.getByText('Cannot place module')
     screen.getByText('mock SlotMap')
   })
   it('renders a heater-shaker for flex and can select different slots', () => {

--- a/protocol-designer/src/components/modals/EditModulesModal/index.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/index.tsx
@@ -395,7 +395,11 @@ const EditModulesModalComponent = (
             {slotIssue ? (
               <PDAlert
                 alertType="warning"
-                title={validation.selectedSlot}
+                title={
+                  robotType === OT2_ROBOT_TYPE
+                    ? t('alert:module_placement.SLOT_OCCUPIED.title')
+                    : validation.selectedSlot
+                }
                 description={''}
               />
             ) : null}

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -120,6 +120,7 @@ export const getSlotIdsBlockedBySpanning = (
 
   return []
 }
+//  TODO(jr, 3/13/24): refactor this util it is messy and confusing
 export const getSlotIsEmpty = (
   initialDeckSetup: InitialDeckSetup,
   slot: string,
@@ -127,6 +128,7 @@ export const getSlotIsEmpty = (
      since labware/wasteChute can still go on top of staging areas  **/
   includeStagingAreas?: boolean
 ): boolean => {
+  //   special-casing the TC's slot A1 for the Flex
   if (
     slot === 'cutoutA1' &&
     Object.values(initialDeckSetup.modules).find(
@@ -166,8 +168,13 @@ export const getSlotIsEmpty = (
   })
   return (
     [
-      ...values(initialDeckSetup.modules).filter((moduleOnDeck: ModuleOnDeck) =>
-        slot.includes(moduleOnDeck.slot)
+      ...values(initialDeckSetup.modules).filter(
+        (moduleOnDeck: ModuleOnDeck) => {
+          const cutoutForSlotOt2 = slotToCutoutOt2Map[slot]
+          return cutoutForSlotOt2 != null
+            ? moduleOnDeck.slot === slot
+            : slot.includes(moduleOnDeck.slot)
+        }
       ),
       ...values(initialDeckSetup.labware).filter(
         (labware: LabwareOnDeckType) => labware.slot === slot

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -11,7 +11,7 @@ import { SPAN7_8_10_11_SLOT, TC_SPAN_SLOTS } from '../../constants'
 import { hydrateField } from '../../steplist/fieldLevel'
 import { LabwareDefByDefURI } from '../../labware-defs'
 import type { DeckSlotId, ModuleType } from '@opentrons/shared-data'
-import {
+import type {
   AdditionalEquipmentOnDeck,
   InitialDeckSetup,
   ModuleOnDeck,
@@ -132,7 +132,7 @@ export const getSlotIsEmpty = (
   if (
     slot === 'cutoutA1' &&
     Object.values(initialDeckSetup.modules).find(
-      module => module.type === 'thermocyclerModuleType'
+      module => module.type === THERMOCYCLER_MODULE_TYPE
     )
   ) {
     return false

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -128,6 +128,13 @@ export const getSlotIsEmpty = (
   includeStagingAreas?: boolean
 ): boolean => {
   if (
+    slot === 'cutoutA1' &&
+    Object.values(initialDeckSetup.modules).find(
+      module => module.type === 'thermocyclerModuleType'
+    )
+  ) {
+    return false
+  } else if (
     slot === SPAN7_8_10_11_SLOT &&
     TC_SPAN_SLOTS.some(slot => !getSlotIsEmpty(initialDeckSetup, slot))
   ) {
@@ -157,11 +164,10 @@ export const getSlotIsEmpty = (
       return additionalEquipment.location?.includes(slot) && includeStaging
     }
   })
-
   return (
     [
-      ...values(initialDeckSetup.modules).filter(
-        (moduleOnDeck: ModuleOnDeck) => moduleOnDeck.slot === slot
+      ...values(initialDeckSetup.modules).filter((moduleOnDeck: ModuleOnDeck) =>
+        slot.includes(moduleOnDeck.slot)
       ),
       ...values(initialDeckSetup.labware).filter(
         (labware: LabwareOnDeckType) => labware.slot === slot


### PR DESCRIPTION
closes RQA-2498 RQA-2499

# Overview

There seems to be an issue with this `getSlotEmpty` util all the time 😅  PD on edge was incorrectly stating that a slot was empty but it had a module in it and it was an issue with cutoutId vs slot. This PR fixes it

# Test Plan

create a flex protocol and add a thermocycler and the trash bin. Move the trash bin in slot A1 and B1 and see that it errors saying the slot is occupied for both slots. 

# Changelog

modify the util logic and account for `cutoutId`

# Review requests

see test plan

# Risk assessment

low