### PR TITLE
fix(api): Raise cases for unsupported nozzle layouts

### DIFF
--- a/api/docs/v2/pipettes/partial_tip_pickup.rst
+++ b/api/docs/v2/pipettes/partial_tip_pickup.rst
@@ -25,10 +25,6 @@ For greater convenience, also import the individual layout constants that you pl
 
 Then when you call ``configure_nozzle_layout`` later in your protocol, you can set ``style=COLUMN``. 
 
-It is important to note that for versions <= 7.3, when configuring for COLUMN layout, there may be a noticeable tip overlap offset that will need to be accounted for through Labware Position Check.
-
-Along that same line of logic, it would be advisable to determine a configuration to be used for a specific labware, and only interact with that labware when in said configuration.
-
 Here is the start of a protocol that performs both imports, loads a 96-channel pipette, and sets it to pick up a single column of tips.
 
 .. code-block:: python

--- a/api/docs/v2/pipettes/partial_tip_pickup.rst
+++ b/api/docs/v2/pipettes/partial_tip_pickup.rst
@@ -25,6 +25,10 @@ For greater convenience, also import the individual layout constants that you pl
 
 Then when you call ``configure_nozzle_layout`` later in your protocol, you can set ``style=COLUMN``. 
 
+It is important to note that for versions <= 7.3, when configuring for COLUMN layout, there may be a noticeable tip overlap offset that will need to be accounted for through Labware Position Check.
+
+Along that same line of logic, it would be advisable to determine a configuration to be used for a specific labware, and only interact with that labware when in said configuration.
+
 Here is the start of a protocol that performs both imports, loads a 96-channel pipette, and sets it to pick up a single column of tips.
 
 .. code-block:: python

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1928,13 +1928,6 @@ class InstrumentContext(publisher.CommandPublisher):
             should be of the same format used when identifying wells by name.
             Required unless setting ``style=ALL``.
 
-            .. note:
-                When configuring for the ``COLUMN`` layout in versions <= 7.3 it is
-                recommended to perform Labware Position Check on the labware that will be
-                interacted with in a partial configuration. Failure to do so may result
-                in a tip overlap of up to 0.5mm and the raising of Overpressure errors
-                in certain edge cases.
-
         :type start: str or ``None``
         :param tip_racks: Behaves the same as setting the ``tip_racks`` parameter of
             :py:meth:`.load_instrument`. If not specified, the new configuration resets

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1928,12 +1928,12 @@ class InstrumentContext(publisher.CommandPublisher):
             should be of the same format used when identifying wells by name.
             Required unless setting ``style=ALL``.
 
-            .. note::
-                When using the ``COLUMN`` layout, the only fully supported value is
-                ``start="A12"``. You can use ``start="A1"``, but this will disable tip
-                tracking and you will have to specify the ``location`` every time you
-                call :py:meth:`.pick_up_tip`, such that the pipette picks up columns of
-                tips *from right to left* on the tip rack.
+            .. note:
+                When configuring for the ``COLUMN`` layout in versions <= 7.3 it is
+                recommended to perform Labware Position Check on the labware that will be
+                interacted with in a partial configuration. Failure to do so may result
+                in a tip overlap of up to 0.5mm and the raising of Overpressure errors
+                in certain edge cases.
 
         :type start: str or ``None``
         :param tip_racks: Behaves the same as setting the ``tip_racks`` parameter of
@@ -1947,6 +1947,20 @@ class InstrumentContext(publisher.CommandPublisher):
         #       :param front_right: The nozzle at the front left of the layout. Only used for
         #           NozzleLayout.QUADRANT configurations.
         #       :type front_right: str or ``None``
+        #
+        #       NOTE: Disabled layouts error case can be removed once desired map configurations
+        #       have appropriate data regarding tip-type to map current values added to the
+        #       pipette definitions.
+        disabled_layouts = [
+            NozzleLayout.ROW,
+            NozzleLayout.SINGLE,
+            NozzleLayout.QUADRANT,
+        ]
+        if style in disabled_layouts:
+            raise ValueError(
+                f"Nozzle layout configuration of style {style.value} is currently unsupported."
+            )
+
         if style != NozzleLayout.ALL:
             if start is None:
                 raise ValueError(

--- a/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
@@ -414,7 +414,7 @@ def test_96_config_identification(
         )
         == nozzle_manager.NozzleConfigurationType.SUBRECT
     )
-    subject.update_nozzle_configuration("A1", "D12")
+    subject.update_nozzle_configuration("A1", "B12")
     assert (
         cast(
             nozzle_manager.NozzleConfigurationType,
@@ -422,7 +422,7 @@ def test_96_config_identification(
         )
         == nozzle_manager.NozzleConfigurationType.SUBRECT
     )
-    subject.update_nozzle_configuration("E1", "H12")
+    subject.update_nozzle_configuration("G1", "H12")
     assert (
         cast(
             nozzle_manager.NozzleConfigurationType,
@@ -430,7 +430,7 @@ def test_96_config_identification(
         )
         == nozzle_manager.NozzleConfigurationType.SUBRECT
     )
-    subject.update_nozzle_configuration("A1", "H6")
+    subject.update_nozzle_configuration("A1", "H3")
     assert (
         cast(
             nozzle_manager.NozzleConfigurationType,
@@ -438,7 +438,7 @@ def test_96_config_identification(
         )
         == nozzle_manager.NozzleConfigurationType.SUBRECT
     )
-    subject.update_nozzle_configuration("A7", "H12")
+    subject.update_nozzle_configuration("A10", "H12")
     assert (
         cast(
             nozzle_manager.NozzleConfigurationType,

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -1121,17 +1121,17 @@ def test_next_tip_automatic_tip_tracking_with_partial_configurations(
         )
         return configure_nozzle_private_result.nozzle_map
 
-    map = _reconfigure_nozzle_layout("A1", "A1", "H10")
-    _assert_and_pickup("A3", map)
+    map = _reconfigure_nozzle_layout("A1", "A1", "H3")
+    _assert_and_pickup("A10", map)
     map = _reconfigure_nozzle_layout("A1", "A1", "F2")
-    _assert_and_pickup("C1", map)
+    _assert_and_pickup("C8", map)
 
     # Configure to single tip pickups
     map = _reconfigure_nozzle_layout("H12", "H12", "H12")
     _assert_and_pickup("A1", map)
     map = _reconfigure_nozzle_layout("H1", "H1", "H1")
-    _assert_and_pickup("A2", map)
+    _assert_and_pickup("A9", map)
     map = _reconfigure_nozzle_layout("A12", "A12", "A12")
-    _assert_and_pickup("B1", map)
+    _assert_and_pickup("H1", map)
     map = _reconfigure_nozzle_layout("A1", "A1", "A1")
-    _assert_and_pickup("B2", map)
+    _assert_and_pickup("B9", map)

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -434,7 +434,9 @@ def _load_pipette(
     # NOTE: 8ch QC testing means testing 1 channel at a time,
     #       so we need to decrease the pick-up current to work with 1 tip.
     if pipette.channels == 8 and not increment and not photometric:
-        pipette.configure_nozzle_layout(NozzleLayout.SINGLE, "A1")
+        pipette._core.configure_nozzle_layout(
+            style=NozzleLayout.SINGLE, primary_nozzle="A1", front_right_nozzle="A1"
+        )
         # override deck conflict checking cause we specially lay out our tipracks
         DeckConflit.check_safe_for_pipette_movement = (
             _override_check_safe_for_pipette_movement


### PR DESCRIPTION
# Overview
See RTC-440

This PR seeks to limit user access to unapproved configurations through the PAPI and raise errors when configuring potentially unsafe layouts for the nozzle map.

UPDATE:
After discussion, doc side changes and API docstrings have been moved to alternative PR.

# Test Plan
Ensure that protocols with that attempt to utilize unsupported single/row/quadrants API commands are rejected. Ensure that if engine commands are used, no more than 24 tips can be added to partial configuration.

# Changelog

- Added disabled layouts filter to PAPI to prevent configuration in unapproved layouts (these layouts can still be achieved through backend commands, which is desired for hardware testing or advanced users)
- Limit the size of configurations that are not `FULL` to 24 nozzles, a size limit found by hardware testing.

# Review requests


# Risk assessment
Relatively low as we were not exposing these configurations publicly yet anyways, however some use cases involving non-public facing API may be effected.