### PR TITLE
refactor(api): only ignore stalls for downward portion of force pickup routine

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2096,14 +2096,14 @@ class OT3API(
                 target = target_position_from_relative(
                     mount, top_types.Point(z=press.distance), self._current_position
                 )
-            if press.distance < 0:
-                # we expect a stall has happened during a downward movement into the tiprack, so
-                # we want to update the motor estimation
-                await self._move(target, speed=press.speed, expect_stalls=True)
-                await self._update_position_estimation([Axis.by_mount(mount)])
-            else:
-                # we should not ignore stalls that happen during the retract part of the routine
-                await self._move(target, speed=press.speed, expect_stalls=False)
+                if press.distance < 0:
+                    # we expect a stall has happened during a downward movement into the tiprack, so
+                    # we want to update the motor estimation
+                    await self._move(target, speed=press.speed, expect_stalls=True)
+                    await self._update_position_estimation([Axis.by_mount(mount)])
+                else:
+                    # we should not ignore stalls that happen during the retract part of the routine
+                    await self._move(target, speed=press.speed, expect_stalls=False)
 
     async def _tip_motor_action(
         self, mount: OT3Mount, pipette_spec: List[TipActionMoveSpec]

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2093,14 +2093,17 @@ class OT3API(
     ) -> None:
         for press in pipette_spec.tip_action_moves:
             async with self._backend.motor_current(run_currents=press.currents):
-                target_down = target_position_from_relative(
+                target = target_position_from_relative(
                     mount, top_types.Point(z=press.distance), self._current_position
                 )
-                await self._move(target_down, speed=press.speed, expect_stalls=True)
             if press.distance < 0:
                 # we expect a stall has happened during a downward movement into the tiprack, so
                 # we want to update the motor estimation
+                await self._move(target, speed=press.speed, expect_stalls=True)
                 await self._update_position_estimation([Axis.by_mount(mount)])
+            else:
+                # we should not ignore stalls that happen during the retract part of the routine
+                await self._move(target, speed=press.speed, expect_stalls=False)
 
     async def _tip_motor_action(
         self, mount: OT3Mount, pipette_spec: List[TipActionMoveSpec]


### PR DESCRIPTION
## Overview
During force tip-pickup, the z stage ignores stalls for all parts of the movement, including when it retracts back up towards the home position. This is believed to be the cause of some 'unknown position' problems popping in testing, so this changes the code to only ignore stalls during the parts of the routine that are actually pushing into the tiprack.

## Changelog
- make ignoring stalls during the pickup routine conditional on the direction of movement
- change the `target_down` variable to `target` for readability purposes