### PR TITLE
refactor(api): more clear error messages for type validation when creating runtime parameters

### DIFF
--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -151,7 +151,7 @@ def convert_type_string_for_enum(
         return "str"
     else:
         raise ParameterValueError(
-            f"Cannot resolve parameter type {parameter_type} for an enumerated parameter."
+            f"Cannot resolve parameter type '{parameter_type.__name__}' for an enumerated parameter."
         )
 
 
@@ -163,7 +163,7 @@ def convert_type_string_for_num_param(parameter_type: type) -> Literal["int", "f
         return "float"
     else:
         raise ParameterValueError(
-            f"Cannot resolve parameter type {parameter_type} for a number parameter."
+            f"Cannot resolve parameter type '{parameter_type.__name__}' for a number parameter."
         )
 
 
@@ -189,7 +189,7 @@ def _validate_choices(
         ensure_display_name(display_name)
         if not isinstance(value, parameter_type):
             raise ParameterDefinitionError(
-                f"All choices provided must be of type {parameter_type}"
+                f"All choices provided must be of type '{parameter_type.__name__}'"
             )
 
 
@@ -211,11 +211,13 @@ def _validate_min_and_max(
         if parameter_type is int or parameter_type is float:
             if not isinstance(minimum, parameter_type):
                 raise ParameterDefinitionError(
-                    f"Minimum is type {type(minimum)}, but must be of parameter type {parameter_type}"
+                    f"Minimum is type '{type(minimum).__name__}',"
+                    f" but must be of parameter type '{parameter_type.__name__}'"
                 )
             if not isinstance(maximum, parameter_type):
                 raise ParameterDefinitionError(
-                    f"Maximum is type {type(maximum)}, but must be of parameter type {parameter_type}"
+                    f"Maximum is type {type(maximum).__name__},"
+                    f" but must be of parameter type '{parameter_type.__name__}'"
                 )
             # These asserts are for the type checker and should never actually be asserted false
             assert isinstance(minimum, (int, float))
@@ -234,7 +236,8 @@ def validate_type(value: ParamType, parameter_type: type) -> None:
     """Validate parameter value is the correct type."""
     if not isinstance(value, parameter_type):
         raise ParameterValueError(
-            f"Parameter value {value} has type {type(value)}, but must be of type {parameter_type}."
+            f"Parameter value {value} has type '{type(value).__name__}',"
+            f" but must be of type '{parameter_type.__name__}'."
         )
 
 
@@ -248,7 +251,8 @@ def validate_options(
     """Validate default values and all possible constraints for a valid parameter definition."""
     if not isinstance(default, parameter_type):
         raise ParameterValueError(
-            f"Parameter default {default} has type {type(default)}, but must be of type {parameter_type}."
+            f"Parameter default {default} has type '{type(default).__name__}',"
+            f" but must be of type '{parameter_type.__name__}'."
         )
 
     if choices is None and minimum is None and maximum is None:

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -216,7 +216,7 @@ def _validate_min_and_max(
                 )
             if not isinstance(maximum, parameter_type):
                 raise ParameterDefinitionError(
-                    f"Maximum is type {type(maximum).__name__},"
+                    f"Maximum is type '{type(maximum).__name__}',"
                     f" but must be of parameter type '{parameter_type.__name__}'"
                 )
             # These asserts are for the type checker and should never actually be asserted false

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -29,6 +29,10 @@ def validate_variable_name_unique(
 
 def ensure_display_name(display_name: str) -> str:
     """Validate display name is within the character limit."""
+    if not isinstance(display_name, str):
+        raise ParameterNameError(
+            f"Display name must be a string and less than {DISPLAY_NAME_MAX_LEN} characters."
+        )
     if len(display_name) > DISPLAY_NAME_MAX_LEN:
         raise ParameterNameError(
             f"Display name {display_name} greater than {DISPLAY_NAME_MAX_LEN} characters."
@@ -38,6 +42,8 @@ def ensure_display_name(display_name: str) -> str:
 
 def ensure_variable_name(variable_name: str) -> str:
     """Validate variable name is a valid python variable name."""
+    if not isinstance(variable_name, str):
+        raise ParameterNameError("Variable name must be a string.")
     if not variable_name.isidentifier():
         raise ParameterNameError(
             "Variable name must only contain alphanumeric characters, underscores, and cannot start with a digit."
@@ -49,19 +55,29 @@ def ensure_variable_name(variable_name: str) -> str:
 
 def ensure_description(description: Optional[str]) -> Optional[str]:
     """Validate description is within the character limit."""
-    if description is not None and len(description) > DESCRIPTION_MAX_LEN:
-        raise ParameterNameError(
-            f"Description {description} greater than {DESCRIPTION_MAX_LEN} characters."
-        )
+    if description is not None:
+        if not isinstance(description, str):
+            raise ParameterNameError(
+                f"Description must be a string and less than {DESCRIPTION_MAX_LEN} characters."
+            )
+        if len(description) > DESCRIPTION_MAX_LEN:
+            raise ParameterNameError(
+                f"Description {description} greater than {DESCRIPTION_MAX_LEN} characters."
+            )
     return description
 
 
 def ensure_unit_string_length(unit: Optional[str]) -> Optional[str]:
     """Validate unit is within the character limit."""
-    if unit is not None and len(unit) > UNIT_MAX_LEN:
-        raise ParameterNameError(
-            f"Description {unit} greater than {UNIT_MAX_LEN} characters."
-        )
+    if unit is not None:
+        if not isinstance(unit, str):
+            raise ParameterNameError(
+                f"Unit must be a string and less than {UNIT_MAX_LEN} characters."
+            )
+        if len(unit) > UNIT_MAX_LEN:
+            raise ParameterNameError(
+                f"Description {unit} greater than {UNIT_MAX_LEN} characters."
+            )
     return unit
 
 
@@ -173,7 +189,7 @@ def _validate_choices(
         ensure_display_name(display_name)
         if not isinstance(value, parameter_type):
             raise ParameterDefinitionError(
-                f"All choices provided must match type {type(parameter_type)}"
+                f"All choices provided must match type {parameter_type}"
             )
 
 
@@ -192,21 +208,25 @@ def _validate_min_and_max(
             "If a maximum value is provided a minimum must also be provided."
         )
     elif maximum is not None and minimum is not None:
-        if isinstance(maximum, (int, float)) and isinstance(minimum, (int, float)):
+        if parameter_type is int or parameter_type is float:
+            if not isinstance(minimum, parameter_type):
+                raise ParameterDefinitionError(
+                    f"Minimum is type {type(minimum)}, must match parameter type {parameter_type}"
+                )
+            if not isinstance(maximum, parameter_type):
+                raise ParameterDefinitionError(
+                    f"Maximum is type {type(minimum)}, must match parameter type {parameter_type}"
+                )
+            # These asserts are for the type checker and should never actually be asserted false
+            assert isinstance(minimum, (int, float))
+            assert isinstance(maximum, (int, float))
             if maximum <= minimum:
                 raise ParameterDefinitionError(
                     "Maximum must be greater than the minimum"
                 )
-
-            if not isinstance(minimum, parameter_type) or not isinstance(
-                maximum, parameter_type
-            ):
-                raise ParameterDefinitionError(
-                    f"Minimum and maximum must match type {parameter_type}"
-                )
         else:
             raise ParameterDefinitionError(
-                "Only parameters of type float or int can have a minimum and maximum"
+                f"Parameter of type {parameter_type} does not support minimum or maximum arguments."
             )
 
 
@@ -226,7 +246,10 @@ def validate_options(
     parameter_type: type,
 ) -> None:
     """Validate default values and all possible constraints for a valid parameter definition."""
-    validate_type(default, parameter_type)
+    if not isinstance(default, parameter_type):
+        raise ParameterValueError(
+            f"Parameter default {default} has type {type(default)}, must match type {parameter_type}."
+        )
 
     if choices is None and minimum is None and maximum is None:
         raise ParameterDefinitionError(

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -31,11 +31,11 @@ def ensure_display_name(display_name: str) -> str:
     """Validate display name is within the character limit."""
     if not isinstance(display_name, str):
         raise ParameterNameError(
-            f"Display name must be a string and less than {DISPLAY_NAME_MAX_LEN} characters."
+            f"Display name must be a string and at most {DISPLAY_NAME_MAX_LEN} characters."
         )
     if len(display_name) > DISPLAY_NAME_MAX_LEN:
         raise ParameterNameError(
-            f"Display name {display_name} greater than {DISPLAY_NAME_MAX_LEN} characters."
+            f'Display name "{display_name}" greater than {DISPLAY_NAME_MAX_LEN} characters.'
         )
     return display_name
 
@@ -58,11 +58,11 @@ def ensure_description(description: Optional[str]) -> Optional[str]:
     if description is not None:
         if not isinstance(description, str):
             raise ParameterNameError(
-                f"Description must be a string and less than {DESCRIPTION_MAX_LEN} characters."
+                f"Description must be a string and at most {DESCRIPTION_MAX_LEN} characters."
             )
         if len(description) > DESCRIPTION_MAX_LEN:
             raise ParameterNameError(
-                f"Description {description} greater than {DESCRIPTION_MAX_LEN} characters."
+                f'Description "{description}" greater than {DESCRIPTION_MAX_LEN} characters.'
             )
     return description
 
@@ -72,11 +72,11 @@ def ensure_unit_string_length(unit: Optional[str]) -> Optional[str]:
     if unit is not None:
         if not isinstance(unit, str):
             raise ParameterNameError(
-                f"Unit must be a string and less than {UNIT_MAX_LEN} characters."
+                f"Unit must be a string and at most {UNIT_MAX_LEN} characters."
             )
         if len(unit) > UNIT_MAX_LEN:
             raise ParameterNameError(
-                f"Description {unit} greater than {UNIT_MAX_LEN} characters."
+                f'Unit "{unit}" greater than {UNIT_MAX_LEN} characters.'
             )
     return unit
 
@@ -189,7 +189,7 @@ def _validate_choices(
         ensure_display_name(display_name)
         if not isinstance(value, parameter_type):
             raise ParameterDefinitionError(
-                f"All choices provided must match type {parameter_type}"
+                f"All choices provided must be of type {parameter_type}"
             )
 
 
@@ -211,11 +211,11 @@ def _validate_min_and_max(
         if parameter_type is int or parameter_type is float:
             if not isinstance(minimum, parameter_type):
                 raise ParameterDefinitionError(
-                    f"Minimum is type {type(minimum)}, must match parameter type {parameter_type}"
+                    f"Minimum is type {type(minimum)}, but must be of parameter type {parameter_type}"
                 )
             if not isinstance(maximum, parameter_type):
                 raise ParameterDefinitionError(
-                    f"Maximum is type {type(minimum)}, must match parameter type {parameter_type}"
+                    f"Maximum is type {type(maximum)}, but must be of parameter type {parameter_type}"
                 )
             # These asserts are for the type checker and should never actually be asserted false
             assert isinstance(minimum, (int, float))
@@ -226,7 +226,7 @@ def _validate_min_and_max(
                 )
         else:
             raise ParameterDefinitionError(
-                f"Parameter of type {parameter_type} does not support minimum or maximum arguments."
+                "Only parameters of type float or int can have a minimum and maximum."
             )
 
 
@@ -234,7 +234,7 @@ def validate_type(value: ParamType, parameter_type: type) -> None:
     """Validate parameter value is the correct type."""
     if not isinstance(value, parameter_type):
         raise ParameterValueError(
-            f"Parameter value {value} has type {type(value)}, must match type {parameter_type}."
+            f"Parameter value {value} has type {type(value)}, but must be of type {parameter_type}."
         )
 
 
@@ -248,7 +248,7 @@ def validate_options(
     """Validate default values and all possible constraints for a valid parameter definition."""
     if not isinstance(default, parameter_type):
         raise ParameterValueError(
-            f"Parameter default {default} has type {type(default)}, must match type {parameter_type}."
+            f"Parameter default {default} has type {type(default)}, but must be of type {parameter_type}."
         )
 
     if choices is None and minimum is None and maximum is None:

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -283,9 +283,10 @@ def test_convert_type_string_for_num_param_raises(param_type: type) -> None:
         (123, 1, None, None, int, "maximum must also"),
         (123, None, 100, None, int, "minimum must also"),
         (123, 100, 1, None, int, "Maximum must be greater"),
-        (123, 1.1, 100, None, int, "Minimum and maximum must match type"),
-        (123, 1, 100.5, None, int, "Minimum and maximum must match type"),
-        (123, "1", "100", None, int, "Only parameters of type float or int"),
+        (123, 1.1, 100, None, int, "Minimum is type"),
+        (123, 1, 100.5, None, int, "Maximum is type"),
+        (123.0, "1.0", 100.0, None, float, "Minimum is type"),
+        ("blah", 1, 100, None, str, "does not support minimum or maximum"),
     ],
 )
 def test_validate_options_raise_definition_error(

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -278,7 +278,7 @@ def test_convert_type_string_for_num_param_raises(param_type: type) -> None:
             None,
             [{"display_name": "abc", "value": "123"}],
             int,
-            "must match type",
+            "must be of type",
         ),
         (123, 1, None, None, int, "maximum must also"),
         (123, None, 100, None, int, "minimum must also"),
@@ -286,7 +286,7 @@ def test_convert_type_string_for_num_param_raises(param_type: type) -> None:
         (123, 1.1, 100, None, int, "Minimum is type"),
         (123, 1, 100.5, None, int, "Maximum is type"),
         (123.0, "1.0", 100.0, None, float, "Minimum is type"),
-        ("blah", 1, 100, None, str, "does not support minimum or maximum"),
+        ("blah", 1, 100, None, str, "Only parameters of type float or int"),
     ],
 )
 def test_validate_options_raise_definition_error(


### PR DESCRIPTION
# Overview

This PR closes a bunch of tickets related to unclear/confusing/incorrect error messages in failed analysis for RTP protocols.

The first set of fixes applies to AUTH-303, AUTH-305, AUTH-307 and AUTH-309, which all relate to string validation for `variable_name`, `display_name` (for both the parameter and choices) and `unit`. For these, we were not explicitly checking that the value given was a string, which could lead to related but unclear messages when those types inevitably would fail at some step on the process. Now, before we do any validation on string length, we ensure the value given is a string and raise an appropriate error message if it is not.

AUTH-304 related to an unclear message if the `value` key in a parameter choice was of the wrong type. This was a case of accidentally wrapping `type` around a type object, causing it to print `<class 'type'>` instead of `<class 'str'>` for example. This was a simple fix of just removing the `type()` call.

AUTH-306 was about unclear messages for the wrong type being used for minimum and maximum. The validation steps used for those was shifted around to more helpfully catch and point to incorrect types, rather than more generic error messages that didn't say which value was wrong.

Finally, AUTH-308 similarly brought up that there was no distinct error message when the `default` value was of the wrong type. To fix for this was just to make a bespoke check for that to raise a unique error message, rather than using the  same check that setting the `value` uses. Its a small instance of repeated code but the check is simple enough and unlikely to be changed.

# Test Plan

Ran through all the test protocols linked in the tickets above and ensured that they all had clear error messages relating to each individual one.

# Changelog

- Provide more clear error messages when non-string values are given to arguments that are string-only
- Fix error message for wrong choice `value` not printing out the actual type that's expected
- Refactored `minimum`/`maximum` validation to provide more clear error text to disambiguate which value is wrong.
- Disambugate error message when `default` value is of the wrong type.

# Review requests
# Risk assessment
Low