### PR TITLE
fix(app): set default selected robot on slideout to first valid robot

### DIFF
--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -193,12 +193,18 @@ export function ChooseRobotSlideout(
 
   // this useEffect sets the default selection to the first robot in the list. state is managed by the caller
   React.useEffect(() => {
-    if (selectedRobot == null && reducerAvailableRobots.length > 0) {
+    if (
+      (selectedRobot == null ||
+        !reducerAvailableRobots.some(
+          robot => robot.name === selectedRobot.name
+        )) &&
+      reducerAvailableRobots.length > 0
+    ) {
       setSelectedRobot(reducerAvailableRobots[0])
     } else if (reducerAvailableRobots.length === 0) {
       setSelectedRobot(null)
     }
-  }, [healthyReachableRobots, selectedRobot, setSelectedRobot])
+  }, [reducerAvailableRobots, selectedRobot, setSelectedRobot])
 
   const unavailableCount =
     unhealthyReachableRobots.length + unreachableRobots.length


### PR DESCRIPTION
closes [RQA-2578](https://opentrons.atlassian.net/browse/RQA-2578)

# Overview

In `ChooseRobotSlideout`, `robotBusyStatusByNameReducer` does not initially return the correct busy status of each robot, resulting in setting the selected robot to the first connectable robot even if it is busy. This PR updates the useEffect resetting the default selection once the robots' busy statuses are properly retrieved.

# Test Plan

- select any protocol
- start setup
- observe that the selected robot defaults to the first available robot option on the slideout

# Changelog

- check that the slideout's selected robot exists in available robots after the robots' busy statuses are fully retrieved
- reset to the first available robot if the selected robot is not available

# Review requests

@mjhuff per working together

# Risk assessment

low

[RQA-2578]: https://opentrons.atlassian.net/browse/RQA-2578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ