### PR TITLE
feat(app): push recent RTP run card click to protocol details

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -3,6 +3,7 @@ import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
 import { formatDistance } from 'date-fns'
+import { last } from 'lodash'
 
 import {
   BORDERS,
@@ -17,14 +18,14 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useProtocolQuery } from '@opentrons/react-api-client'
+import {
+  useProtocolAnalysisAsDocumentQuery,
+  useProtocolQuery,
+} from '@opentrons/react-api-client'
 import {
   RUN_STATUS_FAILED,
   RUN_STATUS_STOPPED,
   RUN_STATUS_SUCCEEDED,
-  Run,
-  RunData,
-  RunStatus,
 } from '@opentrons/api-client'
 
 import { ODD_FOCUS_VISIBLE } from '../../../atoms/buttons//constants'
@@ -38,6 +39,7 @@ import {
   INIT_STATUS,
 } from '../../../resources/health/hooks'
 
+import type { Run, RunData, RunStatus } from '@opentrons/api-client'
 import type { ProtocolResource } from '@opentrons/shared-data'
 
 interface RecentRunProtocolCardProps {
@@ -98,6 +100,14 @@ export function ProtocolWithLastRun({
   const protocolName =
     protocolData.metadata.protocolName ?? protocolData.files[0].name
 
+  const protocolId = protocolData.id
+
+  const { data: analysis } = useProtocolAnalysisAsDocumentQuery(
+    protocolId,
+    last(protocolData?.analysisSummaries)?.id ?? null,
+    { enabled: protocolData != null }
+  )
+
   const PROTOCOL_CARD_STYLE = css`
     flex: 1 0 0;
     &:active {
@@ -125,13 +135,22 @@ export function ProtocolWithLastRun({
     height: max-content;
   `
 
+  const hasRunTimeParameters =
+    analysis?.runTimeParameters != null
+      ? analysis?.runTimeParameters.length > 0
+      : false
+
   const handleCardClick = (): void => {
     setShowSpinner(true)
-    cloneRun()
-    trackEvent({
-      name: 'proceedToRun',
-      properties: { sourceLocation: 'RecentRunProtocolCard' },
-    })
+    if (hasRunTimeParameters) {
+      history.push(`/protocols/${protocolId}`)
+    } else {
+      cloneRun()
+      trackEvent({
+        name: 'proceedToRun',
+        properties: { sourceLocation: 'RecentRunProtocolCard' },
+      })
+    }
     // TODO(BC, 08/29/23): reintroduce this analytics event when we refactor the hook to fetch data lazily (performance concern)
     // trackProtocolRunEvent({ name: 'runAgain' })
   }

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -3,7 +3,7 @@ import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { useHistory } from 'react-router-dom'
 import { formatDistance } from 'date-fns'
-import { last } from 'lodash'
+import last from 'lodash/last'
 
 import {
   BORDERS,

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -282,7 +282,7 @@ describe('RecentRunProtocolCard', () => {
     getByText('mock Skeleton')
   })
 
-  it.only('should push to protocol details if protocol contains runtime parameters', () => {
+  it('should push to protocol details if protocol contains runtime parameters', () => {
     vi.mocked(useProtocolAnalysisAsDocumentQuery).mockReturnValue({
       data: simpleAnalysisFileFixture,
     } as any)

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -5,8 +5,14 @@ import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import { useProtocolQuery } from '@opentrons/react-api-client'
-import { RUN_STATUS_FAILED } from '@opentrons/api-client'
+import {
+  useProtocolQuery,
+  useProtocolAnalysisAsDocumentQuery,
+} from '@opentrons/react-api-client'
+import {
+  RUN_STATUS_FAILED,
+  simpleAnalysisFileFixture,
+} from '@opentrons/api-client'
 import { COLORS } from '@opentrons/components'
 
 import { renderWithProviders } from '../../../../__testing-utils__'
@@ -24,11 +30,23 @@ import {
   INIT_STATUS,
 } from '../../../../resources/health/hooks'
 
+import type { useHistory } from 'react-router-dom'
 import type { ProtocolHardware } from '../../../../pages/Protocols/hooks'
+
+const mockPush = vi.fn()
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof useHistory>()
+  return {
+    ...actual,
+    useHistory: () => ({ push: mockPush } as any),
+  }
+})
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('../../../../atoms/Skeleton')
 vi.mock('../../../../pages/Protocols/hooks')
+vi.mock('../../../../pages/ProtocolDetails')
 vi.mock('../../../../organisms/Devices/hooks')
 vi.mock('../../../../organisms/RunTimeControl/hooks')
 vi.mock('../../../../organisms/ProtocolUpload/hooks')
@@ -128,7 +146,18 @@ describe('RecentRunProtocolCard', () => {
       data: { data: [mockRunData] },
     } as any)
     vi.mocked(useProtocolQuery).mockReturnValue({
-      data: { data: { metadata: { protocolName: 'mockProtocol' } } },
+      data: {
+        data: {
+          metadata: { protocolName: 'mockProtocol' },
+          id: 'mockProtocolId',
+        },
+      },
+    } as any)
+    vi.mocked(useProtocolAnalysisAsDocumentQuery).mockReturnValue({
+      data: {
+        ...simpleAnalysisFileFixture,
+        runTimeParameters: [],
+      },
     } as any)
     vi.mocked(useRobotInitializationStatus).mockReturnValue(
       INIT_STATUS.SUCCEEDED
@@ -251,5 +280,15 @@ describe('RecentRunProtocolCard', () => {
     vi.mocked(useRobotInitializationStatus).mockReturnValue(null)
     const [{ getByText }] = render(props)
     getByText('mock Skeleton')
+  })
+
+  it.only('should push to protocol details if protocol contains runtime parameters', () => {
+    vi.mocked(useProtocolAnalysisAsDocumentQuery).mockReturnValue({
+      data: simpleAnalysisFileFixture,
+    } as any)
+    render(props)
+    const button = screen.getByLabelText('RecentRunProtocolCard')
+    fireEvent.click(button)
+    expect(mockPush).toBeCalledWith('/protocols/mockProtocolId')
   })
 })


### PR DESCRIPTION
# Overview

Because we don't yet have designs displaying details of a recent protocol run card with specific runtime parameter values, we want to allow the user to reset parameter values afer clicking a recent run card for an RTP-containing protocol. Behavior for non-RTP protocols will not change and will push the user directly to protocol run setup.

In the future, ideally, we can communicate RTP overrides on the recent run card and produce unique cards for different parameter selections on the same protocol ID. In this way, we can clone the run and avoid having to re-select parameters.

# Test Plan

- push this branch to Flex ODD
- send an RTP protocol and a non-RTP protocol to the Flex
- setup run both protocols to produce recent run cards on the robot dashboard recent run carousel
- click the non-RTP recent run card and verify that you are pushed directly to protocol run setup
- click the RTP recent run card and verify that you are pushed to protocol details to have the ability to reset parameter values

https://github.com/Opentrons/opentrons/assets/47604184/280e3095-f83e-4cc8-b944-5ad0cf81ebf0


# Changelog

- check for RTPs on recent run card
- on click, push to protocol details if RTPs exist
- add test for RTP recent run click

# Review requests

auth

# Risk assessment

medium