### PR TITLE
refactor(protocol-designer): minimize and extend position and tuberac…

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -234,6 +234,7 @@ export const TipPositionModal = (
     yValue != null &&
     (parseInt(yValue) > PERCENT_RANGE_TO_SHOW_WARNING * yMaxWidth ||
       parseInt(yValue) < PERCENT_RANGE_TO_SHOW_WARNING * yMinWidth)
+  const isZValueAtBottom = zValue != null && zValue === '0'
 
   const TipPositionInputField = !isDefault ? (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
@@ -315,7 +316,8 @@ export const TipPositionModal = (
         <p>{t(`tip_position.body.${zSpec?.name}`)}</p>
       </div>
 
-      {(isXValueNearEdge || isYValueNearEdge) && !isDefault ? (
+      {(isXValueNearEdge || isYValueNearEdge || isZValueAtBottom) &&
+      !isDefault ? (
         <Flex marginTop={SPACING.spacing8}>
           <PDAlert
             alertType="warning"

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/__tests__/TipPositionModal.test.tsx
@@ -66,7 +66,7 @@ describe('TipPositionModal', () => {
     render(props)
     screen.getByText('warning')
     screen.getByText(
-      'The X and/or Y position value is close to edge of the well and might collide with it'
+      'One or more position offset values are close to the edge of the well and might collide with it'
     )
   })
   it('renders the alert if the x/y position values are too close to the max/min for y value', () => {
@@ -74,7 +74,7 @@ describe('TipPositionModal', () => {
     render(props)
     screen.getByText('warning')
     screen.getByText(
-      'The X and/or Y position value is close to edge of the well and might collide with it'
+      'One or more position offset values are close to the edge of the well and might collide with it'
     )
   })
   it('renders the custom options, captions, and visual', () => {

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -70,7 +70,7 @@
   "tip_position": {
     "title": "Tip Positioning",
     "caption": "between {{min}} and {{max}}",
-    "warning": "The X and/or Y position value is close to edge of the well and might collide with it",
+    "warning": "One or more position offset values are close to the edge of the well and might collide with it",
     "radio_button": {
       "default": "{{defaultMmFromBottom}} mm from the bottom center (default)",
       "blowout": "0 mm from the top center (default)",

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -29,9 +29,8 @@ import {
   minDisposalVolume,
   minAspirateAirGapVolume,
   minDispenseAirGapVolume,
-  aspirateTipPositionInTube,
-  dispenseTipPositionInTube,
   mixTipPositionInTube,
+  tipPositionInTube,
 } from './warnings'
 
 import { HydratedFormdata, StepType } from '../../form-types'
@@ -75,8 +74,7 @@ const stepFormHelperMap: Partial<Record<StepType, FormHelpers>> = {
       minDisposalVolume,
       minAspirateAirGapVolume,
       minDispenseAirGapVolume,
-      aspirateTipPositionInTube,
-      dispenseTipPositionInTube
+      tipPositionInTube
     ),
   },
   magnet: {

--- a/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/warnings.test.ts
@@ -5,8 +5,7 @@ import {
   belowPipetteMinimumVolume,
   minDisposalVolume,
   maxDispenseWellVolume,
-  aspirateTipPositionInTube,
-  dispenseTipPositionInTube,
+  tipPositionInTube,
   mixTipPositionInTube,
 } from '../warnings'
 import type { LabwareEntity } from '@opentrons/step-generation'
@@ -294,26 +293,20 @@ describe('Max dispense well volume', () => {
         dispense_mmFromBottom: null,
       }
     })
-    it('renders the errors for all 3', () => {
-      expect(aspirateTipPositionInTube(fields)?.type).toBe(
-        'ASPIRATE_TIP_POSITIONED_LOW_IN_TUBE'
-      )
-      expect(dispenseTipPositionInTube(fields)?.type).toBe(
-        'DISPENSE_TIP_POSITIONED_LOW_IN_TUBE'
-      )
+    it('renders the errors for all 2', () => {
+      expect(tipPositionInTube(fields)?.type).toBe('TIP_POSITIONED_LOW_IN_TUBE')
       expect(mixTipPositionInTube(fields)?.type).toBe(
         'MIX_TIP_POSITIONED_LOW_IN_TUBE'
       )
     })
-    it('renders null for all 3 when the number has been adjusted', () => {
+    it('renders null for both when the number has been adjusted', () => {
       fields.aspirate_mmFromBottom = 3
       fields.dispense_mmFromBottom = 3
       fields.mix_mmFromBottom = 3
-      expect(aspirateTipPositionInTube(fields)).toBe(null)
-      expect(dispenseTipPositionInTube(fields)).toBe(null)
+      expect(tipPositionInTube(fields)).toBe(null)
       expect(mixTipPositionInTube(fields)).toBe(null)
     })
-    it('renders null for all 3 when the labware is not a tube rack', () => {
+    it('renders null for both when the labware is not a tube rack', () => {
       fields.aspirate_labware = {
         def: fixture96Plate as LabwareDefinition2,
         id: 'mockId',
@@ -329,8 +322,7 @@ describe('Max dispense well volume', () => {
         id: 'mockId',
         labwareDefURI: 'mockURI',
       }
-      expect(aspirateTipPositionInTube(fields)).toBe(null)
-      expect(dispenseTipPositionInTube(fields)).toBe(null)
+      expect(tipPositionInTube(fields)).toBe(null)
       expect(mixTipPositionInTube(fields)).toBe(null)
     })
   })

--- a/protocol-designer/src/steplist/formLevel/warnings.tsx
+++ b/protocol-designer/src/steplist/formLevel/warnings.tsx
@@ -104,9 +104,10 @@ export const tipPositionInTube = (
         : false
   }
 
-  if (isAspirateTubeRack && aspirate_mmFromBottom === null) {
-    return tipPositionedLowInTube()
-  } else if (isDispenseTubeRack && dispense_mmFromBottom === null) {
+  if (
+    (isAspirateTubeRack && aspirate_mmFromBottom === null) ||
+    (isDispenseTubeRack && dispense_mmFromBottom === null)
+  ) {
     return tipPositionedLowInTube()
   } else {
     return null


### PR DESCRIPTION
…k warnings

closes AUTH-370 AUTH-371

# Overview

This PR addresses 2 issues that were documents by Anothony from testing PD

1. the tuberack aspirating/dispensing too low into the well warnings were overbearing since it showed 2 warnings in one step. so this PR combines them
2. the x/y position warning banner only existed for x/y and not the z position, so this PR includes the z position as well

# Test Plan

Create a flex or ot-2 protocol and go to the deck map. Add a tube rack. Add an aspirate/dispense into the tube rack and see that a form warning shows up saying that the default aspirate/dispense height is close to the bottom of the well. NOTE: in order to trigger this warning, you need to add both an aspirate and dispense labware location and click out of the dropdown, this is the legacy behavior for all form warnings in PD where you have to click out of the field to trigger it. 

Now, adjust the tip position field and add a custom z position that = 0, see that the warning banner shows up

<img width="1003" alt="Screenshot 2024-04-24 at 13 36 47" src="https://github.com/Opentrons/opentrons/assets/66035149/cfd9677f-13a0-4a3f-a442-e405b6391650">

<img width="616" alt="Screenshot 2024-04-24 at 13 34 46" src="https://github.com/Opentrons/opentrons/assets/66035149/4b3e369a-1ab0-46b3-aeac-6949de21fd36">

# Changelog

- add banner logic for z position
- refactor the aspirate/dispense in tuberack warning to be combined

# Review requests

see test plan

# Risk assessment

low