### PR TITLE
fix(app): prevent "run again" banner from rendering after navigating away from the current run

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/ProtocolRunHeader.test.tsx
@@ -814,7 +814,7 @@ describe('ProtocolRunHeader', () => {
 
     screen.getByText('Run completed.')
   })
-  it('clicking close on a terminal run banner closes the run context and dismisses the banner', async () => {
+  it('clicking close on a terminal run banner closes the run context', async () => {
     when(vi.mocked(useNotifyRunQuery))
       .calledWith(RUN_ID)
       .thenReturn({
@@ -827,9 +827,20 @@ describe('ProtocolRunHeader', () => {
 
     fireEvent.click(screen.getByTestId('Banner_close-button'))
     expect(mockCloseCurrentRun).toBeCalled()
-    await waitFor(() => {
-      expect(screen.queryByText('Run completed.')).not.toBeInTheDocument()
-    })
+  })
+
+  it('does not display the "run successful" banner if the successful run is not current', async () => {
+    when(vi.mocked(useNotifyRunQuery))
+      .calledWith(RUN_ID)
+      .thenReturn({
+        data: { data: { ...mockSucceededRun, current: false } },
+      } as UseQueryResult<OpentronsApiClient.Run>)
+    when(vi.mocked(useRunStatus))
+      .calledWith(RUN_ID)
+      .thenReturn(RUN_STATUS_SUCCEEDED)
+    render()
+
+    expect(screen.queryByText('Run completed.')).not.toBeInTheDocument()
   })
 
   it('if a heater shaker is shaking, clicking on start run should render HeaterShakerIsRunningModal', async () => {


### PR DESCRIPTION
Closes [RQA-2620](https://opentrons.atlassian.net/browse/RQA-2620)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR fixes the "run successful" banner, so it only displays for the current run. 

There are a few minor refactors included as well. `ProtocolRunHeader` needs some serious refactoring, and I've added a TODO and made a ticket for it. 

### Current Behavior

https://github.com/Opentrons/opentrons/assets/64858653/f24ec18f-0be9-40d5-8a8e-9a530cf681b8

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/8a478006-13c7-4df0-a96c-3b33a52443f2

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Follow the videos as guides.

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- The "run successful" banner now displays on the current run only.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2620]: https://opentrons.atlassian.net/browse/RQA-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ