### PR TITLE
refactor(api,app): remove internal_only flag from enableOEMMode setting

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -238,11 +238,6 @@ settings = [
         title="Enable OEM Mode",
         description="This setting anonymizes Opentrons branding in the ODD app.",
         robot_type=[RobotTypeEnum.FLEX],
-        show_if=(
-            "enableOEMMode",
-            True,
-        ),
-        internal_only=True,
     ),
     SettingDefinition(
         _id="enablePerformanceMetrics",

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsFeatureFlags.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsFeatureFlags.tsx
@@ -29,6 +29,7 @@ interface RobotSettingsFeatureFlagsProps {
 
 const NON_FEATURE_FLAG_SETTINGS = [
   'enableDoorSafetySwitch',
+  'enableOEMMode',
   'disableHomeOnBoot',
   'deckCalibrationDots',
   'shortFixedTrash',


### PR DESCRIPTION
# Overview

enableOEMMode isn't really an internal_only setting, and we need it included in the robot settings api response. change needed for the ODD text to anonymize and the factory mode toggle to work. originally part of oem-mode-integration branch.

# Test Plan

verified that the desktop app factory mode toggle now works to toggle between branded and anonymous ODD

# Changelog

 - Removes internal_only flag from enableOEMMode setting

# Review requests

# Risk assessment

low