### PR TITLE
fix(app): reset robot and protocol slideout states on close

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -331,6 +331,15 @@ export function ChooseProtocolSlideoutComponent(
       }
     }) ?? null
 
+  const resetRunTimeParameters = (): void => {
+    setRunTimeParametersOverrides(
+      runTimeParametersOverrides?.map(parameter => ({
+        ...parameter,
+        value: parameter.default,
+      }))
+    )
+  }
+
   const pageTwoBody = (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <Flex justifyContent={JUSTIFY_END}>
@@ -339,13 +348,7 @@ export function ChooseProtocolSlideoutComponent(
           css={
             isRestoreDefaultsLinkEnabled ? ENABLED_LINK_CSS : DISABLED_LINK_CSS
           }
-          onClick={() => {
-            const clone = runTimeParametersOverrides.map(parameter => ({
-              ...parameter,
-              value: parameter.default,
-            }))
-            setRunTimeParametersOverrides(clone)
-          }}
+          onClick={resetRunTimeParameters}
           paddingBottom={SPACING.spacing10}
           {...targetProps}
         >
@@ -408,7 +411,11 @@ export function ChooseProtocolSlideoutComponent(
   return (
     <MultiSlideout
       isExpanded={showSlideout}
-      onCloseClick={onCloseClick}
+      onCloseClick={() => {
+        onCloseClick()
+        setCurrentPage(1)
+        resetRunTimeParameters()
+      }}
       currentStep={currentPage}
       maxSteps={hasRunTimeParameters ? 2 : 1}
       title={t('choose_protocol_to_run', { name })}

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -113,6 +113,7 @@ interface ChooseRobotSlideoutProps
   showIdleOnly?: boolean
   multiSlideout?: { currentPage: number } | null
   setHasParamError?: (isError: boolean) => void
+  resetRunTimeParameters?: () => void
 }
 
 export function ChooseRobotSlideout(
@@ -139,6 +140,7 @@ export function ChooseRobotSlideout(
     runTimeParametersOverrides,
     setRunTimeParametersOverrides,
     setHasParamError,
+    resetRunTimeParameters = () => {},
   } = props
 
   const dispatch = useDispatch<Dispatch>()
@@ -506,15 +508,7 @@ export function ChooseRobotSlideout(
                 ? ENABLED_LINK_CSS
                 : DISABLED_LINK_CSS
             }
-            onClick={() => {
-              const clone = runTimeParametersOverrides.map(parameter => ({
-                ...parameter,
-                value: parameter.default,
-              }))
-              if (setRunTimeParametersOverrides != null) {
-                setRunTimeParametersOverrides(clone)
-              }
-            }}
+            onClick={() => resetRunTimeParameters()}
             paddingBottom={SPACING.spacing10}
             {...targetProps}
           >

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -508,9 +508,7 @@ export function ChooseRobotSlideout(
                 ? ENABLED_LINK_CSS
                 : DISABLED_LINK_CSS
             }
-            onClick={
-              resetRunTimeParameters !== undefined && resetRunTimeParameters()
-            }
+            onClick={() => resetRunTimeParameters?.()}
             paddingBottom={SPACING.spacing10}
             {...targetProps}
           >

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -140,7 +140,7 @@ export function ChooseRobotSlideout(
     runTimeParametersOverrides,
     setRunTimeParametersOverrides,
     setHasParamError,
-    resetRunTimeParameters = () => {},
+    resetRunTimeParameters,
   } = props
 
   const dispatch = useDispatch<Dispatch>()
@@ -508,7 +508,9 @@ export function ChooseRobotSlideout(
                 ? ENABLED_LINK_CSS
                 : DISABLED_LINK_CSS
             }
-            onClick={() => resetRunTimeParameters()}
+            onClick={
+              resetRunTimeParameters != undefined && resetRunTimeParameters()
+            }
             paddingBottom={SPACING.spacing10}
             {...targetProps}
           >

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -509,7 +509,7 @@ export function ChooseRobotSlideout(
                 : DISABLED_LINK_CSS
             }
             onClick={
-              resetRunTimeParameters != undefined && resetRunTimeParameters()
+              resetRunTimeParameters !== undefined && resetRunTimeParameters()
             }
             paddingBottom={SPACING.spacing10}
             {...targetProps}

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -132,6 +132,8 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     'downgrade',
   ].includes(autoUpdateAction)
 
+  const hasRunTimeParameters = runTimeParameters.length > 0
+
   if (
     protocolKey == null ||
     srcFileNames == null ||
@@ -174,7 +176,14 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     </PrimaryButton>
   )
 
-  const hasRunTimeParameters = runTimeParameters.length > 0
+  const resetRunTimeParameters = (): void => {
+    setRunTimeParametersOverrides(
+      runTimeParametersOverrides?.map(parameter => ({
+        ...parameter,
+        value: parameter.default,
+      }))
+    )
+  }
 
   return (
     <ChooseRobotSlideout
@@ -183,7 +192,12 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       isSelectedRobotOnDifferentSoftwareVersion={
         isSelectedRobotOnDifferentSoftwareVersion
       }
-      onCloseClick={onCloseClick}
+      onCloseClick={() => {
+        onCloseClick()
+        resetRunTimeParameters()
+        setCurrentPage(1)
+        setSelectedRobot(null)
+      }}
       title={
         hasRunTimeParameters && currentPage === 2
           ? t('select_parameters_for_robot', {
@@ -250,8 +264,9 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       reset={resetCreateRun}
       runCreationError={runCreationError}
       runCreationErrorCode={runCreationErrorCode}
-      showIdleOnly={true}
+      showIdleOnly
       setHasParamError={setHasParamError}
+      resetRunTimeParameters={resetRunTimeParameters}
     />
   )
 }


### PR DESCRIPTION
closes [RQA-2572](https://opentrons.atlassian.net/browse/RQA-2572)

# Overview

When a user clicks out of a ChooseRobot or ChooseProtocol slideout, the slideout should
1) reset to the first page if a multi-page slideout
2) reset default robot or protocol selection to the first valid option if one exists, and 
3) restore runtime parameter values to default if setting up protocol.

Note that if a user is on runtime parameters step and selects 'Change robot', any overriden parameter values will persist when parameter setup screen is proceeded to again.

https://github.com/Opentrons/opentrons/assets/47604184/e2bfea1b-56f6-4465-9bd0-e7147c69835e


# Test Plan

### ChooseProtocolSlideout
- Select a robot
- Select overflow menu > run a protocol 
- Select an RTP protocol
- Continue to parameters
- Enter override values
- Close slideout
- Reopen slideout by again selecting overflow menu > run a protocol
- Verify that you land back on protocol selection page and selected protocol is reset to first option

### ChooseRobotToRunProtooclSlideout
- Select a protocol
- Select Start setup
- Select a robot
- Continue to parameters
- Enter override values
- Close slideout
- Reopen slideout by again selecting Start setup
- Verify that you land back on robot selection page and selected robot is reset to first option
- Continue to parameters again
- Enter override values
- Select "change robot" and select a new robot
- Continue to parameters again
- Verify that parameter overrides persist

# Changelog

- add behavior to `onCloseClick` callback to reset slideout page number and parameter values

# Review requests

auth

# Risk assessment

low

[RQA-2572]: https://opentrons.atlassian.net/browse/RQA-2572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ