### PR TITLE
feat(app, components): fix ProtocolDetails ParametersTable

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -39,6 +39,7 @@
   "not_connected": "not connected",
   "not_in_protocol": "no {{section}} is specified for this protocol",
   "num_choices": "{{num}} choices",
+  "num_options": "{{num}} options",
   "off": "Off",
   "on_off": "On, off",
   "on": "On",

--- a/app/src/organisms/ProtocolDetails/ProtocolParameters/__tests__/ProtocolParameters.test.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolParameters/__tests__/ProtocolParameters.test.tsx
@@ -126,7 +126,7 @@ describe('ProtocolParameters', () => {
 
     screen.getByText('Default Module Offsets')
     screen.getByText('No offsets')
-    screen.getByText('3 choices')
+    screen.getByText('3 options')
 
     screen.getByText('pipette mount')
     screen.getByText('Left')

--- a/components/src/molecules/ParametersTable/__tests__/ParametersTable.test.tsx
+++ b/components/src/molecules/ParametersTable/__tests__/ParametersTable.test.tsx
@@ -74,7 +74,7 @@ const render = (props: React.ComponentProps<typeof ParametersTable>) => {
   return renderWithProviders(<ParametersTable {...props} />)
 }
 
-describe('ParametersTabl', () => {
+describe('ParametersTable', () => {
   let props: React.ComponentProps<typeof ParametersTable>
 
   beforeEach(() => {
@@ -100,10 +100,12 @@ describe('ParametersTabl', () => {
     screen.getByText('6.5 mL')
     screen.getByText('1.5-10')
 
+    // more than 2 options
     screen.getByText('Default Module Offsets')
     screen.getByText('No offsets')
-    screen.getByText('3 choices')
+    screen.getByText('3 options')
 
+    // 2 options
     screen.getByText('pipette mount')
     screen.getByText('Left')
     screen.getByText('Left, Right')
@@ -115,5 +117,10 @@ describe('ParametersTabl', () => {
     screen.getByText('name')
     screen.getByText('default_value')
     screen.getByText('range')
+  })
+
+  it('should render a description icon if description is provided', () => {
+    render(props)
+    screen.getByTestId('Icon_0')
   })
 })

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react'
 import styled from 'styled-components'
 import { formatRunTimeParameterDefaultValue } from '@opentrons/shared-data'
-import { BORDERS } from '../../helix-design-system'
+import { BORDERS, COLORS } from '../../helix-design-system'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants/index'
 import { StyledText } from '../../atoms/StyledText'
+import { Tooltip, useHoverTooltip } from '../../tooltips'
+import { Icon } from '../../icons'
+import { Flex } from '../../primitives'
+import { ALIGN_CENTER } from '../../styles'
 
 import type { RunTimeParameter } from '@opentrons/shared-data'
 
@@ -28,18 +32,20 @@ export function ParametersTable({
       'choices' in runTimeParameter ? runTimeParameter.choices : []
     const count = choices.length
 
+    if (count > 0) {
+      return count > 2
+        ? t != null
+          ? t('num_options', { num: count })
+          : `${count} options`
+        : choices.map(choice => choice.displayName).join(', ')
+    }
+
     switch (type) {
       case 'int':
       case 'float':
         return minMax
       case 'bool':
         return t != null ? t('on_off') : 'On, off'
-      case 'str':
-        if (count > 2) {
-          return t != null ? t('choices', { count }) : `${count} choices`
-        } else {
-          return choices.map(choice => choice.displayName).join(', ')
-        }
     }
     return ''
   }
@@ -64,9 +70,12 @@ export function ParametersTable({
               isLast={index === runTimeParameters.length - 1}
               key={`runTimeParameter-${index}`}
             >
-              <StyledTableCell isLast={index === runTimeParameters.length - 1}>
-                <StyledText as="p">{parameter.displayName}</StyledText>
-              </StyledTableCell>
+              <ParameterName
+                displayName={parameter.displayName}
+                description={parameter.description}
+                isLast={index === runTimeParameters.length - 1}
+                index={index}
+              />
               <StyledTableCell isLast={index === runTimeParameters.length - 1}>
                 <StyledText as="p">
                   {formatRunTimeParameterDefaultValue(parameter, t)}
@@ -82,6 +91,46 @@ export function ParametersTable({
         })}
       </tbody>
     </StyledTable>
+  )
+}
+
+interface ParameterNameProps {
+  displayName: string
+  description: string | null
+  isLast: boolean
+  index: number
+}
+
+const ParameterName = (props: ParameterNameProps): JSX.Element => {
+  const { displayName, description, isLast, index } = props
+  const [targetProps, tooltipProps] = useHoverTooltip()
+
+  return (
+    <StyledTableCell isLast={isLast}>
+      <Flex gridGap={SPACING.spacing8}>
+        <StyledText as="p">{displayName}</StyledText>
+        {description != null ? (
+          <>
+            <Flex {...targetProps} alignItems={ALIGN_CENTER}>
+              <Icon
+                name="information"
+                size={SPACING.spacing12}
+                color={COLORS.grey60}
+                data-testid={`Icon_${index}`}
+              />
+            </Flex>
+            <Tooltip
+              {...tooltipProps}
+              backgroundColor={COLORS.black90}
+              width={'8.75rem'}
+              css={TYPOGRAPHY.labelRegular}
+            >
+              {description}
+            </Tooltip>
+          </>
+        ) : null}
+      </Flex>
+    </StyledTableCell>
   )
 }
 
@@ -111,6 +160,7 @@ interface StyledTableCellProps {
 }
 
 const StyledTableCell = styled.td<StyledTableCellProps>`
+  width: 33%;
   padding-left: ${SPACING.spacing8};
   padding-top: ${SPACING.spacing12};
   padding-bottom: ${props => (props.isLast ? 0 : SPACING.spacing12)};

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -122,7 +122,7 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
             <Tooltip
               {...tooltipProps}
               backgroundColor={COLORS.black90}
-              width={'8.75rem'}
+              width="8.75rem"
               css={TYPOGRAPHY.labelRegular}
             >
               {description}

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -46,8 +46,9 @@ export function ParametersTable({
         return minMax
       case 'bool':
         return t != null ? t('on_off') : 'On, off'
+      default:
+        return ''
     }
-    return ''
   }
 
   return (


### PR DESCRIPTION
# Overview

Update styling of `ParametersTable` component used in desktop `ProtocolDetails`

# Test Plan

- upload protocol containing RTPs 
- click protocol to open protocol details
- verify that you land on 'Parameters' tab
- verify that hovering a parameter's info icon renders a tooltip containing parameter description text
- verify that 'Range' for choice parameter containing 2 options displays "option 1, option 2"
- verify that 'Range' for choice parameter containing >2 options displays "[#options] options"

<img width="639" alt="Screenshot 2024-04-04 at 12 00 03 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/63ca13d7-25d5-4ac5-861b-72703b76d51c">

# Changelog

- refactor `ParametersTable` component to include hoverable icon for tooltip description
- update rendering of choice parameter range depending on number of choices
- add translation key for number of options
- add tests

# Review requests

authorship devs

# Risk assessment

low