### PR TITLE
refactor(protocol-designer): tweak when module cards are disabled in …

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -31,6 +31,7 @@ import {
   getModuleType,
   FLEX_ROBOT_TYPE,
   MAGNETIC_BLOCK_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getIsCrashablePipetteSelected } from '../../../step-forms'
 import gripperImage from '../../../images/flex_gripper.png'
@@ -44,7 +45,7 @@ import { ModuleFields } from '../FilePipettesModal/ModuleFields'
 import { GoBack } from './GoBack'
 import {
   getCrashableModuleSelected,
-  getIsSlotAvailable,
+  getNumSlotsAvailable,
   getTrashOptionDisabled,
 } from './utils'
 import { EquipmentOption } from './EquipmentOption'
@@ -221,7 +222,12 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
         const moduleType = getModuleType(moduleModel)
         const isModuleOnDeck = moduleTypesOnDeck.includes(moduleType)
 
-        const isDisabled = !getIsSlotAvailable(modules, additionalEquipment)
+        let isDisabled =
+          getNumSlotsAvailable(modules, additionalEquipment) === 0
+        //  special-casing TC since it takes up 2 slots
+        if (moduleType === THERMOCYCLER_MODULE_TYPE) {
+          isDisabled = getNumSlotsAvailable(modules, additionalEquipment) === 1
+        }
 
         const handleMultiplesClick = (num: number): void => {
           const temperatureModules =

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
@@ -8,7 +8,7 @@ import {
   getUnoccupiedStagingAreaSlots,
   getTrashSlot,
   getTrashOptionDisabled,
-  getIsSlotAvailable,
+  getNumSlotsAvailable,
 } from '../utils'
 import { STANDARD_EMPTY_SLOTS } from '../StagingAreaTile'
 import type { FormPipettesByMount } from '../../../../step-forms'
@@ -53,12 +53,12 @@ describe('getUnoccupiedStagingAreaSlots', () => {
     ])
   })
 })
-describe('getIsSlotAvailable', () => {
-  it('should return true when there are no modules or additional equipment', () => {
-    const result = getIsSlotAvailable(null, [])
-    expect(result).toBe(true)
+describe('getNumSlotsAvailable', () => {
+  it('should return 8 when there are no modules or additional equipment', () => {
+    const result = getNumSlotsAvailable(null, [])
+    expect(result).toBe(8)
   })
-  it('should return false when there is a TC and 7 modules', () => {
+  it('should return 0 when there is a TC and 7 modules', () => {
     const mockModules = {
       0: {
         model: 'heaterShakerModuleV1',
@@ -96,10 +96,10 @@ describe('getIsSlotAvailable', () => {
         slot: 'C3',
       },
     } as any
-    const result = getIsSlotAvailable(mockModules, [])
-    expect(result).toBe(false)
+    const result = getNumSlotsAvailable(mockModules, [])
+    expect(result).toBe(0)
   })
-  it('should return true when there are 9 additional equipment and 1 is a waste chute on the staging area and one is a gripper', () => {
+  it('should return 1 when there are 9 additional equipment and 1 is a waste chute on the staging area and one is a gripper', () => {
     const mockAdditionalEquipment: AdditionalEquipment[] = [
       'trashBin',
       'stagingArea_cutoutA3',
@@ -111,8 +111,19 @@ describe('getIsSlotAvailable', () => {
       'gripper',
       'trashBin',
     ]
-    const result = getIsSlotAvailable(null, mockAdditionalEquipment)
-    expect(result).toBe(true)
+    const result = getNumSlotsAvailable(null, mockAdditionalEquipment)
+    expect(result).toBe(1)
+  })
+  it('should return 8 even when there is a magnetic block', () => {
+    const mockModules = {
+      0: {
+        model: 'magneticBlockV1',
+        type: 'magneticBlockType',
+        slot: 'B2',
+      },
+    } as any
+    const result = getNumSlotsAvailable(mockModules, [])
+    expect(result).toBe(8)
   })
 })
 describe('getTrashSlot', () => {

--- a/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
@@ -90,7 +90,6 @@ export const getNumSlotsAvailable = (
   modules: FormState['modules'],
   additionalEquipment: FormState['additionalEquipment']
 ): number => {
-  const moduleLength = modules != null ? Object.keys(modules).length : 0
   const additionalEquipmentLength = additionalEquipment.length
   const hasTC = Object.values(modules || {}).some(
     module => module.type === THERMOCYCLER_MODULE_TYPE
@@ -98,7 +97,7 @@ export const getNumSlotsAvailable = (
   const hasMagneticBlock = Object.values(modules || {}).some(
     module => module.type === MAGNETIC_BLOCK_TYPE
   )
-  let filteredModuleLength = moduleLength
+  let filteredModuleLength = modules != null ? Object.keys(modules).length : 0
   if (hasTC) {
     filteredModuleLength = filteredModuleLength + 1
   }


### PR DESCRIPTION
…createFileWizard

closes AUTH-369

# Overview

There were 2 things that the `getIsSlotAvailable` logic did not account for and it is 
1) the TC taking up 2 slots
2) the magnetic block not taking up any slots

This pr fixes that and adds test coverage

# Test Plan

I have good unit testing for this so main priority is reviewing the logic

If you want, turn on the MoaM feature flag and create a flex protocol On the "Additional Items" page, add 6 temperature modules and see that the TC is disabled since there is only 1 slot available. Add another module and see that all modules + waste chute slot cards are disabled except for the magnetic block (this is because it is placed in an inner deck slot)

# Changelog

- rename util and refactor to return number of available slots 
- add support for TC and magnetic block

# Review requests

see test plan

# Risk assessment

low