### PR TITLE
feat(api): add oem mode setting

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -233,6 +233,13 @@ settings = [
         robot_type=[RobotTypeEnum.FLEX],
         internal_only=True,
     ),
+    SettingDefinition(
+        _id="enableOEMMode",
+        title="Enable OEM Mode",
+        description="This setting anonymizes Opentrons branding in the ODD app.",
+        robot_type=[RobotTypeEnum.FLEX],
+        internal_only=True,
+    ),
 ]
 
 if (
@@ -691,6 +698,15 @@ def _migrate30to31(previous: SettingsMap) -> SettingsMap:
     newmap["enableErrorRecoveryExperiments"] = None
     return newmap
 
+def _migrate31to32(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 32 of the feature flags file.
+
+    - Adds the enableOEMMode config element.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["enableOEMMode"] = None
+    return newmap
+
 
 _MIGRATIONS = [
     _migrate0to1,
@@ -724,6 +740,7 @@ _MIGRATIONS = [
     _migrate28to29,
     _migrate29to30,
     _migrate30to31,
+    _migrate31to32,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -698,6 +698,7 @@ def _migrate30to31(previous: SettingsMap) -> SettingsMap:
     newmap["enableErrorRecoveryExperiments"] = None
     return newmap
 
+
 def _migrate31to32(previous: SettingsMap) -> SettingsMap:
     """Migrate to version 32 of the feature flags file.
 

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -8,7 +8,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 31
+    return 32
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -30,6 +30,7 @@ def default_file_settings() -> Dict[str, Any]:
         "disableOverpressureDetection": None,
         "estopNotRequired": None,
         "enableErrorRecoveryExperiments": None,
+        "enableOEMMode": None,
     }
 
 
@@ -378,6 +379,17 @@ def v31_config(v30_config: Dict[str, Any]) -> Dict[str, Any]:
     )
     return r
 
+@pytest.fixture
+def v32_config(v31_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v31_config.copy()
+    r.update(
+        {
+            "_version": 32,
+            "enableOEMMode": None,
+        }
+    )
+    return r
+
 
 @pytest.fixture(
     scope="session",
@@ -415,6 +427,7 @@ def v31_config(v30_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v29_config"),
         lazy_fixture("v30_config"),
         lazy_fixture("v31_config"),
+        lazy_fixture("v32_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:
@@ -507,4 +520,5 @@ def test_ensures_config() -> None:
         "estopNotRequired": None,
         "disableOverpressureDetection": None,
         "enableErrorRecoveryExperiments": None,
+        "enableOEMMode": None,
     }

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -379,6 +379,7 @@ def v31_config(v30_config: Dict[str, Any]) -> Dict[str, Any]:
     )
     return r
 
+
 @pytest.fixture
 def v32_config(v31_config: Dict[str, Any]) -> Dict[str, Any]:
     r = v31_config.copy()


### PR DESCRIPTION
# Overview

adds an enableOEMMode robot setting to track whether OEM mode is enabled for the ODD

closes PLAT-186

# Test Plan

updated feature flags migration test

# Changelog

 - Adds OEM mode setting

# Review requests

is this the right place for this?

# Risk assessment

low
