### PR TITLE
feat(app): Only follow rear tip sensor during calibration setup

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1524,10 +1524,10 @@ class OT3Controller(FlexBackend):
     async def get_tip_status(
         self,
         mount: OT3Mount,
-        ht_operational_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         return await self.tip_presence_manager.get_tip_status(
-            mount, ht_operational_sensor
+            mount, ht_follow_singular_sensor
         )
 
     def current_tip_state(self, mount: OT3Mount) -> Optional[bool]:

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1524,10 +1524,10 @@ class OT3Controller(FlexBackend):
     async def get_tip_status(
         self,
         mount: OT3Mount,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         return await self.tip_presence_manager.get_tip_status(
-            mount, ht_follow_singular_sensor
+            mount, follow_singular_sensor
         )
 
     def current_tip_state(self, mount: OT3Mount) -> Optional[bool]:

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -783,7 +783,7 @@ class OT3Simulator(FlexBackend):
     async def get_tip_status(
         self,
         mount: OT3Mount,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         return TipStateType(self._sim_tip_state[mount])
 

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -783,7 +783,7 @@ class OT3Simulator(FlexBackend):
     async def get_tip_status(
         self,
         mount: OT3Mount,
-        ht_operational_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         return TipStateType(self._sim_tip_state[mount])
 

--- a/api/src/opentrons/hardware_control/backends/tip_presence_manager.py
+++ b/api/src/opentrons/hardware_control/backends/tip_presence_manager.py
@@ -116,21 +116,21 @@ class TipPresenceManager:
     @staticmethod
     def _get_tip_presence(
         results: List[tip_types.TipNotification],
-        ht_operational_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         """
-        We can use ht_operational_sensor used to specify that we only care
+        We can use ht_follow_singular_sensor used to specify that we only care
         about the status of one tip presence sensor on a high throughput
         pipette, and the other is allowed to be different.
         """
-        if ht_operational_sensor:
-            target_sensor_id = sensor_id_for_instrument(ht_operational_sensor)
+        if ht_follow_singular_sensor:
+            target_sensor_id = sensor_id_for_instrument(ht_follow_singular_sensor)
             for r in results:
                 if r.sensor == target_sensor_id:
                     return TipStateType(r.presence)
             # raise an error if requested sensor response isn't found
             raise GeneralError(
-                message=f"Requested status for sensor {ht_operational_sensor} not found."
+                message=f"Requested status for sensor {ht_follow_singular_sensor} not found."
             )
         # more than one sensor reported, we have to check if their states match
         if len(set(r.presence for r in results)) > 1:
@@ -142,11 +142,11 @@ class TipPresenceManager:
     async def get_tip_status(
         self,
         mount: OT3Mount,
-        ht_operational_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         detector = self.get_detector(mount)
         return self._get_tip_presence(
-            await detector.request_tip_status(), ht_operational_sensor
+            await detector.request_tip_status(), ht_follow_singular_sensor
         )
 
     def get_detector(self, mount: OT3Mount) -> TipDetector:

--- a/api/src/opentrons/hardware_control/backends/tip_presence_manager.py
+++ b/api/src/opentrons/hardware_control/backends/tip_presence_manager.py
@@ -116,21 +116,21 @@ class TipPresenceManager:
     @staticmethod
     def _get_tip_presence(
         results: List[tip_types.TipNotification],
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         """
-        We can use ht_follow_singular_sensor used to specify that we only care
+        We can use follow_singular_sensor used to specify that we only care
         about the status of one tip presence sensor on a high throughput
         pipette, and the other is allowed to be different.
         """
-        if ht_follow_singular_sensor:
-            target_sensor_id = sensor_id_for_instrument(ht_follow_singular_sensor)
+        if follow_singular_sensor:
+            target_sensor_id = sensor_id_for_instrument(follow_singular_sensor)
             for r in results:
                 if r.sensor == target_sensor_id:
                     return TipStateType(r.presence)
             # raise an error if requested sensor response isn't found
             raise GeneralError(
-                message=f"Requested status for sensor {ht_follow_singular_sensor} not found."
+                message=f"Requested status for sensor {follow_singular_sensor} not found."
             )
         # more than one sensor reported, we have to check if their states match
         if len(set(r.presence for r in results)) > 1:
@@ -142,11 +142,11 @@ class TipPresenceManager:
     async def get_tip_status(
         self,
         mount: OT3Mount,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         detector = self.get_detector(mount)
         return self._get_tip_presence(
-            await detector.request_tip_status(), ht_follow_singular_sensor
+            await detector.request_tip_status(), follow_singular_sensor
         )
 
     def get_detector(self, mount: OT3Mount) -> TipDetector:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2086,6 +2086,7 @@ class OT3API(
                     and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
                 ):
                     await stack.enter_async_context(self._high_throughput_check_tip())
+                result = await self._backend.get_tip_status(
                     real_mount, ht_follow_singular_sensor
                 )
             return result

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2072,7 +2072,7 @@ class OT3API(
     async def get_tip_presence_status(
         self,
         mount: Union[top_types.Mount, OT3Mount],
-        ht_operational_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         """
         Check tip presence status. If a high throughput pipette is present,
@@ -2086,8 +2086,7 @@ class OT3API(
                     and self._gantry_load == GantryLoad.HIGH_THROUGHPUT
                 ):
                     await stack.enter_async_context(self._high_throughput_check_tip())
-                result = await self._backend.get_tip_status(
-                    real_mount, ht_operational_sensor
+                    real_mount, ht_follow_singular_sensor
                 )
             return result
 
@@ -2095,10 +2094,12 @@ class OT3API(
         self,
         mount: Union[top_types.Mount, OT3Mount],
         expected: TipStateType,
-        ht_operational_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         real_mount = OT3Mount.from_mount(mount)
-        status = await self.get_tip_presence_status(real_mount, ht_operational_sensor)
+        status = await self.get_tip_presence_status(
+            real_mount, ht_follow_singular_sensor
+        )
         if status != expected:
             raise FailedTipStateCheck(expected, status.value)
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2072,7 +2072,7 @@ class OT3API(
     async def get_tip_presence_status(
         self,
         mount: Union[top_types.Mount, OT3Mount],
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> TipStateType:
         """
         Check tip presence status. If a high throughput pipette is present,
@@ -2087,7 +2087,7 @@ class OT3API(
                 ):
                     await stack.enter_async_context(self._high_throughput_check_tip())
                 result = await self._backend.get_tip_status(
-                    real_mount, ht_follow_singular_sensor
+                    real_mount, follow_singular_sensor
                 )
             return result
 
@@ -2095,12 +2095,10 @@ class OT3API(
         self,
         mount: Union[top_types.Mount, OT3Mount],
         expected: TipStateType,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         real_mount = OT3Mount.from_mount(mount)
-        status = await self.get_tip_presence_status(
-            real_mount, ht_follow_singular_sensor
-        )
+        status = await self.get_tip_presence_status(real_mount, follow_singular_sensor)
         if status != expected:
             raise FailedTipStateCheck(expected, status.value)
 

--- a/api/src/opentrons/hardware_control/protocols/flex_instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/flex_instrument_configurer.py
@@ -1,5 +1,5 @@
 """Flex-specific extensions to instrument configuration."""
-from typing import Union
+from typing import Union, Optional
 from typing_extensions import Protocol
 
 from .types import MountArgType
@@ -9,6 +9,7 @@ from opentrons.hardware_control.dev_types import (
 )
 from opentrons.hardware_control.types import (
     TipStateType,
+    InstrumentProbeType,
 )
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     PipetteOffsetSummary,
@@ -42,7 +43,10 @@ class FlexInstrumentConfigurer(Protocol[MountArgType]):
         ...
 
     async def verify_tip_presence(
-        self, mount: MountArgType, expected: TipStateType
+        self,
+        mount: MountArgType,
+        expected: TipStateType,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Check tip presence status and raise if it does not match `expected`."""
         ...

--- a/api/src/opentrons/hardware_control/protocols/flex_instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/flex_instrument_configurer.py
@@ -46,7 +46,7 @@ class FlexInstrumentConfigurer(Protocol[MountArgType]):
         self,
         mount: MountArgType,
         expected: TipStateType,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Check tip presence status and raise if it does not match `expected`."""
         ...

--- a/api/src/opentrons/hardware_control/protocols/flex_instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/flex_instrument_configurer.py
@@ -46,7 +46,7 @@ class FlexInstrumentConfigurer(Protocol[MountArgType]):
         self,
         mount: MountArgType,
         expected: TipStateType,
-        follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Check tip presence status and raise if it does not match `expected`."""
         ...

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -8,7 +8,7 @@ from typing_extensions import Literal
 from .pipetting_common import PipetteIdMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
 
-from ..types import TipPresenceStatus
+from ..types import TipPresenceStatus, InstrumentSensorId
 
 if TYPE_CHECKING:
     from ..execution import TipHandler
@@ -22,6 +22,9 @@ class VerifyTipPresenceParams(PipetteIdMixin):
 
     expectedState: TipPresenceStatus = Field(
         ..., description="The expected tip presence status on the pipette."
+    )
+    ht_follow_singular_sensor: Optional[InstrumentSensorId] = Field(
+        default=None, description="The sensor id to follow if the other can be ignored."
     )
 
 
@@ -47,10 +50,18 @@ class VerifyTipPresenceImplementation(
         """Verify if tip presence is as expected for the requested pipette."""
         pipette_id = params.pipetteId
         expected_state = params.expectedState
+        ht_follow_singular_sensor = (
+            InstrumentSensorId.to_instrument_probe_type(
+                params.ht_follow_singular_sensor
+            )
+            if params.ht_follow_singular_sensor
+            else None
+        )
 
         await self._tip_handler.verify_tip_presence(
             pipette_id=pipette_id,
             expected=expected_state,
+            ht_follow_singular_sensor=ht_follow_singular_sensor,
         )
 
         return VerifyTipPresenceResult()

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -51,10 +51,8 @@ class VerifyTipPresenceImplementation(
         pipette_id = params.pipetteId
         expected_state = params.expectedState
         ht_follow_singular_sensor = (
-            InstrumentSensorId.to_instrument_probe_type(
-                params.ht_follow_singular_sensor
-            )
-            if params.ht_follow_singular_sensor
+            InstrumentSensorId.to_instrument_probe_type(params.htFollowSingularSensor)
+            if params.htFollowSingularSensor
             else None
         )
 

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -23,7 +23,7 @@ class VerifyTipPresenceParams(PipetteIdMixin):
     expectedState: TipPresenceStatus = Field(
         ..., description="The expected tip presence status on the pipette."
     )
-    htFollowSingularSensor: Optional[InstrumentSensorId] = Field(
+    FollowSingularSensor: Optional[InstrumentSensorId] = Field(
         default=None, description="The sensor id to follow if the other can be ignored."
     )
 
@@ -50,16 +50,16 @@ class VerifyTipPresenceImplementation(
         """Verify if tip presence is as expected for the requested pipette."""
         pipette_id = params.pipetteId
         expected_state = params.expectedState
-        ht_follow_singular_sensor = (
-            InstrumentSensorId.to_instrument_probe_type(params.htFollowSingularSensor)
-            if params.htFollowSingularSensor
+        follow_singular_sensor = (
+            InstrumentSensorId.to_instrument_probe_type(params.FollowSingularSensor)
+            if params.FollowSingularSensor
             else None
         )
 
         await self._tip_handler.verify_tip_presence(
             pipette_id=pipette_id,
             expected=expected_state,
-            ht_follow_singular_sensor=ht_follow_singular_sensor,
+            follow_singular_sensor=follow_singular_sensor,
         )
 
         return VerifyTipPresenceResult()

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -23,7 +23,7 @@ class VerifyTipPresenceParams(PipetteIdMixin):
     expectedState: TipPresenceStatus = Field(
         ..., description="The expected tip presence status on the pipette."
     )
-    FollowSingularSensor: Optional[InstrumentSensorId] = Field(
+    followSingularSensor: Optional[InstrumentSensorId] = Field(
         default=None, description="The sensor id to follow if the other can be ignored."
     )
 
@@ -51,8 +51,8 @@ class VerifyTipPresenceImplementation(
         pipette_id = params.pipetteId
         expected_state = params.expectedState
         follow_singular_sensor = (
-            InstrumentSensorId.to_instrument_probe_type(params.FollowSingularSensor)
-            if params.FollowSingularSensor
+            InstrumentSensorId.to_instrument_probe_type(params.followSingularSensor)
+            if params.followSingularSensor
             else None
         )
 

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -23,7 +23,7 @@ class VerifyTipPresenceParams(PipetteIdMixin):
     expectedState: TipPresenceStatus = Field(
         ..., description="The expected tip presence status on the pipette."
     )
-    ht_follow_singular_sensor: Optional[InstrumentSensorId] = Field(
+    htFollowSingularSensor: Optional[InstrumentSensorId] = Field(
         default=None, description="The sensor id to follow if the other can be ignored."
     )
 

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -77,7 +77,7 @@ class TipHandler(TypingProtocol):
         self,
         pipette_id: str,
         expected: TipPresenceStatus,
-        follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Verify the expected tip presence status."""
 
@@ -243,7 +243,7 @@ class HardwareTipHandler(TipHandler):
         self,
         pipette_id: str,
         expected: TipPresenceStatus,
-        follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Verify the expecterd tip presence status of the pipette.
 
@@ -254,7 +254,7 @@ class HardwareTipHandler(TipHandler):
             ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
             hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()
             await ot3api.verify_tip_presence(
-                hw_mount, expected.to_hw_state(), follow_singular_sensor
+                hw_mount, expected.to_hw_state(), ht_follow_singular_sensor
             )
         except HardwareNotSupportedError:
             # Tip presence sensing is not supported on the OT2
@@ -343,7 +343,7 @@ class VirtualTipHandler(TipHandler):
         self,
         pipette_id: str,
         expected: TipPresenceStatus,
-        follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Verify tip presence.
 

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -77,7 +77,7 @@ class TipHandler(TypingProtocol):
         self,
         pipette_id: str,
         expected: TipPresenceStatus,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Verify the expected tip presence status."""
 
@@ -243,7 +243,7 @@ class HardwareTipHandler(TipHandler):
         self,
         pipette_id: str,
         expected: TipPresenceStatus,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Verify the expecterd tip presence status of the pipette.
 
@@ -254,7 +254,7 @@ class HardwareTipHandler(TipHandler):
             ot3api = ensure_ot3_hardware(hardware_api=self._hardware_api)
             hw_mount = self._state_view.pipettes.get_mount(pipette_id).to_hw_mount()
             await ot3api.verify_tip_presence(
-                hw_mount, expected.to_hw_state(), ht_follow_singular_sensor
+                hw_mount, expected.to_hw_state(), follow_singular_sensor
             )
         except HardwareNotSupportedError:
             # Tip presence sensing is not supported on the OT2
@@ -343,7 +343,7 @@ class VirtualTipHandler(TipHandler):
         self,
         pipette_id: str,
         expected: TipPresenceStatus,
-        ht_follow_singular_sensor: Optional[InstrumentProbeType] = None,
+        follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         """Verify tip presence.
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -10,7 +10,10 @@ from typing_extensions import Literal, TypeGuard
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName, StagingSlotName
-from opentrons.hardware_control.types import TipStateType as HwTipStateType
+from opentrons.hardware_control.types import (
+    TipStateType as HwTipStateType,
+    InstrumentProbeType,
+)
 from opentrons.hardware_control.modules import (
     ModuleType as ModuleType,
 )
@@ -828,6 +831,22 @@ NozzleLayoutConfigurationType = Union[
 DeckConfigurationType = List[
     Tuple[str, str, Optional[str]]
 ]  # cutout_id, cutout_fixture_id, opentrons_module_serial_number
+
+
+class InstrumentSensorId(str, Enum):
+    """Primary and secondary sensor ids."""
+
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
+    BOTH = "both"
+
+    def to_instrument_probe_type(self) -> InstrumentProbeType:
+        """Convert to InstrumentProbeType."""
+        return {
+            InstrumentSensorId.PRIMARY: InstrumentProbeType.PRIMARY,
+            InstrumentSensorId.SECONDARY: InstrumentProbeType.SECONDARY,
+            InstrumentSensorId.BOTH: InstrumentProbeType.BOTH,
+        }[self]
 
 
 class TipPresenceStatus(str, Enum):

--- a/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
@@ -413,11 +413,11 @@ async def test_verify_tip_presence_on_ot3(
         decoy.when(mock_state_view.pipettes.get_mount("pipette-id")).then_return(
             MountType.LEFT
         )
-        await subject.verify_tip_presence("pipette-id", expected)
+        await subject.verify_tip_presence("pipette-id", expected, None)
 
         decoy.verify(
             await ot3_hardware_api.verify_tip_presence(
-                Mount.LEFT, expected.to_hw_state()
+                Mount.LEFT, expected.to_hw_state(), None
             )
         )
 

--- a/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
@@ -96,7 +96,11 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     const verifyCommands: CreateCommand[] = [
       {
         commandType: 'verifyTipPresence',
-        params: { pipetteId: pipetteId, expectedState: 'present', FollowSingularSensor: 'primary' },
+        params: {
+          pipetteId: pipetteId,
+          expectedState: 'present',
+          followSingularSensor: 'primary',
+        },
       },
     ]
     const homeCommands: CreateCommand[] = [

--- a/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
@@ -96,7 +96,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     const verifyCommands: CreateCommand[] = [
       {
         commandType: 'verifyTipPresence',
-        params: { pipetteId: pipetteId, expectedState: 'present', htFollowSingularSensor: 'primary' },
+        params: { pipetteId: pipetteId, expectedState: 'present', FollowSingularSensor: 'primary' },
       },
     ]
     const homeCommands: CreateCommand[] = [

--- a/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LabwarePositionCheck/AttachProbe.tsx
@@ -96,7 +96,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     const verifyCommands: CreateCommand[] = [
       {
         commandType: 'verifyTipPresence',
-        params: { pipetteId: pipetteId, expectedState: 'present' },
+        params: { pipetteId: pipetteId, expectedState: 'present', htFollowSingularSensor: 'primary' },
       },
     ]
     const homeCommands: CreateCommand[] = [

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -79,7 +79,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     const verifyCommands: CreateCommand[] = [
       {
         commandType: 'verifyTipPresence',
-        params: { pipetteId: pipetteId, expectedState: 'present', htFollowSingularSensor: 'primary' },
+        params: { pipetteId: pipetteId, expectedState: 'present', FollowSingularSensor: 'primary' },
       },
     ]
     const homeCommands: CreateCommand[] = [

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -79,7 +79,11 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     const verifyCommands: CreateCommand[] = [
       {
         commandType: 'verifyTipPresence',
-        params: { pipetteId: pipetteId, expectedState: 'present', FollowSingularSensor: 'primary' },
+        params: {
+          pipetteId: pipetteId,
+          expectedState: 'present',
+          followSingularSensor: 'primary',
+        },
       },
     ]
     const homeCommands: CreateCommand[] = [

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -79,7 +79,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     const verifyCommands: CreateCommand[] = [
       {
         commandType: 'verifyTipPresence',
-        params: { pipetteId: pipetteId, expectedState: 'present' },
+        params: { pipetteId: pipetteId, expectedState: 'present', htFollowSingularSensor: 'primary' },
       },
     ]
     const homeCommands: CreateCommand[] = [

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -71,7 +71,7 @@ describe('AttachProbe', () => {
         [
           {
             commandType: 'verifyTipPresence',
-            params: { pipetteId: 'abc', expectedState: 'present' },
+            params: { pipetteId: 'abc', expectedState: 'present', followSingularSensor: 'primary'},
           },
         ],
         false
@@ -205,7 +205,7 @@ describe('AttachProbe', () => {
         [
           {
             commandType: 'verifyTipPresence',
-            params: { pipetteId: 'abc', expectedState: 'present' },
+            params: { pipetteId: 'abc', expectedState: 'present', followSingularSensor: 'primary'},
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/AttachProbe.test.tsx
@@ -71,7 +71,11 @@ describe('AttachProbe', () => {
         [
           {
             commandType: 'verifyTipPresence',
-            params: { pipetteId: 'abc', expectedState: 'present', followSingularSensor: 'primary'},
+            params: {
+              pipetteId: 'abc',
+              expectedState: 'present',
+              followSingularSensor: 'primary',
+            },
           },
         ],
         false
@@ -205,7 +209,11 @@ describe('AttachProbe', () => {
         [
           {
             commandType: 'verifyTipPresence',
-            params: { pipetteId: 'abc', expectedState: 'present', followSingularSensor: 'primary'},
+            params: {
+              pipetteId: 'abc',
+              expectedState: 'present',
+              followSingularSensor: 'primary',
+            },
           },
         ],
         false

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -249,7 +249,11 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
       "type": "string"
     },
     "WellOffset": {
@@ -334,12 +338,22 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup", "fixit"],
+      "enum": [
+        "protocol",
+        "setup",
+        "fixit"
+      ],
       "type": "string"
     },
     "AspirateCreate": {
@@ -350,7 +364,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": ["aspirate"],
+          "enum": [
+            "aspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -370,7 +386,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -395,7 +413,11 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -405,7 +427,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": ["aspirateInPlace"],
+          "enum": [
+            "aspirateInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -425,7 +449,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -438,7 +464,9 @@
           "type": "string"
         }
       },
-      "required": ["message"]
+      "required": [
+        "message"
+      ]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -448,7 +476,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": ["comment"],
+          "enum": [
+            "comment"
+          ],
           "type": "string"
         },
         "params": {
@@ -468,7 +498,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -487,7 +519,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "volume"]
+      "required": [
+        "pipetteId",
+        "volume"
+      ]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -497,7 +532,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": ["configureForVolume"],
+          "enum": [
+            "configureForVolume"
+          ],
           "type": "string"
         },
         "params": {
@@ -517,7 +554,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -527,7 +566,9 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": ["ALL"],
+          "enum": [
+            "ALL"
+          ],
           "type": "string"
         }
       }
@@ -540,17 +581,26 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": ["SINGLE"],
+          "enum": [
+            "SINGLE"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -560,17 +610,26 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": ["ROW"],
+          "enum": [
+            "ROW"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -580,17 +639,26 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": ["COLUMN"],
+          "enum": [
+            "COLUMN"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"]
+      "required": [
+        "primaryNozzle"
+      ]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -600,13 +668,20 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": ["QUADRANT"],
+          "enum": [
+            "QUADRANT"
+          ],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -616,7 +691,10 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle", "frontRightNozzle"]
+      "required": [
+        "primaryNozzle",
+        "frontRightNozzle"
+      ]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -649,7 +727,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "configurationParams"]
+      "required": [
+        "pipetteId",
+        "configurationParams"
+      ]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -659,7 +740,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": ["configureNozzleLayout"],
+          "enum": [
+            "configureNozzleLayout"
+          ],
           "type": "string"
         },
         "params": {
@@ -679,7 +762,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -695,7 +780,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": ["custom"],
+          "enum": [
+            "custom"
+          ],
           "type": "string"
         },
         "params": {
@@ -715,7 +802,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -764,7 +853,13 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -774,7 +869,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": ["dispense"],
+          "enum": [
+            "dispense"
+          ],
           "type": "string"
         },
         "params": {
@@ -794,7 +891,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -824,7 +923,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"]
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -834,7 +937,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": ["dispenseInPlace"],
+          "enum": [
+            "dispenseInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -854,7 +959,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -892,7 +999,12 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -902,7 +1014,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": ["blowout"],
+          "enum": [
+            "blowout"
+          ],
           "type": "string"
         },
         "params": {
@@ -922,7 +1036,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -941,7 +1057,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"]
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -951,7 +1070,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": ["blowOutInPlace"],
+          "enum": [
+            "blowOutInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -971,12 +1092,19 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1038,7 +1166,11 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"]
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1048,7 +1180,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": ["dropTip"],
+          "enum": [
+            "dropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -1068,7 +1202,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1086,7 +1222,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1096,7 +1234,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": ["dropTipInPlace"],
+          "enum": [
+            "dropTipInPlace"
+          ],
           "type": "string"
         },
         "params": {
@@ -1116,7 +1256,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1136,7 +1278,11 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "type": "string"
     },
     "HomeParams": {
@@ -1169,7 +1315,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": ["home"],
+          "enum": [
+            "home"
+          ],
           "type": "string"
         },
         "params": {
@@ -1189,7 +1337,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1205,7 +1355,9 @@
           ]
         }
       },
-      "required": ["axis"]
+      "required": [
+        "axis"
+      ]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1215,7 +1367,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": ["retractAxis"],
+          "enum": [
+            "retractAxis"
+          ],
           "type": "string"
         },
         "params": {
@@ -1235,7 +1389,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1281,7 +1437,9 @@
           ]
         }
       },
-      "required": ["slotName"]
+      "required": [
+        "slotName"
+      ]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1294,7 +1452,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1307,7 +1467,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"]
+      "required": [
+        "labwareId"
+      ]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1320,7 +1482,9 @@
           "type": "string"
         }
       },
-      "required": ["addressableAreaName"]
+      "required": [
+        "addressableAreaName"
+      ]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1341,7 +1505,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             },
             {
@@ -1375,7 +1541,12 @@
           "type": "string"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"]
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1385,7 +1556,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": ["loadLabware"],
+          "enum": [
+            "loadLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1405,7 +1578,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1431,7 +1606,11 @@
           }
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"]
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1441,7 +1620,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": ["loadLiquid"],
+          "enum": [
+            "loadLiquid"
+          ],
           "type": "string"
         },
         "params": {
@@ -1461,7 +1642,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1506,7 +1689,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"]
+      "required": [
+        "model",
+        "location"
+      ]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1516,7 +1702,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": ["loadModule"],
+          "enum": [
+            "loadModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -1536,7 +1724,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1589,7 +1779,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteName", "mount"]
+      "required": [
+        "pipetteName",
+        "mount"
+      ]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1599,7 +1792,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": ["loadPipette"],
+          "enum": [
+            "loadPipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -1619,12 +1814,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1645,7 +1846,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1671,7 +1876,9 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": ["offDeck"],
+              "enum": [
+                "offDeck"
+              ],
               "type": "string"
             },
             {
@@ -1706,7 +1913,11 @@
           ]
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"]
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1716,7 +1927,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": ["moveLabware"],
+          "enum": [
+            "moveLabware"
+          ],
           "type": "string"
         },
         "params": {
@@ -1736,12 +1949,18 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1768,7 +1987,11 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "axis", "distance"]
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -1778,7 +2001,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": ["moveRelative"],
+          "enum": [
+            "moveRelative"
+          ],
           "type": "string"
         },
         "params": {
@@ -1798,7 +2023,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -1818,7 +2045,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -1856,7 +2087,10 @@
           ]
         }
       },
-      "required": ["pipetteId", "coordinates"]
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -1866,7 +2100,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": ["moveToCoordinates"],
+          "enum": [
+            "moveToCoordinates"
+          ],
           "type": "string"
         },
         "params": {
@@ -1886,7 +2122,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -1934,7 +2172,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -1944,7 +2186,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": ["moveToWell"],
+          "enum": [
+            "moveToWell"
+          ],
           "type": "string"
         },
         "params": {
@@ -1964,7 +2208,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -1984,7 +2230,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2038,7 +2288,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"]
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2048,7 +2301,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": ["moveToAddressableArea"],
+          "enum": [
+            "moveToAddressableArea"
+          ],
           "type": "string"
         },
         "params": {
@@ -2068,7 +2323,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2128,7 +2385,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"]
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2138,7 +2398,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": ["moveToAddressableAreaForDropTip"],
+          "enum": [
+            "moveToAddressableAreaForDropTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2158,7 +2420,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2171,7 +2435,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2181,7 +2447,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": ["prepareToAspirate"],
+          "enum": [
+            "prepareToAspirate"
+          ],
           "type": "string"
         },
         "params": {
@@ -2201,7 +2469,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2223,7 +2493,10 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "type": "string"
         },
         "params": {
@@ -2243,7 +2516,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2261,7 +2536,9 @@
           "type": "string"
         }
       },
-      "required": ["seconds"]
+      "required": [
+        "seconds"
+      ]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2271,7 +2548,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": ["waitForDuration"],
+          "enum": [
+            "waitForDuration"
+          ],
           "type": "string"
         },
         "params": {
@@ -2291,7 +2570,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2323,7 +2604,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2333,7 +2618,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": ["pickUpTip"],
+          "enum": [
+            "pickUpTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2353,7 +2640,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2377,7 +2666,9 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2387,7 +2678,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": ["savePosition"],
+          "enum": [
+            "savePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -2407,7 +2700,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2420,7 +2715,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"]
+      "required": [
+        "on"
+      ]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2430,7 +2727,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": ["setRailLights"],
+          "enum": [
+            "setRailLights"
+          ],
           "type": "string"
         },
         "params": {
@@ -2450,7 +2749,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2493,7 +2794,11 @@
           "type": "number"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"]
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2503,7 +2808,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": ["touchTip"],
+          "enum": [
+            "touchTip"
+          ],
           "type": "string"
         },
         "params": {
@@ -2523,12 +2830,20 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": ["idle", "confirm", "updating", "disco", "off"]
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2544,7 +2859,9 @@
           ]
         }
       },
-      "required": ["animation"]
+      "required": [
+        "animation"
+      ]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2554,7 +2871,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": ["setStatusBar"],
+          "enum": [
+            "setStatusBar"
+          ],
           "type": "string"
         },
         "params": {
@@ -2574,12 +2893,28 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": ["present", "absent", "unknown"],
+      "enum": [
+        "present",
+        "absent",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "InstrumentSensorId": {
+      "title": "InstrumentSensorId",
+      "description": "Primary and secondary sensor ids.",
+      "enum": [
+        "primary",
+        "secondary",
+        "both"
+      ],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -2600,16 +2935,19 @@
             }
           ]
         },
-        "FollowSingularSensor":  {
-          "description": "Which high throughput sensor to use, if we're indifferent to the other.",
+        "followSingularSensor": {
+          "description": "The sensor id to follow if the other can be ignored.",
           "allOf": [
             {
-              "$ref": "#/definitions/TipPresenceStatus"
+              "$ref": "#/definitions/InstrumentSensorId"
             }
           ]
         }
       },
-      "required": ["pipetteId", "expectedState"]
+      "required": [
+        "pipetteId",
+        "expectedState"
+      ]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -2619,7 +2957,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": ["verifyTipPresence"],
+          "enum": [
+            "verifyTipPresence"
+          ],
           "type": "string"
         },
         "params": {
@@ -2639,7 +2979,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -2652,7 +2994,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"]
+      "required": [
+        "pipetteId"
+      ]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -2662,7 +3006,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": ["getTipPresence"],
+          "enum": [
+            "getTipPresence"
+          ],
           "type": "string"
         },
         "params": {
@@ -2682,7 +3028,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -2700,7 +3048,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -2710,7 +3060,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": ["heaterShaker/waitForTemperature"],
+          "enum": [
+            "heaterShaker/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2730,7 +3082,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -2748,7 +3102,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -2758,7 +3115,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": ["heaterShaker/setTargetTemperature"],
+          "enum": [
+            "heaterShaker/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -2778,7 +3137,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -2791,7 +3152,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -2801,7 +3164,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": ["heaterShaker/deactivateHeater"],
+          "enum": [
+            "heaterShaker/deactivateHeater"
+          ],
           "type": "string"
         },
         "params": {
@@ -2821,7 +3186,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -2839,7 +3206,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"]
+      "required": [
+        "moduleId",
+        "rpm"
+      ]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -2849,7 +3219,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
+          "enum": [
+            "heaterShaker/setAndWaitForShakeSpeed"
+          ],
           "type": "string"
         },
         "params": {
@@ -2869,7 +3241,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -2882,7 +3256,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -2892,7 +3268,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": ["heaterShaker/deactivateShaker"],
+          "enum": [
+            "heaterShaker/deactivateShaker"
+          ],
           "type": "string"
         },
         "params": {
@@ -2912,7 +3290,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -2925,7 +3305,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -2935,7 +3317,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": ["heaterShaker/openLabwareLatch"],
+          "enum": [
+            "heaterShaker/openLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -2955,7 +3339,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -2968,7 +3354,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -2978,7 +3366,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": ["heaterShaker/closeLabwareLatch"],
+          "enum": [
+            "heaterShaker/closeLabwareLatch"
+          ],
           "type": "string"
         },
         "params": {
@@ -2998,7 +3388,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3011,7 +3403,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3021,7 +3415,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": ["magneticModule/disengage"],
+          "enum": [
+            "magneticModule/disengage"
+          ],
           "type": "string"
         },
         "params": {
@@ -3041,7 +3437,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3059,7 +3457,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "height"]
+      "required": [
+        "moduleId",
+        "height"
+      ]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3069,7 +3470,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": ["magneticModule/engage"],
+          "enum": [
+            "magneticModule/engage"
+          ],
           "type": "string"
         },
         "params": {
@@ -3089,7 +3492,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3107,7 +3512,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3117,7 +3525,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": ["temperatureModule/setTargetTemperature"],
+          "enum": [
+            "temperatureModule/setTargetTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3137,7 +3547,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3155,7 +3567,9 @@
           "type": "number"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3165,7 +3579,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": ["temperatureModule/waitForTemperature"],
+          "enum": [
+            "temperatureModule/waitForTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3185,7 +3601,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3198,7 +3616,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3208,7 +3628,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": ["temperatureModule/deactivate"],
+          "enum": [
+            "temperatureModule/deactivate"
+          ],
           "type": "string"
         },
         "params": {
@@ -3228,7 +3650,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3256,7 +3680,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3266,7 +3693,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": ["thermocycler/setTargetBlockTemperature"],
+          "enum": [
+            "thermocycler/setTargetBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3286,7 +3715,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3299,7 +3730,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3309,7 +3742,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": ["thermocycler/waitForBlockTemperature"],
+          "enum": [
+            "thermocycler/waitForBlockTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3329,7 +3764,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -3347,7 +3784,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "celsius"]
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -3357,7 +3797,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": ["thermocycler/setTargetLidTemperature"],
+          "enum": [
+            "thermocycler/setTargetLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3377,7 +3819,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -3390,7 +3834,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -3400,7 +3846,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": ["thermocycler/waitForLidTemperature"],
+          "enum": [
+            "thermocycler/waitForLidTemperature"
+          ],
           "type": "string"
         },
         "params": {
@@ -3420,7 +3868,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -3433,7 +3883,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -3443,7 +3895,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": ["thermocycler/deactivateBlock"],
+          "enum": [
+            "thermocycler/deactivateBlock"
+          ],
           "type": "string"
         },
         "params": {
@@ -3463,7 +3917,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -3476,7 +3932,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -3486,7 +3944,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": ["thermocycler/deactivateLid"],
+          "enum": [
+            "thermocycler/deactivateLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3506,7 +3966,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -3519,7 +3981,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -3529,7 +3993,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": ["thermocycler/openLid"],
+          "enum": [
+            "thermocycler/openLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3549,7 +4015,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -3562,7 +4030,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"]
+      "required": [
+        "moduleId"
+      ]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -3572,7 +4042,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": ["thermocycler/closeLid"],
+          "enum": [
+            "thermocycler/closeLid"
+          ],
           "type": "string"
         },
         "params": {
@@ -3592,7 +4064,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -3610,7 +4084,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"]
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -3636,7 +4113,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "profile"]
+      "required": [
+        "moduleId",
+        "profile"
+      ]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -3646,7 +4126,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": ["thermocycler/runProfile"],
+          "enum": [
+            "thermocycler/runProfile"
+          ],
           "type": "string"
         },
         "params": {
@@ -3666,12 +4148,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": ["front", "rear"]
+      "enum": [
+        "front",
+        "rear"
+      ]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -3691,7 +4178,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"]
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -3716,7 +4207,9 @@
           ]
         }
       },
-      "required": ["jaw"]
+      "required": [
+        "jaw"
+      ]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -3726,7 +4219,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": ["calibration/calibrateGripper"],
+          "enum": [
+            "calibration/calibrateGripper"
+          ],
           "type": "string"
         },
         "params": {
@@ -3746,7 +4241,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -3762,7 +4259,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -3772,7 +4271,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": ["calibration/calibratePipette"],
+          "enum": [
+            "calibration/calibratePipette"
+          ],
           "type": "string"
         },
         "params": {
@@ -3792,7 +4293,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -3818,7 +4321,11 @@
           ]
         }
       },
-      "required": ["moduleId", "labwareId", "mount"]
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -3828,7 +4335,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": ["calibration/calibrateModule"],
+          "enum": [
+            "calibration/calibrateModule"
+          ],
           "type": "string"
         },
         "params": {
@@ -3848,12 +4357,17 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"]
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -3878,7 +4392,9 @@
           ]
         }
       },
-      "required": ["mount"]
+      "required": [
+        "mount"
+      ]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -3888,7 +4404,9 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": ["calibration/moveToMaintenancePosition"],
+          "enum": [
+            "calibration/moveToMaintenancePosition"
+          ],
           "type": "string"
         },
         "params": {
@@ -3908,7 +4426,9 @@
           "type": "string"
         }
       },
-      "required": ["params"]
+      "required": [
+        "params"
+      ]
     }
   },
   "$id": "opentronsCommandSchemaV8",

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -2599,6 +2599,14 @@
               "$ref": "#/definitions/TipPresenceStatus"
             }
           ]
+        },
+        "htFollowSingularSensor":  {
+          "description": "Which high throughput sensor to use, if we're indifferent to the other.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TipPresenceStatus"
+            }
+          ]
         }
       },
       "required": ["pipetteId", "expectedState"]

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -249,11 +249,7 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "type": "string"
     },
     "WellOffset": {
@@ -338,22 +334,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup",
-        "fixit"
-      ],
+      "enum": ["protocol", "setup", "fixit"],
       "type": "string"
     },
     "AspirateCreate": {
@@ -364,9 +350,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": [
-            "aspirate"
-          ],
+          "enum": ["aspirate"],
           "type": "string"
         },
         "params": {
@@ -386,9 +370,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -413,11 +395,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -427,9 +405,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": [
-            "aspirateInPlace"
-          ],
+          "enum": ["aspirateInPlace"],
           "type": "string"
         },
         "params": {
@@ -449,9 +425,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -464,9 +438,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ]
+      "required": ["message"]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -476,9 +448,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": [
-            "comment"
-          ],
+          "enum": ["comment"],
           "type": "string"
         },
         "params": {
@@ -498,9 +468,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -519,10 +487,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "volume"
-      ]
+      "required": ["pipetteId", "volume"]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -532,9 +497,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": [
-            "configureForVolume"
-          ],
+          "enum": ["configureForVolume"],
           "type": "string"
         },
         "params": {
@@ -554,9 +517,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -566,9 +527,7 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": [
-            "ALL"
-          ],
+          "enum": ["ALL"],
           "type": "string"
         }
       }
@@ -581,26 +540,17 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": [
-            "SINGLE"
-          ],
+          "enum": ["SINGLE"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -610,26 +560,17 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": [
-            "ROW"
-          ],
+          "enum": ["ROW"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -639,26 +580,17 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": [
-            "COLUMN"
-          ],
+          "enum": ["COLUMN"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -668,20 +600,13 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": [
-            "QUADRANT"
-          ],
+          "enum": ["QUADRANT"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -691,10 +616,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle",
-        "frontRightNozzle"
-      ]
+      "required": ["primaryNozzle", "frontRightNozzle"]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -727,10 +649,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "configurationParams"
-      ]
+      "required": ["pipetteId", "configurationParams"]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -740,9 +659,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": [
-            "configureNozzleLayout"
-          ],
+          "enum": ["configureNozzleLayout"],
           "type": "string"
         },
         "params": {
@@ -762,9 +679,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -780,9 +695,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": [
-            "custom"
-          ],
+          "enum": ["custom"],
           "type": "string"
         },
         "params": {
@@ -802,9 +715,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -853,13 +764,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -869,9 +774,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": [
-            "dispense"
-          ],
+          "enum": ["dispense"],
           "type": "string"
         },
         "params": {
@@ -891,9 +794,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -923,11 +824,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -937,9 +834,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": [
-            "dispenseInPlace"
-          ],
+          "enum": ["dispenseInPlace"],
           "type": "string"
         },
         "params": {
@@ -959,9 +854,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -999,12 +892,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -1014,9 +902,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": [
-            "blowout"
-          ],
+          "enum": ["blowout"],
           "type": "string"
         },
         "params": {
@@ -1036,9 +922,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -1057,10 +941,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -1070,9 +951,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": [
-            "blowOutInPlace"
-          ],
+          "enum": ["blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -1092,19 +971,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1166,11 +1038,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ]
+      "required": ["pipetteId", "labwareId", "wellName"]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1180,9 +1048,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": [
-            "dropTip"
-          ],
+          "enum": ["dropTip"],
           "type": "string"
         },
         "params": {
@@ -1202,9 +1068,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1222,9 +1086,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1234,9 +1096,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": [
-            "dropTipInPlace"
-          ],
+          "enum": ["dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -1256,9 +1116,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1278,11 +1136,7 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "type": "string"
     },
     "HomeParams": {
@@ -1315,9 +1169,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": [
-            "home"
-          ],
+          "enum": ["home"],
           "type": "string"
         },
         "params": {
@@ -1337,9 +1189,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1355,9 +1205,7 @@
           ]
         }
       },
-      "required": [
-        "axis"
-      ]
+      "required": ["axis"]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1367,9 +1215,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": [
-            "retractAxis"
-          ],
+          "enum": ["retractAxis"],
           "type": "string"
         },
         "params": {
@@ -1389,9 +1235,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1437,9 +1281,7 @@
           ]
         }
       },
-      "required": [
-        "slotName"
-      ]
+      "required": ["slotName"]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1452,9 +1294,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1467,9 +1307,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1482,9 +1320,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "addressableAreaName"
-      ]
+      "required": ["addressableAreaName"]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1505,9 +1341,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -1541,12 +1375,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ]
+      "required": ["location", "loadName", "namespace", "version"]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1556,9 +1385,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": [
-            "loadLabware"
-          ],
+          "enum": ["loadLabware"],
           "type": "string"
         },
         "params": {
@@ -1578,9 +1405,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1606,11 +1431,7 @@
           }
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ]
+      "required": ["liquidId", "labwareId", "volumeByWell"]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1620,9 +1441,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": [
-            "loadLiquid"
-          ],
+          "enum": ["loadLiquid"],
           "type": "string"
         },
         "params": {
@@ -1642,9 +1461,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1689,10 +1506,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ]
+      "required": ["model", "location"]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1702,9 +1516,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": [
-            "loadModule"
-          ],
+          "enum": ["loadModule"],
           "type": "string"
         },
         "params": {
@@ -1724,9 +1536,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1779,10 +1589,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ]
+      "required": ["pipetteName", "mount"]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1792,9 +1599,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": [
-            "loadPipette"
-          ],
+          "enum": ["loadPipette"],
           "type": "string"
         },
         "params": {
@@ -1814,18 +1619,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1846,11 +1645,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1876,9 +1671,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -1913,11 +1706,7 @@
           ]
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ]
+      "required": ["labwareId", "newLocation", "strategy"]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -1927,9 +1716,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": [
-            "moveLabware"
-          ],
+          "enum": ["moveLabware"],
           "type": "string"
         },
         "params": {
@@ -1949,18 +1736,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -1987,11 +1768,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ]
+      "required": ["pipetteId", "axis", "distance"]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -2001,9 +1778,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": [
-            "moveRelative"
-          ],
+          "enum": ["moveRelative"],
           "type": "string"
         },
         "params": {
@@ -2023,9 +1798,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -2045,11 +1818,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -2087,10 +1856,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ]
+      "required": ["pipetteId", "coordinates"]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -2100,9 +1866,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": [
-            "moveToCoordinates"
-          ],
+          "enum": ["moveToCoordinates"],
           "type": "string"
         },
         "params": {
@@ -2122,9 +1886,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -2172,11 +1934,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -2186,9 +1944,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": [
-            "moveToWell"
-          ],
+          "enum": ["moveToWell"],
           "type": "string"
         },
         "params": {
@@ -2208,9 +1964,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -2230,11 +1984,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2288,10 +2038,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2301,9 +2048,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": [
-            "moveToAddressableArea"
-          ],
+          "enum": ["moveToAddressableArea"],
           "type": "string"
         },
         "params": {
@@ -2323,9 +2068,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2385,10 +2128,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2398,9 +2138,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": [
-            "moveToAddressableAreaForDropTip"
-          ],
+          "enum": ["moveToAddressableAreaForDropTip"],
           "type": "string"
         },
         "params": {
@@ -2420,9 +2158,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2435,9 +2171,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2447,9 +2181,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": [
-            "prepareToAspirate"
-          ],
+          "enum": ["prepareToAspirate"],
           "type": "string"
         },
         "params": {
@@ -2469,9 +2201,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2493,10 +2223,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "type": "string"
         },
         "params": {
@@ -2516,9 +2243,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2536,9 +2261,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "seconds"
-      ]
+      "required": ["seconds"]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2548,9 +2271,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": [
-            "waitForDuration"
-          ],
+          "enum": ["waitForDuration"],
           "type": "string"
         },
         "params": {
@@ -2570,9 +2291,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2604,11 +2323,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2618,9 +2333,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": [
-            "pickUpTip"
-          ],
+          "enum": ["pickUpTip"],
           "type": "string"
         },
         "params": {
@@ -2640,9 +2353,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2666,9 +2377,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2678,9 +2387,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": [
-            "savePosition"
-          ],
+          "enum": ["savePosition"],
           "type": "string"
         },
         "params": {
@@ -2700,9 +2407,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2715,9 +2420,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ]
+      "required": ["on"]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2727,9 +2430,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": [
-            "setRailLights"
-          ],
+          "enum": ["setRailLights"],
           "type": "string"
         },
         "params": {
@@ -2749,9 +2450,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2794,11 +2493,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2808,9 +2503,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": [
-            "touchTip"
-          ],
+          "enum": ["touchTip"],
           "type": "string"
         },
         "params": {
@@ -2830,20 +2523,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ]
+      "enum": ["idle", "confirm", "updating", "disco", "off"]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2859,9 +2544,7 @@
           ]
         }
       },
-      "required": [
-        "animation"
-      ]
+      "required": ["animation"]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2871,9 +2554,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": [
-            "setStatusBar"
-          ],
+          "enum": ["setStatusBar"],
           "type": "string"
         },
         "params": {
@@ -2893,28 +2574,18 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": [
-        "present",
-        "absent",
-        "unknown"
-      ],
+      "enum": ["present", "absent", "unknown"],
       "type": "string"
     },
     "InstrumentSensorId": {
       "title": "InstrumentSensorId",
       "description": "Primary and secondary sensor ids.",
-      "enum": [
-        "primary",
-        "secondary",
-        "both"
-      ],
+      "enum": ["primary", "secondary", "both"],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -2944,10 +2615,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "expectedState"
-      ]
+      "required": ["pipetteId", "expectedState"]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -2957,9 +2625,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": [
-            "verifyTipPresence"
-          ],
+          "enum": ["verifyTipPresence"],
           "type": "string"
         },
         "params": {
@@ -2979,9 +2645,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -2994,9 +2658,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -3006,9 +2668,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": [
-            "getTipPresence"
-          ],
+          "enum": ["getTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3028,9 +2688,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3048,9 +2706,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3060,9 +2716,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": [
-            "heaterShaker/waitForTemperature"
-          ],
+          "enum": ["heaterShaker/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3082,9 +2736,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3102,10 +2754,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3115,9 +2764,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": [
-            "heaterShaker/setTargetTemperature"
-          ],
+          "enum": ["heaterShaker/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3137,9 +2784,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -3152,9 +2797,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -3164,9 +2807,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": [
-            "heaterShaker/deactivateHeater"
-          ],
+          "enum": ["heaterShaker/deactivateHeater"],
           "type": "string"
         },
         "params": {
@@ -3186,9 +2827,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -3206,10 +2845,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ]
+      "required": ["moduleId", "rpm"]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -3219,9 +2855,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": [
-            "heaterShaker/setAndWaitForShakeSpeed"
-          ],
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "type": "string"
         },
         "params": {
@@ -3241,9 +2875,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -3256,9 +2888,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -3268,9 +2898,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": [
-            "heaterShaker/deactivateShaker"
-          ],
+          "enum": ["heaterShaker/deactivateShaker"],
           "type": "string"
         },
         "params": {
@@ -3290,9 +2918,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -3305,9 +2931,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -3317,9 +2941,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": [
-            "heaterShaker/openLabwareLatch"
-          ],
+          "enum": ["heaterShaker/openLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3339,9 +2961,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -3354,9 +2974,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -3366,9 +2984,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": [
-            "heaterShaker/closeLabwareLatch"
-          ],
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3388,9 +3004,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3403,9 +3017,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3415,9 +3027,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": [
-            "magneticModule/disengage"
-          ],
+          "enum": ["magneticModule/disengage"],
           "type": "string"
         },
         "params": {
@@ -3437,9 +3047,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3457,10 +3065,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ]
+      "required": ["moduleId", "height"]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3470,9 +3075,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": [
-            "magneticModule/engage"
-          ],
+          "enum": ["magneticModule/engage"],
           "type": "string"
         },
         "params": {
@@ -3492,9 +3095,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3512,10 +3113,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3525,9 +3123,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": [
-            "temperatureModule/setTargetTemperature"
-          ],
+          "enum": ["temperatureModule/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3547,9 +3143,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3567,9 +3161,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3579,9 +3171,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": [
-            "temperatureModule/waitForTemperature"
-          ],
+          "enum": ["temperatureModule/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3601,9 +3191,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3616,9 +3204,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3628,9 +3214,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": [
-            "temperatureModule/deactivate"
-          ],
+          "enum": ["temperatureModule/deactivate"],
           "type": "string"
         },
         "params": {
@@ -3650,9 +3234,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3680,10 +3262,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3693,9 +3272,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": [
-            "thermocycler/setTargetBlockTemperature"
-          ],
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -3715,9 +3292,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3730,9 +3305,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3742,9 +3315,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": [
-            "thermocycler/waitForBlockTemperature"
-          ],
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -3764,9 +3335,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -3784,10 +3353,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -3797,9 +3363,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": [
-            "thermocycler/setTargetLidTemperature"
-          ],
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -3819,9 +3383,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -3834,9 +3396,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -3846,9 +3406,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": [
-            "thermocycler/waitForLidTemperature"
-          ],
+          "enum": ["thermocycler/waitForLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -3868,9 +3426,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -3883,9 +3439,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -3895,9 +3449,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": [
-            "thermocycler/deactivateBlock"
-          ],
+          "enum": ["thermocycler/deactivateBlock"],
           "type": "string"
         },
         "params": {
@@ -3917,9 +3469,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -3932,9 +3482,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -3944,9 +3492,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": [
-            "thermocycler/deactivateLid"
-          ],
+          "enum": ["thermocycler/deactivateLid"],
           "type": "string"
         },
         "params": {
@@ -3966,9 +3512,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -3981,9 +3525,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -3993,9 +3535,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": [
-            "thermocycler/openLid"
-          ],
+          "enum": ["thermocycler/openLid"],
           "type": "string"
         },
         "params": {
@@ -4015,9 +3555,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -4030,9 +3568,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -4042,9 +3578,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": [
-            "thermocycler/closeLid"
-          ],
+          "enum": ["thermocycler/closeLid"],
           "type": "string"
         },
         "params": {
@@ -4064,9 +3598,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -4084,10 +3616,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ]
+      "required": ["celsius", "holdSeconds"]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -4113,10 +3642,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ]
+      "required": ["moduleId", "profile"]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -4126,9 +3652,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": [
-            "thermocycler/runProfile"
-          ],
+          "enum": ["thermocycler/runProfile"],
           "type": "string"
         },
         "params": {
@@ -4148,17 +3672,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": [
-        "front",
-        "rear"
-      ]
+      "enum": ["front", "rear"]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -4178,11 +3697,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -4207,9 +3722,7 @@
           ]
         }
       },
-      "required": [
-        "jaw"
-      ]
+      "required": ["jaw"]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -4219,9 +3732,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": [
-            "calibration/calibrateGripper"
-          ],
+          "enum": ["calibration/calibrateGripper"],
           "type": "string"
         },
         "params": {
@@ -4241,9 +3752,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -4259,9 +3768,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -4271,9 +3778,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": [
-            "calibration/calibratePipette"
-          ],
+          "enum": ["calibration/calibratePipette"],
           "type": "string"
         },
         "params": {
@@ -4293,9 +3798,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -4321,11 +3824,7 @@
           ]
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ]
+      "required": ["moduleId", "labwareId", "mount"]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -4335,9 +3834,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": [
-            "calibration/calibrateModule"
-          ],
+          "enum": ["calibration/calibrateModule"],
           "type": "string"
         },
         "params": {
@@ -4357,17 +3854,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ]
+      "enum": ["attachPlate", "attachInstrument"]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -4392,9 +3884,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -4404,9 +3894,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": [
-            "calibration/moveToMaintenancePosition"
-          ],
+          "enum": ["calibration/moveToMaintenancePosition"],
           "type": "string"
         },
         "params": {
@@ -4426,9 +3914,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     }
   },
   "$id": "opentronsCommandSchemaV8",

--- a/shared-data/command/schemas/8.json
+++ b/shared-data/command/schemas/8.json
@@ -2600,7 +2600,7 @@
             }
           ]
         },
-        "htFollowSingularSensor":  {
+        "FollowSingularSensor":  {
           "description": "Which high throughput sensor to use, if we're indifferent to the other.",
           "allOf": [
             {

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -282,7 +282,7 @@ interface WellLocationParam {
 
 interface VerifyTipPresenceParams extends PipetteIdentityParams {
   expectedState?: 'present' | 'absent'
-  htFollowSingularSensor?: 'primary' | 'secondary'
+  FollowSingularSensor?: 'primary' | 'secondary'
 }
 
 interface BasicLiquidHandlingResult {

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -282,6 +282,7 @@ interface WellLocationParam {
 
 interface VerifyTipPresenceParams extends PipetteIdentityParams {
   expectedState?: 'present' | 'absent'
+  htFollowSingularSensor?: 'primary' | 'secondary'
 }
 
 interface BasicLiquidHandlingResult {

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -282,7 +282,7 @@ interface WellLocationParam {
 
 interface VerifyTipPresenceParams extends PipetteIdentityParams {
   expectedState?: 'present' | 'absent'
-  FollowSingularSensor?: 'primary' | 'secondary'
+  followSingularSensor?: 'primary' | 'secondary'
 }
 
 interface BasicLiquidHandlingResult {


### PR DESCRIPTION
## Overview
Accompanies https://github.com/Opentrons/opentrons/pull/14980.

## Changelog

- changes `ht_operational_sensor` name to `ht_follow_singular_sensor`
- use primary sensor in calibration and lpc probe attach flow