### PR TITLE
fix(protocol-designer): filter out module addressable areas from newL…

### DIFF
--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -11,6 +11,7 @@ import {
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
   isAddressableAreaStandardSlot,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
+  FLEX_MODULE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 import { COLUMN_4_SLOTS } from '@opentrons/step-generation'
 import {
@@ -232,7 +233,8 @@ export const getUnoccupiedLabwareLocationOptions: Selector<
             .includes(slotId) &&
           !isTrashSlot &&
           !WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slotId) &&
-          !notSelectedStagingAreaAddressableAreas.includes(slotId)
+          !notSelectedStagingAreaAddressableAreas.includes(slotId) &&
+          !FLEX_MODULE_ADDRESSABLE_AREAS.includes(slotId)
         )
       })
       .map(slotId => ({ name: slotId, value: slotId }))


### PR DESCRIPTION
…ocation dropdown

closes AUTH-348

# Overview

When modules got added to deck config, there were a lot more addressable areas added for each module and their slot location. This PR filters them out in the new location dropdown for move labware

# Test Plan

create a flex protocol. add a move labware step and move the tiprack. In the new location dropdown, only slots and off-deck should be available. the module addressable areas should not be available.

# Changelog

- check if slot is a module addressable area and remove it

# Review requests

see test plan

# Risk assessment

low