### PR TITLE
feat(app): add Parameters tab to odd protocolDetails

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -32,6 +32,7 @@
   "location": "location",
   "modules": "modules",
   "name": "Name",
+  "num_choices": "{{num}} choices",
   "no_available_robots_found": "No available robots found",
   "no_parameters": "No parameters specified in this protocol",
   "no_summary": "no summary specified for this protocol.",

--- a/app/src/pages/ProtocolDetails/EmptySection.tsx
+++ b/app/src/pages/ProtocolDetails/EmptySection.tsx
@@ -14,13 +14,19 @@ import { useTranslation } from 'react-i18next'
 import { StyledText } from '../../atoms/text'
 
 interface EmptySectionProps {
-  section: 'hardware' | 'labware' | 'liquids'
+  section: 'hardware' | 'labware' | 'liquids' | 'parameters'
 }
 
 export const EmptySection = (props: EmptySectionProps): JSX.Element => {
   const { section } = props
   const { t, i18n } = useTranslation('protocol_details')
 
+  let sectionText: string = t('not_in_protocol', { section: section })
+  if (section === 'liquids') {
+    sectionText = t('liquids_not_in_protocol')
+  } else if (section === 'parameters') {
+    sectionText = t('no_parameters')
+  }
   return (
     <Flex
       backgroundColor={COLORS.grey35}
@@ -40,12 +46,7 @@ export const EmptySection = (props: EmptySectionProps): JSX.Element => {
         aria-label="EmptySection_ot-alert"
       />
       <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-        {i18n.format(
-          section === 'liquids'
-            ? t('liquids_not_in_protocol')
-            : t('not_in_protocol', { section: section }),
-          'capitalize'
-        )}
+        {i18n.format(sectionText, 'capitalize')}
       </StyledText>
     </Flex>
   )

--- a/app/src/pages/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ProtocolDetails/Parameters.tsx
@@ -10,6 +10,7 @@ import {
   WRAP,
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
+import { useToaster } from '../../organisms/ToasterOven'
 import { useRequiredProtocolHardware } from '../Protocols/hooks'
 import { EmptySection } from './EmptySection'
 
@@ -37,12 +38,12 @@ const TableDatum = styled('td')`
   white-space: break-spaces;
   text-overflow: ${WRAP};
   &:first-child {
-    border-top-left-radius: ${BORDERS.borderRadiusSize4};
-    border-bottom-left-radius: ${BORDERS.borderRadiusSize4};
+    border-top-left-radius: ${BORDERS.borderRadius4};
+    border-bottom-left-radius: ${BORDERS.borderRadius4};
   }
   &:last-child {
-    border-top-right-radius: ${BORDERS.borderRadiusSize4};
-    border-bottom-right-radius: ${BORDERS.borderRadiusSize4};
+    border-top-right-radius: ${BORDERS.borderRadius4};
+    border-bottom-right-radius: ${BORDERS.borderRadius4};
   }
 `
 
@@ -51,12 +52,16 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
   const { requiredProtocolHardware } = useRequiredProtocolHardware(
     props.protocolId
   )
+  const { makeSnackbar } = useToaster()
   const { t, i18n } = useTranslation('protocol_details')
 
+  const makeSnack = (): void => {
+    makeSnackbar(t('start_setup_customize_values'))
+  }
   return requiredProtocolHardware.length === 0 ? (
     <EmptySection section="parameters" />
   ) : (
-    <Table>
+    <Table onClick={makeSnack}>
       <thead>
         <tr>
           <TableHeader>

--- a/app/src/pages/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ProtocolDetails/Parameters.tsx
@@ -78,7 +78,7 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
         return `${props.min}-${props.max}`
       }
       case 'str': {
-        return ''
+        return t('multi')
       }
     }
   }

--- a/app/src/pages/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ProtocolDetails/Parameters.tsx
@@ -13,7 +13,7 @@ import { StyledText } from '../../atoms/text'
 import { useToaster } from '../../organisms/ToasterOven'
 import { useRunTimeParameters } from '../Protocols/hooks'
 import { EmptySection } from './EmptySection'
-import type { RunTimeParameters } from '@opentrons/shared-data'
+import type { RunTimeParameter } from '@opentrons/shared-data'
 
 const Table = styled('table')`
   font-size: ${TYPOGRAPHY.fontSize22};
@@ -58,7 +58,7 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
     makeSnackbar(t('start_setup_customize_values'))
   }
 
-  const getRange = (parameter: RunTimeParameters): string => {
+  const getRange = (parameter: RunTimeParameter): string => {
     const { type } = parameter
     const min = 'min' in parameter ? parameter.min : 0
     const max = 'max' in parameter ? parameter.max : 0
@@ -85,7 +85,7 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
     }
   }
 
-  const getDefault = (parameter: RunTimeParameters): string => {
+  const getDefault = (parameter: RunTimeParameter): string => {
     const { type, default: defaultValue } = parameter
     const suffix =
       'suffix' in parameter && parameter.suffix != null ? parameter.suffix : ''
@@ -109,9 +109,7 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
     return ''
   }
 
-  return runTimeParameters.length === 0 ? (
-    <EmptySection section="parameters" />
-  ) : (
+  return runTimeParameters.length > 0 ? (
     <Table onClick={makeSnack} data-testid="Parameters_table">
       <thead>
         <tr>
@@ -156,5 +154,7 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
         })}
       </tbody>
     </Table>
+  ) : (
+    <EmptySection section="parameters" />
   )
 }

--- a/app/src/pages/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ProtocolDetails/Parameters.tsx
@@ -11,18 +11,30 @@ import {
 } from '@opentrons/components'
 import { StyledText } from '../../atoms/text'
 import { useToaster } from '../../organisms/ToasterOven'
-import { useRequiredProtocolHardware } from '../Protocols/hooks'
+import { useRunTimeParameters } from '../Protocols/hooks'
 import { EmptySection } from './EmptySection'
+import type { RunTimeParameters } from '@opentrons/shared-data'
+
+interface RangeProps {
+  type: RunTimeParameters['type']
+  max: number
+  min: number
+}
+interface DefaultProps {
+  default: unknown
+  suffix?: string
+}
 
 const Table = styled('table')`
-  ${TYPOGRAPHY.labelRegular}
-  table-layout: auto;
+  font-size: ${TYPOGRAPHY.fontSize22};
   width: 100%;
   border-spacing: 0 ${SPACING.spacing8};
   margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
 const TableHeader = styled('th')`
+  font-size: ${TYPOGRAPHY.fontSize20};
+  font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
   padding: ${SPACING.spacing4};
   color: ${COLORS.grey60};
 `
@@ -48,60 +60,91 @@ const TableDatum = styled('td')`
 `
 
 export const Parameters = (props: { protocolId: string }): JSX.Element => {
-  //  TODO(Jr, 3/14/24): replace hook with correct hook to get parameters
-  const { requiredProtocolHardware } = useRequiredProtocolHardware(
-    props.protocolId
-  )
+  const runTimeParameters = useRunTimeParameters(props.protocolId)
   const { makeSnackbar } = useToaster()
   const { t, i18n } = useTranslation('protocol_details')
 
   const makeSnack = (): void => {
     makeSnackbar(t('start_setup_customize_values'))
   }
-  return requiredProtocolHardware.length === 0 ? (
+
+  const getRange = (props: RangeProps): string => {
+    switch (props.type) {
+      case 'boolean': {
+        return t('on_off')
+      }
+      case 'float':
+      case 'int': {
+        return `${props.min}-${props.max}`
+      }
+      case 'str': {
+        return ''
+      }
+    }
+  }
+
+  const getDefault = (props: DefaultProps): string => {
+    if (props.suffix != null) {
+      return `${props.default} ${props.suffix}`
+    } else if (props.default === false) {
+      return t('off')
+    } else if (props.default === true) {
+      return t('on')
+    } else {
+      return `${props.default}`
+    }
+  }
+
+  return runTimeParameters.length === 0 ? (
     <EmptySection section="parameters" />
   ) : (
-    <Table onClick={makeSnack}>
+    <Table onClick={makeSnack} data-testid="Parameters_table">
       <thead>
         <tr>
           <TableHeader>
-            <StyledText
-              css={TYPOGRAPHY.labelSemiBold}
-              paddingLeft={SPACING.spacing24}
-            >
+            <StyledText paddingLeft={SPACING.spacing24}>
               {i18n.format(t('name'), 'capitalize')}
             </StyledText>
           </TableHeader>
           <TableHeader>
-            <StyledText
-              css={TYPOGRAPHY.labelSemiBold}
-              paddingLeft={SPACING.spacing24}
-            >
+            <StyledText paddingLeft={SPACING.spacing24}>
               {i18n.format(t('default_value'), 'capitalize')}
             </StyledText>
           </TableHeader>
           <TableHeader>
-            <StyledText
-              css={TYPOGRAPHY.labelSemiBold}
-              paddingLeft={SPACING.spacing24}
-            >
+            <StyledText paddingLeft={SPACING.spacing24}>
               {i18n.format(t('range'), 'capitalize')}
             </StyledText>
           </TableHeader>
         </tr>
       </thead>
       <tbody>
-        <TableRow>
-          <TableDatum>
-            <Flex paddingLeft={SPACING.spacing24}>TODO</Flex>
-          </TableDatum>
-          <TableDatum>
-            <Flex paddingLeft={SPACING.spacing24}>TODO</Flex>
-          </TableDatum>
-          <TableDatum>
-            <Flex paddingLeft={SPACING.spacing24}>TODO</Flex>
-          </TableDatum>
-        </TableRow>
+        {runTimeParameters.map((parameter, index) => {
+          const min = 'min' in parameter ? parameter.min : 0
+          const max = 'max' in parameter ? parameter.max : 0
+          return (
+            <TableRow key={index}>
+              <TableDatum>
+                <Flex paddingLeft={SPACING.spacing24}>
+                  {parameter.displayName}
+                </Flex>
+              </TableDatum>
+              <TableDatum>
+                <Flex paddingLeft={SPACING.spacing24} color={COLORS.grey60}>
+                  {getDefault({
+                    default: parameter.default,
+                    suffix: parameter.suffix,
+                  })}
+                </Flex>
+              </TableDatum>
+              <TableDatum>
+                <Flex paddingLeft={SPACING.spacing24} color={COLORS.grey60}>
+                  {getRange({ type: parameter.type, max, min })}
+                </Flex>
+              </TableDatum>
+            </TableRow>
+          )
+        })}
       </tbody>
     </Table>
   )

--- a/app/src/pages/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ProtocolDetails/Parameters.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import styled from 'styled-components'
+import {
+  BORDERS,
+  COLORS,
+  Flex,
+  SPACING,
+  TYPOGRAPHY,
+  WRAP,
+} from '@opentrons/components'
+import { StyledText } from '../../atoms/text'
+import { useRequiredProtocolHardware } from '../Protocols/hooks'
+import { EmptySection } from './EmptySection'
+
+const Table = styled('table')`
+  ${TYPOGRAPHY.labelRegular}
+  table-layout: auto;
+  width: 100%;
+  border-spacing: 0 ${SPACING.spacing8};
+  margin: ${SPACING.spacing16} 0;
+  text-align: ${TYPOGRAPHY.textAlignLeft};
+`
+const TableHeader = styled('th')`
+  padding: ${SPACING.spacing4};
+  color: ${COLORS.grey60};
+`
+
+const TableRow = styled('tr')`
+  background-color: ${COLORS.grey35};
+  border: 1px ${COLORS.white} solid;
+  height: 4.75rem;
+`
+
+const TableDatum = styled('td')`
+  padding: ${SPACING.spacing4};
+  white-space: break-spaces;
+  text-overflow: ${WRAP};
+  &:first-child {
+    border-top-left-radius: ${BORDERS.borderRadiusSize4};
+    border-bottom-left-radius: ${BORDERS.borderRadiusSize4};
+  }
+  &:last-child {
+    border-top-right-radius: ${BORDERS.borderRadiusSize4};
+    border-bottom-right-radius: ${BORDERS.borderRadiusSize4};
+  }
+`
+
+export const Parameters = (props: { protocolId: string }): JSX.Element => {
+  //  TODO(Jr, 3/14/24): replace hook with correct hook to get parameters
+  const { requiredProtocolHardware } = useRequiredProtocolHardware(
+    props.protocolId
+  )
+  const { t, i18n } = useTranslation('protocol_details')
+
+  return requiredProtocolHardware.length === 0 ? (
+    <EmptySection section="parameters" />
+  ) : (
+    <Table>
+      <thead>
+        <tr>
+          <TableHeader>
+            <StyledText
+              css={TYPOGRAPHY.labelSemiBold}
+              paddingLeft={SPACING.spacing24}
+            >
+              {i18n.format(t('name'), 'capitalize')}
+            </StyledText>
+          </TableHeader>
+          <TableHeader>
+            <StyledText
+              css={TYPOGRAPHY.labelSemiBold}
+              paddingLeft={SPACING.spacing24}
+            >
+              {i18n.format(t('default_value'), 'capitalize')}
+            </StyledText>
+          </TableHeader>
+          <TableHeader>
+            <StyledText
+              css={TYPOGRAPHY.labelSemiBold}
+              paddingLeft={SPACING.spacing24}
+            >
+              {i18n.format(t('range'), 'capitalize')}
+            </StyledText>
+          </TableHeader>
+        </tr>
+      </thead>
+      <tbody>
+        <TableRow>
+          <TableDatum>
+            <Flex paddingLeft={SPACING.spacing24}>TODO</Flex>
+          </TableDatum>
+          <TableDatum>
+            <Flex paddingLeft={SPACING.spacing24}>TODO</Flex>
+          </TableDatum>
+          <TableDatum>
+            <Flex paddingLeft={SPACING.spacing24}>TODO</Flex>
+          </TableDatum>
+        </TableRow>
+      </tbody>
+    </Table>
+  )
+}

--- a/app/src/pages/ProtocolDetails/__tests__/EmptySection.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/EmptySection.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { it, describe } from 'vitest'
+import { screen } from '@testing-library/react'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
 import { EmptySection } from '../EmptySection'
@@ -17,22 +18,29 @@ describe('EmptySection', () => {
     props = {
       section: 'labware',
     }
-    const { getByText, getByLabelText } = render(props)
-    getByLabelText('EmptySection_ot-alert')
-    getByText('No labware is specified for this protocol')
+    render(props)
+    screen.getByLabelText('EmptySection_ot-alert')
+    screen.getByText('No labware is specified for this protocol')
   })
   it('should render text for liquid', () => {
     props = {
       section: 'liquids',
     }
-    const { getByText } = render(props)
-    getByText('No liquids are specified for this protocol')
+    render(props)
+    screen.getByText('No liquids are specified for this protocol')
   })
   it('should render text for hardware', () => {
     props = {
       section: 'hardware',
     }
-    const { getByText } = render(props)
-    getByText('No hardware is specified for this protocol')
+    render(props)
+    screen.getByText('No hardware is specified for this protocol')
+  })
+  it('should render text for paramters', () => {
+    props = {
+      section: 'parameters',
+    }
+    render(props)
+    screen.getByText('No parameters are specified in this protocol')
   })
 })

--- a/app/src/pages/ProtocolDetails/__tests__/EmptySection.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/EmptySection.test.tsx
@@ -36,11 +36,11 @@ describe('EmptySection', () => {
     render(props)
     screen.getByText('No hardware is specified for this protocol')
   })
-  it('should render text for paramters', () => {
+  it('should render text for parameters', () => {
     props = {
       section: 'parameters',
     }
     render(props)
-    screen.getByText('No parameters are specified in this protocol')
+    screen.getByText('No parameters specified in this protocol')
   })
 })

--- a/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
@@ -90,6 +90,23 @@ const mockRTPData: RunTimeParameters[] = [
     ],
     default: 'none',
   },
+  {
+    displayName: '2 choices',
+    variableName: 'TWO',
+    description: '',
+    type: 'str',
+    choices: [
+      {
+        displayName: 'one choice',
+        value: '1',
+      },
+      {
+        displayName: 'the second',
+        value: '2',
+      },
+    ],
+    default: '2',
+  },
 ]
 
 const render = (props: React.ComponentProps<typeof Parameters>) => {
@@ -118,6 +135,11 @@ describe('Parameters', () => {
     screen.getByText('Default value')
     screen.getByText('Range')
     screen.getByText('Dry Run')
+    screen.getByText('6.5')
     screen.getByText('Use Gripper')
+    screen.getByText('Default Module Offsets')
+    screen.getByText('3 choices')
+    screen.getByText('EtoH Volume')
+    screen.getByText('one choice, the second')
   })
 })

--- a/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
@@ -7,12 +7,12 @@ import { useToaster } from '../../../organisms/ToasterOven'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { useRunTimeParameters } from '../../Protocols/hooks'
 import { Parameters } from '../Parameters'
-import type { RunTimeParameters } from '@opentrons/shared-data'
+import type { RunTimeParameter } from '@opentrons/shared-data'
 
 vi.mock('../../../organisms/ToasterOven')
 vi.mock('../../Protocols/hooks')
 
-const mockRTPData: RunTimeParameters[] = [
+const mockRTPData: RunTimeParameter[] = [
   {
     displayName: 'Dry Run',
     variableName: 'DRYRUN',
@@ -141,5 +141,6 @@ describe('Parameters', () => {
     screen.getByText('3 choices')
     screen.getByText('EtoH Volume')
     screen.getByText('one choice, the second')
+    screen.getByText('fda')
   })
 })

--- a/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
@@ -141,6 +141,5 @@ describe('Parameters', () => {
     screen.getByText('3 choices')
     screen.getByText('EtoH Volume')
     screen.getByText('one choice, the second')
-    screen.getByText('fda')
   })
 })

--- a/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
@@ -1,0 +1,3 @@
+import { it } from 'vitest'
+
+it.todo('renders the parameters labels and mock data')

--- a/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/Parameters.test.tsx
@@ -1,3 +1,123 @@
-import { it } from 'vitest'
+import * as React from 'react'
+import { when } from 'vitest-when'
+import { it, describe, beforeEach, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { i18n } from '../../../i18n'
+import { useToaster } from '../../../organisms/ToasterOven'
+import { renderWithProviders } from '../../../__testing-utils__'
+import { useRunTimeParameters } from '../../Protocols/hooks'
+import { Parameters } from '../Parameters'
+import type { RunTimeParameters } from '@opentrons/shared-data'
 
-it.todo('renders the parameters labels and mock data')
+vi.mock('../../../organisms/ToasterOven')
+vi.mock('../../Protocols/hooks')
+
+const mockRTPData: RunTimeParameters[] = [
+  {
+    displayName: 'Dry Run',
+    variableName: 'DRYRUN',
+    description: 'a dry run description',
+    type: 'boolean',
+    default: false,
+  },
+  {
+    displayName: 'Use Gripper',
+    variableName: 'USE_GRIPPER',
+    description: '',
+    type: 'boolean',
+    default: true,
+  },
+  {
+    displayName: 'Trash Tips',
+    variableName: 'TIP_TRASH',
+    description: 'throw tip in trash',
+    type: 'boolean',
+    default: true,
+  },
+  {
+    displayName: 'Deactivate Temperatures',
+    variableName: 'DEACTIVATE_TEMP',
+    description: 'deactivate temperature?',
+    type: 'boolean',
+    default: true,
+  },
+  {
+    displayName: 'Columns of Samples',
+    variableName: 'COLUMNS',
+    description: '',
+    suffix: 'mL',
+    type: 'int',
+    min: 1,
+    max: 14,
+    default: 4,
+  },
+  {
+    displayName: 'PCR Cycles',
+    variableName: 'PCR_CYCLES',
+    description: '',
+    type: 'int',
+    min: 1,
+    max: 10,
+    default: 6,
+  },
+  {
+    displayName: 'EtoH Volume',
+    variableName: 'ETOH_VOLUME',
+    description: '',
+    type: 'float',
+    min: 1.5,
+    max: 10.0,
+    default: 6.5,
+  },
+  {
+    displayName: 'Default Module Offsets',
+    variableName: 'DEFAULT_OFFSETS',
+    description: '',
+    type: 'str',
+    choices: [
+      {
+        displayName: 'no offsets',
+        value: 'none',
+      },
+      {
+        displayName: 'temp offset',
+        value: '1',
+      },
+      {
+        displayName: 'heater-shaker offset',
+        value: '2',
+      },
+    ],
+    default: 'none',
+  },
+]
+
+const render = (props: React.ComponentProps<typeof Parameters>) => {
+  return renderWithProviders(<Parameters {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+const MOCK_MAKE_SNACK_BAR = vi.fn()
+describe('Parameters', () => {
+  let props: React.ComponentProps<typeof Parameters>
+
+  beforeEach(() => {
+    props = {
+      protocolId: 'mockId',
+    }
+    when(useToaster)
+      .calledWith()
+      .thenReturn({
+        makeSnackBar: MOCK_MAKE_SNACK_BAR,
+      } as any)
+    vi.mocked(useRunTimeParameters).mockReturnValue(mockRTPData)
+  })
+  it('renders the parameters labels and mock data', () => {
+    render(props)
+    screen.getByText('Name')
+    screen.getByText('Default value')
+    screen.getByText('Range')
+    screen.getByText('Dry Run')
+    screen.getByText('Use Gripper')
+  })
+})

--- a/app/src/pages/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -21,6 +21,7 @@ import { i18n } from '../../../i18n'
 import { useHardwareStatusText } from '../../../organisms/OnDeviceDisplay/RobotDashboard/hooks'
 import { useOffsetCandidatesForAnalysis } from '../../../organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { useMissingProtocolHardware } from '../../Protocols/hooks'
+import { useFeatureFlag } from '../../../redux/config'
 import { formatTimeWithUtcLabel } from '../../../resources/runs'
 import { ProtocolDetails } from '..'
 import { Deck } from '../Deck'
@@ -52,6 +53,7 @@ vi.mock('../Deck')
 vi.mock('../Hardware')
 vi.mock('../Labware')
 vi.mock('../Parameters')
+vi.mock('../../../redux/config')
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})
@@ -90,6 +92,7 @@ const render = (path = '/protocols/fakeProtocolId') => {
 
 describe('ODDProtocolDetails', () => {
   beforeEach(() => {
+    vi.mocked(useFeatureFlag).mockReturnValue(true)
     vi.mocked(useCreateRunMutation).mockReturnValue({
       createRun: mockCreateRun,
     } as any)

--- a/app/src/pages/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -26,6 +26,7 @@ import { ProtocolDetails } from '..'
 import { Deck } from '../Deck'
 import { Hardware } from '../Hardware'
 import { Labware } from '../Labware'
+import { Parameters } from '../Parameters'
 
 // Mock IntersectionObserver
 class IntersectionObserver {
@@ -50,6 +51,7 @@ vi.mock('../../Protocols/hooks')
 vi.mock('../Deck')
 vi.mock('../Hardware')
 vi.mock('../Labware')
+vi.mock('../Parameters')
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})
@@ -181,7 +183,11 @@ describe('ODDProtocolDetails', () => {
     vi.mocked(Hardware).mockReturnValue(<div>Mock Hardware</div>)
     vi.mocked(Labware).mockReturnValue(<div>Mock Labware</div>)
     vi.mocked(Deck).mockReturnValue(<div>Mock Initial Deck Layout</div>)
+    vi.mocked(Parameters).mockReturnValue(<div>Mock Parameters</div>)
+
     render()
+    const parametersButton = screen.getByRole('button', { name: 'Parameters' })
+    fireEvent.click(parametersButton)
     const hardwareButton = screen.getByRole('button', { name: 'Hardware' })
     fireEvent.click(hardwareButton)
     screen.getByText('Mock Hardware')

--- a/app/src/pages/ProtocolDetails/index.tsx
+++ b/app/src/pages/ProtocolDetails/index.tsx
@@ -45,7 +45,9 @@ import {
   getPinnedProtocolIds,
   updateConfigValue,
 } from '../../redux/config'
+import { useOffsetCandidatesForAnalysis } from '../../organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { useMissingProtocolHardware } from '../Protocols/hooks'
+import { Parameters } from './Parameters'
 import { Deck } from './Deck'
 import { Hardware } from './Hardware'
 import { Labware } from './Labware'
@@ -56,7 +58,6 @@ import type { Protocol } from '@opentrons/api-client'
 import type { ModalHeaderBaseProps } from '../../molecules/Modal/types'
 import type { Dispatch } from '../../redux/types'
 import type { OnDeviceRouteParams } from '../../App/types'
-import { useOffsetCandidatesForAnalysis } from '../../organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 
 interface ProtocolHeaderProps {
   title?: string | null
@@ -156,6 +157,7 @@ const ProtocolHeader = ({
 
 const protocolSectionTabOptions = [
   'Summary',
+  'Parameters',
   'Hardware',
   'Labware',
   'Liquids',
@@ -255,6 +257,9 @@ const ProtocolSectionContent = ({
           description={protocolData.data.metadata.description ?? null}
         />
       )
+      break
+    case 'Parameters':
+      protocolSection = <Parameters protocolId={protocolId} />
       break
     case 'Hardware':
       protocolSection = <Hardware protocolId={protocolId} />

--- a/app/src/pages/ProtocolDetails/index.tsx
+++ b/app/src/pages/ProtocolDetails/index.tsx
@@ -44,6 +44,7 @@ import {
   getApplyHistoricOffsets,
   getPinnedProtocolIds,
   updateConfigValue,
+  useFeatureFlag,
 } from '../../redux/config'
 import { useOffsetCandidatesForAnalysis } from '../../organisms/ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { useMissingProtocolHardware } from '../Protocols/hooks'
@@ -163,8 +164,17 @@ const protocolSectionTabOptions = [
   'Liquids',
   'Deck',
 ] as const
+const protocolSectionTabOptionsWithoutParameters = [
+  'Summary',
+  'Hardware',
+  'Labware',
+  'Liquids',
+  'Deck',
+] as const
 
-type TabOption = typeof protocolSectionTabOptions[number]
+type TabOption =
+  | typeof protocolSectionTabOptions[number]
+  | typeof protocolSectionTabOptionsWithoutParameters[number]
 
 interface ProtocolSectionTabsProps {
   currentOption: TabOption
@@ -175,9 +185,13 @@ const ProtocolSectionTabs = ({
   currentOption,
   setCurrentOption,
 }: ProtocolSectionTabsProps): JSX.Element => {
+  const enableRtpFF = useFeatureFlag('enableRunTimeParameters')
+  const options = enableRtpFF
+    ? protocolSectionTabOptions
+    : protocolSectionTabOptionsWithoutParameters
   return (
     <Flex gridGap={SPACING.spacing8}>
-      {protocolSectionTabOptions.map(option => {
+      {options.map(option => {
         return (
           <TabbedButton
             isSelected={option === currentOption}
@@ -290,6 +304,7 @@ export function ProtocolDetails(): JSX.Element | null {
     'protocol_info',
     'shared',
   ])
+  const enableRtpFF = useFeatureFlag('enableRunTimeParameters')
   const { protocolId } = useParams<OnDeviceRouteParams>()
   const {
     missingProtocolHardware,
@@ -305,8 +320,11 @@ export function ProtocolDetails(): JSX.Element | null {
   const { makeSnackbar } = useToaster()
   const queryClient = useQueryClient()
   const [currentOption, setCurrentOption] = React.useState<TabOption>(
-    protocolSectionTabOptions[0]
+    enableRtpFF
+      ? protocolSectionTabOptions[0]
+      : protocolSectionTabOptionsWithoutParameters[0]
   )
+
   const [showMaxPinsAlert, setShowMaxPinsAlert] = React.useState<boolean>(false)
   const {
     data: protocolRecord,

--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -332,7 +332,9 @@ export const useRunTimeParameters = (
     },
   ]
   //  TODO(jr, 3/14/24): remove the mockData
-  return analysis?.runTimeParameters ?? mockData
+  return analysis?.runTimeParameters?.length === 0
+    ? mockData
+    : analysis?.runTimeParameters ?? []
 }
 
 /**

--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -332,9 +332,7 @@ export const useRunTimeParameters = (
     },
   ]
   //  TODO(jr, 3/14/24): remove the mockData
-  return analysis?.runTimeParameters?.length === 0
-    ? mockData
-    : analysis?.runTimeParameters ?? []
+  return  analysis?.runTimeParameters ?? mockData
 }
 
 /**

--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -332,7 +332,7 @@ export const useRunTimeParameters = (
     },
   ]
   //  TODO(jr, 3/14/24): remove the mockData
-  return  analysis?.runTimeParameters ?? mockData
+  return analysis?.runTimeParameters ?? mockData
 }
 
 /**


### PR DESCRIPTION
closes AUTH-113, AUTH-124, AUTH-115, AUTH-114


# Overview

Creates the parameters tab in the ProtocolDetails section of the ODD also modify the empty section component for parameters

# Test Plan

go to protocol details on the odd and see that the parameters tab exists. clicking on the tab should display the empty parameters component. Observe the Parameters page and click on it to make sure the snackbar appears.

# Changelog

- add support to `EmptySection` for parameters
- create new `Parameters` component and test
- add `Parameters` as an option in the types to add it as a tab
- add snackbar to the parameters component 

# Review requests

see test plan

# Risk assessment

low