### PR TITLE
fix(app): properly disable proceed button if no available robots

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -296,4 +296,18 @@ describe('ChooseRobotSlideout', () => {
       ip: 'otherIp',
     })
   })
+
+  it('sets selected robot to null if no available robots', () => {
+    vi.mocked(getConnectableRobots).mockReturnValue([])
+    render({
+      onCloseClick: vi.fn(),
+      isExpanded: true,
+      isSelectedRobotOnDifferentSoftwareVersion: false,
+      selectedRobot: null,
+      setSelectedRobot: mockSetSelectedRobot,
+      title: 'choose robot slideout title',
+      robotType: OT2_ROBOT_TYPE,
+    })
+    expect(mockSetSelectedRobot).toBeCalledWith(null)
+  })
 })

--- a/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/__tests__/ChooseRobotSlideout.test.tsx
@@ -3,6 +3,7 @@ import { vi, it, describe, expect, beforeEach } from 'vitest'
 
 import { StaticRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
@@ -22,7 +23,7 @@ import { useFeatureFlag } from '../../../redux/config'
 import { getNetworkInterfaces } from '../../../redux/networking'
 import { ChooseRobotSlideout } from '..'
 import { useNotifyService } from '../../../resources/useNotifyService'
-import { OT2_ROBOT_TYPE, RunTimeParameter } from '@opentrons/shared-data'
+import type { RunTimeParameter } from '@opentrons/shared-data'
 
 vi.mock('../../../redux/discovery')
 vi.mock('../../../redux/robot-update')

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -184,10 +184,9 @@ export function ChooseRobotSlideout(
     {}
   )
 
-  const reducerAvailable = healthyReachableRobots.filter(
-    robot => !robotBusyStatusByName[robot.name]
+  const reducerAvailable = healthyReachableRobots.filter(robot =>
+    showIdleOnly ? !robotBusyStatusByName[robot.name] : robot
   )
-
   const reducerBusyCount = healthyReachableRobots.filter(
     robot => robotBusyStatusByName[robot.name]
   ).length

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -79,7 +79,7 @@ interface RobotBusyStatusByName {
 
 export type RobotBusyStatusAction = RobotIsBusyAction | RobotIsIdleAction
 
-export function robotBusyStatusByNameReducer(
+function robotBusyStatusByNameReducer(
   state: RobotBusyStatusByName,
   action: RobotBusyStatusAction
 ): RobotBusyStatusByName {
@@ -184,7 +184,7 @@ export function ChooseRobotSlideout(
     {}
   )
 
-  const reducerAvailable = healthyReachableRobots.filter(robot =>
+  const reducerAvailableRobots = healthyReachableRobots.filter(robot =>
     showIdleOnly ? !robotBusyStatusByName[robot.name] : robot
   )
   const reducerBusyCount = healthyReachableRobots.filter(
@@ -193,9 +193,9 @@ export function ChooseRobotSlideout(
 
   // this useEffect sets the default selection to the first robot in the list. state is managed by the caller
   React.useEffect(() => {
-    if (selectedRobot == null && reducerAvailable.length > 0) {
-      setSelectedRobot(reducerAvailable[0])
-    } else if (reducerAvailable.length === 0) {
+    if (selectedRobot == null && reducerAvailableRobots.length > 0) {
+      setSelectedRobot(reducerAvailableRobots[0])
+    } else if (reducerAvailableRobots.length === 0) {
       setSelectedRobot(null)
     }
   }, [healthyReachableRobots, selectedRobot, setSelectedRobot])

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -79,7 +79,7 @@ interface RobotBusyStatusByName {
 
 export type RobotBusyStatusAction = RobotIsBusyAction | RobotIsIdleAction
 
-function robotBusyStatusByNameReducer(
+export function robotBusyStatusByNameReducer(
   state: RobotBusyStatusByName,
   action: RobotBusyStatusAction
 ): RobotBusyStatusByName {
@@ -184,15 +184,19 @@ export function ChooseRobotSlideout(
     {}
   )
 
+  const reducerAvailable = healthyReachableRobots.filter(
+    robot => !robotBusyStatusByName[robot.name]
+  )
+
   const reducerBusyCount = healthyReachableRobots.filter(
     robot => robotBusyStatusByName[robot.name]
   ).length
 
   // this useEffect sets the default selection to the first robot in the list. state is managed by the caller
   React.useEffect(() => {
-    if (selectedRobot == null && healthyReachableRobots.length > 0) {
-      setSelectedRobot(healthyReachableRobots[0])
-    } else if (healthyReachableRobots.length === 0) {
+    if (selectedRobot == null && reducerAvailable.length > 0) {
+      setSelectedRobot(reducerAvailable[0])
+    } else if (reducerAvailable.length === 0) {
       setSelectedRobot(null)
     }
   }, [healthyReachableRobots, selectedRobot, setSelectedRobot])

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -390,4 +390,17 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
       {}
     )
   })
+
+  it('disables proceed button if no available robots', () => {
+    vi.mocked(getConnectableRobots).mockReturnValue([])
+    render({
+      storedProtocolData: storedProtocolDataFixture,
+      onCloseClick: vi.fn(),
+      showSlideout: true,
+    })
+    const proceedButton = screen.getByRole('button', {
+      name: 'Continue to parameters',
+    })
+    expect(proceedButton).toBeDisabled()
+  })
 })


### PR DESCRIPTION
closes [RQA-2517](https://opentrons.atlassian.net/browse/RQA-2517)

# Overview

Fixes bug where ChooseRobotSlideout rendered by ChooseRobotToRunProtocolSlideout sets the selected robot to the first _connectable_ robot, even if there is no _available_ robot, when all connectable robots are busy (in runs). Checks for healthy reachable AND available robots when setting the selected robot on the slideout.

Leave current behavior for slideout when called by SendProtocolToFlexSlideout, since we can still send protocols to Flexes in active runs.

# Test Plan

- limit connectable robots to one or a few (one way is to disconnect from the network and only run dev robot server)
- begin protocol setup on all connectable robots
- navigate to `Protocols` tab and open the slideout by selecting "Start setup"
- confirm that no available robots options are shown and that the footer button is disabled
- on the protocol details page, select "Send to Opentrons Flex" from the overflow menu
- confirm that all connectable Flexes show, even if they are in runs

https://github.com/Opentrons/opentrons/assets/47604184/34a4f8e9-00e1-465c-932f-5e47fef788de

# Changelog

- if starting protocol setup, map AvailableRobotOption to only available robots
- fix test

# Review requests

@mjhuff per working on bug fix together

# Risk assessment

low

[RQA-2517]: https://opentrons.atlassian.net/browse/RQA-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ