### PR TITLE
fix(app): fix font size in parameters screen odd

### DIFF
--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -231,7 +231,7 @@ export function ProtocolSetupParameters({
                 onClickSetupStep={() => console.log('TODO: wire this up')}
                 detail={getDefault(parameter)}
                 description={parameter.description}
-                hasLargeFont
+                fontSize="h4"
               />
             </React.Fragment>
           )

--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -7,12 +7,13 @@ import {
   Flex,
   SPACING,
 } from '@opentrons/components'
-import { ProtocolSetupStep, SetupScreens } from '../../pages/ProtocolSetup'
+import { ProtocolSetupStep } from '../../pages/ProtocolSetup'
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { ChildNavigation } from '../ChildNavigation'
 import { ResetValuesModal } from './ResetValuesModal'
 
 import type { RunTimeParameter } from '@opentrons/shared-data'
+import type { SetupScreens } from '../../pages/ProtocolSetup'
 
 const mockData: RunTimeParameter[] = [
   {
@@ -230,6 +231,7 @@ export function ProtocolSetupParameters({
                 onClickSetupStep={() => console.log('TODO: wire this up')}
                 detail={getDefault(parameter)}
                 description={parameter.description}
+                hasLargeFont
               />
             </React.Fragment>
           )

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -117,7 +117,7 @@ interface ProtocolSetupStepProps {
   //  optional removal of the icon
   hasIcon?: boolean
   //  optional enlarge the font size
-  hasLargeFont?: boolean
+  fontSize?: string
 }
 
 export function ProtocolSetupStep({
@@ -130,7 +130,7 @@ export function ProtocolSetupStep({
   disabledReason,
   description,
   hasIcon = true,
-  hasLargeFont = false,
+  fontSize = 'p',
 }: ProtocolSetupStepProps): JSX.Element {
   const backgroundColorByStepStatus = {
     ready: COLORS.green35,
@@ -214,7 +214,7 @@ export function ProtocolSetupStep({
           }
         >
           <StyledText
-            as={hasLargeFont ? 'h4' : 'p'}
+            as={fontSize}
             textAlign={TEXT_ALIGN_RIGHT}
             color={disabled ? COLORS.grey50 : COLORS.black90}
             maxWidth="20rem"

--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -116,6 +116,8 @@ interface ProtocolSetupStepProps {
   description?: string
   //  optional removal of the icon
   hasIcon?: boolean
+  //  optional enlarge the font size
+  hasLargeFont?: boolean
 }
 
 export function ProtocolSetupStep({
@@ -128,6 +130,7 @@ export function ProtocolSetupStep({
   disabledReason,
   description,
   hasIcon = true,
+  hasLargeFont = false,
 }: ProtocolSetupStepProps): JSX.Element {
   const backgroundColorByStepStatus = {
     ready: COLORS.green35,
@@ -161,6 +164,8 @@ export function ProtocolSetupStep({
       background-color: ${backgroundColor};
     }
   `
+
+  const isToggle = detail === 'On' || detail === 'Off'
 
   return (
     <Btn
@@ -201,9 +206,15 @@ export function ProtocolSetupStep({
             {description}
           </StyledText>
         </Flex>
-        <Flex flex="1" justifyContent={JUSTIFY_END}>
+        <Flex
+          flex="1"
+          justifyContent={JUSTIFY_END}
+          padding={
+            isToggle ? `${SPACING.spacing12} ${SPACING.spacing10}` : 'undefined'
+          }
+        >
           <StyledText
-            as="p"
+            as={hasLargeFont ? 'h4' : 'p'}
             textAlign={TEXT_ALIGN_RIGHT}
             color={disabled ? COLORS.grey50 : COLORS.black90}
             maxWidth="20rem"


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
the design team requested us to update the font size of value in parameters screen. (22px -> 28px)
close AUTH-218

[related thread](https://opentrons.slack.com/archives/C06M6R72UDS/p1710863687506439)

![Screenshot 2024-03-19 at 2 22 56 PM](https://github.com/Opentrons/opentrons/assets/474225/db4a0e87-a905-482f-8e4c-1ede4e031a76)
![Screenshot 2024-03-19 at 2 22 40 PM](https://github.com/Opentrons/opentrons/assets/474225/00fcffd6-b665-4331-8a40-9a1f229b7aea)



<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
If there is more efficient way to fix this except re-structuring a component, please let me know.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
