### PR TITLE
feat(app): add pipette selection screen to quick transfer flow

### DIFF
--- a/app/src/assets/localization/en/quick_transfer.json
+++ b/app/src/assets/localization/en/quick_transfer.json
@@ -1,5 +1,8 @@
 {
   "create_new_transfer": "Create new quick transfer",
+  "left_mount": "Left Mount",
+  "both_mounts": "Left + Right Mount",
+  "right_mount": "Right Mount",
   "select_attached_pipette": "Select attached pipette",
   "select_dest_labware": "Select destination labware",
   "select_dest_wells": "Select destination wells",

--- a/app/src/atoms/buttons/LargeButton.stories.tsx
+++ b/app/src/atoms/buttons/LargeButton.stories.tsx
@@ -45,3 +45,16 @@ export const Alert: Story = {
     iconName: 'reset',
   },
 }
+export const PrimaryNoIcon: Story = {
+  args: {
+    buttonText: 'Button text',
+    disabled: false,
+  },
+}
+export const PrimaryWithSubtext: Story = {
+  args: {
+    buttonText: 'Button text',
+    disabled: false,
+    subtext: 'Button subtext',
+  },
+}

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -7,6 +7,7 @@ import {
   DIRECTION_COLUMN,
   DISPLAY_FLEX,
   Icon,
+  Flex,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   StyledText,
@@ -20,7 +21,8 @@ interface LargeButtonProps extends StyleProps {
   onClick: () => void
   buttonType?: LargeButtonTypes
   buttonText: React.ReactNode
-  iconName: IconName
+  iconName?: IconName
+  subtext?: string
   disabled?: boolean
 }
 
@@ -29,6 +31,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     buttonType = 'primary',
     buttonText,
     iconName,
+    subtext,
     disabled = false,
     ...buttonProps
   } = props
@@ -110,23 +113,36 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabled={disabled}
       {...buttonProps}
     >
-      <StyledText
-        fontSize="2rem"
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-        lineHeight="2.625rem"
-      >
-        {buttonText}
-      </StyledText>
-      <Icon
-        name={iconName}
-        aria-label={`${iconName} icon`}
-        color={
-          disabled
-            ? COLORS.grey50
-            : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
-        }
-        size="5rem"
-      />
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <StyledText
+          fontSize="2rem"
+          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          lineHeight="2.625rem"
+        >
+          {buttonText}
+        </StyledText>
+        {subtext ? (
+          <StyledText
+            fontSize="2rem"
+            lineHeight="2.625rem"
+            fontWeight={TYPOGRAPHY.fontWeightRegular}
+          >
+            {subtext}
+          </StyledText>
+        ) : null}
+      </Flex>
+      {iconName ? (
+        <Icon
+          name={iconName}
+          aria-label={`${iconName} icon`}
+          color={
+            disabled
+              ? COLORS.grey50
+              : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
+          }
+          size="5rem"
+        />
+      ) : null}
     </Btn>
   )
 }

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -114,19 +114,11 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       {...buttonProps}
     >
       <Flex flexDirection={DIRECTION_COLUMN}>
-        <StyledText
-          fontSize="2rem"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          lineHeight="2.625rem"
-        >
+        <StyledText css={TYPOGRAPHY.level3HeaderSemiBold}>
           {buttonText}
         </StyledText>
         {subtext ? (
-          <StyledText
-            fontSize="2rem"
-            lineHeight="2.625rem"
-            fontWeight={TYPOGRAPHY.fontWeightRegular}
-          >
+          <StyledText css={TYPOGRAPHY.level3HeaderRegular}>
             {subtext}
           </StyledText>
         ) : null}

--- a/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
@@ -55,13 +55,14 @@ export function SelectPipette(props: SelectPipetteProps): JSX.Element {
       selectedPipette === LEFT ? leftPipetteSpecs : rightPipetteSpecs
 
     // the button will be disabled if these values are null
-    if (selectedPipette != null && selectedPipetteSpecs != null)
+    if (selectedPipette != null && selectedPipetteSpecs != null) {
       dispatch({
         type: 'SELECT_PIPETTE',
         pipette: selectedPipetteSpecs,
         mount: selectedPipette,
       })
-    onNext()
+      onNext()
+    }
   }
   return (
     <Flex>

--- a/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
@@ -31,16 +31,14 @@ export function SelectPipette(props: SelectPipetteProps): JSX.Element {
   const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
   const { data: attachedInstruments } = useInstrumentsQuery()
 
-  // @ts-expect-error mount should be enough of a type narrower here
-  const leftPipette: PipetteData | undefined = attachedInstruments?.data.find(
-    instrument => instrument.ok && instrument.mount === LEFT
+  const leftPipette = attachedInstruments?.data.find(
+    (i): i is PipetteData => i.ok && i.mount === LEFT
   )
   const leftPipetteSpecs =
     leftPipette != null ? getPipetteSpecsV2(leftPipette.instrumentModel) : null
 
-  // @ts-expect-error mount should be enough of a type narrower here
-  const rightPipette: PipetteData | undefined = attachedInstruments?.data.find(
-    instrument => instrument.ok && instrument.mount === RIGHT
+  const rightPipette = attachedInstruments?.data.find(
+    (i): i is PipetteData => i.ok && i.mount === RIGHT
   )
   const rightPipetteSpecs =
     rightPipette != null

--- a/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  Flex,
+  SPACING,
+  StyledText,
+  TYPOGRAPHY,
+  DIRECTION_COLUMN,
+} from '@opentrons/components'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import { getPipetteSpecsV2, RIGHT, LEFT } from '@opentrons/shared-data'
+import { SmallButton, LargeButton } from '../../atoms/buttons'
+import { ChildNavigation } from '../ChildNavigation'
+
+import type { PipetteData, Mount } from '@opentrons/api-client'
+import type {
+  QuickTransferSetupState,
+  QuickTransferWizardAction,
+} from './types'
+
+interface SelectPipetteProps {
+  onNext: () => void
+  onBack: () => void
+  exitButtonProps: React.ComponentProps<typeof SmallButton>
+  state: QuickTransferSetupState
+  dispatch: React.Dispatch<QuickTransferWizardAction>
+}
+
+export function SelectPipette(props: SelectPipetteProps): JSX.Element {
+  const { onNext, onBack, exitButtonProps, state, dispatch } = props
+  const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
+  const { data: attachedInstruments } = useInstrumentsQuery()
+
+  // @ts-expect-error mount should be enough of a type narrower here
+  const leftPipette: PipetteData | undefined = attachedInstruments?.data.find(
+    instrument => instrument.ok && instrument.mount === LEFT
+  )
+  const leftPipetteSpecs =
+    leftPipette != null ? getPipetteSpecsV2(leftPipette.instrumentModel) : null
+
+  // @ts-expect-error mount should be enough of a type narrower here
+  const rightPipette: PipetteData | undefined = attachedInstruments?.data.find(
+    instrument => instrument.ok && instrument.mount === RIGHT
+  )
+  const rightPipetteSpecs =
+    rightPipette != null
+      ? getPipetteSpecsV2(rightPipette.instrumentModel)
+      : null
+
+  // automatically select 96 channel if it is attached
+  const [selectedPipette, setSelectedPipette] = React.useState<
+    Mount | undefined
+  >(leftPipetteSpecs?.channels === 96 ? LEFT : state.mount)
+
+  const handleClickNext = (): void => {
+    const selectedPipetteSpecs =
+      selectedPipette === LEFT ? leftPipetteSpecs : rightPipetteSpecs
+
+    // the button will be disabled if these values are null
+    if (selectedPipette != null && selectedPipetteSpecs != null)
+      dispatch({
+        type: 'SELECT_PIPETTE',
+        pipette: selectedPipetteSpecs,
+        mount: selectedPipette,
+      })
+    onNext()
+  }
+  return (
+    <Flex>
+      <ChildNavigation
+        header={t('select_attached_pipette')}
+        buttonText={i18n.format(t('shared:continue'), 'capitalize')}
+        onClickBack={onBack}
+        onClickButton={handleClickNext}
+        secondaryButtonProps={exitButtonProps}
+        top={SPACING.spacing8}
+        buttonIsDisabled={selectedPipette == null}
+      />
+      <Flex
+        marginTop={SPACING.spacing120}
+        flexDirection={DIRECTION_COLUMN}
+        padding={`${SPACING.spacing16} ${SPACING.spacing60} ${SPACING.spacing40} ${SPACING.spacing60}`}
+        gridGap={SPACING.spacing16}
+      >
+        <StyledText css={TYPOGRAPHY.level4HeaderRegular}>
+          {t('pipette_currently_attached')}
+        </StyledText>
+        {leftPipetteSpecs != null ? (
+          <LargeButton
+            buttonType={selectedPipette === LEFT ? 'primary' : 'secondary'}
+            onClick={() => {
+              setSelectedPipette(LEFT)
+            }}
+            buttonText={
+              leftPipetteSpecs.channels === 96
+                ? t('both_mounts')
+                : t('left_mount')
+            }
+            subtext={leftPipetteSpecs.displayName}
+          />
+        ) : null}
+        {rightPipetteSpecs != null ? (
+          <LargeButton
+            buttonType={selectedPipette === RIGHT ? 'primary' : 'secondary'}
+            onClick={() => {
+              setSelectedPipette(RIGHT)
+            }}
+            buttonText={t('right_mount')}
+            subtext={rightPipetteSpecs.displayName}
+          />
+        ) : null}
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/organisms/QuickTransferFlow/__tests__/SelectPipette.test.tsx
+++ b/app/src/organisms/QuickTransferFlow/__tests__/SelectPipette.test.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+import { useInstrumentsQuery } from '@opentrons/react-api-client'
+
+import { renderWithProviders } from '../../../__testing-utils__'
+import { i18n } from '../../../i18n'
+import { SelectPipette } from '../SelectPipette'
+
+vi.mock('@opentrons/react-api-client')
+const render = (props: React.ComponentProps<typeof SelectPipette>) => {
+  return renderWithProviders(<SelectPipette {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('SelectPipette', () => {
+  let props: React.ComponentProps<typeof SelectPipette>
+
+  beforeEach(() => {
+    props = {
+      onNext: vi.fn(),
+      onBack: vi.fn(),
+      exitButtonProps: {
+        buttonType: 'tertiaryLowLight',
+        buttonText: 'Exit',
+        onClick: vi.fn(),
+      },
+      state: {},
+      dispatch: vi.fn(),
+    }
+    vi.mocked(useInstrumentsQuery).mockReturnValue({
+      data: {
+        data: [
+          {
+            instrumentType: 'pipette',
+            mount: 'left',
+            ok: true,
+            firmwareVersion: 12,
+            instrumentName: 'p10_single',
+            instrumentModel: 'p1000_multi_v3.4',
+            data: {},
+          } as any,
+          {
+            instrumentType: 'pipette',
+            mount: 'right',
+            ok: true,
+            firmwareVersion: 12,
+            instrumentName: 'p10_single',
+            instrumentModel: 'p1000_multi_v3.4',
+            data: {},
+          } as any,
+        ],
+      },
+    } as any)
+  })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders the select pipette screen, header, and exit button', () => {
+    render(props)
+    screen.getByText('Select attached pipette')
+    screen.getByText(
+      'Quick transfer options depend on the pipettes currently attached to your robot.'
+    )
+    const exitBtn = screen.getByText('Exit')
+    fireEvent.click(exitBtn)
+    expect(props.exitButtonProps.onClick).toHaveBeenCalled()
+  })
+
+  it('renders continue button and it is disabled if no pipette is selected', () => {
+    render(props)
+    screen.getByText('Continue')
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeDisabled()
+  })
+
+  it('renders both pipette buttons if there are two attached', () => {
+    render(props)
+    screen.getByText('Left Mount')
+    screen.getByText('Right Mount')
+  })
+
+  it('selects pipette by default if there is one in state, button will be enabled', () => {
+    render({ ...props, state: { mount: 'left' } })
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeEnabled()
+    fireEvent.click(continueBtn)
+    expect(props.onNext).toHaveBeenCalled()
+  })
+
+  it('enables continue button if you click a pipette', () => {
+    render(props)
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeDisabled()
+    const leftButton = screen.getByText('Left Mount')
+    fireEvent.click(leftButton)
+    expect(continueBtn).toBeEnabled()
+    fireEvent.click(continueBtn)
+    expect(props.dispatch).toHaveBeenCalled()
+    expect(props.onNext).toHaveBeenCalled()
+  })
+
+  it('renders left and right button if 96 is attached and automatically selects the pipette', () => {
+    vi.mocked(useInstrumentsQuery).mockReturnValue({
+      data: {
+        data: [
+          {
+            instrumentType: 'pipette',
+            mount: 'left',
+            ok: true,
+            firmwareVersion: 12,
+            instrumentName: 'p1000_96',
+            instrumentModel: 'p1000_96_v1',
+            data: {},
+          } as any,
+        ],
+      },
+    } as any)
+    render(props)
+    screen.getByText('Left + Right Mount')
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeEnabled()
+  })
+})

--- a/app/src/organisms/QuickTransferFlow/index.tsx
+++ b/app/src/organisms/QuickTransferFlow/index.tsx
@@ -6,90 +6,20 @@ import { SmallButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 import { CreateNewTransfer } from './CreateNewTransfer'
 import { SelectPipette } from './SelectPipette'
+import { quickTransferReducer } from './utils'
 
-import type {
-  QuickTransferSetupState,
-  QuickTransferWizardAction,
-} from './types'
+import type { QuickTransferSetupState } from './types'
 
 const QUICK_TRANSFER_WIZARD_STEPS = 8
-
 const initialQuickTransferState: QuickTransferSetupState = {}
-export function reducer(
-  state: QuickTransferSetupState,
-  action: QuickTransferWizardAction
-): QuickTransferSetupState {
-  switch (action.type) {
-    case 'SELECT_PIPETTE': {
-      return {
-        pipette: action.pipette,
-        mount: action.mount,
-      }
-    }
-    case 'SELECT_TIP_RACK': {
-      return {
-        pipette: state.pipette,
-        mount: state.mount,
-        tipRack: action.tipRack,
-      }
-    }
-    case 'SET_SOURCE_LABWARE': {
-      return {
-        pipette: state.pipette,
-        mount: state.mount,
-        tipRack: state.tipRack,
-        source: action.labware,
-      }
-    }
-    case 'SET_SOURCE_WELLS': {
-      return {
-        pipette: state.pipette,
-        mount: state.mount,
-        tipRack: state.tipRack,
-        source: state.source,
-        sourceWells: action.wells,
-      }
-    }
-    case 'SET_DEST_LABWARE': {
-      return {
-        pipette: state.pipette,
-        mount: state.mount,
-        tipRack: state.tipRack,
-        source: state.source,
-        sourceWells: state.sourceWells,
-        destination: action.labware,
-      }
-    }
-    case 'SET_DEST_WELLS': {
-      return {
-        pipette: state.pipette,
-        mount: state.mount,
-        tipRack: state.tipRack,
-        source: state.source,
-        sourceWells: state.sourceWells,
-        destination: state.destination,
-        destinationWells: action.wells,
-      }
-    }
-    case 'SET_VOLUME': {
-      return {
-        pipette: state.pipette,
-        mount: state.mount,
-        tipRack: state.tipRack,
-        source: state.source,
-        sourceWells: state.sourceWells,
-        destination: state.destination,
-        destinationWells: state.destinationWells,
-        volume: action.volume,
-      }
-    }
-  }
-}
 
 export const QuickTransferFlow = (): JSX.Element => {
   const history = useHistory()
   const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
-  const [state, dispatch] = React.useReducer(reducer, initialQuickTransferState)
+  const [state, dispatch] = React.useReducer(
+    quickTransferReducer,
+    initialQuickTransferState
+  )
   const [currentStep, setCurrentStep] = React.useState(1)
   const [continueIsDisabled] = React.useState<boolean>(false)
 
@@ -104,6 +34,8 @@ export const QuickTransferFlow = (): JSX.Element => {
       history.push('protocols')
     },
   }
+
+  // these will be moved to the child components once they all exist
   const ORDERED_STEP_HEADERS: string[] = [
     t('create_new_transfer'),
     t('select_attached_pipette'),

--- a/app/src/organisms/QuickTransferFlow/index.tsx
+++ b/app/src/organisms/QuickTransferFlow/index.tsx
@@ -93,10 +93,6 @@ export const QuickTransferFlow = (): JSX.Element => {
   const [currentStep, setCurrentStep] = React.useState(1)
   const [continueIsDisabled] = React.useState<boolean>(false)
 
-  React.useEffect(() => {
-    console.log(state)
-  }, [state])
-
   // every child component will take state as a prop, an anonymous
   // dispatch function related to that step (except create new),
   // and a function to disable the continue button
@@ -143,7 +139,6 @@ export const QuickTransferFlow = (): JSX.Element => {
   }
 
   // until each page is wired up, show header title with empty screen
-
   return (
     <>
       <StepMeter

--- a/app/src/organisms/QuickTransferFlow/index.tsx
+++ b/app/src/organisms/QuickTransferFlow/index.tsx
@@ -5,6 +5,7 @@ import { Flex, StepMeter, SPACING } from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 import { CreateNewTransfer } from './CreateNewTransfer'
+import { SelectPipette } from './SelectPipette'
 
 import type {
   QuickTransferSetupState,
@@ -13,7 +14,7 @@ import type {
 
 const QUICK_TRANSFER_WIZARD_STEPS = 8
 
-// const initialQuickTransferState: QuickTransferSetupState = {}
+const initialQuickTransferState: QuickTransferSetupState = {}
 export function reducer(
   state: QuickTransferSetupState,
   action: QuickTransferWizardAction
@@ -22,17 +23,20 @@ export function reducer(
     case 'SELECT_PIPETTE': {
       return {
         pipette: action.pipette,
+        mount: action.mount,
       }
     }
     case 'SELECT_TIP_RACK': {
       return {
         pipette: state.pipette,
+        mount: state.mount,
         tipRack: action.tipRack,
       }
     }
     case 'SET_SOURCE_LABWARE': {
       return {
         pipette: state.pipette,
+        mount: state.mount,
         tipRack: state.tipRack,
         source: action.labware,
       }
@@ -40,6 +44,7 @@ export function reducer(
     case 'SET_SOURCE_WELLS': {
       return {
         pipette: state.pipette,
+        mount: state.mount,
         tipRack: state.tipRack,
         source: state.source,
         sourceWells: action.wells,
@@ -48,6 +53,7 @@ export function reducer(
     case 'SET_DEST_LABWARE': {
       return {
         pipette: state.pipette,
+        mount: state.mount,
         tipRack: state.tipRack,
         source: state.source,
         sourceWells: state.sourceWells,
@@ -57,6 +63,7 @@ export function reducer(
     case 'SET_DEST_WELLS': {
       return {
         pipette: state.pipette,
+        mount: state.mount,
         tipRack: state.tipRack,
         source: state.source,
         sourceWells: state.sourceWells,
@@ -67,6 +74,7 @@ export function reducer(
     case 'SET_VOLUME': {
       return {
         pipette: state.pipette,
+        mount: state.mount,
         tipRack: state.tipRack,
         source: state.source,
         sourceWells: state.sourceWells,
@@ -81,9 +89,13 @@ export function reducer(
 export const QuickTransferFlow = (): JSX.Element => {
   const history = useHistory()
   const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
-  // const [state, dispatch] = React.useReducer(reducer, initialQuickTransferState)
+  const [state, dispatch] = React.useReducer(reducer, initialQuickTransferState)
   const [currentStep, setCurrentStep] = React.useState(1)
   const [continueIsDisabled] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    console.log(state)
+  }, [state])
 
   // every child component will take state as a prop, an anonymous
   // dispatch function related to that step (except create new),
@@ -112,6 +124,16 @@ export const QuickTransferFlow = (): JSX.Element => {
   if (currentStep === 1) {
     modalContent = (
       <CreateNewTransfer
+        onNext={() => setCurrentStep(prevStep => prevStep + 1)}
+        exitButtonProps={exitButtonProps}
+      />
+    )
+  } else if (currentStep === 2) {
+    modalContent = (
+      <SelectPipette
+        state={state}
+        dispatch={dispatch}
+        onBack={() => setCurrentStep(prevStep => prevStep - 1)}
         onNext={() => setCurrentStep(prevStep => prevStep + 1)}
         exitButtonProps={exitButtonProps}
       />

--- a/app/src/organisms/QuickTransferFlow/types.ts
+++ b/app/src/organisms/QuickTransferFlow/types.ts
@@ -1,9 +1,10 @@
 import { ACTIONS } from './constants'
-import type { PipetteData } from '@opentrons/api-client'
-import type { LabwareDefinition1 } from '@opentrons/shared-data'
+import type { Mount } from '@opentrons/api-client'
+import type { LabwareDefinition1, PipetteV2Specs } from '@opentrons/shared-data'
 
 export interface QuickTransferSetupState {
-  pipette?: PipetteData
+  pipette?: PipetteV2Specs
+  mount?: Mount
   tipRack?: LabwareDefinition1
   source?: LabwareDefinition1
   sourceWells?: string[]
@@ -23,7 +24,8 @@ export type QuickTransferWizardAction =
 
 interface SelectPipetteAction {
   type: typeof ACTIONS.SELECT_PIPETTE
-  pipette: PipetteData
+  mount: Mount
+  pipette: PipetteV2Specs
 }
 interface SelectTipRackAction {
   type: typeof ACTIONS.SELECT_TIP_RACK

--- a/app/src/organisms/QuickTransferFlow/utils.ts
+++ b/app/src/organisms/QuickTransferFlow/utils.ts
@@ -1,0 +1,75 @@
+import type {
+  QuickTransferSetupState,
+  QuickTransferWizardAction,
+} from './types'
+
+export function quickTransferReducer(
+  state: QuickTransferSetupState,
+  action: QuickTransferWizardAction
+): QuickTransferSetupState {
+  switch (action.type) {
+    case 'SELECT_PIPETTE': {
+      return {
+        pipette: action.pipette,
+        mount: action.mount,
+      }
+    }
+    case 'SELECT_TIP_RACK': {
+      return {
+        pipette: state.pipette,
+        mount: state.mount,
+        tipRack: action.tipRack,
+      }
+    }
+    case 'SET_SOURCE_LABWARE': {
+      return {
+        pipette: state.pipette,
+        mount: state.mount,
+        tipRack: state.tipRack,
+        source: action.labware,
+      }
+    }
+    case 'SET_SOURCE_WELLS': {
+      return {
+        pipette: state.pipette,
+        mount: state.mount,
+        tipRack: state.tipRack,
+        source: state.source,
+        sourceWells: action.wells,
+      }
+    }
+    case 'SET_DEST_LABWARE': {
+      return {
+        pipette: state.pipette,
+        mount: state.mount,
+        tipRack: state.tipRack,
+        source: state.source,
+        sourceWells: state.sourceWells,
+        destination: action.labware,
+      }
+    }
+    case 'SET_DEST_WELLS': {
+      return {
+        pipette: state.pipette,
+        mount: state.mount,
+        tipRack: state.tipRack,
+        source: state.source,
+        sourceWells: state.sourceWells,
+        destination: state.destination,
+        destinationWells: action.wells,
+      }
+    }
+    case 'SET_VOLUME': {
+      return {
+        pipette: state.pipette,
+        mount: state.mount,
+        tipRack: state.tipRack,
+        source: state.source,
+        sourceWells: state.sourceWells,
+        destination: state.destination,
+        destinationWells: state.destinationWells,
+        volume: action.volume,
+      }
+    }
+  }
+}

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -2,12 +2,8 @@
   "machine": "OT-3 Standard",
   "strict_attached_instruments": false,
   "attached_instruments": {
-    "right": {
-      "model": "p1000_single_3.4",
-      "id": "321"
-    },
     "left": {
-      "model": "p50_single_3.4",
+      "model": "p1000_96_v1",
       "id": "123"
     }
   },


### PR DESCRIPTION
fix PLAT-174

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
Add pipette selection screen to quick transfer flow
<img width="1027" alt="Screen Shot 2024-04-15 at 5 29 00 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/b1af953d-6c93-463d-82fe-3413f41d6ca7">
<img width="1029" alt="Screen Shot 2024-04-15 at 5 29 08 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/83755ae7-3138-4071-8f03-6b08184b049e">
<img width="1032" alt="Screen Shot 2024-04-15 at 5 38 09 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/20bc7a14-c2f7-47eb-a277-395ca75c7750">

# Test Plan
Initiate quick transfer flow and proceed to the second screen, see that the pipettes currently attached are represented and you can select one and proceed to the next step
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Update LargeButton to make icon optional and add subtext to be in line with design system
2. Add SelectPipette screen and all test cases
3. Update type for stored pipette data from AttachedPipette to PipetteSpecsV2 and Mount

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Go through code for clarity
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, behind FF
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
