### PR TITLE
fix(api): better error message for non-string variable names and min/max validation adjustment

### DIFF
--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -222,7 +222,7 @@ def _validate_min_and_max(
             # These asserts are for the type checker and should never actually be asserted false
             assert isinstance(minimum, (int, float))
             assert isinstance(maximum, (int, float))
-            if maximum <= minimum:
+            if maximum < minimum:
                 raise ParameterDefinitionError(
                     "Maximum must be greater than the minimum"
                 )

--- a/api/src/opentrons/protocols/parameters/validation.py
+++ b/api/src/opentrons/protocols/parameters/validation.py
@@ -20,7 +20,7 @@ def validate_variable_name_unique(
     variable_name: str, other_variable_names: Set[str]
 ) -> None:
     """Validate that the given variable name is unique."""
-    if variable_name in other_variable_names:
+    if isinstance(variable_name, str) and variable_name in other_variable_names:
         raise ParameterNameError(
             f'"{variable_name}" is already defined as a variable name for another parameter.'
             f" All variable names must be unique."

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -13,8 +13,9 @@ from opentrons.protocols.parameters import validation as subject
 
 
 def test_validate_variable_name_unique() -> None:
-    """It should no-op if the name is unique and raise if it is not."""
+    """It should no-op if the name is unique or if it's not a string, and raise if it is not."""
     subject.validate_variable_name_unique("one of a kind", {"fee", "foo", "fum"})
+    subject.validate_variable_name_unique({}, {"fee", "foo", "fum"})  # type: ignore[arg-type]
     with pytest.raises(ParameterNameError):
         subject.validate_variable_name_unique("copy", {"paste", "copy", "cut"})
 

--- a/api/tests/opentrons/protocols/parameters/test_validation.py
+++ b/api/tests/opentrons/protocols/parameters/test_validation.py
@@ -104,10 +104,12 @@ def test_ensure_variable_name_raises_keyword(variable_name: str) -> None:
 def test_validate_options() -> None:
     """It should not raise when given valid constraints"""
     subject.validate_options(123, 1, 100, None, int)
+    subject.validate_options(123, 100, 100, None, int)
     subject.validate_options(
         123, None, None, [{"display_name": "abc", "value": 456}], int
     )
     subject.validate_options(12.3, 1.1, 100.9, None, float)
+    subject.validate_options(12.3, 1.1, 1.1, None, float)
     subject.validate_options(
         12.3, None, None, [{"display_name": "abc", "value": 45.6}], float
     )


### PR DESCRIPTION
# Overview

Closes AUTH-303.

This PR fixes an issue where if a non-string was given for a variable name, it would fail with an unhelpful error message instead of raising the proper error saying that the variable name was not a string. This was due to the uniqueness check which was not checking if the variable name was a string, which could lead to `unhashable type` errors for certain values (like dictionaries).

The other part of this PR is a small adjustment to the validation for minimum and maximum. Previously we would not allow minimum and maximum values that were the same. After talk with the Authorship team, it was decided that these values _would_ be allowed, since there is one valid option for the parameter. This matches with the current behavior of allowing only one `choice` parameter. The error message "Maximum must be greater than the minimum" was kept however, so as not to point users in this direction.

# Test Plan

Tested that this protocol fails with a "Variable name must be a string." error

```
metadata = {
    "protocolName": "RTP variable name dict",
}
requirements = {"robotType": "OT-2", "apiLevel": "2.18"}
def add_parameters(parameters):
    parameters.add_int(
        display_name="int 1",
        variable_name={},
        default=1,
        minimum=1,
        maximum=3,
    )

def run(context):
    for variable_name, value in context.params.get_all().items():
        context.comment(f"variable {variable_name} has value {value}")
```

and this following PR passes analysis

```
metadata = {
    "protocolName": "RTP Parameters with Min=Max",
}
requirements = {"robotType": "OT-2", "apiLevel": "2.18"}

def add_parameters(parameters):
    parameters.add_int(
        display_name="Display Name",
        variable_name="int_var",
        default=5,
        minimum=5,
        maximum=5,
    )
    parameters.add_float(
        display_name="Display Name",
        variable_name="float_var",
        default=5.0,
        minimum=5.0,
        maximum=5.0,
    )


def run(context):
    for variable_name, value in context.params.get_all().items():
        context.comment(f"variable {variable_name} has value {value}")
```

# Changelog

- Fix uniqueness check for variable names to ignore non-string values (those will be caught on a later validation check)
- Allow `minimum` and `maximum` to be the same for int and float parameters

# Review requests

# Risk assessment

Low