### PR TITLE
feat(robot-server): add deck_configuration notification publisher

### DIFF
--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -15,6 +15,8 @@ from opentrons.calibration_storage import types as calibration_storage_types
 
 from opentrons.protocol_engine.types import DeckType
 
+from robot_server.service.notifications import DeckConfigurationPublisher
+
 from . import defaults
 from . import models
 from opentrons.protocol_engine.types import DeckConfigurationType
@@ -22,7 +24,12 @@ from opentrons.protocol_engine.types import DeckConfigurationType
 
 # TODO(mm, 2023-11-17): Add unit tests for DeckConfigurationStore.
 class DeckConfigurationStore:  # noqa: D101
-    def __init__(self, deck_type: DeckType, path: Path) -> None:
+    def __init__(
+        self,
+        deck_type: DeckType,
+        path: Path,
+        deck_configuration_publisher: DeckConfigurationPublisher,
+    ) -> None:
         """A persistent store of the robot's deck configuration.
 
         Params:
@@ -37,6 +44,7 @@ class DeckConfigurationStore:  # noqa: D101
 
         self._deck_type = deck_type
         self._path = anyio.Path(path)
+        self._deck_configuration_publisher = deck_configuration_publisher
 
         # opentrons.calibration_storage is not generally safe for concurrent access.
         self._lock = asyncio.Lock()
@@ -62,6 +70,8 @@ class DeckConfigurationStore:  # noqa: D101
                 ],
                 last_modified_at=last_modified_at,
             )
+            await self._deck_configuration_publisher.publish_deck_configuration()
+
             return await self._get_assuming_locked()
 
     async def get(self) -> models.DeckConfigurationResponse:
@@ -82,6 +92,7 @@ class DeckConfigurationStore:  # noqa: D101
         """Delete the robot's current deck configuration, resetting it to the default."""
         async with self._lock:
             await self._path.unlink(missing_ok=True)
+            await self._deck_configuration_publisher.publish_deck_configuration()
 
     async def _get_assuming_locked(self) -> models.DeckConfigurationResponse:
         from_storage = await _read(self._path)

--- a/robot-server/robot_server/service/notifications/__init__.py
+++ b/robot-server/robot_server/service/notifications/__init__.py
@@ -10,8 +10,10 @@ from .publisher_notifier import PublisherNotifier, get_notify_publishers
 from .publishers import (
     MaintenanceRunsPublisher,
     RunsPublisher,
+    DeckConfigurationPublisher,
     get_maintenance_runs_publisher,
     get_runs_publisher,
+    get_deck_configuration_publisher,
 )
 from .change_notifier import ChangeNotifier
 from .topics import Topics
@@ -22,6 +24,7 @@ __all__ = [
     # notification "route" equivalents
     "MaintenanceRunsPublisher",
     "RunsPublisher",
+    "DeckConfigurationPublisher",
     # initialization and teardown
     "initialize_notifications",
     "clean_up_notification_client",
@@ -30,6 +33,7 @@ __all__ = [
     "get_notify_publishers",
     "get_maintenance_runs_publisher",
     "get_runs_publisher",
+    "get_deck_configuration_publisher",
     # for testing
     "PublisherNotifier",
     "ChangeNotifier",

--- a/robot-server/robot_server/service/notifications/publishers/__init__.py
+++ b/robot-server/robot_server/service/notifications/publishers/__init__.py
@@ -8,12 +8,18 @@ from .maintenance_runs_publisher import (
     get_maintenance_runs_publisher,
 )
 from .runs_publisher import RunsPublisher, get_runs_publisher
+from .deck_configuration_publisher import (
+    DeckConfigurationPublisher,
+    get_deck_configuration_publisher,
+)
 
 __all__ = [
     # publish "route" equivalents
     "MaintenanceRunsPublisher",
     "RunsPublisher",
+    "DeckConfigurationPublisher",
     # for use by FastAPI
     "get_maintenance_runs_publisher",
     "get_runs_publisher",
+    "get_deck_configuration_publisher",
 ]

--- a/robot-server/robot_server/service/notifications/publishers/deck_configuration_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/deck_configuration_publisher.py
@@ -1,0 +1,48 @@
+from fastapi import Depends
+
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+from ..notification_client import NotificationClient, get_notification_client
+from ..topics import Topics
+
+
+class DeckConfigurationPublisher:
+    """Publishes deck configuration topics."""
+
+    def __init__(self, client: NotificationClient) -> None:
+        """Returns a configured Deck Configuration Publisher."""
+        self._client = client
+
+    async def publish_deck_configuration(
+        self,
+    ) -> None:
+        """Publishes the equivalent of GET /deck_configuration"""
+        await self._client.publish_advise_refetch_async(topic=Topics.DECK_CONFIGURATION)
+
+
+_deck_configuration_publisher_accessor: AppStateAccessor[
+    DeckConfigurationPublisher
+] = AppStateAccessor[DeckConfigurationPublisher]("deck_configuration_publisher")
+
+
+async def get_deck_configuration_publisher(
+    app_state: AppState = Depends(get_app_state),
+    notification_client: NotificationClient = Depends(get_notification_client),
+) -> DeckConfigurationPublisher:
+    """Get a singleton DeckConfigurationPublisher to publish deck configuration topics."""
+    deck_configuration_publisher = _deck_configuration_publisher_accessor.get_from(
+        app_state
+    )
+
+    if deck_configuration_publisher is None:
+        deck_configuration_publisher = DeckConfigurationPublisher(
+            client=notification_client
+        )
+        _deck_configuration_publisher_accessor.set_on(
+            app_state, deck_configuration_publisher
+        )
+
+    return deck_configuration_publisher

--- a/robot-server/robot_server/service/notifications/topics.py
+++ b/robot-server/robot_server/service/notifications/topics.py
@@ -14,3 +14,4 @@ class Topics(str, Enum):
     MAINTENANCE_RUNS_CURRENT_RUN = f"{_TOPIC_BASE}/maintenance_runs/current_run"
     RUNS_CURRENT_COMMAND = f"{_TOPIC_BASE}/runs/current_command"
     RUNS = f"{_TOPIC_BASE}/runs"
+    DECK_CONFIGURATION = f"{_TOPIC_BASE}/deck_configuration"

--- a/robot-server/tests/service/notifications/publishers/test_deck_configuration_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_deck_configuration_publisher.py
@@ -1,0 +1,31 @@
+"""Tests for the deck configuration publisher."""
+import pytest
+from unittest.mock import AsyncMock
+
+from robot_server.service.notifications import DeckConfigurationPublisher, Topics
+
+
+@pytest.fixture
+def notification_client() -> AsyncMock:
+    """Mocked notification client."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def deck_configuration_publisher(
+    notification_client: AsyncMock,
+) -> DeckConfigurationPublisher:
+    """Instantiate DeckConfigurationPublisher."""
+    return DeckConfigurationPublisher(notification_client)
+
+
+@pytest.mark.asyncio
+async def test_publish_current_maintenance_run(
+    notification_client: AsyncMock,
+    deck_configuration_publisher: DeckConfigurationPublisher,
+) -> None:
+    """It should publish a notify flag for deck configuration updates."""
+    await deck_configuration_publisher.publish_deck_configuration()
+    notification_client.publish_advise_refetch_async.assert_awaited_once_with(
+        topic=Topics.DECK_CONFIGURATION
+    )


### PR DESCRIPTION
Closes [EXEC-168](https://opentrons.atlassian.net/browse/EXEC-168)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Add a deck configuration publisher to the robot server. This will enable the app to avoid polling for updated deck config state. An app-sided PR will follow this one.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- On the desktop app/ODD, mess around with the deck config. Any time you update the deck state, you should see an MQTT refetch flag published on the `robot-server/deck_configuration` topic. Postman is the easiest way to visualize this.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Add a deck configuration publisher to the robot server.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Double check me on the `store.py` changes. I don't think there's anything weird/wrong here, but it would be nice for a python dev to confirm. We just publish a refetch flag any time the store is updated, and I believe I've covered the only spots updates happen.
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low - this is about as vanilla as you can get for a notification publisher
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-168]: https://opentrons.atlassian.net/browse/EXEC-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ