### PR TITLE
feat(robot-server,api): Add the skeleton for a new `complete-recovery` run action

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -82,11 +82,14 @@ export interface Runs {
 export const RUN_ACTION_TYPE_PLAY: 'play' = 'play'
 export const RUN_ACTION_TYPE_PAUSE: 'pause' = 'pause'
 export const RUN_ACTION_TYPE_STOP: 'stop' = 'stop'
+export const RUN_ACTION_TYPE_COMPLETE_RECOVERY: 'complete-recovery' =
+  'complete-recovery'
 
 export type RunActionType =
   | typeof RUN_ACTION_TYPE_PLAY
   | typeof RUN_ACTION_TYPE_PAUSE
   | typeof RUN_ACTION_TYPE_STOP
+  | typeof RUN_ACTION_TYPE_COMPLETE_RECOVERY
 
 export interface RunAction {
   id: string

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -82,14 +82,14 @@ export interface Runs {
 export const RUN_ACTION_TYPE_PLAY: 'play' = 'play'
 export const RUN_ACTION_TYPE_PAUSE: 'pause' = 'pause'
 export const RUN_ACTION_TYPE_STOP: 'stop' = 'stop'
-export const RUN_ACTION_TYPE_COMPLETE_RECOVERY: 'complete-recovery' =
-  'complete-recovery'
+export const RUN_ACTION_TYPE_RESUME_FROM_RECOVERY: 'resume-from-recovery' =
+  'resume-from-recovery'
 
 export type RunActionType =
   | typeof RUN_ACTION_TYPE_PLAY
   | typeof RUN_ACTION_TYPE_PAUSE
   | typeof RUN_ACTION_TYPE_STOP
-  | typeof RUN_ACTION_TYPE_COMPLETE_RECOVERY
+  | typeof RUN_ACTION_TYPE_RESUME_FROM_RECOVERY
 
 export interface RunAction {
   id: string

--- a/api/.flake8
+++ b/api/.flake8
@@ -14,6 +14,9 @@ extend-ignore =
     ANN102
     # do not require docstring for __init__, put them on the class
     D107,
+    # Don't forbid the function signature from being mentioned in the first line of the
+    # docstring. It tends to raise false positives when referring to other functions.
+    D402,
 
 # configure flake8-docstrings
 # https://pypi.org/project/flake8-docstrings/

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -62,8 +62,8 @@ class StopAction:
 
 
 @dataclass(frozen=True)
-class CompleteRecoveryAction:
-    """See `ProtocolEngine.complete_recovery()`."""
+class ResumeFromRecoveryAction:
+    """See `ProtocolEngine.resume_from_recovery()`."""
 
     pass
 
@@ -210,7 +210,7 @@ Action = Union[
     PlayAction,
     PauseAction,
     StopAction,
-    CompleteRecoveryAction,
+    ResumeFromRecoveryAction,
     FinishAction,
     HardwareStoppedAction,
     DoorChangeAction,

--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -62,6 +62,13 @@ class StopAction:
 
 
 @dataclass(frozen=True)
+class CompleteRecoveryAction:
+    """See `ProtocolEngine.complete_recovery()`."""
+
+    pass
+
+
+@dataclass(frozen=True)
 class FinishErrorDetails:
     """Error details for the payload of a FinishAction or HardwareStoppedAction."""
 
@@ -203,6 +210,7 @@ Action = Union[
     PlayAction,
     PauseAction,
     StopAction,
+    CompleteRecoveryAction,
     FinishAction,
     HardwareStoppedAction,
     DoorChangeAction,

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -2,7 +2,7 @@
 from contextlib import AsyncExitStack
 from logging import getLogger
 from typing import Dict, Optional, Union
-from opentrons.protocol_engine.actions.actions import CompleteRecoveryAction
+from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
 
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
@@ -160,10 +160,10 @@ class ProtocolEngine:
         self._action_dispatcher.dispatch(action)
         self._hardware_api.pause(HardwarePauseType.PAUSE)
 
-    def complete_recovery(self) -> None:
+    def resume_from_recovery(self) -> None:
         """Resume normal protocol execution after the engine was `AWAITING_RECOVERY`."""
         action = self._state_store.commands.validate_action_allowed(
-            CompleteRecoveryAction()
+            ResumeFromRecoveryAction()
         )
         self._action_dispatcher.dispatch(action)
 

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -2,6 +2,7 @@
 from contextlib import AsyncExitStack
 from logging import getLogger
 from typing import Dict, Optional, Union
+from opentrons.protocol_engine.actions.actions import CompleteRecoveryAction
 
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
@@ -158,6 +159,13 @@ class ProtocolEngine:
         )
         self._action_dispatcher.dispatch(action)
         self._hardware_api.pause(HardwarePauseType.PAUSE)
+
+    def complete_recovery(self) -> None:
+        """Resume normal protocol execution after the engine was `AWAITING_RECOVERY`."""
+        action = self._state_store.commands.validate_action_allowed(
+            CompleteRecoveryAction()
+        )
+        self._action_dispatcher.dispatch(action)
 
     def add_command(self, request: commands.CommandCreate) -> commands.Command:
         """Add a command to the `ProtocolEngine`'s queue.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.errors import EnumeratedError, ErrorCodes, PythonExce
 from opentrons.ordered_set import OrderedSet
 
 from opentrons.hardware_control.types import DoorState
-from opentrons.protocol_engine.actions.actions import CompleteRecoveryAction
+from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
 
 from ..actions import (
     Action,
@@ -672,11 +672,15 @@ class CommandView(HasState[CommandState]):
             PlayAction,
             PauseAction,
             StopAction,
-            CompleteRecoveryAction,
+            ResumeFromRecoveryAction,
             QueueCommandAction,
         ],
     ) -> Union[
-        PlayAction, PauseAction, StopAction, CompleteRecoveryAction, QueueCommandAction
+        PlayAction,
+        PauseAction,
+        StopAction,
+        ResumeFromRecoveryAction,
+        QueueCommandAction,
     ]:
         """Validate whether a given control action is allowed.
 
@@ -711,7 +715,7 @@ class CommandView(HasState[CommandState]):
                 )
 
         elif (
-            isinstance(action, CompleteRecoveryAction)
+            isinstance(action, ResumeFromRecoveryAction)
             or self.get_status() == EngineStatus.AWAITING_RECOVERY
         ):
             # While we're developing error recovery, we'll conservatively disallow

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -101,9 +101,9 @@ class AbstractRunner(ABC):
                 post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             )
 
-    def complete_recovery(self) -> None:
-        """See `ProtocolEngine.complete_recovery()`."""
-        self._protocol_engine.complete_recovery()
+    def resume_from_recovery(self) -> None:
+        """See `ProtocolEngine.resume_from_recovery()`."""
+        self._protocol_engine.resume_from_recovery()
 
     @abstractmethod
     async def run(

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -101,6 +101,10 @@ class AbstractRunner(ABC):
                 post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             )
 
+    def complete_recovery(self) -> None:
+        """See `ProtocolEngine.complete_recovery()`."""
+        self._protocol_engine.complete_recovery()
+
     @abstractmethod
     async def run(
         self,

--- a/api/tests/opentrons/protocol_engine/state/test_command_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view.py
@@ -14,6 +14,7 @@ from opentrons.protocol_engine.actions import (
     StopAction,
     QueueCommandAction,
 )
+from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
 
 from opentrons.protocol_engine.state.commands import (
     CommandState,
@@ -322,8 +323,14 @@ class ActionAllowedSpec(NamedTuple):
     """Spec data to test CommandView.validate_action_allowed."""
 
     subject: CommandView
-    action: Union[PlayAction, PauseAction, StopAction, QueueCommandAction]
-    expected_error: Optional[Type[errors.ProtocolEngineError]]
+    action: Union[
+        PlayAction,
+        PauseAction,
+        StopAction,
+        QueueCommandAction,
+        ResumeFromRecoveryAction,
+    ]
+    expected_error: Optional[Type[Exception]]
 
 
 action_allowed_specs: List[ActionAllowedSpec] = [
@@ -455,6 +462,13 @@ action_allowed_specs: List[ActionAllowedSpec] = [
         ),
         expected_error=errors.SetupCommandNotAllowedError,
     ),
+    # Resuming from error recovery is not implemented yet.
+    # https://opentrons.atlassian.net/browse/EXEC-301
+    ActionAllowedSpec(
+        subject=get_command_view(),
+        action=ResumeFromRecoveryAction(),
+        expected_error=NotImplementedError,
+    ),
 ]
 
 
@@ -462,7 +476,7 @@ action_allowed_specs: List[ActionAllowedSpec] = [
 def test_validate_action_allowed(
     subject: CommandView,
     action: Union[PlayAction, PauseAction, StopAction],
-    expected_error: Optional[Type[errors.ProtocolEngineError]],
+    expected_error: Optional[Type[Exception]],
 ) -> None:
     """It should validate allowed play/pause/stop actions."""
     expectation = pytest.raises(expected_error) if expected_error else does_not_raise()

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -8,7 +8,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons.ordered_set import OrderedSet
-from opentrons.protocol_engine.actions.actions import CompleteRecoveryAction
+from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
 
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
@@ -428,20 +428,20 @@ def test_pause(
     )
 
 
-def test_complete_recovery(
+def test_resume_from_recovery(
     decoy: Decoy,
     state_store: StateStore,
     action_dispatcher: ActionDispatcher,
     subject: ProtocolEngine,
 ) -> None:
-    """It should dispatch a CompleteRecoveryAction."""
-    expected_action = CompleteRecoveryAction()
+    """It should dispatch a ResumeFromRecoveryAction."""
+    expected_action = ResumeFromRecoveryAction()
 
     decoy.when(
         state_store.commands.validate_action_allowed(expected_action)
     ).then_return(expected_action)
 
-    subject.complete_recovery()
+    subject.resume_from_recovery()
 
     decoy.verify(action_dispatcher.dispatch(expected_action))
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -8,6 +8,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons.ordered_set import OrderedSet
+from opentrons.protocol_engine.actions.actions import CompleteRecoveryAction
 
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
@@ -425,6 +426,24 @@ def test_pause(
         action_dispatcher.dispatch(expected_action),
         hardware_api.pause(HardwarePauseType.PAUSE),
     )
+
+
+def test_complete_recovery(
+    decoy: Decoy,
+    state_store: StateStore,
+    action_dispatcher: ActionDispatcher,
+    subject: ProtocolEngine,
+) -> None:
+    """It should dispatch a CompleteRecoveryAction."""
+    expected_action = CompleteRecoveryAction()
+
+    decoy.when(
+        state_store.commands.validate_action_allowed(expected_action)
+    ).then_return(expected_action)
+
+    subject.complete_recovery()
+
+    decoy.verify(action_dispatcher.dispatch(expected_action))
 
 
 @pytest.mark.parametrize("drop_tips_after_run", [True, False])

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -294,15 +294,15 @@ async def test_stop_when_run_never_started(
         (lazy_fixture("live_runner_subject")),
     ],
 )
-def test_complete_recovery(
+def test_resume_from_recovery(
     decoy: Decoy,
     protocol_engine: ProtocolEngine,
     subject: AnyRunner,
 ) -> None:
-    """It should call `complete_recovery()` on the underlying engine."""
-    subject.complete_recovery()
+    """It should call `resume_from_recovery()` on the underlying engine."""
+    subject.resume_from_recovery()
 
-    decoy.verify(protocol_engine.complete_recovery(), times=1)
+    decoy.verify(protocol_engine.resume_from_recovery(), times=1)
 
 
 async def test_run_json_runner(

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -169,7 +169,7 @@ def live_runner_subject(
         (None, LiveRunner),
     ],
 )
-async def test_create_protocol_runner(
+def test_create_protocol_runner(
     protocol_engine: ProtocolEngine,
     hardware_api: HardwareAPI,
     task_queue: TaskQueue,
@@ -203,7 +203,7 @@ async def test_create_protocol_runner(
         (lazy_fixture("live_runner_subject")),
     ],
 )
-async def test_play_starts_run(
+def test_play_starts_run(
     decoy: Decoy,
     protocol_engine: ProtocolEngine,
     task_queue: TaskQueue,
@@ -223,7 +223,7 @@ async def test_play_starts_run(
         (lazy_fixture("live_runner_subject")),
     ],
 )
-async def test_pause(
+def test_pause(
     decoy: Decoy,
     protocol_engine: ProtocolEngine,
     subject: AnyRunner,
@@ -284,6 +284,25 @@ async def test_stop_when_run_never_started(
         ),
         times=1,
     )
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        (lazy_fixture("json_runner_subject")),
+        (lazy_fixture("legacy_python_runner_subject")),
+        (lazy_fixture("live_runner_subject")),
+    ],
+)
+def test_complete_recovery(
+    decoy: Decoy,
+    protocol_engine: ProtocolEngine,
+    subject: AnyRunner,
+) -> None:
+    """It should call `complete_recovery()` on the underlying engine."""
+    subject.complete_recovery()
+
+    decoy.verify(protocol_engine.complete_recovery(), times=1)
 
 
 async def test_run_json_runner(

--- a/robot-server/robot_server/runs/action_models.py
+++ b/robot-server/robot_server/runs/action_models.py
@@ -12,11 +12,15 @@ class RunActionType(str, Enum):
     * `"play"`: Start or resume a run.
     * `"pause"`: Pause a run.
     * `"stop"`: Stop (cancel) a run.
+    * `"complete-recovery"`: Resume normal protocol execution after a command failed,
+      the run was placed in `awaiting-recovery` mode, and manual recovery steps
+      were taken.
     """
 
     PLAY = "play"
     PAUSE = "pause"
     STOP = "stop"
+    COMPLETE_RECOVERY = "complete-recovery"
 
 
 class RunActionCreate(BaseModel):

--- a/robot-server/robot_server/runs/action_models.py
+++ b/robot-server/robot_server/runs/action_models.py
@@ -12,7 +12,7 @@ class RunActionType(str, Enum):
     * `"play"`: Start or resume a run.
     * `"pause"`: Pause a run.
     * `"stop"`: Stop (cancel) a run.
-    * `"complete-recovery"`: Resume normal protocol execution after a command failed,
+    * `"resume-from-recovery"`: Resume normal protocol execution after a command failed,
       the run was placed in `awaiting-recovery` mode, and manual recovery steps
       were taken.
     """
@@ -20,7 +20,7 @@ class RunActionType(str, Enum):
     PLAY = "play"
     PAUSE = "pause"
     STOP = "stop"
-    COMPLETE_RECOVERY = "complete-recovery"
+    RESUME_FROM_RECOVERY = "resume-from-recovery"
 
 
 class RunActionCreate(BaseModel):

--- a/robot-server/robot_server/runs/action_models.py
+++ b/robot-server/robot_server/runs/action_models.py
@@ -7,12 +7,11 @@ from robot_server.service.json_api import ResourceModel
 
 
 class RunActionType(str, Enum):
-    """Types of run control actions.
+    """The type of the run control action.
 
-    Args:
-        PLAY: Start or resume a protocol run.
-        PAUSE: Pause a run.
-        STOP: Stop (cancel) a run.
+    * `"play"`: Start or resume a run.
+    * `"pause"`: Pause a run.
+    * `"stop"`: Stop (cancel) a run.
     """
 
     PLAY = "play"

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -87,7 +87,6 @@ async def get_run_controller(
 async def create_run_action(
     runId: str,
     request_body: RequestModel[RunActionCreate],
-    engine_store: EngineStore = Depends(get_engine_store),
     run_controller: RunController = Depends(get_run_controller),
     action_id: str = Depends(get_unique_id),
     created_at: datetime = Depends(get_current_time),

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -85,8 +85,8 @@ class RunController:
                 log.info(f'Stopping run "{self._run_id}".')
                 self._task_runner.run(self._engine_store.runner.stop)
 
-            elif action_type == RunActionType.COMPLETE_RECOVERY:
-                self._engine_store.runner.complete_recovery()
+            elif action_type == RunActionType.RESUME_FROM_RECOVERY:
+                self._engine_store.runner.resume_from_recovery()
 
         except ProtocolEngineError as e:
             raise RunActionNotAllowedError(message=e.message, wrapping=[e]) from e

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -85,6 +85,9 @@ class RunController:
                 log.info(f'Stopping run "{self._run_id}".')
                 self._task_runner.run(self._engine_store.runner.stop)
 
+            elif action_type == RunActionType.COMPLETE_RECOVERY:
+                self._engine_store.runner.complete_recovery()
+
         except ProtocolEngineError as e:
             raise RunActionNotAllowedError(message=e.message, wrapping=[e]) from e
 

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -168,7 +168,7 @@ async def test_create_play_action_to_start(
     )
 
 
-async def test_create_pause_action(
+def test_create_pause_action(
     decoy: Decoy,
     mock_engine_store: EngineStore,
     mock_run_store: RunStore,
@@ -193,7 +193,7 @@ async def test_create_pause_action(
     decoy.verify(mock_engine_store.runner.pause(), times=1)
 
 
-async def test_create_stop_action(
+def test_create_stop_action(
     decoy: Decoy,
     mock_engine_store: EngineStore,
     mock_run_store: RunStore,
@@ -217,6 +217,32 @@ async def test_create_stop_action(
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
     decoy.verify(mock_task_runner.run(mock_engine_store.runner.stop), times=1)
+
+
+def test_create_complete_recovery_action(
+    decoy: Decoy,
+    mock_engine_store: EngineStore,
+    mock_run_store: RunStore,
+    mock_task_runner: TaskRunner,
+    run_id: str,
+    subject: RunController,
+) -> None:
+    """It should call `complete_recovery()` on the underlying engine store."""
+    result = subject.create_action(
+        action_id="some-action-id",
+        action_type=RunActionType.COMPLETE_RECOVERY,
+        created_at=datetime(year=2021, month=1, day=1),
+        action_payload=[],
+    )
+
+    assert result == RunAction(
+        id="some-action-id",
+        actionType=RunActionType.COMPLETE_RECOVERY,
+        createdAt=datetime(year=2021, month=1, day=1),
+    )
+
+    decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
+    decoy.verify(mock_engine_store.runner.complete_recovery())
 
 
 @pytest.mark.parametrize(

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -219,7 +219,7 @@ def test_create_stop_action(
     decoy.verify(mock_task_runner.run(mock_engine_store.runner.stop), times=1)
 
 
-def test_create_complete_recovery_action(
+def test_create_resume_from_recovery_action(
     decoy: Decoy,
     mock_engine_store: EngineStore,
     mock_run_store: RunStore,
@@ -227,22 +227,22 @@ def test_create_complete_recovery_action(
     run_id: str,
     subject: RunController,
 ) -> None:
-    """It should call `complete_recovery()` on the underlying engine store."""
+    """It should call `resume_from_recovery()` on the underlying engine store."""
     result = subject.create_action(
         action_id="some-action-id",
-        action_type=RunActionType.COMPLETE_RECOVERY,
+        action_type=RunActionType.RESUME_FROM_RECOVERY,
         created_at=datetime(year=2021, month=1, day=1),
         action_payload=[],
     )
 
     assert result == RunAction(
         id="some-action-id",
-        actionType=RunActionType.COMPLETE_RECOVERY,
+        actionType=RunActionType.RESUME_FROM_RECOVERY,
         createdAt=datetime(year=2021, month=1, day=1),
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_engine_store.runner.complete_recovery())
+    decoy.verify(mock_engine_store.runner.resume_from_recovery())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

Closes EXEC-300.

# Changelog

* Add a new action type for `POST /runs/{id}/actions`: `complete-recovery`.
* Connect it to `ProtocolEngine` and update unit tests along the way.
* For now, have `ProtocolEngine` raise a `NotImplementedError` whenever it encounters it. The actual implementation will be done in future PRs.
* Update TypeScript bindings.

# Test Plan

I've tested with Postman that I can post a `complete-recovery` action to a run, and it raises the expected `NotImplementedError`.

# Review requests

Do we like the name `complete-recovery` for this?

# Risk assessment

Low.