### PR TITLE
fix(protocol-designer): display correct tip position offset

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
@@ -33,7 +33,7 @@ export function TipPositionField(props: TipPositionFieldProps): JSX.Element {
     updateValue,
     isIndeterminate,
     labwareId,
-    value: rawValue
+    value: rawValue,
   } = props
   const { t } = useTranslation('application')
   const [targetProps, tooltipProps] = useHoverTooltip()

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/index.tsx
@@ -33,6 +33,7 @@ export function TipPositionField(props: TipPositionFieldProps): JSX.Element {
     updateValue,
     isIndeterminate,
     labwareId,
+    value: rawValue
   } = props
   const { t } = useTranslation('application')
   const [targetProps, tooltipProps] = useHoverTooltip()
@@ -69,7 +70,7 @@ export function TipPositionField(props: TipPositionFieldProps): JSX.Element {
   const isTouchTipField = getIsTouchTipField(name)
   const isDelayPositionField = getIsDelayPositionField(name)
   let value: string | number = '0'
-  const mmFromBottom = typeof value === 'number' ? value : null
+  const mmFromBottom = typeof rawValue === 'number' ? rawValue : null
   if (wellDepthMm !== null) {
     // show default value for field in parens if no mmFromBottom value is selected
     value =


### PR DESCRIPTION
# Overview
This PR fixes a bug where PD was rendering the wrong tip position field.

closes RESC-223


# Test Plan
- Verified that when updating tip position in the move liquid form the form field updates
- Verified that when updating tip position in the mix form the form field updates
- Verified that when updating tip position in the batch edit form the form field updates

# Changelog

- Display correct tip position offset


# Review requests

See test plan

# Risk assessment
Low
