### PR TITLE
feat(robot-server): add runtime parameter definitions to run summary

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v3_to_v4.py
+++ b/robot-server/robot_server/persistence/_migrations/v3_to_v4.py
@@ -50,3 +50,8 @@ class Migration3to4(Migration):  # noqa: D101
                 schema_4.analysis_table.name,
                 schema_4.analysis_table.c.run_time_parameter_values_and_defaults,
             )
+            add_column(
+                dest_engine,
+                schema_4.run_table.name,
+                schema_4.run_table.c.run_time_parameters,
+            )

--- a/robot-server/robot_server/persistence/_migrations/v3_to_v4.py
+++ b/robot-server/robot_server/persistence/_migrations/v3_to_v4.py
@@ -3,6 +3,7 @@
 Summary of changes from schema 3:
 
 - Adds a new "run_time_parameter_values_and_defaults" column to analysis table
+- Adds a new "run_time_parameters" column to run table
 """
 
 from pathlib import Path

--- a/robot-server/robot_server/persistence/pydantic.py
+++ b/robot-server/robot_server/persistence/pydantic.py
@@ -1,7 +1,8 @@
 """Store Pydantic objects in the SQL database."""
 
-from typing import Type, TypeVar
-from pydantic import BaseModel, parse_raw_as
+import json
+from typing import Type, TypeVar, List, Sequence
+from pydantic import BaseModel, parse_raw_as, parse_obj_as
 
 
 _BaseModelT = TypeVar("_BaseModelT", bound=BaseModel)
@@ -17,6 +18,16 @@ def pydantic_to_json(obj: BaseModel) -> str:
     )
 
 
-def json_to_pydantic(model: Type[_BaseModelT], json: str) -> _BaseModelT:
+def pydantic_list_to_json(obj_list: Sequence[BaseModel]) -> str:
+    """Serialize a list of Pydantic objects for storing in the SQL database."""
+    return json.dumps([obj.dict(by_alias=True, exclude_none=True) for obj in obj_list])
+
+
+def json_to_pydantic(model: Type[_BaseModelT], json_str: str) -> _BaseModelT:
     """Parse a Pydantic object stored in the SQL database."""
-    return parse_raw_as(model, json)
+    return parse_raw_as(model, json_str)
+
+
+def json_to_pydantic_list(model: Type[_BaseModelT], json_str: str) -> List[_BaseModelT]:
+    """Parse a list of Pydantic objects stored in the SQL database."""
+    return [parse_obj_as(model, obj_dict) for obj_dict in json.loads(json_str)]

--- a/robot-server/robot_server/persistence/tables/schema_4.py
+++ b/robot-server/robot_server/persistence/tables/schema_4.py
@@ -85,6 +85,13 @@ run_table = sqlalchemy.Table(
     sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
     # column added in schema v1
     sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
+    # column added in schema v4
+    sqlalchemy.Column(
+        "run_time_parameters",
+        # Stores a JSON string. See RunStore.
+        sqlalchemy.String,
+        nullable=True,
+    ),
 )
 
 action_table = sqlalchemy.Table(

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -106,4 +106,5 @@ class RunController:
             run_id=self._run_id,
             summary=result.state_summary,
             commands=result.commands,
+            run_time_parameters=result.parameters,
         )

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -175,6 +175,7 @@ class RunDataManager:
                 run_id=prev_run_id,
                 summary=prev_run_result.state_summary,
                 commands=prev_run_result.commands,
+                run_time_parameters=prev_run_result.parameters,
             )
         state_summary = await self._engine_store.create(
             run_id=run_id,
@@ -316,6 +317,7 @@ class RunDataManager:
                 run_id=run_id,
                 summary=state_summary,
                 commands=commands,
+                run_time_parameters=parameters,
             )
         else:
             state_summary = self._engine_store.engine.state_view.get_summary()
@@ -398,4 +400,4 @@ class RunDataManager:
         if run_id == self._engine_store.current_run_id:
             return self._engine_store.runner.run_time_parameters
         else:
-            return []
+            return self._run_store.get_run_time_parameters(run_id=run_id)

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -124,10 +124,9 @@ class Run(ResourceModel):
     runTimeParameters: List[RunTimeParameter] = Field(
         default_factory=list,
         description=(
-            "Run time parameters used during analysis."
+            "Run time parameters used during the run."
             " These are the parameters that are defined in the protocol, with values"
-            " specified either in the protocol creation request or reanalysis request"
-            " (whichever started this analysis), or default values from the protocol"
+            " specified either in the run creation request or default values from the protocol"
             " if none are specified in the request."
         ),
     )
@@ -198,10 +197,9 @@ class BadRun(ResourceModel):
     runTimeParameters: List[RunTimeParameter] = Field(
         default_factory=list,
         description=(
-            "Run time parameters used during analysis."
+            "Run time parameters used during the run."
             " These are the parameters that are defined in the protocol, with values"
-            " specified either in the protocol creation request or reanalysis request"
-            " (whichever started this analysis), or default values from the protocol"
+            " specified either in the run creation request or default values from the protocol"
             " if none are specified in the request."
         ),
     )

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -18,7 +18,7 @@ from opentrons.protocol_engine import (
     Liquid,
     CommandNote,
 )
-from opentrons.protocol_engine.types import RunTimeParamValuesType
+from opentrons.protocol_engine.types import RunTimeParameter, RunTimeParamValuesType
 from opentrons_shared_data.errors import GeneralError
 from robot_server.service.json_api import ResourceModel
 from robot_server.errors.error_responses import ErrorDetails
@@ -121,6 +121,16 @@ class Run(ResourceModel):
         ...,
         description="Labware offsets to apply as labware are loaded.",
     )
+    runTimeParameters: List[RunTimeParameter] = Field(
+        default_factory=list,
+        description=(
+            "Run time parameters used during analysis."
+            " These are the parameters that are defined in the protocol, with values"
+            " specified either in the protocol creation request or reanalysis request"
+            " (whichever started this analysis), or default values from the protocol"
+            " if none are specified in the request."
+        ),
+    )
     protocolId: Optional[str] = Field(
         None,
         description=(
@@ -184,6 +194,16 @@ class BadRun(ResourceModel):
     labwareOffsets: List[LabwareOffset] = Field(
         ...,
         description="Labware offsets to apply as labware are loaded.",
+    )
+    runTimeParameters: List[RunTimeParameter] = Field(
+        default_factory=list,
+        description=(
+            "Run time parameters used during analysis."
+            " These are the parameters that are defined in the protocol, with values"
+            " specified either in the protocol creation request or reanalysis request"
+            " (whichever started this analysis), or default values from the protocol"
+            " if none are specified in the request."
+        ),
     )
     protocolId: Optional[str] = Field(
         None,

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from opentrons.util.helpers import utc_now
 from opentrons.protocol_engine import StateSummary, CommandSlice
 from opentrons.protocol_engine.commands import Command
+from opentrons.protocol_engine.types import RunTimeParameter
 
 from opentrons_shared_data.errors.exceptions import (
     EnumeratedError,
@@ -25,7 +26,12 @@ from robot_server.persistence.tables import (
     run_command_table,
     action_table,
 )
-from robot_server.persistence.pydantic import json_to_pydantic, pydantic_to_json
+from robot_server.persistence.pydantic import (
+    json_to_pydantic,
+    pydantic_to_json,
+    json_to_pydantic_list,
+    pydantic_list_to_json,
+)
 from robot_server.protocols.protocol_store import ProtocolNotFoundError
 
 from .action_models import RunAction, RunActionType
@@ -102,6 +108,7 @@ class RunStore:
         run_id: str,
         summary: StateSummary,
         commands: List[Command],
+        run_time_parameters: List[RunTimeParameter],
     ) -> RunResource:
         """Update the run's state summary and commands list.
 
@@ -109,6 +116,7 @@ class RunStore:
             run_id: The run to update
             summary: The run's equipment and status summary.
             commands: The run's commands.
+            run_time_parameters: The run's run time parameters, if any.
 
         Returns:
             The run resource.
@@ -124,6 +132,7 @@ class RunStore:
                     run_id=run_id,
                     state_summary=summary,
                     engine_status=summary.status,
+                    run_time_parameters=run_time_parameters,
                 )
             )
         )
@@ -346,6 +355,33 @@ class RunStore:
                 )
             )
 
+    @lru_cache(maxsize=_CACHE_ENTRIES)
+    def get_run_time_parameters(self, run_id: str) -> List[RunTimeParameter]:
+        """Get the archived run time parameters.
+
+        This is a list of the run's parameter definitions (if any),
+        including the values used in the run itself, along with the default value,
+        constraints and associated names and descriptions.
+        """
+        select_run_data = sqlalchemy.select(run_table.c.run_time_parameters).where(
+            run_table.c.id == run_id
+        )
+
+        with self._sql_engine.begin() as transaction:
+            row = transaction.execute(select_run_data).one()
+
+        try:
+            return (
+                json_to_pydantic_list(RunTimeParameter, row.run_time_parameters)  # type: ignore[arg-type]
+                if row.run_time_parameters is not None
+                else []
+            )
+        except ValidationError:
+            log.warning(
+                f"Error retrieving run time parameters for {run_id}", exc_info=True
+            )
+            return []
+
     def get_commands_slice(
         self,
         run_id: str,
@@ -476,6 +512,7 @@ class RunStore:
         self.get_all.cache_clear()
         self.get_state_summary.cache_clear()
         self.get_command.cache_clear()
+        self.get_run_time_parameters.cache_clear()
 
 
 # The columns that must be present in a row passed to _convert_row_to_run().
@@ -552,9 +589,11 @@ def _convert_state_to_sql_values(
     run_id: str,
     state_summary: StateSummary,
     engine_status: str,
+    run_time_parameters: List[RunTimeParameter],
 ) -> Dict[str, object]:
     return {
         "state_summary": pydantic_to_json(state_summary),
         "engine_status": engine_status,
         "_updated_at": utc_now(),
+        "run_time_parameters": pydantic_list_to_json(run_time_parameters),
     }

--- a/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v6_protocol_run.tavern.yaml
@@ -50,6 +50,7 @@ stages:
               displayName: Water
               description: Liquid H2O
               displayColor: '#7332a8'
+          runTimeParameters: []
           protocolId: '{protocol_id}'
 
   - name: Execute a setup command

--- a/robot-server/tests/integration/http_api/runs/test_json_v7_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_json_v7_protocol_run.tavern.yaml
@@ -45,6 +45,7 @@ stages:
               definitionUri: opentrons/opentrons_1_trash_1100ml_fixed/1
               location: !anydict
           labwareOffsets: []
+          runTimeParameters: []
           liquids:
             - id: waterId
               displayName: Water

--- a/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_protocol_run.tavern.yaml
@@ -42,6 +42,7 @@ stages:
               definitionUri: opentrons/opentrons_1_trash_1100ml_fixed/1
               location: !anydict
           labwareOffsets: []
+          runTimeParameters: []
           protocolId: '{protocol_id}'
           liquids: []
       save:
@@ -237,6 +238,7 @@ stages:
           createdAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           startedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           liquids: []
+          runTimeParameters: []
           completedAt: !re_search "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"
           errors: []
           pipettes: []

--- a/robot-server/tests/integration/http_api/runs/test_run_queued_protocol_commands.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_queued_protocol_commands.tavern.yaml
@@ -94,6 +94,7 @@ stages:
           labware: []
           labwareOffsets: []
           liquids: []
+          runTimeParameters: []
           modules: []
           pipettes: []
           status: 'idle'

--- a/robot-server/tests/integration/http_api/runs/test_run_with_run_time_parameters.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_run_with_run_time_parameters.tavern.yaml
@@ -1,0 +1,203 @@
+test_name: Test the run endpoints with run time parameters
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - name: Upload a protocol
+    request:
+      url: '{ot2_server_base_url}/protocols'
+      method: POST
+      files:
+        files: 'tests/integration/protocols/basic_transfer_with_run_time_parameters.py'
+    response:
+      status_code: 201
+      save:
+        json:
+          protocol_id: data.id
+
+  - name: Create run from protocol
+    request:
+      url: '{ot2_server_base_url}/runs'
+      method: POST
+      json:
+        data:
+          protocolId: '{protocol_id}'
+          runTimeParameterValues:
+            sample_count: 4
+            volume: 10.23
+            dry_run: True
+            pipette: flex_8channel_50
+    response:
+      status_code: 201
+      save:
+        json:
+          run_id: data.id
+      json:
+        data:
+          id: !anystr
+          ok: True
+          createdAt: !anystr
+          status: idle
+          current: True
+          actions: []
+          errors: []
+          pipettes: []
+          modules: []
+          labware: []
+          labwareOffsets: []
+          runTimeParameters: []
+          liquids: []
+          protocolId: '{protocol_id}'
+
+  - name: Play the run
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/actions'
+      method: POST
+      json:
+        data:
+          actionType: play
+    response:
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          actionType: play
+          createdAt: !anystr
+
+  - name: Wait for the protocol to complete
+    max_retries: 10
+    delay_after: 0.1
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          status: succeeded
+
+  - name: Verify the run contains the set run time parameters
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          id: !anystr
+          ok: True
+          createdAt: !anystr
+          status: succeeded
+          current: True
+          runTimeParameters:
+            - displayName: Sample count
+              variableName: sample_count
+              type: int
+              default: 6.0
+              min: 1.0
+              max: 12.0
+              value: 4.0
+              description: How many samples to process.
+            - displayName: Pipette volume
+              variableName: volume
+              type: float
+              default: 20.1
+              choices:
+                - displayName: Low Volume
+                  value: 10.23
+                - displayName: Medium Volume
+                  value: 20.1
+                - displayName: High Volume
+                  value: 50.5
+              value: 10.23
+              description: How many microliters to pipette of each sample.
+            - displayName: Dry Run
+              variableName: dry_run
+              type: bool
+              default: false
+              value: true
+              description: Skip aspirate and dispense steps.
+            - displayName: Pipette Name
+              variableName: pipette
+              type: str
+              choices:
+                - displayName: Single channel 50µL
+                  value: flex_1channel_50
+                - displayName: Eight Channel 50µL
+                  value: flex_8channel_50
+              default: flex_1channel_50
+              value: flex_8channel_50
+              description: What pipette to use during the protocol.
+          protocolId: '{protocol_id}'
+
+  - name: Mark the run as not-current
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: PATCH
+      json:
+        data:
+          current: False
+    response:
+      status_code: 200
+
+  - name: Verify the archived run still contains the set run time parameters
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          id: !anystr
+          ok: True
+          createdAt: !anystr
+          status: succeeded
+          current: False
+          runTimeParameters:
+            - displayName: Sample count
+              variableName: sample_count
+              type: int
+              default: 6.0
+              min: 1.0
+              max: 12.0
+              value: 4.0
+              description: How many samples to process.
+            - displayName: Pipette volume
+              variableName: volume
+              type: float
+              default: 20.1
+              choices:
+                - displayName: Low Volume
+                  value: 10.23
+                - displayName: Medium Volume
+                  value: 20.1
+                - displayName: High Volume
+                  value: 50.5
+              value: 10.23
+              description: How many microliters to pipette of each sample.
+            - displayName: Dry Run
+              variableName: dry_run
+              type: bool
+              default: false
+              value: true
+              description: Skip aspirate and dispense steps.
+            - displayName: Pipette Name
+              variableName: pipette
+              type: str
+              choices:
+                - displayName: Single channel 50µL
+                  value: flex_1channel_50
+                - displayName: Eight Channel 50µL
+                  value: flex_8channel_50
+              default: flex_1channel_50
+              value: flex_8channel_50
+              description: What pipette to use during the protocol.
+          protocolId: '{protocol_id}'

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -56,6 +56,7 @@ EXPECTED_STATEMENTS_LATEST = [
         state_summary VARCHAR,
         engine_status VARCHAR,
         _updated_at DATETIME,
+        run_time_parameters VARCHAR,
         PRIMARY KEY (id),
         FOREIGN KEY(protocol_id) REFERENCES protocol (id)
     )

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine import (
     commands as pe_commands,
     errors as pe_errors,
 )
+from opentrons.protocol_engine.types import RunTimeParameter, BooleanParameter
 from opentrons.protocol_runner import RunResult, JsonRunner, PythonAndLegacyRunner
 
 from robot_server.service.task_runner import TaskRunner
@@ -58,6 +59,19 @@ def engine_state_summary() -> StateSummary:
         modules=[],
         liquids=[],
     )
+
+
+@pytest.fixture()
+def run_time_parameters() -> List[RunTimeParameter]:
+    """Get a RunTimeParameter list."""
+    return [
+        BooleanParameter(
+            displayName="Display Name",
+            variableName="variable_name",
+            value=False,
+            default=True,
+        )
+    ]
 
 
 @pytest.fixture
@@ -122,6 +136,7 @@ async def test_create_play_action_to_start(
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     engine_state_summary: StateSummary,
+    run_time_parameters: List[RunTimeParameter],
     protocol_commands: List[pe_commands.Command],
     run_id: str,
     subject: RunController,
@@ -153,7 +168,7 @@ async def test_create_play_action_to_start(
         RunResult(
             commands=protocol_commands,
             state_summary=engine_state_summary,
-            parameters=[],
+            parameters=run_time_parameters,
         )
     )
 
@@ -164,6 +179,7 @@ async def test_create_play_action_to_start(
             run_id=run_id,
             summary=engine_state_summary,
             commands=protocol_commands,
+            run_time_parameters=run_time_parameters,
         ),
         times=1,
     )

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -125,11 +125,33 @@ def run_time_parameters() -> List[pe_types.RunTimeParameter]:
     """Get a RunTimeParameter list."""
     return [
         pe_types.BooleanParameter(
-            displayName="Display Name",
-            variableName="variable_name",
+            displayName="Display Name 1",
+            variableName="variable_name_1",
             value=False,
             default=True,
-        )
+        ),
+        pe_types.NumberParameter(
+            displayName="Display Name 2",
+            variableName="variable_name_2",
+            type="int",
+            min=123.0,
+            max=456.0,
+            value=333.0,
+            default=222.0,
+        ),
+        pe_types.EnumParameter(
+            displayName="Display Name 3",
+            variableName="variable_name_3",
+            type="str",
+            choices=[
+                pe_types.EnumChoice(
+                    displayName="Choice Name",
+                    value="cool choice",
+                )
+            ],
+            default="cooler choice",
+            value="coolest choice",
+        ),
     ]
 
 

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -496,6 +496,62 @@ def test_get_state_summary_none(subject: RunStore) -> None:
     assert result.dataError.code == ErrorCodes.INVALID_STORED_DATA
 
 
+def test_get_run_time_parameters(
+    subject: RunStore,
+    state_summary: StateSummary,
+    run_time_parameters: List[pe_types.RunTimeParameter],
+) -> None:
+    """It should be able to get store run time parameters."""
+    subject.insert(
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+    subject.update_run_state(
+        run_id="run-id",
+        summary=state_summary,
+        commands=[],
+        run_time_parameters=run_time_parameters,
+    )
+    result = subject.get_run_time_parameters(run_id="run-id")
+    assert result == run_time_parameters
+
+
+def test_get_run_time_parameters_invalid(
+    subject: RunStore,
+    state_summary: StateSummary,
+) -> None:
+    """It should return an empty list if there invalid parameters."""
+    bad_parameters = [pe_types.BooleanParameter.construct(foo="bar")]  # type: ignore[call-arg]
+    subject.insert(
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+    subject.update_run_state(
+        run_id="run-id",
+        summary=state_summary,
+        commands=[],
+        run_time_parameters=bad_parameters,  # type: ignore[arg-type]
+    )
+    result = subject.get_run_time_parameters(run_id="run-id")
+    assert result == []
+
+
+def test_get_run_time_parameters_none(
+    subject: RunStore,
+    state_summary: StateSummary,
+) -> None:
+    """It should return an empty list if there are no run time parameters associated."""
+    subject.insert(
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+    result = subject.get_run_time_parameters(run_id="run-id")
+    assert result == []
+
+
 def test_has_run_id(subject: RunStore) -> None:
     """It should tell us if a given ID is in the store."""
     subject.insert(


### PR DESCRIPTION
# Overview

Closes AUTH-105

This PR adds the runtime parameter definitions to the run summary for both current and non current runs, accessible via the `GET` `/runs` and `/runs/{run_id}` endpoints. These definitions contain all parameter settings, including the value used during the run itself. An additional column, `run_time_parameters` was added to the run table in the database, along with a migration step for it in the existing v3 to v4 database schema migration added in PR #14762

Because we don't actually parse a run's parameters until the run has first started, when a run is first created, it will not have any runtime parameters. This matches the pattern for other values in the run summary, like `labware` and `pipettes` that don't get populated until it reaches that step of the protocol (typically the beginning by convention). This means if a protocol is cancelled before it starts, the RTP values will be empty for that summary. Otherwise, it will reflect the parameters used.

# Test Plan

On robot testing using postman to ensure that current and non current runs returned the correct parameters in the response to the `GET` runs endpoints. Also tested on robot that the migration worked and that older runs from v3 schema were properly migrated to the v4 schema. Unit and integration test coverage along with this as well.

# Changelog

- Added `runTimeParameters` field to the `Run` `ResourceModel` returned via the `GET` `/runs` and `/runs/{run_id}` endpoints.
- Added new column `run_time_parameters` to the run table for v4 database schema, along with serialization and deserialization methods for a list of pydantic objects to and from json

# Review requests

# Risk assessment

Lowish-medium, adds new data to an existing endpoint but changes are small in scope and have been tested and covered by automated tests.