### PR TITLE
feat(protocol-designer): export and announcement modal for PD 8.1

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -127,7 +127,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
 
           cy.get('div')
             .contains(
-              'This protocol can only run on app and robot server version 7.2 or higher'
+              'This protocol can only run on app and robot server version 7.2.0 or higher'
             )
             .should('exist')
           cy.get('button').contains('continue', { matchCase: false }).click()

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -127,7 +127,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
 
           cy.get('div')
             .contains(
-              'This protocol can only run on app and robot server version 7.1 or higher'
+              'This protocol can only run on app and robot server version 7.2 or higher'
             )
             .should('exist')
           cy.get('button').contains('continue', { matchCase: false }).click()

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -237,9 +237,9 @@ export function v8WarningContent(t: any): JSX.Element {
   return (
     <div>
       <p>
-        {t(`hint.export_v8_protocol_7_1.body1`)}{' '}
-        <strong>{t(`hint.export_v8_protocol_7_1.body2`)}</strong>
-        {t(`hint.export_v8_protocol_7_1.body3`)}
+        {t(`hint.export_v8_1_protocol_7_2.body1`)}{' '}
+        <strong>{t(`hint.export_v8_1_protocol_7_2.body2`)}</strong>
+        {t(`hint.export_v8_1_protocol_7_2.body3`)}
       </p>
     </div>
   )
@@ -350,7 +350,7 @@ export function FileSidebar(): JSX.Element {
     content: React.ReactNode
   } => {
     return {
-      hintKey: 'export_v8_protocol_7_1',
+      hintKey: 'export_v8_1_protocol_7_2',
       content: v8WarningContent(t),
     }
   }

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -74,6 +74,13 @@ describe('FileSidebar', () => {
     vi.resetAllMocks()
     cleanup()
   })
+  it('renders the file sidebar and exports with blocking hint for exporting', () => {
+    vi.mocked(useBlockingHint).mockReturnValue(<div>mock blocking hint</div>)
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+    expect(vi.mocked(useBlockingHint)).toHaveBeenCalled()
+    screen.getByText('mock blocking hint')
+  })
   it('renders the file sidebar and buttons work as expected with no warning upon export', () => {
     render()
     screen.getByText('Protocol File')

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -269,7 +269,7 @@ export const useAnnouncements = (): Announcement[] => {
       announcementKey: 'customParamsAndMultiTipAndModule8.1',
       image: (
         //  TODO(jr, 4/11/24): add image to announcement modal
-        <Flex/>
+        <Flex />
       ),
       heading: t('announcements.header', { pd: PD }),
       message: (

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -267,10 +267,7 @@ export const useAnnouncements = (): Announcement[] => {
     },
     {
       announcementKey: 'customParamsAndMultiTipAndModule8.1',
-      image: (
-        //  TODO(jr, 4/11/24): add image to announcement modal
-        <Flex />
-      ),
+      image: <Flex />,
       heading: t('announcements.header', { pd: PD }),
       message: (
         <>
@@ -282,7 +279,6 @@ export const useAnnouncements = (): Announcement[] => {
           <ul>
             <li>{t('announcements.customParamsAndMultiTipAndModule.body2')}</li>
             <li>
-              {' '}
               <Trans
                 t={t}
                 i18nKey={'announcements.customParamsAndMultiTipAndModule.body3'}

--- a/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
+++ b/protocol-designer/src/components/modals/AnnouncementModal/announcements.tsx
@@ -265,5 +265,43 @@ export const useAnnouncements = (): Announcement[] => {
         </>
       ),
     },
+    {
+      announcementKey: 'customParamsAndMultiTipAndModule8.1',
+      image: (
+        //  TODO(jr, 4/11/24): add image to announcement modal
+        <Flex/>
+      ),
+      heading: t('announcements.header', { pd: PD }),
+      message: (
+        <>
+          <p>
+            {t('announcements.customParamsAndMultiTipAndModule.body1', {
+              pd: PD,
+            })}
+          </p>
+          <ul>
+            <li>{t('announcements.customParamsAndMultiTipAndModule.body2')}</li>
+            <li>
+              {' '}
+              <Trans
+                t={t}
+                i18nKey={'announcements.customParamsAndMultiTipAndModule.body3'}
+                components={{ i: <em /> }}
+              />
+            </li>
+            <li>{t('announcements.customParamsAndMultiTipAndModule.body4')}</li>
+            <li>{t('announcements.customParamsAndMultiTipAndModule.body5')}</li>
+          </ul>
+          <p>
+            <Trans
+              t={t}
+              i18nKey={'announcements.customParamsAndMultiTipAndModule.body6'}
+              components={{ strong: <strong /> }}
+              values={{ app: APP }}
+            />
+          </p>
+        </>
+      ),
+    },
   ]
 }

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -53,10 +53,10 @@
       "title": "Missing labware",
       "body": "One or more module has no labware on it. We recommend you add labware before proceeding"
     },
-    "export_v8_protocol_7_1": {
+    "export_v8_1_protocol_7_2": {
       "title": "Robot and app update may be required",
       "body1": "This protocol can only run on app and robot server version",
-      "body2": "7.1 or higher",
+      "body2": "7.2 or higher",
       "body3": ". Please ensure your robot is updated to the correct version."
     },
     "change_magnet_module_model": {

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -56,7 +56,7 @@
     "export_v8_1_protocol_7_2": {
       "title": "Robot and app update may be required",
       "body1": "This protocol can only run on app and robot server version",
-      "body2": "7.2 or higher",
+      "body2": "7.2.0 or higher",
       "body3": ". Please ensure your robot is updated to the correct version."
     },
     "change_magnet_module_model": {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -42,6 +42,14 @@
     "deckConfigAnd96Channel": {
       "body1": "Introducing the {{pd}} 8.0 with deck configuration and 96-channel pipette support!",
       "body2": "All protocols now require {{app}} version <strong> 7.1+ </strong> to run."
+    },
+    "customParamsAndMultiTipAndModule": {
+      "body1": "Introducing the {{pd}} 8.1. Starting today, you will be able to:",
+      "body2": "Customize blowout flowRate speed and height",
+      "body3": "Customize aspirate, dispense, and mix <i>'x'</i> and <i>'y'</i> well positioning",
+      "body4": "Assign up to 3 types of tipracks to a single pipette",
+      "body5": "For the Flex only; add up to 7 Temperature Modules on the deck at the same time",
+      "body6": "All protocols require {{app}} version <strong> 7.2+ </strong> to run."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -44,12 +44,12 @@
       "body2": "All protocols now require {{app}} version <strong> 7.1+ </strong> to run."
     },
     "customParamsAndMultiTipAndModule": {
-      "body1": "Introducing the {{pd}} 8.1. Starting today, you will be able to:",
-      "body2": "Customize blowout flowRate speed and height",
-      "body3": "Customize aspirate, dispense, and mix <i>'x'</i> and <i>'y'</i> well positioning",
-      "body4": "Assign up to 3 types of tipracks to a single pipette",
-      "body5": "For the Flex only; add up to 7 Temperature Modules on the deck at the same time",
-      "body6": "All protocols require {{app}} version <strong> 7.2+ </strong> to run."
+      "body1": "Introducing {{pd}} 8.1. Starting today, you will be able to:",
+      "body2": "Customize blowout speed and height.",
+      "body3": "Adjust horizontal position within a well when aspirating, dispensing, or mixing.",
+      "body4": "Assign up to three types of tip racks to a single pipette.",
+      "body5": "Add multiple Temperature Modules to the deck (Flex only).",
+      "body6": "All protocols require {{app}} version <strong>7.2.0 or later</strong> to run."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -11,7 +11,7 @@ type HintKey =  // normal hints
   | 'waste_chute_warning'
   // blocking hints
   | 'custom_labware_with_modules'
-  | 'export_v8_protocol_7_1'
+  | 'export_v8_1_protocol_7_2'
   | 'change_magnet_module_model'
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
 // 'export_v4_protocol'
@@ -20,5 +20,6 @@ type HintKey =  // normal hints
 // | 'export_v6_protocol_6_10'
 // | 'export_v6_protocol_6_20'
 // | 'export_v7_protocol_7_0'
+// | 'export_v8_protocol_7_1'
 export { actions, rootReducer, selectors }
 export type { RootState, HintKey }


### PR DESCRIPTION
closes AUTH-8 AUTH-9

# Overview

Add announcement and update export modal. App version 7.2.0 or higher is needed in order to match the pipette collision warnings that were introduced in App 7.2

<img width="645" alt="Screenshot 2024-04-11 at 12 01 09" src="https://github.com/Opentrons/opentrons/assets/66035149/48c23f3b-bdb9-4dcb-b017-219e3186e51b">

<img width="630" alt="Screenshot 2024-04-11 at 12 01 31" src="https://github.com/Opentrons/opentrons/assets/66035149/51e8a1c2-17b1-40e0-96fd-4371ac4f11cd">



# Test Plan

check the 2 modals -> first opening PD and then exporting a protocol

# Changelog

- add new announcement and text
- update export modal
- add test coverage for blocking hint

# Review requests

see test plan

# Risk assessment

low