### PR TITLE
chore: Make analyses-snapshot-test PR titles usable as commit titles

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -65,7 +65,7 @@ jobs:
       uses: peter-evans/create-pull-request@v5
       with:
           commit-message: 'fix(app-testing): snapshot failure capture'
-          title: 'Evaluate Analyses Snapshot Update ${{ env.TARGET }}'
+          title: 'fix(app-testing): snapshot failure capture'
           body: 'This PR is an automated snapshot update request. Please review the changes and merge if they are acceptable or find you bug and fix it.'
           branch: 'app-testing/${{ env.TARGET }}-from-${{ env.TEST_SOURCE}}'
           base: ${{ env.TEST_SOURCE}}


### PR DESCRIPTION
# Overview

Something in our GitHub config changed recently where, when you click the green merge button on a PR like #14586, it autocompletes the commit message like this:

> Evaluate Analyses Snapshot Update edge ([PR number])

We want it to autocomplete like this instead:

> fix(app-testing): snapshot failure capture ([PR number])

# Test Plan

None needed.

# Changelog

* Change the titles of PRs created by the `analyses-snapshot-test.yaml` workflow, because they're used to autocomplete the squash commit message.

# Review requests

None in particular.

# Risk assessment

Low.