### PR TITLE
fix(modules): use parse from packaging module

### DIFF
--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -91,6 +91,8 @@ class AbstractModule(abc.ABC):
             device_version = parse_version(self.device_info["version"])
             available_version = parse_version(self._bundled_fw.version)
             return cast(bool, available_version > device_version)
+        elif self.device_info and not self._bundled_fw:
+            return True
         return False
 
     async def wait_for_is_running(self) -> None:

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -76,7 +76,7 @@ class AbstractModule(abc.ABC):
             return None
         file_prefix = self.firmware_prefix()
 
-        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin).*$")
+        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin)$")
         for fw_resource in ROBOT_FIRMWARE_DIR.iterdir():  # type: ignore
             matches = MODULE_FW_RE.search(fw_resource.name)
             if matches:

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -2,9 +2,8 @@ import abc
 import asyncio
 import logging
 import re
-from pkg_resources import parse_version
-from typing import ClassVar, Mapping, Optional, cast, TypeVar
-
+from typing import ClassVar, Mapping, Optional, TypeVar
+from packaging.version import InvalidVersion, parse
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
 

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -76,7 +76,7 @@ class AbstractModule(abc.ABC):
             return None
         file_prefix = self.firmware_prefix()
 
-        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin)$")
+        MODULE_FW_RE = re.compile(f"^{file_prefix}@v(.*)[.](hex|bin).*$")
         for fw_resource in ROBOT_FIRMWARE_DIR.iterdir():  # type: ignore
             matches = MODULE_FW_RE.search(fw_resource.name)
             if matches:
@@ -91,8 +91,6 @@ class AbstractModule(abc.ABC):
             device_version = parse_version(self.device_info["version"])
             available_version = parse_version(self._bundled_fw.version)
             return cast(bool, available_version > device_version)
-        elif self.device_info and not self._bundled_fw:
-            return True
         return False
 
     async def wait_for_is_running(self) -> None:

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -3,6 +3,7 @@ import pytest
 
 from pathlib import Path
 from unittest import mock
+from packaging.version import Version
 
 from opentrons.hardware_control import ExecutionManager
 from opentrons.hardware_control.modules import ModuleAtPort
@@ -22,6 +23,7 @@ from opentrons.hardware_control.modules import (
     HeaterShaker,
     AbstractModule,
 )
+from opentrons.hardware_control.modules.mod_abc import parse_fw_version
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 
@@ -422,3 +424,20 @@ def test_magnetic_module_revision_parsing(revision, model):
 )
 def test_temperature_module_revision_parsing(revision, model):
     assert TempDeck._model_from_revision(revision) == model
+
+
+@pytest.mark.parametrize(
+    argnames=["device_version", "expected_result"],
+    argvalues=[
+        ["v1.0.4", Version("v1.0.4")],
+        ["v0.5.6", Version("v0.5.6")],
+        ["v1.0.4-dhfs", Version("v0.0.0")],
+        ["v3.0.dshjfd", Version("v0.0.0")],
+    ],
+)
+async def test_catch_invalid_fw_version(
+    device_version: str,
+    expected_result: bool,
+) -> None:
+    """Assert that invalid firmware versions prompt a valid Version object of v0.0.0."""
+    assert parse_fw_version(device_version) == expected_result

--- a/robot-server/tests/modules/test_router.py
+++ b/robot-server/tests/modules/test_router.py
@@ -3,7 +3,6 @@ import inspect
 import pytest
 from decoy import Decoy
 from typing_extensions import Final
-from packaging.version import Version
 
 from opentrons.calibration_storage.ot3.models.v1 import CalibrationStatus
 from opentrons.calibration_storage.types import SourceType
@@ -74,24 +73,6 @@ async def test_get_modules_empty(
 
     assert result.content.data == []
     assert result.status_code == 200
-
-
-@pytest.mark.parametrize(
-    argnames=["device_version", "expected_result"],
-    argvalues=[
-        ["v1.0.4", Version("v1.0.4")],
-        ["v0.5.6", Version("v0.5.6")],
-        ["v1.0.4-dhfs", Version("v0.0.0")],
-        ["v3.0.dshjfd", Version("v0.0.0")],
-    ],
-)
-async def test_catch_invalid_fw_version(
-    decoy: Decoy,
-    device_version: str,
-    expected_result: bool,
-) -> None:
-    """Assert that invalid firmware versions prompt a valid Version object of v0.0.0."""
-    assert parse_fw_version(device_version) == expected_result
 
 
 async def test_get_modules_maps_data_and_id(

--- a/robot-server/tests/modules/test_router.py
+++ b/robot-server/tests/modules/test_router.py
@@ -8,12 +8,8 @@ from opentrons.calibration_storage.ot3.models.v1 import CalibrationStatus
 from opentrons.calibration_storage.types import SourceType
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.drivers.rpi_drivers.types import USBPort as HardwareUSBPort, PortGroup
-from opentrons.hardware_control.modules import (
-    MagDeck,
-    ModuleType,
-    MagneticStatus,
-    module_calibration,
-)
+from opentrons.hardware_control.modules import MagDeck, ModuleType, MagneticStatus
+from opentrons.hardware_control.modules import module_calibration
 
 from opentrons.types import Point
 from opentrons.protocol_engine import ModuleModel
@@ -28,6 +24,7 @@ from robot_server.modules.module_models import (
     ModuleCalibrationData,
     UsbPort,
 )
+
 
 _HTTP_API_VERSION: Final = 3
 

--- a/robot-server/tests/modules/test_router.py
+++ b/robot-server/tests/modules/test_router.py
@@ -14,7 +14,6 @@ from opentrons.hardware_control.modules import (
     MagneticStatus,
     module_calibration,
 )
-from opentrons.hardware_control.modules.mod_abc import parse_fw_version
 
 from opentrons.types import Point
 from opentrons.protocol_engine import ModuleModel

--- a/robot-server/tests/modules/test_router.py
+++ b/robot-server/tests/modules/test_router.py
@@ -3,13 +3,19 @@ import inspect
 import pytest
 from decoy import Decoy
 from typing_extensions import Final
+from packaging.version import Version
 
 from opentrons.calibration_storage.ot3.models.v1 import CalibrationStatus
 from opentrons.calibration_storage.types import SourceType
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.drivers.rpi_drivers.types import USBPort as HardwareUSBPort, PortGroup
-from opentrons.hardware_control.modules import MagDeck, ModuleType, MagneticStatus
-from opentrons.hardware_control.modules import module_calibration
+from opentrons.hardware_control.modules import (
+    MagDeck,
+    ModuleType,
+    MagneticStatus,
+    module_calibration,
+)
+from opentrons.hardware_control.modules.mod_abc import parse_fw_version
 
 from opentrons.types import Point
 from opentrons.protocol_engine import ModuleModel
@@ -24,7 +30,6 @@ from robot_server.modules.module_models import (
     ModuleCalibrationData,
     UsbPort,
 )
-
 
 _HTTP_API_VERSION: Final = 3
 
@@ -69,6 +74,24 @@ async def test_get_modules_empty(
 
     assert result.content.data == []
     assert result.status_code == 200
+
+
+@pytest.mark.parametrize(
+    argnames=["device_version", "expected_result"],
+    argvalues=[
+        ["v1.0.4", Version("v1.0.4")],
+        ["v0.5.6", Version("v0.5.6")],
+        ["v1.0.4-dhfs", Version("v0.0.0")],
+        ["v3.0.dshjfd", Version("v0.0.0")],
+    ],
+)
+async def test_catch_invalid_fw_version(
+    decoy: Decoy,
+    device_version: str,
+    expected_result: bool,
+) -> None:
+    """Assert that invalid firmware versions prompt a valid Version object of v0.0.0."""
+    assert parse_fw_version(device_version) == expected_result
 
 
 async def test_get_modules_maps_data_and_id(


### PR DESCRIPTION
Fix for https://github.com/Opentrons/opentrons/pull/14712.

We were using parse_version from `pkg_resources,` which can raise an `InvalidVersionError`, and importing `InvalidVersionError` from a separate packaging module. This imports the `parse` function from the same module the error would be raised from.