### PR TITLE
fix(hardware): remove can messenger `motor_enabled` listener

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
@@ -122,7 +122,9 @@ async def get_motor_enabled(
             )
         else:
             log.debug("Read motor status terminated, no missing nodes.")
-    return reported
+    finally:
+        can_messenger.remove_listener(_listener)
+        return reported
 
 
 async def get_tip_motor_enabled(


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When #14479 was added, the motor enable message listener was never cleaned up properly and thus causing the robot to slow down significantly as it runs more and more move commands. 
