### PR TITLE
fix(app): fix infinitely re-rendering/never rendering firmware success toasts

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -58,7 +58,7 @@
   "firmware_update_needed": "Instrument firmware update needed. Start the update on the robot's touchscreen.",
   "firmware_update_available": "Firmware update available.",
   "firmware_update_failed": "Failed to update module firmware",
-  "firmware_update_installation_successful": "Installation successful",
+  "firmware_updated_successfully": "Firmware updated successfully",
   "firmware_update_occurring": "Firmware update in progress...",
   "fixture": "Fixture",
   "have_not_run_description": "After you run some protocols, they will appear here.",

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -33,6 +33,7 @@ import { PipetteCard } from './PipetteCard'
 import { FlexPipetteCard } from './PipetteCard/FlexPipetteCard'
 import { GripperCard } from '../GripperCard'
 import { useIsEstopNotDisengaged } from '../../resources/devices/hooks/useIsEstopNotDisengaged'
+import { useModuleApiRequests } from '../ModuleCard/utils'
 
 import type {
   BadGripper,
@@ -62,6 +63,7 @@ export function InstrumentsAndModules({
   const currentRunId = useCurrentRunId()
   const { isRunTerminal, isRunRunning } = useRunStatuses()
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
+  const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
 
   const { data: attachedInstruments } = useInstrumentsQuery({
     refetchInterval: EQUIPMENT_POLL_MS,
@@ -218,6 +220,8 @@ export function InstrumentsAndModules({
                   attachPipetteRequired={attachPipetteRequired}
                   calibratePipetteRequired={calibratePipetteRequired}
                   updatePipetteFWRequired={updatePipetteFWRequired}
+                  latestRequestId={getLatestRequestId(module.serialNumber)}
+                  handleModuleApiRequests={handleModuleApiRequests}
                 />
               ))}
             </Flex>
@@ -267,6 +271,8 @@ export function InstrumentsAndModules({
                   attachPipetteRequired={attachPipetteRequired}
                   calibratePipetteRequired={calibratePipetteRequired}
                   updatePipetteFWRequired={updatePipetteFWRequired}
+                  latestRequestId={getLatestRequestId(module.serialNumber)}
+                  handleModuleApiRequests={handleModuleApiRequests}
                 />
               ))}
             </Flex>

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunModuleControls.tsx
@@ -10,6 +10,8 @@ import {
 } from '@opentrons/components'
 import { ModuleCard } from '../../ModuleCard'
 import { useModuleRenderInfoForProtocolById } from '../hooks'
+import { useModuleApiRequests } from '../../ModuleCard/utils'
+
 import type { BadPipette, PipetteData } from '@opentrons/api-client'
 
 interface PipetteStatus {
@@ -77,6 +79,7 @@ export const ProtocolRunModuleControls = ({
     calibratePipetteRequired,
     updatePipetteFWRequired,
   } = usePipetteIsReady()
+  const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
 
   const moduleRenderInfoForProtocolById = useModuleRenderInfoForProtocolById(
     runId,
@@ -120,6 +123,10 @@ export const ProtocolRunModuleControls = ({
               attachPipetteRequired={attachPipetteRequired}
               calibratePipetteRequired={calibratePipetteRequired}
               updatePipetteFWRequired={updatePipetteFWRequired}
+              latestRequestId={getLatestRequestId(
+                module.attachedModuleMatch.serialNumber
+              )}
+              handleModuleApiRequests={handleModuleApiRequests}
             />
           ) : null
         )}
@@ -141,6 +148,10 @@ export const ProtocolRunModuleControls = ({
               attachPipetteRequired={attachPipetteRequired}
               calibratePipetteRequired={calibratePipetteRequired}
               updatePipetteFWRequired={updatePipetteFWRequired}
+              latestRequestId={getLatestRequestId(
+                module.attachedModuleMatch.serialNumber
+              )}
+              handleModuleApiRequests={handleModuleApiRequests}
             />
           ) : null
         )}

--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -24,7 +24,6 @@ import {
   getRequestById,
   PENDING,
   SUCCESS,
-  useDispatchApiRequest,
 } from '../../../redux/robot-api'
 import { useCurrentRunStatus } from '../../RunTimeControl/hooks'
 import { useToaster } from '../../ToasterOven'
@@ -43,7 +42,7 @@ import type {
   MagneticModule,
   ThermocyclerModule,
 } from '../../../redux/modules/types'
-import type { DispatchApiRequestType } from '../../../redux/robot-api'
+import type { Mock } from 'vitest'
 
 vi.mock('../ErrorInfo')
 vi.mock('../MagneticModuleData')
@@ -182,6 +181,8 @@ const mockMakeSnackbar = vi.fn()
 const mockMakeToast = vi.fn()
 const mockEatToast = vi.fn()
 
+const MOCK_LATEST_REQUEST_ID = '1234'
+
 const render = (props: React.ComponentProps<typeof ModuleCard>) => {
   return renderWithProviders(<ModuleCard {...props} />, {
     i18nInstance: i18n,
@@ -189,10 +190,12 @@ const render = (props: React.ComponentProps<typeof ModuleCard>) => {
 }
 
 describe('ModuleCard', () => {
-  let dispatchApiRequest: DispatchApiRequestType
   let props: React.ComponentProps<typeof ModuleCard>
+  let mockHandleModuleApiRequests: Mock
 
   beforeEach(() => {
+    mockHandleModuleApiRequests = vi.fn()
+
     props = {
       module: mockMagneticModule,
       robotName: mockRobot.name,
@@ -200,14 +203,11 @@ describe('ModuleCard', () => {
       attachPipetteRequired: false,
       calibratePipetteRequired: false,
       updatePipetteFWRequired: false,
+      handleModuleApiRequests: mockHandleModuleApiRequests,
+      latestRequestId: MOCK_LATEST_REQUEST_ID,
     }
 
-    dispatchApiRequest = vi.fn()
     vi.mocked(ErrorInfo).mockReturnValue(null)
-    vi.mocked(useDispatchApiRequest).mockReturnValue([
-      dispatchApiRequest,
-      ['id'],
-    ])
     vi.mocked(MagneticModuleData).mockReturnValue(
       <div>Mock Magnetic Module Data</div>
     )

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import last from 'lodash/last'
 import { useHistory } from 'react-router-dom'
 
 import {
@@ -31,9 +30,7 @@ import {
 import { RUN_STATUS_FINISHING, RUN_STATUS_RUNNING } from '@opentrons/api-client'
 
 import { OverflowBtn } from '../../atoms/MenuList/OverflowBtn'
-import { updateModule } from '../../redux/modules'
 import {
-  useDispatchApiRequest,
   getRequestById,
   PENDING,
   FAILURE,
@@ -85,6 +82,8 @@ interface ModuleCardProps {
   attachPipetteRequired: boolean
   calibratePipetteRequired: boolean
   updatePipetteFWRequired: boolean
+  latestRequestId: string | null
+  handleModuleApiRequests: (robotName: string, serialNumber: string) => void
   runId?: string
   slotName?: string
 }
@@ -100,6 +99,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     attachPipetteRequired,
     calibratePipetteRequired,
     updatePipetteFWRequired,
+    latestRequestId,
+    handleModuleApiRequests,
   } = props
   const dispatch = useDispatch<Dispatch>()
   const {
@@ -115,13 +116,12 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const [hasSecondary, setHasSecondary] = React.useState(false)
   const [showAboutModule, setShowAboutModule] = React.useState(false)
   const [showTestShake, setShowTestShake] = React.useState(false)
-  const [showHSWizard, setShowHSWizard] = React.useState<boolean>(false)
-  const [showFWBanner, setShowFWBanner] = React.useState<boolean>(true)
-  const [showCalModal, setShowCalModal] = React.useState<boolean>(false)
+  const [showHSWizard, setShowHSWizard] = React.useState(false)
+  const [showFWBanner, setShowFWBanner] = React.useState(true)
+  const [showCalModal, setShowCalModal] = React.useState(false)
 
   const [targetProps, tooltipProps] = useHoverTooltip()
   const history = useHistory()
-  const [dispatchApiRequest, requestIds] = useDispatchApiRequest()
   const runStatus = useCurrentRunStatus({
     onSettled: data => {
       if (data == null) {
@@ -138,10 +138,24 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
     (!attachPipetteRequired ?? false) &&
     (!calibratePipetteRequired ?? false) &&
     (!updatePipetteFWRequired ?? false)
-  const latestRequestId = last(requestIds)
+
   const latestRequest = useSelector<State, RequestState | null>(state =>
-    latestRequestId ? getRequestById(state, latestRequestId) : null
+    latestRequestId != null ? getRequestById(state, latestRequestId) : null
   )
+
+  const hasUpdated =
+    !module.hasAvailableUpdate && latestRequest?.status === SUCCESS
+  const [showFirmwareToast, setShowFirmwareToast] = React.useState(hasUpdated)
+  const { makeToast } = useToaster()
+  if (showFirmwareToast) {
+    makeToast(t('firmware_updated_successfully'), SUCCESS_TOAST)
+    setShowFirmwareToast(false)
+  }
+
+  const handleFirmwareUpdateClick = (): void => {
+    robotName && handleModuleApiRequests(robotName, module.serialNumber)
+  }
+
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
 
   const handleCloseErrorModal = (): void => {
@@ -149,18 +163,6 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
       dispatch(dismissRequest(latestRequestId))
     }
   }
-
-  const handleFirmwareUpdateClick = (): void => {
-    robotName &&
-      dispatchApiRequest(updateModule(robotName, module.serialNumber))
-  }
-
-  const { makeToast } = useToaster()
-  React.useEffect(() => {
-    if (!module.hasAvailableUpdate && latestRequest?.status === SUCCESS) {
-      makeToast(t('firmware_update_installation_successful'), SUCCESS_TOAST)
-    }
-  }, [module.hasAvailableUpdate, latestRequest?.status, makeToast, t])
 
   const isPending = latestRequest?.status === PENDING
   const hotToTouch: IconProps = { name: 'ot-hot-to-touch' }

--- a/app/src/organisms/ModuleCard/utils.ts
+++ b/app/src/organisms/ModuleCard/utils.ts
@@ -1,3 +1,9 @@
+import * as React from 'react'
+import last from 'lodash/last'
+
+import { useDispatchApiRequest } from '../../redux/robot-api'
+import { updateModule } from '../../redux/modules'
+
 import magneticModule from '../../assets/images/magnetic_module_gen_2_transparent.png'
 import temperatureModule from '../../assets/images/temp_deck_gen_2_transparent.png'
 import thermoModuleGen1Closed from '../../assets/images/thermocycler_closed.png'
@@ -5,6 +11,7 @@ import thermoModuleGen1Opened from '../../assets/images/thermocycler_open_transp
 import heaterShakerModule from '../../assets/images/heater_shaker_module_transparent.png'
 import thermoModuleGen2Closed from '../../assets/images/thermocycler_gen_2_closed.png'
 import thermoModuleGen2Opened from '../../assets/images/thermocycler_gen_2_opened.png'
+
 import type { AttachedModule } from '../../redux/modules/types'
 
 export function getModuleCardImage(attachedModule: AttachedModule): string {
@@ -34,4 +41,59 @@ export function getModuleCardImage(attachedModule: AttachedModule): string {
     default:
       return 'unknown module model, this is an error'
   }
+}
+
+type RequestIdsBySerialNumber = Record<string, string[]>
+type HandleModuleApiRequestsType = (robotName: string, moduleId: string) => void
+type GetLatestRequestIdType = (moduleId: string) => string | null
+
+export function useModuleApiRequests(): [
+  GetLatestRequestIdType,
+  HandleModuleApiRequestsType
+] {
+  const [dispatchApiRequest] = useDispatchApiRequest()
+  const [
+    requestIdsBySerial,
+    setRequestIdsBySerial,
+  ] = React.useState<RequestIdsBySerialNumber>({})
+
+  const handleModuleApiRequests = (
+    robotName: string,
+    serialNumber: string
+  ): void => {
+    const action = dispatchApiRequest(updateModule(robotName, serialNumber))
+    const { requestId } = action.meta
+
+    if (requestId != null) {
+      if (serialNumber in requestIdsBySerial) {
+        setRequestIdsBySerial((prevState: RequestIdsBySerialNumber) => {
+          const existingRequestIds = prevState[serialNumber] || []
+          return {
+            ...prevState,
+            [serialNumber]: [...existingRequestIds, requestId],
+          }
+        })
+      } else {
+        setRequestIdsBySerial(prevState => {
+          return {
+            ...prevState,
+            [serialNumber]: [requestId],
+          }
+        })
+      }
+    }
+  }
+
+  const getLatestRequestId = React.useCallback(
+    (serialNumber: string): string | null => {
+      if (serialNumber in requestIdsBySerial) {
+        return last(requestIdsBySerial[serialNumber]) ?? null
+      } else {
+        return null
+      }
+    },
+    [requestIdsBySerial]
+  )
+
+  return [getLatestRequestId, handleModuleApiRequests]
 }


### PR DESCRIPTION
Closes [RQA-2588](https://opentrons.atlassian.net/browse/RQA-2588)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

There are two issues with rendering firmware update toasts. 

First, the toasts depend on a request id stored as state within the ModuleCard, but ModuleCards most often unrender during the firmware update process, so this state is lost. This causes the toast never to render. 

The second issue is that sometimes, given the timing of the polling for attached modules, the module is always attached during the firmware update, thereby causing the module card not to unrender. When this happens, the useEffect hook responsible for making the success toast has conditional logic that is always true after an update, causing the toast to render infinitely. 

The solution to both these problems is to lift the request id state out of the module card itself and then abstract away the storage/retrieval via a utility hook, which is utilized by all parent components of ModuleCard.


### Current Behavior


https://github.com/Opentrons/opentrons/assets/64858653/3056ed9f-0c62-4248-a0db-90fde6e8a5d4

### Fixed Behavior

https://github.com/Opentrons/opentrons/assets/64858653/0f5261b9-4d68-462a-a7e2-5924efdb9383


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Update a module's firmware then verify the update successful toast renders once. Let me know if you need help downgrading a module to test!
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Firmware update toasts now work.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2588]: https://opentrons.atlassian.net/browse/RQA-2588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ