### PR TITLE
fix(opentrons-shared-data): fix performance module not being recognized

### DIFF
--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -19,24 +19,6 @@ _should_track = ff.enable_performance_metrics(
     RobotTypeEnum.robot_literal_to_enum(robot_configs.load().model)
 )
 
-
-def _handle_package_import() -> Type[SupportsTracking]:
-    """Handle the import of the performance_metrics package.
-
-    If the package is not available, return a stubbed tracker.
-    """
-    try:
-        from performance_metrics import RobotContextTracker
-
-        return RobotContextTracker
-    except ImportError:
-        return StubbedTracker
-
-
-package_to_use = _handle_package_import()
-_robot_context_tracker: SupportsTracking | None = None
-
-
 class StubbedTracker(SupportsTracking):
     """A stubbed tracker that does nothing."""
 
@@ -57,6 +39,23 @@ class StubbedTracker(SupportsTracking):
         """Do nothing."""
         pass
 
+
+
+def _handle_package_import() -> Type[SupportsTracking]:
+    """Handle the import of the performance_metrics package.
+
+    If the package is not available, return a stubbed tracker.
+    """
+    try:
+        from performance_metrics import RobotContextTracker
+
+        return RobotContextTracker
+    except ImportError:
+        return StubbedTracker
+
+
+package_to_use = _handle_package_import()
+_robot_context_tracker: SupportsTracking | None = None
 
 def _get_robot_context_tracker() -> SupportsTracking:
     """Singleton for the robot context tracker."""

--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -19,6 +19,7 @@ _should_track = ff.enable_performance_metrics(
     RobotTypeEnum.robot_literal_to_enum(robot_configs.load().model)
 )
 
+
 class StubbedTracker(SupportsTracking):
     """A stubbed tracker that does nothing."""
 
@@ -40,7 +41,6 @@ class StubbedTracker(SupportsTracking):
         pass
 
 
-
 def _handle_package_import() -> Type[SupportsTracking]:
     """Handle the import of the performance_metrics package.
 
@@ -56,6 +56,7 @@ def _handle_package_import() -> Type[SupportsTracking]:
 
 package_to_use = _handle_package_import()
 _robot_context_tracker: SupportsTracking | None = None
+
 
 def _get_robot_context_tracker() -> SupportsTracking:
     """Singleton for the robot context tracker."""

--- a/shared-data/python/opentrons_shared_data/performance/__init__.py
+++ b/shared-data/python/opentrons_shared_data/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance metrics."""

--- a/shared-data/python/tests/performance/test_module_builds.py
+++ b/shared-data/python/tests/performance/test_module_builds.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import pytest
+from opentrons_shared_data.performance.dev_types import MetricsMetadata
+
+def test_metrics_metadata(tmp_path: Path) -> None:
+    MetricsMetadata(
+        name="test",
+        storage_dir=tmp_path,
+        headers=("a", "b")
+    )

--- a/shared-data/python/tests/performance/test_module_builds.py
+++ b/shared-data/python/tests/performance/test_module_builds.py
@@ -1,10 +1,6 @@
 from pathlib import Path
-import pytest
-from opentrons_shared_data.performance.dev_types import MetricsMetadata
+from opentrons_shared_data.performance.dev_types import RobotContextState
+
 
 def test_metrics_metadata(tmp_path: Path) -> None:
-    MetricsMetadata(
-        name="test",
-        storage_dir=tmp_path,
-        headers=("a", "b")
-    )
+    RobotContextState.ANALYZING_PROTOCOL


### PR DESCRIPTION
# Overview

Fixes https://opentrons.atlassian.net/browse/RQA-2623

performance directory was missing an `__init__.py`

# Test Plan

- I added a test just to import the module and create one of the objects inside the dev_types.py. The issue is that the tests don't run against the built version of the package. I built the app and everything imports correctly
- I cannot test that opentrons_shared_data is being utilized correctly on the robot until I have a built buildroot image. Because currently my robot and app have different versions (due to the dev build) so the app will not let me trigger an analysis. 
- I instead pushed opentrons-shared-data to my robot and verified that the performance module existed in `/usr/lib/python3.10/site-packages/opentrons_shared_data`. But I can't test that the imports actually work until I have the system image and the app together

# Changelog

- Added `__init__.py` to performance directory to tell python to import it as a module
- Reorganized performance_helpers.py to not have an import error

# Review requests

- Nothing to block this fix, but what should be done to make sure this doesn't happen again? This is a weird packaging thing that doesn't show up when running dev or CI testing. 
- I wonder if there is a smoke test we can perform automatically just to make sure everything imports correctly? Running opentrons.simulate against the actual built package would have caught this


# Risk assessment

Medium, I mean I can't break it any worse than I already did 
