### PR TITLE
chore(internal release): notes

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,6 +2,20 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 1.4.0-alpha.0
+
+This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@1.3.0-alpha.0...ot3@1.4.0-alpha.0>
+
+---
+
+## Internal Release 1.3.0-alpha.0
+
+This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.
+
+<https://github.com/Opentrons/opentrons/compare/v7.2.2...ot3@1.3.0-alpha.0>
+
 ---
 
 # Internal Release 1.1.0

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,6 +1,20 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 1.4.0-alpha.0
+
+This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@1.3.0-alpha.0...ot3@1.4.0-alpha.0>
+
+---
+
+## Internal Release 1.3.0-alpha.0
+
+This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.
+
+<https://github.com/Opentrons/opentrons/compare/v7.2.2...ot3@1.3.0-alpha.0>
+
 ---
 
 # Internal Release 1.1.0


### PR DESCRIPTION
# Internal release notes

Get in the habit of updating these notes, even if only to create the comparison URL.  Most often I expect these notes are not worth the effort but for stable internal releases will be a nice way to list what is tested.
