### PR TITLE
fix(app): add robotSerialNumber to proceedToRun event

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunOverflowMenu.tsx
@@ -32,7 +32,7 @@ import {
   ANALYTICS_PROTOCOL_RUN_AGAIN,
 } from '../../redux/analytics'
 import { getRobotUpdateDisplayInfo } from '../../redux/robot-update'
-import { useDownloadRunLog, useTrackProtocolRunEvent } from './hooks'
+import { useDownloadRunLog, useTrackProtocolRunEvent, useRobot } from './hooks'
 import { useIsEstopNotDisengaged } from '../../resources/devices/hooks/useIsEstopNotDisengaged'
 
 import type { Run } from '@opentrons/api-client'
@@ -132,6 +132,9 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const { reset } = useRunControls(runId, onResetSuccess)
   const { deleteRun } = useDeleteRunMutation()
+  const robot = useRobot(robotName)
+  const robotSerialNumber =
+    robot?.health?.robot_serial ?? robot?.serverHealth?.serialNumber ?? null
 
   const handleResetClick: React.MouseEventHandler<HTMLButtonElement> = (
     e
@@ -142,7 +145,10 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     reset()
     trackEvent({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-      properties: { sourceLocation: 'HistoricalProtocolRun' },
+      properties: {
+        sourceLocation: 'HistoricalProtocolRun',
+        robotSerialNumber,
+      },
     })
     trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_AGAIN })
   }

--- a/app/src/organisms/Devices/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
+++ b/app/src/organisms/Devices/__tests__/HistoricalProtocolRunOverflowMenu.test.tsx
@@ -5,23 +5,24 @@ import '@testing-library/jest-dom/vitest'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { when } from 'vitest-when'
 import { MemoryRouter } from 'react-router-dom'
-import { UseQueryResult } from 'react-query'
 import {
   useAllCommandsQuery,
   useDeleteRunMutation,
 } from '@opentrons/react-api-client'
 import { i18n } from '../../../i18n'
 import runRecord from '../../../organisms/RunDetails/__fixtures__/runRecord.json'
-import { useDownloadRunLog, useTrackProtocolRunEvent } from '../hooks'
+import { useDownloadRunLog, useTrackProtocolRunEvent, useRobot } from '../hooks'
 import { useRunControls } from '../../RunTimeControl/hooks'
 import {
   useTrackEvent,
   ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
 } from '../../../redux/analytics'
+import { mockConnectableRobot } from '../../../redux/discovery/__fixtures__'
 import { getRobotUpdateDisplayInfo } from '../../../redux/robot-update'
 import { useIsEstopNotDisengaged } from '../../../resources/devices/hooks/useIsEstopNotDisengaged'
 import { HistoricalProtocolRunOverflowMenu } from '../HistoricalProtocolRunOverflowMenu'
 
+import type { UseQueryResult } from 'react-query'
 import type { CommandsData } from '@opentrons/api-client'
 
 vi.mock('../../../redux/analytics')
@@ -104,6 +105,9 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
       robotName: ROBOT_NAME,
       robotIsBusy: false,
     }
+    when(vi.mocked(useRobot))
+      .calledWith(ROBOT_NAME)
+      .thenReturn(mockConnectableRobot)
   })
 
   it('renders the correct menu when a runId is present', () => {
@@ -122,7 +126,10 @@ describe('HistoricalProtocolRunOverflowMenu', () => {
     fireEvent.click(rerunBtn)
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
-      properties: { sourceLocation: 'HistoricalProtocolRun' },
+      properties: {
+        robotSerialNumber: 'mock-serial',
+        sourceLocation: 'HistoricalProtocolRun',
+      },
     })
     expect(useRunControls).toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()

--- a/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
+++ b/app/src/organisms/Devices/hooks/__tests__/useProtocolRunAnalyticsData.test.tsx
@@ -131,7 +131,7 @@ describe('useProtocolAnalysisErrors hook', () => {
         protocolText: 'hashedString',
         protocolType: '',
         robotType: 'OT-2 Standard',
-        robotSerialNumber: '',
+        robotSerialNumber: 'mock-serial',
       },
       runTime: '1:00:00',
     })
@@ -160,7 +160,7 @@ describe('useProtocolAnalysisErrors hook', () => {
         protocolText: 'hashedString',
         protocolType: 'json',
         robotType: 'OT-2 Standard',
-        robotSerialNumber: '',
+        robotSerialNumber: 'mock-serial',
       },
       runTime: '1:00:00',
     })

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/RecentRunProtocolCard.tsx
@@ -29,7 +29,10 @@ import {
 } from '@opentrons/api-client'
 
 import { ODD_FOCUS_VISIBLE } from '../../../atoms/buttons//constants'
-import { useTrackEvent } from '../../../redux/analytics'
+import {
+  useTrackEvent,
+  ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+} from '../../../redux/analytics'
 import { Skeleton } from '../../../atoms/Skeleton'
 import { useMissingProtocolHardware } from '../../../pages/Protocols/hooks'
 import { useCloneRun } from '../../ProtocolUpload/hooks'
@@ -147,7 +150,7 @@ export function ProtocolWithLastRun({
     } else {
       cloneRun()
       trackEvent({
-        name: 'proceedToRun',
+        name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
         properties: { sourceLocation: 'RecentRunProtocolCard' },
       })
     }

--- a/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -20,7 +20,10 @@ import { i18n } from '../../../../i18n'
 import { Skeleton } from '../../../../atoms/Skeleton'
 import { useMissingProtocolHardware } from '../../../../pages/Protocols/hooks'
 import { useTrackProtocolRunEvent } from '../../../Devices/hooks'
-import { useTrackEvent } from '../../../../redux/analytics'
+import {
+  useTrackEvent,
+  ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+} from '../../../../redux/analytics'
 import { useCloneRun } from '../../../ProtocolUpload/hooks'
 import { useRerunnableStatusText } from '../hooks'
 import { RecentRunProtocolCard } from '../'
@@ -250,7 +253,7 @@ describe('RecentRunProtocolCard', () => {
     expect(button).toHaveStyle(`background-color: ${COLORS.green40}`)
     fireEvent.click(button)
     expect(mockTrackEvent).toHaveBeenCalledWith({
-      name: 'proceedToRun',
+      name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
       properties: { sourceLocation: 'RecentRunProtocolCard' },
     })
     // TODO(BC, 08/30/23): reintroduce check for tracking when tracking is reintroduced lazily

--- a/app/src/pages/RunSummary/index.tsx
+++ b/app/src/pages/RunSummary/index.tsx
@@ -57,6 +57,7 @@ import {
   // ANALYTICS_PROTOCOL_RUN_CANCEL,
   ANALYTICS_PROTOCOL_RUN_AGAIN,
   ANALYTICS_PROTOCOL_RUN_FINISH,
+  ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
 } from '../../redux/analytics'
 import { getLocalRobot } from '../../redux/discovery'
 import { RunFailedModal } from '../../organisms/OnDeviceDisplay/RunningProtocol'
@@ -124,6 +125,10 @@ export function RunSummary(): JSX.Element {
   const [showRunAgainSpinner, setShowRunAgainSpinner] = React.useState<boolean>(
     false
   )
+  const robotSerialNumber =
+    localRobot?.health?.robot_serial ??
+    localRobot?.serverHealth?.serialNumber ??
+    null
 
   let headerText = t('run_complete_splash')
   if (runStatus === RUN_STATUS_FAILED) {
@@ -167,8 +172,8 @@ export function RunSummary(): JSX.Element {
         setShowRunAgainSpinner(true)
         reset()
         trackEvent({
-          name: 'proceedToRun',
-          properties: { sourceLocation: 'RunSummary' },
+          name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,
+          properties: { sourceLocation: 'RunSummary', robotSerialNumber },
         })
         trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_AGAIN })
       }

--- a/app/src/redux/discovery/__fixtures__/index.ts
+++ b/app/src/redux/discovery/__fixtures__/index.ts
@@ -18,6 +18,7 @@ export const mockHealthResponse = {
   api_version: '0.0.0-mock',
   fw_version: '0.0.0-mock',
   system_version: '0.0.0-mock',
+  robot_serial: 'mock-serial',
   logs: [] as string[],
   protocol_api_version: [2, 0] as [number, number],
 }


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add robotSerialNumber to `proceedToRun`

A few of `proceedToRun` events don't have robotSerialNumber because the events are sent before selecting a robot.
fix RQA-2386

I think we would need to create a custom hook that can handle trackEvents efficiently and we would need to update the package version. We use `2.22.1` but the latest version is `2.49.0`. 

I think we would need to organize all information about trackEvents to test all cases properly.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- pass robotSerialNumber to cases that can retrieve robot serial number
- modify tests for the above update
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
