### PR TITLE
feat(hardware): add CAN error code for hepa uv door/reed errors

### DIFF
--- a/hardware/opentrons_hardware/errors.py
+++ b/hardware/opentrons_hardware/errors.py
@@ -12,6 +12,7 @@ from opentrons_shared_data.errors.exceptions import (
     PipetteOverpressureError,
     LabwareDroppedError,
     PythonException,
+    HepaUVFailedError,
 )
 
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
@@ -113,7 +114,7 @@ def raise_from_error_message(  # noqa: C901
         )
 
     if error_code in (ErrorCode.door_open, ErrorCode.reed_open):
-        raise RoboticsInteractionError(message="", detail=detail_dict)
+        raise HepaUVFailedError(message="Hepa UV failed", detail=detail_dict)
 
     if error_code in (ErrorCode.timeout,):
         raise CommandTimedOutError(

--- a/hardware/opentrons_hardware/errors.py
+++ b/hardware/opentrons_hardware/errors.py
@@ -112,6 +112,9 @@ def raise_from_error_message(  # noqa: C901
             message="Motor busy when operation requested", detail=detail_dict
         )
 
+    if error_code in (ErrorCode.door_open, ErrorCode.reed_open):
+        raise RoboticsInteractionError(message="", detail=detail_dict)
+
     if error_code in (ErrorCode.timeout,):
         raise CommandTimedOutError(
             message="Command timeout from hardware", detail=detail_dict

--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -285,6 +285,8 @@ class ErrorCode(int, Enum):
     motor_busy = 0x0B
     stop_requested = 0x0C
     over_pressure = 0x0D
+    door_open = 0x0E
+    reed_open = 0x0F
 
 
 @unique

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -190,6 +190,10 @@
       "detail": "Tip Detector Not Created",
       "category": "roboticsInteractionError"
     },
+    "3019": {
+      "detail": "HEPA UV Failed",
+      "category": "roboticsInteractionError"
+    },
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -77,6 +77,7 @@ class ErrorCodes(Enum):
     INVALID_INSTRUMENT_DATA = _code_from_dict_entry("3016")
     INVALID_LIQUID_CLASS_NAME = _code_from_dict_entry("3017")
     TIP_DETECTOR_NOT_FOUND = _code_from_dict_entry("3018")
+    HEPA_UV_FAILED = _code_from_dict_entry("3019")
     GENERAL_ERROR = _code_from_dict_entry("4000")
     ROBOT_IN_USE = _code_from_dict_entry("4001")
     API_REMOVED = _code_from_dict_entry("4002")

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -678,7 +678,7 @@ class UnexpectedTipAttachError(RoboticsInteractionError):
         super().__init__(ErrorCodes.UNEXPECTED_TIP_ATTACH, message, detail, wrapping)
 
 
-class HepaUVFailedError(RoboticsControlError):
+class HepaUVFailedError(RoboticsInteractionError):
     """An error indicating that the HEPA UV module has errored."""
 
     def __init__(

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -678,6 +678,19 @@ class UnexpectedTipAttachError(RoboticsInteractionError):
         super().__init__(ErrorCodes.UNEXPECTED_TIP_ATTACH, message, detail, wrapping)
 
 
+class HepaUVFailedError(RoboticsControlError):
+    """An error indicating that the HEPA UV module has errored."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an HepaUVFailedError."""
+        super().__init__(ErrorCodes.HEPA_UV_FAILED, message, detail, wrapping)
+
+
 class FirmwareUpdateRequiredError(RoboticsInteractionError):
     """An error indicating that a firmware update is required."""
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR adds two error codes for the hepa-uv so it can issue a warning to the host when a state change has occurred.