### PR TITLE
feat(robot-server): limit the maximum number of analyses stored per protocol

### DIFF
--- a/robot-server/robot_server/protocols/analysis_memcache.py
+++ b/robot-server/robot_server/protocols/analysis_memcache.py
@@ -63,3 +63,14 @@ class MemoryCache(Generic[K, V]):
         self._pop_eldest(key)
         self._cache[key] = value
         self._cache_order.appendleft(key)
+
+    def remove(self, key: K) -> None:
+        """Remove the cached element specified by the key.
+
+        If no such element exists in cache, then simply no-op.
+        """
+        try:
+            self._cache.pop(key)
+            self._cache_order.remove(key)  # O(n) operation, use sparingly
+        except KeyError:
+            pass

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -129,8 +129,6 @@ class AnalysisStore:
         Returns:
             A summary of the just-added analysis.
         """
-        # TODO (spp, 2024-03-19): cap the number of analyses being stored by
-        #  auto-deleting old ones
         new_pending_analysis = self._pending_store.add(
             protocol_id=protocol_id, analysis_id=analysis_id
         )

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -21,6 +21,8 @@ from .analysis_memcache import MemoryCache
 
 _log = getLogger(__name__)
 
+MAX_ANALYSES_TO_STORE = 5
+
 
 @dataclass
 class CompletedAnalysisResource:
@@ -336,6 +338,7 @@ class CompletedAnalysisStore:
 
     async def add(self, completed_analysis_resource: CompletedAnalysisResource) -> None:
         """Add a resource to the store."""
+        self._make_room_for_new_analysis(completed_analysis_resource.protocol_id)
         statement = analysis_table.insert().values(
             await completed_analysis_resource.to_sql_values()
         )
@@ -344,3 +347,30 @@ class CompletedAnalysisStore:
         self._memcache.insert(
             completed_analysis_resource.id, completed_analysis_resource
         )
+
+    def _make_room_for_new_analysis(self, protocol_id: str) -> None:
+        """Remove the oldest analysis in store if the number of analyses exceed the max allowed.
+
+        Unlike protocols, a protocol analysis IDs are not stored by any DB entities
+        other than the analysis store itself. So we do not have to worry about cleaning up
+        any other tables,
+        """
+        # Get length of analyses list for this protocol
+        analyses_ids = self.get_ids_by_protocol(protocol_id)
+
+        # Delete all analyses exceeding max number allowed,
+        # plus an additional one to create room for the new one.
+        # Most existing databases will not have multiple extra analyses per protocol
+        # but there would be some internally that added multiple analyses before
+        # we started capping the number of analyses.
+        analyses_to_delete = analyses_ids[
+            : len(analyses_ids) - MAX_ANALYSES_TO_STORE + 1
+        ]
+
+        for analysis_id in analyses_to_delete:
+            self._memcache.remove(analysis_id)
+            delete_statement = sqlalchemy.delete(analysis_table).where(
+                analysis_table.c.id == analysis_id
+            )
+            with self._sql_engine.begin() as transaction:
+                transaction.execute(delete_statement)

--- a/robot-server/robot_server/protocols/completed_analysis_store.py
+++ b/robot-server/robot_server/protocols/completed_analysis_store.py
@@ -349,13 +349,12 @@ class CompletedAnalysisStore:
         )
 
     def _make_room_for_new_analysis(self, protocol_id: str) -> None:
-        """Remove the oldest analysis in store if the number of analyses exceed the max allowed.
+        """Remove the oldest analyses in store if the number of analyses exceed the max allowed.
 
-        Unlike protocols, a protocol analysis IDs are not stored by any DB entities
+        Unlike protocols, protocol analysis IDs are not stored by any DB entities
         other than the analysis store itself. So we do not have to worry about cleaning up
-        any other tables,
+        any other tables.
         """
-        # Get length of analyses list for this protocol
         analyses_ids = self.get_ids_by_protocol(protocol_id)
 
         # Delete all analyses exceeding max number allowed,

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -316,7 +316,7 @@ async def test_add_makes_room_for_new_analysis(
     """It should delete old analyses and make room for new analysis."""
     protocol_store.insert(make_dummy_protocol_resource("protocol-id"))
 
-    # Set up the database with extra analyses
+    # Set up the database with existing analyses
     resources = [
         _completed_analysis_resource(
             analysis_id=analysis_id,

--- a/robot-server/tests/protocols/test_memcache.py
+++ b/robot-server/tests/protocols/test_memcache.py
@@ -22,3 +22,19 @@ def test_cache_retains_new_values() -> None:
     for val in range(1, 4):
         assert subject.contains(f"key-{val}")
         assert subject.get(f"key-{val}") == f"value-{val}"
+
+
+def test_cache_removes_values_by_key() -> None:
+    """It should eject values when asked for it."""
+    subject = MemoryCache(3, str, str)
+    for val in range(3):
+        subject.insert(f"key-{val}", f"value-{val}")
+    subject.remove("key-1")
+    assert not subject.contains("key-1")
+
+    # Make sure cache order is updated
+    assert subject.contains("key-0") and subject.contains("key-2")
+    subject.insert("key-4", "value-4")
+    assert subject.contains("key-0")
+    subject.insert("key-5", "value-5")
+    assert not subject.contains("key-0")


### PR DESCRIPTION
Closes AUTH-317

# Overview

Adds a max-analyses-per-protocol limit of 5 analyses. Auto-deletes the oldest analysis (es) before adding a new one if the number of analyses stored exceeds the max.

# Test Plan

- Tested on dev server and robot that number of analyses don't exceed 5 and the oldest analysis gets deleted first.
- Also tested that if a dev server already had more than 5 analyses in the DB, then the first analyses addition since updating to this branch deletes all excess analyses.

# Changelog

- added analyses auto-deletion before new addition in `CompletedAnalysisStore`
- also added a way to remove the excess analyses from memory cache

# Review requests

Usual code review. I've added in-line comments for things that need extra attention.

# Risk assessment

Low. Well tested and pretty isolated feature.
