### PR TITLE
fix(app): add optional description icon to dropdownMenu

### DIFF
--- a/app/src/atoms/MenuList/DropdownMenu.tsx
+++ b/app/src/atoms/MenuList/DropdownMenu.tsx
@@ -15,7 +15,9 @@ import {
   TYPOGRAPHY,
   useOnClickOutside,
   POSITION_RELATIVE,
+  useHoverTooltip,
 } from '@opentrons/components'
+import { Tooltip } from '../Tooltip'
 import { MenuItem } from './MenuItem'
 
 export interface DropdownOption {
@@ -33,6 +35,7 @@ export interface DropdownMenuProps {
   dropdownType?: DropdownBorder
   title?: string
   caption?: string | null
+  tooltipText?: string
 }
 
 // TODO: (smb: 4/15/22) refactor this to use html select for accessibility
@@ -46,7 +49,9 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
     dropdownType = 'rounded',
     title,
     caption,
+    tooltipText,
   } = props
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const [showDropdownMenu, setShowDropdownMenu] = React.useState<boolean>(false)
   const toggleSetShowDropdownMenu = (): void => {
     setShowDropdownMenu(!showDropdownMenu)
@@ -96,13 +101,27 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_COLUMN} ref={dropDownMenuWrapperRef}>
       {title !== null ? (
-        <StyledText
-          as="label"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          paddingBottom={SPACING.spacing8}
-        >
-          {title}
-        </StyledText>
+        <Flex gridGap={SPACING.spacing8}>
+          <StyledText
+            as="label"
+            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            paddingBottom={SPACING.spacing8}
+          >
+            {title}
+          </StyledText>
+          {tooltipText != null ? (
+            <>
+              <Flex {...targetProps}>
+                <Icon
+                  name="information"
+                  size={SPACING.spacing12}
+                  color={COLORS.grey60}
+                />
+              </Flex>
+              <Tooltip tooltipProps={tooltipProps}>{tooltipText}</Tooltip>
+            </>
+          ) : null}
+        </Flex>
       ) : null}
       <Flex flexDirection={DIRECTION_COLUMN} position={POSITION_RELATIVE}>
         <Flex

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -374,6 +374,7 @@ export function ChooseRobotSlideout(
             title={runtimeParam.displayName}
             width="100%"
             dropdownType="neutral"
+            tooltipText={runtimeParam.description}
           />
         )
       } else if (runtimeParam.type === 'int' || runtimeParam.type === 'float') {


### PR DESCRIPTION
closes AUTH-311

# Overview

Add a description icon with a description tooltip to choices dropdown menu for RTP.

# Test Plan

Upload the protocol attached to the ticket's comment and see that there is an icon with a tooltip which matches the description text in the parameters slideout for desktop app

# Changelog

- extend `DropdownMenu` to include an optional tooltip text which renders an icon and tooltip
- add tooltip text prop to the slideout
# Review requests

see test plan

# Risk assessment

low

