### PR TITLE
refactor(modules): return has update for unexpected module fw filename

### DIFF
--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -4,7 +4,7 @@ import logging
 import re
 from pkg_resources import parse_version
 from typing import ClassVar, Mapping, Optional, cast, TypeVar
-
+from packaging.version import InvalidVersion
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
 
@@ -75,7 +75,7 @@ class AbstractModule(abc.ABC):
             return None
         file_prefix = self.firmware_prefix()
 
-        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin).*$")
+        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin)$")
         for fw_resource in ROBOT_FIRMWARE_DIR.iterdir():  # type: ignore
             matches = MODULE_FW_RE.search(fw_resource.name)
             if matches:
@@ -87,8 +87,15 @@ class AbstractModule(abc.ABC):
     def has_available_update(self) -> bool:
         """Return whether a newer firmware file is available"""
         if self.device_info and self._bundled_fw:
-            device_version = parse_version(self.device_info["version"])
-            available_version = parse_version(self._bundled_fw.version)
+            # try catch this
+            try:
+                device_version = parse_version(self.device_info["version"])
+            except InvalidVersion:
+                device_version = parse_version("v0.0.0")
+            try:
+                available_version = parse_version(self._bundled_fw.version)
+            except InvalidVersion:
+                available_version = parse_version("v0.0.0")
             return cast(bool, available_version > device_version)
         return False
 

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -75,7 +75,7 @@ class AbstractModule(abc.ABC):
             return None
         file_prefix = self.firmware_prefix()
 
-        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin)$")
+        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin).*$")
         for fw_resource in ROBOT_FIRMWARE_DIR.iterdir():  # type: ignore
             matches = MODULE_FW_RE.search(fw_resource.name)
             if matches:
@@ -90,8 +90,6 @@ class AbstractModule(abc.ABC):
             device_version = parse_version(self.device_info["version"])
             available_version = parse_version(self._bundled_fw.version)
             return cast(bool, available_version > device_version)
-        elif self.device_info and not self._bundled_fw:
-            return True
         return False
 
     async def wait_for_is_running(self) -> None:

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -90,6 +90,8 @@ class AbstractModule(abc.ABC):
             device_version = parse_version(self.device_info["version"])
             available_version = parse_version(self._bundled_fw.version)
             return cast(bool, available_version > device_version)
+        elif self.device_info and not self._bundled_fw:
+            return True
         return False
 
     async def wait_for_is_running(self) -> None:


### PR DESCRIPTION
## Overview
When we flash local firmware changes to a module using an ST-Link, the file produced will have the usual firmware filename for the module, except with a commit hash amended in the middle of it. 

Currently, having the filename altered like this causes the robot server not to recognize that a module is present at all. Instead, this change allows the app to reflect that the module is there and offer an available update.

## Changelog

- catch and handle an `InvalidVersion` error for both current and available device versions