### PR TITLE
fix(app-shell): Fix isConnectingToBroker nullish coalescence

### DIFF
--- a/app-shell/src/notifications/__tests__/store.test.ts
+++ b/app-shell/src/notifications/__tests__/store.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { connectionStore } from '../store'
+
+const MOCK_IP = 'MOCK_IP'
+const MOCK_ROBOT = 'MOCK_ROBOT'
+const MOCK_WINDOW = {} as any
+const MOCK_CLIENT = { connected: true } as any
+const MOCK_TOPIC = 'MOCK_TOPIC' as any
+
+describe('ConnectionStore', () => {
+  beforeEach(() => {
+    connectionStore.clearStore()
+  })
+
+  describe('getBrowserWindow', () => {
+    it('should return the browser window', () => {
+      connectionStore.setBrowserWindow(MOCK_WINDOW)
+      expect(connectionStore.getBrowserWindow()).toBe(MOCK_WINDOW)
+    })
+  })
+
+  describe('getAllBrokersInStore', () => {
+    it('should return an empty array if there are no brokers in the store', () => {
+      expect(connectionStore.getAllBrokersInStore()).toEqual([])
+    })
+
+    it('should return an array of broker names in the store', async () => {
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setPendingConnection('robot2')
+      expect(connectionStore.getAllBrokersInStore()).toEqual([
+        MOCK_ROBOT,
+        'robot2',
+      ])
+    })
+  })
+
+  describe('getClient', () => {
+    it('should return null if the given IP is not associated with a connection', () => {
+      expect(connectionStore.getClient(MOCK_IP)).toBeNull()
+    })
+
+    it('should return the client if the given IP is associated with a connection', async () => {
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      expect(connectionStore.getClient(MOCK_IP)).toBe(MOCK_CLIENT)
+    })
+  })
+
+  describe('setErrorStatus and getFailedConnectionStatus', () => {
+    it('should return null if the given IP is not associated with a connection', () => {
+      expect(connectionStore.getFailedConnectionStatus(MOCK_IP)).toBeNull()
+    })
+
+    it('should return the unreachable status for the given IP', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setErrorStatus(MOCK_IP, 'ECONNFAILED')
+      expect(connectionStore.getFailedConnectionStatus(MOCK_IP)).toBe(
+        'ECONNFAILED'
+      )
+    })
+
+    it('should return "ECONNFAILED" if the unreachable status for the given IP is "ECONNREFUSED" after the first error status check', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setErrorStatus(MOCK_IP, 'ECONNREFUSED')
+      expect(connectionStore.getFailedConnectionStatus(MOCK_IP)).toBe(
+        'ECONNREFUSED'
+      )
+      expect(connectionStore.getFailedConnectionStatus(MOCK_IP)).toBe(
+        'ECONNFAILED'
+      )
+    })
+
+    it('should throw an error if the given IP is not associated with a connection', async () => {
+      await expect(
+        connectionStore.setErrorStatus(MOCK_IP, 'Connection refused')
+      ).rejects.toThrowError('MOCK_IP is not associated with a connection')
+    })
+  })
+
+  describe('getRobotNameByIP', () => {
+    it('should return null if the given IP is not associated with a connection', () => {
+      expect(connectionStore.getRobotNameByIP(MOCK_IP)).toBeNull()
+    })
+
+    it('should return the robot name associated with the given IP', () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      expect(connectionStore.getRobotNameByIP(MOCK_IP)).toBe(MOCK_ROBOT)
+    })
+  })
+
+  describe('setBrowserWindow', () => {
+    it('should set the browser window', () => {
+      connectionStore.setBrowserWindow(MOCK_WINDOW)
+      expect(connectionStore.getBrowserWindow()).toBe(MOCK_WINDOW)
+    })
+  })
+
+  describe('setPendingConnection', () => {
+    it('should create a new connection if there is no connection currently connecting', async () => {
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      expect(connectionStore.getAllBrokersInStore()).toEqual([MOCK_ROBOT])
+    })
+
+    it('should reject with an error if there is already a connection currently connecting', async () => {
+      await expect(
+        connectionStore.setPendingConnection(MOCK_ROBOT)
+      ).resolves.toBeUndefined()
+      await expect(
+        connectionStore.setPendingConnection(MOCK_ROBOT)
+      ).rejects.toThrowError(
+        'Cannot create a new connection while currently connecting.'
+      )
+    })
+  })
+
+  describe('setConnected', () => {
+    it('should set the client for the given robot name', async () => {
+      connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      expect(connectionStore.getClient(MOCK_IP)).toBe(MOCK_CLIENT)
+    })
+
+    it('should reject with an error if there is already a connection for the given robot name', async () => {
+      const MOCK_CLIENT_2 = {} as any
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await expect(
+        connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT_2)
+      ).rejects.toThrowError('Connection already exists for MOCK_ROBOT')
+    })
+
+    it('should reject with an error if the given robot name is not associated with a connection', async () => {
+      await expect(
+        connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      ).rejects.toThrowError('IP is not associated with a connection')
+    })
+  })
+
+  describe('setSubStatus', () => {
+    it('should set the pending sub status for the given IP and topic', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'pending')
+      expect(connectionStore.isPendingSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(true)
+    })
+
+    it('should set the subscribed status for the given IP and topic', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'subscribed')
+      expect(connectionStore.isActiveSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(true)
+      expect(connectionStore.isPendingSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should throw an error if the given IP is not associated with a connection', async () => {
+      await expect(
+        connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'pending')
+      ).rejects.toThrowError('IP is not associated with a connection')
+    })
+  })
+
+  describe('setUnsubStatus', () => {
+    it('should set the pending unsub status for the given IP and topic if it is currently subscribed', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'subscribed')
+      await connectionStore.setUnsubStatus(MOCK_IP, MOCK_TOPIC, 'pending')
+      expect(connectionStore.isPendingUnsub(MOCK_IP, MOCK_TOPIC)).toBe(true)
+      expect(connectionStore.isActiveSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(true)
+    })
+
+    it('should set the unsubscribed status for the given IP and topic if it is currently subscribed', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'subscribed')
+      await connectionStore.setUnsubStatus(MOCK_IP, MOCK_TOPIC, 'unsubscribed')
+      expect(connectionStore.isActiveSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(false)
+      expect(connectionStore.isPendingUnsub(MOCK_IP, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should not do anything if the given IP is not associated with a connection', async () => {
+      await expect(
+        connectionStore.setUnsubStatus(MOCK_IP, MOCK_TOPIC, 'pending')
+      ).rejects.toThrowError('IP is not associated with a connection')
+    })
+  })
+
+  describe('associateIPWithRobotName', () => {
+    it('should associate the given IP with the given robot name', () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      expect(connectionStore.getRobotNameByIP(MOCK_IP)).toBe(MOCK_ROBOT)
+    })
+
+    it('should update the association if the IP is already associated with a different robot name', () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      connectionStore.associateIPWithRobotName(MOCK_IP, 'robot2')
+      expect(connectionStore.getRobotNameByIP(MOCK_IP)).toBe('robot2')
+    })
+  })
+
+  describe('clearStore', () => {
+    it('should clear all connections and robot names', async () => {
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      connectionStore.setBrowserWindow(MOCK_WINDOW)
+      expect(connectionStore.getAllBrokersInStore()).not.toEqual([])
+      expect(connectionStore.getBrowserWindow()).not.toBeNull()
+      connectionStore.clearStore()
+      expect(connectionStore.getAllBrokersInStore()).toEqual([])
+      expect(connectionStore.getBrowserWindow()).toBeNull()
+    })
+  })
+
+  describe('isConnectedToBroker', () => {
+    it('should return false if the given robot name is not associated with a connection', () => {
+      expect(connectionStore.isConnectedToBroker(MOCK_ROBOT)).toBe(false)
+    })
+
+    it('should return false if the connection client is null', async () => {
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      expect(connectionStore.isConnectedToBroker(MOCK_ROBOT)).toBe(false)
+    })
+
+    it('should return true if the connection client is not null', async () => {
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      expect(connectionStore.isConnectedToBroker(MOCK_ROBOT)).toBe(true)
+    })
+  })
+
+  describe('isConnectingToBroker', () => {
+    it('should return false if the given robot name is not associated with a connection', () => {
+      expect(connectionStore.isConnectingToBroker(MOCK_ROBOT)).toBe(false)
+    })
+
+    it('should return false if the connection client is not null', () => {
+      connectionStore.setPendingConnection(MOCK_ROBOT)
+      connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      expect(connectionStore.isConnectingToBroker(MOCK_ROBOT)).toBe(false)
+    })
+
+    it('should return true if the connection client is null and the connection is not terminated', () => {
+      connectionStore.setPendingConnection(MOCK_ROBOT)
+      expect(connectionStore.isConnectingToBroker(MOCK_ROBOT)).toBe(true)
+    })
+  })
+
+  describe('isPendingSub', () => {
+    it('should return false if the given IP is not associated with a connection', () => {
+      expect(connectionStore.isPendingSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should return false if the topic is not pending', () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      expect(connectionStore.isPendingSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should return true if the topic is pending', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'pending')
+      expect(connectionStore.isPendingSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(true)
+    })
+  })
+
+  describe('isActiveSub', () => {
+    it('should return false if the given IP is not associated with a connection', () => {
+      expect(connectionStore.isActiveSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should return false if the topic is not subscribed', () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      expect(connectionStore.isActiveSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should return true if the topic is subscribed', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'subscribed')
+      expect(connectionStore.isActiveSub(MOCK_ROBOT, MOCK_TOPIC)).toBe(true)
+    })
+  })
+
+  describe('isPendingUnsub', () => {
+    it('should return false if the given IP is not associated with a connection', () => {
+      expect(connectionStore.isPendingUnsub(MOCK_IP, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should return false if the topic is not pending', () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      expect(connectionStore.isPendingUnsub(MOCK_IP, MOCK_TOPIC)).toBe(false)
+    })
+
+    it('should return true if the topic is pending', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setSubStatus(MOCK_IP, MOCK_TOPIC, 'subscribed')
+      await connectionStore.setUnsubStatus(MOCK_IP, MOCK_TOPIC, 'pending')
+      expect(connectionStore.isPendingUnsub(MOCK_IP, MOCK_TOPIC)).toBe(true)
+    })
+  })
+
+  describe('isConnectionTerminated', () => {
+    it('should return true if the given robot name is not associated with a connection', () => {
+      expect(connectionStore.isConnectionTerminated(MOCK_ROBOT)).toBe(true)
+    })
+
+    it('should return true if the unreachable status is not null', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      await connectionStore.setErrorStatus(MOCK_IP, 'Connection refused')
+      expect(connectionStore.isConnectionTerminated(MOCK_ROBOT)).toBe(true)
+    })
+
+    it('should return false if the unreachable status is null', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      await connectionStore.setConnected(MOCK_ROBOT, MOCK_CLIENT)
+      expect(connectionStore.isConnectionTerminated(MOCK_ROBOT)).toBe(false)
+    })
+  })
+
+  describe('isKnownPortBlockedIP', () => {
+    it('should return false if the given IP is not in the known port blocked IPs set', () => {
+      expect(connectionStore.isKnownPortBlockedIP('MOCK_IP_2')).toBe(false)
+    })
+
+    it('should return true if the given IP is in the known port blocked IPs set', async () => {
+      connectionStore.associateIPWithRobotName(MOCK_IP, MOCK_ROBOT)
+      await connectionStore.setPendingConnection(MOCK_ROBOT)
+      connectionStore.setErrorStatus(MOCK_IP, 'ECONNREFUSED')
+      expect(connectionStore.isKnownPortBlockedIP(MOCK_IP)).toBe(true)
+    })
+  })
+})

--- a/app-shell/src/notifications/store.ts
+++ b/app-shell/src/notifications/store.ts
@@ -207,7 +207,8 @@ class ConnectionStore {
 
   public isConnectingToBroker(robotName: string): boolean {
     return (
-      (this.hostsByRobotName[robotName]?.client == null ?? false) &&
+      robotName in this.hostsByRobotName &&
+      this.hostsByRobotName[robotName].client == null &&
       !this.isConnectionTerminated(robotName)
     )
   }


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The left side operand of the nullish coalesence conditional always evalutes to true, generating app-shell logs. Based on current usage, this shouldn't have caused any user-facing bugs. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verified no more app-shell logs containing this error are generated.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- App-shell logs now contain one less error message.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
