### PR TITLE
fix(app): disable the factory mode complete and restart robot button when robot is busy

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryModeSlideout.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryModeSlideout.tsx
@@ -33,6 +33,7 @@ import type { Dispatch } from '../../../../../redux/types'
 
 interface FactoryModeSlideoutProps {
   isExpanded: boolean
+  isRobotBusy: boolean
   onCloseClick: () => void
   robotName: string
 }
@@ -43,6 +44,7 @@ interface FormValues {
 
 export function FactoryModeSlideout({
   isExpanded,
+  isRobotBusy,
   onCloseClick,
   robotName,
 }: FactoryModeSlideoutProps): JSX.Element {
@@ -160,7 +162,8 @@ export function FactoryModeSlideout({
               disabled={
                 (toggleValue && file == null) ||
                 isUploading ||
-                fileError != null
+                fileError != null ||
+                isRobotBusy
               }
               onClick={handleCompleteClick}
               width="100%"

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -140,6 +140,7 @@ export function RobotSettingsAdvanced({
         {showFactoryModeSlideout && (
           <FactoryModeSlideout
             isExpanded={showFactoryModeSlideout}
+            isRobotBusy={isRobotBusy || isEstopNotDisengaged}
             onCloseClick={() => setShowFactoryModeSlideout(false)}
             robotName={robotName}
           />


### PR DESCRIPTION
# Overview

passes a robotIsBusy boolean to the factory mode slideout to disable the complete and restart robot button when the robot is busy. this covers the edge case where the robot becomes busy after the slideout is opened.

closes RQA-2632

# Test Plan

manually verified disabled complete and restart robot button when the robot is busy, e.g. a current run exists

# Changelog

 - Disables the factory mode complete and restart robot button when robot is busy

# Review requests

check the edge case, start a run/maintenance run after the factory mode slideout is open

# Risk assessment

low
