### PR TITLE
feat(app, api-client): add optional runTimeParameterValues when cloning run

### DIFF
--- a/api-client/src/runs/createRun.ts
+++ b/api-client/src/runs/createRun.ts
@@ -5,13 +5,13 @@ import type { HostConfig } from '../types'
 import type {
   Run,
   LabwareOffsetCreateData,
-  RuntimeParameterCreateData,
+  RunTimeParameterCreateData,
 } from './types'
 
 export interface CreateRunData {
   protocolId?: string
   labwareOffsets?: LabwareOffsetCreateData[]
-  runTimeParameterValues?: RuntimeParameterCreateData
+  runTimeParameterValues?: RunTimeParameterCreateData
 }
 
 export function createRun(

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -47,7 +47,7 @@ export interface LegacyGoodRunData {
   modules: LoadedModule[]
   protocolId?: string
   labwareOffsets?: LabwareOffset[]
-  runTimeParameterValues?: RuntimeParameterCreateData
+  runTimeParameterValues?: RunTimeParameterCreateData
 }
 
 export interface KnownGoodRunData extends LegacyGoodRunData {
@@ -126,7 +126,7 @@ export interface LabwareOffsetCreateData {
   vector: VectorOffset
 }
 
-export interface RuntimeParameterCreateData {
+export interface RunTimeParameterCreateData {
   [key: string]: string | boolean | number
 }
 

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -47,6 +47,7 @@ export interface LegacyGoodRunData {
   modules: LoadedModule[]
   protocolId?: string
   labwareOffsets?: LabwareOffset[]
+  runTimeParameterValues?: RuntimeParameterCreateData
 }
 
 export interface KnownGoodRunData extends LegacyGoodRunData {

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -47,6 +47,7 @@ import { useCreateRunFromProtocol } from '../ChooseRobotToRunProtocolSlideout/us
 import { ApplyHistoricOffsets } from '../ApplyHistoricOffsets'
 import { useOffsetCandidatesForAnalysis } from '../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { getAnalysisStatus } from '../ProtocolsLanding/utils'
+import type { RunTimeParameterCreateData } from '@opentrons/api-client'
 import type { RunTimeParameter } from '@opentrons/shared-data'
 import type { Robot } from '../../redux/discovery/types'
 import type { StoredProtocolData } from '../../redux/protocol-storage'
@@ -161,7 +162,7 @@ export function ChooseProtocolSlideoutComponent(
           definitionUri,
         }))
       : [],
-    runTimeParametersOverrides.reduce(
+    runTimeParametersOverrides.reduce<RunTimeParameterCreateData>(
       (acc, param) =>
         param.value !== param.default
           ? { ...acc, [param.variableName]: param.value }

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -14,7 +14,7 @@ import type {
   HostConfig,
   LabwareOffsetCreateData,
   Protocol,
-  RuntimeParameterCreateData,
+  RunTimeParameterCreateData,
 } from '@opentrons/api-client'
 import type { UseCreateRunMutationOptions } from '@opentrons/react-api-client/src/runs/useCreateRunMutation'
 import type { CreateProtocolVariables } from '@opentrons/react-api-client/src/protocols/useCreateProtocolMutation'
@@ -37,7 +37,7 @@ export function useCreateRunFromProtocol(
   options: UseCreateRunMutationOptions,
   hostOverride?: HostConfig | null,
   labwareOffsets?: LabwareOffsetCreateData[],
-  runTimeParameterValues?: RuntimeParameterCreateData
+  runTimeParameterValues?: RunTimeParameterCreateData
 ): UseCreateRun {
   const contextHost = useHost()
   const host =

--- a/app/src/organisms/ProtocolUpload/hooks/__tests__/useCloneRun.test.tsx
+++ b/app/src/organisms/ProtocolUpload/hooks/__tests__/useCloneRun.test.tsx
@@ -30,6 +30,7 @@ describe('useCloneRun hook', () => {
             id: RUN_ID,
             protocolId: 'protocolId',
             labwareOffsets: 'someOffset',
+            runTimeParameterValues: 'someRtp',
           },
         },
       } as any)
@@ -60,6 +61,7 @@ describe('useCloneRun hook', () => {
     expect(mockCreateRun).toHaveBeenCalledWith({
       protocolId: 'protocolId',
       labwareOffsets: 'someOffset',
+      runTimeParameterValues: 'someRtp',
     })
   })
 })

--- a/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
+++ b/app/src/organisms/ProtocolUpload/hooks/useCloneRun.ts
@@ -30,8 +30,12 @@ export function useCloneRun(
   })
   const cloneRun = (): void => {
     if (runRecord != null) {
-      const { protocolId, labwareOffsets } = runRecord.data
-      createRun({ protocolId, labwareOffsets })
+      const {
+        protocolId,
+        labwareOffsets,
+        runTimeParameterValues,
+      } = runRecord.data
+      createRun({ protocolId, labwareOffsets, runTimeParameterValues })
     } else {
       console.info('failed to clone run record, source run record not found')
     }


### PR DESCRIPTION
closes [AUTH-287](https://opentrons.atlassian.net/browse/AUTH-287)
closes [AUTH-257](https://opentrons.atlassian.net/browse/AUTH-257)

# Overview

Extend useCloneRun hook to pass optional runTimeParameterValues (overrides) to a cloned run

# Test Plan


# Changelog

- add optional runTimeParamterValues` key to `LegacyGoodRunData` type
- pull those RTP override values when cloning a run
- add test

# Review requests

authorship devs

# Risk assessment

low

[AUTH-257]: https://opentrons.atlassian.net/browse/AUTH-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[AUTH-287]: https://opentrons.atlassian.net/browse/AUTH-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ