### PR TITLE
fix(app): refactor Flex pipette card to reference /instruments

### DIFF
--- a/app/src/molecules/InstrumentCard/index.tsx
+++ b/app/src/molecules/InstrumentCard/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import {
   ALIGN_FLEX_START,
+  ALIGN_CENTER,
   BORDERS,
   Box,
   COLORS,
@@ -80,13 +81,19 @@ export function InstrumentCard(props: InstrumentCardProps): JSX.Element {
         </Flex>
       ) : null}
       {instrumentDiagramProps?.pipetteSpecs != null ? (
-        <InstrumentDiagram
-          pipetteSpecs={instrumentDiagramProps.pipetteSpecs}
-          mount={instrumentDiagramProps.mount}
-          transform="scale(0.3)"
-          size="3.125rem"
-          transformOrigin="20% -10%"
-        />
+        <Flex
+          alignItems={ALIGN_CENTER}
+          width="3.75rem"
+          height="3.375rem"
+          paddingRight={SPACING.spacing8}
+        >
+          <InstrumentDiagram
+            pipetteSpecs={instrumentDiagramProps.pipetteSpecs}
+            mount={instrumentDiagramProps.mount}
+            transform="scale(0.3)"
+            transformOrigin={'-5% 52%'}
+          />
+        </Flex>
       ) : null}
       <Flex
         alignItems={ALIGN_FLEX_START}

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -226,7 +226,7 @@ export function InstrumentsAndModules({
               flexDirection={DIRECTION_COLUMN}
               gridGap={SPACING.spacing8}
             >
-              {!isFlex && (
+              {!isFlex ? (
                 <PipetteCard
                   pipetteId={attachedPipettes.right?.id}
                   pipetteModelSpecs={
@@ -240,7 +240,7 @@ export function InstrumentsAndModules({
                   isRunActive={currentRunId != null && isRunRunning}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
-              )}
+              ) : null}
               {isFlex && !is96ChannelAttached ? (
                 <FlexPipetteCard
                   attachedPipette={attachedRightPipette}

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { getPipetteModelSpecs, LEFT, RIGHT } from '@opentrons/shared-data'
 import {
-  useAllPipetteOffsetCalibrationsQuery,
   useModulesQuery,
   usePipettesQuery,
   useInstrumentsQuery,
@@ -28,10 +27,10 @@ import { ModuleCard } from '../ModuleCard'
 import { useIsFlex, useIsRobotViewable, useRunStatuses } from './hooks'
 import {
   getIs96ChannelPipetteAttached,
-  getOffsetCalibrationForMount,
   getShowPipetteCalibrationWarning,
 } from './utils'
 import { PipetteCard } from './PipetteCard'
+import { FlexPipetteCard } from './PipetteCard/FlexPipetteCard'
 import { GripperCard } from '../GripperCard'
 import { useIsEstopNotDisengaged } from '../../resources/devices/hooks/useIsEstopNotDisengaged'
 
@@ -43,7 +42,6 @@ import type {
 } from '@opentrons/api-client'
 
 const EQUIPMENT_POLL_MS = 5000
-const FETCH_PIPETTE_CAL_POLL = 30000
 interface InstrumentsAndModulesProps {
   robotName: string
 }
@@ -52,20 +50,22 @@ export function InstrumentsAndModules({
   robotName,
 }: InstrumentsAndModulesProps): JSX.Element | null {
   const { t } = useTranslation(['device_details', 'shared'])
+  const isFlex = useIsFlex(robotName)
   const attachedPipettes = usePipettesQuery(
     {},
     {
       refetchInterval: EQUIPMENT_POLL_MS,
+      enabled: !isFlex,
     }
   )?.data ?? { left: undefined, right: undefined }
   const isRobotViewable = useIsRobotViewable(robotName)
   const currentRunId = useCurrentRunId()
   const { isRunTerminal, isRunRunning } = useRunStatuses()
-  const isFlex = useIsFlex(robotName)
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
 
   const { data: attachedInstruments } = useInstrumentsQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
+    enabled: isFlex,
   })
 
   const attachedGripper =
@@ -120,26 +120,6 @@ export function InstrumentsAndModules({
   const leftColumnModules = attachedModules?.slice(0, halfAttachedModulesSize)
   const rightColumnModules = attachedModules?.slice(halfAttachedModulesSize)
 
-  // The following pipetteOffset related code has been lifted out of the PipetteCard component
-  // to eliminate duplicated useInterval calls to `calibration/pipette_offset` coming from each card.
-  // Instead we now capture all offset calibration data here, and pass the appropriate calibration
-  // data to the associated card via props
-  const pipetteOffsetCalibrations =
-    useAllPipetteOffsetCalibrationsQuery({
-      refetchInterval: FETCH_PIPETTE_CAL_POLL,
-      enabled: !isFlex,
-    })?.data?.data ?? []
-  const leftMountOffsetCalibration = getOffsetCalibrationForMount(
-    pipetteOffsetCalibrations,
-    attachedPipettes,
-    LEFT
-  )
-  const rightMountOffsetCalibration = getOffsetCalibrationForMount(
-    pipetteOffsetCalibrations,
-    attachedPipettes,
-    RIGHT
-  )
-
   return (
     <Flex
       alignItems={ALIGN_FLEX_START}
@@ -186,37 +166,46 @@ export function InstrumentsAndModules({
               flexDirection={DIRECTION_COLUMN}
               gridGap={SPACING.spacing8}
             >
-              <PipetteCard
-                pipetteId={attachedPipettes.left?.id}
-                pipetteModelSpecs={
-                  attachedPipettes.left?.model != null
-                    ? getPipetteModelSpecs(attachedPipettes.left?.model) ?? null
-                    : null
-                }
-                isPipetteCalibrated={
-                  isFlex && attachedLeftPipette?.ok
-                    ? attachedLeftPipette?.data?.calibratedOffset
-                        ?.last_modified != null
-                    : leftMountOffsetCalibration != null
-                }
-                mount={LEFT}
-                robotName={robotName}
-                pipetteIs96Channel={is96ChannelAttached}
-                pipetteIsBad={badLeftPipette != null}
-                isRunActive={currentRunId != null && isRunRunning}
-                isEstopNotDisengaged={isEstopNotDisengaged}
-              />
-              {isFlex && (
-                <GripperCard
-                  attachedGripper={attachedGripper}
-                  isCalibrated={
-                    attachedGripper?.ok === true &&
-                    attachedGripper?.data?.calibratedOffset?.last_modified !=
-                      null
+              {!isFlex ? (
+                <PipetteCard
+                  pipetteId={attachedPipettes.left?.id}
+                  pipetteModelSpecs={
+                    attachedPipettes.left?.model != null
+                      ? getPipetteModelSpecs(attachedPipettes.left?.model) ??
+                        null
+                      : null
                   }
+                  mount={LEFT}
+                  robotName={robotName}
                   isRunActive={currentRunId != null && isRunRunning}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
+              ) : (
+                <>
+                  <FlexPipetteCard
+                    attachedPipette={attachedLeftPipette}
+                    pipetteModelSpecs={
+                      attachedLeftPipette?.instrumentModel != null
+                        ? getPipetteModelSpecs(
+                            attachedLeftPipette.instrumentModel
+                          ) ?? null
+                        : null
+                    }
+                    mount={LEFT}
+                    isRunActive={currentRunId != null && isRunRunning}
+                    isEstopNotDisengaged={isEstopNotDisengaged}
+                  />
+                  <GripperCard
+                    attachedGripper={attachedGripper}
+                    isCalibrated={
+                      attachedGripper?.ok === true &&
+                      attachedGripper?.data?.calibratedOffset?.last_modified !=
+                        null
+                    }
+                    isRunActive={currentRunId != null && isRunRunning}
+                    isEstopNotDisengaged={isEstopNotDisengaged}
+                  />
+                </>
               )}
               {leftColumnModules.map((module, index) => (
                 <ModuleCard
@@ -237,7 +226,7 @@ export function InstrumentsAndModules({
               flexDirection={DIRECTION_COLUMN}
               gridGap={SPACING.spacing8}
             >
-              {!Boolean(is96ChannelAttached) && (
+              {!isFlex && (
                 <PipetteCard
                   pipetteId={attachedPipettes.right?.id}
                   pipetteModelSpecs={
@@ -246,20 +235,27 @@ export function InstrumentsAndModules({
                         null
                       : null
                   }
-                  isPipetteCalibrated={
-                    isFlex && attachedRightPipette?.ok
-                      ? attachedRightPipette?.data?.calibratedOffset
-                          ?.last_modified != null
-                      : rightMountOffsetCalibration != null
-                  }
                   mount={RIGHT}
                   robotName={robotName}
-                  pipetteIs96Channel={false}
-                  pipetteIsBad={badRightPipette != null}
                   isRunActive={currentRunId != null && isRunRunning}
                   isEstopNotDisengaged={isEstopNotDisengaged}
                 />
               )}
+              {isFlex && !is96ChannelAttached ? (
+                <FlexPipetteCard
+                  attachedPipette={attachedRightPipette}
+                  pipetteModelSpecs={
+                    attachedRightPipette?.instrumentModel != null
+                      ? getPipetteModelSpecs(
+                          attachedRightPipette.instrumentModel
+                        ) ?? null
+                      : null
+                  }
+                  mount={RIGHT}
+                  isRunActive={currentRunId != null && isRunRunning}
+                  isEstopNotDisengaged={isEstopNotDisengaged}
+                />
+              ) : null}
               {rightColumnModules.map((module, index) => (
                 <ModuleCard
                   key={`moduleCard_${String(module.moduleType)}_${String(

--- a/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
+++ b/app/src/organisms/Devices/PipetteCard/AboutPipetteSlideout.tsx
@@ -9,17 +9,15 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { Slideout } from '../../../atoms/Slideout'
 
 import type { AttachedPipette } from '../../../redux/pipettes/types'
-import type { PipetteData } from '@opentrons/api-client'
-import type { PipetteModelSpecs, PipetteMount } from '@opentrons/shared-data'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
 
 interface AboutPipetteSlideoutProps {
   pipetteId: AttachedPipette['id']
   pipetteName: PipetteModelSpecs['displayName']
-  mount: PipetteMount
+  firmwareVersion?: string
   onCloseClick: () => unknown
   isExpanded: boolean
 }
@@ -27,14 +25,14 @@ interface AboutPipetteSlideoutProps {
 export const AboutPipetteSlideout = (
   props: AboutPipetteSlideoutProps
 ): JSX.Element | null => {
-  const { pipetteId, pipetteName, isExpanded, mount, onCloseClick } = props
+  const {
+    pipetteId,
+    pipetteName,
+    isExpanded,
+    firmwareVersion,
+    onCloseClick,
+  } = props
   const { i18n, t } = useTranslation(['device_details', 'shared'])
-  const { data: attachedInstruments } = useInstrumentsQuery()
-  const instrumentInfo =
-    attachedInstruments?.data?.find(
-      (i): i is PipetteData =>
-        i.instrumentType === 'pipette' && i.ok && i.mount === mount
-    ) ?? null
 
   return (
     <Slideout
@@ -52,7 +50,7 @@ export const AboutPipetteSlideout = (
       }
     >
       <Flex flexDirection={DIRECTION_COLUMN}>
-        {instrumentInfo?.firmwareVersion != null && (
+        {firmwareVersion != null && (
           <>
             <StyledText
               as="h6"
@@ -66,7 +64,7 @@ export const AboutPipetteSlideout = (
               paddingTop={SPACING.spacing4}
               paddingBottom={SPACING.spacing16}
             >
-              {instrumentInfo.firmwareVersion}
+              {firmwareVersion}
             </StyledText>
           </>
         )}

--- a/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -98,7 +98,7 @@ export function FlexPipetteCard({
   const handleChoosePipette: React.MouseEventHandler<HTMLButtonElement> = () => {
     setShowChoosePipette(true)
   }
-  const handleAttach = () => {
+  const handleAttach = (): void => {
     setShowChoosePipette(false)
     handleLaunchPipetteWizardFlows(FLOWS.ATTACH)
   }

--- a/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -1,0 +1,281 @@
+import * as React from 'react'
+import { Trans, useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
+import { SPACING, TYPOGRAPHY, StyledText } from '@opentrons/components'
+import {
+  NINETY_SIX_CHANNEL,
+  SINGLE_MOUNT_PIPETTES,
+  FLEX_ROBOT_TYPE,
+  LEFT,
+} from '@opentrons/shared-data'
+import {
+  useCurrentSubsystemUpdateQuery,
+  useHost,
+} from '@opentrons/react-api-client'
+import { Banner } from '../../../atoms/Banner'
+import { InstrumentCard } from '../../../molecules/InstrumentCard'
+import { ChoosePipette } from '../../PipetteWizardFlows/ChoosePipette'
+import { FLOWS } from '../../PipetteWizardFlows/constants'
+import { handlePipetteWizardFlows } from '../../PipetteWizardFlows'
+import { DropTipWizard } from '../../DropTipWizard'
+
+import { AboutPipetteSlideout } from './AboutPipetteSlideout'
+
+import type {
+  BadPipette,
+  Mount,
+  PipetteData,
+  HostConfig,
+} from '@opentrons/api-client'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
+import type {
+  PipetteWizardFlow,
+  SelectablePipettes,
+} from '../../PipetteWizardFlows/types'
+
+interface FlexPipetteCardProps {
+  attachedPipette: PipetteData | BadPipette | null
+  pipetteModelSpecs: PipetteModelSpecs | null
+  mount: Mount
+  isRunActive: boolean
+  isEstopNotDisengaged: boolean
+}
+const BANNER_LINK_CSS = css`
+  text-decoration: ${TYPOGRAPHY.textDecorationUnderline};
+  cursor: pointer;
+  margin-left: ${SPACING.spacing8};
+`
+
+const INSTRUMENT_CARD_STYLE = css`
+  p {
+    text-transform: lowercase;
+  }
+
+  p::first-letter {
+    text-transform: uppercase;
+  }
+`
+
+const POLL_DURATION_MS = 5000
+
+export function FlexPipetteCard({
+  pipetteModelSpecs,
+  attachedPipette,
+  mount,
+  isRunActive,
+  isEstopNotDisengaged,
+}: FlexPipetteCardProps): JSX.Element {
+  const { t, i18n } = useTranslation(['device_details', 'shared'])
+  const host = useHost() as HostConfig
+
+  const [
+    showAboutPipetteSlideout,
+    setShowAboutPipetteSlideout,
+  ] = React.useState<boolean>(false)
+  const [showChoosePipette, setShowChoosePipette] = React.useState(false)
+  const [showDropTipWizard, setShowDropTipWizard] = React.useState(false)
+  const [
+    selectedPipette,
+    setSelectedPipette,
+  ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
+  const attachedPipetteIs96Channel =
+    attachedPipette?.ok && attachedPipette.instrumentName === 'p1000_96'
+  const selectedPipetteForWizard = attachedPipetteIs96Channel
+    ? NINETY_SIX_CHANNEL
+    : selectedPipette
+  const setCloseFlow = (): void => {
+    setSelectedPipette(SINGLE_MOUNT_PIPETTES)
+  }
+
+  const handleLaunchPipetteWizardFlows = (flowType: PipetteWizardFlow): void =>
+    handlePipetteWizardFlows({
+      flowType,
+      mount,
+      closeFlow: setCloseFlow,
+      selectedPipette: selectedPipetteForWizard,
+      host,
+    })
+  const handleChoosePipette: React.MouseEventHandler<HTMLButtonElement> = () => {
+    setShowChoosePipette(true)
+  }
+  const handleAttach = () => {
+    setShowChoosePipette(false)
+    handleLaunchPipetteWizardFlows(FLOWS.ATTACH)
+  }
+
+  const handleDetach: React.MouseEventHandler<HTMLButtonElement> = () => {
+    handleLaunchPipetteWizardFlows(FLOWS.DETACH)
+  }
+
+  const handleCalibrate: React.MouseEventHandler<HTMLButtonElement> = () => {
+    handleLaunchPipetteWizardFlows(FLOWS.CALIBRATE)
+  }
+  const handleDropTip = (): void => {
+    setShowDropTipWizard(true)
+  }
+
+  const [pollForSubsystemUpdate, setPollForSubsystemUpdate] = React.useState(
+    false
+  )
+  const subsystem = attachedPipette?.subsystem ?? null
+  const { data: subsystemUpdateData } = useCurrentSubsystemUpdateQuery(
+    subsystem,
+    {
+      enabled: pollForSubsystemUpdate,
+      refetchInterval: POLL_DURATION_MS,
+    }
+  )
+  const pipetteDisplayName = pipetteModelSpecs?.displayName
+  // we should poll for a subsystem update from the time a bad instrument is
+  // detected until the update has been done for 5 seconds
+  // this gives the instruments endpoint time to start reporting
+  // a good instrument
+  React.useEffect(() => {
+    if (attachedPipette?.ok === false) {
+      setPollForSubsystemUpdate(true)
+    } else if (
+      subsystemUpdateData != null &&
+      subsystemUpdateData.data.updateStatus === 'done'
+    ) {
+      setTimeout(() => {
+        setPollForSubsystemUpdate(false)
+      }, POLL_DURATION_MS)
+    }
+  }, [attachedPipette?.ok, subsystemUpdateData])
+
+  const menuOverlayItems =
+    attachedPipette == null || !attachedPipette.ok
+      ? [
+          {
+            label: t('attach_pipette'),
+            disabled: attachedPipette != null || isRunActive,
+            onClick: handleChoosePipette,
+          },
+        ]
+      : [
+          {
+            label:
+              attachedPipette.data.calibratedOffset?.last_modified != null
+                ? t('recalibrate_pipette')
+                : t('calibrate_pipette'),
+            disabled: attachedPipette == null || isRunActive,
+            onClick: handleCalibrate,
+          },
+          {
+            label: t('detach_pipette'),
+            disabled: attachedPipette == null || isRunActive,
+            onClick: handleDetach,
+          },
+          {
+            label: t('about_pipette'),
+            disabled: attachedPipette == null,
+            onClick: () => setShowAboutPipetteSlideout(true),
+          },
+          {
+            label: i18n.format(t('drop_tips'), 'capitalize'),
+            disabled: attachedPipette == null || isRunActive,
+            onClick: () => handleDropTip(),
+          },
+        ]
+  return (
+    <>
+      {(attachedPipette == null || attachedPipette.ok) &&
+      subsystemUpdateData == null ? (
+        <InstrumentCard
+          description={
+            attachedPipette != null ? pipetteDisplayName : t('shared:empty')
+          }
+          instrumentDiagramProps={{
+            pipetteSpecs: pipetteModelSpecs,
+            mount,
+          }}
+          banner={
+            attachedPipette?.ok &&
+            attachedPipette.data.calibratedOffset?.last_modified == null ? (
+              <Banner type="error" marginBottom={SPACING.spacing4} width="100%">
+                {isEstopNotDisengaged ? (
+                  <StyledText as="p">
+                    {t('calibration_needed_without_link')}
+                  </StyledText>
+                ) : (
+                  <Trans
+                    t={t}
+                    i18nKey={'calibration_needed'}
+                    components={{
+                      calLink: (
+                        <StyledText
+                          as="p"
+                          css={BANNER_LINK_CSS}
+                          onClick={handleCalibrate}
+                        />
+                      ),
+                    }}
+                  />
+                )}
+              </Banner>
+            ) : null
+          }
+          label={
+            attachedPipetteIs96Channel
+              ? t('both_mounts')
+              : t('mount', {
+                  side: mount === LEFT ? t('left') : t('right'),
+                })
+          }
+          menuOverlayItems={menuOverlayItems}
+          isEstopNotDisengaged={isEstopNotDisengaged}
+        />
+      ) : null}
+      {attachedPipette?.ok === false ||
+      (subsystemUpdateData != null && pollForSubsystemUpdate) ? (
+        <InstrumentCard
+          label={i18n.format(t('mount', { side: mount }), 'capitalize')}
+          css={INSTRUMENT_CARD_STYLE}
+          description={t('instrument_attached')}
+          banner={
+            <Banner
+              type={subsystemUpdateData != null ? 'warning' : 'error'}
+              marginBottom={SPACING.spacing4}
+            >
+              <Trans
+                t={t}
+                i18nKey={
+                  subsystemUpdateData != null
+                    ? 'firmware_update_occurring'
+                    : 'firmware_update_needed'
+                }
+              />
+            </Banner>
+          }
+          isEstopNotDisengaged={isEstopNotDisengaged}
+        />
+      ) : null}
+      {showDropTipWizard && pipetteModelSpecs != null ? (
+        <DropTipWizard
+          robotType={FLEX_ROBOT_TYPE}
+          mount={mount}
+          instrumentModelSpecs={pipetteModelSpecs}
+          closeFlow={() => setShowDropTipWizard(false)}
+        />
+      ) : null}
+      {attachedPipette?.ok && showAboutPipetteSlideout && (
+        <AboutPipetteSlideout
+          pipetteId={attachedPipette.serialNumber}
+          pipetteName={pipetteDisplayName ?? attachedPipette.instrumentName}
+          firmwareVersion={attachedPipette.firmwareVersion}
+          isExpanded={showAboutPipetteSlideout}
+          onCloseClick={() => setShowAboutPipetteSlideout(false)}
+        />
+      )}
+      {showChoosePipette ? (
+        <ChoosePipette
+          proceed={handleAttach}
+          setSelectedPipette={setSelectedPipette}
+          selectedPipette={selectedPipette}
+          exit={() => setShowChoosePipette(false)}
+          mount={mount}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -21,12 +21,7 @@ import { DropTipWizard } from '../../DropTipWizard'
 
 import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 
-import type {
-  BadPipette,
-  Mount,
-  PipetteData,
-  HostConfig,
-} from '@opentrons/api-client'
+import type { BadPipette, Mount, PipetteData } from '@opentrons/api-client'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type {
   PipetteWizardFlow,
@@ -66,7 +61,7 @@ export function FlexPipetteCard({
   isEstopNotDisengaged,
 }: FlexPipetteCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
-  const host = useHost() as HostConfig
+  const host = useHost()
 
   const [
     showAboutPipetteSlideout,
@@ -258,7 +253,7 @@ export function FlexPipetteCard({
           closeFlow={() => setShowDropTipWizard(false)}
         />
       ) : null}
-      {attachedPipette?.ok && showAboutPipetteSlideout && (
+      {attachedPipette?.ok && showAboutPipetteSlideout ? (
         <AboutPipetteSlideout
           pipetteId={attachedPipette.serialNumber}
           pipetteName={pipetteDisplayName ?? attachedPipette.instrumentName}
@@ -266,7 +261,7 @@ export function FlexPipetteCard({
           isExpanded={showAboutPipetteSlideout}
           onCloseClick={() => setShowAboutPipetteSlideout(false)}
         />
-      )}
+      ) : null}
       {showChoosePipette ? (
         <ChoosePipette
           proceed={handleAttach}

--- a/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -21,7 +21,12 @@ import { DropTipWizard } from '../../DropTipWizard'
 
 import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 
-import type { BadPipette, Mount, PipetteData } from '@opentrons/api-client'
+import type {
+  BadPipette,
+  HostConfig,
+  Mount,
+  PipetteData,
+} from '@opentrons/api-client'
 import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type {
   PipetteWizardFlow,
@@ -61,7 +66,7 @@ export function FlexPipetteCard({
   isEstopNotDisengaged,
 }: FlexPipetteCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
-  const host = useHost()
+  const host = useHost() as HostConfig
 
   const [
     showAboutPipetteSlideout,

--- a/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
+++ b/app/src/organisms/Devices/PipetteCard/PipetteOverflowMenu.tsx
@@ -10,11 +10,7 @@ import {
   SPACING,
   DIRECTION_COLUMN,
 } from '@opentrons/components'
-import {
-  isFlexPipette,
-  PipetteModelSpecs,
-  PipetteName,
-} from '@opentrons/shared-data'
+import { PipetteModelSpecs } from '@opentrons/shared-data'
 
 import { MenuItem } from '../../../atoms/MenuList/MenuItem'
 import { Divider } from '../../../atoms/structure'
@@ -28,10 +24,8 @@ interface PipetteOverflowMenuProps {
   mount: Mount
   handleChangePipette: () => void
   handleDropTip: () => void
-  handleCalibrate: () => void
   handleAboutSlideout: () => void
   handleSettingsSlideout: () => void
-  isPipetteCalibrated: boolean
   isRunActive: boolean
 }
 
@@ -45,18 +39,13 @@ export const PipetteOverflowMenu = (
     pipetteSettings,
     handleChangePipette,
     handleDropTip,
-    handleCalibrate,
     handleAboutSlideout,
     handleSettingsSlideout,
-    isPipetteCalibrated,
     isRunActive,
   } = props
 
-  const pipetteName =
-    pipetteSpecs?.name != null ? pipetteSpecs.name : t('empty')
   const pipetteDisplayName =
     pipetteSpecs?.displayName != null ? pipetteSpecs.displayName : t('empty')
-  const isFlexPipetteAttached = isFlexPipette(pipetteName as PipetteName)
 
   return (
     <Flex position={POSITION_RELATIVE}>
@@ -80,18 +69,6 @@ export const PipetteOverflowMenu = (
           </MenuItem>
         ) : (
           <>
-            {isFlexPipetteAttached ? (
-              <MenuItem
-                onClick={() => handleCalibrate()}
-                disabled={isRunActive}
-              >
-                {t(
-                  isPipetteCalibrated
-                    ? 'recalibrate_pipette'
-                    : 'calibrate_pipette'
-                )}
-              </MenuItem>
-            ) : null}
             <MenuItem
               onClick={() => handleChangePipette()}
               disabled={isRunActive}
@@ -105,7 +82,7 @@ export const PipetteOverflowMenu = (
               {i18n.format(t('drop_tips'), 'capitalize')}
             </MenuItem>
             <Divider marginY="0" />
-            {!isFlexPipetteAttached && pipetteSettings != null ? (
+            {pipetteSettings != null ? (
               <MenuItem
                 key={`${pipetteDisplayName}_${mount}_view_settings`}
                 onClick={() => handleSettingsSlideout()}

--- a/app/src/organisms/Devices/PipetteCard/__tests__/AboutPipetteSlideout.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/AboutPipetteSlideout.test.tsx
@@ -2,12 +2,10 @@ import * as React from 'react'
 import { describe, it, vi, beforeEach, expect } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { renderWithProviders } from '../../../../__testing-utils__'
-import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { fireEvent, screen } from '@testing-library/react'
 import { i18n } from '../../../../i18n'
 import { AboutPipetteSlideout } from '../AboutPipetteSlideout'
 import { mockLeftSpecs } from '../../../../redux/pipettes/__fixtures__'
-import { LEFT } from '../../../../redux/pipettes'
 
 vi.mock('@opentrons/react-api-client')
 
@@ -23,13 +21,9 @@ describe('AboutPipetteSlideout', () => {
     props = {
       pipetteId: '123',
       pipetteName: mockLeftSpecs.displayName,
-      mount: LEFT,
       isExpanded: true,
       onCloseClick: vi.fn(),
     }
-    vi.mocked(useInstrumentsQuery).mockReturnValue({
-      data: { data: [] },
-    } as any)
   })
 
   it('renders correct info', () => {
@@ -43,19 +37,13 @@ describe('AboutPipetteSlideout', () => {
     expect(props.onCloseClick).toHaveBeenCalled()
   })
   it('renders the firmware version if it exists', () => {
-    vi.mocked(useInstrumentsQuery).mockReturnValue({
-      data: {
-        data: [
-          {
-            instrumentType: 'pipette',
-            mount: LEFT,
-            ok: true,
-            firmwareVersion: 12,
-          } as any,
-        ],
-      },
-    } as any)
-
+    props = {
+      pipetteId: '123',
+      pipetteName: mockLeftSpecs.displayName,
+      isExpanded: true,
+      firmwareVersion: '12',
+      onCloseClick: vi.fn(),
+    }
     render(props)
 
     screen.getByText('CURRENT VERSION')

--- a/app/src/organisms/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
+import { mockLeftSpecs } from '../../../../redux/pipettes/__fixtures__'
 import { handlePipetteWizardFlows } from '../../../PipetteWizardFlows'
 import { AboutPipetteSlideout } from '../AboutPipetteSlideout'
 import { FlexPipetteCard } from '../FlexPipetteCard'
@@ -11,7 +12,6 @@ import { ChoosePipette } from '../../../PipetteWizardFlows/ChoosePipette'
 import { DropTipWizard } from '../../../DropTipWizard'
 
 import type { PipetteData } from '@opentrons/api-client'
-import { mockLeftSpecs } from '../../../../redux/pipettes/__fixtures__'
 
 vi.mock('../../../PipetteWizardFlows')
 vi.mock('../../../PipetteWizardFlows/ChoosePipette')

--- a/app/src/organisms/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/FlexPipetteCard.test.tsx
@@ -1,0 +1,256 @@
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, it, vi, beforeEach, afterEach, expect } from 'vitest'
+import { renderWithProviders } from '../../../../__testing-utils__'
+import { useCurrentSubsystemUpdateQuery } from '@opentrons/react-api-client'
+import { i18n } from '../../../../i18n'
+import { handlePipetteWizardFlows } from '../../../PipetteWizardFlows'
+import { AboutPipetteSlideout } from '../AboutPipetteSlideout'
+import { FlexPipetteCard } from '../FlexPipetteCard'
+import { ChoosePipette } from '../../../PipetteWizardFlows/ChoosePipette'
+import { DropTipWizard } from '../../../DropTipWizard'
+
+import type { PipetteData } from '@opentrons/api-client'
+import { mockLeftSpecs } from '../../../../redux/pipettes/__fixtures__'
+
+vi.mock('../../../PipetteWizardFlows')
+vi.mock('../../../PipetteWizardFlows/ChoosePipette')
+vi.mock('../AboutPipetteSlideout')
+vi.mock('../../../DropTipWizard')
+vi.mock('@opentrons/react-api-client')
+
+const render = (props: React.ComponentProps<typeof FlexPipetteCard>) => {
+  return renderWithProviders(<FlexPipetteCard {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('FlexPipetteCard', () => {
+  let props: React.ComponentProps<typeof FlexPipetteCard>
+  beforeEach(() => {
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
+      attachedPipette: {
+        instrumentType: 'pipette',
+        instrumentName: 'pipette',
+        subsystem: 'pipette_left',
+        mount: 'left',
+        instrumentModel: 'p50_single_v3.1',
+        serialNumber: '123',
+        firmwareVersion: '12',
+        ok: true,
+        data: {
+          channels: 1,
+          min_volume: 5,
+          max_volume: 50,
+          calibratedOffset: {
+            offset: { x: 1, y: 2, z: 3 },
+            source: 'default',
+            last_modified: '12/2/4',
+          },
+        },
+      } as PipetteData,
+      mount: 'left',
+      isRunActive: false,
+      isEstopNotDisengaged: false,
+    }
+    vi.mocked(useCurrentSubsystemUpdateQuery).mockReturnValue({
+      data: undefined,
+    } as any)
+  })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders correct info when gripper is attached', () => {
+    render(props)
+    screen.getByText('left Mount')
+    screen.getByText('Left Pipette')
+    const overflowButton = screen.getByRole('button', {
+      name: /overflow/i,
+    })
+    fireEvent.click(overflowButton)
+    screen.getByText('Recalibrate pipette')
+    screen.getByText('Detach pipette')
+    screen.getByText('Drop tips')
+    screen.getByText('About pipette')
+  })
+  it('renders correct info when 96 channel is attached', () => {
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
+      attachedPipette: {
+        instrumentType: 'pipette',
+        instrumentName: 'p1000_96',
+        subsystem: 'pipette_left',
+        mount: 'left',
+        instrumentModel: 'p50_single_v3.1',
+        serialNumber: '123',
+        firmwareVersion: '12',
+        ok: true,
+        data: {
+          channels: 1,
+          min_volume: 5,
+          max_volume: 50,
+          calibratedOffset: {
+            offset: { x: 1, y: 2, z: 3 },
+            source: 'default',
+            last_modified: '12/2/4',
+          },
+        },
+      } as PipetteData,
+      mount: 'left',
+      isRunActive: false,
+      isEstopNotDisengaged: false,
+    }
+    render(props)
+    screen.getByText('Both Mounts')
+    screen.getByText('Left Pipette')
+  })
+  it('renders recalibrate banner when no calibration data is present', () => {
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
+      attachedPipette: {
+        instrumentType: 'pipette',
+        instrumentName: 'pipette',
+        subsystem: 'pipette_left',
+        mount: 'left',
+        instrumentModel: 'p50_single_v3.1',
+        serialNumber: '123',
+        firmwareVersion: '12',
+        ok: true,
+        data: {
+          channels: 1,
+          min_volume: 5,
+          max_volume: 50,
+        },
+      } as PipetteData,
+      mount: 'left',
+      isRunActive: false,
+      isEstopNotDisengaged: false,
+    }
+
+    render(props)
+    screen.getByText('Calibration needed.')
+    screen.getByText('Calibrate now')
+  })
+
+  it('renders recalibrate banner without calibrate now when no calibration data is present and e-stop is pressed', () => {
+    props = {
+      pipetteModelSpecs: mockLeftSpecs,
+      attachedPipette: {
+        instrumentType: 'pipette',
+        instrumentName: 'pipette',
+        subsystem: 'pipette_left',
+        mount: 'left',
+        instrumentModel: 'p50_single_v3.1',
+        serialNumber: '123',
+        firmwareVersion: '12',
+        ok: true,
+        data: {
+          channels: 1,
+          min_volume: 5,
+          max_volume: 50,
+        },
+      } as PipetteData,
+      mount: 'left',
+      isRunActive: false,
+      isEstopNotDisengaged: true,
+    }
+
+    render(props)
+    screen.getByText('Calibration needed.')
+  })
+
+  it('opens the about pipette slideout when button is pressed', () => {
+    render(props)
+    const overflowButton = screen.getByRole('button', {
+      name: /overflow/i,
+    })
+    fireEvent.click(overflowButton)
+    const aboutPipetteButton = screen.getByText('About pipette')
+    fireEvent.click(aboutPipetteButton)
+    expect(vi.mocked(AboutPipetteSlideout)).toHaveBeenCalled()
+  })
+  it('renders choose pipette modal when attach button is pressed', () => {
+    props = {
+      mount: 'left',
+      attachedPipette: null,
+      pipetteModelSpecs: null,
+      isRunActive: false,
+      isEstopNotDisengaged: false,
+    }
+    render(props)
+    const overflowButton = screen.getByRole('button', {
+      name: /overflow/i,
+    })
+    fireEvent.click(overflowButton)
+    const attachPipetteButton = screen.getByText('Attach pipette')
+    fireEvent.click(attachPipetteButton)
+    expect(vi.mocked(ChoosePipette)).toHaveBeenCalled()
+  })
+  it('renders wizard flow when recalibrate button is pressed', () => {
+    render(props)
+    const overflowButton = screen.getByRole('button', {
+      name: /overflow/i,
+    })
+    fireEvent.click(overflowButton)
+    const recalibratePipetteButton = screen.getByText('Recalibrate pipette')
+    fireEvent.click(recalibratePipetteButton)
+    expect(vi.mocked(handlePipetteWizardFlows)).toHaveBeenCalled()
+  })
+  it('renders wizard flow when detach button is pressed', () => {
+    render(props)
+    const overflowButton = screen.getByRole('button', {
+      name: /InstrumentCard_overflowMenu/i,
+    })
+    fireEvent.click(overflowButton)
+    const dropTipButton = screen.getByText('Detach pipette')
+    fireEvent.click(dropTipButton)
+    expect(vi.mocked(handlePipetteWizardFlows)).toHaveBeenCalled()
+  })
+  it('renders drop tip wizard when drop tip button is pressed', () => {
+    render(props)
+    const overflowButton = screen.getByRole('button', {
+      name: /InstrumentCard_overflowMenu/i,
+    })
+    fireEvent.click(overflowButton)
+    const dropTipButton = screen.getByText('Drop tips')
+    fireEvent.click(dropTipButton)
+    expect(vi.mocked(DropTipWizard)).toHaveBeenCalled()
+  })
+  it('renders firmware update needed state if pipette is bad', () => {
+    props = {
+      attachedPipette: {
+        ok: false,
+      } as any,
+      mount: 'left',
+      pipetteModelSpecs: null,
+      isRunActive: false,
+      isEstopNotDisengaged: false,
+    }
+    render(props)
+    screen.getByText('Left mount')
+    screen.getByText('Instrument attached')
+    screen.getByText(
+      `Instrument firmware update needed. Start the update on the robot's touchscreen.`
+    )
+  })
+  it('renders firmware update in progress state if gripper is bad and update in progress', () => {
+    vi.mocked(useCurrentSubsystemUpdateQuery).mockReturnValue({
+      data: { data: { updateProgress: 50 } as any },
+    } as any)
+    props = {
+      attachedPipette: {
+        ok: false,
+      } as any,
+      mount: 'left',
+      pipetteModelSpecs: null,
+      isRunActive: false,
+      isEstopNotDisengaged: false,
+    }
+    render(props)
+    screen.getByText('Left mount')
+    screen.getByText('Instrument attached')
+    screen.getByText('Firmware update in progress...')
+  })
+})

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -10,7 +10,6 @@ import { i18n } from '../../../../i18n'
 import { getHasCalibrationBlock } from '../../../../redux/config'
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
 import { PipetteOverflowMenu } from '../PipetteOverflowMenu'
-import { AboutPipetteSlideout } from '../AboutPipetteSlideout'
 import { PipetteCard } from '..'
 
 import {
@@ -22,7 +21,6 @@ import type { DispatchApiRequestType } from '../../../../redux/robot-api'
 
 vi.mock('../PipetteOverflowMenu')
 vi.mock('../../../../redux/config')
-vi.mock('../AboutPipetteSlideout')
 vi.mock('../../../../redux/robot-api')
 vi.mock('@opentrons/react-api-client')
 vi.mock('../../../../redux/pipettes')
@@ -35,12 +33,10 @@ const render = (props: React.ComponentProps<typeof PipetteCard>) => {
 
 const mockRobotName = 'mockRobotName'
 describe('PipetteCard', () => {
-  let startWizard: any
   let dispatchApiRequest: DispatchApiRequestType
   let props: React.ComponentProps<typeof PipetteCard>
 
   beforeEach(() => {
-    startWizard = vi.fn()
     dispatchApiRequest = vi.fn()
     props = {
       pipetteModelSpecs: mockLeftSpecs,
@@ -50,9 +46,6 @@ describe('PipetteCard', () => {
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
-    vi.mocked(AboutPipetteSlideout).mockReturnValue(
-      <div>mock about slideout</div>
-    )
     vi.mocked(PipetteOverflowMenu).mockReturnValue(
       <div>mock pipette overflow menu</div>
     )

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteCard.test.tsx
@@ -5,16 +5,10 @@ import { describe, it, vi, beforeEach, expect } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { LEFT, RIGHT } from '@opentrons/shared-data'
-import {
-  useCurrentSubsystemUpdateQuery,
-  usePipetteSettingsQuery,
-} from '@opentrons/react-api-client'
+import { usePipetteSettingsQuery } from '@opentrons/react-api-client'
 import { i18n } from '../../../../i18n'
 import { getHasCalibrationBlock } from '../../../../redux/config'
 import { useDispatchApiRequest } from '../../../../redux/robot-api'
-import { AskForCalibrationBlockModal } from '../../../CalibrateTipLength'
-import { useCalibratePipetteOffset } from '../../../CalibratePipetteOffset/useCalibratePipetteOffset'
-import { useDeckCalibrationData, useIsFlex } from '../../hooks'
 import { PipetteOverflowMenu } from '../PipetteOverflowMenu'
 import { AboutPipetteSlideout } from '../AboutPipetteSlideout'
 import { PipetteCard } from '..'
@@ -23,15 +17,11 @@ import {
   mockLeftSpecs,
   mockRightSpecs,
 } from '../../../../redux/pipettes/__fixtures__'
-import { mockDeckCalData } from '../../../../redux/calibration/__fixtures__'
 
 import type { DispatchApiRequestType } from '../../../../redux/robot-api'
 
 vi.mock('../PipetteOverflowMenu')
 vi.mock('../../../../redux/config')
-vi.mock('../../../CalibratePipetteOffset/useCalibratePipetteOffset')
-vi.mock('../../../CalibrateTipLength')
-vi.mock('../../hooks')
 vi.mock('../AboutPipetteSlideout')
 vi.mock('../../../../redux/robot-api')
 vi.mock('@opentrons/react-api-client')
@@ -57,35 +47,20 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
-    when(useIsFlex).calledWith(mockRobotName).thenReturn(false)
     vi.mocked(AboutPipetteSlideout).mockReturnValue(
       <div>mock about slideout</div>
     )
-    when(useDeckCalibrationData).calledWith(mockRobotName).thenReturn({
-      isDeckCalibrated: true,
-      deckCalibrationData: mockDeckCalData,
-    })
     vi.mocked(PipetteOverflowMenu).mockReturnValue(
       <div>mock pipette overflow menu</div>
     )
     vi.mocked(getHasCalibrationBlock).mockReturnValue(null)
-    vi.mocked(useCalibratePipetteOffset).mockReturnValue([startWizard, null])
-    vi.mocked(AskForCalibrationBlockModal).mockReturnValue(
-      <div>Mock AskForCalibrationBlockModal</div>
-    )
     vi.mocked(useDispatchApiRequest).mockReturnValue([
       dispatchApiRequest,
       ['id'],
     ])
-    vi.mocked(useCurrentSubsystemUpdateQuery).mockReturnValue({
-      data: undefined,
-    } as any)
     when(usePipetteSettingsQuery)
       .calledWith({ refetchInterval: 5000, enabled: true })
       .thenReturn({} as any)
@@ -97,57 +72,12 @@ describe('PipetteCard', () => {
       mount: LEFT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
     screen.getByText('left Mount')
     screen.getByText('Left Pipette')
-  })
-  it('renders information for a 96 channel pipette with overflow menu button not disabled', () => {
-    props = {
-      pipetteModelSpecs: mockLeftSpecs,
-      mount: LEFT,
-      robotName: mockRobotName,
-      pipetteId: 'id',
-      pipetteIs96Channel: true,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
-      isRunActive: false,
-      isEstopNotDisengaged: false,
-    }
-    render(props)
-    screen.getByText('Both Mounts')
-    const overflowButton = screen.getByRole('button', {
-      name: /overflow/i,
-    })
-    fireEvent.click(overflowButton)
-    expect(overflowButton).not.toBeDisabled()
-    screen.getByText('mock pipette overflow menu')
-  })
-
-  it('renders information for a 96 channel pipette with overflow menu button disabled when e-stop is pressed', () => {
-    props = {
-      pipetteModelSpecs: mockLeftSpecs,
-      mount: LEFT,
-      robotName: mockRobotName,
-      pipetteId: 'id',
-      pipetteIs96Channel: true,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
-      isRunActive: false,
-      isEstopNotDisengaged: true,
-    }
-    render(props)
-    screen.getByText('Both Mounts')
-    const overflowButton = screen.getByRole('button', {
-      name: /overflow/i,
-    })
-    fireEvent.click(overflowButton)
-    expect(overflowButton).toBeDisabled()
   })
 
   it('renders information for a right pipette', () => {
@@ -156,9 +86,6 @@ describe('PipetteCard', () => {
       mount: RIGHT,
       robotName: mockRobotName,
       pipetteId: 'id',
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
@@ -171,9 +98,6 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: null,
       mount: RIGHT,
       robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
@@ -186,9 +110,6 @@ describe('PipetteCard', () => {
       pipetteModelSpecs: null,
       mount: LEFT,
       robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
@@ -197,43 +118,21 @@ describe('PipetteCard', () => {
     screen.getByText('Empty')
   })
   it('does not render banner to calibrate for ot2 pipette if not calibrated', () => {
-    when(useIsFlex).calledWith(mockRobotName).thenReturn(false)
     props = {
       pipetteModelSpecs: mockLeftSpecs,
       mount: LEFT,
       robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
     render(props)
     expect(screen.queryByText('Calibrate now')).toBeNull()
   })
-  it('renders banner to calibrate for ot3 pipette if not calibrated', () => {
-    when(useIsFlex).calledWith(mockRobotName).thenReturn(true)
-    props = {
-      pipetteModelSpecs: { ...mockLeftSpecs, name: 'p300_single_flex' },
-      mount: LEFT,
-      robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
-      isRunActive: false,
-      isEstopNotDisengaged: false,
-    }
-    render(props)
-    screen.getByText('Calibrate now')
-  })
   it('renders kebab icon, opens and closes overflow menu on click', () => {
     props = {
       pipetteModelSpecs: mockRightSpecs,
       mount: RIGHT,
       robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: false,
       isRunActive: false,
       isEstopNotDisengaged: false,
     }
@@ -248,43 +147,6 @@ describe('PipetteCard', () => {
     const overflowMenu = screen.getByText('mock pipette overflow menu')
     fireEvent.click(overflowMenu)
     expect(screen.queryByText('mock pipette overflow menu')).toBeNull()
-  })
-  it('renders firmware update needed state if pipette is bad', () => {
-    props = {
-      pipetteModelSpecs: mockRightSpecs,
-      mount: RIGHT,
-      robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: true,
-      isRunActive: false,
-      isEstopNotDisengaged: false,
-    }
-    render(props)
-    screen.getByText('Right mount')
-    screen.getByText('Instrument attached')
-    screen.getByText(
-      `Instrument firmware update needed. Start the update on the robot's touchscreen.`
-    )
-  })
-  it('renders firmware update in progress state if pipette is bad and update in progress', () => {
-    vi.mocked(useCurrentSubsystemUpdateQuery).mockReturnValue({
-      data: { data: { updateProgress: 50 } as any },
-    } as any)
-    props = {
-      pipetteModelSpecs: mockRightSpecs,
-      mount: RIGHT,
-      robotName: mockRobotName,
-      pipetteIs96Channel: false,
-      isPipetteCalibrated: false,
-      pipetteIsBad: true,
-      isRunActive: false,
-      isEstopNotDisengaged: false,
-    }
-    render(props)
-    screen.getByText('Right mount')
-    screen.getByText('Instrument attached')
-    screen.getByText('Firmware update in progress...')
   })
   it('does not render a pipette settings slideout card if the pipette has no settings', () => {
     render(props)

--- a/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/PipetteCard/__tests__/PipetteOverflowMenu.test.tsx
@@ -40,10 +40,8 @@ describe('PipetteOverflowMenu', () => {
       mount: LEFT,
       handleDropTip: vi.fn(),
       handleChangePipette: vi.fn(),
-      handleCalibrate: vi.fn(),
       handleAboutSlideout: vi.fn(),
       handleSettingsSlideout: vi.fn(),
-      isPipetteCalibrated: false,
       isRunActive: false,
     }
   })
@@ -73,52 +71,6 @@ describe('PipetteOverflowMenu', () => {
     fireEvent.click(btn)
     expect(props.handleChangePipette).toHaveBeenCalled()
   })
-  it('renders recalibrate pipette text for Flex pipette', () => {
-    vi.mocked(isFlexPipette).mockReturnValue(true)
-    props = {
-      ...props,
-      isPipetteCalibrated: true,
-    }
-    render(props)
-    const recalibrate = screen.getByRole('button', {
-      name: 'Recalibrate pipette',
-    })
-    fireEvent.click(recalibrate)
-    expect(props.handleCalibrate).toHaveBeenCalled()
-  })
-
-  it('should render recalibrate pipette text for Flex pipette', () => {
-    vi.mocked(isFlexPipette).mockReturnValue(true)
-    props = {
-      ...props,
-      isPipetteCalibrated: true,
-    }
-    render(props)
-    screen.getByRole('button', {
-      name: 'Recalibrate pipette',
-    })
-  })
-
-  it('renders only the about pipette button if FLEX pipette is attached', () => {
-    vi.mocked(isFlexPipette).mockReturnValue(true)
-
-    render(props)
-
-    const calibrate = screen.getByRole('button', {
-      name: 'Calibrate pipette',
-    })
-    const detach = screen.getByRole('button', { name: 'Detach pipette' })
-    const settings = screen.queryByRole('button', { name: 'Pipette Settings' })
-    const about = screen.getByRole('button', { name: 'About pipette' })
-
-    fireEvent.click(calibrate)
-    expect(props.handleCalibrate).toHaveBeenCalled()
-    fireEvent.click(detach)
-    expect(props.handleChangePipette).toHaveBeenCalled()
-    expect(settings).toBeNull()
-    fireEvent.click(about)
-    expect(props.handleAboutSlideout).toHaveBeenCalled()
-  })
 
   it('does not render the pipette settings button if the pipette has no settings', () => {
     vi.mocked(isFlexPipette).mockReturnValue(false)
@@ -130,30 +82,6 @@ describe('PipetteOverflowMenu', () => {
     const settings = screen.queryByRole('button', { name: 'Pipette Settings' })
 
     expect(settings).not.toBeInTheDocument()
-  })
-
-  it('should disable certain menu items if a run is active for Flex pipette', () => {
-    vi.mocked(isFlexPipette).mockReturnValue(true)
-    props = {
-      ...props,
-      isRunActive: true,
-    }
-    render(props)
-    expect(
-      screen.getByRole('button', {
-        name: 'Calibrate pipette',
-      })
-    ).toBeDisabled()
-    expect(
-      screen.getByRole('button', {
-        name: 'Detach pipette',
-      })
-    ).toBeDisabled()
-    expect(
-      screen.getByRole('button', {
-        name: 'Drop tips',
-      })
-    ).toBeDisabled()
   })
 
   it('should disable certain menu items if a run is active for OT-2 pipette', () => {

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -142,7 +142,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
                   pipetteSpecs={pipetteModelSpecs}
                   mount={mount}
                   transform="scale(0.3)"
-                  transformOrigin={'20% 52%'}
+                  transformOrigin="20% 52%"
                 />
               </Flex>
             ) : null}

--- a/app/src/organisms/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Devices/PipetteCard/index.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
-import { Trans, useTranslation } from 'react-i18next'
-import { css } from 'styled-components'
+import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
@@ -17,76 +16,39 @@ import {
   TYPOGRAPHY,
   useOnClickOutside,
 } from '@opentrons/components'
-import {
-  FLEX_ROBOT_TYPE,
-  isFlexPipette,
-  NINETY_SIX_CHANNEL,
-  OT2_ROBOT_TYPE,
-  SINGLE_MOUNT_PIPETTES,
-} from '@opentrons/shared-data'
-import {
-  useCurrentSubsystemUpdateQuery,
-  usePipetteSettingsQuery,
-  useHost,
-} from '@opentrons/react-api-client'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import { usePipetteSettingsQuery } from '@opentrons/react-api-client'
 
 import { LEFT } from '../../../redux/pipettes'
 import { OverflowBtn } from '../../../atoms/MenuList/OverflowBtn'
-import { Banner } from '../../../atoms/Banner'
 import { useMenuHandleClickOutside } from '../../../atoms/MenuList/hooks'
-import { InstrumentCard } from '../../../molecules/InstrumentCard'
 import { ChangePipette } from '../../ChangePipette'
-import { FLOWS } from '../../PipetteWizardFlows/constants'
-import { handlePipetteWizardFlows } from '../../PipetteWizardFlows'
-import { ChoosePipette } from '../../PipetteWizardFlows/ChoosePipette'
-import { useIsFlex } from '../hooks'
 import { PipetteOverflowMenu } from './PipetteOverflowMenu'
 import { PipetteSettingsSlideout } from './PipetteSettingsSlideout'
 import { AboutPipetteSlideout } from './AboutPipetteSlideout'
 
-import type { PipetteModelSpecs, PipetteName } from '@opentrons/shared-data'
+import type { PipetteModelSpecs } from '@opentrons/shared-data'
 import type { AttachedPipette, Mount } from '../../../redux/pipettes/types'
-import type {
-  PipetteWizardFlow,
-  SelectablePipettes,
-} from '../../PipetteWizardFlows/types'
 import { DropTipWizard } from '../../DropTipWizard'
-import { HostConfig } from '@opentrons/api-client'
 
 interface PipetteCardProps {
   pipetteModelSpecs: PipetteModelSpecs | null
   pipetteId?: AttachedPipette['id'] | null
-  isPipetteCalibrated: boolean
   mount: Mount
   robotName: string
-  pipetteIs96Channel: boolean
-  pipetteIsBad: boolean
   isRunActive: boolean
   isEstopNotDisengaged: boolean
 }
 
-const INSTRUMENT_CARD_STYLE = css`
-  p {
-    text-transform: lowercase;
-  }
-
-  p::first-letter {
-    text-transform: uppercase;
-  }
-`
-
 const POLL_DURATION_MS = 5000
 
 export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
-  const { t, i18n } = useTranslation(['device_details', 'protocol_setup'])
+  const { t } = useTranslation(['device_details', 'protocol_setup'])
   const {
     pipetteModelSpecs,
-    isPipetteCalibrated,
     mount,
     robotName,
     pipetteId,
-    pipetteIs96Channel,
-    pipetteIsBad,
     isRunActive,
     isEstopNotDisengaged,
   } = props
@@ -96,10 +58,6 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
     showOverflowMenu,
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
-  const isFlex = useIsFlex(robotName)
-  const host = useHost() as HostConfig
-  const pipetteName = pipetteModelSpecs?.name
-  const isFlexPipetteAttached = isFlexPipette(pipetteName as PipetteName)
   const pipetteDisplayName = pipetteModelSpecs?.displayName
   const pipetteOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => setShowOverflowMenu(false),
@@ -107,35 +65,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const [showChangePipette, setChangePipette] = React.useState(false)
   const [showDropTipWizard, setShowDropTipWizard] = React.useState(false)
   const [showSlideout, setShowSlideout] = React.useState(false)
-  const [showAttachPipette, setShowAttachPipette] = React.useState(false)
   const [showAboutSlideout, setShowAboutSlideout] = React.useState(false)
-  const subsystem = mount === LEFT ? 'pipette_left' : 'pipette_right'
-  const [pollForSubsystemUpdate, setPollForSubsystemUpdate] = React.useState(
-    false
-  )
-  const { data: subsystemUpdateData } = useCurrentSubsystemUpdateQuery(
-    subsystem,
-    {
-      enabled: pollForSubsystemUpdate,
-      refetchInterval: POLL_DURATION_MS,
-    }
-  )
-  // we should poll for a subsystem update from the time a bad instrument is
-  // detected until the update has been done for 5 seconds
-  // this gives the instruments endpoint time to start reporting
-  // a good instrument
-  React.useEffect(() => {
-    if (pipetteIsBad && isFlex) {
-      setPollForSubsystemUpdate(true)
-    } else if (
-      subsystemUpdateData != null &&
-      subsystemUpdateData.data.updateStatus === 'done'
-    ) {
-      setTimeout(() => {
-        setPollForSubsystemUpdate(false)
-      }, POLL_DURATION_MS)
-    }
-  }, [pipetteIsBad, subsystemUpdateData, isFlex])
 
   const settings =
     usePipetteSettingsQuery({
@@ -143,29 +73,11 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       enabled: pipetteId != null,
     })?.data?.[pipetteId ?? '']?.fields ?? null
 
-  const [
-    selectedPipette,
-    setSelectedPipette,
-  ] = React.useState<SelectablePipettes>(SINGLE_MOUNT_PIPETTES)
-  const selectedPipetteForWizard =
-    pipetteName === 'p1000_96' ? NINETY_SIX_CHANNEL : selectedPipette
-
   const handleChangePipette = (): void => {
-    if (isFlexPipetteAttached && isFlex) {
-      handleLaunchPipetteWizardFlows(FLOWS.DETACH)
-    } else if (!isFlexPipetteAttached && isFlex) {
-      setShowAttachPipette(true)
-    } else {
-      setChangePipette(true)
-    }
+    setChangePipette(true)
   }
   const handleDropTip = (): void => {
     setShowDropTipWizard(true)
-  }
-  const handleCalibrate = (): void => {
-    if (isFlexPipetteAttached) {
-      handleLaunchPipetteWizardFlows(FLOWS.CALIBRATE)
-    }
   }
   const handleAboutSlideout = (): void => {
     setShowAboutSlideout(true)
@@ -173,22 +85,6 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const handleSettingsSlideout = (): void => {
     setShowSlideout(true)
   }
-  const handleAttachPipette = (): void => {
-    setShowAttachPipette(false)
-    handleLaunchPipetteWizardFlows(FLOWS.ATTACH)
-  }
-  const setCloseFlow = (): void => {
-    setSelectedPipette(SINGLE_MOUNT_PIPETTES)
-  }
-  const handleLaunchPipetteWizardFlows = (flowType: PipetteWizardFlow): void =>
-    handlePipetteWizardFlows({
-      flowType,
-      mount,
-      closeFlow: setCloseFlow,
-      selectedPipette: selectedPipetteForWizard,
-      host,
-    })
-
   return (
     <Flex
       backgroundColor={COLORS.grey10}
@@ -196,15 +92,6 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       width="100%"
       data-testid={`PipetteCard_${String(pipetteDisplayName)}`}
     >
-      {showAttachPipette ? (
-        <ChoosePipette
-          proceed={handleAttachPipette}
-          setSelectedPipette={setSelectedPipette}
-          selectedPipette={selectedPipette}
-          exit={() => setShowAttachPipette(false)}
-          mount={mount}
-        />
-      ) : null}
       {showChangePipette && (
         <ChangePipette
           robotName={robotName}
@@ -214,7 +101,7 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
       )}
       {showDropTipWizard && pipetteModelSpecs != null ? (
         <DropTipWizard
-          robotType={isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE}
+          robotType={OT2_ROBOT_TYPE}
           mount={mount}
           instrumentModelSpecs={pipetteModelSpecs}
           closeFlow={() => setShowDropTipWizard(false)}
@@ -237,127 +124,66 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
         <AboutPipetteSlideout
           pipetteId={pipetteId}
           pipetteName={pipetteModelSpecs.displayName}
-          mount={mount}
           onCloseClick={() => setShowAboutSlideout(false)}
           isExpanded={true}
         />
       )}
-      {!pipetteIsBad && subsystemUpdateData == null && (
-        <>
-          <Box padding={SPACING.spacing16} width="100%">
-            <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing8}>
-              {pipetteModelSpecs !== null ? (
-                <Flex
-                  alignItems={ALIGN_CENTER}
-                  width="3.75rem"
-                  height="3.375rem"
-                  paddingRight={SPACING.spacing8}
-                >
-                  <InstrumentDiagram
-                    pipetteSpecs={pipetteModelSpecs}
-                    mount={mount}
-                    //  pipette images for Flex are slightly smaller so need to be scaled accordingly
-                    transform="scale(0.3)"
-                    transformOrigin={isFlex ? '-5% 52%' : '20% 52%'}
-                  />
-                </Flex>
-              ) : null}
-              <Flex flexDirection={DIRECTION_COLUMN} flex="100%">
-                {isFlexPipetteAttached && !isPipetteCalibrated ? (
-                  <Banner type="error" marginBottom={SPACING.spacing4}>
-                    {isEstopNotDisengaged ? (
-                      <StyledText as="p">
-                        {t('calibration_needed_without_link')}
-                      </StyledText>
-                    ) : (
-                      <Trans
-                        t={t}
-                        i18nKey="calibration_needed"
-                        components={{
-                          calLink: (
-                            <StyledText
-                              as="p"
-                              css={css`
-                                text-decoration: ${TYPOGRAPHY.textDecorationUnderline};
-                                cursor: pointer;
-                                margin-left: ${SPACING.spacing8};
-                              `}
-                              onClick={handleCalibrate}
-                            />
-                          ),
-                        }}
-                      />
-                    )}
-                  </Banner>
-                ) : null}
-                <StyledText
-                  textTransform={TYPOGRAPHY.textTransformUppercase}
-                  color={COLORS.grey60}
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  fontSize={TYPOGRAPHY.fontSizeH6}
-                  paddingBottom={SPACING.spacing4}
-                  data-testid={`PipetteCard_mount_${String(
-                    pipetteDisplayName
-                  )}`}
-                >
-                  {pipetteIs96Channel
-                    ? t('both_mounts')
-                    : t('mount', {
-                        side: mount === LEFT ? t('left') : t('right'),
-                      })}
+      <>
+        <Box padding={SPACING.spacing16} width="100%">
+          <Flex flexDirection={DIRECTION_ROW} paddingRight={SPACING.spacing8}>
+            {pipetteModelSpecs !== null ? (
+              <Flex
+                alignItems={ALIGN_CENTER}
+                width="3.75rem"
+                height="3.375rem"
+                paddingRight={SPACING.spacing8}
+              >
+                <InstrumentDiagram
+                  pipetteSpecs={pipetteModelSpecs}
+                  mount={mount}
+                  transform="scale(0.3)"
+                  transformOrigin={'20% 52%'}
+                />
+              </Flex>
+            ) : null}
+            <Flex flexDirection={DIRECTION_COLUMN} flex="100%">
+              <StyledText
+                textTransform={TYPOGRAPHY.textTransformUppercase}
+                color={COLORS.grey60}
+                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                fontSize={TYPOGRAPHY.fontSizeH6}
+                paddingBottom={SPACING.spacing4}
+                data-testid={`PipetteCard_mount_${String(pipetteDisplayName)}`}
+              >
+                {t('mount', {
+                  side: mount === LEFT ? t('left') : t('right'),
+                })}
+              </StyledText>
+              <Flex
+                paddingBottom={SPACING.spacing4}
+                data-testid={`PipetteCard_display_name_${String(
+                  pipetteDisplayName
+                )}`}
+              >
+                <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
+                  {pipetteDisplayName ?? t('empty')}
                 </StyledText>
-                <Flex
-                  paddingBottom={SPACING.spacing4}
-                  data-testid={`PipetteCard_display_name_${String(
-                    pipetteDisplayName
-                  )}`}
-                >
-                  <StyledText fontSize={TYPOGRAPHY.fontSizeP}>
-                    {pipetteDisplayName ?? t('empty')}
-                  </StyledText>
-                </Flex>
               </Flex>
             </Flex>
-          </Box>
-          <Box
-            alignSelf={ALIGN_START}
-            padding={SPACING.spacing4}
-            data-testid={`PipetteCard_overflow_btn_${String(
-              pipetteDisplayName
-            )}`}
-          >
-            <OverflowBtn
-              aria-label="overflow"
-              onClick={handleOverflowClick}
-              disabled={isEstopNotDisengaged}
-            />
-          </Box>
-        </>
-      )}
-      {(pipetteIsBad ||
-        (subsystemUpdateData != null && pollForSubsystemUpdate)) && (
-        <InstrumentCard
-          label={i18n.format(t('mount', { side: mount }), 'capitalize')}
-          css={INSTRUMENT_CARD_STYLE}
-          description={t('instrument_attached')}
-          banner={
-            <Banner
-              type={subsystemUpdateData != null ? 'warning' : 'error'}
-              marginBottom={SPACING.spacing4}
-            >
-              <Trans
-                t={t}
-                i18nKey={
-                  subsystemUpdateData != null
-                    ? 'firmware_update_occurring'
-                    : 'firmware_update_needed'
-                }
-              />
-            </Banner>
-          }
-          isEstopNotDisengaged={isEstopNotDisengaged}
-        />
-      )}
+          </Flex>
+        </Box>
+        <Box
+          alignSelf={ALIGN_START}
+          padding={SPACING.spacing4}
+          data-testid={`PipetteCard_overflow_btn_${String(pipetteDisplayName)}`}
+        >
+          <OverflowBtn
+            aria-label="overflow"
+            onClick={handleOverflowClick}
+            disabled={isEstopNotDisengaged}
+          />
+        </Box>
+      </>
       {showOverflowMenu && (
         <>
           <Box
@@ -371,8 +197,6 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
               handleDropTip={handleDropTip}
               handleSettingsSlideout={handleSettingsSlideout}
               handleAboutSlideout={handleAboutSlideout}
-              handleCalibrate={handleCalibrate}
-              isPipetteCalibrated={isPipetteCalibrated}
               pipetteSettings={settings}
               isRunActive={isRunActive}
             />


### PR DESCRIPTION
fix RQA-2433

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Currently, the pipette cards on the desktop app for Flex reference `/pipettes` while those on ODD reference `/instruments`. This has caused confusion because occasionally the pipettes would be visible on desktop but not ODD. Seth made a change in https://github.com/Opentrons/opentrons/pull/14608 that makes the `/instruments` response report cached data like `/pipettes` does, which should have eliminated this discrepancy. This PR ensures that by using `/instruments` as the one source of truth for pipettes on Flex.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Smoke test pipette cards and all possible overflow menu actions for both Flex and OT-2 pipettes. This includes OT-2 pipette settings, attach, detach, and calibrate flows, drop tip wizard, and the about pipette menu.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Create new `FlexPipetteCard` and pull all `Flex` specific logic out of `PipetteCard` into here.
2. Cleanup `PipetteCard` and `PipetteOverflowMenu`, removing all `Flex` logic which has been moved to `FlexPipetteCard` and some leftover OT-2 calibration logic that is no longer used since we only allow pipette cal from the calibration dashboard now.
3. From `InstrumentsAndModules` only enable `usePipettesQuery` for OT-2 and `useInstrumentsQuery` for Flex. Display `PipetteCard` or `FlexPipetteCard` accordingly.
4. Update all tests, refactoring some logic to bring them in line with our vitest best practices

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look through the code - did I miss anything? And test this out if you can!
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Medium
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
