### PR TITLE
style(app): Adjust desktop app "moveToWell" command text font size

### DIFF
--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -190,11 +190,15 @@ export function CommandText(props: Props): JSX.Element | null {
               robotType
             )
           : ''
-      return t('move_to_well', {
-        well_name: wellName,
-        labware: getLabwareName(robotSideAnalysis, labwareId),
-        labware_location: displayLocation,
-      })
+      return (
+        <StyledText as="p" {...styleProps}>
+          {t('move_to_well', {
+            well_name: wellName,
+            labware: getLabwareName(robotSideAnalysis, labwareId),
+            labware_location: displayLocation,
+          })}
+        </StyledText>
+      )
     }
     case 'moveLabware': {
       return (


### PR DESCRIPTION
Closes [RQA-2428](https://opentrons.atlassian.net/browse/RQA-2428)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The "moveToWell" command text was never wrapped in `StyledText`, causing it to render at an improper font size on the desktop app. This did not impact the ODD, since command text is handled in a different component. 

### Current Behavior

<img width="1016" alt="Screenshot 2024-04-09 at 1 39 05 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/b7d21e08-9357-410a-a612-d68c410427df">

### With Fix

<img width="1009" alt="Screenshot 2024-04-09 at 2 17 05 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/1120c0df-79dd-4a59-b1cc-cc4a14e0a03f">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verify using a protocol with a moveToWell command. See ticket for an attached protocol. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2428]: https://opentrons.atlassian.net/browse/RQA-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ