### PR TITLE
fix(robot-server): add internal flag to subsystem updates so we know if updates are started automatically or explicitly.

### DIFF
--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -418,7 +418,7 @@ async def _do_updates(
 ) -> None:
     update_handles = [
         await update_manager.start_update_process(
-            str(uuid4()), SubSystem.from_hw(subsystem), utc_now()
+            str(uuid4()), SubSystem.from_hw(subsystem), utc_now(), internal=True,
         )
         for subsystem, subsystem_state in hardware.attached_subsystems.items()
         if not subsystem_state.ok or subsystem_state.fw_update_needed

--- a/robot-server/robot_server/subsystems/models.py
+++ b/robot-server/robot_server/subsystems/models.py
@@ -126,6 +126,10 @@ class UpdateProgressData(BaseModel):
         ...,
         description="If the process failed, this will contain a string description of the reason.",
     )
+    internal: bool = Field(
+        ..., description="Whether this update was started internally or not."
+    )
+
 
 
 class UpdateProgressSummary(BaseModel):
@@ -138,4 +142,7 @@ class UpdateProgressSummary(BaseModel):
     )
     updateStatus: UpdateState = Field(
         ..., description="Whether an update is queued, in progress or completed"
+    )
+    internal: bool = Field(
+        ..., description="Whether this update was started internally or not."
     )

--- a/robot-server/robot_server/subsystems/router.py
+++ b/robot-server/robot_server/subsystems/router.py
@@ -200,6 +200,7 @@ async def get_subsystem_updates(
             subsystem=handle.process_details.subsystem,
             updateStatus=handle.cached_state,
             createdAt=handle.process_details.created_at,
+            internal=handle.process_details.internal,
         )
         for handle in handles
     ]
@@ -242,6 +243,7 @@ async def get_subsystem_update(
                 updateStatus=progress.state,
                 updateProgress=progress.progress,
                 updateError=_error_str(progress.error),
+                internal=handle.process_details.internal,
             )
         )
     )
@@ -271,6 +273,7 @@ async def get_update_processes(
             subsystem=update.process_details.subsystem,
             updateStatus=update.cached_state,
             createdAt=update.process_details.created_at,
+            internal=update.process_details.internal,
         )
         for update in update_manager.all_update_processes()
     ]
@@ -306,6 +309,7 @@ async def get_update_process(
                 updateStatus=progress.state,
                 updateProgress=progress.progress,
                 updateError=_error_str(progress.error),
+                internal=handle.process_details.internal,
             )
         )
     )
@@ -340,6 +344,7 @@ async def begin_subsystem_update(
             update_process_id,
             subsystem,
             created_at,
+            internal=False,
         )
     except _SubsystemNotFound as e:
         raise SubsystemNotPresent(
@@ -373,6 +378,7 @@ async def begin_subsystem_update(
                 updateStatus=progress.state,
                 updateProgress=progress.progress,
                 updateError=_error_str(progress.error),
+                internal=summary.process_details.internal,
             )
         ),
         status_code=status.HTTP_201_CREATED,


### PR DESCRIPTION
# Overview

Helps Address: [RQA-2574](https://opentrons.atlassian.net/browse/RQA-2574)

# Test Plan

- [ ] Make sure that we add the `internal` flag to the `/subsystem/updates/all` response
- [ ] Make sure that we add the `internal` flag to the `/subsystem/updates/current`, etc
- [ ] Make sure when the system boot up firmware updates are correctly tagged as `internal = True`
- [ ] Make sure that updates started by the client are labeled as `internal = False`

# Changelog

- add `internal` flag to UpdateProgressSummary and UpdateProgressData for `/subsystem/updates/*` endpoints

# Review requests

- Does this make sense?

# Risk assessment

Med, affects firmware updates, needs testing on desktop app and ODD

[RQA-2574]: https://opentrons.atlassian.net/browse/RQA-2574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ