### PR TITLE
feat(app): add small size to Chip component for ODD

### DIFF
--- a/app/src/atoms/Chip/Chip.stories.tsx
+++ b/app/src/atoms/Chip/Chip.stories.tsx
@@ -20,6 +20,13 @@ export default {
       },
       defaultValue: true,
     },
+    chipSize: {
+      options: ['medium', 'small'],
+      control: {
+        type: 'select',
+      },
+      defaultValue: 'medium',
+    },
   },
   component: Chip,
   parameters: touchScreenViewport,
@@ -45,4 +52,5 @@ ChipComponent.args = {
   type: 'basic',
   text: 'Chip component',
   hasIcon: true,
+  chipSize: 'medium',
 }

--- a/app/src/atoms/Chip/__tests__/Chip.test.tsx
+++ b/app/src/atoms/Chip/__tests__/Chip.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, it, expect } from 'vitest'
 import { screen } from '@testing-library/react'
-import { BORDERS, COLORS } from '@opentrons/components'
+import { BORDERS, COLORS, SPACING } from '@opentrons/components'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { Chip } from '..'
 
@@ -40,6 +40,7 @@ describe('Chip', () => {
     expect(chipText).toHaveStyle(`color: ${COLORS.green60}`)
     const icon = screen.getByLabelText('icon_mockSuccess')
     expect(icon).toHaveStyle(`color: ${COLORS.green60}`)
+    expect(icon).toHaveStyle(`width: 1.5rem`)
   })
 
   it('should render text, icon, no bgcolor with success colors and bg false', () => {
@@ -191,5 +192,35 @@ describe('Chip', () => {
     }
     render(props)
     expect(screen.queryByText('icon_mockInfo')).not.toBeInTheDocument()
+  })
+
+  it('render text with smaller padding and smaller icon when chip size is small and background is false', () => {
+    props = {
+      background: false,
+      text: 'mockInfo',
+      type: 'info',
+      chipSize: 'small',
+    }
+    render(props)
+    const chip = screen.getByTestId('Chip_info')
+    expect(chip).toHaveStyle(`padding: ${SPACING.spacing4} 0`)
+    const icon = screen.getByLabelText('icon_mockInfo')
+    expect(icon).toHaveStyle(`width: 1.25rem`)
+  })
+
+  it('render text with smaller padding and smaller icon when chip size is small and background is true', () => {
+    props = {
+      background: true,
+      text: 'mockInfo',
+      type: 'info',
+      chipSize: 'small',
+    }
+    render(props)
+    const chip = screen.getByTestId('Chip_info')
+    expect(chip).toHaveStyle(
+      `padding: ${SPACING.spacing4} ${SPACING.spacing10}`
+    )
+    const icon = screen.getByLabelText('icon_mockInfo')
+    expect(icon).toHaveStyle(`width: 1.25rem`)
   })
 })

--- a/app/src/atoms/Chip/index.tsx
+++ b/app/src/atoms/Chip/index.tsx
@@ -134,7 +134,6 @@ export function Chip(props: ChipProps): JSX.Element {
           color={CHIP_PROPS_BY_TYPE[type].iconColor}
           aria-label={`icon_${text}`}
           size={chipSize === 'medium' ? '1.5rem' : '1.25rem'}
-          data-testid={`RenderResult_icon_${chipSize}`}
         />
       ) : null}
       <StyledText

--- a/app/src/atoms/Chip/index.tsx
+++ b/app/src/atoms/Chip/index.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react'
-
+import { css } from 'styled-components'
 import {
-  BORDERS,
-  Flex,
-  DIRECTION_ROW,
   ALIGN_CENTER,
+  BORDERS,
+  COLORS,
+  DIRECTION_ROW,
+  Flex,
+  Icon,
   SPACING,
   TYPOGRAPHY,
-  Icon,
-  COLORS,
 } from '@opentrons/components'
 
 import { StyledText } from '../text'
@@ -23,6 +23,8 @@ export type ChipType =
   | 'success'
   | 'warning'
 
+type ChipSize = 'medium' | 'small'
+
 interface ChipProps extends StyleProps {
   /** Display background color? */
   background?: boolean
@@ -34,6 +36,8 @@ interface ChipProps extends StyleProps {
   type: ChipType
   /** has icon */
   hasIcon?: boolean
+  /** Chip size medium is the default size */
+  chipSize?: ChipSize
 }
 
 const CHIP_PROPS_BY_TYPE: Record<
@@ -91,6 +95,7 @@ export function Chip(props: ChipProps): JSX.Element {
     type,
     text,
     hasIcon = true,
+    chipSize = 'medium',
     ...styleProps
   } = props
   const backgroundColor =
@@ -98,16 +103,28 @@ export function Chip(props: ChipProps): JSX.Element {
       ? COLORS.transparent
       : CHIP_PROPS_BY_TYPE[type].backgroundColor
   const icon = iconName ?? CHIP_PROPS_BY_TYPE[type].iconName ?? 'ot-alert'
+
+  const TOUCHSCREEN_MEDIUM_CONTAINER_STYLE = css`
+    padding: ${SPACING.spacing8} ${background === false ? 0 : SPACING.spacing16};
+    grid-gap: ${SPACING.spacing8};
+  `
+
+  const TOUCHSCREEN_SMALL_CONTAINER_STYLE = css`
+    padding: ${SPACING.spacing4} ${background === false ? 0 : SPACING.spacing10};
+    grid-gap: ${SPACING.spacing4};
+  `
+
   return (
     <Flex
       alignItems={ALIGN_CENTER}
       backgroundColor={backgroundColor}
       borderRadius={CHIP_PROPS_BY_TYPE[type].borderRadius}
       flexDirection={DIRECTION_ROW}
-      padding={`${SPACING.spacing8} ${
-        background === false ? 0 : SPACING.spacing16
-      }`}
-      gridGap={SPACING.spacing8}
+      css={
+        chipSize === 'medium'
+          ? TOUCHSCREEN_MEDIUM_CONTAINER_STYLE
+          : TOUCHSCREEN_SMALL_CONTAINER_STYLE
+      }
       data-testid={`Chip_${type}`}
       {...styleProps}
     >
@@ -116,14 +133,16 @@ export function Chip(props: ChipProps): JSX.Element {
           name={icon}
           color={CHIP_PROPS_BY_TYPE[type].iconColor}
           aria-label={`icon_${text}`}
-          size="1.5rem"
-          data-testid="RenderResult_icon"
+          size={chipSize === 'medium' ? '1.5rem' : '1.25rem'}
+          data-testid={`RenderResult_icon_${chipSize}`}
         />
       ) : null}
       <StyledText
-        fontSize={TYPOGRAPHY.fontSize22}
-        lineHeight={TYPOGRAPHY.lineHeight28}
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+        css={
+          chipSize === 'medium'
+            ? TYPOGRAPHY.bodyTextSemiBold
+            : TYPOGRAPHY.smallBodyTextSemiBold
+        }
         color={CHIP_PROPS_BY_TYPE[type].textColor}
       >
         {text}

--- a/app/src/organisms/ProtocolSetupParameters/ViewOnlyParameters.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/ViewOnlyParameters.tsx
@@ -123,7 +123,12 @@ export function ViewOnlyParameters({
                   {getDefault(parameter)}
                 </StyledText>
                 {hasCustomValue ? (
-                  <Chip type="success" text={t('updated')} hasIcon={false} />
+                  <Chip
+                    type="success"
+                    text={t('updated')}
+                    hasIcon={false}
+                    chipSize="small"
+                  />
                 ) : null}
               </Flex>
             </Flex>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add small size to Chip component for ODD

![Screenshot 2024-03-22 at 12 44 01 PM](https://github.com/Opentrons/opentrons/assets/474225/c4744d95-858d-4fcc-baa9-15de2e661e1e)

also update view-only parameters screen's chip prop
![IMG_0987](https://github.com/Opentrons/opentrons/assets/474225/dbd576a5-0abb-462b-99e5-87bb0adc7e2d)


design
https://www.figma.com/file/1ot18My22DALIcjdLl5LJh/Helix-Design-System?node-id=2771%3A31729&mode=dev

Chip for Desktop (unification) will be implemented in a following PR. (when [this pr](https://github.com/Opentrons/opentrons/pull/14715) is merged into edge) 

close AUTH-233

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add chipSize to Chip component and update its test and storybook
- ViewOnlyParameters.tsx

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
