### PR TITLE
chore(monorepo): remove old squad code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,18 +8,6 @@
 *.d.ts @Opentrons/js
 /webpack-config @Opentrons/js
 
-# subprojects - those with clear team ownership should have appropriate notifications
-/protocol-designer @Opentrons/app-and-uis
-/labware-designer @Opentrons/app-and-uis
-/labware-library @Opentrons/app-and-uis
-/update-server @Opentrons/robot-svcs
-/discovery-client @Opentrons/robot-svcs @Opentrons/app-and-uis
-/shared-data/pipette @Opentrons/embedded-sw
-/shared-data/protocol @Opentrons/robot-svcs @Opentrons/app-and-uis
-/shared-data/module @Opentrons/embedded-sw
-/shared-data/deck @Opentrons/embedded-sw
-/shared-data/labware @Opentrons/embedded-sw
-
 # subprojects by language - some subprojects are shared by teams but united by a
 # language community (including makefiles and config) so mark them appropriately
 /app @Opentrons/js


### PR DESCRIPTION
# Overview

This PR removes app ui, rss, and embedded as code owners to specific packages in the monorepo. Each new team (platform expansion, execution and authorship) can configure their own auto review settings through their github team settings.

# Risk assessment

Low