### PR TITLE
refactor(app): add RTP properties to protocol run event analytics

### DIFF
--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
@@ -37,6 +37,16 @@ const MODULES = {
   module1: { model: 'module1' },
   module2: { model: 'module2' },
 }
+const RUNTIME_PARAMETERS = [
+  {
+    displayName: 'test param',
+    variableName: 'test_param',
+    description: 'Mock boolean parameter',
+    type: 'bool',
+    default: true,
+    value: true,
+  },
+]
 const FORMATTED_MODULES = 'module1,module2'
 const STORED_PROTOCOL_ANALYSIS = {
   config: { protocolType: 'json', schemaVersion: 1.11 },
@@ -49,11 +59,13 @@ const STORED_PROTOCOL_ANALYSIS = {
   robotType: 'OT-2 Standard',
   pipettes: PIPETTES,
   modules: MODULES,
+  runTimeParameters: RUNTIME_PARAMETERS,
 }
 const ROBOT_PROTOCOL_ANALYSIS = {
   robotType: 'OT-2 Standard',
   pipettes: PIPETTES,
   modules: MODULES,
+  runTimeParameters: RUNTIME_PARAMETERS,
 }
 
 describe('useProtocolAnalysisErrors hook', () => {
@@ -126,6 +138,8 @@ describe('useProtocolAnalysisErrors hook', () => {
         protocolAppName: 'Python API',
         protocolAppVersion: 2.3,
         protocolAuthor: 'hashedString',
+        protocolHasRunTimeParameterCustomValues: false,
+        protocolHasRunTimeParameters: true,
         protocolName: 'robot protocol',
         protocolSource: 'robot protocol source',
         protocolText: 'hashedString',
@@ -156,6 +170,8 @@ describe('useProtocolAnalysisErrors hook', () => {
         protocolAppVersion: '1.1',
         protocolAuthor: 'hashedString',
         protocolName: 'stored protocol',
+        protocolHasRunTimeParameterCustomValues: false,
+        protocolHasRunTimeParameters: true,
         protocolSource: 'stored protocol source',
         protocolText: 'hashedString',
         protocolType: 'json',

--- a/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
@@ -52,11 +52,11 @@ export const parseProtocolRunAnalyticsData = (
       protocolAuthor: protocolAuthor !== '' ? protocolAuthor : '',
       protocolText: protocolText !== '' ? protocolText : '',
       protocolHasRunTimeParameters:
-        protocolAnalysis != null
-          ? protocolAnalysis.runTimeParameters.length > 0
+        protocolAnalysis?.runTimeParameters != null
+          ? protocolAnalysis?.runTimeParameters?.length > 0
           : false,
       protocolHasRunTimeParameterCustomValues:
-        protocolAnalysis?.runTimeParameters.some(
+        protocolAnalysis?.runTimeParameters?.some(
           param => param.value !== param.default
         ) ?? false,
       robotType:

--- a/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
+++ b/app/src/organisms/Devices/hooks/useProtocolRunAnalyticsData.ts
@@ -51,6 +51,14 @@ export const parseProtocolRunAnalyticsData = (
         .join(','),
       protocolAuthor: protocolAuthor !== '' ? protocolAuthor : '',
       protocolText: protocolText !== '' ? protocolText : '',
+      protocolHasRunTimeParameters:
+        protocolAnalysis != null
+          ? protocolAnalysis.runTimeParameters.length > 0
+          : false,
+      protocolHasRunTimeParameterCustomValues:
+        protocolAnalysis?.runTimeParameters.some(
+          param => param.value !== param.default
+        ) ?? false,
       robotType:
         protocolAnalysis?.robotType != null
           ? protocolAnalysis?.robotType


### PR DESCRIPTION
closes [AUTH-281](https://opentrons.atlassian.net/browse/AUTH-281)

# Overview

add analytics RTP properties for:
1. whether protocol has RTP or not
2. whether any RTP values are non-default

to protocol events as described in [this doc](https://opentrons.atlassian.net/wiki/spaces/PAR/pages/4073586724/Runtime+Parameters+MVP+-+Analytics+Plan).

# Test Plan


# Changelog


# Review requests

authorship

# Risk assessment

low

[AUTH-281]: https://opentrons.atlassian.net/browse/AUTH-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ