### PR TITLE
fix(app): check /instruments for 96 channel attachment

### DIFF
--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -99,9 +99,8 @@ export function InstrumentsAndModules({
         !i.ok &&
         i.subsystem === 'pipette_right'
     ) ?? null
-  const is96ChannelAttached = getIs96ChannelPipetteAttached(
-    attachedPipettes?.left ?? null
-  )
+  const is96ChannelAttached = attachedLeftPipette?.data.channels === 96
+
   const attachPipetteRequired =
     attachedLeftPipette == null && attachedRightPipette == null
   const calibratePipetteRequired =

--- a/app/src/organisms/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Devices/InstrumentsAndModules.tsx
@@ -25,10 +25,7 @@ import { PipetteRecalibrationWarning } from './PipetteCard/PipetteRecalibrationW
 import { useCurrentRunId } from '../ProtocolUpload/hooks'
 import { ModuleCard } from '../ModuleCard'
 import { useIsFlex, useIsRobotViewable, useRunStatuses } from './hooks'
-import {
-  getIs96ChannelPipetteAttached,
-  getShowPipetteCalibrationWarning,
-} from './utils'
+import { getShowPipetteCalibrationWarning } from './utils'
 import { PipetteCard } from './PipetteCard'
 import { FlexPipetteCard } from './PipetteCard/FlexPipetteCard'
 import { GripperCard } from '../GripperCard'

--- a/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
+++ b/app/src/organisms/Devices/__tests__/InstrumentsAndModules.test.tsx
@@ -21,10 +21,7 @@ import { GripperCard } from '../../GripperCard'
 import { PipetteCard } from '../PipetteCard'
 import { FlexPipetteCard } from '../PipetteCard/FlexPipetteCard'
 import { PipetteRecalibrationWarning } from '../PipetteCard/PipetteRecalibrationWarning'
-import {
-  getIs96ChannelPipetteAttached,
-  getShowPipetteCalibrationWarning,
-} from '../utils'
+import { getShowPipetteCalibrationWarning } from '../utils'
 import { useIsEstopNotDisengaged } from '../../../resources/devices/hooks/useIsEstopNotDisengaged'
 import type * as Components from '@opentrons/components'
 
@@ -65,7 +62,6 @@ describe('InstrumentsAndModules', () => {
       isRunStill: true,
       isRunTerminal: false,
     })
-    vi.mocked(getIs96ChannelPipetteAttached).mockReturnValue(false)
     vi.mocked(getShowPipetteCalibrationWarning).mockReturnValue(false)
     vi.mocked(useInstrumentsQuery).mockReturnValue({
       data: { data: [] },
@@ -129,7 +125,20 @@ describe('InstrumentsAndModules', () => {
   })
   it('renders 1 pipette card when a 96 channel is attached', () => {
     when(useIsFlex).calledWith(ROBOT_NAME).thenReturn(true)
-    vi.mocked(getIs96ChannelPipetteAttached).mockReturnValue(true)
+    vi.mocked(useInstrumentsQuery).mockReturnValue({
+      data: {
+        data: [
+          {
+            ok: true,
+            instrumentType: 'pipette',
+            mount: 'left',
+            data: {
+              channels: 96,
+            },
+          },
+        ],
+      },
+    } as any)
     vi.mocked(useIsRobotViewable).mockReturnValue(true)
     render()
     expect(vi.mocked(FlexPipetteCard)).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Fix RQA-2633
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
I disabled the `/pipettes` query for Flex in favor of using `/instruments` but missed switching the reference for whether a 96 channel is attached to this data. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Look at the desktop app with a 96 channel attached, no Right Pipette card should be visible
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Check left pipette data from `/instruments` to see if it is a 96 channel
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over changes
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
