### PR TITLE
refactor(app, robot-server): Rename refetchUsingHTTP -> refetch

### DIFF
--- a/app-shell-odd/src/notifications/deserialize.ts
+++ b/app-shell-odd/src/notifications/deserialize.ts
@@ -12,7 +12,7 @@ import type {
 import { FAILURE_STATUSES } from '../constants'
 
 const VALID_NOTIFY_RESPONSES: [NotifyRefetchData, NotifyUnsubscribeData] = [
-  { refetchUsingHTTP: true },
+  { refetch: true },
   { unsubscribe: true },
 ]
 

--- a/app-shell/src/notifications/__tests__/deserialize.test.ts
+++ b/app-shell/src/notifications/__tests__/deserialize.test.ts
@@ -4,7 +4,7 @@ import { deserializeExpectedMessages } from '../deserialize'
 
 import type { NotifyResponseData } from '@opentrons/app/src/redux/shell/types'
 
-const MOCK_VALID_RESPONSE: NotifyResponseData = { refetchUsingHTTP: true }
+const MOCK_VALID_RESPONSE: NotifyResponseData = { refetch: true }
 const MOCK_VALID_STRING_RESPONSE = JSON.stringify(MOCK_VALID_RESPONSE)
 const MOCK_INVALID_OBJECT = JSON.stringify({ test: 'MOCK_RESPONSE' })
 const MOCK_INVALID_STRING = 'MOCK_STRING'

--- a/app-shell/src/notifications/deserialize.ts
+++ b/app-shell/src/notifications/deserialize.ts
@@ -18,7 +18,7 @@ interface SendToBrowserParams {
 }
 
 const VALID_NOTIFY_RESPONSES: [NotifyRefetchData, NotifyUnsubscribeData] = [
-  { refetchUsingHTTP: true },
+  { refetch: true },
   { unsubscribe: true },
 ]
 

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -20,7 +20,7 @@ export type IpcListener = (
 ) => void
 
 export interface NotifyRefetchData {
-  refetchUsingHTTP: boolean
+  refetch: boolean
 }
 
 export interface NotifyUnsubscribeData {

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -53,7 +53,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -68,7 +68,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: { ...MOCK_OPTIONS, forceHttpPolling: true },
       } as any)
     )
@@ -81,7 +81,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: { ...MOCK_OPTIONS, enabled: false },
       } as any)
     )
@@ -94,7 +94,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: { ...MOCK_OPTIONS, staleTime: Infinity },
       } as any)
     )
@@ -111,7 +111,7 @@ describe('useNotifyService', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -128,7 +128,7 @@ describe('useNotifyService', () => {
     const { rerender } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -142,12 +142,12 @@ describe('useNotifyService', () => {
       callback,
     }): any {
       // eslint-disable-next-line n/no-callback-literal
-      callback({ refetchUsingHTTP: true })
+      callback({ refetch: true })
     })
     const { rerender } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -165,7 +165,7 @@ describe('useNotifyService', () => {
     const { rerender } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       } as any)
     )
@@ -177,7 +177,7 @@ describe('useNotifyService', () => {
     const { unmount } = renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       })
     )
@@ -190,7 +190,7 @@ describe('useNotifyService', () => {
       useNotifyService({
         hostOverride: MOCK_HOST_CONFIG,
         topic: MOCK_TOPIC,
-        setRefetchUsingHTTP: mockHTTPRefetch,
+        setRefetch: mockHTTPRefetch,
         options: MOCK_OPTIONS,
       })
     )

--- a/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
+++ b/app/src/resources/maintenance_runs/useNotifyCurrentMaintenanceRun.ts
@@ -14,24 +14,18 @@ import type {
 export function useNotifyCurrentMaintenanceRun(
   options: QueryOptionsWithPolling<MaintenanceRun, Error> = {}
 ): UseQueryResult<MaintenanceRun> | UseQueryResult<MaintenanceRun, Error> {
-  const [
-    refetchUsingHTTP,
-    setRefetchUsingHTTP,
-  ] = React.useState<HTTPRefetchFrequency>(null)
+  const [refetch, setRefetch] = React.useState<HTTPRefetchFrequency>(null)
 
   useNotifyService<MaintenanceRun, Error>({
     topic: 'robot-server/maintenance_runs/current_run',
-    setRefetchUsingHTTP,
+    setRefetch,
     options,
   })
 
   const httpQueryResult = useCurrentMaintenanceRun({
     ...options,
-    enabled: options?.enabled !== false && refetchUsingHTTP != null,
-    onSettled:
-      refetchUsingHTTP === 'once'
-        ? () => setRefetchUsingHTTP(null)
-        : () => null,
+    enabled: options?.enabled !== false && refetch != null,
+    onSettled: refetch === 'once' ? () => setRefetch(null) : () => null,
   })
 
   return httpQueryResult

--- a/app/src/resources/runs/useNotifyAllRunsQuery.ts
+++ b/app/src/resources/runs/useNotifyAllRunsQuery.ts
@@ -18,14 +18,11 @@ export function useNotifyAllRunsQuery(
   options: QueryOptionsWithPolling<UseAllRunsQueryOptions, AxiosError> = {},
   hostOverride?: HostConfig | null
 ): UseQueryResult<Runs, AxiosError> {
-  const [
-    refetchUsingHTTP,
-    setRefetchUsingHTTP,
-  ] = React.useState<HTTPRefetchFrequency>(null)
+  const [refetch, setRefetch] = React.useState<HTTPRefetchFrequency>(null)
 
   useNotifyService<UseAllRunsQueryOptions, AxiosError>({
     topic: 'robot-server/runs',
-    setRefetchUsingHTTP,
+    setRefetch,
     options,
     hostOverride,
   })
@@ -34,11 +31,8 @@ export function useNotifyAllRunsQuery(
     params,
     {
       ...(options as UseAllRunsQueryOptions),
-      enabled: options?.enabled !== false && refetchUsingHTTP != null,
-      onSettled:
-        refetchUsingHTTP === 'once'
-          ? () => setRefetchUsingHTTP(null)
-          : () => null,
+      enabled: options?.enabled !== false && refetch != null,
+      onSettled: refetch === 'once' ? () => setRefetch(null) : () => null,
     },
     hostOverride
   )

--- a/app/src/resources/runs/useNotifyLastRunCommandKey.ts
+++ b/app/src/resources/runs/useNotifyLastRunCommandKey.ts
@@ -13,24 +13,18 @@ export function useNotifyLastRunCommandKey(
   runId: string,
   options: QueryOptionsWithPolling<CommandsData, Error> = {}
 ): string | null {
-  const [
-    refetchUsingHTTP,
-    setRefetchUsingHTTP,
-  ] = React.useState<HTTPRefetchFrequency>(null)
+  const [refetch, setRefetch] = React.useState<HTTPRefetchFrequency>(null)
 
   useNotifyService({
     topic: 'robot-server/runs/current_command',
-    setRefetchUsingHTTP,
+    setRefetch,
     options,
   })
 
   const httpResponse = useLastRunCommandKey(runId, {
     ...options,
-    enabled: options?.enabled !== false && refetchUsingHTTP != null,
-    onSettled:
-      refetchUsingHTTP === 'once'
-        ? () => setRefetchUsingHTTP(null)
-        : () => null,
+    enabled: options?.enabled !== false && refetch != null,
+    onSettled: refetch === 'once' ? () => setRefetch(null) : () => null,
   })
 
   return httpResponse

--- a/app/src/resources/runs/useNotifyRunQuery.ts
+++ b/app/src/resources/runs/useNotifyRunQuery.ts
@@ -16,26 +16,20 @@ export function useNotifyRunQuery<TError = Error>(
   runId: string | null,
   options: QueryOptionsWithPolling<Run, TError> = {}
 ): UseQueryResult<Run, TError> {
-  const [
-    refetchUsingHTTP,
-    setRefetchUsingHTTP,
-  ] = React.useState<HTTPRefetchFrequency>(null)
+  const [refetch, setRefetch] = React.useState<HTTPRefetchFrequency>(null)
 
   const isEnabled = options.enabled !== false && runId != null
 
   useNotifyService({
     topic: `robot-server/runs/${runId}` as NotifyTopic,
-    setRefetchUsingHTTP,
+    setRefetch,
     options: { ...options, enabled: options.enabled != null && runId != null },
   })
 
   const httpResponse = useRunQuery(runId, {
     ...options,
-    enabled: isEnabled && refetchUsingHTTP != null,
-    onSettled:
-      refetchUsingHTTP === 'once'
-        ? () => setRefetchUsingHTTP(null)
-        : () => null,
+    enabled: isEnabled && refetch != null,
+    onSettled: refetch === 'once' ? () => setRefetch(null) : () => null,
   })
 
   return httpResponse

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -25,14 +25,14 @@ export interface QueryOptionsWithPolling<TData, TError = Error>
 
 interface UseNotifyServiceProps<TData, TError = Error> {
   topic: NotifyTopic
-  setRefetchUsingHTTP: (refetch: HTTPRefetchFrequency) => void
+  setRefetch: (refetch: HTTPRefetchFrequency) => void
   options: QueryOptionsWithPolling<TData, TError>
   hostOverride?: HostConfig | null
 }
 
 export function useNotifyService<TData, TError = Error>({
   topic,
-  setRefetchUsingHTTP,
+  setRefetch,
   options,
   hostOverride,
 }: UseNotifyServiceProps<TData, TError>): void {
@@ -55,7 +55,7 @@ export function useNotifyService<TData, TError = Error>({
   React.useEffect(() => {
     if (shouldUseNotifications) {
       // Always fetch on initial mount.
-      setRefetchUsingHTTP('once')
+      setRefetch('once')
       appShellListener({
         hostname,
         topic,
@@ -65,7 +65,7 @@ export function useNotifyService<TData, TError = Error>({
       hasUsedNotifyService.current = true
       seenHostname.current = hostname
     } else {
-      setRefetchUsingHTTP('always')
+      setRefetch('always')
     }
 
     return () => {
@@ -82,7 +82,7 @@ export function useNotifyService<TData, TError = Error>({
 
   function onDataEvent(data: NotifyResponseData): void {
     if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
-      setRefetchUsingHTTP('always')
+      setRefetch('always')
       // TODO(jh 2023-02-23): remove the robot type check once OT-2s support MQTT.
       if (data === 'ECONNREFUSED' && isFlex) {
         doTrackEvent({
@@ -90,8 +90,8 @@ export function useNotifyService<TData, TError = Error>({
           properties: {},
         })
       }
-    } else if ('refetchUsingHTTP' in data || 'unsubscribe' in data) {
-      setRefetchUsingHTTP('once')
+    } else if ('refetch' in data || 'unsubscribe' in data) {
+      setRefetch('once')
     }
   }
 }

--- a/robot-server/robot_server/service/json_api/response.py
+++ b/robot-server/robot_server/service/json_api/response.py
@@ -287,7 +287,7 @@ class ResponseList(BaseModel, Generic[ResponseDataT]):
 class NotifyRefetchBody(BaseResponseBody):
     """A notification response that returns a flag for refetching via HTTP."""
 
-    refetchUsingHTTP: bool = True
+    refetch: bool = True
 
 
 class NotifyUnsubscribeBody(BaseResponseBody):

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -59,24 +59,26 @@ class NotificationClient:
         # MQTT is somewhat particular about the client_id format and will connect erratically
         # if an unexpected string is supplied. This clientId is derived from the paho-mqtt library.
         self._client_id: str = f"robot-server-{random.randint(0, 1000000)}"
-        self.client: mqtt.Client = mqtt.Client(
+        self._client: mqtt.Client = mqtt.Client(
             client_id=self._client_id, protocol=protocol_version
         )
-        self.client.on_connect = self._on_connect
-        self.client.on_disconnect = self._on_disconnect
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
 
     def connect(self) -> None:
         """Connect the client to the MQTT broker."""
-        self.client.on_connect = self._on_connect
-        self.client.on_disconnect = self._on_disconnect
+        self._client.on_connect = self._on_connect
+        self._client.on_disconnect = self._on_disconnect
 
-        self.client.connect(host=self._host, port=self._port, keepalive=self._keepalive)
-        self.client.loop_start()
+        self._client.connect(
+            host=self._host, port=self._port, keepalive=self._keepalive
+        )
+        self._client.loop_start()
 
     async def disconnect(self) -> None:
         """Disconnect the client from the MQTT broker."""
-        self.client.loop_stop()
-        await to_thread.run_sync(self.client.disconnect)
+        self._client.loop_stop()
+        await to_thread.run_sync(self._client.disconnect)
 
     async def publish_advise_refetch_async(self, topic: str) -> None:
         """Asynchronously publish a refetch message on a specific topic to the MQTT broker.
@@ -105,7 +107,7 @@ class NotificationClient:
         """
         message = NotifyRefetchBody.construct()
         payload = message.json()
-        self.client.publish(
+        self._client.publish(
             topic=topic,
             payload=payload,
             qos=self._default_qos,
@@ -123,7 +125,7 @@ class NotificationClient:
         """
         message = NotifyUnsubscribeBody.construct()
         payload = message.json()
-        self.client.publish(
+        self._client.publish(
             topic=topic,
             payload=payload,
             qos=self._default_qos,

--- a/robot-server/tests/service/json_api/test_response.py
+++ b/robot-server/tests/service/json_api/test_response.py
@@ -116,7 +116,7 @@ RESPONSE_SPECS = [
             "links": {"sibling": {"href": "/bar", "meta": None}},
         },
     ),
-    ResponseSpec(subject=NotifyRefetchBody(), expected={"refetchUsingHTTP": True}),
+    ResponseSpec(subject=NotifyRefetchBody(), expected={"refetch": True}),
     ResponseSpec(
         subject=NotifyUnsubscribeBody(),
         expected={"unsubscribe": True},


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The `refetchUsingHTTP` flag is a vestige from prototyping push notifications. There's no need to specify the exact implementation required to do the refetch, and this semantically fits better with the `unsubscribe` flag. Also, this will make me feel better.

`Notification_client`'s `client` is now private as well. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Covered by automated tests. You can grep for `refetchUsingHTTP` if you'd like.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
