### PR TITLE
fix(protocol-designer): auto-generate trashBin for flex if no pipetting commands exist

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
@@ -67,12 +67,12 @@ export const getCrashableModuleSelected = (
 
 export const MOVABLE_TRASH_CUTOUTS = [
   {
-    value: 'cutoutA1',
-    slot: 'A1',
-  },
-  {
     value: 'cutoutA3',
     slot: 'A3',
+  },
+  {
+    value: 'cutoutA1',
+    slot: 'A1',
   },
   {
     value: 'cutoutB1',
@@ -240,13 +240,6 @@ export const getTrashSlot = (values: FormState): string => {
   const wasteChuteSlot = Boolean(hasWasteChute)
     ? [WASTE_CHUTE_CUTOUT as string]
     : []
-
-  if (
-    !cutouts.includes(FLEX_TRASH_DEFAULT_SLOT) &&
-    !moduleSlots.includes('A3')
-  ) {
-    return FLEX_TRASH_DEFAULT_SLOT
-  }
 
   const unoccupiedSlot = MOVABLE_TRASH_CUTOUTS.find(
     cutout =>

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -67,8 +67,10 @@ import {
   createPresavedStepForm,
   getDeckItemIdInSlot,
   getIdsInRange,
+  getUnoccupiedSlotForMoveableTrash,
 } from '../utils'
-import {
+
+import type {
   CreateModuleAction,
   CreatePipettesAction,
   DeleteModuleAction,
@@ -124,6 +126,7 @@ import type {
   NormalizedLabwareById,
   ModuleEntities,
 } from '../types'
+import { e } from 'vitest/dist/reporters-1evA5lom'
 
 type FormState = FormData | null
 const unsavedFormInitialState = null
@@ -1379,6 +1382,12 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
         ]),
       ]
 
+      const unoccupiedSlotForMovableTrash = getUnoccupiedSlotForMoveableTrash(
+        file,
+        hasWasteChuteCommands,
+        stagingAreaSlotNames
+      )
+
       const stagingAreas = stagingAreaSlotNames.reduce((acc, slot) => {
         const stagingAreaId = `${uuid()}:stagingArea`
         const cutoutId = getCutoutIdByAddressableArea(
@@ -1531,11 +1540,11 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           }
         : {}
 
-      const hardcodedTrashBinId = `${uuid()}:fixedTrash`
-      const hardcodedTrashBin = {
-        [hardcodedTrashBinId]: {
+      const hardcodedTrashBinIdOt2 = `${uuid()}:fixedTrash`
+      const hardcodedTrashBinOt2 = {
+        [hardcodedTrashBinIdOt2]: {
           name: 'trashBin' as const,
-          id: hardcodedTrashBinId,
+          id: hardcodedTrashBinIdOt2,
           location: getCutoutIdByAddressableArea(
             'fixedTrash' as AddressableAreaName,
             'fixedTrashSlot',
@@ -1543,23 +1552,54 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
           ),
         },
       }
+      const hardcodedTrashAddressableAreaName = `movableTrash${unoccupiedSlotForMovableTrash}`
+      const hardcodedTrashBinIdFlex = `${uuid()}:${hardcodedTrashAddressableAreaName}`
+      const hardcodedTrashBinFlex = {
+        [hardcodedTrashBinIdFlex]: {
+          name: 'trashBin' as const,
+          id: hardcodedTrashBinIdFlex,
+          location: getCutoutIdByAddressableArea(
+            hardcodedTrashAddressableAreaName as AddressableAreaName,
+            'trashBinAdapter',
+            FLEX_ROBOT_TYPE
+          ),
+        },
+      }
 
       if (isFlex) {
-        return {
-          ...state,
-          ...gripper,
-          ...trashBin,
-          ...wasteChute,
-          ...stagingAreas,
+        if (trashBin != null) {
+          return {
+            ...state,
+            ...gripper,
+            ...trashBin,
+            ...wasteChute,
+            ...stagingAreas,
+          }
+        } else if (trashBin == null && !hasWasteChuteCommands) {
+          //  always hardcode a trash bin when no pipetting command is provided since return tip
+          //  is not supported
+          return {
+            ...state,
+            ...gripper,
+            ...hardcodedTrashBinFlex,
+            ...wasteChute,
+            ...stagingAreas,
+          }
+        } else {
+          return {
+            ...state,
+            ...gripper,
+            ...wasteChute,
+            ...stagingAreas,
+          }
         }
       } else {
         if (trashBin != null) {
           return { ...state, ...trashBin }
         } else {
-          //  when importing an OT-2 protocol, ensure that there is always a trashBin
-          //  entity created even when the protocol does not have a command that involves
-          //  the trash. Since no trash for OT-2 is not supported
-          return { ...state, ...hardcodedTrashBin }
+          //  always hardcode a trash bin when no pipetting command is provided since no trash for
+          //  OT-2 is not supported
+          return { ...state, ...hardcodedTrashBinOt2 }
         }
       }
     },

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -126,7 +126,6 @@ import type {
   NormalizedLabwareById,
   ModuleEntities,
 } from '../types'
-import { e } from 'vitest/dist/reporters-1evA5lom'
 
 type FormState = FormData | null
 const unsavedFormInitialState = null

--- a/protocol-designer/src/step-forms/test/utils.test.ts
+++ b/protocol-designer/src/step-forms/test/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { getIdsInRange, getUnoccupiedSlotForMoveableTrash } from '../utils'
-import { AddressableAreaName, CreateCommand } from '@opentrons/shared-data'
+import type { AddressableAreaName, CreateCommand } from '@opentrons/shared-data'
+
 describe('getIdsInRange', () => {
   it('gets id in array of length 1', () => {
     expect(getIdsInRange(['X'], 'X', 'X')).toEqual(['X'])
@@ -31,7 +32,7 @@ describe('getIdsInRange', () => {
   })
 })
 describe('getUnoccupiedSlotForMoveableTrash', () => {
-  it('returns slot C3 when all other slots are occupied by modules, labware, moveLabware, and staging areas', () => {
+  it('returns slot D1 when all other slots are occupied by modules, labware, moveLabware, and staging areas', () => {
     const mockPDFile: any = {
       commands: [
         {
@@ -101,6 +102,22 @@ describe('getUnoccupiedSlotForMoveableTrash', () => {
             namespace: 'opentrons',
             version: 2,
             location: { slotName: 'B3' },
+          },
+        },
+        {
+          key: 'fb1807fe-ca16-4f75-b44d-803d704c7d98',
+          commandType: 'loadLabware',
+          params: {
+            displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
+            labwareId:
+              '11fdsa8b1-bf4b-4a6c-80cb-b8e5bdfe309b:opentrons/opentrons_flex_96_tiprack_50ul/1',
+            loadName: 'opentrons_flex_96_tiprack_50ul',
+            namespace: 'opentrons',
+            version: 1,
+            location: {
+              labwareId:
+                '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
+            },
           },
         },
         {

--- a/protocol-designer/src/step-forms/test/utils.test.ts
+++ b/protocol-designer/src/step-forms/test/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { getIdsInRange } from '../utils'
+import { getIdsInRange, getUnoccupiedSlotForMoveableTrash } from '../utils'
+import { AddressableAreaName, CreateCommand } from '@opentrons/shared-data'
 describe('getIdsInRange', () => {
   it('gets id in array of length 1', () => {
     expect(getIdsInRange(['X'], 'X', 'X')).toEqual(['X'])
@@ -27,5 +28,112 @@ describe('getIdsInRange', () => {
     ])
     // startId same as endId
     expect(getIdsInRange(orderedIds, 'T', 'T')).toEqual(['T'])
+  })
+})
+describe('getUnoccupiedSlotForMoveableTrash', () => {
+  it('returns slot C3 when all other slots are occupied by modules, labware, moveLabware, and staging areas', () => {
+    const mockPDFile: any = {
+      commands: [
+        {
+          key: '7353ae60-c85e-45c4-8d69-59ff3a97debd',
+          commandType: 'loadModule',
+          params: {
+            model: 'thermocyclerModuleV2',
+            location: { slotName: 'B1' },
+            moduleId:
+              '771f390f-01a9-4615-9c4e-4dbfc95844b5:thermocyclerModuleType',
+          },
+        },
+        {
+          key: '82e5d08f-ceae-4eb8-8600-b61a973d47d9',
+          commandType: 'loadModule',
+          params: {
+            model: 'heaterShakerModuleV1',
+            location: { slotName: 'D1' },
+            moduleId:
+              'b9df03af-3844-4ae8-a1cf-cae61a6b4992:heaterShakerModuleType',
+          },
+        },
+        {
+          key: '49bc2a29-a7d2-42a6-8610-e07a9ad166df',
+          commandType: 'loadModule',
+          params: {
+            model: 'temperatureModuleV2',
+            location: { slotName: 'D3' },
+            moduleId:
+              '52bea856-eea6-473c-80df-b316f3559692:temperatureModuleType',
+          },
+        },
+        {
+          key: '864fadd7-f2c1-400a-b2ef-24d0c887a3c8',
+          commandType: 'loadLabware',
+          params: {
+            displayName: 'Opentrons Flex 96 Tip Rack 50 µL',
+            labwareId:
+              '88881828-037c-4445-ba57-121164f4a53a:opentrons/opentrons_flex_96_tiprack_50ul/1',
+            loadName: 'opentrons_flex_96_tiprack_50ul',
+            namespace: 'opentrons',
+            version: 1,
+            location: { slotName: 'C2' },
+          },
+        },
+        {
+          key: '79994418-d664-4884-9441-4b0fa62bd143',
+          commandType: 'loadLabware',
+          params: {
+            displayName: 'Bio-Rad 96 Well Plate 200 µL PCR',
+            labwareId:
+              '733c04a8-ae8c-449f-a1f9-ca3783fdda58:opentrons/biorad_96_wellplate_200ul_pcr/2',
+            loadName: 'biorad_96_wellplate_200ul_pcr',
+            namespace: 'opentrons',
+            version: 2,
+            location: { addressableAreaName: 'A4' },
+          },
+        },
+        {
+          key: 'b2170a2c-d202-4129-9cd7-ffa4e35d57bb',
+          commandType: 'loadLabware',
+          params: {
+            displayName: 'Corning 24 Well Plate 3.4 mL Flat',
+            labwareId:
+              '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
+            loadName: 'corning_24_wellplate_3.4ml_flat',
+            namespace: 'opentrons',
+            version: 2,
+            location: { slotName: 'B3' },
+          },
+        },
+        {
+          commandType: 'moveLabware',
+          key: '1395243a-958f-4305-9687-52cdaf39f2b6',
+          params: {
+            labwareId:
+              '733c04a8-ae8c-449f-a1f9-ca3783fdda58:opentrons/biorad_96_wellplate_200ul_pcr/2',
+            strategy: 'usingGripper',
+            newLocation: { slotName: 'C1' },
+          },
+        },
+        {
+          commandType: 'moveLabware',
+          key: '4e39e7ec-4ada-4e3c-8369-1ff7421061a9',
+          params: {
+            labwareId:
+              '32e97c67-866e-4153-bcb7-2b86b1d3f1fe:opentrons/corning_24_wellplate_3.4ml_flat/2',
+            strategy: 'usingGripper',
+            newLocation: { addressableAreaName: 'A4' },
+          },
+        },
+      ] as CreateCommand[],
+    }
+    const mockStagingAreaSlotNames: AddressableAreaName[] = ['A4', 'B4']
+    const mockHasWasteChuteCommands = false
+
+    expect(
+      getUnoccupiedSlotForMoveableTrash(
+        mockPDFile,
+        mockHasWasteChuteCommands,
+        mockStagingAreaSlotNames
+      )
+    ).toStrictEqual('C3')
   })
 })

--- a/protocol-designer/src/step-forms/test/utils.test.ts
+++ b/protocol-designer/src/step-forms/test/utils.test.ts
@@ -32,7 +32,7 @@ describe('getIdsInRange', () => {
   })
 })
 describe('getUnoccupiedSlotForMoveableTrash', () => {
-  it('returns slot D1 when all other slots are occupied by modules, labware, moveLabware, and staging areas', () => {
+  it('returns slot C1 when all other slots are occupied by modules, labware, moveLabware, and staging areas', () => {
     const mockPDFile: any = {
       commands: [
         {

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -13,6 +13,7 @@ import {
 import { SPAN7_8_10_11_SLOT, TC_SPAN_SLOTS } from '../../constants'
 import { hydrateField } from '../../steplist/fieldLevel'
 import { LabwareDefByDefURI } from '../../labware-defs'
+import { getCutoutIdByAddressableArea } from '../../utils'
 import type {
   AddressableAreaName,
   CutoutId,
@@ -41,7 +42,6 @@ import type {
   FormPipette,
   LabwareOnDeck as LabwareOnDeckType,
 } from '../types'
-import { getCutoutIdByAddressableArea } from '../../utils'
 export { createPresavedStepForm } from './createPresavedStepForm'
 
 const MOVABLE_TRASH_CUTOUTS = [
@@ -297,14 +297,12 @@ export function getHydratedForm(
   return hydratedForm
 }
 
-export function getUnoccupiedSlotForMoveableTrash(
+export const getUnoccupiedSlotForMoveableTrash = (
   file: PDProtocolFile,
   hasWasteChuteCommands: boolean,
   stagingAreaSlotNames: AddressableAreaName[]
-): string {
-  const wasteChuteSlot = hasWasteChuteCommands
-    ? [WASTE_CHUTE_CUTOUT as string]
-    : []
+): string => {
+  const wasteChuteSlot = hasWasteChuteCommands ? [WASTE_CHUTE_CUTOUT] : []
   const stagingAreaCutoutIds = stagingAreaSlotNames.map(slotName =>
     getCutoutIdByAddressableArea(
       slotName,
@@ -365,7 +363,7 @@ export function getUnoccupiedSlotForMoveableTrash(
       !allLoadLabwareSlotNames.includes(cutout.slot) &&
       !allLoadModuleSlotNames.includes(cutout.slot) &&
       !allMoveLabwareLocations.includes(cutout.slot) &&
-      !wasteChuteSlot.includes(cutout.value) &&
+      !wasteChuteSlot.includes(cutout.value as typeof WASTE_CHUTE_CUTOUT) &&
       !stagingAreaCutoutIds.includes(cutout.value as CutoutId)
   )
   if (unoccupiedSlot == null) {
@@ -375,5 +373,5 @@ export function getUnoccupiedSlotForMoveableTrash(
     return ''
   }
 
-  return unoccupiedSlot?.slot
+  return unoccupiedSlot.slot
 }

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -325,33 +325,11 @@ export function getUnoccupiedSlotForMoveableTrash(
         'slotName' in location
       ) {
         return [...acc, location.slotName]
-      } else if (
-        location !== 'offDeck' &&
-        location !== null &&
-        'labwareId' in location
-      ) {
-        const adapterId = location.labwareId
-        const adapter = Object.values(file.commands).find(
-          (command): command is LoadLabwareCreateCommand =>
-            command.commandType === 'loadLabware' &&
-            command.params.labwareId === adapterId
-        )
-        if (adapter == null) {
-          console.error('expected to find adapter but could not')
-        }
-        const adapterLocation = adapter?.params.location
-        if (
-          adapterLocation !== 'offDeck' &&
-          adapterLocation != null &&
-          'slotName' in adapterLocation
-        ) {
-          return [...acc, adapterLocation.slotName]
-        }
       }
       return acc
     }, [])
 
-  const allModuleSlotNames = Object.values(file.commands)
+  const allLoadModuleSlotNames = Object.values(file.commands)
     .filter(
       (command): command is LoadModuleCreateCommand =>
         command.commandType === 'loadModule'
@@ -385,7 +363,7 @@ export function getUnoccupiedSlotForMoveableTrash(
   const unoccupiedSlot = MOVABLE_TRASH_CUTOUTS.find(
     cutout =>
       !allLoadLabwareSlotNames.includes(cutout.slot) &&
-      !allModuleSlotNames.includes(cutout.slot) &&
+      !allLoadModuleSlotNames.includes(cutout.slot) &&
       !allMoveLabwareLocations.includes(cutout.slot) &&
       !wasteChuteSlot.includes(cutout.value) &&
       !stagingAreaCutoutIds.includes(cutout.value as CutoutId)

--- a/protocol-designer/src/step-forms/utils/index.ts
+++ b/protocol-designer/src/step-forms/utils/index.ts
@@ -8,18 +8,19 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
+  FLEX_ROBOT_TYPE,
 } from '@opentrons/shared-data'
 import { SPAN7_8_10_11_SLOT, TC_SPAN_SLOTS } from '../../constants'
 import { hydrateField } from '../../steplist/fieldLevel'
 import { LabwareDefByDefURI } from '../../labware-defs'
-import { MOVABLE_TRASH_CUTOUTS } from '../../components/modals/CreateFileWizard/utils'
 import type {
+  AddressableAreaName,
+  CutoutId,
   DeckSlotId,
-  ModuleType,
   LoadLabwareCreateCommand,
   LoadModuleCreateCommand,
+  ModuleType,
   MoveLabwareCreateCommand,
-  AddressableAreaName,
 } from '@opentrons/shared-data'
 import type {
   NormalizedPipette,
@@ -29,9 +30,9 @@ import type {
   InvariantContext,
   ModuleEntity,
 } from '@opentrons/step-generation'
-import type { PDProtocolFile } from '../../file-types'
 import type { DeckSlot } from '../../types'
 import type { FormData } from '../../form-types'
+import type { PDProtocolFile } from '../../file-types'
 import type {
   AdditionalEquipmentOnDeck,
   InitialDeckSetup,
@@ -40,7 +41,43 @@ import type {
   FormPipette,
   LabwareOnDeck as LabwareOnDeckType,
 } from '../types'
+import { getCutoutIdByAddressableArea } from '../../utils'
 export { createPresavedStepForm } from './createPresavedStepForm'
+
+const MOVABLE_TRASH_CUTOUTS = [
+  {
+    value: 'cutoutA3',
+    slot: 'A3',
+  },
+  {
+    value: 'cutoutA1',
+    slot: 'A1',
+  },
+  {
+    value: 'cutoutB1',
+    slot: 'B1',
+  },
+  {
+    value: 'cutoutB3',
+    slot: 'B3',
+  },
+  {
+    value: 'cutoutC1',
+    slot: 'C1',
+  },
+  {
+    value: 'cutoutC3',
+    slot: 'C3',
+  },
+  {
+    value: 'cutoutD1',
+    slot: 'D1',
+  },
+  {
+    value: 'cutoutD3',
+    slot: 'D3',
+  },
+]
 
 const slotToCutoutOt2Map: { [key: string]: string } = {
   '1': 'cutout1',
@@ -268,7 +305,13 @@ export function getUnoccupiedSlotForMoveableTrash(
   const wasteChuteSlot = hasWasteChuteCommands
     ? [WASTE_CHUTE_CUTOUT as string]
     : []
-
+  const stagingAreaCutoutIds = stagingAreaSlotNames.map(slotName =>
+    getCutoutIdByAddressableArea(
+      slotName,
+      'stagingAreaRightSlot',
+      FLEX_ROBOT_TYPE
+    )
+  )
   const allLoadLabwareSlotNames = Object.values(file.commands)
     .filter(
       (command): command is LoadLabwareCreateCommand =>
@@ -345,7 +388,7 @@ export function getUnoccupiedSlotForMoveableTrash(
       !allModuleSlotNames.includes(cutout.slot) &&
       !allMoveLabwareLocations.includes(cutout.slot) &&
       !wasteChuteSlot.includes(cutout.value) &&
-      !stagingAreaSlotNames.includes(cutout.value as AddressableAreaName)
+      !stagingAreaCutoutIds.includes(cutout.value as CutoutId)
   )
   if (unoccupiedSlot == null) {
     console.error(


### PR DESCRIPTION
closes AUTH-267

# Overview

In PD in production, if you create a Flex protocol with no pipetting steps and reupload it to the app, it does not auto generate a trash bin for you. Technically there is a way around it by adding a trash bin entity. But its a weird state because return tip and no trash entity is not supported in PD. 

Ot-2 does not have this issue because it always ensures a hardcoded fixed trash is generated

So this PR auto-generates a trash bin for a flex if there is none when importing a protocol.

# Test Plan

I created a test case to test all scenarios, so it should work as expected. 

However, you can create a flex protocol and add a pause step. Download the protocol and reimport it back to PD. See that the trash bin is generated.

# Changelog

- create util for getting an unoccupied slot, taking into account modules, labwares, move labware commands, waste chute, and staging area slots
- add test

# Review requests

see test plan

# Risk assessment

low