### PR TITLE
fix(robot-server): notify /runs when a non-current run is deleted

### DIFF
--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -284,7 +284,8 @@ class RunDataManager:
         """
         if run_id == self._engine_store.current_run_id:
             await self._engine_store.clear()
-            await self._runs_publisher.clean_up_current_run()
+
+        await self._runs_publisher.clean_up_run(run_id=run_id)
 
         self._run_store.remove(run_id=run_id)
 

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -71,12 +71,12 @@ class RunsPublisher:
         )
         self._engine_state_slice = EngineStateSlice()
 
-        await self._publish_runs_advise_refetch_async()
+        await self._publish_runs_advise_refetch_async(run_id=run_id)
 
-    async def clean_up_current_run(self) -> None:
-        """Publish final refetch and unsubscribe flags."""
-        await self._publish_runs_advise_refetch_async()
-        await self._publish_runs_advise_unsubscribe_async()
+    async def clean_up_run(self, run_id: str) -> None:
+        """Publish final refetch and unsubscribe flags for the given run."""
+        await self._publish_runs_advise_refetch_async(run_id=run_id)
+        await self._publish_runs_advise_unsubscribe_async(run_id=run_id)
 
     async def _publish_current_command(self) -> None:
         """Publishes the equivalent of GET /runs/:runId/commands?cursor=null&pageLength=1."""
@@ -84,20 +84,20 @@ class RunsPublisher:
             topic=Topics.RUNS_CURRENT_COMMAND
         )
 
-    async def _publish_runs_advise_refetch_async(self) -> None:
+    async def _publish_runs_advise_refetch_async(self, run_id: str) -> None:
         """Publish a refetch flag for relevant runs topics."""
+        await self._client.publish_advise_refetch_async(topic=Topics.RUNS)
+
         if self._run_hooks is not None:
-            await self._client.publish_advise_refetch_async(topic=Topics.RUNS)
             await self._client.publish_advise_refetch_async(
-                topic=f"{Topics.RUNS}/{self._run_hooks.run_id}"
+                topic=f"{Topics.RUNS}/{run_id}"
             )
 
-    async def _publish_runs_advise_unsubscribe_async(self) -> None:
+    async def _publish_runs_advise_unsubscribe_async(self, run_id: str) -> None:
         """Publish an unsubscribe flag for relevant runs topics."""
-        if self._run_hooks is not None:
-            await self._client.publish_advise_unsubscribe_async(
-                topic=f"{Topics.RUNS}/{self._run_hooks.run_id}"
-            )
+        await self._client.publish_advise_unsubscribe_async(
+            topic=f"{Topics.RUNS}/{run_id}"
+        )
 
     async def _handle_current_command_change(self) -> None:
         """Publish a refetch flag if the current command has changed."""
@@ -121,7 +121,9 @@ class RunsPublisher:
                 and self._engine_state_slice.state_summary_status
                 != current_state_summary.status
             ):
-                await self._publish_runs_advise_refetch_async()
+                await self._publish_runs_advise_refetch_async(
+                    run_id=self._run_hooks.run_id
+                )
                 self._engine_state_slice.state_summary_status = (
                     current_state_summary.status
                 )

--- a/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
@@ -71,7 +71,7 @@ async def test_clean_up_current_run(
     """It should publish to appropriate topics at the end of a run."""
     await runs_publisher.initialize("1234", AsyncMock(), AsyncMock())
 
-    await runs_publisher.clean_up_current_run()
+    await runs_publisher.clean_up_run(run_id="1234")
 
     notification_client.publish_advise_refetch_async.assert_any_await(topic=Topics.RUNS)
     notification_client.publish_advise_refetch_async.assert_any_await(


### PR DESCRIPTION
Closes [RQA-2599](https://opentrons.atlassian.net/browse/RQA-2599)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When a non-current run is deleted, the server does not publish to the /runs topic a refetch flag. Instead of conditionally publishing a notify flag when a run is deleted, do so always.

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/f173b7f5-ac56-4072-b23b-82a3a07a7b85


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- E2E verify following the steps in the video above, or send a DELETE to /runs/:runId while connected to the MQTT server via postman and verify a refetch flag is issued. 

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed an issue in which deleting a run record did not properly update on the desktop app/ODD unless the user first navigates away from the screen. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low 
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2599]: https://opentrons.atlassian.net/browse/RQA-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ