### PR TITLE
refactor(protocol-designer): show title of protocol at final deck state

### DIFF
--- a/protocol-designer/src/containers/ConnectedTitleBar.tsx
+++ b/protocol-designer/src/containers/ConnectedTitleBar.tsx
@@ -109,10 +109,9 @@ export const ConnectedTitleBar = (): JSX.Element => {
           getLabwareDisplayName(labwareEntity.def).replace('µL', 'uL')
         backButtonLabel = 'Deck'
       }
-
+      title = title || fileName || ''
       if (selectedTerminalId === START_TERMINAL_ITEM_ID) {
         subtitle = START_TERMINAL_TITLE
-        title = title || fileName || ''
       } else if (selectedTerminalId === END_TERMINAL_ITEM_ID) {
         subtitle = END_TERMINAL_TITLE
         if (drilledDownLabwareId) {


### PR DESCRIPTION
closes RQA-2510

# Overview

This bug was introduced when refactoring out the class components in PD. There was no title specified for the end deck state

# Test Plan

Follow the steps outlined in the ticket. Create a new protocol (ot2 or flex) and go to deck map. See that the title renders with the title bar. Then click on the final deck state and see that the title bar still includes the title.

# Changelog

- define title outside of the if/else statement

# Review requests

see test plan

# Risk assessment

low