### PR TITLE
ci(components): fix github deploy action

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -178,6 +178,7 @@ jobs:
         run: |
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
+          make setup-js
       - name: 'build typescript'
         run: make build-ts
       - name: 'build library'


### PR DESCRIPTION
# Overview

Somewhere in the vite migration when we got rid of yarn, adopted pnpm, then got rid of pnpm and brought back yarn we forgot to install deps for the components deploy action. This PR adds a line back to actually install deps.

closes AUTH-331

# Test Plan

- Verified deps get installed in gh action


# Changelog

- Install deps in components deploy action


# Risk assessment

Low
