### PR TITLE
fix(app): ensure ApplyHistoricOffsets renders on non-RTP protocols

### DIFF
--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -403,4 +403,18 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     })
     expect(proceedButton).toBeDisabled()
   })
+
+  it('renders labware offset data selection and learn more button launches help modal', () => {
+    render({
+      storedProtocolData: storedProtocolDataFixture,
+      onCloseClick: vi.fn(),
+      showSlideout: true,
+    })
+    screen.getByText('No offset data available')
+    const learnMoreLink = screen.getByText('Learn more')
+    fireEvent.click(learnMoreLink)
+    screen.getByText(
+      'Labware offset data references previous protocol run labware locations to save you time. If all the labware in this protocol have been checked in previous runs, that data will be applied to this run.'
+    )
+  })
 })

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -158,7 +158,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       ? mostRecentAnalysis?.robotType ?? null
       : null
 
-  const SinglePageButtonWithoutFF = (
+  const singlePageButton = (
     <PrimaryButton
       disabled={
         isCreatingRun ||
@@ -259,7 +259,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
           ) : (
             <>
               {offsetsComponent}
-              {SinglePageButtonWithoutFF}
+              {singlePageButton}
             </>
           )}
         </Flex>

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -176,6 +176,17 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     </PrimaryButton>
   )
 
+  const offsetsComponent = (
+    <ApplyHistoricOffsets
+      offsetCandidates={offsetCandidates}
+      shouldApplyOffsets={shouldApplyOffsets}
+      setShouldApplyOffsets={setShouldApplyOffsets}
+      commands={mostRecentAnalysis?.commands ?? []}
+      labware={mostRecentAnalysis?.labware ?? []}
+      modules={mostRecentAnalysis?.modules ?? []}
+    />
+  )
+
   const resetRunTimeParameters = (): void => {
     setRunTimeParametersOverrides(
       runTimeParametersOverrides?.map(parameter => ({
@@ -214,14 +225,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
           {hasRunTimeParameters ? (
             currentPage === 1 ? (
               <>
-                <ApplyHistoricOffsets
-                  offsetCandidates={offsetCandidates}
-                  shouldApplyOffsets={shouldApplyOffsets}
-                  setShouldApplyOffsets={setShouldApplyOffsets}
-                  commands={mostRecentAnalysis?.commands ?? []}
-                  labware={mostRecentAnalysis?.labware ?? []}
-                  modules={mostRecentAnalysis?.modules ?? []}
-                />
+                {offsetsComponent}
                 <PrimaryButton
                   onClick={() => setCurrentPage(2)}
                   width="100%"
@@ -253,7 +257,10 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
               </Flex>
             )
           ) : (
-            SinglePageButtonWithoutFF
+            <>
+              {offsetsComponent}
+              {SinglePageButtonWithoutFF}
+            </>
           )}
         </Flex>
       }


### PR DESCRIPTION
closes [RQA-2606](https://opentrons.atlassian.net/browse/RQA-2606)

# Overview

The `ApplyHistoricOffsets` component was accidentally removed from the `ChooseRobotToRunProtocolSlideout` component for non-RTP protocols. Here, I add it back.

# Test Plan

- upload protocol without RTP
- start protocol setup
- verify that labware offsets checkbox shows on slideout footer
<img width="309" alt="Screenshot 2024-04-18 at 12 59 34 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/7e6757ce-7c7b-4ec0-ba24-dc1c0e62f477">

# Changelog

- add back `ApplyHistoricOffsets` component to slideout footer

# Review requests

js

# Risk assessment

low

[RQA-2606]: https://opentrons.atlassian.net/browse/RQA-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ