### PR TITLE
feat(api): add analysis context tracking

### DIFF
--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -28,6 +28,7 @@ from opentrons.protocol_engine import (
 )
 
 from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons.util.performance_helpers import track_analysis
 
 
 @click.command()
@@ -63,6 +64,7 @@ def _get_input_files(files_and_dirs: Sequence[Path]) -> List[Path]:
     return results
 
 
+@track_analysis
 async def _analyze(
     files_and_dirs: Sequence[Path],
     json_output: Optional[AsyncPath],

--- a/api/src/opentrons/config/__init__.py
+++ b/api/src/opentrons/config/__init__.py
@@ -284,6 +284,13 @@ CONFIG_ELEMENTS = (
         ConfigElementType.DIR,
         "The dir where module calibration is stored",
     ),
+    ConfigElement(
+        "performance_metrics_dir",
+        "Performance Metrics Directory",
+        Path("performance_metrics_data"),
+        ConfigElementType.DIR,
+        "The dir where performance metrics are stored",
+    ),
 )
 #: The available configuration file elements to modify. All of these can be
 #: changed by editing opentrons.json, where the keys are the name elements,
@@ -602,3 +609,7 @@ def get_tip_length_cal_path() -> Path:
 
 def get_custom_tiprack_def_path() -> Path:
     return get_opentrons_path("custom_tiprack_dir")
+
+
+def get_performance_metrics_data_dir() -> Path:
+    return get_opentrons_path("performance_metrics_dir")

--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -6,7 +6,18 @@ from opentrons_shared_data.performance.dev_types import (
     F,
     RobotContextState,
 )
+from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 from typing import Callable, Type
+from opentrons.config import (
+    feature_flags as ff,
+    get_performance_metrics_data_dir,
+    robot_configs,
+)
+
+
+_should_track = ff.enable_performance_metrics(
+    RobotTypeEnum.robot_literal_to_enum(robot_configs.load().model)
+)
 
 
 def _handle_package_import() -> Type[SupportsTracking]:
@@ -52,5 +63,7 @@ def _get_robot_context_tracker() -> SupportsTracking:
     global _robot_context_tracker
     if _robot_context_tracker is None:
         # TODO: replace with path lookup and should_store lookup
-        _robot_context_tracker = package_to_use(Path("A path"), True)
+        _robot_context_tracker = package_to_use(
+            get_performance_metrics_data_dir(), _should_track
+        )
     return _robot_context_tracker

--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -29,7 +29,7 @@ _robot_context_tracker: SupportsTracking | None = None
 class StubbedTracker(SupportsTracking):
     """A stubbed tracker that does nothing."""
 
-    def __init__(self, storage_dir: Path, should_track: bool) -> None:
+    def __init__(self, storage_location: Path, should_track: bool) -> None:
         """Initialize the stubbed tracker."""
         pass
 

--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -67,3 +67,10 @@ def _get_robot_context_tracker() -> SupportsTracking:
             get_performance_metrics_data_dir(), _should_track
         )
     return _robot_context_tracker
+
+
+def track_analysis(func: F) -> F:
+    """Track the analysis of a protocol."""
+    return _get_robot_context_tracker().track(RobotContextState.ANALYZING_PROTOCOL)(
+        func
+    )

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -1,4 +1,6 @@
 """Test cli execution."""
+
+
 import json
 import tempfile
 import textwrap
@@ -9,8 +11,17 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from opentrons.util.performance_helpers import _get_robot_context_tracker
 
-from opentrons.cli.analyze import analyze
+
+# Enable tracking for the RobotContextTracker
+# This must come before the import of the analyze CLI
+context_tracker = _get_robot_context_tracker()
+
+# Ignore the type error for the next line, as we're setting a private attribute for testing purposes
+context_tracker._should_track = True  # type: ignore[attr-defined]
+
+from opentrons.cli.analyze import analyze  # noqa: E402
 
 
 def _list_fixtures(version: int) -> Iterator[Path]:
@@ -242,3 +253,24 @@ def test_python_error_line_numbers(
     assert result.json_output is not None
     [error] = result.json_output["errors"]
     assert error["detail"] == expected_detail
+
+
+def test_track_analysis(tmp_path: Path) -> None:
+    """Test that the RobotContextTracker tracks analysis."""
+    protocol_source = textwrap.dedent(
+        """
+        requirements = {"apiLevel": "2.15"}
+
+        def run(protocol):
+            pass
+        """
+    )
+
+    protocol_source_file = tmp_path / "protocol.py"
+    protocol_source_file.write_text(protocol_source, encoding="utf-8")
+
+    before_analysis = len(context_tracker._storage)  # type: ignore[attr-defined]
+
+    _get_analysis_result([protocol_source_file])
+
+    assert len(context_tracker._storage) == before_analysis + 1  # type: ignore[attr-defined]

--- a/performance-metrics/src/performance_metrics/robot_context_tracker.py
+++ b/performance-metrics/src/performance_metrics/robot_context_tracker.py
@@ -47,10 +47,12 @@ timing_function = _get_timing_function()
 class RobotContextTracker(SupportsTracking):
     """Tracks and stores robot context and execution duration for different operations."""
 
-    def __init__(self, storage_file_path: Path, should_track: bool = False) -> None:
+    FILE_NAME = "context_data.csv"
+
+    def __init__(self, storage_location: Path, should_track: bool = False) -> None:
         """Initializes the RobotContextTracker with an empty storage list."""
         self._storage: deque[RawContextData] = deque()
-        self._storage_file_path = storage_file_path
+        self._storage_file_path = storage_location / self.FILE_NAME
         self._should_track = should_track
 
     def track(self, state: RobotContextState) -> Callable:  # type: ignore

--- a/performance-metrics/tests/performance_metrics/test_robot_context_tracker.py
+++ b/performance-metrics/tests/performance_metrics/test_robot_context_tracker.py
@@ -19,7 +19,7 @@ SHUTTING_DOWN_TIME = 0.005
 @pytest.fixture
 def robot_context_tracker(tmp_path: Path) -> RobotContextTracker:
     """Fixture to provide a fresh instance of RobotContextTracker for each test."""
-    return RobotContextTracker(storage_file_path=tmp_path, should_track=True)
+    return RobotContextTracker(storage_location=tmp_path, should_track=True)
 
 
 def test_robot_context_tracker(robot_context_tracker: RobotContextTracker) -> None:
@@ -242,8 +242,7 @@ def test_no_tracking(tmp_path: Path) -> None:
 
 async def test_storing_to_file(tmp_path: Path) -> None:
     """Tests storing the tracked data to a file."""
-    file_path = tmp_path / "test_file.csv"
-    robot_context_tracker = RobotContextTracker(file_path, should_track=True)
+    robot_context_tracker = RobotContextTracker(tmp_path, should_track=True)
 
     @robot_context_tracker.track(state=RobotContextState.STARTING_UP)
     def starting_robot() -> None:
@@ -263,7 +262,7 @@ async def test_storing_to_file(tmp_path: Path) -> None:
 
     robot_context_tracker.store()
 
-    with open(file_path, "r") as file:
+    with open(robot_context_tracker._storage_file_path, "r") as file:
         lines = file.readlines()
         assert (
             len(lines) == 4

--- a/shared-data/python/opentrons_shared_data/performance/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/performance/dev_types.py
@@ -10,7 +10,7 @@ F = TypeVar("F", bound=Callable[..., Any])
 class SupportsTracking(Protocol):
     """Protocol for classes that support tracking of robot context."""
 
-    def __init__(self, storage_dir: Path, should_track: bool) -> None:
+    def __init__(self, storage_location: Path, should_track: bool) -> None:
         """Initialize the tracker."""
         ...
 


### PR DESCRIPTION
# Overview

Closes https://opentrons.atlassian.net/browse/EXEC-399

Evaluate robot context as `In Analysis` when _analyze is running in `opentrons.cli.analyze`

# Changelog

- Add `performance_metrics_data` directory 
- Inside of performance_helpers.py
    - Add logic to determine if tracking should be enabled (based off FF)
    - Add `track_analysis` factory decorator (I think that is the right name for it lol)
-  Wrap `opentrons.cli.analyze._analyze` with `track_analysis` decorator
- Change attribute naming on SupportsTracking to `storage_location`. If the passed Path wants to be a dir that needs to have a file defined or a direct file path, is an implementation detail.
- Have `RobotContextTracker` define its own file name

# Test Plan

- Verifying storage with tests in test_cli.py. A follow-up PR will implement storing to a file on the robot. At that point, testing will be done on the robot. 
- Did verify that `performance_metrics_data` directory is getting created

# Review requests

None

# Risk assessment

Low, although this is wrapping production code, it is gated by a feature flag that defaults to false