### PR TITLE
feat(app): add tooltips to ChooseRobotToRunProtocolSlideout RTPs, update types

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -66,6 +66,7 @@
   "robot_is_busy": "{{robotName}} is busy",
   "robot": "robot",
   "run_protocol": "Run protocol",
+  "select_parameters_for_robot": "Select parameters for {{robot_name}}",
   "send": "Send",
   "sending": "Sending",
   "show_in_folder": "Show in folder",

--- a/app/src/atoms/InputField/index.tsx
+++ b/app/src/atoms/InputField/index.tsx
@@ -8,12 +8,15 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   Flex,
+  Icon,
   RESPONSIVENESS,
   SPACING,
   StyledText,
   TEXT_ALIGN_RIGHT,
   TYPOGRAPHY,
+  useHoverTooltip,
 } from '@opentrons/components'
+import { Tooltip } from '../Tooltip'
 
 export const INPUT_TYPE_NUMBER = 'number' as const
 export const INPUT_TYPE_TEXT = 'text' as const
@@ -38,6 +41,8 @@ export interface InputFieldProps {
   error?: string | null
   /** optional title */
   title?: string | null
+  /** optional text for tooltip */
+  tooltipText?: string
   /** optional caption. hidden when `error` is given */
   caption?: string | null
   /** appears to the right of the caption. Used for character limits, eg '0/45' */
@@ -93,11 +98,13 @@ function Input(props: InputFieldProps): JSX.Element {
     textAlign = TYPOGRAPHY.textAlignLeft,
     size = 'small',
     title,
+    tooltipText,
     ...inputProps
   } = props
   const error = props.error != null
   const value = props.isIndeterminate ?? false ? '' : props.value ?? ''
   const placeHolder = props.isIndeterminate ?? false ? '-' : props.placeholder
+  const [targetProps, tooltipProps] = useHoverTooltip()
 
   const OUTER_CSS = css`
     @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
@@ -230,9 +237,23 @@ function Input(props: InputFieldProps): JSX.Element {
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} width="100%">
-      {props.title != null ? (
-        <Flex as="label" htmlFor={inputProps.id} css={TITLE_STYLE}>
-          {props.title}
+      {title != null ? (
+        <Flex gridGap={SPACING.spacing8}>
+          <Flex as="label" htmlFor={props.id} css={TITLE_STYLE}>
+            {title}
+          </Flex>
+          {tooltipText != null ? (
+            <>
+              <Flex {...targetProps}>
+                <Icon
+                  name="information"
+                  size={SPACING.spacing12}
+                  color={COLORS.grey60}
+                />
+              </Flex>
+              <Tooltip tooltipProps={tooltipProps}>{tooltipText}</Tooltip>
+            </>
+          ) : null}
         </Flex>
       ) : null}
       <Flex width="100%" flexDirection={DIRECTION_COLUMN} css={OUTER_CSS}>

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -211,7 +211,7 @@ describe('ChooseRobotSlideout', () => {
     screen.getByText('Step 2 / 2')
   })
 
-  mockRunTimeParameters.forEach((param, index) => {
+  mockRunTimeParameters.forEach(param => {
     it('renders runtime parameter with title and caption', () => {
       render({
         onCloseClick: vi.fn(),
@@ -226,7 +226,11 @@ describe('ChooseRobotSlideout', () => {
       })
 
       screen.getByText(param.displayName)
-      screen.getByText(param.description)
+      if (param.type === 'boolean' || 'choices' in param) {
+        screen.getByText(param.description)
+      } else {
+        screen.getByText(`${param.min}-${param.max}`)
+      }
     })
   })
 

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -378,7 +378,8 @@ export function ChooseRobotSlideout(
             placeholder={value.toString()}
             value={value}
             title={runtimeParam.displayName}
-            caption={runtimeParam.description}
+            tooltipText={runtimeParam.description}
+            caption={`${runtimeParam.min}-${runtimeParam.max}`}
             id={id}
             onChange={e => {
               const clone = runTimeParametersOverrides.map((parameter, i) => {
@@ -523,10 +524,10 @@ const ENABLED_LINK_CSS = css`
 
 const DISABLED_LINK_CSS = css`
   ${TYPOGRAPHY.linkPSemiBold}
-  color: ${COLORS.grey50};
+  color: ${COLORS.grey40};
   cursor: default;
 
   &:hover {
-    color: ${COLORS.grey50};
+    color: ${COLORS.grey40};
   }
 `

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -242,19 +242,6 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
               protocol_name: protocolDisplayName,
             })
       }
-      // title={
-      //   enableRunTimeParametersFF && runTimeParameters.length > 0
-      //     ? currentPage === 1
-      //       ? t('choose_robot_to_run', {
-      //           protocol_name: protocolDisplayName,
-      //         })
-      //       : t('select_parameters_for_robot', {
-      //           robot_name: selectedRobot?.name,
-      //         })
-      //     : t('choose_robot_to_run', {
-      //         protocol_name: protocolDisplayName,
-      //       })
-      // }
       runTimeParametersOverrides={runTimeParametersOverrides}
       setRunTimeParametersOverrides={setRunTimeParametersOverrides}
       footer={

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -63,7 +63,6 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   )
 
   // TODO: (nd: 3/20/24) remove stubs and pull parameters from analysis
-
   const mockRunTimeParameters: RunTimeParameter[] = [
     {
       displayName: 'Dry Run',
@@ -117,10 +116,11 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       default: 'none',
     },
   ]
+  const runTimeParameters: RunTimeParameter[] = mockRunTimeParameters
   const [
     runTimeParametersOverrides,
     setRunTimeParametersOverrides,
-  ] = React.useState<RunTimeParameter[]>(mockRunTimeParameters)
+  ] = React.useState<RunTimeParameter[]>(runTimeParameters)
 
   const offsetCandidates = useOffsetCandidatesForAnalysis(
     mostRecentAnalysis,
@@ -231,14 +231,35 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
         isSelectedRobotOnDifferentSoftwareVersion
       }
       onCloseClick={onCloseClick}
-      title={t('choose_robot_to_run', {
-        protocol_name: protocolDisplayName,
-      })}
+      title={
+        enableRunTimeParametersFF &&
+        runTimeParameters.length > 0 &&
+        currentPage === 2
+          ? t('select_parameters_for_robot', {
+              robot_name: selectedRobot?.name,
+            })
+          : t('choose_robot_to_run', {
+              protocol_name: protocolDisplayName,
+            })
+      }
+      // title={
+      //   enableRunTimeParametersFF && runTimeParameters.length > 0
+      //     ? currentPage === 1
+      //       ? t('choose_robot_to_run', {
+      //           protocol_name: protocolDisplayName,
+      //         })
+      //       : t('select_parameters_for_robot', {
+      //           robot_name: selectedRobot?.name,
+      //         })
+      //     : t('choose_robot_to_run', {
+      //         protocol_name: protocolDisplayName,
+      //       })
+      // }
       runTimeParametersOverrides={runTimeParametersOverrides}
       setRunTimeParametersOverrides={setRunTimeParametersOverrides}
       footer={
         <Flex flexDirection={DIRECTION_COLUMN}>
-          {enableRunTimeParametersFF ? (
+          {enableRunTimeParametersFF && runTimeParameters.length > 0 ? (
             currentPage === 1 ? (
               <>
                 <ApplyHistoricOffsets

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -590,7 +590,8 @@ export interface AnalysisError {
   createdAt: string
 }
 
-interface IntParameter {
+export interface NumberParameter {
+  type: NumberParameterType
   min: number
   max: number
   default: number
@@ -602,22 +603,29 @@ interface Choice {
 }
 
 interface ChoiceParameter {
+  type: RunTimeParameterType
   choices: Choice[]
   default: string
 }
 
 interface BooleanParameter {
+  type: BooleanParameterType
   default: boolean
 }
 
-type RunTimeParameterType = 'int' | 'float' | 'str' | 'boolean'
+type NumberParameterType = 'int' | 'float'
+type BooleanParameterType = 'boolean'
+type StringParameterType = 'str'
+type RunTimeParameterType =
+  | NumberParameter
+  | BooleanParameterType
+  | StringParameterType
 
-type ParameterType = IntParameter | ChoiceParameter | BooleanParameter
+type ParameterType = NumberParameter | ChoiceParameter | BooleanParameter
 interface BaseRunTimeParameter {
   displayName: string
   variableName: string
   description: string
-  type: RunTimeParameterType
   value: unknown
   suffix?: string
 }

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -599,13 +599,13 @@ export interface NumberParameter {
 
 interface Choice {
   displayName: string
-  value: unknown
+  value: RunTimeParameterType
 }
 
 interface ChoiceParameter {
   type: RunTimeParameterType
   choices: Choice[]
-  default: string
+  default: RunTimeParameterType
 }
 
 interface BooleanParameter {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -599,13 +599,13 @@ export interface NumberParameter {
 
 interface Choice {
   displayName: string
-  value: RunTimeParameterType
+  value: number | boolean | string
 }
 
 interface ChoiceParameter {
   type: RunTimeParameterType
   choices: Choice[]
-  default: RunTimeParameterType
+  default: number | boolean | string
 }
 
 interface BooleanParameter {
@@ -626,7 +626,7 @@ interface BaseRunTimeParameter {
   displayName: string
   variableName: string
   description: string
-  value: unknown
+  value: number | boolean | string
   suffix?: string
 }
 


### PR DESCRIPTION
closes [AUTH-100](https://opentrons.atlassian.net/browse/AUTH-100)

# Overview

According to designs, number type RTPs should display their respective numerical ranges as InputField captions. The optional RTP description should be displayed in a tooltip when an information icon is hovered next to the RTP title. As part of the scope of this change, I also refactor the runtime parameter types so that the type of the RTP (numerical vs choice vs boolean) will narrow to the appropriate properties of that specific RTP when mapping.

# Test Plan

- Select any protocol from Desktop (mock data is still used for now)
- Select `Start setup`
- Choose any robot and select `Continue to parameters`
- Observe style of numerical RTPs with hoverable information icon
- Select `Change robot`
- Verify that slideout moves back to robot select

<img width="306" alt="Screenshot 2024-03-27 at 9 39 21 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/ba262762-ba7e-4784-a9db-8762d52b0163">

# Changelog


# Risk assessment

low

[AUTH-100]: https://opentrons.atlassian.net/browse/AUTH-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ