### PR TITLE
feat(protocol-designer): temperature form multiple module support

### DIFF
--- a/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
+++ b/protocol-designer/src/components/DeckSetup/LabwareOverlays/LabwareHighlight.tsx
@@ -3,11 +3,14 @@ import cx from 'classnames'
 import { useSelector } from 'react-redux'
 import { Icon } from '@opentrons/components'
 import { getHoveredStepLabware, getHoveredStepId } from '../../../ui/steps'
-import { getSavedStepForms } from '../../../step-forms/selectors'
+import {
+  getLabwareEntities,
+  getSavedStepForms,
+} from '../../../step-forms/selectors'
 import { THERMOCYCLER_PROFILE } from '../../../constants'
 
 import styles from './LabwareOverlays.module.css'
-import { LabwareOnDeck } from '../../../step-forms'
+import type { LabwareOnDeck } from '../../../step-forms'
 
 interface LabwareHighlightProps {
   labwareOnDeck: LabwareOnDeck
@@ -17,8 +20,14 @@ export const LabwareHighlight = (
   props: LabwareHighlightProps
 ): JSX.Element | null => {
   const { labwareOnDeck } = props
+  const labwareEntities = useSelector(getLabwareEntities)
+  const adapterId =
+    labwareEntities[labwareOnDeck.slot] != null
+      ? labwareEntities[labwareOnDeck.slot].id
+      : null
+
   const highlighted = useSelector(getHoveredStepLabware).includes(
-    labwareOnDeck.id
+    adapterId ?? labwareOnDeck.id
   )
 
   let isTcProfile = false

--- a/protocol-designer/src/components/Hints/index.tsx
+++ b/protocol-designer/src/components/Hints/index.tsx
@@ -81,7 +81,6 @@ export const Hints = (): JSX.Element | null => {
             <p>{t(`alert:hint.${hintKey}.body`)}</p>
           </>
         )
-      case 'multiple_modules_without_labware':
 
       case 'thermocycler_lid_passive_cooling':
         return (

--- a/protocol-designer/src/components/Hints/index.tsx
+++ b/protocol-designer/src/components/Hints/index.tsx
@@ -74,12 +74,15 @@ export const Hints = (): JSX.Element | null => {
             <p>{t(`hint.${hintKey}.body3`)}</p>
           </>
         )
+      case 'multiple_modules_without_labware':
       case 'module_without_labware':
         return (
           <>
             <p>{t(`alert:hint.${hintKey}.body`)}</p>
           </>
         )
+      case 'multiple_modules_without_labware':
+
       case 'thermocycler_lid_passive_cooling':
         return (
           <>

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from 'react-i18next'
 import { FormGroup } from '@opentrons/components'
 import { selectors as uiModuleSelectors } from '../../../ui/modules'
 import { StepFormDropdown, RadioGroupField, TextField } from '../fields'
-import styles from '../StepEditForm.module.css'
 import type { StepFormProps } from '../types'
+
+import styles from '../StepEditForm.module.css'
 
 export const TemperatureForm = (props: StepFormProps): JSX.Element => {
   const { t } = useTranslation(['application', 'form'])
@@ -18,6 +19,7 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
 
   const { propsForFields } = props
   const { setTemperature, moduleId } = props.formData
+
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -35,19 +37,6 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
             options={moduleLabwareOptions}
           />
         </FormGroup>
-        {/* TODO (ka 2020-1-6):
-          moduleID dropdown will autoselect when creating a new step,
-          but this will not be the case when returning to a never saved form.
-          Rather than defaulting to one or the other when null,
-          display a message (copy, design, etc TBD) that you need to select a module to continue
-        */}
-
-        {moduleId === null && (
-          <p className={styles.select_module_message}>
-            Please ensure a compatible module is present on the deck and
-            selected to create a temperature step.
-          </p>
-        )}
         {temperatureModuleIds != null
           ? temperatureModuleIds.map(id =>
               id === moduleId ? (

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
@@ -12,13 +12,12 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions
   )
-  const temperatureModuleId = useSelector(
-    uiModuleSelectors.getSingleTemperatureModuleId
+  const temperatureModuleIds = useSelector(
+    uiModuleSelectors.getTemperatureModuleIds
   )
 
   const { propsForFields } = props
   const { setTemperature, moduleId } = props.formData
-
   return (
     <div className={styles.form_wrapper}>
       <div className={styles.section_header}>
@@ -49,43 +48,47 @@ export const TemperatureForm = (props: StepFormProps): JSX.Element => {
             selected to create a temperature step.
           </p>
         )}
-        {moduleId === temperatureModuleId && temperatureModuleId != null && (
-          <>
-            <div className={styles.checkbox_row}>
-              <RadioGroupField
-                {...propsForFields.setTemperature}
-                options={[
-                  {
-                    name: t(
-                      'form:step_edit_form.field.setTemperature.options.true'
-                    ),
-                    value: 'true',
-                  },
-                ]}
-              />
-              {setTemperature === 'true' && (
-                <TextField
-                  {...propsForFields.targetTemperature}
-                  className={styles.small_field}
-                  units={t('units.degrees')}
-                />
-              )}
-            </div>
-            <div className={styles.checkbox_row}>
-              <RadioGroupField
-                {...propsForFields.setTemperature}
-                options={[
-                  {
-                    name: t(
-                      'form:step_edit_form.field.setTemperature.options.false'
-                    ),
-                    value: 'false',
-                  },
-                ]}
-              />
-            </div>
-          </>
-        )}
+        {temperatureModuleIds != null
+          ? temperatureModuleIds.map(id =>
+              id === moduleId ? (
+                <React.Fragment key={id}>
+                  <div className={styles.checkbox_row}>
+                    <RadioGroupField
+                      {...propsForFields.setTemperature}
+                      options={[
+                        {
+                          name: t(
+                            'form:step_edit_form.field.setTemperature.options.true'
+                          ),
+                          value: 'true',
+                        },
+                      ]}
+                    />
+                    {setTemperature === 'true' && (
+                      <TextField
+                        {...propsForFields.targetTemperature}
+                        className={styles.small_field}
+                        units={t('units.degrees')}
+                      />
+                    )}
+                  </div>
+                  <div className={styles.checkbox_row}>
+                    <RadioGroupField
+                      {...propsForFields.setTemperature}
+                      options={[
+                        {
+                          name: t(
+                            'form:step_edit_form.field.setTemperature.options.false'
+                          ),
+                          value: 'false',
+                        },
+                      ]}
+                    />
+                  </div>
+                </React.Fragment>
+              ) : null
+            )
+          : null}
       </div>
     </div>
   )

--- a/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/TemperatureForm.tsx
@@ -8,7 +8,7 @@ import type { StepFormProps } from '../types'
 
 import styles from '../StepEditForm.module.css'
 
-export const TemperatureForm = (props: StepFormProps): JSX.Element => {
+export function TemperatureForm(props: StepFormProps): JSX.Element {
   const { t } = useTranslation(['application', 'form'])
   const moduleLabwareOptions = useSelector(
     uiModuleSelectors.getTemperatureLabwareOptions

--- a/protocol-designer/src/components/StepEditForm/forms/__tests__/TemperatureForm.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/__tests__/TemperatureForm.test.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react'
+import { describe, it, vi, beforeEach } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../../__testing-utils__'
+import { i18n } from '../../../../localization'
+import {
+  getTemperatureLabwareOptions,
+  getTemperatureModuleIds,
+} from '../../../../ui/modules/selectors'
+import { TemperatureForm } from '../TemperatureForm'
+
+vi.mock('../../../../ui/modules/selectors', async importOriginal => {
+  const actualFields = await importOriginal<
+    typeof import('../../../../ui/modules/selectors')
+  >()
+  return {
+    ...actualFields,
+    getTemperatureLabwareOptions: vi.fn(),
+    getTemperatureModuleIds: vi.fn(),
+  }
+})
+const render = (props: React.ComponentProps<typeof TemperatureForm>) => {
+  return renderWithProviders(<TemperatureForm {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('TemperatureForm', () => {
+  let props: React.ComponentProps<typeof TemperatureForm>
+
+  beforeEach(() => {
+    props = {
+      formData: {
+        id: 'formId',
+        stepType: 'temperature',
+        moduleId: 'mockId',
+        setTemperature: true,
+      } as any,
+      focusHandlers: {
+        blur: vi.fn(),
+        focus: vi.fn(),
+        dirtyFields: [],
+        focusedField: null,
+      },
+      propsForFields: {
+        moduleId: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'setTemperature',
+          updateValue: vi.fn(),
+          value: 'mockId',
+        },
+        setTemperature: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'setTemperature',
+          updateValue: vi.fn(),
+          value: true,
+        },
+        targetTemperature: {
+          onFieldFocus: vi.fn(),
+          onFieldBlur: vi.fn(),
+          errorToShow: null,
+          disabled: false,
+          name: 'targetTemperature',
+          updateValue: vi.fn(),
+          value: null,
+        },
+      },
+    }
+
+    vi.mocked(getTemperatureModuleIds).mockReturnValue(['mockId'])
+    vi.mocked(getTemperatureLabwareOptions).mockReturnValue([
+      {
+        name: 'mock module',
+        value: 'mockId',
+      },
+    ])
+  })
+
+  it('renders a temperature module', () => {
+    render(props)
+    screen.getByText('temperature')
+    screen.getByText('module')
+    const change = screen.getByText('Change to temperature')
+    screen.getByText('Deactivate module')
+    fireEvent.click(change)
+    const changeTempInput = screen.getByRole('combobox', { name: '' })
+    fireEvent.change(changeTempInput, { target: { value: 40 } })
+  })
+})

--- a/protocol-designer/src/components/steplist/ModuleStepItems.tsx
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.tsx
@@ -43,7 +43,7 @@ interface ModuleStepItemsProps {
   message?: string | null
 }
 
-export const ModuleStepItems = (props: ModuleStepItemsProps): JSX.Element => {
+export function ModuleStepItems(props: ModuleStepItemsProps): JSX.Element {
   const {
     moduleType,
     actionText,
@@ -63,7 +63,7 @@ export const ModuleStepItems = (props: ModuleStepItemsProps): JSX.Element => {
 
   return (
     <>
-      {!hideHeader && (
+      {!Boolean(hideHeader) ? (
         <li className={styles.substep_header}>
           <span>
             {moduleSlot != null
@@ -75,7 +75,7 @@ export const ModuleStepItems = (props: ModuleStepItemsProps): JSX.Element => {
           </span>
           <span>{action}</span>
         </li>
-      )}
+      ) : null}
       <Tooltip {...tooltipProps}>
         <LabwareTooltipContents labwareNickname={labwareNickname} />
       </Tooltip>

--- a/protocol-designer/src/components/steplist/ModuleStepItems.tsx
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.tsx
@@ -31,17 +31,17 @@ export const ModuleStepItemRow = (
   </PDListItem>
 )
 
-interface Props {
-  action?: string
+interface ModuleStepItemsProps {
   moduleType: ModuleType
   actionText: string
   labwareNickname?: string | null
   message?: string | null
   children?: React.ReactNode
   hideHeader?: boolean
+  action?: string
 }
 
-export const ModuleStepItems = (props: Props): JSX.Element => {
+export const ModuleStepItems = (props: ModuleStepItemsProps): JSX.Element => {
   const { t } = useTranslation('modules')
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'bottom-start',

--- a/protocol-designer/src/components/steplist/ModuleStepItems.tsx
+++ b/protocol-designer/src/components/steplist/ModuleStepItems.tsx
@@ -9,8 +9,9 @@ import {
 } from '@opentrons/components'
 import { PDListItem } from '../lists'
 import { LabwareTooltipContents } from './LabwareTooltipContents'
+import type { ModuleType } from '@opentrons/shared-data'
+
 import styles from './StepItem.module.css'
-import { ModuleType } from '@opentrons/shared-data'
 
 export interface ModuleStepItemRowProps {
   label?: string | null
@@ -34,41 +35,61 @@ export const ModuleStepItemRow = (
 interface ModuleStepItemsProps {
   moduleType: ModuleType
   actionText: string
-  labwareNickname?: string | null
-  message?: string | null
+  moduleSlot?: string
+  action?: string
   children?: React.ReactNode
   hideHeader?: boolean
-  action?: string
+  labwareNickname?: string | null
+  message?: string | null
 }
 
 export const ModuleStepItems = (props: ModuleStepItemsProps): JSX.Element => {
-  const { t } = useTranslation('modules')
+  const {
+    moduleType,
+    actionText,
+    moduleSlot,
+    action,
+    hideHeader,
+    labwareNickname,
+    children,
+    message,
+  } = props
+  const { t } = useTranslation(['modules', 'application'])
   const [targetProps, tooltipProps] = useHoverTooltip({
     placement: 'bottom-start',
     strategy: TOOLTIP_FIXED,
   })
+  const moduleLongName = t(`module_long_names.${moduleType}`)
+
   return (
     <>
-      {!props.hideHeader && (
+      {!hideHeader && (
         <li className={styles.substep_header}>
-          <span>{t(`module_long_names.${props.moduleType}`)}</span>
-          <span>{props.action}</span>
+          <span>
+            {moduleSlot != null
+              ? t('application:module_and_slot', {
+                  moduleLongName,
+                  slotName: moduleSlot,
+                })
+              : moduleLongName}
+          </span>
+          <span>{action}</span>
         </li>
       )}
       <Tooltip {...tooltipProps}>
-        <LabwareTooltipContents labwareNickname={props.labwareNickname} />
+        <LabwareTooltipContents labwareNickname={labwareNickname} />
       </Tooltip>
       <ModuleStepItemRow
-        label={props.labwareNickname}
+        label={labwareNickname}
         targetProps={targetProps}
-        value={props.actionText}
+        value={actionText}
       />
-      {props.children}
-      {props.message && (
+      {children}
+      {message != null ? (
         <PDListItem className={cx(styles.substep_content, 'step-item-message')}>
-          &quot;{props.message}&quot;
+          &quot;{message}&quot;
         </PDListItem>
-      )}
+      ) : null}
     </>
   )
 }

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -41,7 +41,11 @@ import {
   WellIngredientNames,
 } from '../../steplist/types'
 import { MoveLabwareHeader } from './MoveLabwareHeader'
-import type { AdditionalEquipmentEntities } from '@opentrons/step-generation'
+import type {
+  AdditionalEquipmentEntities,
+  ModuleEntities,
+} from '@opentrons/step-generation'
+import { InitialDeckSetup } from '../../step-forms'
 
 export interface StepItemProps {
   description?: string | null
@@ -121,11 +125,10 @@ export interface StepItemContentsProps {
   rawForm: FormData | null | undefined
   stepType: StepType
   substeps: SubstepItemData | null | undefined
-
   ingredNames: WellIngredientNames
   labwareNicknamesById: { [labwareId: string]: string }
   additionalEquipmentEntities: AdditionalEquipmentEntities
-
+  modules: InitialDeckSetup['modules']
   highlightSubstep: (substepIdentifier: SubstepIdentifier) => unknown
   hoveredSubstep: SubstepIdentifier | null | undefined
 }
@@ -293,6 +296,7 @@ export const StepItemContents = (
   props: StepItemContentsProps
 ): JSX.Element | JSX.Element[] | null => {
   const {
+    modules,
     rawForm,
     stepType,
     substeps,
@@ -326,6 +330,8 @@ export const StepItemContents = (
 
   if (substeps && substeps.substepType === 'temperature') {
     const temperature = makeTemperatureText(substeps.temperature, t)
+    const moduleSlot =
+      substeps.moduleId != null ? modules[substeps.moduleId].slot : ''
 
     return (
       <ModuleStepItems
@@ -334,6 +340,7 @@ export const StepItemContents = (
         actionText={temperature}
         moduleType={TEMPERATURE_MODULE_TYPE}
         labwareNickname={substeps.labwareNickname}
+        moduleSlot={moduleSlot}
       />
     )
   }

--- a/protocol-designer/src/components/steplist/StepItem.tsx
+++ b/protocol-designer/src/components/steplist/StepItem.tsx
@@ -25,6 +25,7 @@ import {
   makeTemperatureText,
   makeTimerText,
 } from '../../utils'
+import { InitialDeckSetup } from '../../step-forms'
 import { PDListItem, TitledStepList } from '../lists'
 import { TitledListNotes } from '../TitledListNotes'
 import { AspirateDispenseHeader } from './AspirateDispenseHeader'
@@ -41,11 +42,7 @@ import {
   WellIngredientNames,
 } from '../../steplist/types'
 import { MoveLabwareHeader } from './MoveLabwareHeader'
-import type {
-  AdditionalEquipmentEntities,
-  ModuleEntities,
-} from '@opentrons/step-generation'
-import { InitialDeckSetup } from '../../step-forms'
+import type { AdditionalEquipmentEntities } from '@opentrons/step-generation'
 
 export interface StepItemProps {
   description?: string | null

--- a/protocol-designer/src/containers/ConnectedStepItem.tsx
+++ b/protocol-designer/src/containers/ConnectedStepItem.tsx
@@ -42,7 +42,12 @@ import {
 import { SubstepIdentifier } from '../steplist/types'
 import { StepIdType } from '../form-types'
 import { BaseState, ThunkAction } from '../types'
-import { getAdditionalEquipmentEntities } from '../step-forms/selectors'
+import {
+  getAdditionalEquipmentEntities,
+  getInitialDeckSetup,
+  getLabwareEntities,
+  getModuleEntities,
+} from '../step-forms/selectors'
 import { ThunkDispatch } from 'redux-thunk'
 
 export interface ConnectedStepItemProps {
@@ -86,7 +91,7 @@ export const ConnectedStepItem = (
 
   const hasWarnings =
     hasTimelineWarningsPerStep[stepId] || hasFormLevelWarningsPerStep[stepId]
-
+  const initialDeckSetup = useSelector(getInitialDeckSetup)
   const collapsed = useSelector(getCollapsedSteps)[stepId]
   const hoveredSubstep = useSelector(getHoveredSubstep)
   const hoveredStep = useSelector(getHoveredStepId)
@@ -217,6 +222,7 @@ export const ConnectedStepItem = (
   }
 
   const stepItemContentsProps: StepItemContentsProps = {
+    modules: initialDeckSetup.modules,
     rawForm: step,
     stepType: step.stepType,
     substeps,

--- a/protocol-designer/src/containers/ConnectedStepItem.tsx
+++ b/protocol-designer/src/containers/ConnectedStepItem.tsx
@@ -24,7 +24,6 @@ import {
   SelectMultipleStepsAction,
 } from '../ui/steps'
 import { selectors as fileDataSelectors } from '../file-data'
-
 import {
   StepItem,
   StepItemContents,
@@ -38,17 +37,15 @@ import {
   ConfirmDeleteModal,
   DeleteModalType,
 } from '../components/modals/ConfirmDeleteModal'
-
-import { SubstepIdentifier } from '../steplist/types'
-import { StepIdType } from '../form-types'
-import { BaseState, ThunkAction } from '../types'
 import {
   getAdditionalEquipmentEntities,
   getInitialDeckSetup,
-  getLabwareEntities,
-  getModuleEntities,
 } from '../step-forms/selectors'
-import { ThunkDispatch } from 'redux-thunk'
+
+import type { SubstepIdentifier } from '../steplist/types'
+import type { StepIdType } from '../form-types'
+import type { BaseState, ThunkAction } from '../types'
+import type { ThunkDispatch } from 'redux-thunk'
 
 export interface ConnectedStepItemProps {
   stepId: StepIdType
@@ -242,7 +239,6 @@ export const ConnectedStepItem = (
       return CLOSE_STEP_FORM_WITH_CHANGES
     }
   }
-
   return (
     <>
       {showConfirmation && (

--- a/protocol-designer/src/containers/ConnectedStepItem.tsx
+++ b/protocol-designer/src/containers/ConnectedStepItem.tsx
@@ -42,10 +42,10 @@ import {
   getInitialDeckSetup,
 } from '../step-forms/selectors'
 
+import type { ThunkDispatch } from 'redux-thunk'
 import type { SubstepIdentifier } from '../steplist/types'
 import type { StepIdType } from '../form-types'
 import type { BaseState, ThunkAction } from '../types'
-import type { ThunkDispatch } from 'redux-thunk'
 
 export interface ConnectedStepItemProps {
   stepId: StepIdType

--- a/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.tsx
+++ b/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.tsx
@@ -1,5 +1,378 @@
-import { describe, it } from 'vitest'
+import * as React from 'react'
+import { describe, it, beforeEach, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '../../__testing-utils__'
+import { i18n } from '../../localization'
+import {
+  getAdditionalEquipmentEntities,
+  getArgsAndErrorsByStepId,
+  getBatchEditFormHasUnsavedChanges,
+  getCurrentFormCanBeSaved,
+  getCurrentFormHasUnsavedChanges,
+  getInitialDeckSetup,
+  getOrderedStepIds,
+  getSavedStepForms,
+} from '../../step-forms/selectors'
+import { selectors as labwareIngredSelectors } from '../../labware-ingred/selectors'
+import { getErrorStepId, getSubsteps } from '../../file-data/selectors'
+import { getHasTimelineWarningsPerStep } from '../../top-selectors/timelineWarnings'
+import { getHasFormLevelWarningsPerStep } from '../../dismiss/selectors'
+import {
+  getCollapsedSteps,
+  getHoveredSubstep,
+  getIsMultiSelectMode,
+  getMultiSelectItemIds,
+  getMultiSelectLastSelected,
+  getSelectedStepId,
+} from '../../ui/steps'
+import { getLabwareNicknamesById } from '../../ui/labware/selectors'
+import { ConnectedStepItem } from '../ConnectedStepItem'
+import { LabwareDefinition2, fixture96Plate } from '@opentrons/shared-data'
 
+vi.mock('../../step-forms/selectors')
+vi.mock('../../file-data/selectors')
+vi.mock('../../top-selectors/timelineWarnings')
+vi.mock('../../dismiss/selectors')
+vi.mock('../../ui/steps')
+vi.mock('../../labware-ingred/selectors')
+vi.mock('../../ui/labware/selectors')
+
+const render = (props: React.ComponentProps<typeof ConnectedStepItem>) => {
+  return renderWithProviders(<ConnectedStepItem {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+const pauseStepId = 'pauseId'
+const magnetStepId = 'magnetStepId'
+const heaterShakerStepId = 'hsStepId'
+const thermocyclerStepId = 'tcStepId'
+const temperatureStepId = 'tempStepId'
+const moveLabwareStepId = 'moveLabwareId'
+
+//  TODO(jr, 4/8/24): add test coverage for mix and moveLiquid!!!
 describe('ConnectedStepItem', () => {
-  it.todo('replace deprecated enzyme test')
+  let props: React.ComponentProps<typeof ConnectedStepItem>
+  beforeEach(() => {
+    props = {
+      stepId: pauseStepId,
+      stepNumber: 2,
+      onStepContextMenu: vi.fn(),
+    }
+    vi.mocked(getSavedStepForms).mockReturnValue({
+      [pauseStepId]: {
+        stepType: 'pause',
+        id: pauseStepId,
+        pauseHour: '1',
+        pauseMinute: '10',
+        pauseSecond: '5',
+        pauseMessage: 'mock message',
+        pauseTemperature: '10',
+      },
+      [magnetStepId]: {
+        stepType: 'magnet',
+        id: magnetStepId,
+      },
+      [heaterShakerStepId]: {
+        stepType: 'heaterShaker',
+        id: heaterShakerStepId,
+      },
+      [thermocyclerStepId]: {
+        stepType: 'thermocycler',
+        id: thermocyclerStepId,
+      },
+      [temperatureStepId]: {
+        stepType: 'temperature',
+        id: temperatureStepId,
+      },
+      [moveLabwareStepId]: {
+        stepType: 'moveLabware',
+        id: moveLabwareStepId,
+      },
+    })
+    vi.mocked(getArgsAndErrorsByStepId).mockReturnValue({
+      [pauseStepId]: {
+        errors: false,
+        stepArgs: null,
+      },
+      [magnetStepId]: {
+        errors: false,
+        stepArgs: null,
+      },
+      [heaterShakerStepId]: {
+        errors: false,
+        stepArgs: null,
+      },
+      [thermocyclerStepId]: {
+        errors: false,
+        stepArgs: null,
+      },
+      [temperatureStepId]: {
+        errors: false,
+        stepArgs: null,
+      },
+      [moveLabwareStepId]: {
+        errors: false,
+        stepArgs: null,
+      },
+    })
+    vi.mocked(getErrorStepId).mockReturnValue(null)
+    vi.mocked(getHasTimelineWarningsPerStep).mockReturnValue({
+      [pauseStepId]: false,
+      [magnetStepId]: false,
+      [heaterShakerStepId]: false,
+      [thermocyclerStepId]: false,
+      [temperatureStepId]: false,
+      [moveLabwareStepId]: false,
+    })
+    vi.mocked(getHasFormLevelWarningsPerStep).mockReturnValue({
+      [pauseStepId]: false,
+      [magnetStepId]: false,
+      [heaterShakerStepId]: false,
+      [thermocyclerStepId]: false,
+      [temperatureStepId]: false,
+      [moveLabwareStepId]: false,
+    })
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      pipettes: {},
+      modules: {
+        thermocyclerId: {
+          id: 'thermocyclerId',
+          type: 'thermocyclerModuleType',
+          model: 'thermocyclerModuleV2',
+          slot: 'B1',
+          moduleState: {} as any,
+        },
+        temperatureId: {
+          id: 'temperatureId',
+          type: 'temperatureModuleType',
+          model: 'temperatureModuleV2',
+          slot: 'C3',
+          moduleState: {} as any,
+        },
+        heaterShakerId: {
+          id: 'heaterShakerId',
+          type: 'heaterShakerModuleType',
+          model: 'heaterShakerModuleV1',
+          slot: 'D1',
+          moduleState: {} as any,
+        },
+        magnetId: {
+          id: 'magnetId',
+          type: 'magneticModuleType',
+          model: 'magneticModuleV2',
+          slot: 'C1',
+          moduleState: {} as any,
+        },
+      },
+      additionalEquipmentOnDeck: {
+        stagingAreaId: {
+          name: 'stagingArea',
+          location: 'B3',
+          id: 'stagingAreaId',
+        },
+      },
+      labware: {
+        labwareId: {
+          id: 'labwareId',
+          labwareDefURI: `opentrons/fixture_96_plate/1`,
+          slot: 'A2',
+          def: fixture96Plate as LabwareDefinition2,
+        },
+      },
+    })
+    vi.mocked(getCollapsedSteps).mockReturnValue({
+      [pauseStepId]: false,
+      [magnetStepId]: true,
+      [heaterShakerStepId]: true,
+      [thermocyclerStepId]: true,
+      [temperatureStepId]: true,
+      [moveLabwareStepId]: true,
+    })
+    vi.mocked(getHoveredSubstep).mockReturnValue(null)
+    vi.mocked(getSelectedStepId).mockReturnValue(pauseStepId)
+    vi.mocked(getOrderedStepIds).mockReturnValue([
+      pauseStepId,
+      magnetStepId,
+      heaterShakerStepId,
+      thermocyclerStepId,
+      moveLabwareStepId,
+      temperatureStepId,
+    ])
+    vi.mocked(getMultiSelectItemIds).mockReturnValue(null)
+    vi.mocked(getMultiSelectLastSelected).mockReturnValue(null)
+    vi.mocked(getIsMultiSelectMode).mockReturnValue(false)
+    vi.mocked(getSubsteps).mockReturnValue({
+      [pauseStepId]: {
+        substepType: 'pause',
+        pauseStepArgs: {
+          commandCreatorFnName: 'delay',
+          wait: 10,
+          name: 'pause',
+          description: '',
+          meta: { hours: 1, minutes: 10, seconds: 15 },
+        },
+      },
+      [magnetStepId]: {
+        substepType: 'magnet',
+        engage: true,
+        labwareNickname: 'mockLabware',
+        message: 'engaging height',
+      },
+      [heaterShakerStepId]: {
+        substepType: 'heaterShaker',
+        labwareNickname: 'mockLabware',
+        targetHeaterShakerTemperature: 20,
+        targetSpeed: 200,
+        latchOpen: false,
+        heaterShakerTimerMinutes: 5,
+        heaterShakerTimerSeconds: 11,
+      },
+      [thermocyclerStepId]: {
+        substepType: 'thermocyclerProfile',
+        blockTargetTempHold: 30,
+        labwareNickname: 'mockLabware',
+        lidOpenHold: false,
+        lidTargetTempHold: 32,
+        meta: { rawProfileItems: [] },
+        profileSteps: [
+          { holdTime: 7, temperature: 87 },
+          { holdTime: 2, temperature: 55 },
+        ],
+        profileTargetLidTemp: 40,
+        profileVolume: 21,
+      },
+      [temperatureStepId]: {
+        substepType: 'temperature',
+        temperature: 18,
+        labwareNickname: 'mockLabware',
+        moduleId: 'temperatureId',
+        message: 'mock message',
+      },
+      [moveLabwareStepId]: {
+        substepType: 'moveLabware',
+        moveLabwareArgs: {
+          commandCreatorFnName: 'moveLabware',
+          name: 'move labware',
+          description: '',
+          labware: 'labwareId',
+          useGripper: false,
+          newLocation: { slotName: 'B2' },
+        },
+      },
+    })
+    vi.mocked(labwareIngredSelectors.getLiquidNamesById).mockReturnValue({})
+    vi.mocked(getLabwareNicknamesById).mockReturnValue({})
+    vi.mocked(getAdditionalEquipmentEntities).mockReturnValue({
+      stagingAreaId: { name: 'stagingArea', location: 'B3', id: 'stagingArea' },
+    })
+    vi.mocked(getCurrentFormCanBeSaved).mockReturnValue(true)
+    vi.mocked(getCurrentFormHasUnsavedChanges).mockReturnValue(false)
+    vi.mocked(getBatchEditFormHasUnsavedChanges).mockReturnValue(false)
+  })
+  it('renders an expanded step item for pause', () => {
+    render(props)
+    screen.getByText('2. pause')
+    screen.getByText('Pause for Time')
+    screen.getByText('1 h')
+    screen.getByText('10 m')
+    screen.getByText('15 s')
+  })
+  it('renders an expanded step item for magnet', () => {
+    vi.mocked(getCollapsedSteps).mockReturnValue({
+      [pauseStepId]: true,
+      [magnetStepId]: false,
+      [heaterShakerStepId]: false,
+      [thermocyclerStepId]: true,
+      [temperatureStepId]: true,
+      [moveLabwareStepId]: true,
+    })
+    vi.mocked(getSelectedStepId).mockReturnValue(magnetStepId)
+    props.stepId = magnetStepId
+    render(props)
+    screen.getByText('2. magnet')
+    screen.getByText('Magnetic module')
+    screen.getByText('mockLabware')
+    screen.getByText('engage')
+  })
+  it('renders an expanded step item for heater-shaker', () => {
+    vi.mocked(getCollapsedSteps).mockReturnValue({
+      [pauseStepId]: true,
+      [magnetStepId]: true,
+      [heaterShakerStepId]: false,
+      [thermocyclerStepId]: true,
+      [temperatureStepId]: true,
+      [moveLabwareStepId]: true,
+    })
+    vi.mocked(getSelectedStepId).mockReturnValue(heaterShakerStepId)
+    props.stepId = heaterShakerStepId
+    render(props)
+    screen.getByText('2. heater-shaker')
+    screen.getByText('Heater-Shaker module')
+    screen.getByText('go to')
+    screen.getByText('mockLabware')
+    screen.getByText('20 °C')
+    screen.getByText('Labware Latch')
+    screen.getByText('Closed and Locked')
+    screen.getByText('Shaker')
+    screen.getByText('200 rpm')
+    screen.getByText('Deactivate after')
+  })
+  it('renders an expanded step item for thermocycler', () => {
+    vi.mocked(getCollapsedSteps).mockReturnValue({
+      [pauseStepId]: true,
+      [magnetStepId]: true,
+      [heaterShakerStepId]: false,
+      [thermocyclerStepId]: false,
+      [temperatureStepId]: true,
+      [moveLabwareStepId]: true,
+    })
+    vi.mocked(getSelectedStepId).mockReturnValue(thermocyclerStepId)
+    props.stepId = thermocyclerStepId
+    render(props)
+    screen.getByText('2. thermocycler')
+    screen.getByText('Thermocycler module')
+    screen.getByText('profile')
+    screen.getByText('mockLabware')
+    screen.getByText('cycling')
+    screen.getByText('Lid (closed)')
+    screen.getByText('40 °C')
+    screen.getByText('Profile steps (0+ min)')
+    screen.getByText('Ending hold')
+  })
+  it('renders an expanded step item for a temperature module', () => {
+    vi.mocked(getCollapsedSteps).mockReturnValue({
+      [pauseStepId]: true,
+      [magnetStepId]: true,
+      [heaterShakerStepId]: true,
+      [thermocyclerStepId]: true,
+      [temperatureStepId]: false,
+      [moveLabwareStepId]: true,
+    })
+    vi.mocked(getSelectedStepId).mockReturnValue(temperatureStepId)
+    props.stepId = temperatureStepId
+    render(props)
+    screen.getByText('2. temperature')
+    screen.getByText('Temperature module in Slot C3')
+    screen.getByText('go to')
+    screen.getByText('mockLabware')
+    screen.getByText('18 °C')
+    screen.getByText('"mock message"')
+  })
+  it('renders an expanded step for move labware', () => {
+    vi.mocked(getCollapsedSteps).mockReturnValue({
+      [pauseStepId]: true,
+      [magnetStepId]: true,
+      [heaterShakerStepId]: true,
+      [thermocyclerStepId]: true,
+      [temperatureStepId]: true,
+      [moveLabwareStepId]: false,
+    })
+    vi.mocked(getSelectedStepId).mockReturnValue(moveLabwareStepId)
+    props.stepId = moveLabwareStepId
+    render(props)
+    screen.getByText('2. move labware')
+    screen.getByText('Manually')
+    screen.getByText('labware')
+    screen.getByText('new location')
+  })
 })

--- a/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.tsx
+++ b/protocol-designer/src/containers/__tests__/ConnectedStepItem.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { describe, it, beforeEach, vi } from 'vitest'
 import { screen } from '@testing-library/react'
+import { fixture96Plate } from '@opentrons/shared-data'
 import { renderWithProviders } from '../../__testing-utils__'
 import { i18n } from '../../localization'
 import {
@@ -27,7 +28,7 @@ import {
 } from '../../ui/steps'
 import { getLabwareNicknamesById } from '../../ui/labware/selectors'
 import { ConnectedStepItem } from '../ConnectedStepItem'
-import { LabwareDefinition2, fixture96Plate } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 
 vi.mock('../../step-forms/selectors')
 vi.mock('../../file-data/selectors')

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -49,6 +49,10 @@
       "title": "Missing labware",
       "body": "Your module has no labware on it. We recommend you add labware before proceeding."
     },
+    "multiple_modules_without_labware": {
+      "title": "Missing labware",
+      "body": "One or more module has no labware on it. We recommend you add labware before proceeding"
+    },
     "export_v8_protocol_7_1": {
       "title": "Robot and app update may be required",
       "body1": "This protocol can only run on app and robot server version",

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -23,6 +23,7 @@
   "next": "Next",
   "no_batch_edit_shared_settings": "Batch editing of settings is only available for Transfer or Mix steps",
   "manually": "Manually",
+  "module_and_slot": "{{moduleLongName}} in Slot {{slotName}}",
   "stepType": {
     "mix": "mix",
     "moveLabware": "move labware",

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -411,6 +411,7 @@ export function generateSubstepItem(
       temperature: temperature,
       labwareNickname: labwareNames?.nickname,
       message: stepArgs.message,
+      moduleId: stepArgs.module,
     }
   }
 

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -622,6 +622,7 @@ describe('generateSubstepItem', () => {
       temperature: 45,
       labwareNickname: 'temp nickname',
       message: null,
+      moduleId: 'tempId',
     })
   })
 
@@ -652,6 +653,7 @@ describe('generateSubstepItem', () => {
       temperature: 0,
       labwareNickname: 'temp nickname',
       message: null,
+      moduleId: 'tempId',
     })
   })
 
@@ -680,6 +682,7 @@ describe('generateSubstepItem', () => {
       temperature: null,
       labwareNickname: 'temp nickname',
       message: null,
+      moduleId: 'tempId',
     })
   })
 

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -8,6 +8,7 @@ import {
 import { ModuleType } from '@opentrons/shared-data'
 import { StepIdType } from '../form-types'
 import { FormError } from './formLevel/errors'
+import { DeckSlot } from '../types'
 // timeline start and end
 export const START_TERMINAL_ITEM_ID: '__initial_setup__' = '__initial_setup__'
 export const END_TERMINAL_ITEM_ID: '__end__' = '__end__'

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -5,10 +5,9 @@ import {
   PauseArgs,
   ThermocyclerProfileStepArgs,
 } from '@opentrons/step-generation'
-import { ModuleType } from '@opentrons/shared-data'
-import { StepIdType } from '../form-types'
-import { FormError } from './formLevel/errors'
-import { DeckSlot } from '../types'
+import type { ModuleType } from '@opentrons/shared-data'
+import type { StepIdType } from '../form-types'
+import type { FormError } from './formLevel/errors'
 // timeline start and end
 export const START_TERMINAL_ITEM_ID: '__initial_setup__' = '__initial_setup__'
 export const END_TERMINAL_ITEM_ID: '__end__' = '__end__'

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -106,6 +106,7 @@ export interface TemperatureSubstepItem {
   substepType: 'temperature'
   temperature: number | null
   labwareNickname: string | null | undefined
+  moduleId: string | null
   message?: string
 }
 export interface PauseSubstepItem {

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -2,6 +2,7 @@ import * as actions from './actions'
 import { rootReducer, RootState } from './reducers'
 import * as selectors from './selectors'
 type HintKey =  // normal hints
+  | 'multiple_modules_without_labware'
   | 'add_liquids_and_labware'
   | 'deck_setup_explanation'
   | 'module_without_labware'

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -15,6 +15,7 @@ import {
   getModuleOnDeckByType,
   getModuleHasLabware,
   getMagnetLabwareEngageHeight as getMagnetLabwareEngageHeightUtil,
+  getModulesOnDeckByType,
 } from './utils'
 import { Options } from '@opentrons/components'
 import { Selector } from '../../types'
@@ -84,16 +85,18 @@ export const getSingleMagneticModuleId: Selector<
     getModuleOnDeckByType(initialDeckSetup, MAGNETIC_MODULE_TYPE)?.id || null
 )
 
-/** Get single temperature module (assumes no multiples) */
-export const getSingleTemperatureModuleId: Selector<
-  string | null
+/** Get all temperature modules */
+export const getTemperatureModuleIds: Selector<
+  string[] | null
 > = createSelector(
   getInitialDeckSetup,
   initialDeckSetup =>
-    getModuleOnDeckByType(initialDeckSetup, TEMPERATURE_MODULE_TYPE)?.id || null
+    getModulesOnDeckByType(initialDeckSetup, TEMPERATURE_MODULE_TYPE)?.map(
+      module => module.id
+    ) || null
 )
 
-/** Get single temperature module (assumes no multiples) */
+/** Get single thermocycler module (assumes no multiples) */
 export const getSingleThermocyclerModuleId: Selector<
   string | null
 > = createSelector(

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect'
+import mapValues from 'lodash/mapValues'
 import {
   getLabwareDisplayName,
   MAGNETIC_MODULE_TYPE,
@@ -6,7 +7,6 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import mapValues from 'lodash/mapValues'
 import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { getLabwareNicknamesById } from '../labware/selectors'
 import {
@@ -16,10 +16,13 @@ import {
   getModuleHasLabware,
   getMagnetLabwareEngageHeight as getMagnetLabwareEngageHeightUtil,
   getModulesOnDeckByType,
+  getModulesHaveLabware,
+  ModuleAndLabware,
 } from './utils'
-import { Options } from '@opentrons/components'
-import { Selector } from '../../types'
-import { LabwareNamesByModuleId } from '../../steplist/types'
+import type { Options } from '@opentrons/components'
+import type { Selector } from '../../types'
+import type { LabwareNamesByModuleId } from '../../steplist/types'
+
 export const getLabwareNamesByModuleId: Selector<LabwareNamesByModuleId> = createSelector(
   getInitialDeckSetup,
   getLabwareNicknamesById,
@@ -114,13 +117,12 @@ export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
   }
 )
 
-/** Returns boolean if temperature module has labware */
-export const getTemperatureModuleHasLabware: Selector<boolean> = createSelector(
-  getInitialDeckSetup,
-  initialDeckSetup => {
-    return getModuleHasLabware(initialDeckSetup, TEMPERATURE_MODULE_TYPE)
-  }
-)
+/** Returns all moduleIds and if they have labware for MoaM */
+export const getTemperatureModulesHaveLabware: Selector<
+  ModuleAndLabware[]
+> = createSelector(getInitialDeckSetup, initialDeckSetup => {
+  return getModulesHaveLabware(initialDeckSetup, TEMPERATURE_MODULE_TYPE)
+})
 
 /** Returns boolean if thermocycler module has labware */
 export const getThermocyclerModuleHasLabware: Selector<boolean> = createSelector(

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -33,7 +33,12 @@ export function getLabwareOnModule(
   moduleId: string
 ): LabwareOnDeck | null | undefined {
   return values(initialDeckSetup.labware).find(
-    (lab: LabwareOnDeck) => lab.slot === moduleId
+    (labware: LabwareOnDeck) =>
+      labware.slot === moduleId ||
+      //  acccount for adapter!
+      values(initialDeckSetup.labware).find(
+        adapter => adapter.id === labware.slot && adapter.slot === moduleId
+      )
   )
 }
 export function getModuleUnderLabware(

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -20,6 +20,14 @@ export function getModuleOnDeckByType(
     (moduleOnDeck: ModuleOnDeck) => moduleOnDeck.type === type
   )
 }
+export function getModulesOnDeckByType(
+  initialDeckSetup: InitialDeckSetup,
+  type: ModuleType
+): ModuleOnDeck[] | null | undefined {
+  return values(initialDeckSetup.modules).filter(
+    (moduleOnDeck: ModuleOnDeck) => moduleOnDeck.type === type
+  )
+}
 export function getLabwareOnModule(
   initialDeckSetup: InitialDeckSetup,
   moduleId: string
@@ -81,28 +89,39 @@ export function getModuleLabwareOptions(
   nicknamesById: Record<string, string>,
   type: ModuleType
 ): Options {
-  const moduleOnDeck = getModuleOnDeckByType(initialDeckSetup, type)
-  const labware =
-    moduleOnDeck && getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
+  const labwares = initialDeckSetup.labware
+  const modulesOnDeck = getModulesOnDeckByType(initialDeckSetup, type)
   const module = getModuleShortNames(type)
   let options: Options = []
 
-  if (moduleOnDeck) {
-    if (labware) {
-      options = [
-        {
-          name: `${nicknamesById[labware.id]} in ${module}`,
+  if (modulesOnDeck != null) {
+    options = modulesOnDeck.map(moduleOnDeck => {
+      const labware = getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
+      if (labware) {
+        const labwareOnAdapterId =
+          labwares[labware.id] != null ? labwares[labware.id].id : null
+        if (labwareOnAdapterId != null) {
+          return {
+            name: `${nicknamesById[labwareOnAdapterId]} in ${
+              nicknamesById[labware.id]
+            } in ${module} in slot ${moduleOnDeck.slot}`,
+            value: moduleOnDeck.id,
+          }
+        } else {
+          return {
+            name: `${nicknamesById[labware.id]} in ${module} in slot ${
+              moduleOnDeck.slot
+            }`,
+            value: moduleOnDeck.id,
+          }
+        }
+      } else {
+        return {
+          name: `No labware in ${module} in slot ${moduleOnDeck.slot}`,
           value: moduleOnDeck.id,
-        },
-      ]
-    } else {
-      options = [
-        {
-          name: `${module} No labware on module`,
-          value: moduleOnDeck.id,
-        },
-      ]
-    }
+        }
+      }
+    })
   }
 
   return options
@@ -111,10 +130,20 @@ export function getModuleHasLabware(
   initialDeckSetup: InitialDeckSetup,
   type: ModuleType
 ): boolean {
-  const moduleOnDeck = getModuleOnDeckByType(initialDeckSetup, type)
-  const labware =
-    moduleOnDeck && getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
-  return Boolean(moduleOnDeck) && Boolean(labware)
+  const modulesOnDeck = getModulesOnDeckByType(initialDeckSetup, type)
+  const labwaresOnModules: ModuleOnDeck[] = []
+
+  if (modulesOnDeck != null) {
+    for (const module of modulesOnDeck) {
+      const labware = getLabwareOnModule(initialDeckSetup, module.id)
+      if (labware) {
+        labwaresOnModules.push(module)
+        break
+      }
+    }
+  }
+
+  return labwaresOnModules.length === modulesOnDeck?.length
 }
 export const getMagnetLabwareEngageHeight = (
   initialDeckSetup: InitialDeckSetup,

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -135,21 +135,34 @@ export function getModuleHasLabware(
   initialDeckSetup: InitialDeckSetup,
   type: ModuleType
 ): boolean {
-  const modulesOnDeck = getModulesOnDeckByType(initialDeckSetup, type)
-  const labwaresOnModules: ModuleOnDeck[] = []
-
-  if (modulesOnDeck != null) {
-    for (const module of modulesOnDeck) {
-      const labware = getLabwareOnModule(initialDeckSetup, module.id)
-      if (labware) {
-        labwaresOnModules.push(module)
-        break
-      }
-    }
-  }
-
-  return labwaresOnModules.length === modulesOnDeck?.length
+  const moduleOnDeck = getModuleOnDeckByType(initialDeckSetup, type)
+  const labware =
+    moduleOnDeck && getLabwareOnModule(initialDeckSetup, moduleOnDeck.id)
+  return Boolean(moduleOnDeck) && Boolean(labware)
 }
+
+export interface ModuleAndLabware {
+  moduleId: string
+  hasLabware: boolean
+}
+
+export function getModulesHaveLabware(
+  initialDeckSetup: InitialDeckSetup,
+  type: ModuleType
+): ModuleAndLabware[] {
+  const modulesOnDeck = getModulesOnDeckByType(initialDeckSetup, type)
+  const moduleAndLabware: ModuleAndLabware[] = []
+  modulesOnDeck?.forEach(module => {
+    const labwareHasModule = getLabwareOnModule(initialDeckSetup, module.id)
+
+    moduleAndLabware.push({
+      moduleId: module.id,
+      hasLabware: labwareHasModule != null,
+    })
+  })
+  return moduleAndLabware
+}
+
 export const getMagnetLabwareEngageHeight = (
   initialDeckSetup: InitialDeckSetup,
   magnetModuleId: string | null

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -40,7 +40,7 @@ export const addAndSelectStepWithHints: (arg: {
   const magnetModuleHasLabware = uiModuleSelectors.getMagnetModuleHasLabware(
     state
   )
-  const temperatureModuleHasLabware = uiModuleSelectors.getTemperatureModuleHasLabware(
+  const temperatureModulesHaveLabware = uiModuleSelectors.getTemperatureModulesHaveLabware(
     state
   )
   const thermocyclerModuleHasLabware = uiModuleSelectors.getThermocyclerModuleHasLabware(
@@ -52,6 +52,9 @@ export const addAndSelectStepWithHints: (arg: {
   const thermocyclerModuleOnDeck = uiModuleSelectors.getSingleThermocyclerModuleId(
     state
   )
+  const tempHasNoLabware = temperatureModulesHaveLabware.some(
+    module => !module.hasLabware
+  )
   // TODO: Ian 2019-01-17 move out to centralized step info file - see #2926
   const stepNeedsLiquid = ['mix', 'moveLiquid'].includes(payload.stepType)
   const stepMagnetNeedsLabware = ['magnet'].includes(payload.stepType)
@@ -60,16 +63,16 @@ export const addAndSelectStepWithHints: (arg: {
     (stepMagnetNeedsLabware && !magnetModuleHasLabware) ||
     (stepTemperatureNeedsLabware &&
       thermocyclerModuleOnDeck &&
-      !thermocyclerModuleHasLabware)
+      !thermocyclerModuleHasLabware) ||
+    (temperatureModuleOnDeck?.length === 1 && tempHasNoLabware)
 
   if (stepNeedsLiquid && !deckHasLiquid) {
     dispatch(tutorialActions.addHint('add_liquids_and_labware'))
   }
-  if (temperatureModuleOnDeck && !temperatureModuleHasLabware) {
-    dispatch(tutorialActions.addHint('multiple_modules_without_labware'))
-  }
   if (stepModuleMissingLabware) {
     dispatch(tutorialActions.addHint('module_without_labware'))
+  } else if (temperatureModuleOnDeck && tempHasNoLabware) {
+    dispatch(tutorialActions.addHint('multiple_modules_without_labware'))
   }
 }
 export interface ReorderSelectedStepAction {

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -46,7 +46,7 @@ export const addAndSelectStepWithHints: (arg: {
   const thermocyclerModuleHasLabware = uiModuleSelectors.getThermocyclerModuleHasLabware(
     state
   )
-  const temperatureModuleOnDeck = uiModuleSelectors.getSingleTemperatureModuleId(
+  const temperatureModuleOnDeck = uiModuleSelectors.getTemperatureModuleIds(
     state
   )
   const thermocyclerModuleOnDeck = uiModuleSelectors.getSingleThermocyclerModuleId(
@@ -59,13 +59,15 @@ export const addAndSelectStepWithHints: (arg: {
   const stepModuleMissingLabware =
     (stepMagnetNeedsLabware && !magnetModuleHasLabware) ||
     (stepTemperatureNeedsLabware &&
-      ((temperatureModuleOnDeck && !temperatureModuleHasLabware) ||
-        (thermocyclerModuleOnDeck && !thermocyclerModuleHasLabware)))
+      thermocyclerModuleOnDeck &&
+      !thermocyclerModuleHasLabware)
 
   if (stepNeedsLiquid && !deckHasLiquid) {
     dispatch(tutorialActions.addHint('add_liquids_and_labware'))
   }
-
+  if (temperatureModuleOnDeck && !temperatureModuleHasLabware) {
+    dispatch(tutorialActions.addHint('multiple_modules_without_labware'))
+  }
   if (stepModuleMissingLabware) {
     dispatch(tutorialActions.addHint('module_without_labware'))
   }

--- a/protocol-designer/src/ui/steps/selectors.ts
+++ b/protocol-designer/src/ui/steps/selectors.ts
@@ -136,10 +136,11 @@ export const getHoveredStepLabware = createSelector(
       // only 1 labware
       return [stepArgs.labware]
     }
-    // @ts-expect-error(sa, 2021-6-15): type narrow stepArgs.module
-    if (stepArgs.module) {
-      // @ts-expect-error(sa, 2021-6-15): this expect error should not be necessary after type narrowing above
-      const labware = getLabwareOnModule(initialDeckState, stepArgs.module)
+    if ('module' in stepArgs) {
+      const labware = getLabwareOnModule(
+        initialDeckState,
+        stepArgs.module ?? ''
+      )
       return labware ? [labware.id] : []
     }
 
@@ -150,8 +151,9 @@ export const getHoveredStepLabware = createSelector(
 
     // step types that have no labware that gets highlighted
     if (!(stepArgs.commandCreatorFnName === 'delay')) {
-      // TODO Ian 2018-05-08 use assert here
       console.warn(
+        //  @ts-expect-error: should only reach this warning when new step is added and
+        //  highlighted wells is not yet implemented
         `getHoveredStepLabware does not support step type "${stepArgs.commandCreatorFnName}"`
       )
     }


### PR DESCRIPTION
closes AUTH-2

# Overview

This PR modifies logic so the temperature form's drop down now displays all temperature modules on the deck to choose from and send commands to. Additionally, the information in the step item in the timeline is correct and states the temperature's slot number.

# Test Plan

Make sure the feature flag is turned on!

Create a flex protocol and add at least 2 temperature modules. Go to the deck and add an adapter + labware or just labware on top of both of the modules. Click to add a temperature step. Select the drop down, 2 modules should be listed (NOTE: the dropdown information is very long since i added the adapter + labware combo, i'll ask design if i should change it). Add a step for each labware. When you hover over the steps in the timeline, the correct labware in the correct module should highlight. Additionally, the steps should include the module's slot number.

Download the protocol. Open the json file and see that the 2 temperature commands are for the correct temperature modules.

Finally, create a new protocol with 2 temperature modules. Do NOT add any labware on top of them. Click on the temperature form and you should get the warning modal saying that one or more modules is missing labware.

# Changelog

- modify the selectors so they return multiple modules
- modify the dropdown text for modules to include slot and adapter/labware combo (previously, it wasn't taking adapter's labware into account)
- fix highlighted labware logic, it was also not taking adapters into account
- add a new warning for multiple modules missing labwares
- add module slot info to the step item
- fix tests
- add test coverage to `ConnectedStepItem`

# Review requests

see test plan

# Risk assessment

low