### PR TITLE
refactor(protocol-designer): tip position modal max values round down

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -93,12 +93,12 @@ export const TipPositionModal = (
   } => {
     if (getIsTouchTipField(zSpec?.name ?? '')) {
       return {
-        maxMmFromBottom: utils.roundValue(wellDepthMm),
-        minMmFromBottom: utils.roundValue(wellDepthMm / 2),
+        maxMmFromBottom: utils.roundValue(wellDepthMm, 'up'),
+        minMmFromBottom: utils.roundValue(wellDepthMm / 2, 'up'),
       }
     }
     return {
-      maxMmFromBottom: utils.roundValue(wellDepthMm * 2),
+      maxMmFromBottom: utils.roundValue(wellDepthMm * 2, 'up'),
       minMmFromBottom: 0,
     }
   }
@@ -138,10 +138,10 @@ export const TipPositionModal = (
     return utils.getErrorText({ errors, minMm: min, maxMm: max, isPristine, t })
   }
 
-  const roundedXMin = utils.roundValue(xMinWidth)
-  const roundedYMin = utils.roundValue(yMinWidth)
-  const roundedXMax = utils.roundValue(xMaxWidth)
-  const roundedYMax = utils.roundValue(yMaxWidth)
+  const roundedXMin = utils.roundValue(xMinWidth, 'up')
+  const roundedYMin = utils.roundValue(yMinWidth, 'up')
+  const roundedXMax = utils.roundValue(xMaxWidth, 'down')
+  const roundedYMax = utils.roundValue(yMaxWidth, 'down')
 
   const zErrorText = createErrorText(zErrors, minMmFromBottom, maxMmFromBottom)
   const xErrorText = createErrorText(xErrors, roundedXMin, roundedXMax)

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/ZTipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/ZTipPositionModal.tsx
@@ -67,12 +67,12 @@ export function ZTipPositionModal(props: ZTipPositionModalProps): JSX.Element {
   } => {
     if (getIsTouchTipField(name)) {
       return {
-        maxMmFromBottom: utils.roundValue(wellDepthMm),
-        minMmFromBottom: utils.roundValue(wellDepthMm / 2),
+        maxMmFromBottom: utils.roundValue(wellDepthMm, 'up'),
+        minMmFromBottom: utils.roundValue(wellDepthMm / 2, 'up'),
       }
     }
     return {
-      maxMmFromBottom: utils.roundValue(wellDepthMm * 2),
+      maxMmFromBottom: utils.roundValue(wellDepthMm * 2, 'up'),
       minMmFromBottom: 0,
     }
   }
@@ -148,7 +148,7 @@ export function ZTipPositionModal(props: ZTipPositionModalProps): JSX.Element {
   const handleIncrementDecrement = (delta: number): void => {
     const prevValue = value === null ? defaultMm : Number(value)
     setIsDefault(false)
-    handleChange(utils.roundValue(prevValue + delta))
+    handleChange(utils.roundValue(prevValue + delta, 'up'))
   }
 
   const makeHandleIncrement = (step: number): (() => void) => () => {

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
@@ -82,9 +82,9 @@ describe('TipPositionModal', () => {
     fireEvent.click(screen.getByRole('radio', { name: 'Custom' }))
     expect(screen.getAllByRole('textbox', { name: '' })).toHaveLength(3)
     screen.getByText('X position')
-    screen.getByText('between -5.1 and 5.2')
+    screen.getByText('between -5.1 and 5.1')
     screen.getByText('Y position')
-    screen.getByText('between -5.2 and 5.3')
+    screen.getByText('between -5.2 and 5.2')
     screen.getByText('Z position')
     screen.getByText('between 0 and 100')
     screen.getByText('mock TipPositionViz')
@@ -129,8 +129,8 @@ describe('TipPositionModal', () => {
     fireEvent.click(screen.getByText('done'))
     //  display out of bounds error
     screen.getByText('accepted range is 0 to 100')
-    screen.getByText('accepted range is -5.2 to 5.3')
-    screen.getByText('accepted range is -5.1 to 5.2')
+    screen.getByText('accepted range is -5.2 to 5.2')
+    screen.getByText('accepted range is -5.1 to 5.1')
     const xInputField = screen.getAllByRole('textbox', { name: '' })[0]
     fireEvent.change(xInputField, { target: { value: 3.55555 } })
     fireEvent.click(screen.getByText('done'))

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.ts
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.ts
@@ -61,7 +61,6 @@ export const roundValue = (
       return floor(Number(value), DECIMALS_ALLOWED)
     }
   }
-  return value === null ? 0 : round(Number(value), DECIMALS_ALLOWED)
 }
 
 const OUT_OF_BOUNDS: 'OUT_OF_BOUNDS' = 'OUT_OF_BOUNDS'

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.ts
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/utils.ts
@@ -1,3 +1,4 @@
+import floor from 'lodash/floor'
 import round from 'lodash/round'
 import { getIsTouchTipField } from '../../../../form-types'
 import {
@@ -46,7 +47,20 @@ export function getDefaultMmFromBottom(args: {
   }
 }
 
-export const roundValue = (value: number | string | null): number => {
+export const roundValue = (
+  value: number | string | null,
+  direction: 'up' | 'down'
+): number => {
+  if (value === null) return 0
+
+  switch (direction) {
+    case 'up': {
+      return round(Number(value), DECIMALS_ALLOWED)
+    }
+    case 'down': {
+      return floor(Number(value), DECIMALS_ALLOWED)
+    }
+  }
   return value === null ? 0 : round(Number(value), DECIMALS_ALLOWED)
 }
 


### PR DESCRIPTION
closes AUTH-352

# Overview

Since we are rounding the ranges for the x/y values to the nearest 1 decimals, they were being rounded up for the max value which resulted in the highest value in the description to be out of range. This PR rounds down instead of up.

# Test Plan

Just review the code, the test cases tests this.

# Changelog

- use lodash `floor` to round down if needed
- fix test

# Review requests

see test plan

# Risk assessment

low