### PR TITLE
fix(app): add grey square for stale and error protocol map

### DIFF
--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -526,19 +526,35 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                 onClick={() => handleSelectProtocol(storedProtocol)}
               >
                 <Box display="grid" gridTemplateColumns="1fr 3fr">
-                  <Box
-                    marginY={SPACING.spacingAuto}
-                    backgroundColor={isSelected ? COLORS.white : 'inherit'}
-                    marginRight={SPACING.spacing16}
-                    height="4.25rem"
-                    width="4.75rem"
-                  >
-                    {!missingAnalysisData ? (
+                  {!missingAnalysisData ? (
+                    <Box
+                      marginY={SPACING.spacingAuto}
+                      backgroundColor={isSelected ? COLORS.white : 'inherit'}
+                      marginRight={SPACING.spacing16}
+                      height="4.25rem"
+                      width="4.75rem"
+                    >
                       <ProtocolDeck
                         protocolAnalysis={storedProtocol.mostRecentAnalysis}
                       />
-                    ) : null}
-                  </Box>
+                    </Box>
+                  ) : (
+                    <Flex
+                      height="4.25rem"
+                      width="4.75rem"
+                      marginRight={SPACING.spacing16}
+                      backgroundColor={COLORS.grey30}
+                      borderRadius={SPACING.spacing8}
+                      alignItems={ALIGN_CENTER}
+                      justifyContent={JUSTIFY_CENTER}
+                    >
+                      <Icon
+                        name="ot-close"
+                        color={COLORS.grey40}
+                        size="2.25rem"
+                      />
+                    </Flex>
+                  )}
                   <StyledText
                     as="p"
                     fontWeight={TYPOGRAPHY.fontWeightSemiBold}

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -539,21 +539,13 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                       />
                     </Box>
                   ) : (
-                    <Flex
+                    <Box
                       height="4.25rem"
                       width="4.75rem"
                       marginRight={SPACING.spacing16}
                       backgroundColor={COLORS.grey30}
                       borderRadius={SPACING.spacing8}
-                      alignItems={ALIGN_CENTER}
-                      justifyContent={JUSTIFY_CENTER}
-                    >
-                      <Icon
-                        name="ot-close"
-                        color={COLORS.grey40}
-                        size="2.25rem"
-                      />
-                    </Flex>
+                    />
                   )}
                   <StyledText
                     as="p"

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -13,6 +13,7 @@ import {
   getGripperDisplayName,
 } from '@opentrons/shared-data'
 import {
+  ALIGN_CENTER,
   ALIGN_FLEX_START,
   BORDERS,
   Box,
@@ -20,6 +21,7 @@ import {
   DIRECTION_COLUMN,
   Flex,
   Icon,
+  JUSTIFY_CENTER,
   JUSTIFY_FLEX_END,
   ModuleIcon,
   OVERFLOW_WRAP_ANYWHERE,
@@ -52,8 +54,6 @@ import {
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
 import { getProtocolUsesGripper } from '../ProtocolSetupInstruments/utils'
-import { ALIGN_CENTER } from '@opentrons/components'
-import { JUSTIFY_CENTER } from '@opentrons/components'
 
 interface ProtocolCardProps {
   handleRunProtocol: (storedProtocolData: StoredProtocolData) => void

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -187,26 +187,18 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
               />
             ),
             error: (
-              <Flex
+              <Box
                 size="6rem"
                 backgroundColor={COLORS.grey30}
                 borderRadius={SPACING.spacing8}
-                alignItems={ALIGN_CENTER}
-                justifyContent={JUSTIFY_CENTER}
-              >
-                <Icon name="ot-close" color={COLORS.grey40} size="2.75rem" />
-              </Flex>
+              />
             ),
             stale: (
-              <Flex
+              <Box
                 size="6rem"
                 backgroundColor={COLORS.grey30}
                 borderRadius={SPACING.spacing8}
-                alignItems={ALIGN_CENTER}
-                justifyContent={JUSTIFY_CENTER}
-              >
-                <Icon name="ot-close" color={COLORS.grey40} size="2.75rem" />
-              </Flex>
+              />
             ),
             complete:
               mostRecentAnalysis != null ? (

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -52,6 +52,8 @@ import {
 import type { StoredProtocolData } from '../../redux/protocol-storage'
 import type { State } from '../../redux/types'
 import { getProtocolUsesGripper } from '../ProtocolSetupInstruments/utils'
+import { ALIGN_CENTER } from '@opentrons/components'
+import { JUSTIFY_CENTER } from '@opentrons/components'
 
 interface ProtocolCardProps {
   handleRunProtocol: (storedProtocolData: StoredProtocolData) => void
@@ -184,8 +186,28 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
                 size={SIZE_3}
               />
             ),
-            error: <Box size="6rem" backgroundColor={COLORS.grey30} />,
-            stale: <Box size="6rem" backgroundColor={COLORS.grey30} />,
+            error: (
+              <Flex
+                size="6rem"
+                backgroundColor={COLORS.grey30}
+                borderRadius={SPACING.spacing8}
+                alignItems={ALIGN_CENTER}
+                justifyContent={JUSTIFY_CENTER}
+              >
+                <Icon name="ot-close" color={COLORS.grey40} size="2.75rem" />
+              </Flex>
+            ),
+            stale: (
+              <Flex
+                size="6rem"
+                backgroundColor={COLORS.grey30}
+                borderRadius={SPACING.spacing8}
+                alignItems={ALIGN_CENTER}
+                justifyContent={JUSTIFY_CENTER}
+              >
+                <Icon name="ot-close" color={COLORS.grey40} size="2.75rem" />
+              </Flex>
+            ),
             complete:
               mostRecentAnalysis != null ? (
                 <ProtocolDeck protocolAnalysis={mostRecentAnalysis} />

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -13,7 +13,6 @@ import {
   getGripperDisplayName,
 } from '@opentrons/shared-data'
 import {
-  ALIGN_CENTER,
   ALIGN_FLEX_START,
   BORDERS,
   Box,
@@ -21,7 +20,6 @@ import {
   DIRECTION_COLUMN,
   Flex,
   Icon,
-  JUSTIFY_CENTER,
   JUSTIFY_FLEX_END,
   ModuleIcon,
   OVERFLOW_WRAP_ANYWHERE,


### PR DESCRIPTION
fix RQA-2634

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Implement designs for stale protocol state deck map - now a grey square with rounded edges
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Look at choose a protocol slideout and desktop protocols tab to view failed and stale protocols
<img width="917" alt="Screen Shot 2024-04-30 at 1 44 18 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/5776abb6-cb1d-4ee3-bff5-6ef6a2801f66">
<img width="325" alt="Screen Shot 2024-04-30 at 1 43 09 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/7dd5f8fa-5bc4-4376-9cb3-5480e2b9e6fe">
<img width="323" alt="Screen Shot 2024-04-30 at 1 43 04 PM" src="https://github.com/Opentrons/opentrons/assets/14302493/a7964c28-cef9-4fa6-b1ea-0ce507b02349">

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
Updated Choose a Protocol Slideout and Protocol Card to show grey square (rounded edges)
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Test this out
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
