### PR TITLE
refactor(protocol-designer): assign module slot in createFileWizard instead of modal

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -30,7 +30,6 @@ import {
   getModuleDisplayName,
   getModuleType,
   FLEX_ROBOT_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
 } from '@opentrons/shared-data'
 import { getIsCrashablePipetteSelected } from '../../../step-forms'
@@ -45,9 +44,8 @@ import { ModuleFields } from '../FilePipettesModal/ModuleFields'
 import { GoBack } from './GoBack'
 import {
   getCrashableModuleSelected,
-  getDisabledEquipment,
-  getNextAvailableModuleSlot,
-  getTrashBinOptionDisabled,
+  getIsSlotAvailable,
+  getTrashOptionDisabled,
 } from './utils'
 import { EquipmentOption } from './EquipmentOption'
 import { HandleEnter } from './HandleEnter'
@@ -197,10 +195,6 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
   const additionalEquipment = watch('additionalEquipment')
   const moduleTypesOnDeck =
     modules != null ? Object.values(modules).map(module => module.type) : []
-  const trashBinDisabled = getTrashBinOptionDisabled({
-    additionalEquipment,
-    modules,
-  })
 
   const handleSetEquipmentOption = (equipment: AdditionalEquipment): void => {
     if (additionalEquipment.includes(equipment)) {
@@ -209,6 +203,11 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
       setValue('additionalEquipment', [...additionalEquipment, equipment])
     }
   }
+  const trashBinDisabled = getTrashOptionDisabled({
+    additionalEquipment,
+    modules,
+    trashType: 'trashBin',
+  })
 
   React.useEffect(() => {
     if (trashBinDisabled) {
@@ -222,19 +221,8 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
         const moduleType = getModuleType(moduleModel)
         const moduleOnDeck = moduleTypesOnDeck.includes(moduleType)
 
-        let defaultSlot = getNextAvailableModuleSlot(
-          modules,
-          additionalEquipment
-        )
-        if (moduleType === THERMOCYCLER_MODULE_TYPE) {
-          defaultSlot = 'B1'
-        } else if (moduleType === MAGNETIC_BLOCK_TYPE) {
-          defaultSlot = 'D2'
-        }
-        const isDisabled = getDisabledEquipment({
-          additionalEquipment,
-          modules,
-        })?.includes(moduleType)
+        const isDisabled = !getIsSlotAvailable(modules, additionalEquipment)
+
         const handleMultiplesClick = (num: number): void => {
           const temperatureModules =
             modules != null
@@ -250,10 +238,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
                 [uuid()]: {
                   model: moduleModel,
                   type: moduleType,
-                  slot: getNextAvailableModuleSlot(
-                    modules,
-                    additionalEquipment
-                  ),
+                  slot: null,
                 },
               })
             }
@@ -290,7 +275,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
                 [uuid()]: {
                   model: moduleModel,
                   type: moduleType,
-                  slot: defaultSlot,
+                  slot: DEFAULT_SLOT_MAP[moduleModel],
                 },
               })
             }
@@ -304,7 +289,11 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
             isSelected={moduleOnDeck}
             image={<ModuleDiagram type={moduleType} model={moduleModel} />}
             text={getModuleDisplayName(moduleModel)}
-            disabled={isDisabled && !moduleOnDeck}
+            disabled={
+              moduleType === MAGNETIC_BLOCK_TYPE
+                ? false
+                : isDisabled && !moduleOnDeck
+            }
             onClick={handleOnClick}
             multiples={
               moduleType === TEMPERATURE_MODULE_TYPE && enableMoamFf
@@ -345,11 +334,11 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
         robotType={FLEX_ROBOT_TYPE}
         onClick={() => handleSetEquipmentOption('wasteChute')}
         isSelected={additionalEquipment.includes('wasteChute')}
-        disabled={
-          modules != null
-            ? Object.values(modules).some(module => module.slot === 'D3')
-            : false
-        }
+        disabled={getTrashOptionDisabled({
+          additionalEquipment,
+          modules,
+          trashType: 'wasteChute',
+        })}
         image={
           <AdditionalItemImage
             src={wasteChuteImage}

--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -219,7 +219,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
     <Flex flexWrap={WRAP} gridGap={SPACING.spacing4} alignSelf={ALIGN_CENTER}>
       {FLEX_SUPPORTED_MODULE_MODELS.map(moduleModel => {
         const moduleType = getModuleType(moduleModel)
-        const moduleOnDeck = moduleTypesOnDeck.includes(moduleType)
+        const isModuleOnDeck = moduleTypesOnDeck.includes(moduleType)
 
         const isDisabled = !getIsSlotAvailable(modules, additionalEquipment)
 
@@ -259,7 +259,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
             (moduleType !== TEMPERATURE_MODULE_TYPE && enableMoamFf) ||
             !enableMoamFf
           ) {
-            if (moduleOnDeck) {
+            if (isModuleOnDeck) {
               const updatedModules =
                 modules != null
                   ? Object.fromEntries(
@@ -286,13 +286,13 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
           <EquipmentOption
             robotType={FLEX_ROBOT_TYPE}
             key={moduleModel}
-            isSelected={moduleOnDeck}
+            isSelected={isModuleOnDeck}
             image={<ModuleDiagram type={moduleType} model={moduleModel} />}
             text={getModuleDisplayName(moduleModel)}
             disabled={
               moduleType === MAGNETIC_BLOCK_TYPE
                 ? false
-                : isDisabled && !moduleOnDeck
+                : isDisabled && !isModuleOnDeck
             }
             onClick={handleOnClick}
             multiples={

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
@@ -1,22 +1,18 @@
 import { it, describe, expect } from 'vitest'
 import {
   FLEX_ROBOT_TYPE,
-  HEATERSHAKER_MODULE_TYPE,
   SINGLE_RIGHT_SLOT_FIXTURE,
-  TEMPERATURE_MODULE_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   FLEX_TRASH_DEFAULT_SLOT,
   getUnoccupiedStagingAreaSlots,
   getTrashSlot,
-  getNextAvailableModuleSlot,
-  getDisabledEquipment,
-  getTrashBinOptionDisabled,
+  getTrashOptionDisabled,
+  getIsSlotAvailable,
 } from '../utils'
 import { STANDARD_EMPTY_SLOTS } from '../StagingAreaTile'
 import type { FormPipettesByMount } from '../../../../step-forms'
-import type { FormState } from '../types'
+import type { AdditionalEquipment, FormState } from '../types'
 
 let MOCK_FORM_STATE = {
   fields: {
@@ -56,142 +52,67 @@ describe('getUnoccupiedStagingAreaSlots', () => {
       { cutoutId: 'cutoutD3', cutoutFixtureId: SINGLE_RIGHT_SLOT_FIXTURE },
     ])
   })
-  describe('getNextAvailableModuleSlot', () => {
-    it('should return D1 when there are no modules or staging areas', () => {
-      const result = getNextAvailableModuleSlot(null, [])
-      expect(result).toStrictEqual('D1')
-    })
-    it('should return a C3 when all the modules are on the deck', () => {
-      const result = getNextAvailableModuleSlot(
-        {
-          0: {
-            model: 'magneticBlockV1',
-            type: 'magneticBlockType',
-            slot: 'D1',
-          },
-          1: {
-            model: 'thermocyclerModuleV2',
-            type: 'thermocyclerModuleType',
-            slot: 'B1',
-          },
-          2: {
-            model: 'temperatureModuleV2',
-            type: 'temperatureModuleType',
-            slot: 'C1',
-          },
-        },
-        []
-      )
-      expect(result).toStrictEqual('C3')
-    })
-  })
-  it('should return an empty string when all the modules and staging area slots are on the deck without TC', () => {
-    const result = getNextAvailableModuleSlot(
-      {
-        0: {
-          model: 'heaterShakerModuleV1',
-          type: 'heaterShakerModuleType',
-          slot: 'D1',
-        },
-        1: {
-          model: 'temperatureModuleV2',
-          type: 'temperatureModuleType',
-          slot: 'C1',
-        },
-        2: {
-          model: 'temperatureModuleV2',
-          type: 'temperatureModuleType',
-          slot: 'B1',
-        },
-      },
-      [
-        'stagingArea_cutoutA3',
-        'stagingArea_cutoutB3',
-        'stagingArea_cutoutC3',
-        'stagingArea_cutoutD3',
-        'trashBin',
-      ]
-    )
-    expect(result).toStrictEqual('')
-  })
-  it('should return an empty string when all the modules and staging area slots are on the deck with TC', () => {
-    const result = getNextAvailableModuleSlot(
-      {
-        0: {
-          model: 'heaterShakerModuleV1',
-          type: 'heaterShakerModuleType',
-          slot: 'D1',
-        },
-        1: {
-          model: 'thermocyclerModuleV2',
-          type: 'thermocyclerModuleType',
-          slot: 'B1',
-        },
-      },
-      [
-        'stagingArea_cutoutA3',
-        'stagingArea_cutoutB3',
-        'stagingArea_cutoutC3',
-        'stagingArea_cutoutD3',
-        'trashBin',
-      ]
-    )
-    expect(result).toStrictEqual('')
-  })
 })
-describe('getNextAvailableModuleSlot', () => {
-  it('should return nothing as disabled', () => {
-    const result = getDisabledEquipment({
-      additionalEquipment: [],
-      modules: null,
-    })
-    expect(result).toStrictEqual([])
+describe('getIsSlotAvailable', () => {
+  it('should return true when there are no modules or additional equipment', () => {
+    const result = getIsSlotAvailable(null, [])
+    expect(result).toBe(true)
   })
-  it('should return the TC as disabled', () => {
-    const result = getDisabledEquipment({
-      additionalEquipment: [],
-      modules: {
-        0: {
-          model: 'heaterShakerModuleV1',
-          type: 'heaterShakerModuleType',
-          slot: 'A1',
-        },
+  it('should return false when there is a TC and 7 modules', () => {
+    const mockModules = {
+      0: {
+        model: 'heaterShakerModuleV1',
+        type: 'heaterShakerModuleType',
+        slot: 'D1',
       },
-    })
-    expect(result).toStrictEqual([THERMOCYCLER_MODULE_TYPE])
+      1: {
+        model: 'temperatureModuleV2',
+        type: 'temperatureModuleType',
+        slot: 'D3',
+      },
+      2: {
+        model: 'temperatureModuleV2',
+        type: 'temperatureModuleType',
+        slot: 'C1',
+      },
+      3: {
+        model: 'temperatureModuleV2',
+        type: 'temperatureModuleType',
+        slot: 'B3',
+      },
+      4: {
+        model: 'thermocyclerModuleV2',
+        type: 'thermocyclerModuleType',
+        slot: 'B1',
+      },
+      5: {
+        model: 'temperatureModuleV2',
+        type: 'temperatureModuleType',
+        slot: 'A3',
+      },
+      6: {
+        model: 'temperatureModuleV2',
+        type: 'temperatureModuleType',
+        slot: 'C3',
+      },
+    } as any
+    const result = getIsSlotAvailable(mockModules, [])
+    expect(result).toBe(false)
   })
-  it('should return all module types if there is no available slot', () => {
-    const result = getDisabledEquipment({
-      additionalEquipment: [
-        'stagingArea_cutoutA3',
-        'stagingArea_cutoutB3',
-        'stagingArea_cutoutC3',
-        'stagingArea_cutoutD3',
-        'trashBin',
-      ],
-      modules: {
-        0: {
-          model: 'heaterShakerModuleV1',
-          type: 'heaterShakerModuleType',
-          slot: 'D1',
-        },
-        1: {
-          model: 'temperatureModuleV2',
-          type: 'temperatureModuleType',
-          slot: 'C1',
-        },
-        2: {
-          model: 'temperatureModuleV2',
-          type: 'temperatureModuleType',
-          slot: 'B1',
-        },
-      },
-    })
-    expect(result).toStrictEqual([
-      THERMOCYCLER_MODULE_TYPE,
-      TEMPERATURE_MODULE_TYPE,
-      HEATERSHAKER_MODULE_TYPE,
-    ])
+  it('should return true when there are 9 additional equipment and 1 is a waste chute on the staging area and one is a gripper', () => {
+    const mockAdditionalEquipment: AdditionalEquipment[] = [
+      'trashBin',
+      'stagingArea_cutoutA3',
+      'stagingArea_cutoutB3',
+      'stagingArea_cutoutC3',
+      'stagingArea_cutoutD3',
+      'wasteChute',
+      'trashBin',
+      'gripper',
+      'trashBin',
+    ]
+    const result = getIsSlotAvailable(null, mockAdditionalEquipment)
+    expect(result).toBe(true)
   })
 })
 describe('getTrashSlot', () => {
@@ -211,59 +132,62 @@ describe('getTrashSlot', () => {
     const result = getTrashSlot(MOCK_FORM_STATE)
     expect(result).toBe('cutoutA1')
   })
-  describe('getTrashBinOptionDisabled', () => {
-    it('returns false when there is a trash bin already', () => {
-      const result = getTrashBinOptionDisabled({
-        additionalEquipment: ['trashBin'],
-        modules: {
-          0: {
-            model: 'heaterShakerModuleV1',
-            type: 'heaterShakerModuleType',
-            slot: 'D1',
-          },
+})
+describe('getTrashOptionDisabled', () => {
+  it('returns false when there is a trash bin already', () => {
+    const result = getTrashOptionDisabled({
+      trashType: 'trashBin',
+      additionalEquipment: ['trashBin'],
+      modules: {
+        0: {
+          model: 'heaterShakerModuleV1',
+          type: 'heaterShakerModuleType',
+          slot: 'D1',
         },
-      })
-      expect(result).toBe(false)
+      },
     })
-    it('returns false when there is an available slot', () => {
-      const result = getTrashBinOptionDisabled({
-        additionalEquipment: ['trashBin'],
-        modules: null,
-      })
-      expect(result).toBe(false)
+    expect(result).toBe(false)
+  })
+  it('returns false when there is an available slot', () => {
+    const result = getTrashOptionDisabled({
+      trashType: 'trashBin',
+      additionalEquipment: ['trashBin'],
+      modules: null,
     })
-    it('returns true when there is no available slot and trash bin is not selected yet', () => {
-      const result = getTrashBinOptionDisabled({
-        additionalEquipment: [
-          'stagingArea_cutoutA3',
-          'stagingArea_cutoutB3',
-          'stagingArea_cutoutC3',
-          'stagingArea_cutoutD3',
-        ],
-        modules: {
-          0: {
-            model: 'heaterShakerModuleV1',
-            type: 'heaterShakerModuleType',
-            slot: 'D1',
-          },
-          1: {
-            model: 'temperatureModuleV2',
-            type: 'temperatureModuleType',
-            slot: 'C1',
-          },
-          2: {
-            model: 'temperatureModuleV2',
-            type: 'temperatureModuleType',
-            slot: 'B1',
-          },
-          3: {
-            model: 'temperatureModuleV2',
-            type: 'temperatureModuleType',
-            slot: 'A1',
-          },
+    expect(result).toBe(false)
+  })
+  it('returns true when there is no available slot and trash bin is not selected yet', () => {
+    const result = getTrashOptionDisabled({
+      trashType: 'trashBin',
+      additionalEquipment: [
+        'stagingArea_cutoutA3',
+        'stagingArea_cutoutB3',
+        'stagingArea_cutoutC3',
+        'stagingArea_cutoutD3',
+      ],
+      modules: {
+        0: {
+          model: 'heaterShakerModuleV1',
+          type: 'heaterShakerModuleType',
+          slot: 'D1',
         },
-      })
-      expect(result).toBe(true)
+        1: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'C1',
+        },
+        2: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'B1',
+        },
+        3: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'A1',
+        },
+      },
     })
+    expect(result).toBe(true)
   })
 })

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -243,16 +243,14 @@ export function CreateFileWizard(): JSX.Element | null {
       })
 
       modules.forEach(moduleArgs => {
-        if (moduleArgs.slot != null) {
-          return dispatch(stepFormActions.createModule(moduleArgs))
-        } else {
-          return dispatch(
-            createModuleWithNoSlot({
-              model: moduleArgs.model,
-              type: moduleArgs.type,
-            })
-          )
-        }
+        return moduleArgs.slot != null
+          ? dispatch(stepFormActions.createModule(moduleArgs))
+          : dispatch(
+              createModuleWithNoSlot({
+                model: moduleArgs.model,
+                type: moduleArgs.type,
+              })
+            )
       })
 
       // add gripper

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -43,6 +43,7 @@ import {
   createDeckFixture,
   toggleIsGripperRequired,
 } from '../../../step-forms/actions/additionalItems'
+import { createModuleWithNoSlot } from '../../../modules'
 import { RobotTypeTile } from './RobotTypeTile'
 import { MetadataTile } from './MetadataTile'
 import { FirstPipetteTypeTile, SecondPipetteTypeTile } from './PipetteTypeTile'
@@ -229,9 +230,31 @@ export function CreateFileWizard(): JSX.Element | null {
       }
 
       // create modules
-      modules.forEach(moduleArgs =>
-        dispatch(stepFormActions.createModule(moduleArgs))
-      )
+      // sort so modules with slot are created first
+      // then modules without a slot are generated in remaining available slots
+      modules.sort((a, b) => {
+        if (a.slot == null && b.slot != null) {
+          return 1
+        }
+        if (b.slot == null && a.slot != null) {
+          return -1
+        }
+        return 0
+      })
+
+      modules.forEach(moduleArgs => {
+        if (moduleArgs.slot != null) {
+          return dispatch(stepFormActions.createModule(moduleArgs))
+        } else {
+          return dispatch(
+            createModuleWithNoSlot({
+              model: moduleArgs.model,
+              type: moduleArgs.type,
+            })
+          )
+        }
+      })
+
       // add gripper
       if (values.additionalEquipment.includes('gripper')) {
         dispatch(toggleIsGripperRequired())

--- a/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
@@ -91,21 +91,18 @@ export const getIsSlotAvailable = (
 ): boolean => {
   const moduleLength = modules != null ? Object.keys(modules).length : 0
   const additionalEquipmentLength = additionalEquipment.length
-  const hasTC =
-    modules != null
-      ? Object.values(modules).some(
-          module => module.type === THERMOCYCLER_MODULE_TYPE
-        )
-      : false
+  const hasTC = Object.values(modules || {}).some(
+    module => module.type === THERMOCYCLER_MODULE_TYPE
+  )
 
   const filteredModuleLength = hasTC ? moduleLength + 1 : moduleLength
-  const hasWasteChute = additionalEquipment.find(equipment =>
+  const hasWasteChute = additionalEquipment.some(equipment =>
     equipment.includes('wasteChute')
   )
   const isStagingAreaInD3 = additionalEquipment
     .filter(equipment => equipment.includes('stagingArea'))
     .find(stagingArea => stagingArea.split('_')[1] === 'cutoutD3')
-  const hasGripper = additionalEquipment.find(equipment =>
+  const hasGripper = additionalEquipment.some(equipment =>
     equipment.includes('gripper')
   )
 
@@ -133,9 +130,10 @@ export const getTrashOptionDisabled = (
   props: TrashOptionDisabledProps
 ): boolean => {
   const { additionalEquipment, modules, trashType } = props
-  const isSlotAvailable = getIsSlotAvailable(modules, additionalEquipment)
-  const hasTrashBinAlready = additionalEquipment.includes(trashType)
-  return !isSlotAvailable && !hasTrashBinAlready
+  return (
+    !getIsSlotAvailable(modules, additionalEquipment) &&
+    !additionalEquipment.includes(trashType)
+  )
 }
 
 export const getTrashSlot = (values: FormState): string => {

--- a/protocol-designer/src/components/modules/EditModulesCard.tsx
+++ b/protocol-designer/src/components/modules/EditModulesCard.tsx
@@ -28,7 +28,7 @@ import { ModuleRow } from './ModuleRow'
 import { AdditionalItemsRow } from './AdditionalItemsRow'
 import { isModuleWithCollisionIssue } from './utils'
 import { StagingAreasRow } from './StagingAreasRow'
-import { MultipleModuleRow } from './MultipleModuleRow'
+import { MultipleModulesRow } from './MultipleModulesRow'
 
 import type { AdditionalEquipmentEntity } from '@opentrons/step-generation'
 
@@ -146,7 +146,7 @@ export function EditModulesCard(props: Props): JSX.Element {
             )
           } else if (moduleData != null && moduleData.length > 1) {
             return (
-              <MultipleModuleRow
+              <MultipleModulesRow
                 moduleType={moduleType}
                 moduleOnDeck={moduleData}
                 key={`${moduleType}_${i}`}

--- a/protocol-designer/src/components/modules/MultipleModulesRow.tsx
+++ b/protocol-designer/src/components/modules/MultipleModulesRow.tsx
@@ -25,7 +25,9 @@ interface MultipleModulesRowProps {
   moduleOnDeck?: ModuleOnDeck[]
 }
 
-export function MultipleModuleRow(props: MultipleModulesRowProps): JSX.Element {
+export function MultipleModulesRow(
+  props: MultipleModulesRowProps
+): JSX.Element {
   const {
     moduleOnDeck,
     openEditModuleModal,

--- a/protocol-designer/src/components/modules/__tests__/MultipleModuleRow.test.tsx
+++ b/protocol-designer/src/components/modules/__tests__/MultipleModuleRow.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, screen } from '@testing-library/react'
 
 import { i18n } from '../../../localization'
 import { renderWithProviders } from '../../../__testing-utils__'
-import { MultipleModuleRow } from '../MultipleModuleRow'
+import { MultipleModulesRow } from '../MultipleModulesRow'
 import {
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V2,
@@ -15,8 +15,8 @@ import type { ModuleOnDeck } from '../../../step-forms'
 
 vi.mock('../../../step-forms/actions')
 vi.mock('../FlexSlotMap')
-const render = (props: React.ComponentProps<typeof MultipleModuleRow>) => {
-  return renderWithProviders(<MultipleModuleRow {...props} />, {
+const render = (props: React.ComponentProps<typeof MultipleModulesRow>) => {
+  return renderWithProviders(<MultipleModulesRow {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
@@ -37,7 +37,7 @@ const mockTemp2: ModuleOnDeck = {
 }
 
 describe('MultipleModuleRow', () => {
-  let props: React.ComponentProps<typeof MultipleModuleRow>
+  let props: React.ComponentProps<typeof MultipleModulesRow>
   beforeEach(() => {
     props = {
       moduleType: TEMPERATURE_MODULE_TYPE,

--- a/protocol-designer/src/modules/__tests__/moduleData.test.tsx
+++ b/protocol-designer/src/modules/__tests__/moduleData.test.tsx
@@ -34,4 +34,55 @@ describe('getNextAvailableModuleSlot', () => {
     const result = getNextAvailableModuleSlot(mockInitialDeckSetup)
     expect(result).toBe('C1')
   })
+  it('renders undefined when all slots are occupied', () => {
+    const mockInitialDeckSetup: InitialDeckSetup = {
+      modules: {
+        thermocycler: {
+          model: 'thermocyclerModuleV2',
+          id: 'thermocycler',
+          type: 'thermocyclerModuleType',
+          slot: 'B1',
+          moduleState: {} as any,
+        },
+        temperature: {
+          model: 'temperatureModuleV2',
+          id: 'temperature',
+          type: 'temperatureModuleType',
+          slot: 'C1',
+          moduleState: {} as any,
+        },
+      },
+      labware: {},
+      pipettes: {},
+      additionalEquipmentOnDeck: {
+        wasteChuteId: {
+          name: 'wasteChute',
+          id: 'wasteChuteId',
+          location: 'D3',
+        },
+        trashBinId: {
+          name: 'trashBin',
+          id: 'trashBinId',
+          location: 'D1',
+        },
+        stagingArea1: {
+          name: 'stagingArea',
+          id: 'stagingArea1',
+          location: 'A3',
+        },
+        stagingArea2: {
+          name: 'stagingArea',
+          id: 'stagingArea2',
+          location: 'B3',
+        },
+        stagingArea3: {
+          name: 'stagingArea',
+          id: 'stagingArea3',
+          location: 'C3',
+        },
+      },
+    }
+    const result = getNextAvailableModuleSlot(mockInitialDeckSetup)
+    expect(result).toBe(undefined)
+  })
 })

--- a/protocol-designer/src/modules/__tests__/moduleData.test.tsx
+++ b/protocol-designer/src/modules/__tests__/moduleData.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { getNextAvailableModuleSlot } from '../moduleData'
+import type { InitialDeckSetup } from '../../step-forms'
+
+describe('getNextAvailableModuleSlot', () => {
+  it('renders slot D1 when no slots are occupied', () => {
+    const mockInitialDeckSetup: InitialDeckSetup = {
+      modules: {},
+      labware: {},
+      pipettes: {},
+      additionalEquipmentOnDeck: {},
+    }
+    const result = getNextAvailableModuleSlot(mockInitialDeckSetup)
+    expect(result).toBe('D1')
+  })
+  it('renders slot C1 when other slots are occupied', () => {
+    const mockInitialDeckSetup: InitialDeckSetup = {
+      modules: {},
+      labware: {},
+      pipettes: {},
+      additionalEquipmentOnDeck: {
+        wasteChuteId: {
+          name: 'wasteChute',
+          id: 'wasteChuteId',
+          location: 'D3',
+        },
+        trashBinId: {
+          name: 'trashBin',
+          id: 'trashBinId',
+          location: 'D1',
+        },
+      },
+    }
+    const result = getNextAvailableModuleSlot(mockInitialDeckSetup)
+    expect(result).toBe('C1')
+  })
+})

--- a/protocol-designer/src/modules/index.ts
+++ b/protocol-designer/src/modules/index.ts
@@ -1,1 +1,2 @@
 export * from './moduleData'
+export * from './thunks'

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -1,3 +1,4 @@
+import { COLUMN_4_SLOTS } from '@opentrons/step-generation'
 import { SPAN7_8_10_11_SLOT } from '../constants'
 import {
   MAGNETIC_MODULE_TYPE,
@@ -7,8 +8,17 @@ import {
   ModuleType,
   MAGNETIC_BLOCK_TYPE,
   RobotType,
+  CutoutId,
+  MOVABLE_TRASH_ADDRESSABLE_AREAS,
+  WASTE_CHUTE_ADDRESSABLE_AREAS,
+  FIXED_TRASH_ID,
+  AddressableAreaName,
 } from '@opentrons/shared-data'
-import { DropdownOption } from '@opentrons/components'
+import { getStagingAreaAddressableAreas } from '../utils'
+import { InitialDeckSetup, getSlotIsEmpty } from '../step-forms'
+import type { DropdownOption } from '@opentrons/components'
+import type { DeckSlot } from '../types'
+
 export const SUPPORTED_MODULE_TYPES: ModuleType[] = [
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
@@ -269,4 +279,33 @@ export function getAllModuleSlotsByType(
     }
   }
   return slot
+}
+
+const FLEX_MODULE_SLOTS = ['D1', 'D3', 'C1', 'C3', 'B1', 'B3', 'A1', 'A3']
+
+export function getNextAvailableModuleSlot(
+  initialDeckSetup: InitialDeckSetup
+): DeckSlot | undefined {
+  return FLEX_MODULE_SLOTS.find(slot => {
+    const cutoutIds = Object.values(initialDeckSetup.additionalEquipmentOnDeck)
+      .filter(ae => ae.name === 'stagingArea')
+      .map(ae => ae.location as CutoutId)
+    const stagingAreaAddressableAreaNames = getStagingAreaAddressableAreas(
+      cutoutIds
+    )
+    const addressableAreaName = stagingAreaAddressableAreaNames.find(
+      aa => aa === slot
+    )
+    let isSlotEmpty: boolean = getSlotIsEmpty(initialDeckSetup, slot, true)
+    if (addressableAreaName == null && COLUMN_4_SLOTS.includes(slot)) {
+      isSlotEmpty = false
+    } else if (
+      MOVABLE_TRASH_ADDRESSABLE_AREAS.includes(slot as AddressableAreaName) ||
+      WASTE_CHUTE_ADDRESSABLE_AREAS.includes(slot as AddressableAreaName) ||
+      slot === FIXED_TRASH_ID
+    ) {
+      isSlotEmpty = false
+    }
+    return isSlotEmpty
+  })
 }

--- a/protocol-designer/src/modules/moduleData.ts
+++ b/protocol-designer/src/modules/moduleData.ts
@@ -1,22 +1,25 @@
 import { COLUMN_4_SLOTS } from '@opentrons/step-generation'
-import { SPAN7_8_10_11_SLOT } from '../constants'
 import {
   MAGNETIC_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
-  ModuleType,
   MAGNETIC_BLOCK_TYPE,
-  RobotType,
-  CutoutId,
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
   FIXED_TRASH_ID,
+} from '@opentrons/shared-data'
+import { SPAN7_8_10_11_SLOT } from '../constants'
+import { getStagingAreaAddressableAreas } from '../utils'
+import { getSlotIsEmpty } from '../step-forms'
+import type {
+  ModuleType,
+  RobotType,
+  CutoutId,
   AddressableAreaName,
 } from '@opentrons/shared-data'
-import { getStagingAreaAddressableAreas } from '../utils'
-import { InitialDeckSetup, getSlotIsEmpty } from '../step-forms'
 import type { DropdownOption } from '@opentrons/components'
+import type { InitialDeckSetup } from '../step-forms'
 import type { DeckSlot } from '../types'
 
 export const SUPPORTED_MODULE_TYPES: ModuleType[] = [

--- a/protocol-designer/src/modules/thunks.ts
+++ b/protocol-designer/src/modules/thunks.ts
@@ -1,0 +1,33 @@
+import { selectors as stepFormSelectors } from '../step-forms'
+import { uuid } from '../utils'
+import { getNextAvailableModuleSlot } from './moduleData'
+import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
+import type { CreateModuleAction } from '../step-forms/actions'
+import type { ThunkAction } from '../types'
+
+interface CreateModuleWithNoSloArgs {
+  type: ModuleType
+  model: ModuleModel
+}
+export const createModuleWithNoSlot: (
+  args: CreateModuleWithNoSloArgs
+) => ThunkAction<CreateModuleAction> = args => (dispatch, getState) => {
+  const { model, type } = args
+  const state = getState()
+  const initialDeckSetup = stepFormSelectors.getInitialDeckSetup(state)
+  const slot = getNextAvailableModuleSlot(initialDeckSetup)
+
+  if (slot == null) {
+    console.assert(slot, 'expected to find available slot but could not')
+  }
+
+  dispatch({
+    type: 'CREATE_MODULE',
+    payload: {
+      model,
+      type,
+      slot: slot ?? '',
+      id: `${uuid()}:${type}}`,
+    },
+  })
+}


### PR DESCRIPTION
closes AUTH-355 AUTH-22

# Overview

It was a bit wonky when the module slots were being assigned previously so i refactored a lot of the logic that i made a few weeks ago. Now, the slot is assigned at the end of the create file wizard (only for MoaM) instead of during the `module and other` modal of the wizard. singular module types still get assigned slots like before - so Ot-2 behavior for instance should be the same

# Test Plan

create a flex protocol and mess around with adding modules, including multiple temps, and see that they get rendered properly with nothing overlapping on the same slot

# Changelog

- refactor logic in `ModulesAndOtherTile` to now just disable when there is no slot available in terms of space on the deck
- make a redux thunk for creating modules with no slot defined
- create a few new utils and write tests
- wire up the new thunk in `CreateFileWizard`

# Review requests

see test plan

# Risk assessment

low