### PR TITLE
feat(opentrons-ai-client): introduce react-markdown to chat display component

### DIFF
--- a/opentrons-ai-client/package.json
+++ b/opentrons-ai-client/package.json
@@ -26,6 +26,7 @@
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.10",
     "react-i18next": "13.5.0",
+    "react-markdown": "9.0.1",
     "styled-components": "5.3.6"
   },
   "engines": {

--- a/opentrons-ai-client/src/molecules/ChatDisplay/ChatDisplay.stories.tsx
+++ b/opentrons-ai-client/src/molecules/ChatDisplay/ChatDisplay.stories.tsx
@@ -21,12 +21,14 @@ const meta: Meta<typeof ChatDisplay> = {
 }
 export default meta
 type Story = StoryObj<typeof ChatDisplay>
+
 export const OpentronsAI: Story = {
   args: {
-    text: `
-    \`\`\`python
-from opentrons import protocol_api
+    content: `
+## sample output from OpentronsAI
 
+\`\`\`py
+from opentrons import protocol_api
 # Metadata
 metadata = {
     'protocolName': 'ThermoPrime Taq DNA Polymerase PCR Amplification',
@@ -46,13 +48,15 @@ def run(protocol: protocol_api.ProtocolContext):
     TC_SAMPLE_MASTERMIX_MIX_VOLUME = SAMPLE_VOL + MASTERMIX_VOL
     MASTERMIX_BLOCK_TEMP = 10  # degree C
     TEMP_DECK_WAIT_TIME = 50  # seconds
+\`\`\`
 `,
     isUserInput: false,
   },
 }
+
 export const User: Story = {
   args: {
-    text: `
+    content: `
     - Application: Reagent transfer
     - Robot: OT-2
     - API: 2.13

--- a/opentrons-ai-client/src/molecules/ChatDisplay/__tests__/ChatDisplay.test.tsx
+++ b/opentrons-ai-client/src/molecules/ChatDisplay/__tests__/ChatDisplay.test.tsx
@@ -15,7 +15,7 @@ describe('ChatDisplay', () => {
 
   beforeEach(() => {
     props = {
-      text: 'mock text from the backend',
+      content: 'mock text from the backend',
       isUserInput: false,
     }
   })
@@ -29,7 +29,7 @@ describe('ChatDisplay', () => {
   })
   it('should display input from use and label', () => {
     props = {
-      text: 'mock text from user input',
+      content: 'mock text from user input',
       isUserInput: true,
     }
     render(props)

--- a/opentrons-ai-client/src/molecules/ChatDisplay/index.tsx
+++ b/opentrons-ai-client/src/molecules/ChatDisplay/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
+import Markdown from 'react-markdown'
 import {
   BORDERS,
   COLORS,
@@ -10,12 +11,12 @@ import {
 } from '@opentrons/components'
 
 interface ChatDisplayProps {
-  text: string
+  content: string
   isUserInput: boolean
 }
 
 export function ChatDisplay({
-  text,
+  content,
   isUserInput,
 }: ChatDisplayProps): JSX.Element {
   const { t } = useTranslation('protocol_generator')
@@ -25,7 +26,6 @@ export function ChatDisplay({
       gridGap={SPACING.spacing12}
       paddingLeft={isUserInput ? SPACING.spacing40 : undefined}
       paddingRight={isUserInput ? undefined : SPACING.spacing40}
-      //   max-width="58.125rem"
     >
       <StyledText>{isUserInput ? t('you') : t('opentronsai')}</StyledText>
       {/* text should be markdown so this component will have a package or function to parse markdown */}
@@ -35,8 +35,11 @@ export function ChatDisplay({
         data-testid={`ChatDisplay_from_${isUserInput ? 'user' : 'backend'}`}
         borderRadius={BORDERS.borderRadius12}
         width="100%"
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing16}
       >
-        {text}
+        {/* ToDo (kk:04/19/2024) I will get feedback for additional styling  from the design team. */}
+        <Markdown>{content}</Markdown>
       </Flex>
     </Flex>
   )


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
introduce react-markdown to chat display component.

<img width="845" alt="Screenshot 2024-04-19 at 3 34 50 PM" src="https://github.com/Opentrons/opentrons/assets/474225/dfb2c41a-29da-4cd6-b283-05eee1bf5386">

Jamey introduced react-markdown to Desktop for Release Notes modal. opentrons-ai-client uses the same package to parse markdown. For additional styling, I will discuss this with Sue.

close AUTH-359
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. make teardown-js && make setup-js
2. `make -C components dev`
3. go to ChatDiplay -> OpentronsAI

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add react-markdown to opentrons-ai-client
- change a prop name in ChatDisplay from `text` to `content`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
