### PR TITLE
fix(app): disable 'Run a protocol' robot overflow menu item if robot is busy

### DIFF
--- a/app/src/organisms/Devices/RobotOverflowMenu.tsx
+++ b/app/src/organisms/Devices/RobotOverflowMenu.tsx
@@ -84,23 +84,25 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
   if (robot.status === CONNECTABLE && runId == null) {
     menuItems = (
       <>
-        {!isRobotBusy ? (
-          <MenuItem
-            {...targetProps}
-            onClick={handleClickRun}
-            disabled={isRobotOnWrongVersionOfSoftware}
-            data-testid={`RobotOverflowMenu_${robot.name}_runProtocol`}
-            css={css`
-              border-radius: ${BORDERS.borderRadius8} ${BORDERS.borderRadius8} 0
-                0;
-            `}
-          >
-            {t('run_a_protocol')}
-          </MenuItem>
-        ) : null}
+        <MenuItem
+          {...targetProps}
+          onClick={handleClickRun}
+          disabled={isRobotOnWrongVersionOfSoftware || isRobotBusy}
+          data-testid={`RobotOverflowMenu_${robot.name}_runProtocol`}
+          css={css`
+            border-radius: ${BORDERS.borderRadius8} ${BORDERS.borderRadius8} 0 0;
+          `}
+        >
+          {t('run_a_protocol')}
+        </MenuItem>
         {isRobotOnWrongVersionOfSoftware && (
           <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
             {t('shared:a_software_update_is_available')}
+          </Tooltip>
+        )}
+        {!isRobotOnWrongVersionOfSoftware && isRobotBusy && (
+          <Tooltip tooltipProps={tooltipProps} whiteSpace="normal">
+            {t('shared:robot_is_busy')}
           </Tooltip>
         )}
         <Divider marginY="0" />

--- a/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverflowMenu.test.tsx
@@ -20,6 +20,7 @@ vi.mock('../../../redux/robot-update/selectors')
 vi.mock('../../ProtocolUpload/hooks')
 vi.mock('../../ChooseProtocolSlideout')
 vi.mock('../hooks')
+vi.mock('../../../resources/devices/hooks/useIsEstopNotDisengaged')
 
 const render = (props: React.ComponentProps<typeof RobotOverflowMenu>) => {
   return renderWithProviders(
@@ -85,19 +86,13 @@ describe('RobotOverflowMenu', () => {
     expect(run).toBeDisabled()
   })
 
-  it('should only render robot settings when e-stop is pressed or disconnected', () => {
+  it('disables the run a protocol menu item if robot is busy', () => {
     vi.mocked(useCurrentRunId).mockReturnValue(null)
-    vi.mocked(getRobotUpdateDisplayInfo).mockReturnValue({
-      autoUpdateAction: 'upgrade',
-      autoUpdateDisabledReason: null,
-      updateFromFileDisabledReason: null,
-    })
-
     vi.mocked(useIsRobotBusy).mockReturnValue(true)
     render(props)
     const btn = screen.getByLabelText('RobotOverflowMenu_button')
     fireEvent.click(btn)
-    expect(screen.queryByText('Run a protocol')).not.toBeInTheDocument()
-    screen.getByText('Robot settings')
+    const run = screen.getByText('Run a protocol')
+    expect(run).toBeDisabled()
   })
 })


### PR DESCRIPTION
closes [RQA-2570](https://opentrons.atlassian.net/browse/RQA-2570)

# Overview

Rather than removing the 'Run a protocol' menu item if the robot is busy, here, I render and disable the menu item with a hover tooltip.

# Test Plan

- create conditions where robot is busy (calibration in progress, update in progress, run in progress, e-stop engaged or disconnected)
- navigate to robot card on Devices landing
- open overflow menu
- verify that `Run a protocol` menu item renders but is disabled
- verify that hovering the menu item produces a 'Robot is busy' tooltip

<img width="162" alt="Screenshot 2024-04-16 at 12 06 46 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/2155d4d4-ae3c-4f02-bf52-eff016e04d12">

# Changelog

- disable 'Run a protocol' menu item if robot is busy
- update tests

# Review requests

js

# Risk assessment

low

[RQA-2570]: https://opentrons.atlassian.net/browse/RQA-2570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ