### PR TITLE
ci(components): install udev before calling setup

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -174,6 +174,8 @@ jobs:
         with:
           node-version: '18.19.0'
           registry-url: 'https://registry.npmjs.org'
+      - name: 'install udev for usb-detection'
+        run: sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'setup-js'
         run: |
           npm config set cache ./.npm-cache


### PR DESCRIPTION
# Overview

Follow up to https://github.com/Opentrons/opentrons/pull/14935

This PR explicitly installs udev before calling make setup in the components CI workflow. This is required to do a full make setup because our usb bindings need it. 

Hopefully closes [AUTH-331](https://opentrons.atlassian.net/browse/AUTH-331) but I need to push another tag to verify

# Risk assessment

Low

[AUTH-331]: https://opentrons.atlassian.net/browse/AUTH-331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ