### PR TITLE
fix(api): ensure the right mount is enabled for initial homing

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1521,8 +1521,16 @@ class OT3API(
         # G, Q should be handled in the backend through `self._home()`
         assert axis not in [Axis.G, Axis.Q]
 
+        # TODO(CM): This is a temporary fix in response to the right mount causing
+        # errors while trying to home on startup or attachment. We should remove this
+        # when we fix this issue in the firmware.
+        enable_right_mount_on_startup = (
+            self._gantry_load == GantryLoad.HIGH_THROUGHPUT and axis == Axis.Z_R
+        )
         encoder_ok = self._backend.check_encoder_status([axis])
-        if encoder_ok:
+        if (
+            encoder_ok or enable_right_mount_on_startup
+        ):  # or axis == Axis.Z_R: <- this fixes it
             # enable motor (if needed) and update estimation
             await self._enable_before_update_estimation(axis)
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1528,9 +1528,7 @@ class OT3API(
             self._gantry_load == GantryLoad.HIGH_THROUGHPUT and axis == Axis.Z_R
         )
         encoder_ok = self._backend.check_encoder_status([axis])
-        if (
-            encoder_ok or enable_right_mount_on_startup
-        ):  # or axis == Axis.Z_R: <- this fixes it
+        if encoder_ok or enable_right_mount_on_startup:
             # enable motor (if needed) and update estimation
             await self._enable_before_update_estimation(axis)
 


### PR DESCRIPTION
## Overview
On the current main firmware, the 96 channel will fail to home after startup or initial attachment, and as a result won't be able to proceed with protocols or testing.

This pr is a temporary holdover that is tested and fixes the issue from the Python side, and should be removed when a firmware solution is figured out.

## Changelog

- if `_home_axis` is called on the right mount, ensure that a request to engage the motor is sent before the move is executed.