### PR TITLE
refactor(api): be more permissive with accepting int literals for float parameters

### DIFF
--- a/api/src/opentrons/protocol_api/_parameter_context.py
+++ b/api/src/opentrons/protocol_api/_parameter_context.py
@@ -91,10 +91,10 @@ class ParameterContext:
         parameter = parameter_definition.create_float_parameter(
             display_name=display_name,
             variable_name=variable_name,
-            default=default,
-            minimum=minimum,
-            maximum=maximum,
-            choices=choices,
+            default=validation.ensure_float_value(default),
+            minimum=validation.ensure_optional_float_value(minimum),
+            maximum=validation.ensure_optional_float_value(maximum),
+            choices=validation.ensure_float_choices(choices),
             description=description,
             unit=unit,
         )

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -75,6 +75,36 @@ def ensure_value_type(
     return validated_value
 
 
+def ensure_float_value(value: Union[float, int]) -> float:
+    """Ensures that if we are expecting a float and receive an int, that will be converted to a float."""
+    if not isinstance(value, bool) and isinstance(value, int):
+        return float(value)
+    return value
+
+
+def ensure_optional_float_value(value: Optional[Union[float, int]]) -> Optional[float]:
+    """Ensures that if we are expecting an optional float and receive an int, that will be converted to a float."""
+    if not isinstance(value, bool) and isinstance(value, int):
+        return float(value)
+    return value
+
+
+def ensure_float_choices(
+    choices: Optional[List[ParameterChoice]],
+) -> Optional[List[ParameterChoice]]:
+    """Ensures that if we are expecting float parameter choices and any are int types, those will be converted."""
+    if choices is not None:
+        return [
+            ParameterChoice(
+                display_name=choice["display_name"],
+                # Type ignore because if for some reason this is a str or bool, that will raise in `validate_options`
+                value=ensure_float_value(choice["value"]),  # type: ignore[arg-type]
+            )
+            for choice in choices
+        ]
+    return choices
+
+
 def convert_type_string_for_enum(
     parameter_type: type,
 ) -> Literal["int", "float", "str"]:

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -61,7 +61,8 @@ def ensure_value_type(
 
     This does not guarantee that the value will be the correct type for the given parameter, only that any data coming
     in is in the format that we expect. For now, the only transformation it is doing is converting integers represented
-    as floating points to integers, and bools represented as 1.0/0.0 to True/False.
+    as floating points to integers, and bools represented as 1.0/0.0 to True/False, and floating points represented as
+    ints to floats.
 
     If something is labelled as a type but does not get converted here, that will be caught when it is attempted to be
     set as the parameter value and will raise the appropriate error there.
@@ -72,6 +73,8 @@ def ensure_value_type(
             validated_value = bool(value)
         elif parameter_type is int and value.is_integer():
             validated_value = int(value)
+    elif isinstance(value, int) and not isinstance(value, bool) and parameter_type is float:
+        validated_value = float(value)
     return validated_value
 
 

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -73,7 +73,11 @@ def ensure_value_type(
             validated_value = bool(value)
         elif parameter_type is int and value.is_integer():
             validated_value = int(value)
-    elif isinstance(value, int) and not isinstance(value, bool) and parameter_type is float:
+    elif (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and parameter_type is float
+    ):
         validated_value = float(value)
     return validated_value
 

--- a/api/tests/opentrons/protocol_api/test_parameter_context.py
+++ b/api/tests/opentrons/protocol_api/test_parameter_context.py
@@ -77,14 +77,21 @@ def test_add_float(decoy: Decoy, subject: ParameterContext) -> None:
     """It should create and add a float parameter definition."""
     param_def = decoy.mock(cls=mock_parameter_definition.ParameterDefinition)
     decoy.when(param_def.variable_name).then_return("my cooler variable")
+    decoy.when(mock_validation.ensure_float_value(12.3)).then_return(3.21)
+    decoy.when(mock_validation.ensure_optional_float_value(4.5)).then_return(5.4)
+    decoy.when(mock_validation.ensure_optional_float_value(67.8)).then_return(87.6)
+    decoy.when(
+        mock_validation.ensure_float_choices([{"display_name": "foo", "value": 4.2}])
+    ).then_return([{"display_name": "bar", "value": 2.4}])
+
     decoy.when(
         mock_parameter_definition.create_float_parameter(
             display_name="abc",
             variable_name="xyz",
-            default=12.3,
-            minimum=4.5,
-            maximum=67.8,
-            choices=[{"display_name": "foo", "value": 4.2}],
+            default=3.21,
+            minimum=5.4,
+            maximum=87.6,
+            choices=[{"display_name": "bar", "value": 2.4}],
             description="blah blah blah",
             unit="lux",
         )

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -134,6 +134,7 @@ def test_validate_options_raises_name_error() -> None:
     [
         (1.0, int, 1),
         (1.1, int, 1.1),
+        (2, float, 2.0),
         (2.0, float, 2.0),
         (2.2, float, 2.2),
         ("3.0", str, "3.0"),

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -151,6 +151,67 @@ def test_ensure_value_type(
 
 
 @pytest.mark.parametrize(
+    ["value", "result"],
+    [
+        (1, 1.0),
+        (2.0, 2.0),
+        (3.3, 3.3),
+    ],
+)
+def test_ensure_float_value(value: Union[float, int], result: float) -> None:
+    """It should ensure that if applicable, the value is coerced into a float."""
+    assert result == subject.ensure_float_value(value)
+
+
+@pytest.mark.parametrize(
+    ["value", "result"],
+    [
+        (1, 1.0),
+        (2.0, 2.0),
+        (3.3, 3.3),
+        (None, None),
+    ],
+)
+def test_ensure_optional_float_value(value: Union[float, int], result: float) -> None:
+    """It should ensure that if applicable, the value is coerced into a float."""
+    assert result == subject.ensure_optional_float_value(value)
+
+
+@pytest.mark.parametrize(
+    ["choices", "result"],
+    [
+        ([], []),
+        (None, None),
+        (
+            [{"display_name": "foo", "value": 1}],
+            [{"display_name": "foo", "value": 1.0}],
+        ),
+        (
+            [{"display_name": "foo", "value": 2.0}],
+            [{"display_name": "foo", "value": 2.0}],
+        ),
+        (
+            [{"display_name": "foo", "value": 3.3}],
+            [{"display_name": "foo", "value": 3.3}],
+        ),
+        (
+            [{"display_name": "foo", "value": "4"}],
+            [{"display_name": "foo", "value": "4"}],
+        ),
+        (
+            [{"display_name": "foo", "value": True}],
+            [{"display_name": "foo", "value": True}],
+        ),
+    ],
+)
+def test_ensure_float_choices(
+    choices: Optional[List[ParameterChoice]], result: Optional[List[ParameterChoice]]
+) -> None:
+    """It should ensure that if applicable, the value in a choice is coerced into a float."""
+    assert result == subject.ensure_float_choices(choices)
+
+
+@pytest.mark.parametrize(
     ["param_type", "result"],
     [(int, "int"), (float, "float"), (str, "str")],
 )


### PR DESCRIPTION
# Overview

In the course of integrating runtime parameters frontend and backend work, it was discovered that for floating point parameters with a minimum and maximum range, if a literal int or value with only `.0` was entered, the parameter validation would fail as the type `int` did not match the accepted `float`.

While discussing this, it was determined that it would be best to allow those values, while also being less strict in the parameter definition creation `ParameterContext.add_float`. This permissiveness does **not** go the other way for parameter definitions, if a user adds something like `6.0` as a default for `ParameterContext.add_int`, that will still raise an error (value sent over to one of the endpoints however will do this conversion, due to how we defined our Pydantic types). Other values sent over will also not be converted but instead raise the appropriate error elsewhere. This includes values like `bool` which can be type converted in Python, a value of True will also **not** be converted to 1.

# Test Plan

Verified via postman that sending an int literal value for a float parameter override accepts the value and does not error out. Also ensure that this protocol passed analysis.

```
metadata = {
    'protocolName': 'RTP: Float test',
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.18"
}


def add_parameters(parameters):
    parameters.add_float(
        display_name="Volume 1",
        variable_name="volume_1",
        default=20,
        minimum=10,
        maximum=50,
    )
    parameters.add_float(
        display_name="Volume 2",
        variable_name="volume_2",
        default=20.0,
        choices=[
            {"display_name": "Low Volume", "value": 10},
            {"display_name": "Medium Volume", "value": 20},
            {"display_name": "High Volume", "value": 50.0},
        ],
    )


def run(context):
    trash_bin = context.load_trash_bin('A3')
    tip_rack = context.load_labware('opentrons_flex_96_tiprack_50ul', 'D2')
    source = context.load_labware('opentrons_96_wellplate_200ul_pcr_full_skirt', 'C1')
    destination = context.load_labware('opentrons_96_wellplate_200ul_pcr_full_skirt', 'C3')
    pipette = context.load_instrument('flex_1channel_50', mount="left", tip_racks=[tip_rack])

    pipette.pick_up_tip()
    pipette.aspirate(context.params.volume_1, source.wells()[0])
    pipette.dispense(context.params.volume_1, destination.wells()[0])

    pipette.aspirate(context.params.volume_2, source.wells()[0])
    pipette.dispense(context.params.volume_2, destination.wells()[0])
    pipette.drop_tip()
```

# Changelog

- Allow int literals to be send as parameter override values for float parameters
- Allow int literals to be used for the `default`, `minimum`, `maximum` and value key of `choices` for `ParameterContext.add_float`

# Review requests
# Risk assessment

Low.