### PR TITLE
feat(robot-server): update run creation endpoint to accept runtime parameter values

### DIFF
--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -61,14 +61,17 @@ def ensure_value_type(
 
     This does not guarantee that the value will be the correct type for the given parameter, only that any data coming
     in is in the format that we expect. For now, the only transformation it is doing is converting integers represented
-    as floating points to integers. If something is labelled as an int but is not actually an integer, that will be
-    caught when it is attempted to be set as the parameter value and will raise the appropriate error there.
+    as floating points to integers, and bools represented as 1.0/0.0 to True/False.
+
+    If something is labelled as a type but does not get converted here, that will be caught when it is attempted to be
+    set as the parameter value and will raise the appropriate error there.
     """
-    validated_value: AllowedTypes
-    if isinstance(value, float) and parameter_type is int and value.is_integer():
-        validated_value = int(value)
-    else:
-        validated_value = value
+    validated_value: AllowedTypes = value
+    if isinstance(value, float):
+        if parameter_type is bool and (value == 0 or value == 1):
+            validated_value = bool(value)
+        elif parameter_type is int and value.is_integer():
+            validated_value = int(value)
     return validated_value
 
 
@@ -163,7 +166,7 @@ def validate_type(value: ParamType, parameter_type: type) -> None:
     """Validate parameter value is the correct type."""
     if not isinstance(value, parameter_type):
         raise ParameterValueError(
-            f"Parameter value has type {type(value)} must match type {parameter_type}."
+            f"Parameter value {value} has type {type(value)}, must match type {parameter_type}."
         )
 
 

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -146,7 +146,7 @@ def test_validate_options_raises_name_error() -> None:
 def test_ensure_value_type(
     value: Union[float, bool, str], param_type: type, result: AllowedTypes
 ) -> None:
-    """It should ensure the correct type is there, converting floats to ints."""
+    """It should ensure that if applicable, the value is coerced into the expected type"""
     assert result == subject.ensure_value_type(value, param_type)
 
 

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -137,6 +137,9 @@ def test_validate_options_raises_name_error() -> None:
         (2.0, float, 2.0),
         (2.2, float, 2.2),
         ("3.0", str, "3.0"),
+        (0.0, bool, False),
+        (1, bool, True),
+        (3.0, bool, 3.0),
         (True, bool, True),
     ],
 )

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -32,7 +32,10 @@ from opentrons.protocol_engine import (
 )
 
 from robot_server.protocols.protocol_store import ProtocolResource
-from opentrons.protocol_engine.types import DeckConfigurationType
+from opentrons.protocol_engine.types import (
+    DeckConfigurationType,
+    RunTimeParamValuesType,
+)
 
 
 class EngineConflictError(RuntimeError):
@@ -153,13 +156,16 @@ class EngineStore:
         labware_offsets: List[LabwareOffsetCreate],
         deck_configuration: DeckConfigurationType,
         protocol: Optional[ProtocolResource],
+        run_time_param_values: Optional[RunTimeParamValuesType] = None,
     ) -> StateSummary:
         """Create and store a ProtocolRunner and ProtocolEngine for a given Run.
 
         Args:
             run_id: The run resource the engine is assigned to.
             labware_offsets: Labware offsets to create the engine with.
+            deck_configuration: A mapping of fixtures to cutout fixtures the deck will be loaded with.
             protocol: The protocol to load the runner with, if any.
+            run_time_param_values: Any runtime parameter values to set.
 
         Returns:
             The initial equipment and status summary of the engine.
@@ -214,7 +220,7 @@ class EngineStore:
                 # was uploaded before we added stricter validation, and that
                 # doesn't conform to the new rules.
                 python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
-                run_time_param_values=None,
+                run_time_param_values=run_time_param_values,
             )
         elif isinstance(runner, JsonRunner):
             assert (

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -160,6 +160,9 @@ async def create_run(
     """
     protocol_id = request_body.data.protocolId if request_body is not None else None
     offsets = request_body.data.labwareOffsets if request_body is not None else []
+    rtp_values = (
+        request_body.data.runTimeParameterValues if request_body is not None else None
+    )
     protocol_resource = None
 
     deck_configuration = await deck_configuration_store.get_deck_configuration()
@@ -183,6 +186,7 @@ async def create_run(
             created_at=created_at,
             labware_offsets=offsets,
             deck_configuration=deck_configuration,
+            run_time_param_values=rtp_values,
             protocol=protocol_resource,
         )
     except EngineConflictError as e:

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -12,6 +12,7 @@ from opentrons.protocol_engine import (
     CurrentCommand,
     Command,
 )
+from opentrons.protocol_engine.types import RunTimeParamValuesType
 
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.task_runner import TaskRunner
@@ -142,6 +143,7 @@ class RunDataManager:
         created_at: datetime,
         labware_offsets: List[LabwareOffsetCreate],
         deck_configuration: DeckConfigurationType,
+        run_time_param_values: Optional[RunTimeParamValuesType],
         protocol: Optional[ProtocolResource],
     ) -> Union[Run, BadRun]:
         """Create a new, current run.
@@ -171,6 +173,7 @@ class RunDataManager:
             labware_offsets=labware_offsets,
             deck_configuration=deck_configuration,
             protocol=protocol,
+            run_time_param_values=run_time_param_values,
         )
         run_resource = self._run_store.insert(
             run_id=run_id,

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -153,7 +153,10 @@ class RunDataManager:
             run_id: Identifier to assign the new run.
             created_at: Creation datetime.
             labware_offsets: Labware offsets to initialize the engine with.
+            deck_configuration: A mapping of fixtures to cutout fixtures the deck will be loaded with.
             notify_publishers: Utilized by the engine to notify publishers of state changes.
+            run_time_param_values: Any runtime parameter values to set.
+            protocol: The protocol to load the runner with, if any.
 
         Returns:
             The run resource.

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -18,6 +18,7 @@ from opentrons.protocol_engine import (
     Liquid,
     CommandNote,
 )
+from opentrons.protocol_engine.types import RunTimeParamValuesType
 from opentrons_shared_data.errors import GeneralError
 from robot_server.service.json_api import ResourceModel
 from robot_server.errors.error_responses import ErrorDetails
@@ -211,6 +212,12 @@ class RunCreate(BaseModel):
     labwareOffsets: List[LabwareOffsetCreate] = Field(
         default_factory=list,
         description="Labware offsets to apply as labware are loaded.",
+    )
+    runTimeParameterValues: Optional[RunTimeParamValuesType] = Field(
+        None,
+        description="Key-value pairs of run-time parameters defined in a protocol."
+        " Also, if this data is included in the request, the server will"
+        " always trigger an analysis (for now).",
     )
 
 

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -215,9 +215,7 @@ class RunCreate(BaseModel):
     )
     runTimeParameterValues: Optional[RunTimeParamValuesType] = Field(
         None,
-        description="Key-value pairs of run-time parameters defined in a protocol."
-        " Also, if this data is included in the request, the server will"
-        " always trigger an analysis (for now).",
+        description="Key-value pairs of run-time parameters defined in a protocol.",
     )
 
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -87,6 +87,7 @@ async def test_create_run(
             labware_offsets=[labware_offset_create],
             deck_configuration=[],
             protocol=None,
+            run_time_param_values=None,
         )
     ).then_return(expected_response)
 
@@ -162,11 +163,16 @@ async def test_create_protocol_run(
             labware_offsets=[],
             deck_configuration=[],
             protocol=protocol_resource,
+            run_time_param_values={"foo": "bar"},
         )
     ).then_return(expected_response)
 
     result = await create_run(
-        request_body=RequestModel(data=RunCreate(protocolId="protocol-id")),
+        request_body=RequestModel(
+            data=RunCreate(
+                protocolId="protocol-id", runTimeParameterValues={"foo": "bar"}
+            )
+        ),
         protocol_store=mock_protocol_store,
         run_data_manager=mock_run_data_manager,
         run_id=run_id,
@@ -223,6 +229,7 @@ async def test_create_run_conflict(
             labware_offsets=[],
             deck_configuration=[],
             protocol=None,
+            run_time_param_values=None,
         )
     ).then_raise(EngineConflictError("oh no"))
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -138,6 +138,7 @@ async def test_create(
             labware_offsets=[],
             protocol=None,
             deck_configuration=[],
+            run_time_param_values=None,
         )
     ).then_return(engine_state_summary)
     decoy.when(
@@ -154,6 +155,7 @@ async def test_create(
         labware_offsets=[],
         protocol=None,
         deck_configuration=[],
+        run_time_param_values=None,
     )
 
     assert result == Run(
@@ -180,7 +182,7 @@ async def test_create_with_options(
     engine_state_summary: StateSummary,
     run_resource: RunResource,
 ) -> None:
-    """It should handle creation with a protocol and labware offsets."""
+    """It should handle creation with a protocol, labware offsets and parameters."""
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -203,6 +205,7 @@ async def test_create_with_options(
             labware_offsets=[labware_offset],
             protocol=protocol,
             deck_configuration=[],
+            run_time_param_values={"foo": "bar"},
         )
     ).then_return(engine_state_summary)
 
@@ -220,6 +223,7 @@ async def test_create_with_options(
         labware_offsets=[labware_offset],
         protocol=protocol,
         deck_configuration=[],
+        run_time_param_values={"foo": "bar"},
     )
 
     assert result == Run(
@@ -254,6 +258,7 @@ async def test_create_engine_error(
             labware_offsets=[],
             protocol=None,
             deck_configuration=[],
+            run_time_param_values=None,
         )
     ).then_raise(EngineConflictError("oh no"))
 
@@ -264,6 +269,7 @@ async def test_create_engine_error(
             labware_offsets=[],
             protocol=None,
             deck_configuration=[],
+            run_time_param_values=None,
         )
 
     decoy.verify(
@@ -640,6 +646,7 @@ async def test_create_archives_existing(
             labware_offsets=[],
             protocol=None,
             deck_configuration=[],
+            run_time_param_values=None,
         )
     ).then_return(engine_state_summary)
 
@@ -657,6 +664,7 @@ async def test_create_archives_existing(
         labware_offsets=[],
         protocol=None,
         deck_configuration=[],
+        run_time_param_values=None,
     )
 
     decoy.verify(


### PR DESCRIPTION
# Overview

Closes AUTH-130

This PR adds a new, optional argument `runTimeParameterValues` to the request body of the `POST /runs` endpoint to start a run with new runtime parameter values. It is the same shape as the argument for the `/protocols` endpoint (a dictionary/map of variable names to the parameter values), but since this endpoint does not take form data, it does not need to be parsed with in the body of the run create function.

These values are then fed to the `ProtocolRunner` load method which will bind those to the execute function, so that when the protocol starts it will evaluate and use those values when running the protocol. (assuming there are no errors in setting the parameter values).

Since re-analysis has not been implemented yet, when starting a run with overridden values, the frontend will show an incorrect analysis for the run. This will be addressed in a future PR so that it reflects the values (and therefore potentially labware, pipettes, modules used) used in the actual run.

# Test Plan

Continuing to use this test protocol seen in other PRs to test parameter values. Using postman, I was able to post the protocol with default values, then start a run with new overridden values:

- [x] Posting a run with no `runTimeParameterValues` uses the default values
- [x] Posting a run with valid overridden values uses that in the actual run execution
- [x] Posting a run with invalid overridden values causes the run to fail

```
metadata = {
    'protocolName': 'RTP Test 2 - Default only, all types',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.18"
}


def add_parameters(parameters):
    parameters.add_int(
        display_name="Sample count",
        variable_name="sample_count",
        default=6,
        minimum=1,
        maximum=12,
        description="How many samples to process."
    )
    parameters.add_float(
        display_name="Pipette volume",
        variable_name="volume",
        default=20.1,
        choices=[
            {"display_name": "Low Volume", "value": 10.23},
            {"display_name": "Medium Volume", "value": 20.1},
            {"display_name": "High Volume", "value": 50.5},
        ],
        description="How many microliters to pipette of each sample.",
        unit="µL"
    )
    parameters.add_bool(
        display_name="Dry Run",
        variable_name="dry_run",
        default=False,
        description="Skip aspirate and dispense steps."
    )
    parameters.add_str(
        display_name="Pipette Name",
        variable_name="pipette",
        choices=[
            {"display_name": "Single channel 50µL", "value": "flex_1channel_50"},
            {"display_name": "Single channel 1000µL", "value": "flex_1channel_1000"},
            {"display_name": "Eight Channel 50µL", "value": "flex_8channel_50"},
            {"display_name": "Eight Channel 1000µL", "value": "flex_8channel_1000"},
        ],
        default="flex_1channel_50",
        description="What pipette to use during the protocol.",
    )



def run(context):
    trash_bin = context.load_trash_bin('A3')
    tip_rack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'D2')
    source = context.load_labware('opentrons_96_wellplate_200ul_pcr_full_skirt', 'C1')
    destination = context.load_labware('opentrons_96_wellplate_200ul_pcr_full_skirt', 'C3')

    pipette = context.load_instrument(context.params.pipette, mount="left", tip_racks=[tip_rack])

    for i in range(context.params.sample_count):
        source_well = source.wells()[i]
        destination_well = destination.wells()[i]

        pipette.pick_up_tip()
        pipette.move_to(source_well.top())
        if not context.params.dry_run:
            pipette.aspirate(context.params.volume, source_well)
            pipette.dispense(context.params.volume, destination_well)

        pipette.drop_tip()
```

# Changelog

- added `runTimeParameterValues` argument to `POST /runs`
- connected the runtime parameter values to the engine creation so that runs use those values sent

# Review requests

# Risk assessment

Low