### PR TITLE
feat(robot-server): Use a BadRun when we cant load

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -49,7 +49,7 @@ export interface LegacyGoodRunData {
   labwareOffsets?: LabwareOffset[]
 }
 
-export interface KnownGoodRunData extends LegacyGoodRunData{
+export interface KnownGoodRunData extends LegacyGoodRunData {
   ok: true
 }
 
@@ -61,7 +61,6 @@ export interface KnownInvalidRunData extends LegacyGoodRunData {
 export type GoodRunData = KnownGoodRunData | LegacyGoodRunData
 
 export type RunData = GoodRunData | KnownInvalidRunData
-
 
 export interface VectorOffset {
   x: number

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -5,7 +5,7 @@ import type {
   ModuleModel,
   RunTimeCommand,
 } from '@opentrons/shared-data'
-import type { ResourceLink } from '../types'
+import type { ResourceLink, ErrorDetails } from '../types'
 export * from './commands/types'
 
 export const RUN_STATUS_IDLE = 'idle' as const
@@ -33,7 +33,7 @@ export type RunStatus =
   | typeof RUN_STATUS_BLOCKED_BY_OPEN_DOOR
   | typeof RUN_STATUS_AWAITING_RECOVERY
 
-export interface RunData {
+export interface LegacyGoodRunData {
   id: string
   createdAt: string
   completedAt?: string
@@ -48,6 +48,20 @@ export interface RunData {
   protocolId?: string
   labwareOffsets?: LabwareOffset[]
 }
+
+export interface KnownGoodRunData extends LegacyGoodRunData{
+  ok: true
+}
+
+export interface KnownInvalidRunData extends LegacyGoodRunData {
+  ok: false
+  dataError: ErrorDetails
+}
+
+export type GoodRunData = KnownGoodRunData | LegacyGoodRunData
+
+export type RunData = GoodRunData | KnownInvalidRunData
+
 
 export interface VectorOffset {
   x: number

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -36,7 +36,7 @@ from robot_server.protocols.router import ProtocolNotFound
 
 from ..run_models import RunNotFoundError
 from ..run_auto_deleter import RunAutoDeleter
-from ..run_models import Run, RunCreate, RunUpdate
+from ..run_models import Run, BadRun, RunCreate, RunUpdate
 from ..engine_store import EngineConflictError
 from ..run_data_manager import RunDataManager, RunNotCurrentError
 from ..dependencies import get_run_data_manager, get_run_auto_deleter
@@ -99,7 +99,7 @@ class AllRunsLinks(BaseModel):
 async def get_run_data_from_url(
     runId: str,
     run_data_manager: RunDataManager = Depends(get_run_data_manager),
-) -> Run:
+) -> Union[Run, BadRun]:
     """Get the data of a run.
 
     Args:
@@ -144,7 +144,7 @@ async def create_run(
     deck_configuration_store: DeckConfigurationStore = Depends(
         get_deck_configuration_store
     ),
-) -> PydanticResponse[SimpleBody[Run]]:
+) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Create a new run.
 
     Arguments:
@@ -206,7 +206,7 @@ async def create_run(
         "Get a list of all active and inactive runs, in order from oldest to newest."
     ),
     responses={
-        status.HTTP_200_OK: {"model": MultiBody[Run, AllRunsLinks]},
+        status.HTTP_200_OK: {"model": MultiBody[Union[Run, BadRun], AllRunsLinks]},
     },
 )
 async def get_runs(
@@ -220,7 +220,7 @@ async def get_runs(
         ),
     ),
     run_data_manager: RunDataManager = Depends(get_run_data_manager),
-) -> PydanticResponse[MultiBody[Run, AllRunsLinks]]:
+) -> PydanticResponse[MultiBody[Union[Run, BadRun], AllRunsLinks]]:
     """Get all runs, in order from least-recently to most-recently created.
 
     Args:
@@ -248,13 +248,13 @@ async def get_runs(
     summary="Get a run",
     description="Get a specific run by its unique identifier.",
     responses={
-        status.HTTP_200_OK: {"model": SimpleBody[Run]},
+        status.HTTP_200_OK: {"model": SimpleBody[Union[Run, BadRun]]},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
 )
 async def get_run(
     run_data: Run = Depends(get_run_data_from_url),
-) -> PydanticResponse[SimpleBody[Run]]:
+) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Get a run by its ID.
 
     Args:
@@ -316,7 +316,7 @@ async def update_run(
     runId: str,
     request_body: RequestModel[RunUpdate],
     run_data_manager: RunDataManager = Depends(get_run_data_manager),
-) -> PydanticResponse[SimpleBody[Run]]:
+) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Update a run by its ID.
 
     Args:

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -22,7 +22,6 @@ from .run_store import RunResource, RunStore, BadRunResource, BadStateSummary
 from .run_models import Run, BadRun, RunLoadingError
 
 from opentrons.protocol_engine.types import DeckConfigurationType
-from opentrons.protocol_engine import ErrorOccurrence
 
 
 def _build_run(

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -1,7 +1,7 @@
 """Request and response models for run resources."""
 from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import List, Optional
+from typing import List, Optional, Literal
 
 from opentrons.protocol_engine import (
     CommandStatus,
@@ -20,7 +20,18 @@ from opentrons.protocol_engine import (
 )
 from opentrons_shared_data.errors import GeneralError
 from robot_server.service.json_api import ResourceModel
+from robot_server.errors.error_responses import ErrorDetails
 from .action_models import RunAction
+
+
+class RunLoadingError(ErrorDetails):
+    """A model for an error loading a run."""
+
+    title: str = Field(
+        "Run Loading Error",
+        description="A short, human readable name for this type of error",
+    )
+    id: Literal['RunLoadingError'] = "RunLoadingError"
 
 
 # TODO(mc, 2022-02-01): since the `/runs/:run_id/commands` response is now paginated,
@@ -79,6 +90,69 @@ class Run(ResourceModel):
     actions: List[RunAction] = Field(
         ...,
         description="Client-initiated run control actions, ordered oldest to newest.",
+    )
+    errors: List[ErrorOccurrence] = Field(
+        ...,
+        description=(
+            "The run's fatal error, if there was one."
+            " For historical reasons, this is an array,"
+            " but it won't have more than one element."
+        ),
+    )
+    pipettes: List[LoadedPipette] = Field(
+        ...,
+        description="Pipettes that have been loaded into the run.",
+    )
+    modules: List[LoadedModule] = Field(
+        ...,
+        description="Modules that have been loaded into the run.",
+    )
+    labware: List[LoadedLabware] = Field(
+        ...,
+        description="Labware that has been loaded into the run.",
+    )
+    liquids: List[Liquid] = Field(
+        ...,
+        description="Liquids loaded to the run.",
+    )
+    labwareOffsets: List[LabwareOffset] = Field(
+        ...,
+        description="Labware offsets to apply as labware are loaded.",
+    )
+    protocolId: Optional[str] = Field(
+        None,
+        description=(
+            "Protocol resource being run, if any. If not present, the run may"
+            " still be used to execute protocol commands over HTTP."
+        ),
+    )
+    completedAt: Optional[datetime] = Field(
+        None,
+        description="Run completed at timestamp.",
+    )
+    startedAt: Optional[datetime] = Field(
+        None,
+        description="Run started at timestamp.",
+    )
+
+
+class BadRun(ResourceModel):
+    """Resource model representation for a bad run that could not be loaded."""
+
+    dataError: RunLoadingError = Field(..., description="Error from loading the data.")
+    id: str = Field(..., description="Unique run identifier.")
+    createdAt: datetime = Field(..., description="When the run was created")
+    status: RunStatus = Field(..., description="Execution status of the run")
+    current: bool = Field(
+        ...,
+        description=(
+            "Whether this run is currently controlling the robot."
+            " There can be, at most, one current run."
+        ),
+    )
+    actions: Optional[List[RunAction]] = Field(
+        ...,
+        description="Client-initiated run control actions, ordered oldest to newest. If these could not be loaded for this bad run, this will be null.",
     )
     errors: List[ErrorOccurrence] = Field(
         ...,

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -31,7 +31,7 @@ class RunLoadingError(ErrorDetails):
         "Run Loading Error",
         description="A short, human readable name for this type of error",
     )
-    id: Literal['RunLoadingError'] = "RunLoadingError"
+    id: Literal["RunLoadingError"] = "RunLoadingError"
 
 
 # TODO(mc, 2022-02-01): since the `/runs/:run_id/commands` response is now paginated,

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -24,14 +24,14 @@ from robot_server.errors.error_responses import ErrorDetails
 from .action_models import RunAction
 
 
-class RunLoadingError(ErrorDetails):
+class RunDataError(ErrorDetails):
     """A model for an error loading a run."""
 
     title: str = Field(
         "Run Loading Error",
         description="A short, human readable name for this type of error",
     )
-    id: Literal["RunLoadingError"] = "RunLoadingError"
+    id: Literal["RunDataError"] = "RunDataError"
 
 
 # TODO(mc, 2022-02-01): since the `/runs/:run_id/commands` response is now paginated,
@@ -77,6 +77,7 @@ class RunCommandSummary(ResourceModel):
 class Run(ResourceModel):
     """Run resource model."""
 
+    ok: Literal[True] = True
     id: str = Field(..., description="Unique run identifier.")
     createdAt: datetime = Field(..., description="When the run was created")
     status: RunStatus = Field(..., description="Execution status of the run")
@@ -139,7 +140,8 @@ class Run(ResourceModel):
 class BadRun(ResourceModel):
     """Resource model representation for a bad run that could not be loaded."""
 
-    dataError: RunLoadingError = Field(..., description="Error from loading the data.")
+    ok: Literal[False] = False
+    dataError: RunDataError = Field(..., description="Error from loading the data.")
     id: str = Field(..., description="Unique run identifier.")
     createdAt: datetime = Field(..., description="When the run was created")
     status: RunStatus = Field(..., description="Execution status of the run")
@@ -150,7 +152,7 @@ class BadRun(ResourceModel):
             " There can be, at most, one current run."
         ),
     )
-    actions: Optional[List[RunAction]] = Field(
+    actions: List[RunAction] = Field(
         ...,
         description="Client-initiated run control actions, ordered oldest to newest. If these could not be loaded for this bad run, this will be null.",
     )

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -514,7 +514,7 @@ def _convert_row_to_run(
             )
             for action_row in action_rows
         ]
-    except BaseException as be:
+    except Exception as be:
         return BadRunResource(
             ok=False,
             run_id=run_id,

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -344,7 +344,7 @@ class RunStore:
                 )
             )
         except ValidationError as e:
-            log.warning(f"Error retrieving state summary for {run_id}: {e}")
+            log.warning(f"Error retrieving state summary for {run_id}", exc_info=True)
             return BadStateSummary(
                 dataError=InvalidStoredData(
                     message="Could not load stored StateSummary",

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -515,6 +515,7 @@ def _convert_row_to_run(
             for action_row in action_rows
         ]
     except Exception as be:
+        _log.warning("Error reading actions for run ID {run_id}:", exc_info=True)
         return BadRunResource(
             ok=False,
             run_id=run_id,

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -69,7 +69,7 @@ class BadRunResource:
     run_id: str
     protocol_id: Optional[str]
     created_at: datetime
-    actions: Optional[List[RunAction]]
+    actions: List[RunAction]
     error: EnumeratedError
 
 
@@ -515,13 +515,13 @@ def _convert_row_to_run(
             for action_row in action_rows
         ]
     except Exception as be:
-        _log.warning("Error reading actions for run ID {run_id}:", exc_info=True)
+        log.warning("Error reading actions for run ID {run_id}:", exc_info=True)
         return BadRunResource(
             ok=False,
             run_id=run_id,
             created_at=created_at,
             protocol_id=protocol_id,
-            actions=None,
+            actions=[],
             error=InvalidStoredData(
                 message="This run has invalid or unknown actions. It has likely been saved in a future version of software.",
                 detail={"kind": "bad-actions"},

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -31,6 +31,7 @@ stages:
       json:
         data:
           id: !anystr
+          ok: True
           createdAt: !anystr
           status: idle
           current: True

--- a/robot-server/tests/integration/http_api/runs/test_json_v7_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v7_protocol_run.tavern.yaml
@@ -31,6 +31,7 @@ stages:
       json:
         data:
           id: !anystr
+          ok: True
           createdAt: !anystr
           status: idle
           current: True

--- a/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
@@ -28,6 +28,7 @@ stages:
       json:
         data:
           id: !anystr
+          ok: True
           createdAt: !anystr
           status: idle
           current: True
@@ -229,6 +230,7 @@ stages:
         data:
           # Unchanged from when we originally POSTed the resource:
           id: '{run_id}'
+          ok: True
           createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           startedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           liquids: []

--- a/robot-server/tests/integration/http_api/runs/test_run_queued_protocol_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_queued_protocol_commands.tavern.yaml
@@ -18,6 +18,7 @@ stages:
       json:
         data:
           id: !anystr
+          ok: True
           status: idle
           current: true
       save:
@@ -84,6 +85,7 @@ stages:
       status_code: 200
       json:
         data:
+          ok: True
           actions: []
           createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           current: True

--- a/robot-server/tests/runs/test_run_auto_deleter.py
+++ b/robot-server/tests/runs/test_run_auto_deleter.py
@@ -3,21 +3,20 @@
 
 from datetime import datetime
 import logging
+from typing import List, Union
 
 import pytest
 from decoy import Decoy
 
 from robot_server.deletion_planner import RunDeletionPlanner
 from robot_server.runs.run_auto_deleter import RunAutoDeleter
-from robot_server.runs.run_store import (
-    RunStore,
-    RunResource,
-)
+from robot_server.runs.run_store import RunStore, RunResource, BadRunResource
 
 
 def _make_dummy_run_resource(run_id: str) -> RunResource:
     """Return a RunResource with the given ID."""
     return RunResource(
+        ok=True,
         run_id=run_id,
         protocol_id=None,
         created_at=datetime.min,
@@ -35,7 +34,7 @@ def test_make_room_for_new_run(decoy: Decoy, caplog: pytest.LogCaptureFixture) -
         deletion_planner=mock_deletion_planner,
     )
 
-    run_resources = [
+    run_resources: List[Union[RunResource, BadRunResource]] = [
         _make_dummy_run_resource("run-id-1"),
         _make_dummy_run_resource("run-id-2"),
         _make_dummy_run_resource("run-id-3"),

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -24,7 +24,7 @@ from opentrons.protocol_engine import (
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs.engine_store import EngineStore, EngineConflictError
 from robot_server.runs.run_data_manager import RunDataManager, RunNotCurrentError
-from robot_server.runs.run_models import Run, BadRun, RunNotFoundError, RunLoadingError
+from robot_server.runs.run_models import Run, BadRun, RunNotFoundError, RunDataError
 from robot_server.runs.run_store import (
     RunStore,
     RunResource,
@@ -358,7 +358,7 @@ async def test_get_historical_run_no_data(
     run_id = "hello world"
 
     state_exc = InvalidStoredData("Oh no!")
-    run_error = RunLoadingError.from_exc(state_exc)
+    run_error = RunDataError.from_exc(state_exc)
     decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
     decoy.when(mock_run_store.get_state_summary(run_id=run_id)).then_return(
         BadStateSummary(dataError=state_exc)

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -15,7 +15,7 @@ from robot_server.runs.run_store import (
     RunStore,
     RunResource,
     CommandNotFoundError,
-    BadStateSummary
+    BadStateSummary,
 )
 from robot_server.runs.run_models import RunNotFoundError
 from robot_server.runs.action_models import RunAction, RunActionType

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -8,12 +8,14 @@ from sqlalchemy.engine import Engine
 from unittest import mock
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.errors.codes import ErrorCodes
 
 from robot_server.protocols.protocol_store import ProtocolNotFoundError
 from robot_server.runs.run_store import (
     RunStore,
     RunResource,
     CommandNotFoundError,
+    BadStateSummary
 )
 from robot_server.runs.run_models import RunNotFoundError
 from robot_server.runs.action_models import RunAction, RunActionType
@@ -192,6 +194,7 @@ def test_update_run_state(
     )
 
     assert result == RunResource(
+        ok=True,
         run_id="run-id",
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
@@ -227,6 +230,7 @@ def test_add_run(subject: RunStore) -> None:
     )
 
     assert result == RunResource(
+        ok=True,
         run_id="run-id",
         protocol_id=None,
         created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
@@ -267,6 +271,7 @@ def test_get_run_no_actions(subject: RunStore) -> None:
     result = subject.get("run-id")
 
     assert result == RunResource(
+        ok=True,
         run_id="run-id",
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
@@ -293,6 +298,7 @@ def test_get_run(subject: RunStore) -> None:
     result = subject.get(run_id="run-id")
 
     assert result == RunResource(
+        ok=True,
         run_id="run-id",
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
@@ -314,6 +320,7 @@ def test_get_run_missing(subject: RunStore) -> None:
             1,
             [
                 RunResource(
+                    ok=True,
                     run_id="run-id-2",
                     protocol_id=None,
                     created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
@@ -325,12 +332,14 @@ def test_get_run_missing(subject: RunStore) -> None:
             20,
             [
                 RunResource(
+                    ok=True,
                     run_id="run-id-1",
                     protocol_id=None,
                     created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
                     actions=[],
                 ),
                 RunResource(
+                    ok=True,
                     run_id="run-id-2",
                     protocol_id=None,
                     created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
@@ -342,12 +351,14 @@ def test_get_run_missing(subject: RunStore) -> None:
             None,
             [
                 RunResource(
+                    ok=True,
                     run_id="run-id-1",
                     protocol_id=None,
                     created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
                     actions=[],
                 ),
                 RunResource(
+                    ok=True,
                     run_id="run-id-2",
                     protocol_id=None,
                     created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
@@ -447,7 +458,8 @@ def test_get_state_summary_failure(
         run_id="run-id", summary=invalid_state_summary, commands=[]
     )
     result = subject.get_state_summary(run_id="run-id")
-    assert result is None
+    assert isinstance(result, BadStateSummary)
+    assert result.dataError.code == ErrorCodes.INVALID_STORED_DATA
 
 
 def test_get_state_summary_none(subject: RunStore) -> None:
@@ -458,7 +470,8 @@ def test_get_state_summary_none(subject: RunStore) -> None:
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
     )
     result = subject.get_state_summary(run_id="run-id")
-    assert result is None
+    assert isinstance(result, BadStateSummary)
+    assert result.dataError.code == ErrorCodes.INVALID_STORED_DATA
 
 
 def test_has_run_id(subject: RunStore) -> None:

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -221,6 +221,10 @@
     "4007": {
       "detail": "API Command is misconfigured",
       "category": "generalError"
+    },
+    "4008": {
+      "detail": "Invalid stored data",
+      "category": "generalError"
     }
   }
 }

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -85,6 +85,7 @@ class ErrorCodes(Enum):
     COMMAND_PARAMETER_LIMIT_VIOLATED = _code_from_dict_entry("4005")
     INVALID_PROTOCOL_DATA = _code_from_dict_entry("4006")
     API_MISCONFIGURATION = _code_from_dict_entry("4007")
+    INVALID_STORED_DATA = _code_from_dict_entry("4008")
 
     @classmethod
     @lru_cache(25)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -929,3 +929,17 @@ class InvalidProtocolData(GeneralError):
     ) -> None:
         """Build an InvalidProtocolData."""
         super().__init__(ErrorCodes.INVALID_PROTOCOL_DATA, message, detail, wrapping)
+
+class InvalidStoredData(GeneralError):
+    """An error indicating that some stored data is invalid.
+
+    This will usually be because it was saved by a future version of the software.
+    """
+    def __init__(
+            self,
+            message: Optional[str] = None,
+            detail: Optional[Dict[str, str]] = None,
+            wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an InvalidStoredData."""
+        super().__init__(ErrorCodes.INVALID_STORED_DATA, message, detail, wrapping)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -930,16 +930,18 @@ class InvalidProtocolData(GeneralError):
         """Build an InvalidProtocolData."""
         super().__init__(ErrorCodes.INVALID_PROTOCOL_DATA, message, detail, wrapping)
 
+
 class InvalidStoredData(GeneralError):
     """An error indicating that some stored data is invalid.
 
     This will usually be because it was saved by a future version of the software.
     """
+
     def __init__(
-            self,
-            message: Optional[str] = None,
-            detail: Optional[Dict[str, str]] = None,
-            wrapping: Optional[Sequence[EnumeratedError]] = None,
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
         """Build an InvalidStoredData."""
         super().__init__(ErrorCodes.INVALID_STORED_DATA, message, detail, wrapping)


### PR DESCRIPTION
Up to now, if there's a run saved in the persistence layer that cannot be loaded - which is typically because it contains data from a version of the robot server or api package that whatever's currently running can't handle - we error when trying to retrieve it. That includes both a 500 error when trying to access that particular run, which clients can broadly handle, and a 500 error when trying to list all runs, which clients cannot. Without being able to list out all runs, there's no way for clients to find the problematic run - the IDs are UUIDs and cannot be enumerated - and remove it. The only recourse is to delete all the run storage.

A different way to handle this problem is to consider a "bad run", a run whose run metadata or engine state summary cannot be loaded, as a first class entity that can be returned from run access endpoints wherever a run could be, without an HTTP level error. This is done everywhere for consistency in this commit, though the argument could be made that it should only be done in the list-all-runs access and other endpoints should continue to error.

This bad run contains error information about the cause of the invalid data using a new enumerated error. The bad run will carry all the information that could be loaded - in effect, if the state summary is bad then the run metadata will still be present, and the ID should generally be accessible.

Closes EXEC-344

## Review requests
- [ ] normal stuff
- [ ] from an app perspective, does this seem reasonable to work with?

## Testing
- [x] Put it on some robots and see that we get some useful data