### PR TITLE
feat(app): sort robot lists alphabetically

### DIFF
--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -302,7 +302,7 @@ describe('discovery selectors', () => {
       name: 'getConnectableRobots grabs robots with connectable status',
       selector: discovery.getConnectableRobots,
       state: MOCK_STATE,
-      expected: [EXPECTED_FOO, EXPECTED_BAR, EXPECTED_FIZZBUZZ],
+      expected: [EXPECTED_BAR, EXPECTED_FIZZBUZZ, EXPECTED_FOO],
     },
     {
       name: 'getReachableRobots grabs robots with reachable status',
@@ -314,7 +314,7 @@ describe('discovery selectors', () => {
       name: 'getUnreachableRobots grabs robots with unreachable status',
       selector: discovery.getUnreachableRobots,
       state: MOCK_STATE,
-      expected: [EXPECTED_FIZZ, EXPECTED_BUZZ],
+      expected: [EXPECTED_BUZZ, EXPECTED_FIZZ],
     },
     {
       name: 'display name removes opentrons- from connectable robot names',
@@ -412,10 +412,10 @@ describe('discovery selectors', () => {
       selector: discovery.getViewableRobots,
       state: MOCK_STATE,
       expected: [
-        EXPECTED_FOO,
         EXPECTED_BAR,
-        EXPECTED_FIZZBUZZ,
         EXPECTED_BAZ,
+        EXPECTED_FIZZBUZZ,
+        EXPECTED_FOO,
         EXPECTED_QUX,
       ],
     },

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -3,6 +3,7 @@ import concat from 'lodash/concat'
 import head from 'lodash/head'
 import isEqual from 'lodash/isEqual'
 import find from 'lodash/find'
+import orderBy from 'lodash/orderBy'
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
 import semver from 'semver'
 
@@ -146,20 +147,36 @@ export const getDiscoveredRobots: (
     })
   }
 )
-
+// TOME: Just test this works on the slideouts, devices page, etc, and you're good to go! I think I'd rather just sort these compound selectors
+// since that's less TC intensive than sorting ALL the discovered robots each time.
 export const getConnectableRobots: GetConnectableRobots = createSelector(
   getDiscoveredRobots,
-  robots => robots.flatMap(r => (r.status === CONNECTABLE ? [r] : []))
+  robots =>
+    orderBy(
+      robots.flatMap(r => (r.status === CONNECTABLE ? [r] : [])),
+      [robot => robot.displayName.toLowerCase()],
+      ['asc']
+    )
 )
 
 export const getReachableRobots: GetReachableRobots = createSelector(
   getDiscoveredRobots,
-  robots => robots.flatMap(r => (r.status === REACHABLE ? [r] : []))
+  robots =>
+    orderBy(
+      robots.flatMap(r => (r.status === REACHABLE ? [r] : [])),
+      [robot => robot.displayName.toLowerCase()],
+      ['asc']
+    )
 )
 
 export const getUnreachableRobots: GetUnreachableRobots = createSelector(
   getDiscoveredRobots,
-  robots => robots.flatMap(r => (r.status === UNREACHABLE ? [r] : []))
+  robots =>
+    orderBy(
+      robots.flatMap(r => (r.status === UNREACHABLE ? [r] : [])),
+      [robot => robot.displayName.toLowerCase()],
+      ['asc']
+    )
 )
 
 export const getAllRobots: GetAllRobots = createSelector(
@@ -167,13 +184,22 @@ export const getAllRobots: GetAllRobots = createSelector(
   getReachableRobots,
   getUnreachableRobots,
   (cr: DiscoveredRobot[], rr: DiscoveredRobot[], ur: DiscoveredRobot[]) =>
-    concat<DiscoveredRobot>(cr, rr, ur)
+    orderBy(
+      concat<DiscoveredRobot>(cr, rr, ur),
+      [robot => robot.displayName.toLowerCase()],
+      ['asc']
+    )
 )
 
 export const getViewableRobots: GetViewableRobots = createSelector(
   getConnectableRobots,
   getReachableRobots,
-  (cr: ViewableRobot[], rr: ViewableRobot[]) => concat<ViewableRobot>(cr, rr)
+  (cr: ViewableRobot[], rr: ViewableRobot[]) =>
+    orderBy(
+      concat<ViewableRobot>(cr, rr),
+      [robot => robot.displayName.toLowerCase()],
+      ['asc']
+    )
 )
 
 export const getLocalRobot: GetLocalRobot = createSelector(

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -147,8 +147,7 @@ export const getDiscoveredRobots: (
     })
   }
 )
-// TOME: Just test this works on the slideouts, devices page, etc, and you're good to go! I think I'd rather just sort these compound selectors
-// since that's less TC intensive than sorting ALL the discovered robots each time.
+
 export const getConnectableRobots: GetConnectableRobots = createSelector(
   getDiscoveredRobots,
   robots =>


### PR DESCRIPTION
Closes [EXEC-350](https://opentrons.atlassian.net/browse/EXEC-350)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Back during a standup in January, appui agreed that there is no current logic when presenting lists of robots on the Devices tab, sending protocols slideouts, etc. Let's sort robots alphabetically. Doing this via selectors is best because:

1. Selectors are memoized.
2. Sorting already filtered lists of robots means we aren't computing this often.
3. Doing this on every slideout, page, etc. doesn't make much sense, since when we use these selectors, we are using them to display lists of robots.

<img width="1019" alt="Screenshot 2024-03-25 at 9 51 27 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/cbac7c31-f043-470e-b0f8-a64c34955020">

<img width="313" alt="Screenshot 2024-03-25 at 9 51 12 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/f34074c8-c7c9-425a-bac3-197dcc7932a8">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Open the app. Observe robots are sorted on the Devices page and robot slideouts. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Robots are sorted alphabetically on the Devices page and various slideouts. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->




<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-350]: https://opentrons.atlassian.net/browse/EXEC-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ