### PR TITLE
docs(api): add note about speeds that cause resonance

### DIFF
--- a/api/docs/v2/robot_position.rst
+++ b/api/docs/v2/robot_position.rst
@@ -219,6 +219,9 @@ Movement Speeds
 
 In addition to instructing the robot where to move a pipette, you can also control the speed at which it moves. Speed controls can be applied either to all pipette motions or to movement along a particular axis.
 
+.. note::
+    Like all mechanical systems, Opentrons robots have resonant frequencies that depend on their construction and current configuration. It's possible to set a speed that causes your robot to resonate, producing louder sounds than typical operation. This is safe, but if you find it annoying, increase or decrease the speed slightly.
+
 .. _gantry_speed: 
 
 Gantry Speed


### PR DESCRIPTION
# Overview

We got some questions about Flex making loud noises at certain speeds. This note gives reassurance and guidance to users who have found how to make their robot resonate 🙉 

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-noisy-axes-note/v2/robot_position.html#movement-speeds)

# Changelog

Just the note block. Relevant methods link to this page from the API Reference, so I don't think we need to duplicate the text there.

# Review requests

Good message, good words?

# Risk assessment

zero