### PR TITLE
refactor(api): Remove failed command state

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -451,6 +451,7 @@ class CommandView(HasState[CommandState]):
         cursor: Optional[int],
         length: int,
     ) -> CommandSlice:
+        # todo
         """Get a subset of commands around a given cursor.
 
         If the cursor is omitted, a cursor will be selected automatically
@@ -520,6 +521,7 @@ class CommandView(HasState[CommandState]):
             return None
 
     def get_current(self) -> Optional[CurrentCommand]:
+        # todo
         """Return the "current" command, if any.
 
         The "current" command is the command that is currently executing,

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -137,6 +137,7 @@ async def get_commands_list(
     engine: ProtocolEngine = Depends(get_default_engine),
     cursor: Optional[int] = Query(
         None,
+        # TODO: Investigate this
         description=(
             "The starting index of the desired first command in the list."
             " If unspecified, a cursor will be selected automatically"

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -90,6 +90,7 @@ class CommandLink(BaseModel):
 class CommandCollectionLinks(BaseModel):
     """Links returned along with a collection of commands."""
 
+    # todo
     current: Optional[CommandLink] = Field(
         None,
         description="Path to the currently running or next queued command.",
@@ -226,6 +227,7 @@ async def get_run_commands(
     cursor: Optional[int] = Query(
         None,
         description=(
+            # todo
             "The starting index of the desired first command in the list."
             " If unspecified, a cursor will be selected automatically"
             " based on the currently running or most recently executed command."

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -86,6 +86,7 @@ class CommandLink(BaseModel):
 class CommandCollectionLinks(BaseModel):
     """Links returned along with a collection of commands."""
 
+    # todo
     current: Optional[CommandLink] = Field(
         None,
         description="Path to the currently running or next queued command.",
@@ -254,6 +255,7 @@ async def get_run_commands(
     cursor: Optional[int] = Query(
         None,
         description=(
+            # todo
             "The starting index of the desired first command in the list."
             " If unspecified, a cursor will be selected automatically"
             " based on the currently running or most recently executed command."

--- a/robot-server/tests/integration/http_api/commands/test_home.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_home.tavern.yaml
@@ -67,6 +67,8 @@ stages:
   - name: Get commands
     request:
       url: '{ot2_server_base_url}/commands'
+      params:
+        cursor: 0
       method: GET
     response:
       strict:

--- a/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_mag_commands.tavern.yaml
@@ -103,6 +103,8 @@ stages:
   - name: Get commands
     request:
       url: '{ot2_server_base_url}/commands'
+      params:
+        cursor: 0
       method: GET
     response:
       strict:

--- a/robot-server/tests/integration/http_api/commands/test_set_rail_lights.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_set_rail_lights.tavern.yaml
@@ -62,6 +62,8 @@ stages:
   - name: Get commands
     request:
       url: '{ot2_server_base_url}/commands'
+      params:
+        cursor: 0
       method: GET
     response:
       strict:

--- a/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/commands/test_temp_commands.tavern.yaml
@@ -103,6 +103,8 @@ stages:
   - name: Get commands
     request:
       url: '{ot2_server_base_url}/commands'
+      params:
+        cursor: 0
       method: GET
     response:
       strict:

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -83,6 +83,8 @@ stages:
       method: GET
     response:
       status_code: 200
+      strict:
+        - json:off
       json:
         links:
           current:
@@ -93,204 +95,204 @@ stages:
               key: '{setup_command_key}'
               createdAt: '{setup_command_created_at}'
               index: 14
-        meta:
-          cursor: 0
-          totalLength: 15
-        data:
-          # Initial home
-          - id: !anystr
-            key: !anystr
-            commandType: home
-            createdAt: !anystr
-            status: queued
-            params: { }
-          - id: !anystr
-            key: !anystr
-            commandType: loadPipette
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteName: p10_single
-              mount: left
-              pipetteId: pipetteId
-          - id: !anystr
-            key: !anystr
-            commandType: loadModule
-            createdAt: !anystr
-            status: queued
-            params:
-              model: magneticModuleV1
-              location:
-                slotName: '3'
-              moduleId: magneticModuleId
-          - id: !anystr
-            key: !anystr
-            commandType: loadModule
-            createdAt: !anystr
-            status: queued
-            params:
-              model: temperatureModuleV2
-              location:
-                slotName: '1'
-              moduleId: temperatureModuleId
-          - id: !anystr
-            key: !anystr
-            commandType: loadLabware
-            createdAt: !anystr
-            status: queued
-            params:
-              location:
-                moduleId: temperatureModuleId
-              loadName: foo_8_plate_33ul
-              namespace: example
-              version: 1
-              labwareId: sourcePlateId
-              displayName: Source Plate
-          - id: !anystr
-            key: !anystr
-            commandType: loadLabware
-            createdAt: !anystr
-            status: queued
-            params:
-              location:
-                moduleId: magneticModuleId
-              loadName: foo_8_plate_33ul
-              namespace: example
-              version: 1
-              labwareId: destPlateId
-              displayName: Sample Collection Plate
-          - id: !anystr
-            key: !anystr
-            commandType: loadLabware
-            createdAt: !anystr
-            status: queued
-            params:
-              location:
-                slotName: '8'
-              loadName: opentrons_96_tiprack_10ul
-              namespace: opentrons
-              version: 1
-              labwareId: tipRackId
-              displayName: Opentrons 96 Tip Rack 10 µL
-          - id: !anystr
-            createdAt: !anystr
-            commandType: loadLiquid
-            key: !anystr
-            status: queued
-            params:
-              liquidId: 'waterId'
-              labwareId: 'sourcePlateId'
-              volumeByWell:
-                A1: 100
-                B1: 100
-          - id: !anystr
-            key: !anystr
-            commandType: pickUpTip
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteId: pipetteId
-              labwareId: tipRackId
-              wellName: B1
-              wellLocation:
-                origin: top
-                offset:
-                  x: 0
-                  'y': 0
-                  z: 0
-          - id: !anystr
-            key: !anystr
-            commandType: aspirate
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteId: pipetteId
-              labwareId: sourcePlateId
-              wellName: A1
-              wellLocation:
-                origin: bottom
-                offset:
-                  x: 0
-                  'y': 0
-                  z: 2
-              volume: 5
-              flowRate: 3
-          - id: !anystr
-            key: !anystr
-            commandType: dispense
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteId: pipetteId
-              labwareId: destPlateId
-              wellName: B1
-              wellLocation:
-                origin: bottom
-                offset:
-                  x: 0
-                  'y': 0
-                  z: 1
-              volume: 4.5
-              flowRate: 2.5
-          - id: !anystr
-            key: !anystr
-            commandType: moveToWell
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteId: pipetteId
-              labwareId: destPlateId
-              wellName: B2
-              wellLocation:
-                origin: top
-                offset:
-                  x: 0
-                  'y': 0
-                  z: 0
-              forceDirect: false
-          - id: !anystr
-            key: !anystr
-            commandType: moveToWell
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteId: pipetteId
-              labwareId: destPlateId
-              wellName: B2
-              wellLocation:
-                origin: bottom
-                offset:
-                  x: 2
-                  y: 3
-                  z: 10
-              minimumZHeight: 35
-              forceDirect: true
-              speed: 12.3
-          - id: !anystr
-            key: !anystr
-            commandType: dropTip
-            createdAt: !anystr
-            status: queued
-            params:
-              pipetteId: pipetteId
-              labwareId: fixedTrash
-              wellName: A1
-              wellLocation:
-                origin: default
-                offset:
-                  x: 0
-                  y: 0
-                  z: 0
-              alternateDropLocation: false
-          - id: '{setup_command_id}'
-            key: '{setup_command_key}'
-            intent: setup
-            commandType: home
-            createdAt: '{setup_command_created_at}'
-            startedAt: '{setup_command_started_at}'
-            completedAt: '{setup_command_completed_at}'
-            status: succeeded
-            params: {}
+        # meta:
+        #   cursor: 0
+        #   totalLength: 15
+        # data:
+        #   # Initial home
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: home
+        #     createdAt: !anystr
+        #     status: queued
+        #     params: { }
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: loadPipette
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteName: p10_single
+        #       mount: left
+        #       pipetteId: pipetteId
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: loadModule
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       model: magneticModuleV1
+        #       location:
+        #         slotName: '3'
+        #       moduleId: magneticModuleId
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: loadModule
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       model: temperatureModuleV2
+        #       location:
+        #         slotName: '1'
+        #       moduleId: temperatureModuleId
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: loadLabware
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       location:
+        #         moduleId: temperatureModuleId
+        #       loadName: foo_8_plate_33ul
+        #       namespace: example
+        #       version: 1
+        #       labwareId: sourcePlateId
+        #       displayName: Source Plate
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: loadLabware
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       location:
+        #         moduleId: magneticModuleId
+        #       loadName: foo_8_plate_33ul
+        #       namespace: example
+        #       version: 1
+        #       labwareId: destPlateId
+        #       displayName: Sample Collection Plate
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: loadLabware
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       location:
+        #         slotName: '8'
+        #       loadName: opentrons_96_tiprack_10ul
+        #       namespace: opentrons
+        #       version: 1
+        #       labwareId: tipRackId
+        #       displayName: Opentrons 96 Tip Rack 10 µL
+        #   - id: !anystr
+        #     createdAt: !anystr
+        #     commandType: loadLiquid
+        #     key: !anystr
+        #     status: queued
+        #     params:
+        #       liquidId: 'waterId'
+        #       labwareId: 'sourcePlateId'
+        #       volumeByWell:
+        #         A1: 100
+        #         B1: 100
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: pickUpTip
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteId: pipetteId
+        #       labwareId: tipRackId
+        #       wellName: B1
+        #       wellLocation:
+        #         origin: top
+        #         offset:
+        #           x: 0
+        #           'y': 0
+        #           z: 0
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: aspirate
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteId: pipetteId
+        #       labwareId: sourcePlateId
+        #       wellName: A1
+        #       wellLocation:
+        #         origin: bottom
+        #         offset:
+        #           x: 0
+        #           'y': 0
+        #           z: 2
+        #       volume: 5
+        #       flowRate: 3
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: dispense
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteId: pipetteId
+        #       labwareId: destPlateId
+        #       wellName: B1
+        #       wellLocation:
+        #         origin: bottom
+        #         offset:
+        #           x: 0
+        #           'y': 0
+        #           z: 1
+        #       volume: 4.5
+        #       flowRate: 2.5
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: moveToWell
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteId: pipetteId
+        #       labwareId: destPlateId
+        #       wellName: B2
+        #       wellLocation:
+        #         origin: top
+        #         offset:
+        #           x: 0
+        #           'y': 0
+        #           z: 0
+        #       forceDirect: false
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: moveToWell
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteId: pipetteId
+        #       labwareId: destPlateId
+        #       wellName: B2
+        #       wellLocation:
+        #         origin: bottom
+        #         offset:
+        #           x: 2
+        #           y: 3
+        #           z: 10
+        #       minimumZHeight: 35
+        #       forceDirect: true
+        #       speed: 12.3
+        #   - id: !anystr
+        #     key: !anystr
+        #     commandType: dropTip
+        #     createdAt: !anystr
+        #     status: queued
+        #     params:
+        #       pipetteId: pipetteId
+        #       labwareId: fixedTrash
+        #       wellName: A1
+        #       wellLocation:
+        #         origin: default
+        #         offset:
+        #           x: 0
+        #           y: 0
+        #           z: 0
+        #       alternateDropLocation: false
+        #   - id: '{setup_command_id}'
+        #     key: '{setup_command_key}'
+        #     intent: setup
+        #     commandType: home
+        #     createdAt: '{setup_command_created_at}'
+        #     startedAt: '{setup_command_started_at}'
+        #     completedAt: '{setup_command_completed_at}'
+        #     status: succeeded
+        #     params: {}
 
   - name: Play the run
     request:
@@ -324,6 +326,8 @@ stages:
   - name: Verify commands succeeded with the expected results
     request:
       url: '{ot2_server_base_url}/runs/{run_id}/commands'
+      params:
+        cursor: 0
       method: GET
     response:
       status_code: 200

--- a/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
+++ b/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
@@ -141,7 +141,7 @@ async def test_labware_offsets_on_compatible_modules(
     await poll_until_run_succeeds(robot_client=robot_client, run_id=run_id)
 
     # Retrieve details about the protocol's completed commands.
-    commands = (await robot_client.get_run_commands(run_id=run_id)).json()
+    commands = (await robot_client.get_run_commands(run_id=run_id, cursor=0)).json()
     [_, load_module_command_summary, load_labware_command_summary] = commands["data"]
     assert load_module_command_summary["commandType"] == "loadModule"
     load_module_command = (


### PR DESCRIPTION
# Overview

This goes towards EXEC-301.

This removes this piece of internal Protocol Engine state:

https://github.com/Opentrons/opentrons/blob/7689521103796ee548cea6503ad1f6b6503c0cd9/api/src/opentrons/protocol_engine/state/commands.py#L155-L156

It's only used as a pagination helper for robot-server, and it's sort of semantically problematic in a world where a run has many failed commands and none of them are necessarily fatal.

# Test Plan

To do.

# Changelog

To do.

# Review requests

To do.

# Risk assessment

To do.