### PR TITLE
Revert "refactor(modules): return has update for unexpected module fw filename"

### DIFF
--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -4,7 +4,7 @@ import logging
 import re
 from pkg_resources import parse_version
 from typing import ClassVar, Mapping, Optional, cast, TypeVar
-from packaging.version import InvalidVersion
+
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
 
@@ -88,15 +88,8 @@ class AbstractModule(abc.ABC):
     def has_available_update(self) -> bool:
         """Return whether a newer firmware file is available"""
         if self.device_info and self._bundled_fw:
-            # try catch this
-            try:
-                device_version = parse_version(self.device_info["version"])
-            except InvalidVersion:
-                device_version = parse_version("v0.0.0")
-            try:
-                available_version = parse_version(self._bundled_fw.version)
-            except InvalidVersion:
-                available_version = parse_version("v0.0.0")
+            device_version = parse_version(self.device_info["version"])
+            available_version = parse_version(self._bundled_fw.version)
             return cast(bool, available_version > device_version)
         return False
 


### PR DESCRIPTION
Reverts Opentrons/opentrons#14712

Testing on newest edge, I don't think the code after the try-catch is getting executed, and not all modules are showing up.