### PR TITLE
feat(protocol-designer): edit multiple modules modal + row

### DIFF
--- a/protocol-designer/src/components/EditModules.tsx
+++ b/protocol-designer/src/components/EditModules.tsx
@@ -1,22 +1,21 @@
 import * as React from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import {
+  FLEX_ROBOT_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
+import {
   selectors as stepFormSelectors,
   actions as stepFormActions,
 } from '../step-forms'
 import { moveDeckItem } from '../labware-ingred/actions/actions'
+import { getRobotType } from '../file-data/selectors'
+import { getEnableMoam } from '../feature-flags/selectors'
+import { EditMultipleModulesModal } from './modals/EditModulesModal/EditMultipleModulesModal'
 import { useBlockingHint } from './Hints/useBlockingHint'
 import { MagneticModuleWarningModalContent } from './modals/EditModulesModal/MagneticModuleWarningModalContent'
 import { EditModulesModal } from './modals/EditModulesModal'
-import {
-  FLEX_ROBOT_TYPE,
-  ModuleModel,
-  ModuleType,
-  TEMPERATURE_MODULE_TYPE,
-  TEMPERATURE_MODULE_V2,
-} from '@opentrons/shared-data'
-import { getRobotType } from '../file-data/selectors'
-import { EditMultipleModulesModal } from './modals/EditModulesModal/EditMultipleModulesModal'
+import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
 
 export interface EditModulesProps {
   moduleToEdit: {
@@ -36,8 +35,11 @@ export const EditModules = (props: EditModulesProps): JSX.Element => {
   const { moduleId, moduleType } = moduleToEdit
   const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const robotType = useSelector(getRobotType)
+  const moamFf = useSelector(getEnableMoam)
   const showMultipleModuleModal =
-    robotType === FLEX_ROBOT_TYPE && moduleType === TEMPERATURE_MODULE_TYPE
+    robotType === FLEX_ROBOT_TYPE &&
+    moduleType === TEMPERATURE_MODULE_TYPE &&
+    moamFf
 
   const moduleOnDeck = moduleId ? _initialDeckSetup.modules[moduleId] : null
   const [
@@ -99,8 +101,8 @@ export const EditModules = (props: EditModulesProps): JSX.Element => {
     modal = (
       <EditMultipleModulesModal
         onCloseClick={onCloseClick}
-        modules={Object.values(_initialDeckSetup.modules)}
-        moduleType={TEMPERATURE_MODULE_TYPE}
+        allModulesOnDeck={Object.values(_initialDeckSetup.modules)}
+        moduleType={moduleType}
       />
     )
   }

--- a/protocol-designer/src/components/EditModules.tsx
+++ b/protocol-designer/src/components/EditModules.tsx
@@ -8,7 +8,15 @@ import { moveDeckItem } from '../labware-ingred/actions/actions'
 import { useBlockingHint } from './Hints/useBlockingHint'
 import { MagneticModuleWarningModalContent } from './modals/EditModulesModal/MagneticModuleWarningModalContent'
 import { EditModulesModal } from './modals/EditModulesModal'
-import { ModuleModel, ModuleType } from '@opentrons/shared-data'
+import {
+  FLEX_ROBOT_TYPE,
+  ModuleModel,
+  ModuleType,
+  TEMPERATURE_MODULE_TYPE,
+  TEMPERATURE_MODULE_V2,
+} from '@opentrons/shared-data'
+import { getRobotType } from '../file-data/selectors'
+import { EditMultipleModulesModal } from './modals/EditModulesModal/EditMultipleModulesModal'
 
 export interface EditModulesProps {
   moduleToEdit: {
@@ -27,6 +35,9 @@ export const EditModules = (props: EditModulesProps): JSX.Element => {
   const { onCloseClick, moduleToEdit } = props
   const { moduleId, moduleType } = moduleToEdit
   const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
+  const robotType = useSelector(getRobotType)
+  const showMultipleModuleModal =
+    robotType === FLEX_ROBOT_TYPE && moduleType === TEMPERATURE_MODULE_TYPE
 
   const moduleOnDeck = moduleId ? _initialDeckSetup.modules[moduleId] : null
   const [
@@ -74,16 +85,24 @@ export const EditModules = (props: EditModulesProps): JSX.Element => {
     enabled: changeModuleWarningInfo !== null,
   })
 
-  return (
-    changeModuleWarning ?? (
-      <EditModulesModal
-        moduleType={moduleType}
-        moduleOnDeck={moduleOnDeck}
+  let modal = (
+    <EditModulesModal
+      moduleType={moduleType}
+      moduleOnDeck={moduleOnDeck}
+      onCloseClick={onCloseClick}
+      editModuleSlot={editModuleSlot}
+      editModuleModel={editModuleModel}
+      displayModuleWarning={displayModuleWarning}
+    />
+  )
+  if (showMultipleModuleModal) {
+    modal = (
+      <EditMultipleModulesModal
         onCloseClick={onCloseClick}
-        editModuleSlot={editModuleSlot}
-        editModuleModel={editModuleModel}
-        displayModuleWarning={displayModuleWarning}
+        modules={Object.values(_initialDeckSetup.modules)}
+        moduleType={TEMPERATURE_MODULE_TYPE}
       />
     )
-  )
+  }
+  return changeModuleWarning ?? modal
 }

--- a/protocol-designer/src/components/__tests__/EditModules.test.tsx
+++ b/protocol-designer/src/components/__tests__/EditModules.test.tsx
@@ -1,19 +1,29 @@
 import * as React from 'react'
 import { screen } from '@testing-library/react'
 import { vi, beforeEach, describe, it } from 'vitest'
+import {
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { i18n } from '../../localization'
 import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { getDismissedHints } from '../../tutorial/selectors'
 import { EditModules } from '../EditModules'
 import { EditModulesModal } from '../modals/EditModulesModal'
 import { renderWithProviders } from '../../__testing-utils__'
+import { getEnableMoam } from '../../feature-flags/selectors'
+import { getRobotType } from '../../file-data/selectors'
+import { EditMultipleModulesModal } from '../modals/EditModulesModal/EditMultipleModulesModal'
 
 import type { HintKey } from '../../tutorial'
 
 vi.mock('../../step-forms/selectors')
+vi.mock('../modals/EditModulesModal/EditMultipleModulesModal')
 vi.mock('../modals/EditModulesModal')
 vi.mock('../../tutorial/selectors')
-
+vi.mock('../../file-data/selectors')
+vi.mock('../../feature-flags/selectors')
 const render = (props: React.ComponentProps<typeof EditModules>) => {
   return renderWithProviders(<EditModules {...props} />, {
     i18nInstance: i18n,
@@ -51,11 +61,22 @@ describe('EditModules', () => {
     vi.mocked(EditModulesModal).mockReturnValue(
       <div>mock EditModulesModal</div>
     )
+    vi.mocked(EditMultipleModulesModal).mockReturnValue(
+      <div>mock EditMultipleModulesModal</div>
+    )
     vi.mocked(getDismissedHints).mockReturnValue([hintKey])
+    vi.mocked(getRobotType).mockReturnValue(OT2_ROBOT_TYPE)
+    vi.mocked(getEnableMoam).mockReturnValue(true)
   })
 
-  it('renders the edit modules modal', () => {
+  it('renders the edit modules modal for single modules', () => {
     render(props)
     screen.getByText('mock EditModulesModal')
+  })
+  it('renders multiple edit modules modal', () => {
+    props.moduleToEdit.moduleType = TEMPERATURE_MODULE_TYPE
+    vi.mocked(getRobotType).mockReturnValue(FLEX_ROBOT_TYPE)
+    render(props)
+    screen.getByText('mock EditMultipleModulesModal')
   })
 })

--- a/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
@@ -61,15 +61,16 @@ const EditMultipleModulesModalComponent = (
     defaultValue: moduleLocations ?? [],
   })
 
-  const areSlotsEmpty = selectedSlots.map(slot => {
-    return (
-      getSlotIsEmpty(initialDeckSetup, slot) &&
-      modules.find(module => module.type === moduleType && module.slot !== slot)
-    )
+  const areSlotsEmpty = selectedSlots.map(s => {
+    const hasModSlot =
+      modules.find(
+        module => module.type === moduleType && s === `cutout${module.slot}`
+      ) != null
+    return getSlotIsEmpty(initialDeckSetup, s) || hasModSlot
   })
 
   const hasConflictedSlot = areSlotsEmpty.includes(false)
-  const mappedStagingAreas: DeckConfiguration =
+  const mappedModules: DeckConfiguration =
     modules.length > 0
       ? modules.flatMap(module => {
           return [
@@ -89,16 +90,14 @@ const EditMultipleModulesModalComponent = (
 
   STANDARD_EMPTY_SLOTS.forEach(emptySlot => {
     if (
-      !mappedStagingAreas.some(
-        ({ cutoutId }) => cutoutId === emptySlot.cutoutId
-      )
+      !mappedModules.some(({ cutoutId }) => cutoutId === emptySlot.cutoutId)
     ) {
-      mappedStagingAreas.push(emptySlot)
+      mappedModules.push(emptySlot)
     }
   })
 
   const selectableSlots =
-    mappedStagingAreas.length > 0 ? mappedStagingAreas : STANDARD_EMPTY_SLOTS
+    mappedModules.length > 0 ? mappedModules : STANDARD_EMPTY_SLOTS
   const [updatedSlots, setUpdatedSlots] = React.useState<DeckConfiguration>(
     selectableSlots
   )
@@ -155,7 +154,7 @@ const EditMultipleModulesModalComponent = (
             {hasConflictedSlot ? (
               <PDAlert
                 alertType="warning"
-                title={'Slot occupied'}
+                title={t('alert:module_placement.SLOT_OCCUPIED.title')}
                 description={''}
               />
             ) : null}
@@ -206,9 +205,9 @@ export const EditMultipleModulesModal = (
   const moduleLocations = Object.values(modules)
     .filter(module => module.type === moduleType)
     .map(temp => `cutout${temp.slot}`)
+
   const onSaveClick = (data: EditMultipleModulesModalValues): void => {
     onCloseClick()
-
     data.selectedAddressableAreas.forEach(aa => {
       if (!moduleLocations?.includes(aa)) {
         dispatch(
@@ -218,7 +217,6 @@ export const EditMultipleModulesModal = (
             model: TEMPERATURE_MODULE_V2,
           })
         )
-      } else {
       }
     })
     Object.values(modules).forEach(module => {
@@ -232,7 +230,9 @@ export const EditMultipleModulesModal = (
     <form onSubmit={handleSubmit(onSaveClick)}>
       <ModalShell width="48rem">
         <Box marginTop={SPACING.spacing32} paddingX={SPACING.spacing32}>
-          <Text as="h2">{'Temperature modules'}</Text>
+          <Text as="h2">
+            {t('module_display_names.multipleTemperatureModuleTypes')}
+          </Text>
         </Box>
         <EditMultipleModulesModalComponent
           onCloseClick={onCloseClick}

--- a/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector, useDispatch } from 'react-redux'
-import {
-  Control,
-  Controller,
-  ControllerRenderProps,
-  useForm,
-  useWatch,
-} from 'react-hook-form'
+import { Controller, useForm, useWatch } from 'react-hook-form'
 import {
   BUTTON_TYPE_SUBMIT,
   OutlineButton,
@@ -36,6 +30,7 @@ import { getLabwareOnSlot, getSlotIsEmpty } from '../../../step-forms'
 import { getInitialDeckSetup } from '../../../step-forms/selectors'
 import { getLabwareIsCompatible } from '../../../utils/labwareModuleCompatibility'
 import { PDAlert } from '../../alerts/PDAlert'
+import type { Control, ControllerRenderProps } from 'react-hook-form'
 import type { CutoutId, ModuleType } from '@opentrons/shared-data'
 import type { ModuleOnDeck } from '../../../step-forms'
 

--- a/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
@@ -1,0 +1,247 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSelector, useDispatch } from 'react-redux'
+import {
+  Control,
+  Controller,
+  ControllerRenderProps,
+  useForm,
+  useWatch,
+} from 'react-hook-form'
+import {
+  BUTTON_TYPE_SUBMIT,
+  OutlineButton,
+  ModalShell,
+  Flex,
+  SPACING,
+  DIRECTION_ROW,
+  Box,
+  Text,
+  ALIGN_CENTER,
+  JUSTIFY_FLEX_END,
+  JUSTIFY_END,
+  DeckConfigurator,
+  DIRECTION_COLUMN,
+} from '@opentrons/components'
+import {
+  DeckConfiguration,
+  SINGLE_RIGHT_SLOT_FIXTURE,
+  TEMPERATURE_MODULE_CUTOUTS,
+  TEMPERATURE_MODULE_TYPE,
+  TEMPERATURE_MODULE_V2,
+  TEMPERATURE_MODULE_V2_FIXTURE,
+} from '@opentrons/shared-data'
+import { createModule, deleteModule } from '../../../step-forms/actions'
+import { getSlotIsEmpty } from '../../../step-forms'
+import { getInitialDeckSetup } from '../../../step-forms/selectors'
+import { PDAlert } from '../../alerts/PDAlert'
+import type { CutoutId, ModuleType } from '@opentrons/shared-data'
+import type { ModuleOnDeck } from '../../../step-forms'
+
+export interface EditMultipleModulesModalValues {
+  selectedAddressableAreas: string[]
+}
+
+interface EditMultipleModulesModalComponentProps
+  extends EditMultipleModulesModalProps {
+  control: Control<EditMultipleModulesModalValues, 'selectedAddressableAreas'>
+  moduleLocations: string[] | null
+}
+
+const EditMultipleModulesModalComponent = (
+  props: EditMultipleModulesModalComponentProps
+): JSX.Element => {
+  const { t } = useTranslation(['button', 'alert'])
+  const { onCloseClick, modules, control, moduleLocations, moduleType } = props
+  const initialDeckSetup = useSelector(getInitialDeckSetup)
+
+  const selectedSlots = useWatch({
+    control,
+    name: 'selectedAddressableAreas',
+    defaultValue: moduleLocations ?? [],
+  })
+
+  const areSlotsEmpty = selectedSlots.map(slot => {
+    return (
+      getSlotIsEmpty(initialDeckSetup, slot) &&
+      modules.find(module => module.type === moduleType && module.slot !== slot)
+    )
+  })
+
+  const hasConflictedSlot = areSlotsEmpty.includes(false)
+  const mappedStagingAreas: DeckConfiguration =
+    modules.length > 0
+      ? modules.flatMap(module => {
+          return [
+            {
+              cutoutId: `cutout${module.slot}` as CutoutId,
+              cutoutFixtureId: TEMPERATURE_MODULE_V2_FIXTURE,
+            },
+          ]
+        })
+      : []
+  const STANDARD_EMPTY_SLOTS: DeckConfiguration = TEMPERATURE_MODULE_CUTOUTS.map(
+    cutoutId => ({
+      cutoutId,
+      cutoutFixtureId: SINGLE_RIGHT_SLOT_FIXTURE,
+    })
+  )
+
+  STANDARD_EMPTY_SLOTS.forEach(emptySlot => {
+    if (
+      !mappedStagingAreas.some(
+        ({ cutoutId }) => cutoutId === emptySlot.cutoutId
+      )
+    ) {
+      mappedStagingAreas.push(emptySlot)
+    }
+  })
+
+  const selectableSlots =
+    mappedStagingAreas.length > 0 ? mappedStagingAreas : STANDARD_EMPTY_SLOTS
+  const [updatedSlots, setUpdatedSlots] = React.useState<DeckConfiguration>(
+    selectableSlots
+  )
+
+  const handleClickAdd = (
+    cutoutId: string,
+    field: ControllerRenderProps<
+      EditMultipleModulesModalValues,
+      'selectedAddressableAreas'
+    >
+  ): void => {
+    const modifiedSlots: DeckConfiguration = updatedSlots.map(slot => {
+      if (slot.cutoutId === cutoutId) {
+        return {
+          ...slot,
+          cutoutFixtureId: TEMPERATURE_MODULE_V2_FIXTURE,
+        }
+      }
+      return slot
+    })
+    setUpdatedSlots(modifiedSlots)
+    const updatedSelectedSlots = [...selectedSlots, cutoutId]
+    field.onChange(updatedSelectedSlots)
+  }
+
+  const handleClickRemove = (
+    cutoutId: string,
+    field: ControllerRenderProps<
+      EditMultipleModulesModalValues,
+      'selectedAddressableAreas'
+    >
+  ): void => {
+    const modifiedSlots: DeckConfiguration = updatedSlots.map(slot => {
+      if (slot.cutoutId === cutoutId) {
+        return { ...slot, cutoutFixtureId: SINGLE_RIGHT_SLOT_FIXTURE }
+      }
+      return slot
+    })
+    setUpdatedSlots(modifiedSlots)
+
+    field.onChange(selectedSlots.filter(item => item !== cutoutId))
+  }
+
+  return (
+    <>
+      <Flex height="23rem" flexDirection={DIRECTION_COLUMN}>
+        <Flex
+          justifyContent={JUSTIFY_END}
+          alignItems={ALIGN_CENTER}
+          height="4rem"
+          paddingX={SPACING.spacing32}
+        >
+          <Box>
+            {hasConflictedSlot ? (
+              <PDAlert
+                alertType="warning"
+                title={'Slot occupied'}
+                description={''}
+              />
+            ) : null}
+          </Box>
+        </Flex>
+        <Controller
+          name="selectedAddressableAreas"
+          control={control}
+          defaultValue={moduleLocations ?? []}
+          render={({ field }) => (
+            <DeckConfigurator
+              deckConfig={updatedSlots}
+              handleClickAdd={cutoutId => handleClickAdd(cutoutId, field)}
+              handleClickRemove={cutoutId => handleClickRemove(cutoutId, field)}
+              showExpansion={false}
+            />
+          )}
+        />
+      </Flex>
+      <Flex
+        flexDirection={DIRECTION_ROW}
+        justifyContent={JUSTIFY_FLEX_END}
+        paddingRight={SPACING.spacing32}
+        paddingBottom={SPACING.spacing32}
+        gridGap={SPACING.spacing8}
+      >
+        <OutlineButton onClick={onCloseClick}>{t('cancel')}</OutlineButton>
+        <OutlineButton type={BUTTON_TYPE_SUBMIT} disabled={hasConflictedSlot}>
+          {t('save')}
+        </OutlineButton>
+      </Flex>
+    </>
+  )
+}
+
+export interface EditMultipleModulesModalProps {
+  onCloseClick: () => void
+  modules: ModuleOnDeck[]
+  moduleType: ModuleType
+}
+export const EditMultipleModulesModal = (
+  props: EditMultipleModulesModalProps
+): JSX.Element => {
+  const { onCloseClick, modules, moduleType } = props
+  const { t } = useTranslation('modules')
+  const dispatch = useDispatch()
+  const { control, handleSubmit } = useForm<EditMultipleModulesModalValues>()
+  const moduleLocations = Object.values(modules)
+    .filter(module => module.type === moduleType)
+    .map(temp => `cutout${temp.slot}`)
+  const onSaveClick = (data: EditMultipleModulesModalValues): void => {
+    onCloseClick()
+
+    data.selectedAddressableAreas.forEach(aa => {
+      if (!moduleLocations?.includes(aa)) {
+        dispatch(
+          createModule({
+            slot: aa.split('cutout')[1],
+            type: TEMPERATURE_MODULE_TYPE,
+            model: TEMPERATURE_MODULE_V2,
+          })
+        )
+      } else {
+      }
+    })
+    Object.values(modules).forEach(module => {
+      if (!data.selectedAddressableAreas.includes(module.slot)) {
+        dispatch(deleteModule(module.id))
+      }
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSaveClick)}>
+      <ModalShell width="48rem">
+        <Box marginTop={SPACING.spacing32} paddingX={SPACING.spacing32}>
+          <Text as="h2">{'Temperature modules'}</Text>
+        </Box>
+        <EditMultipleModulesModalComponent
+          onCloseClick={onCloseClick}
+          modules={modules}
+          control={control}
+          moduleLocations={moduleLocations}
+          moduleType={moduleType}
+        />
+      </ModalShell>
+    </form>
+  )
+}

--- a/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/EditMultipleModulesModal.tsx
@@ -75,13 +75,15 @@ const EditMultipleModulesModalComponent = (
             module.type === moduleType && slot === `cutout${module.slot}`
         ) != null
       const labwareOnSlot = getLabwareOnSlot(initialDeckSetup, slot)
-      const isEmpty = getSlotIsEmpty(initialDeckSetup, slot, true)
       const isLabwareCompatible =
         (labwareOnSlot &&
           getLabwareIsCompatible(labwareOnSlot.def, moduleType)) ??
         true
+      const isEmpty =
+        (getSlotIsEmpty(initialDeckSetup, slot, true) || hasModSlot) &&
+        isLabwareCompatible
 
-      return { slot, isEmpty: (isEmpty || hasModSlot) && isLabwareCompatible }
+      return { slot, isEmpty }
     })
     .filter(slot => !slot.isEmpty)
   const hasConflictedSlot = occupiedCutoutIds.length > 0
@@ -220,9 +222,9 @@ export interface EditMultipleModulesModalProps {
   allModulesOnDeck: ModuleOnDeck[]
   moduleType: ModuleType
 }
-export const EditMultipleModulesModal = (
+export function EditMultipleModulesModal(
   props: EditMultipleModulesModalProps
-): JSX.Element => {
+): JSX.Element {
   const { onCloseClick, allModulesOnDeck, moduleType } = props
   const { t } = useTranslation('modules')
   const dispatch = useDispatch()

--- a/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditMultipleModulesModal.test.tsx
+++ b/protocol-designer/src/components/modals/EditModulesModal/__tests__/EditMultipleModulesModal.test.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fireEvent, screen, cleanup } from '@testing-library/react'
+import { renderWithProviders } from '../../../../__testing-utils__'
+import { i18n } from '../../../../localization'
+import { getInitialDeckSetup } from '../../../../step-forms/selectors'
+import { getLabwareIsCompatible } from '../../../../utils/labwareModuleCompatibility'
+import {
+  getLabwareOnSlot,
+  getSlotIsEmpty,
+  ModuleOnDeck,
+} from '../../../../step-forms'
+import { EditMultipleModulesModal } from '../EditMultipleModulesModal'
+import type * as Components from '@opentrons/components'
+
+vi.mock('../../../../step-forms/selectors')
+vi.mock('../../../../utils/labwareModuleCompatibility')
+vi.mock('../../../../step-forms')
+vi.mock('@opentrons/components', async importOriginal => {
+  const actual = await importOriginal<typeof Components>()
+  return {
+    ...actual,
+    DeckConfigurator: vi.fn(() => <div>mock deck config</div>),
+  }
+})
+
+const render = (
+  props: React.ComponentProps<typeof EditMultipleModulesModal>
+) => {
+  return renderWithProviders(<EditMultipleModulesModal {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+const mockTemp: ModuleOnDeck = {
+  id: 'temperatureId',
+  type: 'temperatureModuleType',
+  model: 'temperatureModuleV2',
+  slot: 'C3',
+  moduleState: {} as any,
+}
+const mockTemp2: ModuleOnDeck = {
+  id: 'temperatureId',
+  type: 'temperatureModuleType',
+  model: 'temperatureModuleV2',
+  slot: 'A1',
+  moduleState: {} as any,
+}
+const mockHS: ModuleOnDeck = {
+  id: 'heaterShakerId',
+  type: 'heaterShakerModuleType',
+  model: 'heaterShakerModuleV1',
+  moduleState: {} as any,
+  slot: 'A1',
+}
+describe('EditMultipleModulesModal', () => {
+  let props: React.ComponentProps<typeof EditMultipleModulesModal>
+  beforeEach(() => {
+    props = {
+      moduleType: 'temperatureModuleType',
+      onCloseClick: vi.fn(),
+      allModulesOnDeck: [mockTemp, mockTemp2],
+    }
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {
+        temperatureId: mockTemp,
+        temperatureId2: mockTemp2,
+      },
+      labware: {},
+      additionalEquipmentOnDeck: {},
+      pipettes: {},
+    })
+    vi.mocked(getLabwareOnSlot).mockReturnValue(null)
+    vi.mocked(getSlotIsEmpty).mockReturnValue(true)
+  })
+  afterEach(() => {
+    cleanup()
+  })
+  it('renders modal and buttons with no error', () => {
+    vi.mocked(getLabwareIsCompatible).mockReturnValue(true)
+    render(props)
+    screen.getByText('mock deck config')
+    screen.getByText('Multiple Temperatures')
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }))
+    expect(props.onCloseClick).toHaveBeenCalled()
+    screen.getByRole('button', { name: 'save' })
+  })
+  it('renders modal with a cannot place module error', () => {
+    vi.mocked(getLabwareOnSlot).mockReturnValue({ slot: 'A1' } as any)
+    vi.mocked(getLabwareIsCompatible).mockReturnValue(false)
+    vi.mocked(getSlotIsEmpty).mockReturnValue(false)
+    props.allModulesOnDeck = [mockTemp, mockTemp2, mockHS]
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {
+        heaterShakerId: mockHS,
+      },
+      labware: {},
+      additionalEquipmentOnDeck: {},
+      pipettes: {},
+    })
+    render(props)
+    screen.getByText('warning')
+    screen.getByText('Cannot place module')
+    screen.getByText('Multiple slots are occupied')
+  })
+})

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -139,7 +139,7 @@ export function EditModulesCard(props: Props): JSX.Element {
                 type={moduleType}
                 moduleOnDeck={moduleData[0]}
                 showCollisionWarnings={warningsEnabled}
-                key={i}
+                key={`${moduleType}_${i}`}
                 openEditModuleModal={openEditModuleModal}
                 robotType={robotType}
               />
@@ -149,7 +149,7 @@ export function EditModulesCard(props: Props): JSX.Element {
               <MultipleModuleRow
                 moduleType={moduleType}
                 moduleOnDeck={moduleData}
-                key={i}
+                key={`${moduleType}_${i}`}
                 moduleOnDeckType={moduleData[0].type}
                 moduleOnDeckModel={moduleData[0].model}
                 openEditModuleModal={openEditModuleModal}
@@ -159,7 +159,7 @@ export function EditModulesCard(props: Props): JSX.Element {
             return (
               <ModuleRow
                 type={moduleType}
-                key={i}
+                key={`noModule_${i}`}
                 openEditModuleModal={openEditModuleModal}
               />
             )

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -147,7 +147,7 @@ export function EditModulesCard(props: Props): JSX.Element {
           } else if (moduleData != null && moduleData.length > 1) {
             return (
               <MultipleModuleRow
-                type={moduleType}
+                moduleType={moduleType}
                 moduleOnDeck={moduleData}
                 key={i}
                 moduleOnDeckType={moduleData[0].type}

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -27,10 +27,12 @@ import { CrashInfoBox } from './CrashInfoBox'
 import { ModuleRow } from './ModuleRow'
 import { AdditionalItemsRow } from './AdditionalItemsRow'
 import { isModuleWithCollisionIssue } from './utils'
-import styles from './styles.module.css'
-import { AdditionalEquipmentEntity } from '@opentrons/step-generation'
 import { StagingAreasRow } from './StagingAreasRow'
+import { MultipleModuleRow } from './MultipleModuleRow'
 
+import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
+
+import styles from './styles.module.css'
 export interface Props {
   modules: ModulesForEditModulesCard
   openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => void
@@ -38,6 +40,7 @@ export interface Props {
 
 export function EditModulesCard(props: Props): JSX.Element {
   const { modules, openEditModuleModal } = props
+
   const pipettesByMount = useSelector(
     stepFormSelectors.getPipettesForEditPipetteForm
   )
@@ -67,10 +70,10 @@ export function EditModulesCard(props: Props): JSX.Element {
   )
   const hasCrashableMagneticModule =
     magneticModuleOnDeck &&
-    isModuleWithCollisionIssue(magneticModuleOnDeck.model)
+    isModuleWithCollisionIssue(magneticModuleOnDeck[0].model)
   const hasCrashableTempModule =
     temperatureModuleOnDeck &&
-    isModuleWithCollisionIssue(temperatureModuleOnDeck.model)
+    isModuleWithCollisionIssue(temperatureModuleOnDeck[0].model)
   const isHeaterShakerOnDeck = Boolean(heaterShakerOnDeck)
 
   const showTempPipetteCollisons =
@@ -130,15 +133,26 @@ export function EditModulesCard(props: Props): JSX.Element {
         ) : null}
         {SUPPORTED_MODULE_TYPES_FILTERED.map((moduleType, i) => {
           const moduleData = modules[moduleType]
-          if (moduleData) {
+          if (moduleData != null && moduleData.length === 1) {
             return (
               <ModuleRow
                 type={moduleType}
-                moduleOnDeck={moduleData}
+                moduleOnDeck={moduleData[0]}
                 showCollisionWarnings={warningsEnabled}
                 key={i}
                 openEditModuleModal={openEditModuleModal}
                 robotType={robotType}
+              />
+            )
+          } else if (moduleData != null && moduleData.length > 1) {
+            return (
+              <MultipleModuleRow
+                type={moduleType}
+                moduleOnDeck={moduleData}
+                key={i}
+                moduleOnDeckType={moduleData[0].type}
+                moduleOnDeckModel={moduleData[0].model}
+                openEditModuleModal={openEditModuleModal}
               />
             )
           } else {

--- a/protocol-designer/src/components/modules/MultipleModuleRow.tsx
+++ b/protocol-designer/src/components/modules/MultipleModuleRow.tsx
@@ -1,0 +1,122 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
+import {
+  LabeledValue,
+  OutlineButton,
+  ModuleIcon,
+  C_DARK_GRAY,
+  SIZE_1,
+  SPACING,
+} from '@opentrons/components'
+import { actions as stepFormActions, ModuleOnDeck } from '../../step-forms'
+import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../constants'
+import { ModuleDiagram } from './ModuleDiagram'
+import { FlexSlotMap } from './FlexSlotMap'
+import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
+
+import styles from './styles.module.css'
+
+interface MultipleModuleRowProps {
+  type: ModuleType
+  openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => void
+  moduleOnDeckType?: ModuleType
+  moduleOnDeckModel?: ModuleModel
+  moduleOnDeck?: ModuleOnDeck[]
+}
+
+export function MultipleModuleRow(props: MultipleModuleRowProps): JSX.Element {
+  const {
+    moduleOnDeck,
+    openEditModuleModal,
+    moduleOnDeckModel,
+    moduleOnDeckType,
+    type: propsType,
+  } = props
+  const { t } = useTranslation(['modules', 'shared'])
+
+  const type: ModuleType = moduleOnDeckType || propsType
+  const occupiedSlots = moduleOnDeck?.map(module => module.slot) ?? []
+  const occupiedSlotsDisplayName = (
+    moduleOnDeck?.map(module => module.slot) ?? []
+  ).join(', ')
+
+  const setCurrentModule = (moduleType: ModuleType, moduleId?: string) => () =>
+    openEditModuleModal(moduleType, moduleId)
+
+  const addRemoveText = moduleOnDeck ? t('shared:remove') : t('shared:add')
+
+  const dispatch = useDispatch()
+
+  const handleAddOrRemove = (): void => {
+    if (moduleOnDeck != null) {
+      moduleOnDeck.forEach(module => {
+        dispatch(stepFormActions.deleteModule(module.id))
+      })
+    } else {
+      setCurrentModule(type)
+    }
+  }
+  const handleEditModule =
+    moduleOnDeck && setCurrentModule(type, moduleOnDeck[0].id)
+
+  return (
+    <div style={{ marginBottom: SPACING.spacing16 }}>
+      <h4 className={styles.row_title}>
+        <ModuleIcon
+          moduleType={type}
+          size={SIZE_1}
+          color={C_DARK_GRAY}
+          marginRight={SPACING.spacing4}
+        />
+        {t(
+          `module_display_names.${
+            occupiedSlots.length > 1 ? 'multipleTemperatureModuleTypes' : type
+          }`
+        )}
+      </h4>
+      <div className={styles.module_row}>
+        <div className={styles.module_diagram_container}>
+          <ModuleDiagram
+            type={type}
+            model={moduleOnDeckModel || DEFAULT_MODEL_FOR_MODULE_TYPE[type]}
+          />
+        </div>
+        <div className={styles.module_col}>
+          {moduleOnDeckModel && (
+            <LabeledValue
+              label="Model"
+              value={t(`model_display_name.${moduleOnDeckModel}`)}
+            />
+          )}
+        </div>
+        <div className={styles.module_col}>
+          {occupiedSlots.length > 0 ? (
+            <LabeledValue label="Position" value={occupiedSlotsDisplayName} />
+          ) : null}
+        </div>
+        <div className={styles.slot_map}>
+          {occupiedSlots.length > 0 ? (
+            <FlexSlotMap selectedSlots={occupiedSlots} />
+          ) : null}
+        </div>
+        <div className={styles.modules_button_group}>
+          {moduleOnDeck != null ? (
+            <OutlineButton
+              className={styles.module_button}
+              onClick={handleEditModule}
+            >
+              {t('shared:edit')}
+            </OutlineButton>
+          ) : null}
+          <OutlineButton
+            className={styles.module_button}
+            onClick={handleAddOrRemove}
+          >
+            {addRemoveText}
+          </OutlineButton>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/protocol-designer/src/components/modules/MultipleModuleRow.tsx
+++ b/protocol-designer/src/components/modules/MultipleModuleRow.tsx
@@ -6,36 +6,37 @@ import {
   OutlineButton,
   ModuleIcon,
   C_DARK_GRAY,
-  SIZE_1,
   SPACING,
 } from '@opentrons/components'
-import { actions as stepFormActions, ModuleOnDeck } from '../../step-forms'
+import { actions as stepFormActions } from '../../step-forms'
 import { DEFAULT_MODEL_FOR_MODULE_TYPE } from '../../constants'
 import { ModuleDiagram } from './ModuleDiagram'
 import { FlexSlotMap } from './FlexSlotMap'
 import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
+import type { ModuleOnDeck } from '../../step-forms'
 
 import styles from './styles.module.css'
 
-interface MultipleModuleRowProps {
-  type: ModuleType
+interface MultipleModulesRowProps {
+  moduleType: ModuleType
   openEditModuleModal: (moduleType: ModuleType, moduleId?: string) => void
   moduleOnDeckType?: ModuleType
   moduleOnDeckModel?: ModuleModel
   moduleOnDeck?: ModuleOnDeck[]
 }
 
-export function MultipleModuleRow(props: MultipleModuleRowProps): JSX.Element {
+export function MultipleModuleRow(props: MultipleModulesRowProps): JSX.Element {
   const {
     moduleOnDeck,
     openEditModuleModal,
     moduleOnDeckModel,
     moduleOnDeckType,
-    type: propsType,
+    moduleType,
   } = props
   const { t } = useTranslation(['modules', 'shared'])
+  const dispatch = useDispatch()
 
-  const type: ModuleType = moduleOnDeckType || propsType
+  const type: ModuleType = moduleOnDeckType ?? moduleType
   const occupiedSlots = moduleOnDeck?.map(module => module.slot) ?? []
   const occupiedSlotsDisplayName = (
     moduleOnDeck?.map(module => module.slot) ?? []
@@ -45,8 +46,6 @@ export function MultipleModuleRow(props: MultipleModuleRowProps): JSX.Element {
     openEditModuleModal(moduleType, moduleId)
 
   const addRemoveText = moduleOnDeck ? t('shared:remove') : t('shared:add')
-
-  const dispatch = useDispatch()
 
   const handleAddOrRemove = (): void => {
     if (moduleOnDeck != null) {
@@ -65,7 +64,7 @@ export function MultipleModuleRow(props: MultipleModuleRowProps): JSX.Element {
       <h4 className={styles.row_title}>
         <ModuleIcon
           moduleType={type}
-          size={SIZE_1}
+          size="1rem"
           color={C_DARK_GRAY}
           marginRight={SPACING.spacing4}
         />

--- a/protocol-designer/src/components/modules/__tests__/MultipleModuleRow.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/MultipleModuleRow.test.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, screen } from '@testing-library/react'
+
+import { i18n } from '../../../localization'
+import { renderWithProviders } from '../../../__testing-utils__'
+import { MultipleModuleRow } from '../MultipleModuleRow'
+import {
+  TEMPERATURE_MODULE_TYPE,
+  TEMPERATURE_MODULE_V2,
+} from '@opentrons/shared-data'
+import { ModuleOnDeck } from '../../../step-forms'
+import { FlexSlotMap } from '../FlexSlotMap'
+import { deleteModule } from '../../../step-forms/actions'
+
+vi.mock('../../../step-forms/actions')
+vi.mock('../FlexSlotMap')
+const render = (props: React.ComponentProps<typeof MultipleModuleRow>) => {
+  return renderWithProviders(<MultipleModuleRow {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+const mockTemp: ModuleOnDeck = {
+  id: 'temperatureId',
+  type: 'temperatureModuleType',
+  model: 'temperatureModuleV2',
+  slot: 'C3',
+  moduleState: {} as any,
+}
+const mockTemp2: ModuleOnDeck = {
+  id: 'temperatureId',
+  type: 'temperatureModuleType',
+  model: 'temperatureModuleV2',
+  slot: 'A1',
+  moduleState: {} as any,
+}
+
+describe('MultipleModuleRow', () => {
+  let props: React.ComponentProps<typeof MultipleModuleRow>
+  beforeEach(() => {
+    props = {
+      type: TEMPERATURE_MODULE_TYPE,
+      openEditModuleModal: vi.fn(),
+      moduleOnDeckType: TEMPERATURE_MODULE_TYPE,
+      moduleOnDeckModel: TEMPERATURE_MODULE_V2,
+      moduleOnDeck: [mockTemp, mockTemp2],
+    }
+    vi.mocked(FlexSlotMap).mockReturnValue(<div>mock FlexSlotMap</div>)
+  })
+  it('renders 2 modules in the row with text and buttons', () => {
+    render(props)
+    screen.getByText('Multiple Temperatures')
+    screen.getByText('Position:')
+    screen.getByText('C3, A1')
+    screen.getByText('mock FlexSlotMap')
+    fireEvent.click(screen.getByText('edit'))
+    expect(props.openEditModuleModal).toHaveBeenCalled()
+    fireEvent.click(screen.getByText('remove'))
+    expect(vi.mocked(deleteModule)).toHaveBeenCalled()
+  })
+  it('renders no modules', () => {
+    props.moduleOnDeck = undefined
+    render(props)
+    screen.getByText('add')
+  })
+})

--- a/protocol-designer/src/components/modules/__tests__/MultipleModuleRow.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/MultipleModuleRow.test.tsx
@@ -9,9 +9,9 @@ import {
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V2,
 } from '@opentrons/shared-data'
-import { ModuleOnDeck } from '../../../step-forms'
 import { FlexSlotMap } from '../FlexSlotMap'
 import { deleteModule } from '../../../step-forms/actions'
+import type { ModuleOnDeck } from '../../../step-forms'
 
 vi.mock('../../../step-forms/actions')
 vi.mock('../FlexSlotMap')
@@ -40,7 +40,7 @@ describe('MultipleModuleRow', () => {
   let props: React.ComponentProps<typeof MultipleModuleRow>
   beforeEach(() => {
     props = {
-      type: TEMPERATURE_MODULE_TYPE,
+      moduleType: TEMPERATURE_MODULE_TYPE,
       openEditModuleModal: vi.fn(),
       moduleOnDeckType: TEMPERATURE_MODULE_TYPE,
       moduleOnDeckModel: TEMPERATURE_MODULE_V2,

--- a/protocol-designer/src/localization/en/alert.json
+++ b/protocol-designer/src/localization/en/alert.json
@@ -218,6 +218,11 @@
   "export": "Export",
   "import": "Import",
   "module_placement": {
+    "SLOTS_OCCUPIED": {
+      "title": "Cannot place module",
+      "single": "Slot {{slotName}} is occupied",
+      "multi": "Multiple slots are occupied"
+    },
     "SLOT_OCCUPIED": {
       "title": "Cannot place module",
       "body": "Slot {{selectedSlot}} is occupied. Navigate to the design tab and remove the labware or remove the additional item to continue."

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -6,7 +6,7 @@
     "wasteChute": "Waste Chute"
   },
   "module_display_names": {
-    "multipleTemperatureModuleTypes": "Temperatures",
+    "multipleTemperatureModuleTypes": "Multiple Temperatures",
     "temperatureModuleType": "Temperature",
     "magneticModuleType": "Magnetic",
     "thermocyclerModuleType": "Thermocycler",

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -6,6 +6,7 @@
     "wasteChute": "Waste Chute"
   },
   "module_display_names": {
+    "multipleTemperatureModuleTypes": "Temperatures",
     "temperatureModuleType": "Temperature",
     "magneticModuleType": "Magnetic",
     "thermocyclerModuleType": "Thermocycler",

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -454,7 +454,10 @@ export const getModulesForEditModulesCard: Selector<
   reduce<InitialDeckSetup['modules'], ModulesForEditModulesCard>(
     initialDeckSetup.modules,
     (acc, moduleOnDeck: ModuleOnDeck, id) => {
-      acc[moduleOnDeck.type] = moduleOnDeck
+      if (!acc[moduleOnDeck.type]) {
+        acc[moduleOnDeck.type] = []
+      }
+      acc[moduleOnDeck.type]?.push(moduleOnDeck)
       return acc
     },
     {

--- a/protocol-designer/src/step-forms/types.ts
+++ b/protocol-designer/src/step-forms/types.ts
@@ -72,7 +72,7 @@ export interface ModuleTemporalProperties {
 }
 export type ModuleOnDeck = ModuleEntity & ModuleTemporalProperties
 export type ModulesForEditModulesCard = Partial<
-  Record<ModuleType, ModuleOnDeck | null | undefined>
+  Record<ModuleType, ModuleOnDeck[] | null | undefined>
 >
 // =========== LABWARE ========
 export type NormalizedLabwareById = Record<


### PR DESCRIPTION
closes AUTH-16

# Overview

the edit modules modal for MoaM now works for multiples, and the module row now has knowledge of all of the occupied slots

# Test Plan

Make sure the MoaM ff is turned on and create a flex protocol. Add 1 temperature module in the create file wizard. Then edit the temperature modules and make sure it works as expected.

<img width="823" alt="Screenshot 2024-04-17 at 12 24 14" src="https://github.com/Opentrons/opentrons/assets/66035149/80e2cb35-1903-4d56-8132-0c2c261ebf7d">

<img width="1105" alt="Screenshot 2024-04-17 at 12 24 25" src="https://github.com/Opentrons/opentrons/assets/66035149/4c2f7101-fdc9-470b-b0fa-db928e01042f">

# Changelog

- create a new multiple modules component for row and editing
- add test coverage to those new components
- modify `EditModules` and `EditModulesCard` to accommodate the change
- edit the `getModulesForEditModulesCard` selector to accommodate moam

# Review requests

see test plan

# Risk assessment

low