### PR TITLE
feat(api, robot-server): add bool param type, add 'type' field to all param definitions

### DIFF
--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -927,6 +927,7 @@ class EnumParameter(RTPBase):
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
 
+
 RunTimeParameter = Union[NumberParameter, EnumParameter, BooleanParameter]
 
 RunTimeParamValuesType = Dict[

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -852,38 +852,48 @@ class RTPBase(BaseModel):
 
     displayName: str = Field(..., description="Display string for the parameter.")
     variableName: str = Field(..., description="Python variable name of the parameter.")
-    description: str = Field(..., description="Detailed description of the parameter.")
+    description: Optional[str] = Field(
+        None, description="Detailed description of the parameter."
+    )
     suffix: Optional[str] = Field(
         None,
         description="Units (like mL, mm/sec, etc) or a custom suffix for the parameter.",
     )
 
 
-class IntParameter(RTPBase):
+class NumberParameter(RTPBase):
     """An integer parameter defined in a protocol."""
 
-    min: int = Field(
-        ..., description="Minimum value that the integer param is allowed to have."
+    type: Literal["int", "float"] = Field(
+        ..., description="String specifying whether the number is an int or float type."
     )
-    max: int = Field(
-        ..., description="Maximum value that the integer param is allowed to have."
+    min: float = Field(
+        ..., description="Minimum value that the number param is allowed to have."
     )
-    default: int = Field(
+    max: float = Field(
+        ..., description="Maximum value that the number param is allowed to have."
+    )
+    value: float = Field(
+        ...,
+        description="The value assigned to the parameter; if not supplied by the client, will be assigned the default value.",
+    )
+    default: float = Field(
         ...,
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
 
 
-class FloatParameter(RTPBase):
-    """A float parameter defined in a protocol."""
+class BooleanParameter(RTPBase):
+    """A boolean parameter defined in a protocol."""
 
-    min: float = Field(
-        ..., description="Minimum value that the float param is allowed to have."
+    type: Literal["bool"] = Field(
+        default="bool", description="String specifying the type of this parameter"
     )
-    max: float = Field(
-        ..., description="Maximum value that the float param is allowed to have."
+    value: bool = Field(
+        ...,
+        description="The value assigned to the parameter; if not supplied by the client, will be assigned the default value.",
     )
-    default: float = Field(
+    default: bool = Field(
         ...,
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
@@ -893,22 +903,31 @@ class EnumChoice(BaseModel):
     """Components of choices used in RTP Enum Parameters."""
 
     displayName: str = Field(..., description="Display string for the param's choice.")
-    value: str = Field(..., description="Enum value of the param's choice.")
+    value: Union[float, str] = Field(
+        ..., description="Enum value of the param's choice."
+    )
 
 
 class EnumParameter(RTPBase):
     """A string enum defined in a protocol."""
 
+    type: Literal["int", "float", "str"] = Field(
+        ...,
+        description="String specifying whether the parameter is an int or float or string type.",
+    )
     choices: List[EnumChoice] = Field(
         ..., description="List of valid choices for this parameter."
     )
-    default: str = Field(
+    value: Union[float, str] = Field(
+        ...,
+        description="The value assigned to the parameter; if not supplied by the client, will be assigned the default value.",
+    )
+    default: Union[float, str] = Field(
         ...,
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
 
-
-RunTimeParameter = Union[IntParameter, FloatParameter, EnumParameter]
+RunTimeParameter = Union[NumberParameter, EnumParameter, BooleanParameter]
 
 RunTimeParamValuesType = Dict[
     str, Union[float, bool, str]

--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -1,7 +1,7 @@
 """Protocol file models."""
 from datetime import datetime
 from pydantic import BaseModel, Extra, Field
-from typing import Any, List, Optional, Dict, Union
+from typing import Any, List, Optional
 
 from opentrons.protocol_reader import (
     ProtocolType as ProtocolType,
@@ -109,6 +109,3 @@ class Protocol(ResourceModel):
             " See `POST /protocols`."
         ),
     )
-
-
-RunTimeParameterDict = Dict[str, Union[str, int, float, bool]]


### PR DESCRIPTION
Addresses AUTH-125

# Overview

Updates the shape of the parameter definition models in analysis & run responses according to the agreed upon structure in AUTH-125.

# Review requests

- make sure that the shape is agreeable to both the API & HTTP client interfaces.

# Risk assessment

None. Just data model changes