### PR TITLE
fix(app-shell,app): Send labware files and runtime parameters over USB

### DIFF
--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -12,7 +12,9 @@ export function createProtocol(
 ): ResponsePromise<Protocol> {
   const formData = new FormData()
   // TODO
-  files.forEach(file => formData.append('files', file, file.name))
+  files.forEach(file => {
+    formData.append('files', file, file.name)
+  })
   if (protocolKey != null) formData.append('key', protocolKey)
   if (runTimeParameterValues != null)
     formData.append(

--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -11,6 +11,7 @@ export function createProtocol(
   runTimeParameterValues?: RunTimeParameterCreateData
 ): ResponsePromise<Protocol> {
   const formData = new FormData()
+  // TODO
   files.forEach(file => formData.append('files', file, file.name))
   if (protocolKey != null) formData.append('key', protocolKey)
   if (runTimeParameterValues != null)

--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -11,7 +11,6 @@ export function createProtocol(
   runTimeParameterValues?: RunTimeParameterCreateData
 ): ResponsePromise<Protocol> {
   const formData = new FormData()
-  // TODO
   files.forEach(file => {
     formData.append('files', file, file.name)
   })

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -1,7 +1,6 @@
 import fse from 'fs-extra'
 import path from 'path'
 import { shell } from 'electron'
-import first from 'lodash/first'
 
 import {
   ADD_PROTOCOL,
@@ -46,18 +45,6 @@ export const getParsedAnalysisFromPath = (
         : 'protocol analysis file cannot be parsed'
     return createFailedAnalysis(errorMessage)
   }
-}
-
-export const getProtocolSrcFilePaths = (
-  protocolKey: string
-): Promise<string[]> => {
-  const protocolDir = `${FileSystem.PROTOCOLS_DIRECTORY_PATH}/${protocolKey}`
-  return ensureDir(protocolDir)
-    .then(() => FileSystem.parseProtocolDirs([protocolDir]))
-    .then(storedProtocols => {
-      const storedProtocol = first(storedProtocols)
-      return storedProtocol?.srcFilePaths ?? []
-    })
 }
 
 // Revert a v7.0.0 pre-parity stop-gap solution.

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -17,7 +17,7 @@ import {
   USB_DEVICE_REMOVED,
 } from './constants'
 
-import type { StructuredCloneableFormData } from '@opentrons/app/src/redux/shell/types'
+import type { IPCSafeFormData } from '@opentrons/app/src/redux/shell/types'
 import type { UsbDevice } from '@opentrons/app/src/redux/system-info/types'
 import type { PortInfo } from '@opentrons/usb-bridge/node-client'
 import type { Action, Dispatch } from './types'
@@ -82,11 +82,9 @@ function isUsbDeviceOt3(device: UsbDevice): boolean {
   )
 }
 
-function reconstructFormData(
-  structuredCloneableFormData: StructuredCloneableFormData
-): FormData {
+function reconstructFormData(ipcSafeFormData: IPCSafeFormData): FormData {
   const result = new FormData()
-  structuredCloneableFormData.forEach(entry => {
+  ipcSafeFormData.forEach(entry => {
     entry.type === 'file'
       ? result.append(entry.name, Buffer.from(entry.value), entry.filename)
       : result.append(entry.name, entry.value)

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -84,10 +84,18 @@ function isUsbDeviceOt3(device: UsbDevice): boolean {
   )
 }
 
-interface StructuredCloneableFormDataEntry {
-  name: string
-  value: string | Blob | File
-}
+type StructuredCloneableFormDataEntry =
+  | {
+      type: 'string'
+      name: string
+      value: string
+    }
+  | {
+      type: 'file'
+      name: string
+      value: ArrayBuffer
+      filename: string
+    }
 
 type StructuredCloneableFormData = StructuredCloneableFormDataEntry[]
 
@@ -96,7 +104,9 @@ function reconstructFormData(
 ): FormData {
   const result = new FormData()
   structuredCloneableFormData.forEach(entry => {
-    result.append(entry.name, entry.value)
+    entry.type === 'file'
+      ? result.append(entry.name, Buffer.from(entry.value), entry.filename)
+      : result.append(entry.name, entry.value)
   })
   return result
 }

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -1,8 +1,6 @@
 import { ipcMain, IpcMainInvokeEvent } from 'electron'
 import axios, { AxiosRequestConfig } from 'axios'
 import FormData from 'form-data'
-import fs from 'fs'
-import path from 'path'
 
 import {
   fetchSerialPortList,
@@ -12,7 +10,6 @@ import {
 } from '@opentrons/usb-bridge/node-client'
 
 import { createLogger } from './log'
-import { getProtocolSrcFilePaths } from './protocol-storage'
 import { usbRequestsStart, usbRequestsStop } from './config/actions'
 import {
   SYSTEM_INFO_INITIALIZED,

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -97,6 +97,7 @@ async function usbListener(
     const formData = new FormData()
     const { protocolKey } = data.formDataProxy
 
+    // TODO
     const srcFilePaths: string[] = await getProtocolSrcFilePaths(protocolKey)
 
     // create readable stream from file

--- a/app-shell/src/usb.ts
+++ b/app-shell/src/usb.ts
@@ -17,6 +17,7 @@ import {
   USB_DEVICE_REMOVED,
 } from './constants'
 
+import type { StructuredCloneableFormData } from '@opentrons/app/src/redux/shell/types'
 import type { UsbDevice } from '@opentrons/app/src/redux/system-info/types'
 import type { PortInfo } from '@opentrons/usb-bridge/node-client'
 import type { Action, Dispatch } from './types'
@@ -80,21 +81,6 @@ function isUsbDeviceOt3(device: UsbDevice): boolean {
     device.vendorId === parseInt(DEFAULT_VENDOR_ID, 16)
   )
 }
-
-type StructuredCloneableFormDataEntry =
-  | {
-      type: 'string'
-      name: string
-      value: string
-    }
-  | {
-      type: 'file'
-      name: string
-      value: ArrayBuffer
-      filename: string
-    }
-
-type StructuredCloneableFormData = StructuredCloneableFormDataEntry[]
 
 function reconstructFormData(
   structuredCloneableFormData: StructuredCloneableFormData

--- a/app/src/organisms/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/SendProtocolToFlexSlideout/index.tsx
@@ -104,9 +104,6 @@ export function SendProtocolToFlexSlideout(
       disableTimeout: true,
     })
 
-    console.log('srcFileObjects', srcFileObjects)
-    console.log('customLabwareFiles', customLabwareFiles)
-
     createProtocolAsync({
       files: [...srcFileObjects, ...customLabwareFiles],
       protocolKey,

--- a/app/src/organisms/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/SendProtocolToFlexSlideout/index.tsx
@@ -104,6 +104,9 @@ export function SendProtocolToFlexSlideout(
       disableTimeout: true,
     })
 
+    console.log('srcFileObjects', srcFileObjects)
+    console.log('customLabwareFiles', customLabwareFiles)
+
     createProtocolAsync({
       files: [...srcFileObjects, ...customLabwareFiles],
       protocolKey,

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -1,6 +1,5 @@
 // access main process remote modules via attachments to `global`
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
-import type { ResponsePromise } from '@opentrons/api-client'
 import type { Remote, NotifyTopic, NotifyResponseData } from './types'
 
 const emptyRemote: Remote = {} as any

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -4,7 +4,7 @@ import type {
   Remote,
   NotifyTopic,
   NotifyResponseData,
-  StructuredCloneableFormData,
+  IPCSafeFormData,
 } from './types'
 
 const emptyRemote: Remote = {} as any
@@ -27,10 +27,8 @@ export const remote: Remote = new Proxy(emptyRemote, {
 // FormData and File objects can't be sent through invoke().
 // This converts them into simpler objects that can be.
 // app-shell will convert them back.
-async function proxyFormData(
-  formData: FormData
-): Promise<StructuredCloneableFormData> {
-  const result: StructuredCloneableFormData = []
+async function proxyFormData(formData: FormData): Promise<IPCSafeFormData> {
+  const result: IPCSafeFormData = []
   for (const [name, value] of formData.entries()) {
     if (value instanceof File) {
       result.push({

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -1,6 +1,11 @@
 // access main process remote modules via attachments to `global`
 import type { AxiosRequestConfig, AxiosResponse } from 'axios'
-import type { Remote, NotifyTopic, NotifyResponseData } from './types'
+import type {
+  Remote,
+  NotifyTopic,
+  NotifyResponseData,
+  StructuredCloneableFormData,
+} from './types'
 
 const emptyRemote: Remote = {} as any
 
@@ -18,21 +23,6 @@ export const remote: Remote = new Proxy(emptyRemote, {
     return (global as any).APP_SHELL_REMOTE[propName] as Remote
   },
 })
-
-type StructuredCloneableFormDataEntry =
-  | {
-      type: 'string'
-      name: string
-      value: string
-    }
-  | {
-      type: 'file'
-      name: string
-      value: ArrayBuffer
-      filename: string
-    }
-
-type StructuredCloneableFormData = StructuredCloneableFormDataEntry[]
 
 // FormData and File objects can't be sent through invoke().
 // This converts them into simpler objects that can be.

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -24,6 +24,7 @@ export function appShellRequestor<Data>(
   config: AxiosRequestConfig
 ): ResponsePromise<Data> {
   const { data } = config
+  // TODO
   // special case: protocol files and form data cannot be sent through invoke. proxy by protocolKey and handle in app-shell
   const formDataProxy =
     data instanceof FormData

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -164,3 +164,18 @@ export type ShellAction =
   | RobotMassStorageDeviceEnumerated
   | RobotMassStorageDeviceRemoved
   | NotifySubscribeAction
+
+export type StructuredCloneableFormDataEntry =
+  | {
+      type: 'string'
+      name: string
+      value: string
+    }
+  | {
+      type: 'file'
+      name: string
+      value: ArrayBuffer
+      filename: string
+    }
+
+export type StructuredCloneableFormData = StructuredCloneableFormDataEntry[]

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -165,7 +165,7 @@ export type ShellAction =
   | RobotMassStorageDeviceRemoved
   | NotifySubscribeAction
 
-export type StructuredCloneableFormDataEntry =
+export type IPCSafeFormDataEntry =
   | {
       type: 'string'
       name: string
@@ -178,4 +178,4 @@ export type StructuredCloneableFormDataEntry =
       filename: string
     }
 
-export type StructuredCloneableFormData = StructuredCloneableFormDataEntry[]
+export type IPCSafeFormData = IPCSafeFormDataEntry[]


### PR DESCRIPTION
# Overview

Fixes RESC-247 and RQA-2627.

# Test Plan

* [x] Following the steps in RESC-247, make sure protocols with custom labware work over USB now.
* [x] Following the steps in RQA-2627, make sure runtime parameters work over USB now.
* [x] Make sure there's no discernable app freeze or hiccup that wasn't there before when you click the "Send" button, especially with a big protocol.
* [x] Make sure other requests (like toggling the lights) are unaffected.
* [x] Make sure requests over Wi-Fi are unaffected.

# Changelog

When the Electron rendering process wants to send a USB message, it needs to do so through the Electron main process. This is a problem because some JavaScript types for those messages—`File`s and `Blob`s and `FormData`s—can't be sent over IPC. We've worked around this for `POST /protocols` requests by substituting a `protocolKey: string` in place of these problematic types, in the IPC message. The main process then finds that and reconstructs the `File`s and `FormData`s from it.

That implementation didn't account for labware files external to the protocol (RESC-247), nor did it account for new multipart fields for things like run-time parameters. (RQA-2627).

With this PR, the rendering process slurps all the file contents—protocol and labware—into memory, and then sends them over IPC. We still need to use a substitute structure for the `FormData`, and the main process still needs to reconstruct all of this back into `FormData`s and `File`s. But the reconstruction code no longer needs to be concerned with application-level ideas like "labware" and "protocols" and where those things live on the filesystem, which is intended to make all of this a bit more robust.

# Review requests

See my review comments.

# Risk assessment

Medium.
