### PR TITLE
feat(hardware): add new hepa fan rpm field to HepaFanStateResponse

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -665,7 +665,7 @@ class GetHepaFanStatePayloadResponse(EmptyPayload):
 
     duty_cycle: utils.UInt32Field
     fan_on: utils.UInt8Field
-    fan_rpm: utils.UInt32Field
+    fan_rpm: utils.UInt16Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -665,6 +665,7 @@ class GetHepaFanStatePayloadResponse(EmptyPayload):
 
     duty_cycle: utils.UInt32Field
     fan_on: utils.UInt8Field
+    fan_rpm: utils.UInt32Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
@@ -35,6 +35,7 @@ class HepaFanState:
 
     fan_on: bool
     duty_cycle: int
+    fan_rpm: int
 
 
 @dataclass(frozen=True)
@@ -80,6 +81,7 @@ async def get_hepa_fan_state(can_messenger: CanMessenger) -> Optional[HepaFanSta
             fan_state = HepaFanState(
                 fan_on=bool(message.payload.fan_on.value),
                 duty_cycle=int(message.payload.duty_cycle.value),
+                fan_rpm=int(message.payload.fan_rpm.value),
             )
 
     def _filter(arb_id: ArbitrationId) -> bool:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
@@ -45,7 +45,7 @@ def create_hepa_fan_state_response(
         payload=GetHepaFanStatePayloadResponse(
             fan_on=UInt8Field(fan_on),
             duty_cycle=UInt32Field(duty_cycle),
-            fan_rpm=UInt32Field(fan_rpm),
+            fan_rpm=UInt16Field(fan_rpm),
         )
     )
 
@@ -114,10 +114,11 @@ async def test_set_hepa_uv_state(
 @pytest.mark.parametrize(
     "response",
     [
-        (NodeId.host, create_hepa_fan_state_response(True, 75, 4500), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(True, 50, 4540), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(True, 75, 6790), NodeId.hepa_uv),
         (NodeId.host, create_hepa_fan_state_response(True, 0, 0), NodeId.hepa_uv),
         (NodeId.host, create_hepa_fan_state_response(False, 75, 0), NodeId.hepa_uv),
-        (NodeId.host, create_hepa_fan_state_response(False, 100, 4800), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(False, 100, 0), NodeId.hepa_uv),
     ],
 )
 async def test_get_hepa_fan_state(
@@ -150,6 +151,7 @@ async def test_get_hepa_fan_state(
         HepaFanState(
             bool(payload.fan_on.value),
             int(payload.duty_cycle.value),
+            int(payload.fan_rpm.value),
         )
         == res
     )

--- a/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
@@ -37,12 +37,15 @@ def mock_can_messenger() -> AsyncMock:
     return AsyncMock()
 
 
-def create_hepa_fan_state_response(fan_on: bool, duty_cycle: int) -> MessageDefinition:
+def create_hepa_fan_state_response(
+    fan_on: bool, duty_cycle: int, fan_rpm: int
+) -> MessageDefinition:
     """Create a GetHepaFanStateResponse."""
     return md.GetHepaFanStateResponse(
         payload=GetHepaFanStatePayloadResponse(
             fan_on=UInt8Field(fan_on),
             duty_cycle=UInt32Field(duty_cycle),
+            fan_rpm=UInt32Field(fan_rpm),
         )
     )
 
@@ -111,10 +114,10 @@ async def test_set_hepa_uv_state(
 @pytest.mark.parametrize(
     "response",
     [
-        (NodeId.host, create_hepa_fan_state_response(True, 75), NodeId.hepa_uv),
-        (NodeId.host, create_hepa_fan_state_response(True, 0), NodeId.hepa_uv),
-        (NodeId.host, create_hepa_fan_state_response(False, 75), NodeId.hepa_uv),
-        (NodeId.host, create_hepa_fan_state_response(False, 100), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(True, 75, 4500), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(True, 0, 0), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(False, 75, 0), NodeId.hepa_uv),
+        (NodeId.host, create_hepa_fan_state_response(False, 100, 4800), NodeId.hepa_uv),
     ],
 )
 async def test_get_hepa_fan_state(


### PR DESCRIPTION
# Overview

We need to parse the new fan_rpm value that the Hepa/UV sends in this [Opentrons/ot3-firmware#764](https://github.com/Opentrons/ot3-firmware/pull/764) pull request.

Closes: [PLAT-17](https://opentrons.atlassian.net/browse/PLAT-17)

# Test Plan

- [x] Make sure that the new firmware sends the correct rpm when the fan is on/off

# Changelog

- Add a new fan_rpm field to the HepaFanStateResponse CAN message

# Review requests

# Risk assessment

Low, unreleased

[PLAT-17]: https://opentrons.atlassian.net/browse/PLAT-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ