### PR TITLE
fix(shared-data): correctly apply loadname regex

### DIFF
--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -160,7 +160,7 @@ class Parameters(BaseModel):
     loadName: str = Field(
         ...,
         description="Name used to reference a labware definition",
-        pattern=SAFE_STRING_REGEX,
+        regex=SAFE_STRING_REGEX,
     )
     isMagneticModuleCompatible: bool = Field(
         ...,
@@ -262,7 +262,7 @@ class LabwareDefinition(BaseModel):
         "(eg myPlate v1/v2/v3). An incrementing integer",
         ge=1.0,
     )
-    namespace: str = Field(..., pattern=SAFE_STRING_REGEX)
+    namespace: str = Field(..., regex=SAFE_STRING_REGEX)
     metadata: Metadata = Field(
         ..., description="Properties used for search and display"
     )

--- a/shared-data/python/tests/labware/test_validations.py
+++ b/shared-data/python/tests/labware/test_validations.py
@@ -1,0 +1,21 @@
+import pytest
+
+from pydantic import ValidationError
+from opentrons_shared_data.labware import load_definition
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+
+from . import get_ot_defs
+
+
+def test_loadname_regex_applied() -> None:
+    defdict = load_definition(*get_ot_defs()[0])
+    defdict["parameters"]["loadName"] = "ALSJHDAKJLA"
+    with pytest.raises(ValidationError):
+        LabwareDefinition.parse_obj(defdict)
+
+
+def test_namespace_regex_applied() -> None:
+    defdict = load_definition(*get_ot_defs()[0])
+    defdict["namespace"] = "ALSJHDAKJLA"
+    with pytest.raises(ValidationError):
+        LabwareDefinition.parse_obj(defdict)


### PR DESCRIPTION
For some reason I changed this to be pattern= when updating pydantic, but that's still wrong and still needs to be regex.

Closes EXEC-397
