### PR TITLE
 refactor: use Public Sans and Reddit Mono on PAPI docs site

### DIFF
--- a/api/docs/static/override_sphinx.css
+++ b/api/docs/static/override_sphinx.css
@@ -1,11 +1,11 @@
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700');
+@import url('https://fonts.googleapis.com/css?family=Public+Sans:300,400,400i,600,700');
 
 /* OT NAV */
 
 body {
     padding: 0;
     margin: 0;
-    font-family: "Open Sans", "sans-serif";
+    font-family: "Public Sans", "sans-serif";
 }
 
 .highlight-none, .mi, .literal {
@@ -35,7 +35,12 @@ div.document [id] {
 
 div.body p {
     line-height: 20pt;
-    font-family: "Open Sans", "sans-serif";
+    font-family: "Public Sans", "sans-serif";
+}
+
+pre, tt, code {
+    font-size: 0.9em;
+    font-family: "Roboto Mono", "Consolas", "Lucida Console", monospace;
 }
 
 div.body h1 {
@@ -90,7 +95,12 @@ div.body h2,
 div.body h3,
 div.body h4,
 div.body h5 {
-    font-family: "Open Sans", "sans-serif";
+    font-family: "Public Sans", "sans-serif";
+}
+
+/* Links need an extra pixel of padding when body font is Public Sans */
+a.reference {
+    padding-bottom: 1px;
 }
 
 /* Suppressing the display of the toctrees rendered in the doc body means we
@@ -193,13 +203,13 @@ div.body p.caption {
 
 ul {
     /* margin-left: 0; */
-    font-family: "Open Sans", "sans-serif";
+    font-family: "Public Sans", "sans-serif";
 }
 
 ul ul {
     list-style-type: circle;
     margin-left: 30px;
-    font-family: "Open Sans", "sans-serif";
+    font-family: "Public Sans", "sans-serif";
 }
 
 @media screen and (min-device-width: 320px)and (max-device-width: 640px) {

--- a/api/docs/static/override_sphinx.css
+++ b/api/docs/static/override_sphinx.css
@@ -43,6 +43,12 @@ pre, tt, code {
     font-family: "Roboto Mono", "Consolas", "Lucida Console", monospace;
 }
 
+/* classes for API Reference docstring signatures */
+.sig, .sig-name, code.descname, .sig-prename, .optional, .sig-paren {
+    font-size: 1em;
+    font-family: "Roboto Mono", "Consolas", "Lucida Console", monospace;
+}
+
 div.body h1 {
     margin-top: 0;
     margin-bottom: 0;

--- a/api/docs/static/override_sphinx.css
+++ b/api/docs/static/override_sphinx.css
@@ -105,9 +105,10 @@ div.body h5 {
     font-family: "Public Sans", "sans-serif";
 }
 
-/* Links need an extra pixel of padding when body font is Public Sans */
+/* Links need an extra two pixels of padding to compensate between body font height 
+being 1em and code font height being 0.9em */
 a.reference {
-    padding-bottom: 1px;
+    padding-bottom: 2px;
 }
 
 /* Suppressing the display of the toctrees rendered in the doc body means we

--- a/api/docs/static/override_sphinx.css
+++ b/api/docs/static/override_sphinx.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Public+Sans:300,400,400i,600,700');
+@import url('https://fonts.googleapis.com/css2?family=Reddit+Mono:wght@200..900&display=swap');
 
 /* OT NAV */
 
@@ -40,13 +41,13 @@ div.body p {
 
 pre, tt, code {
     font-size: 0.9em;
-    font-family: "Roboto Mono", "Consolas", "Lucida Console", monospace;
+    font-family: "Reddit Mono", "Consolas", "Lucida Console", monospace;
 }
 
 /* classes for API Reference docstring signatures */
 .sig, .sig-name, code.descname, .sig-prename, .optional, .sig-paren {
     font-size: 1em;
-    font-family: "Roboto Mono", "Consolas", "Lucida Console", monospace;
+    font-family: "Reddit Mono", "Consolas", "Lucida Console", monospace;
 }
 
 div.body h1 {


### PR DESCRIPTION
# Overview

Updating the Python API docs to use our design system proportional and fixed-width fonts.

# Test Plan

- public [sansbox](http://sandbox.docs.opentrons.com/docs-public-sans/v2/)
- tested on macOS Safari and Chrome, on computers with and without the fonts installed locally

# Changelog

- Open Sans -> Public Sans
- using Reddit Mono for monospace
- other minor CSS tweaks

# Review requests

is it pretty?

should we also get rid of Akko H1s?

is there a way to get rid of the 1px of white space between the light grey background box of `<a><code>` and the dotted border below it? i've tried every CSS kludge i know of.
![Screenshot 2024-08-19 at 1 37 30 PM](https://github.com/user-attachments/assets/c20d2415-1759-4df7-a221-183c6be5f001)


also need testing assistance on

- [ ] Windows Chrome
- [ ] Windows Edge
- [ ] Linux browsers

# Risk assessment

low