### PR TITLE
feat(protocol-designer): add alert if x/y position is too close to edge

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionInput.module.css
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionInput.module.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-evenly;
-  height: 5rem;
+  height: 4rem;
 }
 
 .main_row {

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -21,6 +21,7 @@ import styles from './TipPositionInput.module.css'
 import * as utils from './utils'
 
 import type { StepFieldName } from '../../../../form-types'
+import { PDAlert } from '../../../alerts/PDAlert'
 
 type Offset = 'x' | 'y' | 'z'
 interface PositionSpec {
@@ -57,7 +58,9 @@ export const TipPositionModal = (
   const { t } = useTranslation(['modal', 'button'])
 
   if (zSpec == null || xSpec == null || ySpec == null) {
-    console.error('expected to find specs for the zPosition but could not')
+    console.error(
+      'expected to find specs for one of the positions but could not'
+    )
   }
 
   const defaultMmFromBottom = utils.getDefaultMmFromBottom({
@@ -218,6 +221,12 @@ export const TipPositionModal = (
   ): void => {
     handleYChange(e.currentTarget.value)
   }
+  const xValueNearEdge =
+    xValue != null &&
+    (parseInt(xValue) > 0.9 * xMaxWidth || parseInt(xValue) < 0.9 * xMinWidth)
+  const yValueNearEdge =
+    yValue != null &&
+    (parseInt(yValue) > 0.9 * yMaxWidth || parseInt(yValue) < 0.9 * yMinWidth)
 
   const TipPositionInputField = !isDefault ? (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
@@ -298,6 +307,17 @@ export const TipPositionModal = (
         <h4>{t('tip_position.title')}</h4>
         <p>{t(`tip_position.body.${zSpec?.name}`)}</p>
       </div>
+
+      {(xValueNearEdge || yValueNearEdge) && !isDefault ? (
+        <Flex marginTop={SPACING.spacing8}>
+          <PDAlert
+            alertType="warning"
+            title=""
+            description={t('tip_position.warning')}
+          />
+        </Flex>
+      ) : null}
+
       <div className={styles.main_row}>
         <Flex alignItems="flex-start">
           <Flex flexDirection={DIRECTION_COLUMN}>

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -12,16 +12,16 @@ import {
   StyledText,
 } from '@opentrons/components'
 import { getMainPagePortalEl } from '../../../portals/MainPageModalPortal'
-import modalStyles from '../../../modals/modal.module.css'
 import { getIsTouchTipField } from '../../../../form-types'
+import { PDAlert } from '../../../alerts/PDAlert'
 import { TOO_MANY_DECIMALS } from './constants'
 import { TipPositionAllViz } from './TipPositionAllViz'
-
-import styles from './TipPositionInput.module.css'
 import * as utils from './utils'
 
+import styles from './TipPositionInput.module.css'
+import modalStyles from '../../../modals/modal.module.css'
+
 import type { StepFieldName } from '../../../../form-types'
-import { PDAlert } from '../../../alerts/PDAlert'
 
 type Offset = 'x' | 'y' | 'z'
 interface PositionSpec {

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -14,7 +14,7 @@ import {
 import { getMainPagePortalEl } from '../../../portals/MainPageModalPortal'
 import { getIsTouchTipField } from '../../../../form-types'
 import { PDAlert } from '../../../alerts/PDAlert'
-import { TOO_MANY_DECIMALS } from './constants'
+import { TOO_MANY_DECIMALS, PERCENT_RANGE_TO_SHOW_WARNING } from './constants'
 import { TipPositionAllViz } from './TipPositionAllViz'
 import * as utils from './utils'
 
@@ -221,12 +221,14 @@ export const TipPositionModal = (
   ): void => {
     handleYChange(e.currentTarget.value)
   }
-  const xValueNearEdge =
+  const isXValueNearEdge =
     xValue != null &&
-    (parseInt(xValue) > 0.9 * xMaxWidth || parseInt(xValue) < 0.9 * xMinWidth)
-  const yValueNearEdge =
+    (parseInt(xValue) > PERCENT_RANGE_TO_SHOW_WARNING * xMaxWidth ||
+      parseInt(xValue) < PERCENT_RANGE_TO_SHOW_WARNING * xMinWidth)
+  const isYValueNearEdge =
     yValue != null &&
-    (parseInt(yValue) > 0.9 * yMaxWidth || parseInt(yValue) < 0.9 * yMinWidth)
+    (parseInt(yValue) > PERCENT_RANGE_TO_SHOW_WARNING * yMaxWidth ||
+      parseInt(yValue) < PERCENT_RANGE_TO_SHOW_WARNING * yMinWidth)
 
   const TipPositionInputField = !isDefault ? (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
@@ -308,7 +310,7 @@ export const TipPositionModal = (
         <p>{t(`tip_position.body.${zSpec?.name}`)}</p>
       </div>
 
-      {(xValueNearEdge || yValueNearEdge) && !isDefault ? (
+      {(isXValueNearEdge || isYValueNearEdge) && !isDefault ? (
         <Flex marginTop={SPACING.spacing8}>
           <PDAlert
             alertType="warning"

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -138,9 +138,14 @@ export const TipPositionModal = (
     return utils.getErrorText({ errors, minMm: min, maxMm: max, isPristine, t })
   }
 
+  const roundedXMin = utils.roundValue(xMinWidth)
+  const roundedYMin = utils.roundValue(yMinWidth)
+  const roundedXMax = utils.roundValue(xMaxWidth)
+  const roundedYMax = utils.roundValue(yMaxWidth)
+
   const zErrorText = createErrorText(zErrors, minMmFromBottom, maxMmFromBottom)
-  const xErrorText = createErrorText(xErrors, xMinWidth, xMaxWidth)
-  const yErrorText = createErrorText(yErrors, yMinWidth, yMaxWidth)
+  const xErrorText = createErrorText(xErrors, roundedXMin, roundedXMax)
+  const yErrorText = createErrorText(yErrors, roundedYMin, roundedYMax)
 
   const handleDone = (): void => {
     setPristine(false)
@@ -238,8 +243,8 @@ export const TipPositionModal = (
         </StyledText>
         <InputField
           caption={t('tip_position.caption', {
-            min: xMinWidth,
-            max: xMaxWidth,
+            min: roundedXMin,
+            max: roundedXMax,
           })}
           error={xErrorText}
           className={styles.position_from_bottom_input}
@@ -255,8 +260,8 @@ export const TipPositionModal = (
         </StyledText>
         <InputField
           caption={t('tip_position.caption', {
-            min: yMinWidth,
-            max: yMaxWidth,
+            min: roundedYMin,
+            max: roundedYMax,
           })}
           error={yErrorText}
           className={styles.position_from_bottom_input}

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
@@ -61,6 +61,22 @@ describe('TipPositionModal', () => {
     expect(mockUpdateYSpec).toHaveBeenCalled()
     expect(mockUpdateZSpec).toHaveBeenCalled()
   })
+  it('renders the alert if the x/y position values are too close to the max/min for x value', () => {
+    props.specs.x.value = 9.7
+    render(props)
+    screen.getByText('warning')
+    screen.getByText(
+      'The X and/or Y position value is close to edge of the well and might collide with it'
+    )
+  })
+  it('renders the alert if the x/y position values are too close to the max/min for y value', () => {
+    props.specs.y.value = -9.7
+    render(props)
+    screen.getByText('warning')
+    screen.getByText(
+      'The X and/or Y position value is close to edge of the well and might collide with it'
+    )
+  })
   it('renders the custom options, captions, and visual', () => {
     render(props)
     fireEvent.click(screen.getByRole('radio', { name: 'Custom' }))

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
@@ -82,9 +82,9 @@ describe('TipPositionModal', () => {
     fireEvent.click(screen.getByRole('radio', { name: 'Custom' }))
     expect(screen.getAllByRole('textbox', { name: '' })).toHaveLength(3)
     screen.getByText('X position')
-    screen.getByText('between -5.15 and 5.15')
+    screen.getByText('between -5.1 and 5.2')
     screen.getByText('Y position')
-    screen.getByText('between -5.25 and 5.25')
+    screen.getByText('between -5.2 and 5.3')
     screen.getByText('Z position')
     screen.getByText('between 0 and 100')
     screen.getByText('mock TipPositionViz')
@@ -129,8 +129,8 @@ describe('TipPositionModal', () => {
     fireEvent.click(screen.getByText('done'))
     //  display out of bounds error
     screen.getByText('accepted range is 0 to 100')
-    screen.getByText('accepted range is -5.25 to 5.25')
-    screen.getByText('accepted range is -5.15 to 5.15')
+    screen.getByText('accepted range is -5.2 to 5.3')
+    screen.getByText('accepted range is -5.1 to 5.2')
     const xInputField = screen.getAllByRole('textbox', { name: '' })[0]
     fireEvent.change(xInputField, { target: { value: 3.55555 } })
     fireEvent.click(screen.getByText('done'))

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/constants.ts
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/constants.ts
@@ -2,4 +2,4 @@ export const DECIMALS_ALLOWED = 1
 export const SMALL_STEP_MM = 1
 export const LARGE_STEP_MM = 10
 export const TOO_MANY_DECIMALS: 'TOO_MANY_DECIMALS' = 'TOO_MANY_DECIMALS'
-export const PERCENT_RANGE_TO_SHOW_WARNING  = 0.9
+export const PERCENT_RANGE_TO_SHOW_WARNING = 0.9

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/constants.ts
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/constants.ts
@@ -2,3 +2,4 @@ export const DECIMALS_ALLOWED = 1
 export const SMALL_STEP_MM = 1
 export const LARGE_STEP_MM = 10
 export const TOO_MANY_DECIMALS: 'TOO_MANY_DECIMALS' = 'TOO_MANY_DECIMALS'
+export const PERCENT_RANGE_TO_SHOW_WARNING  = 0.9

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -62,6 +62,7 @@
   "tip_position": {
     "title": "Tip Positioning",
     "caption": "between {{min}} and {{max}}",
+    "warning": "The X and/or Y position value is close to edge of the well and might collide with it",
     "radio_button": {
       "default": "{{defaultMmFromBottom}} mm from the bottom center (default)",
       "blowout": "0 mm from the top center (default)",


### PR DESCRIPTION
closes AUTH-252

# Overview

Adds a PD alert banner to the tip position modal if the user adds an x or y position that is too close to the edge of the well

# Test Plan

Create a flex or ot-2 protocol. Add a labware. Add a transfer or mix step. In the advanced settings, select the tip position icon and open the tip position modal. Add a custom offset with an x or y position that is at least 90% of the max/min positions. You should see the PD alert banner pop up. It should go away if you change your value

# Changelog

- add alert banner to pop up if the x or y value is >90% of the min or max
- add test cases

# Review requests

see test plan

# Risk assessment

low