### PR TITLE
fix(api): disengage Z motors during 96-channel pipettes bracket detach/attach flows

### DIFF
--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -33,7 +33,7 @@ def subject(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "calibrate_moumt, maintenance_position, verify_axes",
+    "calibrate_mount, maintenance_position, verify_axes",
     [
         (
             MountType.LEFT,

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -82,33 +82,22 @@ async def test_calibration_move_to_location_implementation(
     result = await subject.execute(params=params)
     assert result == MoveToMaintenancePositionResult()
 
+
     decoy.verify(
         await ot3_hardware_api.prepare_for_mount_movement(Mount.LEFT),
-        times=1,
-    )
-    decoy.verify(
         await ot3_hardware_api.retract(Mount.LEFT),
-        times=1,
-    )
-    decoy.verify(
         await ot3_hardware_api.move_to(
             mount=Mount.LEFT,
             abs_position=Point(x=0, y=110, z=250),
             critical_point=CriticalPoint.MOUNT,
         ),
-        times=1,
-    )
-    decoy.verify(
+        await ot3_hardware_api.prepare_for_mount_movement(calibrate_mount.to_hw_mount()),
         await ot3_hardware_api.move_axes(
             position=verify_axes,
         ),
-        times=1,
-    )
-    decoy.verify(
         await ot3_hardware_api.disengage_axes(
             list(verify_axes.keys()),
         ),
-        times=1,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -33,27 +33,38 @@ def subject(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "maintenance_position, verify_axes",
+    "calibrate_moumt, maintenance_position, verify_axes",
     [
         (
+            MountType.LEFT,
             MaintenancePosition.ATTACH_INSTRUMENT,
             {Axis.Z_L: 400},
         ),
         (
+            MountType.RIGHT,
+            MaintenancePosition.ATTACH_INSTRUMENT,
+            {Axis.Z_R: 400},
+        ),
+        (
+            MountType.LEFT,
+            MaintenancePosition.ATTACH_PLATE,
+            {Axis.Z_L: 90, Axis.Z_R: 105},
+        ),
+        (
+            MountType.RIGHT,
             MaintenancePosition.ATTACH_PLATE,
             {Axis.Z_L: 90, Axis.Z_R: 105},
         ),
     ],
 )
-@pytest.mark.parametrize("calibrate_mount", [MountType.LEFT, MountType.RIGHT])
 async def test_calibration_move_to_location_implementation(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,
     state_view: StateView,
     ot3_hardware_api: OT3API,
+    calibrate_mount: MountType,
     maintenance_position: MaintenancePosition,
     verify_axes: Mapping[Axis, float],
-    calibrate_mount: MountType,
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -1,6 +1,6 @@
 """Test for Calibration Set Up Position Implementation."""
 from __future__ import annotations
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING
 
 import pytest
 from decoy import Decoy


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This PR makes sure we are engaging ebrakes when we're attaching/detaching the 96-channel pipette and mount bracket.
On top of that, we can now use retract instead of using a movement Point just to move the z up. 
Fixes [RQA-2631](https://opentrons.atlassian.net/browse/RQA-2631).


[RQA-2631]: https://opentrons.atlassian.net/browse/RQA-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ