### PR TITLE
fix(api): add case correction to module_context.load_labware

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -151,7 +151,7 @@ class ModuleContext(CommandPublisher):
             load_location = loaded_adapter._core
         else:
             load_location = self._core
-
+        name = validation.ensure_lowercase_name(name)
         labware_core = self._protocol_core.load_labware(
             load_name=name,
             label=label,
@@ -467,9 +467,9 @@ class MagneticModuleContext(ModuleContext):
         if height is not None:
             if self._api_version >= _MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN:
                 raise APIVersionError(
-                    "The height parameter of MagneticModuleContext.engage() was removed"
-                    " in {_MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN}."
-                    " Use offset or height_from_base instead."
+                    f"The height parameter of MagneticModuleContext.engage() was removed"
+                    f" in {_MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN}."
+                    f" Use offset or height_from_base instead."
                 )
             self._core.engage(height_from_home=height)
 

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -108,7 +108,7 @@ def test_load_labware(
     decoy.when(mock_labware_core.get_well_columns()).then_return([])
 
     result = subject.load_labware(
-        name="infinite tip rack",
+        name="Infinite Tip Rack",
         label="it doesn't run out",
         namespace="ideal",
         version=101,


### PR DESCRIPTION
Closes RESC-235 and RQA-2610

# Overview

Fixes the `module_context.load_labware()` method by ensuring that labware names are converted into lower case before using them in any part of the code. 

The escalations issue above was caused by a cascade of things happening because the protocol had a module labware loaded with the labware name written in mixed case. There are a few places where we do string comparison of the labware names, including when trying to find new versions of a labware and when looking up LPC offsets for a labware. These string comparisons would fail because all labware definitions have lowercase names, and hence would lead to unexpected behavior. It should no longer create such a problem 

# Test Plan

Tested that this protocol's run uses version 2 of the Nest PCR plate and applies the correct LPC offset to it:

```
requirements = {"robotType": "OT-2", "apiLevel": "2.15"}

def run(protocol_context):

	p300racks = [protocol_context.load_labware('opentrons_96_tiprack_300ul', 2)]
	p300 = protocol_context.load_instrument('p300_single', 'right', tip_racks=p300racks)
	tc = protocol_context.load_module(module_name="thermocyclerModuleV1")
	reaction_plate1 = protocol_context.load_labware(
	    'Nest_96_wellplate_100uL_pcr_full_skirt', 1)
	reaction_plate3 = tc.load_labware('Nest_96_wellplate_100uL_pcr_full_skirt')

	tc.open_lid()
	p300.pick_up_tip()
	p300.aspirate(300, reaction_plate1['A1'])
	p300.dispense(10, reaction_plate3['A1'])
	p300.drop_tip()
```

# Risk assessment

Very low. Tiny bug fix
