### PR TITLE
docs(api): fix or remove broken links on Welcome page

### DIFF
--- a/api/docs/v2/index.rst
+++ b/api/docs/v2/index.rst
@@ -171,17 +171,17 @@ More Resources
 Opentrons App
 +++++++++++++
 
-The `Opentrons App <https://opentrons.com/ot-app/>`__ is the easiest way to run your Python protocols. The app `supports <https://support.opentrons.com/en/articles/2687536-get-started-supported-operating-systems-for-the-opentrons-app>`_ the latest versions of macOS, Windows, and Ubuntu.
+The `Opentrons App <https://opentrons.com/ot-app/>`__ is the easiest way to run your Python protocols. The app runs on the latest versions of macOS, Windows, and Ubuntu.
 
 Support
 +++++++
 
-Questions about setting up your robot, using Opentrons software, or troubleshooting? Check out our `support articles <https://support.opentrons.com/s/>`_ or `get in touch directly <https://support.opentrons.com/s/article/Getting-help-from-Opentrons-Support>`_ with Opentrons Support.
+Questions about setting up your robot, using Opentrons software, or troubleshooting? Check out our `support articles <https://support.opentrons.com/s/>`_ or `contact Opentrons Support directly <mailto:support@opentrons.com>`_.
 
 Custom Protocol Service
 +++++++++++++++++++++++
 
-Don't have the time or resources to write your own protocols? The `Opentrons Custom Protocols <https://shop.opentrons.com/opentrons-remote-custom-protocol-development/>`_ service can get you set up in as little as a week. 
+Don't have the time or resources to write your own protocols? Our `custom protocol development service <https://opentrons.com/instrument-services/>`_ can get you set up in two weeks.
 
 Contributing
 ++++++++++++


### PR DESCRIPTION

# Overview

Some links on the Welcome page weren't going where we intended.

Addresses RTC-437, RTC-427

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-welcome-fixes/v2/)

# Changelog

- remove one Help Center link entirely
- change another to email support
- fix services link and turnaround time

# Review requests

click on 'em.

# Risk assessment

none