### PR TITLE
chore(api,shared-data): Require Python >=3.10, not >=3.8

### DIFF
--- a/api/setup.py
+++ b/api/setup.py
@@ -46,8 +46,6 @@ CLASSIFIERS = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
 ]
@@ -87,7 +85,7 @@ def read(*parts):
 
 if __name__ == "__main__":
     setup(
-        python_requires=">=3.8",
+        python_requires=">=3.10",
         name=DISTNAME,
         description=DESCRIPTION,
         license=LICENSE,

--- a/shared-data/python/setup.py
+++ b/shared-data/python/setup.py
@@ -130,8 +130,6 @@ CLASSIFIERS = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
 ]
@@ -151,7 +149,7 @@ INSTALL_REQUIRES = [
 
 if __name__ == "__main__":
     setup(
-        python_requires=">=3.8",
+        python_requires=">=3.10",
         name=DISTNAME,
         description=DESCRIPTION,
         license=LICENSE,


### PR DESCRIPTION
# Overview

Closes EXEC-391.

# Test Plan

Not sure. Is there a way to do something like  a private PyPI deploy to test this?
# Changelog

* Remove Python 3.8 and 3.9 from `CLASSIFIERS`. As far as I know, these are just human-readable tags, and don't have any behavioral effect.
* Change `python_requires` from `>=3.8` to `>=3.10` for `api` and `shared-data`.

Mercifully, I think we can do this without having to do another `pipenv lock`, which would conflict #14805. `pipenv verify` doesn't complain.

# Review requests

Other than `api` and `shared-data`, are there any other user-facing projects that this needs to happen in?

# Risk assessment

Low.