### PR TITLE
fix(api): Change the camera device to /dev/camera2

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -17,6 +17,7 @@ Welcome to the v7.2.2 release of the Opentrons robot software!
 ### Bug Fixes
 
 - Restores the ability to use the speaker and camera on OT-2.
+- Restores the ability to use the camera on Flex.
 
 ---
 

--- a/api/src/opentrons/system/camera.py
+++ b/api/src/opentrons/system/camera.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 from pathlib import Path
+
 from opentrons.config import ARCHITECTURE, SystemArchitecture
 from opentrons_shared_data.errors.exceptions import CommunicationError
 from opentrons_shared_data.errors.codes import ErrorCodes
@@ -29,7 +30,7 @@ async def take_picture(filename: Path) -> None:
         pass
 
     if ARCHITECTURE == SystemArchitecture.YOCTO:
-        cmd = f"v4l2-ctl --device /dev/video0 --set-fmt-video=width=1280,height=720,pixelformat=MJPG --stream-mmap --stream-to={str(filename)} --stream-count=1"
+        cmd = f"v4l2-ctl --device /dev/video2 --set-fmt-video=width=1280,height=720,pixelformat=MJPG --stream-mmap --stream-to={str(filename)} --stream-count=1"
     elif ARCHITECTURE == SystemArchitecture.BUILDROOT:
         cmd = f"ffmpeg -f video4linux2 -s 640x480 -i /dev/video0 -ss 0:0:1 -frames 1 {str(filename)}"
     else:  # HOST


### PR DESCRIPTION
# Overview

We updated the Linux Kernel recently which has changed the camera device from /dev/video0 to /dev/video2, so lets change it here. This pull request pertains to [Opentrons/oe-core#140](https://github.com/Opentrons/oe-core/pull/140).

Closes: [EXEC-354](https://opentrons.atlassian.net/browse/EXEC-354)

# Test Plan

- [x] Make sure we can take a picture via `/camera/picture` endpoint.

# Changelog

- set the camera device to /dev/video2 when taking a picture

# Review requests

# Risk assessment


[EXEC-354]: https://opentrons.atlassian.net/browse/EXEC-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ