### PR TITLE
fix(robot-server): Update status bar to account for `awaiting-recovery` run state

### DIFF
--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -32,22 +32,21 @@ def _engine_status_to_status_bar(
     initialization_done: bool,
 ) -> StatusBarState:
     """Convert an engine status into a status bar status."""
-    if status is None:
-        return StatusBarState.IDLE if initialization_done else StatusBarState.OFF
-
-    return {
-        EngineStatus.IDLE: StatusBarState.IDLE
-        if initialization_done
-        else StatusBarState.OFF,
-        EngineStatus.RUNNING: StatusBarState.RUNNING,
-        EngineStatus.PAUSED: StatusBarState.PAUSED,
-        EngineStatus.BLOCKED_BY_OPEN_DOOR: StatusBarState.PAUSED,
-        EngineStatus.STOP_REQUESTED: StatusBarState.UPDATING,
-        EngineStatus.STOPPED: StatusBarState.IDLE,
-        EngineStatus.FINISHING: StatusBarState.UPDATING,
-        EngineStatus.FAILED: StatusBarState.HARDWARE_ERROR,
-        EngineStatus.SUCCEEDED: StatusBarState.RUN_COMPLETED,
-    }[status]
+    match status:
+        case None | EngineStatus.IDLE:
+            return StatusBarState.IDLE if initialization_done else StatusBarState.OFF
+        case EngineStatus.RUNNING:
+            return StatusBarState.RUNNING
+        case EngineStatus.PAUSED | EngineStatus.AWAITING_RECOVERY | EngineStatus.BLOCKED_BY_OPEN_DOOR:
+            return StatusBarState.PAUSED
+        case EngineStatus.STOP_REQUESTED | EngineStatus.FINISHING:
+            return StatusBarState.UPDATING
+        case EngineStatus.STOPPED:
+            return StatusBarState.IDLE
+        case EngineStatus.FAILED:
+            return StatusBarState.HARDWARE_ERROR
+        case EngineStatus.SUCCEEDED:
+            return StatusBarState.RUN_COMPLETED
 
 
 def _active_updates_to_status_bar(


### PR DESCRIPTION
# Overview

Closes EXEC-363.

# Test Plan

* [x] Run a protocol with error recovery and make sure the status bar responds appropriately.

# Changelog

* Account for `EngineStatus.AWAITING_RECOVERY` in the light bar task.
* Convert the dict lookup to a `match` statement. This is probably slightly slower, but more type-safe, and just as concise.

# Review requests

None in particular.

# Risk assessment

Low.
