### PR TITLE
fix(protocol-designer, components): discarding vs delete step form button text

### DIFF
--- a/components/src/lists/TitledList.tsx
+++ b/components/src/lists/TitledList.tsx
@@ -101,7 +101,7 @@ export function TitledList(props: TitledListProps): JSX.Element {
     iconProps && iconProps.className
   )
 
-  let textColor = 'auto'
+  let textColor = ''
   if (disabled) {
     //  the below hex code is for our legacy --c-font-disabled to match other text colors
     textColor = '#9c9c9c'

--- a/components/src/lists/TitledList.tsx
+++ b/components/src/lists/TitledList.tsx
@@ -2,9 +2,12 @@
 import * as React from 'react'
 import cx from 'classnames'
 
-import styles from './lists.module.css'
 import { Icon } from '../icons'
+import { StyledText } from '../atoms'
+import { COLORS } from '../helix-design-system'
 import type { IconName, IconProps } from '../icons'
+
+import styles from './lists.module.css'
 
 // TODO(bc, 2021-03-31): reconsider whether this belongs in components library
 // it is bloated with application specific functionality
@@ -98,6 +101,15 @@ export function TitledList(props: TitledListProps): JSX.Element {
     iconProps && iconProps.className
   )
 
+  let textColor = 'auto'
+  if (disabled) {
+    //  the below hex code is for our legacy --c-font-disabled to match other text colors
+    textColor = '#9c9c9c'
+  } else if (props.selected && !disabled) {
+    //  the below hex code is for our legacy --c-highlight to match other text colors
+    textColor = '#5fd8ee'
+  }
+
   return (
     <div
       id={id}
@@ -109,14 +121,9 @@ export function TitledList(props: TitledListProps): JSX.Element {
         {iconName && (
           <Icon {...iconProps} className={iconClass} name={iconName} />
         )}
-        <h3
-          className={cx(styles.title, {
-            [styles.title_enabled]: !(disabled || inert),
-            [styles.title_disabled]: disabled || inert,
-          })}
-        >
+        <StyledText as="h3" backgroundColor={COLORS.white} color={textColor}>
           {props.title}
-        </h3>
+        </StyledText>
         {collapsible && (
           <div
             onClick={handleCollapseToggle}

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -169,7 +169,7 @@
     "closeUnsavedStepForm": {
       "title": "Unsaved step form",
       "body": "You have not saved this step form. If you navigate away without saving, this step will be deleted.",
-      "confirm_button": "delete step"
+      "confirm_button": "discard step"
     },
     "closeBatchEditForm": {
       "title": "Unsaved changes to multiple steps",


### PR DESCRIPTION
closes AUTH-319

# Overview

@koji noticed this bug initially where if you delete a step via the close modal for a form, it was different from deleting a step from the delete button in the form. Upon investigating, the actions were actually correct so I modified the button text to be more clear. When closing from the close modal, you are basically discarding of an unsaved step. So you aren't deleting anything, you are just closing/discarding of it.

Additionally, the `started deck state` and `final deck state` now is highlighted again when it is active (along with the active color in the liquids tab and app in the settings tab), to match legacy behavior that was broken starting in PD 6.0.0 (see that it is not broken here: https://sandbox.designer.opentrons.com/protocol-designer@5.0.0/)

# Test Plan

Create a flex or ot-2 protocol. Go to deck map and see that the starting deck state is blue. Add a step and before saving it, delete it via the the "delete step" button and see that it navigates you to the starting deck state. Now create a new step and delete it via the "cancel" button and see that it just discards of the step and does not navigate you to the starting deck state.

# Changelog

- fix the classname shenanigans issue with the text not being highlighted blue
- update button text 

# Review requests

see test plan

# Risk assessment

low