### PR TITLE
fix(api): set instrument cal tolerance to 4mm

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/instrument_calibration.py
@@ -21,7 +21,7 @@ from opentrons.calibration_storage import (
 )
 from opentrons.hardware_control.types import OT3Mount
 
-PIPETTE_OFFSET_CONSISTENCY_LIMIT: Final = 1.5
+PIPETTE_OFFSET_CONSISTENCY_LIMIT: Final = 4.0
 
 # These type aliases aid typechecking in tests that work the same on this and
 # the hardware_control.instruments.ot2 variant

--- a/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
@@ -134,9 +134,9 @@ def test_load_tip_length(
         (top_types.Point(0, 1.0, 1.5), top_types.Point(-1, 0, 0.2), True),
         # If both points are non-zero but at least one element is more than
         # the range different the test should fail
-        (top_types.Point(0.1, -1, 1.5), top_types.Point(1.7, 0, 0.2), False),
-        (top_types.Point(0.1, -1, 1.5), top_types.Point(0.6, 0.6, 1.3), False),
-        (top_types.Point(0.1, -1, 1.5), top_types.Point(-0.2, -0.1, 5), False),
+        (top_types.Point(0.1, -1, 4.3), top_types.Point(1.7, 0, 0.2), False),
+        (top_types.Point(0.1, -3.2, 1.5), top_types.Point(0.6, 0.9, 1.3), False),
+        (top_types.Point(0.1, -1, 1.5), top_types.Point(-0.2, -0.1, 6), False),
     ],
 )
 def test_instrument_consistency_check_ot3(
@@ -151,4 +151,4 @@ def test_instrument_consistency_check_ot3(
             top_types.Mount.LEFT: left,
             top_types.Mount.RIGHT: right,
         }
-        assert result[0].limit == 1.5
+        assert result[0].limit == 4.0


### PR DESCRIPTION
This limit for the pipette offset consistency warning aligns better with the physical tolerance stackup of our pipettes and mounts.

Closes EXEC-362
