### PR TITLE
fix(app, api-client): fix choose protocol slideout issue

### DIFF
--- a/api-client/src/protocols/__fixtures__/simpleAnalysisFile.json
+++ b/api-client/src/protocols/__fixtures__/simpleAnalysisFile.json
@@ -3989,6 +3989,5 @@
         }
       ]
     }
-  ],
-  "robotType": "OT-2 Standard"
+  ]
 }

--- a/api-client/src/protocols/__fixtures__/simpleAnalysisFile.json
+++ b/api-client/src/protocols/__fixtures__/simpleAnalysisFile.json
@@ -3989,5 +3989,6 @@
         }
       ]
     }
-  ]
+  ],
+  "robotType": "OT-2 Standard"
 }

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -7,7 +7,10 @@ import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
 import { getStoredProtocols } from '../../../redux/protocol-storage'
 import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
-import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/protocol-storage/__fixtures__'
+import {
+  storedProtocolData as storedProtocolDataFixture,
+  storedProtocolDataWithoutRunTimeParameters,
+} from '../../../redux/protocol-storage/__fixtures__'
 import { useTrackCreateProtocolRunEvent } from '../../../organisms/Devices/hooks'
 import { useCreateRunFromProtocol } from '../../ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol'
 import { ChooseProtocolSlideout } from '../'
@@ -86,34 +89,37 @@ describe('ChooseProtocolSlideout', () => {
     ).toBeInTheDocument()
   })
 
-  // it('calls createRunFromProtocolSource if CTA clicked', () => {
-  //   const protocolDataWithoutRunTimeParameter = {
-  //     ...storedProtocolDataFixture,
-  //     runTimeParameters: [],
-  //   }
-  //   vi.mocked(getStoredProtocols).mockReturnValue([
-  //     protocolDataWithoutRunTimeParameter,
-  //   ])
-  //   render({
-  //     robot: mockConnectableRobot,
-  //     onCloseClick: vi.fn(),
-  //     showSlideout: true,
-  //   })
-  //   const proceedButton = screen.getByRole('button', {
-  //     name: 'Proceed to setup',
-  //   })
-  //   fireEvent.click(proceedButton)
-  //   expect(mockCreateRunFromProtocol).toHaveBeenCalledWith({
-  //     files: [expect.any(File)],
-  //     protocolKey: storedProtocolDataFixture.protocolKey,
-  //   })
-  //   expect(mockTrackCreateProtocolRunEvent).toHaveBeenCalled()
-  // })
+  it('calls createRunFromProtocolSource if CTA clicked', () => {
+    const protocolDataWithoutRunTimeParameter = {
+      ...storedProtocolDataWithoutRunTimeParameters,
+    }
+    console.log(
+      'protocolDataWithoutRunTimeParameter',
+      protocolDataWithoutRunTimeParameter
+    )
+    vi.mocked(getStoredProtocols).mockReturnValue([
+      protocolDataWithoutRunTimeParameter,
+    ])
+    render({
+      robot: mockConnectableRobot,
+      onCloseClick: vi.fn(),
+      showSlideout: true,
+    })
+    const proceedButton = screen.getByRole('button', {
+      name: 'Proceed to setup',
+    })
+    fireEvent.click(proceedButton)
+    expect(mockCreateRunFromProtocol).toHaveBeenCalledWith({
+      files: [expect.any(File)],
+      protocolKey: storedProtocolDataFixture.protocolKey,
+    })
+    expect(mockTrackCreateProtocolRunEvent).toHaveBeenCalled()
+  })
 
   it('move to the second slideout if CTA clicked', () => {
     const protocolDataWithoutRunTimeParameter = {
       ...storedProtocolDataFixture,
-      runTimeParameters: [],
+      robotType: 'OT-2 Standard',
     }
     vi.mocked(getStoredProtocols).mockReturnValue([
       protocolDataWithoutRunTimeParameter,
@@ -132,7 +138,7 @@ describe('ChooseProtocolSlideout', () => {
     screen.getByText('Restore default values')
   })
 
-  // ToDo (kk:04/08) update test for RTP
+  // ToDo (kk:04/18/2024) I will update test for RTP
   /*
   it('renders error state when there is a run creation error', () => {
     vi.mocked(useCreateRunFromProtocol).mockReturnValue({

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -93,10 +93,6 @@ describe('ChooseProtocolSlideout', () => {
     const protocolDataWithoutRunTimeParameter = {
       ...storedProtocolDataWithoutRunTimeParameters,
     }
-    console.log(
-      'protocolDataWithoutRunTimeParameter',
-      protocolDataWithoutRunTimeParameter
-    )
     vi.mocked(getStoredProtocols).mockReturnValue([
       protocolDataWithoutRunTimeParameter,
     ])

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -3,6 +3,8 @@ import { vi, it, describe, expect, beforeEach } from 'vitest'
 import { StaticRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
 
+import { simpleAnalysisFileFixture } from '@opentrons/api-client'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
 import { getStoredProtocols } from '../../../redux/protocol-storage'
@@ -15,6 +17,7 @@ import { useTrackCreateProtocolRunEvent } from '../../../organisms/Devices/hooks
 import { useCreateRunFromProtocol } from '../../ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol'
 import { ChooseProtocolSlideout } from '../'
 import { useNotifyService } from '../../../resources/useNotifyService'
+import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 
 vi.mock('../../ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol')
 vi.mock('../../../redux/protocol-storage')
@@ -33,6 +36,20 @@ const render = (props: React.ComponentProps<typeof ChooseProtocolSlideout>) => {
   )
 }
 
+const modifiedSimpleAnalysisFileFixture = {
+  ...simpleAnalysisFileFixture,
+  robotType: OT2_ROBOT_TYPE,
+}
+const mockStoredProtocolDataFixture = [
+  {
+    ...storedProtocolDataFixture,
+    mostRecentAnalysis: ({
+      ...modifiedSimpleAnalysisFileFixture,
+      runTimeParameters: [],
+    } as any) as ProtocolAnalysisOutput,
+  },
+]
+
 describe('ChooseProtocolSlideout', () => {
   let mockCreateRunFromProtocol = vi.fn()
   let mockTrackCreateProtocolRunEvent = vi.fn()
@@ -41,7 +58,7 @@ describe('ChooseProtocolSlideout', () => {
     mockTrackCreateProtocolRunEvent = vi.fn(
       () => new Promise(resolve => resolve({}))
     )
-    vi.mocked(getStoredProtocols).mockReturnValue([storedProtocolDataFixture])
+    vi.mocked(getStoredProtocols).mockReturnValue(mockStoredProtocolDataFixture)
     vi.mocked(useCreateRunFromProtocol).mockReturnValue({
       createRunFromProtocolSource: mockCreateRunFromProtocol,
       reset: vi.fn(),
@@ -115,7 +132,6 @@ describe('ChooseProtocolSlideout', () => {
   it('move to the second slideout if CTA clicked', () => {
     const protocolDataWithoutRunTimeParameter = {
       ...storedProtocolDataFixture,
-      robotType: 'OT-2 Standard',
     }
     vi.mocked(getStoredProtocols).mockReturnValue([
       protocolDataWithoutRunTimeParameter,

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -461,7 +461,7 @@ export function ChooseProtocolSlideoutComponent(
                 setSelectedProtocol(storedProtocol)
               }
             }}
-            robotName={robot.name}
+            robot={robot}
             {...{ selectedProtocol, runCreationError, runCreationErrorCode }}
           />
         ) : (
@@ -483,7 +483,7 @@ interface StoredProtocolListProps {
   handleSelectProtocol: (storedProtocol: StoredProtocolData | null) => void
   runCreationError: string | null
   runCreationErrorCode: number | null
-  robotName: string
+  robot: Robot
 }
 
 function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
@@ -492,11 +492,13 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
     handleSelectProtocol,
     runCreationError,
     runCreationErrorCode,
-    robotName,
+    robot,
   } = props
   const { t } = useTranslation(['device_details', 'protocol_details', 'shared'])
   const storedProtocols = useSelector((state: State) =>
     getStoredProtocols(state)
+  ).filter(
+    protocol => protocol.mostRecentAnalysis?.robotType === robot.robotModel
   )
   React.useEffect(() => {
     handleSelectProtocol(first(storedProtocols) ?? null)
@@ -585,7 +587,7 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                             color: ${COLORS.red60};
                             text-decoration: ${TYPOGRAPHY.textDecorationUnderline};
                           `}
-                          to={`/devices/${robotName}`}
+                          to={`/devices/${robot.name}`}
                         />
                       ),
                     }}

--- a/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useStoredProtocolAnalysis.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import { vi, it, expect, describe, beforeEach, afterEach } from 'vitest'
 import { when } from 'vitest-when'
-import { QueryClient, QueryClientProvider, UseQueryResult } from 'react-query'
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { Provider } from 'react-redux'
-import { createStore, Store } from 'redux'
+import { createStore } from 'redux'
 import { renderHook } from '@testing-library/react'
 
 import {
@@ -12,12 +12,10 @@ import {
   parsePipetteEntity,
 } from '@opentrons/api-client'
 import { useProtocolQuery } from '@opentrons/react-api-client'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { storedProtocolData } from '../../../../redux/protocol-storage/__fixtures__'
-import {
-  getStoredProtocol,
-  StoredProtocolData,
-} from '../../../../redux/protocol-storage'
+import { getStoredProtocol } from '../../../../redux/protocol-storage'
 import { useStoredProtocolAnalysis } from '../useStoredProtocolAnalysis'
 import {
   LABWARE_ENTITY,
@@ -27,7 +25,10 @@ import {
 } from '../__fixtures__/storedProtocolAnalysis'
 import { useNotifyRunQuery } from '../../../../resources/runs'
 
+import type { Store } from 'redux'
+import type { UseQueryResult } from 'react-query'
 import type { Protocol, Run } from '@opentrons/api-client'
+import type { StoredProtocolData } from '../../../../redux/protocol-storage'
 
 vi.mock('@opentrons/api-client')
 vi.mock('@opentrons/react-api-client')
@@ -44,6 +45,7 @@ const modifiedStoredProtocolData = {
     errors: storedProtocolData?.mostRecentAnalysis?.errors,
     runTimeParameters:
       storedProtocolData?.mostRecentAnalysis?.runTimeParameters,
+    robotType: OT2_ROBOT_TYPE,
   },
 }
 

--- a/app/src/redux/protocol-storage/__fixtures__/index.ts
+++ b/app/src/redux/protocol-storage/__fixtures__/index.ts
@@ -11,6 +11,17 @@ export const storedProtocolData: StoredProtocolData = {
   modified: 123456789,
 }
 
+export const storedProtocolDataWithoutRunTimeParameters: StoredProtocolData = {
+  protocolKey: 'protocolKeyStub',
+  mostRecentAnalysis: ({
+    ...simpleAnalysisFileFixture,
+    runTimeParameters: [],
+  } as any) as ProtocolAnalysisOutput,
+  srcFileNames: ['fakeSrcFileName'],
+  srcFiles: ['fakeSrcFile' as any],
+  modified: 123456789,
+}
+
 export const storedProtocolDir: StoredProtocolDir = {
   dirPath: 'path/to/protocol/dir',
   modified: 1234556789,


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Slideout only shows protocols that have the same robotType as well as the selected robot.
As a result, the issue Nus faced won't happen. 

I noticed that the data we use for RTP/non-RTP is wrong.
We used something like below but runtimeParameter is under mostRecentAnalisys and the following doesn't work as non-runtime parameter protocol.

I will update the test in a following pr. 

```
...dataFixture,
runtimeParameter: []
```

close RQA-2607
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add filter to storedProtocol to hide unnecessary protocols(different from the selected robot's robotType)
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
