### PR TITLE
fix(shared-data): format rtp float and int choices to include suffix

### DIFF
--- a/shared-data/js/helpers/__tests__/formatRunTimeParameterValue.test.ts
+++ b/shared-data/js/helpers/__tests__/formatRunTimeParameterValue.test.ts
@@ -41,11 +41,11 @@ describe('utils-formatRunTimeParameterDefaultValue', () => {
     expect(result).toEqual('6.5 mL')
   })
 
-  it('should return value with suffix when type is str', () => {
+  it('should return value when type is str', () => {
     const mockData = {
       value: 'left',
       displayName: 'pipette mount',
-      variableName: 'mont',
+      variableName: 'mount',
       description: 'pipette mount',
       type: 'str',
       choices: [
@@ -64,7 +64,59 @@ describe('utils-formatRunTimeParameterDefaultValue', () => {
     expect(result).toEqual('Left')
   })
 
-  it('should return value with suffix when type is boolean true', () => {
+  it('should return value when type is int choice with suffix', () => {
+    const mockData = {
+      value: 5,
+      displayName: 'num',
+      variableName: 'number',
+      description: 'its just number',
+      type: 'int',
+      suffix: 'mL',
+      min: 1,
+      max: 10,
+      choices: [
+        {
+          displayName: 'one',
+          value: 1,
+        },
+        {
+          displayName: 'six',
+          value: 6,
+        },
+      ],
+      default: 5,
+    } as RunTimeParameter
+    const result = formatRunTimeParameterDefaultValue(mockData, mockTFunction)
+    expect(result).toEqual('5 mL')
+  })
+
+  it('should return value when type is float choice with suffix', () => {
+    const mockData = {
+      value: 5.0,
+      displayName: 'num',
+      variableName: 'number',
+      description: 'its just number',
+      type: 'float',
+      suffix: 'mL',
+      min: 1.0,
+      max: 10.0,
+      choices: [
+        {
+          displayName: 'one',
+          value: 1.0,
+        },
+        {
+          displayName: 'six',
+          value: 6.0,
+        },
+      ],
+      default: 5.0,
+    } as RunTimeParameter
+    const result = formatRunTimeParameterDefaultValue(mockData, mockTFunction)
+    expect(result).toEqual('5 mL')
+  })
+
+  it('should return value when type is boolean true', () => {
     const mockData = {
       value: true,
       displayName: 'Deactivate Temperatures',
@@ -77,7 +129,7 @@ describe('utils-formatRunTimeParameterDefaultValue', () => {
     expect(result).toEqual('On')
   })
 
-  it('should return value with suffix when type is boolean false', () => {
+  it('should return value when type is boolean false', () => {
     const mockData = {
       value: false,
       displayName: 'Dry Run',

--- a/shared-data/js/helpers/formatRunTimeParameterDefaultValue.ts
+++ b/shared-data/js/helpers/formatRunTimeParameterDefaultValue.ts
@@ -9,6 +9,18 @@ export const formatRunTimeParameterDefaultValue = (
     'suffix' in runTimeParameter && runTimeParameter.suffix != null
       ? runTimeParameter.suffix
       : null
+
+  if ('choices' in runTimeParameter && runTimeParameter.choices != null) {
+    const choice = runTimeParameter.choices.find(
+      choice => choice.value === defaultValue
+    )
+    if (choice != null) {
+      return suffix != null
+        ? `${choice.displayName} ${suffix}`
+        : choice.displayName
+    }
+  }
+
   switch (type) {
     case 'int':
     case 'float':
@@ -21,15 +33,7 @@ export const formatRunTimeParameterDefaultValue = (
       } else {
         return Boolean(defaultValue) ? 'On' : 'Off'
       }
-    case 'str':
-      if ('choices' in runTimeParameter && runTimeParameter.choices != null) {
-        const choice = runTimeParameter.choices.find(
-          choice => choice.value === defaultValue
-        )
-        if (choice != null) {
-          return choice.displayName
-        }
-      }
+    default:
       break
   }
   return ''

--- a/shared-data/js/helpers/formatRunTimeParameterValue.ts
+++ b/shared-data/js/helpers/formatRunTimeParameterValue.ts
@@ -9,6 +9,17 @@ export const formatRunTimeParameterValue = (
     'suffix' in runTimeParameter && runTimeParameter.suffix != null
       ? runTimeParameter.suffix
       : null
+
+  if ('choices' in runTimeParameter && runTimeParameter.choices != null) {
+    const choice = runTimeParameter.choices.find(
+      choice => choice.value === value
+    )
+    if (choice != null) {
+      return suffix != null
+        ? `${choice.displayName} ${suffix}`
+        : choice.displayName
+    }
+  }
   switch (type) {
     case 'int':
     case 'float':
@@ -18,15 +29,7 @@ export const formatRunTimeParameterValue = (
     case 'bool': {
       return Boolean(value) ? t('on') : t('off')
     }
-    case 'str':
-      if ('choices' in runTimeParameter && runTimeParameter.choices != null) {
-        const choice = runTimeParameter.choices.find(
-          choice => choice.value === value
-        )
-        if (choice != null) {
-          return choice.displayName
-        }
-      }
+    default:
       break
   }
   return ''


### PR DESCRIPTION
closes AUTH-311

# Overview

display suffixes for int and float choices.

# Test Plan

Upload the attached protocol in the ticket and see that the default and updates values in the table display the suffixes for choices that are type `int` and `float`

# Changelog

- modify the 2 utils and fix the test. choices type can be an int and float so i had to remove it from the switch block

# Review requests

see test plan

# Risk assessment

low