### PR TITLE
fix(protocol-designer): moveLabware newLocation error accounts for cu…

### DIFF
--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -1,8 +1,9 @@
-import { LabwareLocation } from '@opentrons/shared-data'
+import { getLabwareDefIsStandard } from '@opentrons/shared-data'
 import {
   COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE,
   COMPATIBLE_LABWARE_ALLOWLIST_FOR_ADAPTER,
 } from '../../utils/labwareModuleCompatibility'
+import type { LabwareLocation } from '@opentrons/shared-data'
 import type {
   InvariantContext,
   LabwareEntity,
@@ -11,15 +12,18 @@ import type { ProfileFormError } from './profileErrors'
 
 type HydratedFormData = any
 
-//  TODO(Jr, 1/16/24): look into the use case of this util since the i18n strings
-//  previously listed in this util were not found in any json.
 const getMoveLabwareError = (
   labware: LabwareEntity,
   newLocation: LabwareLocation,
   invariantContext: InvariantContext
 ): string | null => {
   let errorString: string | null = null
-  if (labware == null || newLocation == null || newLocation === 'offDeck')
+  if (
+    labware == null ||
+    newLocation == null ||
+    newLocation === 'offDeck' ||
+    !getLabwareDefIsStandard(labware?.def)
+  )
     return null
   const selectedLabwareDefUri = labware?.labwareDefURI
   if ('moduleId' in newLocation) {


### PR DESCRIPTION
…stom labware

closes RESC-243 and RQA-2573

# Overview

Fixes bug outlined in escalations ticket, basically you couldn't move labware onto a module if its a custom labware

# Test Plan

Create an ot-2 protocol and add either a gen1 or gen2 magnetic module. upload the ticket's attached custom labware and place it on the deck. Create a move labware step and move the custom labware onto the magnetic module. it should not error.

# Changelog

- check if the labware definition is standard or not and if it is not, assume its a custom labware and don't return an error string
- remove comment that makes no sense now lol

# Review requests

see test plan

# Risk assessment

low