### PR TITLE
feat(app): add generic run paused splash screen

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -1,0 +1,3 @@
+{
+  "run_paused": "Run paused"
+}

--- a/app/src/assets/localization/en/index.ts
+++ b/app/src/assets/localization/en/index.ts
@@ -29,6 +29,7 @@ import robot_controls from './robot_controls.json'
 import robot_info from './robot_info.json'
 import run_details from './run_details.json'
 import top_navigation from './top_navigation.json'
+import error_recovery from './error_recovery.json'
 
 export const en = {
   shared,
@@ -62,4 +63,5 @@ export const en = {
   robot_info,
   run_details,
   top_navigation,
+  error_recovery,
 }

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import {
   Flex,
@@ -27,7 +28,13 @@ export function RunPausedSplash({
   errorType,
   protocolName,
 }: RunPausedSplashProps): JSX.Element {
-  const subText = protocolName ?? null
+  const { t } = useTranslation('error_recovery')
+
+  let subText: string | null
+  switch (errorType) {
+    default:
+      subText = protocolName ?? null
+  }
 
   return (
     <Btn
@@ -45,7 +52,7 @@ export function RunPausedSplash({
       <SplashFrame>
         <Flex gridGap={SPACING.spacing32} alignItems={ALIGN_CENTER}>
           <Icon name={'ot-alert'} size="4.5rem" color={COLORS.white} />
-          <SplashHeader>{'Run paused'}</SplashHeader>
+          <SplashHeader>{t('run_paused')}</SplashHeader>
         </Flex>
         <Flex width="49rem" justifyContent={JUSTIFY_CENTER}>
           <SplashBody>{subText}</SplashBody>

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+
+import {
+  Flex,
+  Btn,
+  Icon,
+  JUSTIFY_CENTER,
+  ALIGN_CENTER,
+  SPACING,
+  COLORS,
+  DIRECTION_COLUMN,
+  POSITION_ABSOLUTE,
+  TYPOGRAPHY,
+  BORDERS,
+  OVERFLOW_WRAP_BREAK_WORD,
+} from '@opentrons/components'
+import styled from 'styled-components'
+
+interface RunPausedSplashProps {
+  onClose: () => void
+  errorType?: string
+  protocolName?: string
+}
+
+export function RunPausedSplash({
+  onClose,
+  errorType,
+  protocolName,
+}: RunPausedSplashProps): JSX.Element {
+  const subText = protocolName ?? null
+
+  return (
+    <Btn
+      height="100vh"
+      width="100%"
+      justifyContent={JUSTIFY_CENTER}
+      alignItems={ALIGN_CENTER}
+      position={POSITION_ABSOLUTE}
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing40}
+      padding={SPACING.spacing40}
+      backgroundColor={COLORS.grey50}
+      onClick={onClose}
+    >
+      <SplashFrame>
+        <Flex gridGap={SPACING.spacing32} alignItems={ALIGN_CENTER}>
+          <Icon name={'ot-alert'} size="4.5rem" color={COLORS.white} />
+          <SplashHeader>{'Run paused'}</SplashHeader>
+        </Flex>
+        <Flex width="49rem" justifyContent={JUSTIFY_CENTER}>
+          <SplashBody>{subText}</SplashBody>
+        </Flex>
+      </SplashFrame>
+    </Btn>
+  )
+}
+
+const SplashHeader = styled.h1`
+  font-weight: ${TYPOGRAPHY.fontWeightBold};
+  text-align: ${TYPOGRAPHY.textAlignLeft};
+  font-size: 80px;
+  line-height: 94px;
+  color: ${COLORS.white};
+`
+const SplashBody = styled.h4`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+  overflow: hidden;
+  overflow-wrap: ${OVERFLOW_WRAP_BREAK_WORD};
+  font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+  text-align: ${TYPOGRAPHY.textAlignCenter};
+  text-transform: ${TYPOGRAPHY.textTransformCapitalize};
+  font-size: ${TYPOGRAPHY.fontSize32};
+  line-height: ${TYPOGRAPHY.lineHeight42};
+  color: ${COLORS.white};
+`
+
+const SplashFrame = styled(Flex)`
+  width: 100%;
+  height: 100%;
+  flex-direction: ${DIRECTION_COLUMN};
+  justify-content: ${JUSTIFY_CENTER};
+  align-items: ${ALIGN_CENTER};
+  grid-gap: ${SPACING.spacing40};
+  border-radius: ${BORDERS.borderRadius8};
+`

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import styled from 'styled-components'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -13,8 +14,8 @@ import {
   POSITION_ABSOLUTE,
   TYPOGRAPHY,
   OVERFLOW_WRAP_BREAK_WORD,
+  DISPLAY_FLEX,
 } from '@opentrons/components'
-import styled from 'styled-components'
 
 interface RunPausedSplashProps {
   onClose: () => void
@@ -37,6 +38,7 @@ export function RunPausedSplash({
 
   return (
     <Btn
+      display={DISPLAY_FLEX}
       height="100vh"
       width="100%"
       justifyContent={JUSTIFY_CENTER}
@@ -64,7 +66,7 @@ export function RunPausedSplash({
 const SplashHeader = styled.h1`
   font-weight: ${TYPOGRAPHY.fontWeightBold};
   text-align: ${TYPOGRAPHY.textAlignLeft};
-  font-size: ${TYPOGRAPHY.fontSize80}
+  font-size: ${TYPOGRAPHY.fontSize80};
   line-height: ${TYPOGRAPHY.lineHeight96};
   color: ${COLORS.white};
 `

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash.tsx
@@ -12,7 +12,6 @@ import {
   DIRECTION_COLUMN,
   POSITION_ABSOLUTE,
   TYPOGRAPHY,
-  BORDERS,
   OVERFLOW_WRAP_BREAK_WORD,
 } from '@opentrons/components'
 import styled from 'styled-components'
@@ -45,13 +44,13 @@ export function RunPausedSplash({
       position={POSITION_ABSOLUTE}
       flexDirection={DIRECTION_COLUMN}
       gridGap={SPACING.spacing40}
-      padding={SPACING.spacing40}
+      padding={SPACING.spacing120}
       backgroundColor={COLORS.grey50}
       onClick={onClose}
     >
       <SplashFrame>
         <Flex gridGap={SPACING.spacing32} alignItems={ALIGN_CENTER}>
-          <Icon name={'ot-alert'} size="4.5rem" color={COLORS.white} />
+          <Icon name="ot-alert" size="4.5rem" color={COLORS.white} />
           <SplashHeader>{t('run_paused')}</SplashHeader>
         </Flex>
         <Flex width="49rem" justifyContent={JUSTIFY_CENTER}>
@@ -65,8 +64,8 @@ export function RunPausedSplash({
 const SplashHeader = styled.h1`
   font-weight: ${TYPOGRAPHY.fontWeightBold};
   text-align: ${TYPOGRAPHY.textAlignLeft};
-  font-size: 80px;
-  line-height: 94px;
+  font-size: ${TYPOGRAPHY.fontSize80}
+  line-height: ${TYPOGRAPHY.lineHeight96};
   color: ${COLORS.white};
 `
 const SplashBody = styled.h4`
@@ -90,5 +89,4 @@ const SplashFrame = styled(Flex)`
   justify-content: ${JUSTIFY_CENTER};
   align-items: ${ALIGN_CENTER};
   grid-gap: ${SPACING.spacing40};
-  border-radius: ${BORDERS.borderRadius8};
 `

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunPausedSplash.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunPausedSplash.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+
+import { COLORS } from '@opentrons/components'
+
+import { RunPausedSplash } from '../RunPausedSplash'
+import { renderWithProviders } from '../../../../__testing-utils__'
+import { i18n } from '../../../../i18n'
+
+const render = (props: React.ComponentProps<typeof RunPausedSplash>) => {
+  return renderWithProviders(
+    <MemoryRouter>
+      <RunPausedSplash {...props} />
+    </MemoryRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )
+}
+
+const MOCK_PROTOCOL_NAME = 'MOCK_PROTOCOL'
+
+describe('ConfirmCancelRunModal', () => {
+  let props: React.ComponentProps<typeof RunPausedSplash>
+  const mockOnClose = vi.fn()
+
+  beforeEach(() => {
+    props = {
+      onClose: mockOnClose,
+      protocolName: MOCK_PROTOCOL_NAME,
+      errorType: '',
+    }
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should render a generic paused screen if there is no errorType', () => {
+    render(props)
+    expect(screen.getByText('Run paused')).toBeInTheDocument()
+    expect(screen.getByText(MOCK_PROTOCOL_NAME))
+    expect(screen.getByRole('button')).toHaveStyle({
+      'background-color': COLORS.grey50,
+    })
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunPausedSplash.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunPausedSplash.test.tsx
@@ -2,12 +2,12 @@ import * as React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '../../../../__testing-utils__'
+import { i18n } from '../../../../i18n'
 
 import { COLORS } from '@opentrons/components'
 
 import { RunPausedSplash } from '../RunPausedSplash'
-import { renderWithProviders } from '../../../../__testing-utils__'
-import { i18n } from '../../../../i18n'
 
 const render = (props: React.ComponentProps<typeof RunPausedSplash>) => {
   return renderWithProviders(

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -28,6 +28,7 @@ import {
   RUN_STATUS_AWAITING_RECOVERY,
 } from '@opentrons/api-client'
 
+import { useFeatureFlag } from '../../redux/config'
 import { StepMeter } from '../../atoms/StepMeter'
 import { useMostRecentCompletedAnalysis } from '../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import {
@@ -55,7 +56,6 @@ import { ConfirmCancelRunModal } from '../../organisms/OnDeviceDisplay/RunningPr
 import { RunPausedSplash } from '../../organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash'
 import { getLocalRobot } from '../../redux/discovery'
 import { OpenDoorAlertModal } from '../../organisms/OpenDoorAlertModal'
-import { useFeatureFlag } from '../../redux/config'
 
 import type { OnDeviceRouteParams } from '../../App/types'
 
@@ -282,7 +282,7 @@ export function RunningProtocol(): JSX.Element {
                 <RunningProtocolSkeleton currentOption={currentOption} />
               )}
               <Flex
-                marginTop="2rem"
+                marginTop={SPACING.spacing32}
                 flexDirection={DIRECTION_ROW}
                 gridGap={SPACING.spacing16}
                 justifyContent={JUSTIFY_CENTER}

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -25,6 +25,7 @@ import {
 import {
   RUN_STATUS_STOP_REQUESTED,
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
+  RUN_STATUS_AWAITING_RECOVERY,
 } from '@opentrons/api-client'
 
 import { StepMeter } from '../../atoms/StepMeter'
@@ -51,8 +52,10 @@ import {
 } from '../../organisms/Devices/hooks'
 import { CancelingRunModal } from '../../organisms/OnDeviceDisplay/RunningProtocol/CancelingRunModal'
 import { ConfirmCancelRunModal } from '../../organisms/OnDeviceDisplay/RunningProtocol/ConfirmCancelRunModal'
+import { RunPausedSplash } from '../../organisms/OnDeviceDisplay/RunningProtocol/RunPausedSplash'
 import { getLocalRobot } from '../../redux/discovery'
 import { OpenDoorAlertModal } from '../../organisms/OpenDoorAlertModal'
+import { useFeatureFlag } from '../../redux/config'
 
 import type { OnDeviceRouteParams } from '../../App/types'
 
@@ -102,6 +105,7 @@ export function RunningProtocol(): JSX.Element {
   const runStatus = useRunStatus(runId, {
     refetchInterval: RUN_STATUS_REFETCH_INTERVAL,
   })
+  const [enableSplash, setEnableSplash] = React.useState(true)
   const { startedAt, stoppedAt, completedAt } = useRunTimestamps(runId)
   const { data: runRecord } = useNotifyRunQuery(runId, { staleTime: Infinity })
   const protocolId = runRecord?.data.protocolId ?? null
@@ -117,6 +121,10 @@ export function RunningProtocol(): JSX.Element {
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
   const robotType = useRobotType(robotName)
+  const errorType = runRecord?.data.errors[0]?.errorType
+
+  const enableRunNotes = useFeatureFlag('enableRunNotes')
+
   React.useEffect(() => {
     if (
       currentOption === 'CurrentRunningProtocolCommand' &&
@@ -160,114 +168,137 @@ export function RunningProtocol(): JSX.Element {
 
   return (
     <>
-      {runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ? (
-        <OpenDoorAlertModal />
-      ) : null}
-      {runStatus === RUN_STATUS_STOP_REQUESTED ? <CancelingRunModal /> : null}
-      <Flex
-        flexDirection={DIRECTION_COLUMN}
-        position={POSITION_RELATIVE}
-        overflow={OVERFLOW_HIDDEN}
-      >
-        {robotSideAnalysis != null ? (
-          <StepMeter
-            totalSteps={totalIndex != null ? totalIndex : 0}
-            currentStep={
-              currentRunCommandIndex != null
-                ? Number(currentRunCommandIndex) + 1
-                : 1
-            }
-          />
-        ) : null}
-        {showConfirmCancelRunModal ? (
-          <ConfirmCancelRunModal
-            runId={runId}
-            setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
-            isActiveRun={true}
-          />
-        ) : null}
-        {interventionModalCommandKey != null &&
-        runRecord?.data != null &&
-        lastRunCommand != null &&
-        isInterventionCommand(lastRunCommand) ? (
-          <InterventionModal
-            robotName={robotName}
-            command={lastRunCommand}
-            onResume={playRun}
-            run={runRecord.data}
-            analysis={robotSideAnalysis}
-          />
-        ) : null}
-        <Flex
-          ref={swipe.ref}
-          padding={`1.75rem ${SPACING.spacing40} ${SPACING.spacing40}`}
-          flexDirection={DIRECTION_COLUMN}
-        >
-          {robotSideAnalysis != null ? (
-            currentOption === 'CurrentRunningProtocolCommand' ? (
-              <CurrentRunningProtocolCommand
-                playRun={playRun}
-                pauseRun={pauseRun}
-                setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
-                trackProtocolRunEvent={trackProtocolRunEvent}
-                robotType={robotType}
-                robotAnalyticsData={robotAnalyticsData}
-                protocolName={protocolName}
-                runStatus={runStatus}
-                currentRunCommandIndex={currentRunCommandIndex}
-                robotSideAnalysis={robotSideAnalysis}
-                runTimerInfo={{ runStatus, startedAt, stoppedAt, completedAt }}
-                lastAnimatedCommand={lastAnimatedCommand.current}
-                updateLastAnimatedCommand={(newCommandKey: string) =>
-                  (lastAnimatedCommand.current = newCommandKey)
+      {enableSplash &&
+      runStatus === RUN_STATUS_AWAITING_RECOVERY &&
+      enableRunNotes ? (
+        <RunPausedSplash
+          onClose={() => setEnableSplash(false)}
+          errorType={errorType}
+          protocolName={protocolName}
+        />
+      ) : (
+        <>
+          {runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR ? (
+            <OpenDoorAlertModal />
+          ) : null}
+          {runStatus === RUN_STATUS_STOP_REQUESTED ? (
+            <CancelingRunModal />
+          ) : null}
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            position={POSITION_RELATIVE}
+            overflow={OVERFLOW_HIDDEN}
+          >
+            {robotSideAnalysis != null ? (
+              <StepMeter
+                totalSteps={totalIndex != null ? totalIndex : 0}
+                currentStep={
+                  currentRunCommandIndex != null
+                    ? Number(currentRunCommandIndex) + 1
+                    : 1
                 }
               />
-            ) : (
-              <>
-                <RunningProtocolCommandList
-                  protocolName={protocolName}
-                  runStatus={runStatus}
-                  robotType={robotType}
-                  playRun={playRun}
-                  pauseRun={pauseRun}
-                  setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
-                  trackProtocolRunEvent={trackProtocolRunEvent}
-                  robotAnalyticsData={robotAnalyticsData}
-                  currentRunCommandIndex={currentRunCommandIndex}
-                  robotSideAnalysis={robotSideAnalysis}
+            ) : null}
+            {showConfirmCancelRunModal ? (
+              <ConfirmCancelRunModal
+                runId={runId}
+                setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
+                isActiveRun={true}
+              />
+            ) : null}
+            {interventionModalCommandKey != null &&
+            runRecord?.data != null &&
+            lastRunCommand != null &&
+            isInterventionCommand(lastRunCommand) ? (
+              <InterventionModal
+                robotName={robotName}
+                command={lastRunCommand}
+                onResume={playRun}
+                run={runRecord.data}
+                analysis={robotSideAnalysis}
+              />
+            ) : null}
+            <Flex
+              ref={swipe.ref}
+              padding={`1.75rem ${SPACING.spacing40} ${SPACING.spacing40}`}
+              flexDirection={DIRECTION_COLUMN}
+            >
+              {robotSideAnalysis != null ? (
+                currentOption === 'CurrentRunningProtocolCommand' ? (
+                  <CurrentRunningProtocolCommand
+                    playRun={playRun}
+                    pauseRun={pauseRun}
+                    setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}
+                    trackProtocolRunEvent={trackProtocolRunEvent}
+                    robotType={robotType}
+                    robotAnalyticsData={robotAnalyticsData}
+                    protocolName={protocolName}
+                    runStatus={runStatus}
+                    currentRunCommandIndex={currentRunCommandIndex}
+                    robotSideAnalysis={robotSideAnalysis}
+                    runTimerInfo={{
+                      runStatus,
+                      startedAt,
+                      stoppedAt,
+                      completedAt,
+                    }}
+                    lastAnimatedCommand={lastAnimatedCommand.current}
+                    updateLastAnimatedCommand={(newCommandKey: string) =>
+                      (lastAnimatedCommand.current = newCommandKey)
+                    }
+                  />
+                ) : (
+                  <>
+                    <RunningProtocolCommandList
+                      protocolName={protocolName}
+                      runStatus={runStatus}
+                      robotType={robotType}
+                      playRun={playRun}
+                      pauseRun={pauseRun}
+                      setShowConfirmCancelRunModal={
+                        setShowConfirmCancelRunModal
+                      }
+                      trackProtocolRunEvent={trackProtocolRunEvent}
+                      robotAnalyticsData={robotAnalyticsData}
+                      currentRunCommandIndex={currentRunCommandIndex}
+                      robotSideAnalysis={robotSideAnalysis}
+                    />
+                    <Flex
+                      css={css`
+                        background: linear-gradient(
+                          rgba(255, 0, 0, 0) 85%,
+                          #ffffff
+                        );
+                      `}
+                      position={POSITION_ABSOLUTE}
+                      height="20.25rem"
+                      width="59rem"
+                      marginTop="9.25rem"
+                      alignSelf={ALIGN_FLEX_END}
+                    />
+                  </>
+                )
+              ) : (
+                <RunningProtocolSkeleton currentOption={currentOption} />
+              )}
+              <Flex
+                marginTop="2rem"
+                flexDirection={DIRECTION_ROW}
+                gridGap={SPACING.spacing16}
+                justifyContent={JUSTIFY_CENTER}
+                alignItems={ALIGN_CENTER}
+              >
+                <Bullet
+                  isActive={currentOption === 'CurrentRunningProtocolCommand'}
                 />
-                <Flex
-                  css={css`
-                    background: linear-gradient(
-                      rgba(255, 0, 0, 0) 85%,
-                      #ffffff
-                    );
-                  `}
-                  position={POSITION_ABSOLUTE}
-                  height="20.25rem"
-                  width="59rem"
-                  marginTop="9.25rem"
-                  alignSelf={ALIGN_FLEX_END}
+                <Bullet
+                  isActive={currentOption === 'RunningProtocolCommandList'}
                 />
-              </>
-            )
-          ) : (
-            <RunningProtocolSkeleton currentOption={currentOption} />
-          )}
-          <Flex
-            marginTop="2rem"
-            flexDirection={DIRECTION_ROW}
-            gridGap={SPACING.spacing16}
-            justifyContent={JUSTIFY_CENTER}
-            alignItems={ALIGN_CENTER}
-          >
-            <Bullet
-              isActive={currentOption === 'CurrentRunningProtocolCommand'}
-            />
-            <Bullet isActive={currentOption === 'RunningProtocolCommandList'} />
+              </Flex>
+            </Flex>
           </Flex>
-        </Flex>
-      </Flex>
+        </>
+      )}
     </>
   )
 }


### PR DESCRIPTION
Closes [EXEC-387](https://opentrons.atlassian.net/browse/EXEC-387)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Add a fallback run paused splash screen that will show when no specific errorType is handled explicitly. The exact logic used to display the splash message will most likely change (and we'll add specific error type subtext later). 

<img width="518" alt="Screenshot 2024-04-11 at 1 41 31 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/c2524029-f7cc-4686-b8fc-3d51a48795f4">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Make sure the ODD enable run notes FF is on.
- `curl --location '<robot ip>:31950/settings' \
--header 'opentrons-version: *' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data '{
  "id": "enableErrorRecoveryExperiments",
  "value": true
}'` (Please set this to false when you're done testing).
- Run anything that will throw a pick up tip failed error (make sure `edge` is pushed). Verify that the splash screen appears (note that cancelling the run after this point doesn't work currently).
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added "Run paused" splash screen.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-387]: https://opentrons.atlassian.net/browse/EXEC-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ