### PR TITLE
feat(app): add tiprack selection step to quick transfer flow

### DIFF
--- a/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
@@ -79,9 +79,12 @@ export function SelectPipette(props: SelectPipetteProps): JSX.Element {
         marginTop={SPACING.spacing120}
         flexDirection={DIRECTION_COLUMN}
         padding={`${SPACING.spacing16} ${SPACING.spacing60} ${SPACING.spacing40} ${SPACING.spacing60}`}
-        gridGap={SPACING.spacing16}
+        gridGap={SPACING.spacing4}
       >
-        <StyledText css={TYPOGRAPHY.level4HeaderRegular}>
+        <StyledText
+          css={TYPOGRAPHY.level4HeaderRegular}
+          paddingBottom={SPACING.spacing8}
+        >
           {t('pipette_currently_attached')}
         </StyledText>
         {leftPipetteSpecs != null ? (

--- a/app/src/organisms/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectTipRack.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { Flex, SPACING, DIRECTION_COLUMN } from '@opentrons/components'
+import { getAllDefinitions } from '@opentrons/shared-data'
+import { SmallButton, LargeButton } from '../../atoms/buttons'
+import { ChildNavigation } from '../ChildNavigation'
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  QuickTransferSetupState,
+  QuickTransferWizardAction,
+} from './types'
+
+interface SelectTipRackProps {
+  onNext: () => void
+  onBack: () => void
+  exitButtonProps: React.ComponentProps<typeof SmallButton>
+  state: QuickTransferSetupState
+  dispatch: React.Dispatch<QuickTransferWizardAction>
+}
+
+export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
+  const { onNext, onBack, exitButtonProps, state, dispatch } = props
+  const { i18n, t } = useTranslation(['quick_transfer', 'shared'])
+
+  const allLabwareDefinitionsByUri = getAllDefinitions()
+  const selectedPipetteDefaultTipracks =
+    state.pipette?.liquids.default.defaultTipracks ?? []
+
+  const [selectedTipRack, setSelectedTipRack] = React.useState<
+    LabwareDefinition2 | undefined
+  >(state.tipRack)
+
+  const handleClickNext = (): void => {
+    // the button will be disabled if this values is null
+    if (selectedTipRack != null) {
+      dispatch({
+        type: 'SELECT_TIP_RACK',
+        tipRack: selectedTipRack,
+      })
+      onNext()
+    }
+  }
+  return (
+    <Flex>
+      <ChildNavigation
+        header={t('select_tip_rack')}
+        buttonText={i18n.format(t('shared:continue'), 'capitalize')}
+        onClickBack={onBack}
+        onClickButton={handleClickNext}
+        secondaryButtonProps={exitButtonProps}
+        top={SPACING.spacing8}
+        buttonIsDisabled={selectedTipRack == null}
+      />
+      <Flex
+        marginTop={SPACING.spacing120}
+        flexDirection={DIRECTION_COLUMN}
+        padding={`${SPACING.spacing16} ${SPACING.spacing60} ${SPACING.spacing40} ${SPACING.spacing60}`}
+        gridGap={SPACING.spacing4}
+        width="100%"
+      >
+        {selectedPipetteDefaultTipracks.map(tipRack => {
+          const tipRackDef = allLabwareDefinitionsByUri[tipRack]
+          return (
+            <LargeButton
+              buttonType={
+                selectedTipRack === tipRackDef ? 'primary' : 'secondary'
+              }
+              onClick={() => {
+                setSelectedTipRack(tipRackDef)
+              }}
+              buttonText={tipRackDef.metadata.displayName}
+            />
+          )
+        })}
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/organisms/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectTipRack.tsx
@@ -61,7 +61,8 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
       >
         {selectedPipetteDefaultTipracks.map(tipRack => {
           const tipRackDef = allLabwareDefinitionsByUri[tipRack]
-          return (
+
+          return tipRackDef != null ? (
             <LargeButton
               buttonType={
                 selectedTipRack === tipRackDef ? 'primary' : 'secondary'
@@ -71,7 +72,7 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
               }}
               buttonText={tipRackDef.metadata.displayName}
             />
-          )
+          ) : null
         })}
       </Flex>
     </Flex>

--- a/app/src/organisms/QuickTransferFlow/__tests__/SelectTipRack.test.tsx
+++ b/app/src/organisms/QuickTransferFlow/__tests__/SelectTipRack.test.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
+
+import { renderWithProviders } from '../../../__testing-utils__'
+import { i18n } from '../../../i18n'
+import { SelectTipRack } from '../SelectTipRack'
+
+vi.mock('@opentrons/react-api-client')
+const render = (props: React.ComponentProps<typeof SelectTipRack>) => {
+  return renderWithProviders(<SelectTipRack {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('SelectTipRack', () => {
+  let props: React.ComponentProps<typeof SelectTipRack>
+
+  beforeEach(() => {
+    props = {
+      onNext: vi.fn(),
+      onBack: vi.fn(),
+      exitButtonProps: {
+        buttonType: 'tertiaryLowLight',
+        buttonText: 'Exit',
+        onClick: vi.fn(),
+      },
+      state: {
+        mount: 'left',
+        pipette: {
+          liquids: {
+            default: {
+              defaultTipracks: [
+                'opentrons/opentrons_flex_96_tiprack_1000ul/1',
+                'opentrons/opentrons_flex_96_tiprack_200ul/1',
+                'opentrons/opentrons_flex_96_tiprack_50ul/1',
+                'opentrons/opentrons_flex_96_filtertiprack_1000ul/1',
+                'opentrons/opentrons_flex_96_filtertiprack_200ul/1',
+                'opentrons/opentrons_flex_96_filtertiprack_50ul/1',
+              ],
+            },
+          },
+        } as any,
+      },
+      dispatch: vi.fn(),
+    }
+  })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('renders the select tip rack screen, header, and exit button', () => {
+    render(props)
+    screen.getByText('Select tip rack')
+    const exitBtn = screen.getByText('Exit')
+    fireEvent.click(exitBtn)
+    expect(props.exitButtonProps.onClick).toHaveBeenCalled()
+  })
+
+  it('renders continue button and it is disabled if no tip rack is selected', () => {
+    render(props)
+    screen.getByText('Continue')
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeDisabled()
+  })
+
+  it('selects tip rack by default if there is one in state, button will be enabled', () => {
+    render({ ...props, state: { tipRack: { def: 'definition' } as any } })
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeEnabled()
+    fireEvent.click(continueBtn)
+    expect(props.onNext).toHaveBeenCalled()
+  })
+
+  it('enables continue button if you click a tip rack', () => {
+    render(props)
+    const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
+    expect(continueBtn).toBeDisabled()
+    const tipRackButton = screen.getByText('Opentrons Flex 96 Tip Rack 200 µL')
+    fireEvent.click(tipRackButton)
+    expect(continueBtn).toBeEnabled()
+    fireEvent.click(continueBtn)
+    expect(props.dispatch).toHaveBeenCalled()
+    expect(props.onNext).toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/QuickTransferFlow/index.tsx
+++ b/app/src/organisms/QuickTransferFlow/index.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react'
 import { useHistory } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Flex, StepMeter, SPACING } from '@opentrons/components'
+import {
+  Flex,
+  StepMeter,
+  SPACING,
+  POSITION_STICKY,
+} from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 import { CreateNewTransfer } from './CreateNewTransfer'
@@ -87,6 +92,8 @@ export const QuickTransferFlow = (): JSX.Element => {
       <StepMeter
         totalSteps={QUICK_TRANSFER_WIZARD_STEPS}
         currentStep={currentStep}
+        position={POSITION_STICKY}
+        top="0"
       />
       {modalContent == null ? (
         <Flex>

--- a/app/src/organisms/QuickTransferFlow/index.tsx
+++ b/app/src/organisms/QuickTransferFlow/index.tsx
@@ -6,6 +6,7 @@ import { SmallButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 import { CreateNewTransfer } from './CreateNewTransfer'
 import { SelectPipette } from './SelectPipette'
+import { SelectTipRack } from './SelectTipRack'
 import { quickTransferReducer } from './utils'
 
 import type { QuickTransferSetupState } from './types'
@@ -59,6 +60,16 @@ export const QuickTransferFlow = (): JSX.Element => {
   } else if (currentStep === 2) {
     modalContent = (
       <SelectPipette
+        state={state}
+        dispatch={dispatch}
+        onBack={() => setCurrentStep(prevStep => prevStep - 1)}
+        onNext={() => setCurrentStep(prevStep => prevStep + 1)}
+        exitButtonProps={exitButtonProps}
+      />
+    )
+  } else if (currentStep === 3) {
+    modalContent = (
+      <SelectTipRack
         state={state}
         dispatch={dispatch}
         onBack={() => setCurrentStep(prevStep => prevStep - 1)}

--- a/app/src/organisms/QuickTransferFlow/types.ts
+++ b/app/src/organisms/QuickTransferFlow/types.ts
@@ -1,14 +1,14 @@
 import { ACTIONS } from './constants'
 import type { Mount } from '@opentrons/api-client'
-import type { LabwareDefinition1, PipetteV2Specs } from '@opentrons/shared-data'
+import type { LabwareDefinition2, PipetteV2Specs } from '@opentrons/shared-data'
 
 export interface QuickTransferSetupState {
   pipette?: PipetteV2Specs
   mount?: Mount
-  tipRack?: LabwareDefinition1
-  source?: LabwareDefinition1
+  tipRack?: LabwareDefinition2
+  source?: LabwareDefinition2
   sourceWells?: string[]
-  destination?: LabwareDefinition1
+  destination?: LabwareDefinition2
   destinationWells?: string[]
   volume?: number
 }
@@ -29,11 +29,11 @@ interface SelectPipetteAction {
 }
 interface SelectTipRackAction {
   type: typeof ACTIONS.SELECT_TIP_RACK
-  tipRack: LabwareDefinition1
+  tipRack: LabwareDefinition2
 }
 interface SetSourceLabwareAction {
   type: typeof ACTIONS.SET_SOURCE_LABWARE
-  labware: LabwareDefinition1
+  labware: LabwareDefinition2
 }
 interface SetSourceWellsAction {
   type: typeof ACTIONS.SET_SOURCE_WELLS
@@ -41,7 +41,7 @@ interface SetSourceWellsAction {
 }
 interface SetDestLabwareAction {
   type: typeof ACTIONS.SET_DEST_LABWARE
-  labware: LabwareDefinition1
+  labware: LabwareDefinition2
 }
 interface SetDestWellsAction {
   type: typeof ACTIONS.SET_DEST_WELLS

--- a/components/src/atoms/StepMeter/index.tsx
+++ b/components/src/atoms/StepMeter/index.tsx
@@ -5,7 +5,7 @@ import { RESPONSIVENESS, SPACING } from '../../ui-style-constants'
 import { COLORS } from '../../helix-design-system'
 import { POSITION_ABSOLUTE, POSITION_RELATIVE } from '../../styles'
 
-import type { StyleProps } from '@opentrons/components'
+import type { StyleProps } from '../../primitives'
 
 interface StepMeterProps extends StyleProps {
   totalSteps: number

--- a/components/src/atoms/StepMeter/index.tsx
+++ b/components/src/atoms/StepMeter/index.tsx
@@ -5,13 +5,15 @@ import { RESPONSIVENESS, SPACING } from '../../ui-style-constants'
 import { COLORS } from '../../helix-design-system'
 import { POSITION_ABSOLUTE, POSITION_RELATIVE } from '../../styles'
 
-interface StepMeterProps {
+import type { StyleProps } from '@opentrons/components'
+
+interface StepMeterProps extends StyleProps {
   totalSteps: number
   currentStep: number | null
 }
 
 export const StepMeter = (props: StepMeterProps): JSX.Element => {
-  const { totalSteps, currentStep } = props
+  const { totalSteps, currentStep, ...styleProps } = props
   const progress = currentStep != null ? currentStep : 0
   const percentComplete = `${
     //    this logic puts a cap at 100% percentComplete which we should never run into
@@ -21,7 +23,7 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
   }%`
 
   const StepMeterContainer = css`
-    position: ${POSITION_RELATIVE};
+    position: ${styleProps.position ? styleProps.position : POSITION_RELATIVE};
     height: ${SPACING.spacing4};
     background-color: ${COLORS.grey30};
     @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
@@ -41,7 +43,11 @@ export const StepMeter = (props: StepMeterProps): JSX.Element => {
   `
 
   return (
-    <Box data-testid="StepMeter_StepMeterContainer" css={StepMeterContainer}>
+    <Box
+      data-testid="StepMeter_StepMeterContainer"
+      css={StepMeterContainer}
+      {...styleProps}
+    >
       <Box data-testid="StepMeter_StepMeterBar" css={StepMeterBar} />
     </Box>
   )


### PR DESCRIPTION
fix PLAT-290

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Implement the tip rack selection screen for the quick transfer wizard flow
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Launch quick transfer flow on ODD or ODD dev app
2. Select a pipette and proceed to step 3
3. You should see the pipette's default tip racks as options
4. The continue button should be disabled if no tiprack is selected
5. You should also see that if you go back to the selected pipette screen, the previously selected tiprack should be wiped
<img width="1032" alt="Screen Shot 2024-04-18 at 4 15 24 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/acdfd1ba-3d68-4cea-967c-221c995bde1a">
<img width="1029" alt="Screen Shot 2024-04-18 at 4 15 16 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/58b5f5c8-c2f6-4c46-a7f8-51f1122a930b">

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Added tip rack selection screen and test
2. Adjusted some styling to be in line with designs

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Quick look through the changes - I've tested this out a bit
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low, behind FF
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
