### PR TITLE
fix(app): fix excessive /runs network requests

### DIFF
--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -184,4 +184,20 @@ describe('useNotifyService', () => {
     unmount()
     expect(appShellListener).toHaveBeenCalled()
   })
+
+  it('should still clean up the listener if the hostname changes to null after subscribing', () => {
+    const { unmount, rerender } = renderHook(() =>
+      useNotifyService({
+        hostOverride: MOCK_HOST_CONFIG,
+        topic: MOCK_TOPIC,
+        setRefetchUsingHTTP: mockHTTPRefetch,
+        options: MOCK_OPTIONS,
+      })
+    )
+    rerender({ hostOverride: null })
+    unmount()
+    expect(appShellListener).toHaveBeenCalledWith(
+      expect.objectContaining({ hostname: MOCK_HOST_CONFIG.hostname })
+    )
+  })
 })

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -43,6 +43,7 @@ export function useNotifyService<TData, TError = Error>({
   const doTrackEvent = useTrackEvent()
   const isFlex = useIsFlex(host?.robotName ?? '')
   const hasUsedNotifyService = React.useRef(false)
+  const seenHostname = React.useRef<string | null>(null)
   const { enabled, staleTime, forceHttpPolling } = options
 
   const shouldUseNotifications =
@@ -62,6 +63,7 @@ export function useNotifyService<TData, TError = Error>({
       })
       dispatch(notifySubscribeAction(hostname, topic))
       hasUsedNotifyService.current = true
+      seenHostname.current = hostname
     } else {
       setRefetchUsingHTTP('always')
     }
@@ -69,14 +71,14 @@ export function useNotifyService<TData, TError = Error>({
     return () => {
       if (hasUsedNotifyService.current) {
         appShellListener({
-          hostname: hostname as string,
+          hostname: seenHostname.current as string,
           topic,
           callback: onDataEvent,
           isDismounting: true,
         })
       }
     }
-  }, [topic, host, shouldUseNotifications])
+  }, [topic, hostname, shouldUseNotifications])
 
   function onDataEvent(data: NotifyResponseData): void {
     if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {


### PR DESCRIPTION
Closes [EXEC-255](https://opentrons.atlassian.net/browse/EXEC-255)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Fixes useNotifyService to utilize hostname instead of the `host` object, preventing a pass by reference issue causing excessive requests sent to `/runs` that often occurs on the RobotDetails page. This fix is sufficient, since this is all we need from `host` anyway. Let's also ensure that if a robot loses connection while a component has passed a callback to `appShellListener`, we ensure we remove the correct callback from the store.

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/38bacdbc-b56f-466e-836f-a1f66bb18943

### Fixed Bevahior

https://github.com/Opentrons/opentrons/assets/64858653/0d9513c4-31b4-4004-9c4e-3909cf04a607


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verify the fix by going to the Network tab and clicking on a robot in the Devices page.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed excessive network requests to /runs.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-255]: https://opentrons.atlassian.net/browse/EXEC-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ