### PR TITLE
refactor(robot-server): consolidate DB transactions, fix a max analyses length bug

### DIFF
--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -196,7 +196,7 @@ class AnalysisStore:
                 completed_analysis
             ),
         )
-        await self._completed_store.add(
+        await self._completed_store.make_room_and_add(
             completed_analysis_resource=completed_analysis_resource
         )
 

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -319,7 +319,7 @@ async def test_update_adds_rtp_values_and_defaults_to_completed_store(
         liquids=[],
     )
     decoy.verify(
-        await mock_completed_store.add(
+        await mock_completed_store.make_room_and_add(
             completed_analysis_resource=expected_completed_analysis_resource
         )
     )


### PR DESCRIPTION
Closes AUTH-347

# Overview

#14885 added the feature to limit number of analyses we store in DB. In [this](https://github.com/Opentrons/opentrons/pull/14885#discussion_r1563058134) comment, @SyntaxColoring pointed out that we should consolidate the DB transactions for better performance, so that's what this PR does.

Also fixes a bug where if the existing number of analyses in the DB was 3 and we were to add another analysis, then the formula for getting the analysis IDs to delete would result in `analysis_ids[:-1]` and it would delete all analyses except last one.

# Test Plan

- Tested the cases mentioned in #14885 
- Tested the bug case

# Risk assessment

Low. Refactor + small bug fix