### PR TITLE
feat(app): range error handling for number RTPs

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -80,6 +80,7 @@
   "unavailable_robot_not_listed_plural": "{{count}} unavailable robots are not listed.",
   "unavailable_robot_not_listed": "{{count}} unavailable robot is not listed.",
   "unsuccessfully_sent": "Unsuccessfully sent",
+  "value_out_of_range": "Value must be between {{min}}-{{max}}",
   "view_run_details": "View run details",
   "view_unavailable_robots": "View unavailable robots on the Devices page"
 }

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -22,7 +22,7 @@ import { useFeatureFlag } from '../../../redux/config'
 import { getNetworkInterfaces } from '../../../redux/networking'
 import { ChooseRobotSlideout } from '..'
 import { useNotifyService } from '../../../resources/useNotifyService'
-import { RunTimeParameter } from '@opentrons/shared-data'
+import { OT2_ROBOT_TYPE, RunTimeParameter } from '@opentrons/shared-data'
 
 vi.mock('../../../redux/discovery')
 vi.mock('../../../redux/robot-update')
@@ -121,7 +121,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: vi.fn(),
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
     })
     screen.getByText('choose robot slideout title')
   })
@@ -134,7 +134,7 @@ describe('ChooseRobotSlideout', () => {
       setSelectedRobot: vi.fn(),
       title: 'choose robot slideout title',
       isAnalysisError: true,
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
     })
     screen.getByText(
       'This protocol failed in-app analysis. It may be unusable on robots without custom software configurations.'
@@ -148,7 +148,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: vi.fn(),
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
     })
     screen.getByText('opentrons-robot-name')
     screen.getByText('2 unavailable robots are not listed.')
@@ -162,7 +162,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: vi.fn(),
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
     })
     screen.getByText('opentrons-robot-name')
     expect(
@@ -177,7 +177,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
     })[1]
     const refreshButton = screen.getByRole('button', { name: 'refresh' })
     fireEvent.click(refreshButton)
@@ -192,7 +192,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
       multiSlideout: { currentPage: 1 },
     })
     screen.getByText('Step 1 / 2')
@@ -205,7 +205,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
       multiSlideout: { currentPage: 2 },
     })
     screen.getByText('Step 2 / 2')
@@ -220,7 +220,7 @@ describe('ChooseRobotSlideout', () => {
         selectedRobot: null,
         setSelectedRobot: mockSetSelectedRobot,
         title: 'choose robot slideout title',
-        robotType: 'OT-2 Standard',
+        robotType: OT2_ROBOT_TYPE,
         multiSlideout: { currentPage: 2 },
         runTimeParametersOverrides: [param],
       })
@@ -242,7 +242,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
       multiSlideout: { currentPage: 2 },
       runTimeParametersOverrides: [
         {
@@ -254,7 +254,7 @@ describe('ChooseRobotSlideout', () => {
           suffix: 'mL',
           min: 1.5,
           max: 10.0,
-          default: 1000,
+          default: 6.5,
         },
       ],
     })
@@ -273,7 +273,7 @@ describe('ChooseRobotSlideout', () => {
       selectedRobot: null,
       setSelectedRobot: mockSetSelectedRobot,
       title: 'choose robot slideout title',
-      robotType: 'OT-2 Standard',
+      robotType: OT2_ROBOT_TYPE,
     })
     expect(mockSetSelectedRobot).toBeCalledWith({
       ...mockConnectableRobot,

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -229,7 +229,11 @@ describe('ChooseRobotSlideout', () => {
       if (param.type === 'boolean' || 'choices' in param) {
         screen.getByText(param.description)
       } else {
-        screen.getByText(`${param.min}-${param.max}`)
+        if (param.type === 'int') {
+          screen.getByText(`${param.min}-${param.max}`)
+        } else {
+          screen.getByText(`${param.min.toFixed(1)}-${param.max.toFixed(1)}`)
+        }
       }
     })
   })
@@ -258,7 +262,7 @@ describe('ChooseRobotSlideout', () => {
         },
       ],
     })
-    screen.getByText('Value must be between 1.5-10')
+    screen.getByText('Value must be between 1.5-10.0')
   })
 
   it('defaults to first available robot and allows an available robot to be selected', () => {

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -234,6 +234,33 @@ describe('ChooseRobotSlideout', () => {
     })
   })
 
+  it('renders error message for runtime parameter out of range', () => {
+    render({
+      onCloseClick: vi.fn(),
+      isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
+      selectedRobot: null,
+      setSelectedRobot: mockSetSelectedRobot,
+      title: 'choose robot slideout title',
+      robotType: 'OT-2 Standard',
+      multiSlideout: { currentPage: 2 },
+      runTimeParametersOverrides: [
+        {
+          value: 1000,
+          displayName: 'EtoH Volume',
+          variableName: 'ETOH_VOLUME',
+          description: '70% ethanol volume',
+          type: 'float',
+          suffix: 'mL',
+          min: 1.5,
+          max: 10.0,
+          default: 1000,
+        },
+      ],
+    })
+    screen.getByText('Value must be between 1.5-10')
+  })
+
   it('defaults to first available robot and allows an available robot to be selected', () => {
     vi.mocked(getConnectableRobots).mockReturnValue([
       { ...mockConnectableRobot, name: 'otherRobot', ip: 'otherIp' },

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -381,6 +381,13 @@ export function ChooseRobotSlideout(
             tooltipText={runtimeParam.description}
             caption={`${runtimeParam.min}-${runtimeParam.max}`}
             id={id}
+            error={
+              Number.isNaN(value) ||
+              value < runtimeParam.min ||
+              value > runtimeParam.max
+                ? `Value must be between ${runtimeParam.min}-${runtimeParam.max}`
+                : null
+            }
             onChange={e => {
               const clone = runTimeParametersOverrides.map((parameter, i) => {
                 if (i === index) {

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -385,7 +385,10 @@ export function ChooseRobotSlideout(
               Number.isNaN(value) ||
               value < runtimeParam.min ||
               value > runtimeParam.max
-                ? `Value must be between ${runtimeParam.min}-${runtimeParam.max}`
+                ? t(`value_out_of_range`, {
+                    min: runtimeParam.min,
+                    max: runtimeParam.max,
+                  })
                 : null
             }
             onChange={e => {

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -379,15 +379,27 @@ export function ChooseRobotSlideout(
             value={value}
             title={runtimeParam.displayName}
             tooltipText={runtimeParam.description}
-            caption={`${runtimeParam.min}-${runtimeParam.max}`}
+            caption={
+              runtimeParam.type === 'int'
+                ? `${runtimeParam.min}-${runtimeParam.max}`
+                : `${runtimeParam.min.toFixed(1)}-${runtimeParam.max.toFixed(
+                    1
+                  )}`
+            }
             id={id}
             error={
               Number.isNaN(value) ||
               value < runtimeParam.min ||
               value > runtimeParam.max
                 ? t(`value_out_of_range`, {
-                    min: runtimeParam.min,
-                    max: runtimeParam.max,
+                    min:
+                      runtimeParam.type === 'int'
+                        ? runtimeParam.min
+                        : runtimeParam.min.toFixed(1),
+                    max:
+                      runtimeParam.type === 'int'
+                        ? runtimeParam.max
+                        : runtimeParam.max.toFixed(1),
                   })
                 : null
             }


### PR DESCRIPTION
closes [AUTH-104](https://opentrons.atlassian.net/browse/AUTH-104)

# Overview

To build initial error handling for desktop RTP, I add a range check to ensure that the input value for a given int/float type RTP falls within the user-defined range for that RTP.

# Test Plan

- from protocol card/protocol details page, begin protocol setup
- select a robot and proceed to parameters form
- for number-type RTPs, enter an invalid value (falling outside of the defined min-max range for that parameter)
- observe error message
<img width="334" alt="Screenshot 2024-04-01 at 2 19 36 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/e74d498b-b907-430f-b532-a8a469faf8c1">



- for number-type RTPs, delete input field content such that value is `NaN`
- observe error message
<img width="307" alt="Screenshot 2024-04-01 at 12 06 34 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/15d26e8a-5c92-4733-a660-ea755833207c">

# Changelog

- add basic error handling on change to mapped RTP in `ChooseRobotSlideout`
- add tests

# Review requests

authorship devs

# Risk assessment

low

[AUTH-104]: https://opentrons.atlassian.net/browse/AUTH-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ