### PR TITLE
test(robot-server): Fail tests quickly when `GET /health` returns 500

### DIFF
--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -152,9 +152,7 @@ async def test_protocols_analyses_and_runs_available_from_older_persistence_dir(
     async with RobotClient.make(
         base_url=f"http://localhost:{_PORT}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(port=_PORT, persistence_directory=snapshot.get_copy()) as server:
             server.start()
             await robot_client.wait_until_ready(_STARTUP_TIMEOUT)
@@ -227,9 +225,7 @@ async def test_rerun_flex_dev_compat() -> None:
     async with RobotClient.make(
         base_url=f"http://localhost:{_PORT}", version="*"
     ) as client:
-        assert (
-            await client.wait_until_dead()
-        ), "Dev Robot is running but it should not be."
+        assert await client.dead(), "Dev Robot is running but it should not be."
         with DevServer(persistence_directory=snapshot.get_copy(), port=_PORT) as server:
             server.start()
             await client.wait_until_ready(_STARTUP_TIMEOUT)

--- a/robot-server/tests/integration/http_api/persistence/test_compatibility.py
+++ b/robot-server/tests/integration/http_api/persistence/test_compatibility.py
@@ -157,9 +157,7 @@ async def test_protocols_analyses_and_runs_available_from_older_persistence_dir(
         ), "Dev Robot is running and must not be."
         with DevServer(port=_PORT, persistence_directory=snapshot.get_copy()) as server:
             server.start()
-            assert await robot_client.wait_until_alive(
-                _STARTUP_TIMEOUT
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready(_STARTUP_TIMEOUT)
             all_protocols = (await robot_client.get_protocols()).json()["data"]
 
             assert len(all_protocols) == snapshot.expected_protocol_count
@@ -234,9 +232,7 @@ async def test_rerun_flex_dev_compat() -> None:
         ), "Dev Robot is running but it should not be."
         with DevServer(persistence_directory=snapshot.get_copy(), port=_PORT) as server:
             server.start()
-            assert await client.wait_until_alive(
-                _STARTUP_TIMEOUT
-            ), "Dev Robot never became available."
+            await client.wait_until_ready(_STARTUP_TIMEOUT)
 
             [protocol] = (await client.get_protocols()).json()["data"]
             new_run = (

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -92,9 +92,7 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
         ), "Dev Robot is running and must not be."
         with DevServer(port=port) as server:
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             with get_py_protocol(secrets.token_urlsafe(16)) as file:
                 await robot_client.post_protocol([Path(file.name)])
@@ -112,9 +110,7 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
             server.stop()
             assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             await _assert_reset_was_successful(
                 robot_client=robot_client,
@@ -144,9 +140,7 @@ async def test_reset_is_available_even_with_corrupt_persistence_directory() -> N
             server.stop()
             assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             await _assert_reset_was_successful(
                 robot_client=robot_client,

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -87,9 +87,7 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
     async with RobotClient.make(
         base_url=f"http://localhost:{port}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(port=port) as server:
             server.start()
             await robot_client.wait_until_ready()
@@ -108,7 +106,7 @@ async def test_upload_protocols_and_reset_persistence_dir() -> None:
 
             # Restart to enact the reset.
             server.stop()
-            assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
+            assert await robot_client.dead(), "Dev Robot did not stop."
             server.start()
             await robot_client.wait_until_ready()
 
@@ -127,9 +125,7 @@ async def test_reset_is_available_even_with_corrupt_persistence_directory() -> N
     async with RobotClient.make(
         base_url=f"http://localhost:{port}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(port=port, persistence_directory=persistence_dir) as server:
             server.start()
             await _wait_until_initialization_failed(robot_client)
@@ -138,7 +134,7 @@ async def test_reset_is_available_even_with_corrupt_persistence_directory() -> N
 
             # Restart to enact the reset.
             server.stop()
-            assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
+            assert await robot_client.dead(), "Dev Robot did not stop."
             server.start()
             await robot_client.wait_until_ready()
 

--- a/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
@@ -25,9 +25,7 @@ async def test_protocols_auto_delete(
     async with RobotClient.make(
         base_url=f"http://localhost:{port}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(
             port=port, maximum_unused_protocols=num_to_configure_as_maximum
         ) as server:

--- a/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/protocols/test_auto_deletion.py
@@ -32,9 +32,7 @@ async def test_protocols_auto_delete(
             port=port, maximum_unused_protocols=num_to_configure_as_maximum
         ) as server:
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             uploaded_protocol_ids = await _upload_protocols(
                 robot_client=robot_client, num_protocols=num_to_upload

--- a/robot-server/tests/integration/http_api/protocols/test_persistence.py
+++ b/robot-server/tests/integration/http_api/protocols/test_persistence.py
@@ -23,9 +23,7 @@ async def test_protocols_and_analyses_persist(
     async with RobotClient.make(
         base_url=f"http://localhost:{port}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(port=port) as server:
             server.start()
             await robot_client.wait_until_ready()
@@ -50,7 +48,7 @@ async def test_protocols_and_analyses_persist(
             analyses_before_restart = await _get_all_analyses(robot_client)
 
             server.stop()
-            assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
+            assert await robot_client.dead(), "Dev Robot did not stop."
 
             server.start()
             await robot_client.wait_until_ready()
@@ -85,9 +83,7 @@ async def test_protocol_labware_files_persist() -> None:
     async with RobotClient.make(
         base_url=f"http://localhost:{port}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(port=port) as server:
             server.start()
             await robot_client.wait_until_ready()
@@ -111,7 +107,7 @@ async def test_protocol_labware_files_persist() -> None:
             del protocol_detail["analysisSummaries"]
 
             server.stop()
-            assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
+            assert await robot_client.dead(), "Dev Robot did not stop."
             server.start()
             await robot_client.wait_until_ready()
 

--- a/robot-server/tests/integration/http_api/protocols/test_persistence.py
+++ b/robot-server/tests/integration/http_api/protocols/test_persistence.py
@@ -28,9 +28,7 @@ async def test_protocols_and_analyses_persist(
         ), "Dev Robot is running and must not be."
         with DevServer(port=port) as server:
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             # Must not be so high that the server runs out of room and starts
             # auto-deleting old protocols.
@@ -55,9 +53,7 @@ async def test_protocols_and_analyses_persist(
             assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
 
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             protocols_after_restart = (await robot_client.get_protocols()).json()[
                 "data"
@@ -94,9 +90,7 @@ async def test_protocol_labware_files_persist() -> None:
         ), "Dev Robot is running and must not be."
         with DevServer(port=port) as server:
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             protocol = await robot_client.post_protocol(
                 [
@@ -119,9 +113,7 @@ async def test_protocol_labware_files_persist() -> None:
             server.stop()
             assert await robot_client.wait_until_dead(), "Dev Robot did not stop."
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             result = await robot_client.get_protocol(protocol_id)
             restarted_protocol_detail = result.json()["data"]

--- a/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_python_custom_labware.py
@@ -40,9 +40,7 @@ async def robot_client(
     async with RobotClient.make(
         base_url=ot2_server_base_url, version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_alive()
-        ), "Dev Robot never became available."
+        await robot_client.wait_until_ready()
         yield robot_client
 
 

--- a/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
@@ -22,9 +22,7 @@ async def test_runs_auto_delete(
     async with RobotClient.make(
         base_url=f"http://localhost:{port}", version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_dead()
-        ), "Dev Robot is running and must not be."
+        assert await robot_client.dead(), "Dev Robot is running and must not be."
         with DevServer(port=port, maximum_runs=num_to_configure_as_maximum) as server:
             server.start()
             await robot_client.wait_until_ready()

--- a/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
+++ b/robot-server/tests/integration/http_api/runs/test_auto_deletion.py
@@ -27,9 +27,7 @@ async def test_runs_auto_delete(
         ), "Dev Robot is running and must not be."
         with DevServer(port=port, maximum_runs=num_to_configure_as_maximum) as server:
             server.start()
-            assert (
-                await robot_client.wait_until_alive()
-            ), "Dev Robot never became available."
+            await robot_client.wait_until_ready()
 
             created_run_ids = await _create_runs(
                 robot_client=robot_client, num_runs=num_to_upload

--- a/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
+++ b/robot-server/tests/integration/http_api/runs/test_labware_offsets_on_compatible_modules.py
@@ -51,9 +51,7 @@ async def robot_client(
     async with RobotClient.make(
         base_url=ot2_server_base_url, version="*"
     ) as robot_client:
-        assert (
-            await robot_client.wait_until_alive()
-        ), "Dev Robot never became available."
+        await robot_client.wait_until_ready()
         yield robot_client
 
 

--- a/robot-server/tests/integration/http_api/runs/test_persistence.py
+++ b/robot-server/tests/integration/http_api/runs/test_persistence.py
@@ -16,7 +16,7 @@ class ClientServerFixture(NamedTuple):
         self.server.stop()
         assert await self.client.wait_until_dead(), "Server did not stop."
         self.server.start()
-        assert await self.client.wait_until_alive(), "Server never became available."
+        await self.client.wait_until_ready()
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ async def client_and_server(port: str) -> AsyncGenerator[ClientServerFixture, No
 
         with DevServer(port=port) as server:
             server.start()
-            assert await client.wait_until_alive(), "Server never became available."
+            await client.wait_until_ready()
 
             yield ClientServerFixture(client=client, server=server)
 

--- a/robot-server/tests/integration/http_api/runs/test_persistence.py
+++ b/robot-server/tests/integration/http_api/runs/test_persistence.py
@@ -14,7 +14,7 @@ class ClientServerFixture(NamedTuple):
 
     async def restart(self) -> None:
         self.server.stop()
-        assert await self.client.wait_until_dead(), "Server did not stop."
+        assert await self.client.dead(), "Server did not stop."
         self.server.start()
         await self.client.wait_until_ready()
 
@@ -32,7 +32,7 @@ async def client_and_server(port: str) -> AsyncGenerator[ClientServerFixture, No
         base_url=f"http://localhost:{port}",
         version="*",
     ) as client:
-        assert await client.wait_until_dead(), "Server is running and must not be."
+        assert await client.dead(), "Server is running and must not be."
 
         with DevServer(port=port) as server:
             server.start()

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -53,32 +53,34 @@ class RobotClient:
                     base_url=base_url,
                 )
 
-    async def alive(self) -> bool:
-        """Is /health reachable?"""
-        try:
-            await self.get_health()
-            return True
-        except (httpx.ConnectError, httpx.HTTPStatusError):
-            return False
-
     async def dead(self) -> bool:
         """Is /health unreachable?"""
         try:
             await self.get_health()
-            return False
-        except httpx.HTTPStatusError:
-            return False
         except httpx.ConnectError:
-            pass
+            return True
+        except httpx.HTTPStatusError:
+            # If it's alive enough to return an error code, it's not dead.
+            return False
+        else:
+            # If it's alive enough to return a success code, it's super not dead.
+            return False
 
-        return True
-
-    async def _poll_for_alive(self) -> None:
-        """Retry GET /health until reachable."""
-        while not await self.alive():
-            # Avoid spamming the server in case a request immediately
-            # returns some kind of "not ready."
-            await asyncio.sleep(0.1)
+    async def _poll_for_ready(self) -> None:
+        """Retry GET /health until ready."""
+        while True:
+            try:
+                await self.get_health()
+            except httpx.ConnectError:
+                await asyncio.sleep(0.1)  # Wait, then keep polling.
+            except httpx.HTTPStatusError as e:
+                error_is_because_still_initializing = e.response.status_code == 503
+                if error_is_because_still_initializing:
+                    await asyncio.sleep(0.1)  # Wait, then keep polling.
+                else:
+                    raise
+            else:
+                return
 
     async def _poll_for_dead(self) -> None:
         """Poll GET /health until unreachable."""
@@ -87,12 +89,17 @@ class RobotClient:
             # returns some kind of "not ready."
             await asyncio.sleep(0.1)
 
-    async def wait_until_alive(self, timeout_sec: float = _STARTUP_WAIT) -> bool:
-        try:
-            await asyncio.wait_for(self._poll_for_alive(), timeout=timeout_sec)
-            return True
-        except asyncio.TimeoutError:
-            return False
+    async def wait_until_ready(self, timeout_sec: float = _STARTUP_WAIT) -> None:
+        """Wait until the server is ready to handle general requests.
+
+        "Ready to handle general requests" means it's accepting HTTP connections
+        and it's returning a "ready" status from its `/health` endpoint.
+
+        If the `/health` endpoint returns a "still busy initializing" response, this
+        will keep waiting. If it returns any other kind of error response, this
+        will interpret it as a fatal initialization error and raise an exception.
+        """
+        await asyncio.wait_for(self._poll_for_ready(), timeout=timeout_sec)
 
     async def wait_until_dead(self, timeout_sec: float = _SHUTDOWN_WAIT) -> bool:
         """Retry GET /health and until unreachable."""

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -82,13 +82,6 @@ class RobotClient:
             else:
                 return
 
-    async def _poll_for_dead(self) -> None:
-        """Poll GET /health until unreachable."""
-        while not await self.dead():
-            # Avoid spamming the server in case a request immediately
-            # returns some kind of "not ready."
-            await asyncio.sleep(0.1)
-
     async def wait_until_ready(self, timeout_sec: float = _STARTUP_WAIT) -> None:
         """Wait until the server is ready to handle general requests.
 
@@ -100,14 +93,6 @@ class RobotClient:
         will interpret it as a fatal initialization error and raise an exception.
         """
         await asyncio.wait_for(self._poll_for_ready(), timeout=timeout_sec)
-
-    async def wait_until_dead(self, timeout_sec: float = _SHUTDOWN_WAIT) -> bool:
-        """Retry GET /health and until unreachable."""
-        try:
-            await asyncio.wait_for(self._poll_for_dead(), timeout=timeout_sec)
-            return True
-        except asyncio.TimeoutError:
-            return False
 
     async def get_health(self) -> Response:
         """GET /health."""


### PR DESCRIPTION
# Overview

@CaseyBatten ran into a confusing thing with robot-server's integration tests. If we introduce a bug in robot-server's database migration code that makes it fail to start, many of our integration tests hang for a very long time before eventually timing out, obscuring the bug.

This fixes our test code so it fails immediately when robot-server's startup fails with a fatal error.

# Test Plan

I've cherry-picked this atop a known-bad commit and confirmed that it makes the tests fail quickly with the expected "500 internal server error" message.

# Changelog

* Teach the `RobotClient` test helper the difference between an HTTP 503 "busy" and other HTTP error codes. If it's busy, keep waiting. If it's any other kind of error, propagate it.
* Similarly, remove `RobotClient.wait_until_dead()`. Some tests want to make sure that there's no existing server before starting a new one, and that's fine, but they can do that by just checking `RobotClient.dead()` once. They don't need to keep polling; all that does is forestall the inevitable failure.
* While we're here, have `RobotClient.wait_until_alive()` raise a timeout error instead of returning `False`, so callers don't have to remember to `assert` it.

# Review requests

None in particular.

# Risk assessment

Low. We're just changing some test helpers.