### PR TITLE
refactor(protocol-designer): export modal to require app 7.3.0 or higher

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -127,7 +127,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
 
           cy.get('div')
             .contains(
-              'This protocol can only run on app and robot server version 7.2.0 or higher'
+              'This protocol can only run on app and robot server version 7.3.0 or higher'
             )
             .should('exist')
           cy.get('button').contains('continue', { matchCase: false }).click()

--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -237,9 +237,9 @@ export function v8WarningContent(t: any): JSX.Element {
   return (
     <div>
       <p>
-        {t(`hint.export_v8_1_protocol_7_2.body1`)}{' '}
-        <strong>{t(`hint.export_v8_1_protocol_7_2.body2`)}</strong>
-        {t(`hint.export_v8_1_protocol_7_2.body3`)}
+        {t(`hint.export_v8_1_protocol_7_3.body1`)}{' '}
+        <strong>{t(`hint.export_v8_1_protocol_7_3.body2`)}</strong>
+        {t(`hint.export_v8_1_protocol_7_3.body3`)}
       </p>
     </div>
   )
@@ -350,7 +350,7 @@ export function FileSidebar(): JSX.Element {
     content: React.ReactNode
   } => {
     return {
-      hintKey: 'export_v8_1_protocol_7_2',
+      hintKey: 'export_v8_1_protocol_7_3',
       content: v8WarningContent(t),
     }
   }

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -53,10 +53,10 @@
       "title": "Missing labware",
       "body": "One or more module has no labware on it. We recommend you add labware before proceeding"
     },
-    "export_v8_1_protocol_7_2": {
+    "export_v8_1_protocol_7_3": {
       "title": "Robot and app update may be required",
       "body1": "This protocol can only run on app and robot server version",
-      "body2": "7.2.0 or higher",
+      "body2": "7.3.0 or higher",
       "body3": ". Please ensure your robot is updated to the correct version."
     },
     "change_magnet_module_model": {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -49,7 +49,7 @@
       "body3": "Adjust horizontal position within a well when aspirating, dispensing, or mixing.",
       "body4": "Assign up to three types of tip racks to a single pipette.",
       "body5": "Add multiple Temperature Modules to the deck (Flex only).",
-      "body6": "All protocols require {{app}} version <strong>7.2.0 or later</strong> to run."
+      "body6": "All protocols require {{app}} version <strong>7.3.0 or later</strong> to run."
     }
   },
   "labware_selection": {

--- a/protocol-designer/src/tutorial/index.ts
+++ b/protocol-designer/src/tutorial/index.ts
@@ -11,7 +11,7 @@ type HintKey =  // normal hints
   | 'waste_chute_warning'
   // blocking hints
   | 'custom_labware_with_modules'
-  | 'export_v8_1_protocol_7_2'
+  | 'export_v8_1_protocol_7_3'
   | 'change_magnet_module_model'
 // DEPRECATED HINTS (keep a record to avoid name collisions with old persisted dismissal states)
 // 'export_v4_protocol'


### PR DESCRIPTION
closes AUTH-340

# Overview

Basically, as outlined in the ticket, in the past we have generally always required users to update their robot to the latest version that is out at the time of PD's release mainly because there are usually new features in the app that PD depends upon. This time, there are no new features in the app 7.3.0 that PD depends upon. But we want to require 7.3.0 to minimize the app builds that QA needs to test on.

# Test Plan

in PD,  type `localStorage.clear()` in console and refresh, you should see the announcement modal. Make sure it says app 7.3.0 is required. Make a protocol and export and see that the export modal says that app 7.3.0 is required.

# Changelog

- change from 7.2.0 -> 7.3.0

# Review requests

see test plan

# Risk assessment

low