### PR TITLE
fix(app, components): fix parameter table styling

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
@@ -182,7 +182,7 @@ const StyledTable = styled.table`
 const StyledTableHeaderContainer = styled.thead`
   display: grid;
   grid-template-columns: 0.35fr 0.35fr;
-  grid-gap: 48px;
+  grid-gap: ${SPACING.spacing48};
   border-bottom: ${BORDERS.lineBorder};
 `
 
@@ -198,7 +198,7 @@ interface StyledTableRowProps {
 const StyledTableRow = styled.tr<StyledTableRowProps>`
   display: grid;
   grid-template-columns: 0.35fr 0.35fr;
-  grid-gap: 48px;
+  grid-gap: ${SPACING.spacing48};
   border-bottom: ${props => (props.isLast ? 'none' : BORDERS.lineBorder)};
 `
 
@@ -212,5 +212,5 @@ const StyledTableCell = styled.td<StyledTableCellProps>`
   display: ${props => (props.display != null ? props.display : 'table-cell')};
   padding: ${SPACING.spacing8} 0;
   padding-right: ${props =>
-    props.paddingRight != null ? props.paddingRight : '1.0625rem'};
+    props.paddingRight != null ? props.paddingRight : SPACING.spacing16};
 `

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
@@ -212,5 +212,5 @@ const StyledTableCell = styled.td<StyledTableCellProps>`
   display: ${props => (props.display != null ? props.display : 'table-cell')};
   padding: ${SPACING.spacing8} 0;
   padding-right: ${props =>
-    props.paddingRight != null ? props.paddingRight : '17px'};
+    props.paddingRight != null ? props.paddingRight : '1.0625rem'};
 `

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunRunTimeParameters.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { formatRunTimeParameterDefaultValue } from '@opentrons/shared-data'
 import {
   ALIGN_CENTER,
@@ -9,6 +9,7 @@ import {
   COLORS,
   DIRECTION_COLUMN,
   DIRECTION_ROW,
+  DISPLAY_INLINE,
   Flex,
   Icon,
   InfoScreen,
@@ -96,7 +97,7 @@ export function ProtocolRunRuntimeParameters({
                       key={`${index}_${parameter.variableName}`}
                       parameter={parameter}
                       index={index}
-                      runTimeParametersLength={runTimeParameters.length}
+                      isLast={index === runTimeParameters.length - 1}
                       t={t}
                     />
                   )
@@ -113,41 +114,48 @@ export function ProtocolRunRuntimeParameters({
 interface StyledTableRowComponentProps {
   parameter: RunTimeParameter
   index: number
-  runTimeParametersLength: number
+  isLast: boolean
   t: any
 }
 
 const StyledTableRowComponent = (
   props: StyledTableRowComponentProps
 ): JSX.Element => {
-  const { parameter, index, runTimeParametersLength, t } = props
+  const { parameter, index, isLast, t } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
   return (
-    <StyledTableRow
-      isLast={index === runTimeParametersLength - 1}
-      key={`runTimeParameter-${index}`}
-    >
-      <StyledTableCell isLast={index === runTimeParametersLength - 1}>
-        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
-          <StyledText as="p">{parameter.displayName}</StyledText>
-          {parameter.description != null ? (
-            <>
-              <Flex {...targetProps} alignItems={ALIGN_CENTER}>
-                <Icon
-                  name="information"
-                  size={SPACING.spacing12}
-                  color={COLORS.grey60}
-                  data-testid="Icon"
-                />
-              </Flex>
-              <Tooltip tooltipProps={tooltipProps}>
-                {parameter.description}
-              </Tooltip>
-            </>
-          ) : null}
-        </Flex>
+    <StyledTableRow isLast={isLast} key={`runTimeParameter-${index}`}>
+      <StyledTableCell display="span">
+        <StyledText
+          as="p"
+          css={css`
+            display: inline;
+            padding-right: 8px;
+          `}
+        >
+          {parameter.displayName}
+        </StyledText>
+        {parameter.description != null ? (
+          <>
+            <Flex
+              display={DISPLAY_INLINE}
+              {...targetProps}
+              alignItems={ALIGN_CENTER}
+            >
+              <Icon
+                name="information"
+                size={SPACING.spacing12}
+                color={COLORS.grey60}
+                data-testid="Icon"
+              />
+            </Flex>
+            <Tooltip css={TYPOGRAPHY.labelRegular} tooltipProps={tooltipProps}>
+              {parameter.description}
+            </Tooltip>
+          </>
+        ) : null}
       </StyledTableCell>
-      <StyledTableCell isLast={index === runTimeParametersLength - 1}>
+      <StyledTableCell>
         <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
           <StyledText as="p">
             {formatRunTimeParameterDefaultValue(parameter, t)}
@@ -173,14 +181,14 @@ const StyledTable = styled.table`
 `
 const StyledTableHeaderContainer = styled.thead`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 0.35fr 0.35fr;
   grid-gap: 48px;
   border-bottom: ${BORDERS.lineBorder};
 `
 
 const StyledTableHeader = styled.th`
   ${TYPOGRAPHY.labelSemiBold}
-  padding: ${SPACING.spacing8};
+  padding-bottom: ${SPACING.spacing8};
 `
 
 interface StyledTableRowProps {
@@ -189,19 +197,20 @@ interface StyledTableRowProps {
 
 const StyledTableRow = styled.tr<StyledTableRowProps>`
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 0.35fr 0.35fr;
   grid-gap: 48px;
-  padding-top: ${SPACING.spacing8};
-  padding-bottom: ${SPACING.spacing8};
   border-bottom: ${props => (props.isLast ? 'none' : BORDERS.lineBorder)};
-  align-items: ${ALIGN_CENTER};
 `
 
 interface StyledTableCellProps {
-  isLast: boolean
+  paddingRight?: string
+  display?: string
 }
 
 const StyledTableCell = styled.td<StyledTableCellProps>`
-  padding-left: ${SPACING.spacing8};
-  height: 1.25rem;
+  align-items: ${ALIGN_CENTER};
+  display: ${props => (props.display != null ? props.display : 'table-cell')};
+  padding: ${SPACING.spacing8} 0;
+  padding-right: ${props =>
+    props.paddingRight != null ? props.paddingRight : '17px'};
 `

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -84,7 +84,7 @@ export function ParametersTable({
               </StyledTableCell>
               <StyledTableCell
                 isLast={index === runTimeParameters.length - 1}
-                paddingRight="0px"
+                paddingRight="0"
               >
                 <StyledText as="p">
                   {formatRange(parameter, `${min}-${max}`)}
@@ -115,7 +115,7 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
         as="p"
         css={css`
           display: ${DISPLAY_INLINE};
-          padding-right: 8px;
+          padding-right: ${SPACING.spacing8};
         `}
       >
         {displayName}
@@ -152,7 +152,7 @@ const StyledTable = styled.table`
 
 const StyledTableHeader = styled.th`
   ${TYPOGRAPHY.labelSemiBold}
-  grid-gap: 17px;
+  grid-gap: 1.0625rem;
   padding-bottom: ${SPACING.spacing8};
   border-bottom: ${BORDERS.lineBorder};
 `
@@ -162,7 +162,7 @@ interface StyledTableRowProps {
 }
 
 const StyledTableRow = styled.tr<StyledTableRowProps>`
-  grid-gap: 17px;
+  grid-gap: 1.0625rem;
   border-bottom: ${props => (props.isLast ? 'none' : BORDERS.lineBorder)};
 `
 
@@ -178,5 +178,5 @@ const StyledTableCell = styled.td<StyledTableCellProps>`
   padding-top: ${SPACING.spacing12};
   padding-bottom: ${props => (props.isLast ? 0 : SPACING.spacing12)};
   padding-right: ${props =>
-    props.paddingRight != null ? props.paddingRight : '17px'};
+    props.paddingRight != null ? props.paddingRight : '1.0625rem'};
 `

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { formatRunTimeParameterDefaultValue } from '@opentrons/shared-data'
 import { BORDERS, COLORS } from '../../helix-design-system'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants/index'
@@ -7,7 +7,7 @@ import { StyledText } from '../../atoms/StyledText'
 import { Tooltip, useHoverTooltip } from '../../tooltips'
 import { Icon } from '../../icons'
 import { Flex } from '../../primitives'
-import { ALIGN_CENTER } from '../../styles'
+import { DISPLAY_INLINE } from '../../styles'
 
 import type { RunTimeParameter } from '@opentrons/shared-data'
 
@@ -82,7 +82,10 @@ export function ParametersTable({
                   {formatRunTimeParameterDefaultValue(parameter, t)}
                 </StyledText>
               </StyledTableCell>
-              <StyledTableCell isLast={index === runTimeParameters.length - 1}>
+              <StyledTableCell
+                isLast={index === runTimeParameters.length - 1}
+                paddingRight="0px"
+              >
                 <StyledText as="p">
                   {formatRange(parameter, `${min}-${max}`)}
                 </StyledText>
@@ -107,30 +110,36 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
   const [targetProps, tooltipProps] = useHoverTooltip()
 
   return (
-    <StyledTableCell isLast={isLast}>
-      <Flex gridGap={SPACING.spacing8}>
-        <StyledText as="p">{displayName}</StyledText>
-        {description != null ? (
-          <>
-            <Flex {...targetProps} alignItems={ALIGN_CENTER}>
-              <Icon
-                name="information"
-                size={SPACING.spacing12}
-                color={COLORS.grey60}
-                data-testid={`Icon_${index}`}
-              />
-            </Flex>
-            <Tooltip
-              {...tooltipProps}
-              backgroundColor={COLORS.black90}
-              width="8.75rem"
-              css={TYPOGRAPHY.labelRegular}
-            >
-              {description}
-            </Tooltip>
-          </>
-        ) : null}
-      </Flex>
+    <StyledTableCell display="span" isLast={isLast}>
+      <StyledText
+        as="p"
+        css={css`
+          display: ${DISPLAY_INLINE};
+          padding-right: 8px;
+        `}
+      >
+        {displayName}
+      </StyledText>
+      {description != null ? (
+        <>
+          <Flex display={DISPLAY_INLINE} {...targetProps}>
+            <Icon
+              name="information"
+              size={SPACING.spacing12}
+              color={COLORS.grey60}
+              data-testid={`Icon_${index}`}
+            />
+          </Flex>
+          <Tooltip
+            {...tooltipProps}
+            backgroundColor={COLORS.black90}
+            css={TYPOGRAPHY.labelRegular}
+            width="8.75rem"
+          >
+            {description}
+          </Tooltip>
+        </>
+      ) : null}
     </StyledTableCell>
   )
 }
@@ -143,7 +152,8 @@ const StyledTable = styled.table`
 
 const StyledTableHeader = styled.th`
   ${TYPOGRAPHY.labelSemiBold}
-  padding: ${SPACING.spacing8};
+  grid-gap: 17px;
+  padding-bottom: ${SPACING.spacing8};
   border-bottom: ${BORDERS.lineBorder};
 `
 
@@ -152,17 +162,21 @@ interface StyledTableRowProps {
 }
 
 const StyledTableRow = styled.tr<StyledTableRowProps>`
-  padding: ${SPACING.spacing8};
+  grid-gap: 17px;
   border-bottom: ${props => (props.isLast ? 'none' : BORDERS.lineBorder)};
 `
 
 interface StyledTableCellProps {
   isLast: boolean
+  paddingRight?: string
+  display?: string
 }
 
 const StyledTableCell = styled.td<StyledTableCellProps>`
   width: 33%;
-  padding-left: ${SPACING.spacing8};
+  display: ${props => (props.display != null ? props.display : 'table-cell')};
   padding-top: ${SPACING.spacing12};
   padding-bottom: ${props => (props.isLast ? 0 : SPACING.spacing12)};
+  padding-right: ${props =>
+    props.paddingRight != null ? props.paddingRight : '17px'};
 `

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -152,7 +152,7 @@ const StyledTable = styled.table`
 
 const StyledTableHeader = styled.th`
   ${TYPOGRAPHY.labelSemiBold}
-  grid-gap: 1.0625rem;
+  grid-gap: ${SPACING.spacing16};
   padding-bottom: ${SPACING.spacing8};
   border-bottom: ${BORDERS.lineBorder};
 `
@@ -162,7 +162,7 @@ interface StyledTableRowProps {
 }
 
 const StyledTableRow = styled.tr<StyledTableRowProps>`
-  grid-gap: 1.0625rem;
+  grid-gap: ${SPACING.spacing16};
   border-bottom: ${props => (props.isLast ? 'none' : BORDERS.lineBorder)};
 `
 
@@ -178,5 +178,5 @@ const StyledTableCell = styled.td<StyledTableCellProps>`
   padding-top: ${SPACING.spacing12};
   padding-bottom: ${props => (props.isLast ? 0 : SPACING.spacing12)};
   padding-right: ${props =>
-    props.paddingRight != null ? props.paddingRight : '1.0625rem'};
+    props.paddingRight != null ? props.paddingRight : SPACING.spacing16};
 `


### PR DESCRIPTION
# Overview

Fix styling for parameters table at both ProtocolDetails and ProtocolRunRunTimeParameters

# Test Plan

- upload RTP protocol which contains long display names or values
- select protocol to observe ProtocolDetails
- select 'Parameters' tab and resize window to view behavior of wrapped text/icons
<img width="767" alt="Screenshot 2024-04-04 at 4 20 53 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/941f2811-3d85-41a1-b3d2-79d0b548a5a7">

- begin protocol setup
- select 'Parameters' tab and resize window to view behavior of wrapped text/icons
<img width="537" alt="Screenshot 2024-04-04 at 4 21 31 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/0f9529ef-b6cf-4e1c-8235-8b5636d7b133">

# Changelog

- make hoverable description icon inline with parameter display name, even if display name wraps to multiple lines
- resize column widths according to designs

# Review requests

authorship devs

# Risk assessment

low