### PR TITLE
Fix settings tests

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -250,7 +250,7 @@ settings = [
         ),
         robot_type=[RobotTypeEnum.OT2, RobotTypeEnum.FLEX],
         internal_only=True,
-    )
+    ),
 ]
 
 if (
@@ -718,6 +718,7 @@ def _migrate31to32(previous: SettingsMap) -> SettingsMap:
     newmap = {k: v for k, v in previous.items()}
     newmap["enableOEMMode"] = None
     return newmap
+
 
 def _migrate32to33(previous: SettingsMap) -> SettingsMap:
     """Migrate to version 33 of the feature flags file.

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -79,6 +79,4 @@ def enable_error_recovery_experiments() -> bool:
 
 
 def enable_performance_metrics(robot_type: RobotTypeEnum) -> bool:
-    return advs.get_setting_with_env_overload(
-        "enablePerformanceMetrics", robot_type
-    )
+    return advs.get_setting_with_env_overload("enablePerformanceMetrics", robot_type)

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -57,12 +57,12 @@ def mock_settings(
 
 @pytest.fixture
 def mock_read_settings_file_ot2(
-    mock_settings_values_ot2: Dict[str, Optional[bool]],
+    mock_settings_values_ot2_all: Dict[str, Optional[bool]],
     mock_settings_version: int,
 ) -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.advanced_settings._read_settings_file") as p:
         p.return_value = advanced_settings.SettingsData(
-            settings_map=mock_settings_values_ot2,
+            settings_map=mock_settings_values_ot2_all,
             version=mock_settings_version,
         )
         yield p
@@ -168,19 +168,19 @@ def test_get_all_adv_settings_empty(
 
 async def test_set_adv_setting(
     mock_read_settings_file_ot2: MagicMock,
-    mock_settings_values_ot2: MagicMock,
+    mock_settings_values_ot2_all: MagicMock,
     mock_write_settings_file: MagicMock,
     mock_settings_version: int,
     restore_restart_required: None,
 ) -> None:
-    for k, v in mock_settings_values_ot2.items():
+    for k, v in mock_settings_values_ot2_all.items():
         # Toggle the advanced setting
         await advanced_settings.set_adv_setting(k, not v)
         mock_write_settings_file.assert_called_with(
             # Only the current key is toggled
             {
                 nk: nv if nk != k else not v
-                for nk, nv in mock_settings_values_ot2.items()
+                for nk, nv in mock_settings_values_ot2_all.items()
             },
             mock_settings_version,
             CONFIG["feature_flags_file"],

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -33,6 +33,7 @@ def mock_settings_values_flex() -> Dict[str, Optional[bool]]:
         if RobotTypeEnum.FLEX in s.robot_type and not s.internal_only
     }
 
+
 @pytest.fixture
 def mock_settings_values_flex_all() -> Dict[str, Optional[bool]]:
     return {

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -33,6 +33,14 @@ def mock_settings_values_flex() -> Dict[str, Optional[bool]]:
         if RobotTypeEnum.FLEX in s.robot_type and not s.internal_only
     }
 
+@pytest.fixture
+def mock_settings_values_flex_all() -> Dict[str, Optional[bool]]:
+    return {
+        s.id: False
+        for s in advanced_settings.settings
+        if RobotTypeEnum.FLEX in s.robot_type
+    }
+
 
 @pytest.fixture
 def mock_settings_values_empty() -> Dict[str, Optional[bool]]:
@@ -70,12 +78,12 @@ def mock_read_settings_file_ot2(
 
 @pytest.fixture
 def mock_read_settings_file_flex(
-    mock_settings_values_flex: Dict[str, Optional[bool]],
+    mock_settings_values_flex_all: Dict[str, Optional[bool]],
     mock_settings_version: int,
 ) -> Generator[MagicMock, None, None]:
     with patch("opentrons.config.advanced_settings._read_settings_file") as p:
         p.return_value = advanced_settings.SettingsData(
-            settings_map=mock_settings_values_flex,
+            settings_map=mock_settings_values_flex_all,
             version=mock_settings_version,
         )
         yield p


### PR DESCRIPTION
# Overview

When we patch the _read_settings_file function, we are calling to fixtures that exclude flags that have internal_only set to True. When you look at the _read_settings_file function there is no filtering out of flags set to internal_only. 

```python
def _read_settings_file(settings_file: "Path") -> SettingsData:
    """
    Read the settings file, which is a json object with settings IDs as keys
    and boolean values. For each key, look up the `Settings` object with that
    key. If the key is one of the old IDs (kebab case), replace it with the
    new ID and rewrite the settings file

    :param settings_file: the path to the settings file
    :return: a dict with all new settings IDs as the keys, and boolean values
        (the values stored in the settings file, or `False` if the key was not
        found). Along with the version.
    """
    # Read settings from persistent file
    data = _read_json_file(settings_file)
    settings, version = _migrate(data)
    settings = _ensure(settings)

    if data.get("_version") != version:
        _write_settings_file(settings, version, settings_file)

    return SettingsData(settings_map=settings, version=version)
```

Therefore, the patches for the OT-2 and Flex should be calling the fixtures that do not exclude the internal_only flag.