### PR TITLE
fix(app): fix ordering of gripper exit so success screen doesn't flash

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -19,6 +19,7 @@ import { useNotifyCurrentMaintenanceRun } from '../../resources/maintenance_runs
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { getTopPortalEl } from '../../App/portal'
 import { WizardHeader } from '../../molecules/WizardHeader'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { FirmwareUpdateModal } from '../FirmwareUpdateModal'
 import { getIsOnDevice } from '../../redux/config'
 import {
@@ -115,31 +116,30 @@ export function GripperWizardFlows(
   const [isExiting, setIsExiting] = React.useState<boolean>(false)
   const [errorMessage, setErrorMessage] = React.useState<null | string>(null)
 
-  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({
-    onSuccess: () => closeFlow(),
-    onError: () => closeFlow(),
-  })
+  const handleClose = (): void => {
+    if (props?.onComplete != null) props.onComplete()
+    if (maintenanceRunData != null) {
+      deleteMaintenanceRun(maintenanceRunData?.data.id)
+    }
+    closeFlow()
+  }
+
+  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({})
 
   const handleCleanUpAndClose = (): void => {
-    setIsExiting(true)
-    if (maintenanceRunData?.data.id == null) {
-      closeFlow()
-    } else {
+    if (maintenanceRunData?.data.id == null) handleClose()
+    else {
       chainRunCommands(
         maintenanceRunData?.data.id,
         [{ commandType: 'home' as const, params: {} }],
-        true
+        false
       )
         .then(() => {
-          deleteMaintenanceRun(maintenanceRunData?.data.id)
-          setIsExiting(false)
-          props.onComplete?.()
+          handleClose()
         })
         .catch(error => {
-          console.error(error.message)
-          deleteMaintenanceRun(maintenanceRunData?.data.id)
-          setIsExiting(false)
-          props.onComplete?.()
+          setIsExiting(true)
+          setErrorMessage(error.message)
         })
     }
   }
@@ -156,6 +156,7 @@ export function GripperWizardFlows(
         isChainCommandMutationLoading || isCommandLoading || isExiting
       }
       handleCleanUpAndClose={handleCleanUpAndClose}
+      handleClose={handleClose}
       chainRunCommands={chainRunCommands}
       createRunCommand={createMaintenanceCommand}
       errorMessage={errorMessage}
@@ -182,6 +183,7 @@ interface GripperWizardProps {
   setErrorMessage: (message: string | null) => void
   errorMessage: string | null
   handleCleanUpAndClose: () => void
+  handleClose: () => void
   chainRunCommands: ReturnType<
     typeof useChainMaintenanceCommands
   >['chainRunCommands']
@@ -198,6 +200,7 @@ export const GripperWizard = (
     maintenanceRunId,
     createMaintenanceRun,
     handleCleanUpAndClose,
+    handleClose,
     chainRunCommands,
     attachedGripper,
     isCreateLoading,
@@ -273,6 +276,16 @@ export const GripperWizard = (
         handleExit={confirmExit}
         flowType={flowType}
         isRobotMoving={isRobotMoving}
+      />
+    )
+  } else if (isExiting && errorMessage != null) {
+    onExit = handleClose
+    modalContent = (
+      <SimpleWizardBody
+        isSuccess={false}
+        iconColor={COLORS.red50}
+        header={t('shared:error_encountered')}
+        subHeader={errorMessage}
       />
     )
   } else if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {


### PR DESCRIPTION
fix RQA-2629

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Robot finished homing a few seconds before the modal closed, so the robot is moving spinner was unmounted before the modal closed, flashing success screen again. This PR refactors that behavior to match what was done for pipettes in https://github.com/Opentrons/opentrons/pull/14580
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Run through a gripper flow and see that the modal closes from the loader screen 

https://github.com/Opentrons/opentrons/assets/14302493/91cd0c97-3c62-47d6-8974-903668dd5ff3
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Mimic behavior of pipette wizard flows for `isExiting` logic and `handleCleanUpAndClose`

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Look over changes
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
