### PR TITLE
feat(api): command executors can add notes

### DIFF
--- a/api/src/opentrons/protocol_engine/__init__.py
+++ b/api/src/opentrons/protocol_engine/__init__.py
@@ -13,6 +13,7 @@ from .create_protocol_engine import (
 )
 from .protocol_engine import ProtocolEngine
 from .errors import ProtocolEngineError, ErrorOccurrence
+from .notes import CommandNote
 from .commands import (
     Command,
     CommandParams,
@@ -20,7 +21,6 @@ from .commands import (
     CommandStatus,
     CommandType,
     CommandIntent,
-    CommandNote,
 )
 from .state import State, StateView, StateSummary, CommandSlice, CurrentCommand, Config
 from .plugins import AbstractPlugin

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -28,7 +28,6 @@ from .command import (
     BaseCommandCreate,
     CommandStatus,
     CommandIntent,
-    CommandNote,
 )
 
 from .command_unions import (
@@ -333,7 +332,6 @@ __all__ = [
     "BaseCommandCreate",
     "CommandStatus",
     "CommandIntent",
-    "CommandNote",
     # command parameter hashing
     "hash_command_params",
     # command schema generation

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -20,6 +20,7 @@ from ..types import WellLocation, WellOrigin, CurrentWell, DeckPoint
 if TYPE_CHECKING:
     from ..execution import MovementHandler, PipettingHandler
     from ..state import StateView
+    from ..notes import CommandNoteAdder
 
 
 AspirateCommandType = Literal["aspirate"]
@@ -48,12 +49,14 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]
         state_view: StateView,
         hardware_api: HardwareControlAPI,
         movement: MovementHandler,
+        command_note_adder: CommandNoteAdder,
         **kwargs: object,
     ) -> None:
         self._pipetting = pipetting
         self._state_view = state_view
         self._hardware_api = hardware_api
         self._movement = movement
+        self._command_note_adder = command_note_adder
 
     async def execute(self, params: AspirateParams) -> AspirateResult:
         """Move to and aspirate from the requested well.
@@ -98,7 +101,10 @@ class AspirateImplementation(AbstractCommandImpl[AspirateParams, AspirateResult]
         )
 
         volume = await self._pipetting.aspirate_in_place(
-            pipette_id=pipette_id, volume=params.volume, flow_rate=params.flowRate
+            pipette_id=pipette_id,
+            volume=params.volume,
+            flow_rate=params.flowRate,
+            command_note_adder=self._command_note_adder,
         )
 
         return AspirateResult(

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -18,7 +18,7 @@ from ..errors.exceptions import PipetteNotReadyToAspirateError
 if TYPE_CHECKING:
     from ..execution import PipettingHandler
     from ..state import StateView
-
+    from ..notes import CommandNoteAdder
 
 AspirateInPlaceCommandType = Literal["aspirateInPlace"]
 
@@ -45,11 +45,13 @@ class AspirateInPlaceImplementation(
         pipetting: PipettingHandler,
         hardware_api: HardwareControlAPI,
         state_view: StateView,
+        command_note_adder: CommandNoteAdder,
         **kwargs: object,
     ) -> None:
         self._pipetting = pipetting
         self._state_view = state_view
         self._hardware_api = hardware_api
+        self._command_note_adder = command_note_adder
 
     async def execute(self, params: AspirateInPlaceParams) -> AspirateInPlaceResult:
         """Aspirate without moving the pipette.
@@ -69,7 +71,10 @@ class AspirateInPlaceImplementation(
                 " so the plunger can be reset in a known safe position."
             )
         volume = await self._pipetting.aspirate_in_place(
-            pipette_id=params.pipetteId, volume=params.volume, flow_rate=params.flowRate
+            pipette_id=params.pipetteId,
+            volume=params.volume,
+            flow_rate=params.flowRate,
+            command_note_adder=self._command_note_adder,
         )
 
         return AspirateInPlaceResult(volume=volume)

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -12,8 +12,6 @@ from typing import (
     Optional,
     TypeVar,
     Tuple,
-    Union,
-    Literal,
     List,
 )
 
@@ -23,6 +21,7 @@ from pydantic.generics import GenericModel
 from opentrons.hardware_control import HardwareControlAPI
 
 from ..errors import ErrorOccurrence
+from ..notes import CommandNote, CommandNoteAdder
 
 # Work around type-only circular dependencies.
 if TYPE_CHECKING:
@@ -35,29 +34,6 @@ CommandParamsT = TypeVar("CommandParamsT", bound=BaseModel)
 CommandResultT = TypeVar("CommandResultT", bound=BaseModel)
 
 CommandPrivateResultT = TypeVar("CommandPrivateResultT")
-
-NoteKind = Union[Literal["warning", "information"], str]
-
-
-class CommandNote(BaseModel):
-    """A note about a command's execution or dispatch."""
-
-    noteKind: NoteKind = Field(
-        ...,
-        description="The kind of note this is. Only the literal possibilities should be"
-        " relied upon programmatically.",
-    )
-    shortMessage: str = Field(
-        ...,
-        description="The accompanying human-readable short message (suitable for display in a single line)",
-    )
-    longMessage: str = Field(
-        ...,
-        description="A longer message that may contain newlines and formatting characters describing the note.",
-    )
-    source: str = Field(
-        ..., description="An identifier for the party that created the note"
-    )
 
 
 class CommandStatus(str, Enum):
@@ -215,6 +191,7 @@ class AbstractCommandImpl(
         run_control: execution.RunControlHandler,
         rail_lights: execution.RailLightsHandler,
         status_bar: execution.StatusBarHandler,
+        command_note_adder: CommandNoteAdder,
     ) -> None:
         """Initialize the command implementation with execution handlers."""
         pass
@@ -256,6 +233,7 @@ class AbstractCommandWithPrivateResultImpl(
         run_control: execution.RunControlHandler,
         rail_lights: execution.RailLightsHandler,
         status_bar: execution.StatusBarHandler,
+        command_note_adder: CommandNoteAdder,
     ) -> None:
         """Initialize the command implementation with execution handlers."""
         pass

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -184,7 +184,7 @@ class CommandExecutor:
                 "result": result,
                 "status": CommandStatus.SUCCEEDED,
                 "completedAt": self._model_utils.get_timestamp(),
-                **_append_notes_if_notes(running_command, note_tracker.get_notes())
+                **_append_notes_if_notes(running_command, note_tracker.get_notes()),
             }
             completed_command = running_command.copy(update=update)
             self._action_dispatcher.dispatch(

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -184,10 +184,8 @@ class CommandExecutor:
                 "result": result,
                 "status": CommandStatus.SUCCEEDED,
                 "completedAt": self._model_utils.get_timestamp(),
+                **_append_notes_if_notes(running_command, note_tracker.get_notes())
             }
-            update.update(
-                _append_notes_if_notes(running_command, note_tracker.get_notes())
-            )
             completed_command = running_command.copy(update=update)
             self._action_dispatcher.dispatch(
                 UpdateCommandAction(

--- a/api/src/opentrons/protocol_engine/notes/__init__.py
+++ b/api/src/opentrons/protocol_engine/notes/__init__.py
@@ -1,0 +1,5 @@
+"""Protocol engine notes module."""
+
+from .notes import NoteKind, CommandNote, CommandNoteAdder, CommandNoteTracker
+
+__all__ = ["NoteKind", "CommandNote", "CommandNoteAdder", "CommandNoteTracker"]

--- a/api/src/opentrons/protocol_engine/notes/notes.py
+++ b/api/src/opentrons/protocol_engine/notes/notes.py
@@ -1,0 +1,42 @@
+"""Definitions of data and interface shapes for notes."""
+from typing import Union, Literal, Protocol, List
+from pydantic import BaseModel, Field
+
+NoteKind = Union[Literal["warning", "information"], str]
+
+
+class CommandNote(BaseModel):
+    """A note about a command's execution or dispatch."""
+
+    noteKind: NoteKind = Field(
+        ...,
+        description="The kind of note this is. Only the literal possibilities should be"
+        " relied upon programmatically.",
+    )
+    shortMessage: str = Field(
+        ...,
+        description="The accompanying human-readable short message (suitable for display in a single line)",
+    )
+    longMessage: str = Field(
+        ...,
+        description="A longer message that may contain newlines and formatting characters describing the note.",
+    )
+    source: str = Field(
+        ..., description="An identifier for the party that created the note"
+    )
+
+
+class CommandNoteAdder(Protocol):
+    """The shape of a function that something can use to add a command note."""
+
+    def __call__(self, note: CommandNote) -> None:
+        """When called, this function should add the passed Note to some list."""
+        ...
+
+
+class CommandNoteTracker(CommandNoteAdder, Protocol):
+    """The shape of a class that can track notes."""
+
+    def get_notes(self) -> List[CommandNote]:
+        """When called, should return all notes previously added with __call__."""
+        ...

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.commands.aspirate_in_place import (
     AspirateInPlaceImplementation,
 )
 from opentrons.protocol_engine.errors.exceptions import PipetteNotReadyToAspirateError
+from opentrons.protocol_engine.notes import CommandNoteAdder
 
 from opentrons.protocol_engine.state import (
     StateStore,
@@ -40,12 +41,14 @@ def subject(
     pipetting: PipettingHandler,
     state_store: StateStore,
     hardware_api: HardwareAPI,
+    mock_command_note_adder: CommandNoteAdder,
 ) -> AspirateInPlaceImplementation:
     """Get the impelementation subject."""
     return AspirateInPlaceImplementation(
         pipetting=pipetting,
         hardware_api=hardware_api,
         state_view=state_store,
+        command_note_adder=mock_command_note_adder,
     )
 
 
@@ -54,6 +57,7 @@ async def test_aspirate_in_place_implementation(
     pipetting: PipettingHandler,
     state_store: StateStore,
     hardware_api: HardwareAPI,
+    mock_command_note_adder: CommandNoteAdder,
     subject: AspirateInPlaceImplementation,
 ) -> None:
     """It should aspirate in place."""
@@ -71,7 +75,10 @@ async def test_aspirate_in_place_implementation(
 
     decoy.when(
         await pipetting.aspirate_in_place(
-            pipette_id="pipette-id-abc", volume=123, flow_rate=1.234
+            pipette_id="pipette-id-abc",
+            volume=123,
+            flow_rate=1.234,
+            command_note_adder=mock_command_note_adder,
         )
     ).then_return(123)
 
@@ -110,7 +117,10 @@ async def test_handle_aspirate_in_place_request_not_ready_to_aspirate(
 
 
 async def test_aspirate_raises_volume_error(
-    decoy: Decoy, pipetting: PipettingHandler, subject: AspirateInPlaceImplementation
+    decoy: Decoy,
+    pipetting: PipettingHandler,
+    subject: AspirateInPlaceImplementation,
+    mock_command_note_adder: CommandNoteAdder,
 ) -> None:
     """Should raise an assertion error for volume larger than working volume."""
     data = AspirateInPlaceParams(
@@ -122,7 +132,12 @@ async def test_aspirate_raises_volume_error(
     decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id="abc")).then_return(True)
 
     decoy.when(
-        await pipetting.aspirate_in_place(pipette_id="abc", volume=50, flow_rate=1.23)
+        await pipetting.aspirate_in_place(
+            pipette_id="abc",
+            volume=50,
+            flow_rate=1.23,
+            command_note_adder=mock_command_note_adder,
+        )
     ).then_raise(AssertionError("blah blah"))
 
     with pytest.raises(AssertionError):

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -21,6 +21,7 @@ from opentrons.protocol_engine.types import ModuleDefinition
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 from opentrons.hardware_control.api import API
 from opentrons.hardware_control.protocols.types import FlexRobotType, OT2RobotType
+from opentrons.protocol_engine.notes import CommandNoteAdder
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
@@ -230,3 +231,9 @@ def supported_tip_fixture() -> pipette_definition.SupportedTipsDefinition:
         dispense=pipette_definition.ulPerMMDefinition(default={"1": [(0, 0, 0)]}),
         defaultPushOutVolume=3,
     )
+
+
+@pytest.fixture
+def mock_command_note_adder(decoy: Decoy) -> CommandNoteAdder:
+    """Get a command note adder."""
+    return decoy.mock(cls=CommandNoteAdder)

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -570,6 +570,7 @@ async def test_executor_forwards_notes_on_command_success(
         ),
     )
 
+
 async def test_executor_forwards_notes_on_command_failure(
     decoy: Decoy,
     hardware_api: HardwareControlAPI,
@@ -591,7 +592,6 @@ async def test_executor_forwards_notes_on_command_failure(
     """It should handle an error occuring during execution."""
     TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
     command_impl = decoy.mock(cls=_TestCommandImpl)
-
 
     class _TestCommand(BaseCommand[_TestCommandParams, _TestCommandResult]):
         commandType: str = "testCommand"
@@ -634,7 +634,7 @@ async def test_executor_forwards_notes_on_command_failure(
             params=command_params,
         ),
     )
-    running_command_with_notes = running_command.copy(update={'notes': command_notes})
+    running_command_with_notes = running_command.copy(update={"notes": command_notes})
 
     decoy.when(state_store.commands.get(command_id="command-id")).then_return(
         queued_command
@@ -659,7 +659,9 @@ async def test_executor_forwards_notes_on_command_failure(
         command_impl  # type: ignore[arg-type]
     )
 
-    decoy.when(await command_impl.execute(command_params)).then_raise(RuntimeError("oh no"))
+    decoy.when(await command_impl.execute(command_params)).then_raise(
+        RuntimeError("oh no")
+    )
 
     decoy.when(model_utils.generate_id()).then_return("error-id")
     decoy.when(model_utils.get_timestamp()).then_return(

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -45,7 +45,7 @@ from opentrons.protocol_engine.execution.command_executor import (
 )
 
 from opentrons_shared_data.errors.exceptions import EStopActivatedError, PythonException
-from opentrons.protocol_engine.notes import CommandNoteTracker
+from opentrons.protocol_engine.notes import CommandNoteTracker, CommandNote
 
 
 @pytest.fixture
@@ -442,6 +442,247 @@ async def test_execute_raises_protocol_engine_error(
                 error_id="error-id",
                 failed_at=datetime(year=2023, month=3, day=3),
                 error=expected_error,
+            )
+        ),
+    )
+
+
+async def test_executor_forwards_notes_on_command_success(
+    decoy: Decoy,
+    hardware_api: HardwareControlAPI,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    equipment: EquipmentHandler,
+    movement: MovementHandler,
+    mock_gantry_mover: GantryMover,
+    labware_movement: LabwareMovementHandler,
+    pipetting: PipettingHandler,
+    mock_tip_handler: TipHandler,
+    run_control: RunControlHandler,
+    rail_lights: RailLightsHandler,
+    status_bar: StatusBarHandler,
+    model_utils: ModelUtils,
+    command_note_tracker: CommandNoteTracker,
+    subject: CommandExecutor,
+) -> None:
+    """It should be able to add notes during OK execution to command updates."""
+    TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
+    command_impl = decoy.mock(cls=_TestCommandImpl)
+
+    class _TestCommand(BaseCommand[_TestCommandParams, _TestCommandResult]):
+        commandType: str = "testCommand"
+        params: _TestCommandParams
+        result: Optional[_TestCommandResult]
+
+        @property
+        def _ImplementationCls(self) -> Type[_TestCommandImpl]:
+            return TestCommandImplCls
+
+    command_params = _TestCommandParams()
+    command_result = _TestCommandResult()
+
+    queued_command = cast(
+        Command,
+        _TestCommand(
+            id="command-id",
+            key="command-key",
+            createdAt=datetime(year=2021, month=1, day=1),
+            status=CommandStatus.QUEUED,
+            params=command_params,
+        ),
+    )
+
+    command_notes = [
+        CommandNote(
+            noteKind="warning",
+            shortMessage="hello",
+            longMessage="test command note",
+            source="test",
+        )
+    ]
+
+    running_command = cast(
+        Command,
+        _TestCommand(
+            id="command-id",
+            key="command-key",
+            createdAt=datetime(year=2021, month=1, day=1),
+            startedAt=datetime(year=2022, month=2, day=2),
+            status=CommandStatus.RUNNING,
+            params=command_params,
+        ),
+    )
+
+    completed_command = cast(
+        Command,
+        _TestCommand(
+            id="command-id",
+            key="command-key",
+            createdAt=datetime(year=2021, month=1, day=1),
+            startedAt=datetime(year=2022, month=2, day=2),
+            completedAt=datetime(year=2023, month=3, day=3),
+            status=CommandStatus.SUCCEEDED,
+            params=command_params,
+            result=command_result,
+            notes=command_notes,
+        ),
+    )
+
+    decoy.when(state_store.commands.get(command_id="command-id")).then_return(
+        queued_command
+    )
+
+    decoy.when(
+        queued_command._ImplementationCls(
+            state_view=state_store,
+            hardware_api=hardware_api,
+            equipment=equipment,
+            movement=movement,
+            gantry_mover=mock_gantry_mover,
+            labware_movement=labware_movement,
+            pipetting=pipetting,
+            tip_handler=mock_tip_handler,
+            run_control=run_control,
+            rail_lights=rail_lights,
+            status_bar=status_bar,
+            command_note_adder=command_note_tracker,
+        )
+    ).then_return(
+        command_impl  # type: ignore[arg-type]
+    )
+
+    decoy.when(await command_impl.execute(command_params)).then_return(command_result)
+
+    decoy.when(model_utils.get_timestamp()).then_return(
+        datetime(year=2022, month=2, day=2),
+        datetime(year=2023, month=3, day=3),
+    )
+    decoy.when(command_note_tracker.get_notes()).then_return(command_notes)
+
+    await subject.execute("command-id")
+
+    decoy.verify(
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=running_command)
+        ),
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=completed_command)
+        ),
+    )
+
+async def test_executor_forwards_notes_on_command_failure(
+    decoy: Decoy,
+    hardware_api: HardwareControlAPI,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    equipment: EquipmentHandler,
+    movement: MovementHandler,
+    mock_gantry_mover: GantryMover,
+    labware_movement: LabwareMovementHandler,
+    pipetting: PipettingHandler,
+    mock_tip_handler: TipHandler,
+    run_control: RunControlHandler,
+    rail_lights: RailLightsHandler,
+    status_bar: StatusBarHandler,
+    model_utils: ModelUtils,
+    subject: CommandExecutor,
+    command_note_tracker: CommandNoteTracker,
+) -> None:
+    """It should handle an error occuring during execution."""
+    TestCommandImplCls = decoy.mock(func=_TestCommandImpl)
+    command_impl = decoy.mock(cls=_TestCommandImpl)
+
+
+    class _TestCommand(BaseCommand[_TestCommandParams, _TestCommandResult]):
+        commandType: str = "testCommand"
+        params: _TestCommandParams
+        result: Optional[_TestCommandResult]
+
+        @property
+        def _ImplementationCls(self) -> Type[_TestCommandImpl]:
+            return TestCommandImplCls
+
+    command_params = _TestCommandParams()
+    command_notes = [
+        CommandNote(
+            noteKind="warning",
+            shortMessage="hello",
+            longMessage="test command note",
+            source="test",
+        )
+    ]
+
+    queued_command = cast(
+        Command,
+        _TestCommand(
+            id="command-id",
+            key="command-key",
+            createdAt=datetime(year=2021, month=1, day=1),
+            status=CommandStatus.QUEUED,
+            params=command_params,
+        ),
+    )
+
+    running_command = cast(
+        Command,
+        _TestCommand(
+            id="command-id",
+            key="command-key",
+            createdAt=datetime(year=2021, month=1, day=1),
+            startedAt=datetime(year=2022, month=2, day=2),
+            status=CommandStatus.RUNNING,
+            params=command_params,
+        ),
+    )
+    running_command_with_notes = running_command.copy(update={'notes': command_notes})
+
+    decoy.when(state_store.commands.get(command_id="command-id")).then_return(
+        queued_command
+    )
+
+    decoy.when(
+        queued_command._ImplementationCls(
+            state_view=state_store,
+            hardware_api=hardware_api,
+            equipment=equipment,
+            movement=movement,
+            gantry_mover=mock_gantry_mover,
+            labware_movement=labware_movement,
+            pipetting=pipetting,
+            tip_handler=mock_tip_handler,
+            run_control=run_control,
+            rail_lights=rail_lights,
+            status_bar=status_bar,
+            command_note_adder=command_note_tracker,
+        )
+    ).then_return(
+        command_impl  # type: ignore[arg-type]
+    )
+
+    decoy.when(await command_impl.execute(command_params)).then_raise(RuntimeError("oh no"))
+
+    decoy.when(model_utils.generate_id()).then_return("error-id")
+    decoy.when(model_utils.get_timestamp()).then_return(
+        datetime(year=2022, month=2, day=2),
+        datetime(year=2023, month=3, day=3),
+    )
+    decoy.when(command_note_tracker.get_notes()).then_return(command_notes)
+
+    await subject.execute("command-id")
+
+    decoy.verify(
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=running_command)
+        ),
+        action_dispatcher.dispatch(
+            UpdateCommandAction(private_result=None, command=running_command_with_notes)
+        ),
+        action_dispatcher.dispatch(
+            FailCommandAction(
+                command_id="command-id",
+                error_id="error-id",
+                failed_at=datetime(year=2023, month=3, day=3),
+                error=matchers.ErrorMatching(PythonException, match="oh no"),
             )
         ),
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -21,6 +21,8 @@ from opentrons.protocol_engine.errors.exceptions import (
     InvalidPushOutVolumeError,
     InvalidDispenseVolumeError,
 )
+from opentrons.protocol_engine.notes import CommandNoteAdder, CommandNote
+from ..note_utils import CommandNoteMatcher
 
 
 @pytest.fixture
@@ -217,6 +219,7 @@ async def test_hw_aspirate_in_place(
     mock_state_view: StateView,
     mock_hardware_api: HardwareAPI,
     hardware_subject: HardwarePipettingHandler,
+    mock_command_note_adder: CommandNoteAdder,
 ) -> None:
     """Should set flow_rate and call hardware_api aspirate."""
     decoy.when(mock_state_view.pipettes.get_working_volume("pipette-id")).then_return(
@@ -247,7 +250,10 @@ async def test_hw_aspirate_in_place(
     )
 
     result = await hardware_subject.aspirate_in_place(
-        pipette_id="pipette-id", volume=25, flow_rate=2.5
+        pipette_id="pipette-id",
+        volume=25,
+        flow_rate=2.5,
+        command_note_adder=mock_command_note_adder,
     )
 
     assert result == 25
@@ -324,7 +330,7 @@ def test_virtual_get_is_ready_to_aspirate(
 
 
 async def test_virtual_aspirate_in_place(
-    mock_state_view: StateView, decoy: Decoy
+    mock_state_view: StateView, decoy: Decoy, mock_command_note_adder: CommandNoteAdder
 ) -> None:
     """Should return the volume."""
     decoy.when(
@@ -342,7 +348,10 @@ async def test_virtual_aspirate_in_place(
     )
 
     result = await subject.aspirate_in_place(
-        pipette_id="pipette-id", volume=2, flow_rate=5
+        pipette_id="pipette-id",
+        volume=2,
+        flow_rate=5,
+        command_note_adder=mock_command_note_adder,
     )
     assert result == 2
 
@@ -408,7 +417,7 @@ async def test_virtual_dispense_in_place_raises_no_tip(
 
 
 async def test_virtual_aspirate_validate_tip_attached(
-    mock_state_view: StateView, decoy: Decoy
+    mock_state_view: StateView, decoy: Decoy, mock_command_note_adder: CommandNoteAdder
 ) -> None:
     """Should raise an error that a tip is not attached."""
     subject = VirtualPipettingHandler(state_view=mock_state_view)
@@ -420,7 +429,12 @@ async def test_virtual_aspirate_validate_tip_attached(
     with pytest.raises(
         TipNotAttachedError, match="Cannot perform aspirate without a tip attached"
     ):
-        await subject.aspirate_in_place("pipette-id", volume=20, flow_rate=1)
+        await subject.aspirate_in_place(
+            "pipette-id",
+            volume=20,
+            flow_rate=1,
+            command_note_adder=mock_command_note_adder,
+        )
 
 
 async def test_virtual_dispense_validate_tip_attached(
@@ -446,6 +460,7 @@ async def test_aspirate_volume_validation(
     mock_state_view: StateView,
     mock_hardware_api: HardwareAPI,
     hardware_subject: HardwarePipettingHandler,
+    mock_command_note_adder: CommandNoteAdder,
 ) -> None:
     """It should validate the input volume, possibly adjusting it for rounding error.
 
@@ -487,16 +502,33 @@ async def test_aspirate_volume_validation(
     not_ok_volume = 1.01
     expected_adjusted_volume = 1
 
+    decoy.when(
+        mock_command_note_adder(
+            cast(
+                CommandNote,
+                CommandNoteMatcher(
+                    matching_noteKind_regex="warning",
+                    matching_shortMessage_regex="Aspirate clamped to 1 µL",
+                ),
+            )
+        )
+    ).then_return(None)
     for subject in [virtual_subject, hardware_subject]:
         assert (
             await subject.aspirate_in_place(
-                pipette_id="pipette-id", volume=ok_volume, flow_rate=1
+                pipette_id="pipette-id",
+                volume=ok_volume,
+                flow_rate=1,
+                command_note_adder=mock_command_note_adder,
             )
             == expected_adjusted_volume
         )
         with pytest.raises(InvalidAspirateVolumeError):
             await subject.aspirate_in_place(
-                pipette_id="pipette-id", volume=not_ok_volume, flow_rate=1
+                pipette_id="pipette-id",
+                volume=not_ok_volume,
+                flow_rate=1,
+                command_note_adder=mock_command_note_adder,
             )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_pipetting_handler.py
@@ -502,17 +502,6 @@ async def test_aspirate_volume_validation(
     not_ok_volume = 1.01
     expected_adjusted_volume = 1
 
-    decoy.when(
-        mock_command_note_adder(
-            cast(
-                CommandNote,
-                CommandNoteMatcher(
-                    matching_noteKind_regex="warning",
-                    matching_shortMessage_regex="Aspirate clamped to 1 µL",
-                ),
-            )
-        )
-    ).then_return(None)
     for subject in [virtual_subject, hardware_subject]:
         assert (
             await subject.aspirate_in_place(
@@ -522,6 +511,17 @@ async def test_aspirate_volume_validation(
                 command_note_adder=mock_command_note_adder,
             )
             == expected_adjusted_volume
+        )
+        decoy.verify(
+            mock_command_note_adder(
+                cast(
+                    CommandNote,
+                    CommandNoteMatcher(
+                        matching_noteKind_regex="warning",
+                        matching_shortMessage_regex="Aspirate clamped to 1 µL",
+                    ),
+                )
+            )
         )
         with pytest.raises(InvalidAspirateVolumeError):
             await subject.aspirate_in_place(

--- a/api/tests/opentrons/protocol_engine/note_utils.py
+++ b/api/tests/opentrons/protocol_engine/note_utils.py
@@ -1,0 +1,63 @@
+"""Test utilities for dealing with notes."""
+import re
+from typing import Optional
+from opentrons.protocol_engine.notes import CommandNote
+
+
+class CommandNoteMatcher:
+    """Decoy matcher for notes instances."""
+
+    def __init__(
+        self,
+        matching_noteKind_regex: Optional[str] = None,
+        matching_shortMessage_regex: Optional[str] = None,
+        matching_longMessage_regex: Optional[str] = None,
+        matching_source_regex: Optional[str] = None,
+    ) -> None:
+        """Build a CommandNoteMatcher. All provided arguments are checked with re.search."""
+        self._matching_noteKind_regex = (
+            re.compile(matching_noteKind_regex)
+            if matching_noteKind_regex is not None
+            else None
+        )
+        self._matching_shortMessage_regex = (
+            re.compile(matching_shortMessage_regex)
+            if matching_shortMessage_regex is not None
+            else None
+        )
+        self._matching_longMessage_regex = (
+            re.compile(matching_longMessage_regex)
+            if matching_longMessage_regex is not None
+            else None
+        )
+        self._matching_source_regex = (
+            re.compile(matching_source_regex)
+            if matching_source_regex is not None
+            else None
+        )
+
+    def __eq__(self, other: object) -> bool:
+        """Called by Decoy. returns True on a match, False otherwise."""
+        if not isinstance(other, CommandNote):
+            return False
+        if (
+            self._matching_noteKind_regex is not None
+            and not self._matching_noteKind_regex.search(other.noteKind)
+        ):
+            return False
+        if (
+            self._matching_shortMessage_regex is not None
+            and not self._matching_shortMessage_regex.search(other.shortMessage)
+        ):
+            return False
+        if (
+            self._matching_longMessage_regex is not None
+            and not self._matching_longMessage_regex.search(other.longMessage)
+        ):
+            return False
+        if (
+            self._matching_source_regex is not None
+            and not self._matching_source_regex.search(other.source)
+        ):
+            return False
+        return True

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -8,6 +8,7 @@ from opentrons.protocol_engine import (
     CommandSlice,
     CurrentCommand,
     ProtocolEngine,
+    CommandNote,
     commands as pe_commands,
     errors as pe_errors,
 )
@@ -249,7 +250,7 @@ async def test_get_run_commands(
     decoy: Decoy, mock_run_data_manager: RunDataManager
 ) -> None:
     """It should return a list of all commands in a run."""
-    long_note = pe_commands.CommandNote(
+    long_note = CommandNote(
         noteKind="warning",
         shortMessage="this is a warning.",
         longMessage="""
@@ -261,7 +262,7 @@ async def test_get_run_commands(
             """,
         source="test",
     )
-    unenumed_note = pe_commands.CommandNote(
+    unenumed_note = CommandNote(
         noteKind="lahsdlasd",
         shortMessage="Oh no",
         longMessage="its a notekind not in the enum",


### PR DESCRIPTION
This PR adds an interface for command executors to add notes to the command that they're executing, succeed or fail, and uses that interface to implement an example note warning of aspirate volume rounding.

The interface is done by callbacks from the command implementations to the command executor that is executing each command. Implementations, or the functions they call, are responsible for creating the CommandNote instances. The executor just gathers a list of commands and then issues an UpdateCommandAction with the new list. If there are already notes on the command before execution, the new ones are appended. While this doesn't seem necessary right now, we'll want this behavior generically when we have notes also coming from hardware.

One thing that's a little annoying about this interface is that the callbacks have to be threaded through all the way to whatever wants to add a note. For instance, in the example aspirate-rounded note, we have to pass the callback all the way into the pipetting executor. An alternative would be to have an interface that can add notes on one of the state instances that can be called from anything that can access the state instance. The thing is, that function won't have the context to know when commands are currently executing or are done executing without having some sort of state machine that only looks at UpdateCommandActions from elsewhere. That code would be pretty ugly. The alternative there would be to issue a new UpdateCommandAction for each note; this would have race condition issues if it provided new values for the notes list. The alternative _there_ would be a new action called like AddCommandNoteAction that carries the attention of adding to the notes list along with it. Of course, that command is not idempotent.

This interface works well enough for now that I think we should roll with it, and feel free to change it later.

## Still todo
- [x] add tests for actually submitting a new command note

## testing (once todos are todone)
- [x] in simulation, request an aspirate that is 0.0000001 ul higher than the pipette max and see the note in the output
- [x] on an executing flex, do the same
~- [ ] on an executing ot-2, do the same~ will test this in followups

Closes EXEC-291
