### PR TITLE
fix(app): fix restore default values button behavior

### DIFF
--- a/app/src/organisms/ChildNavigation/index.tsx
+++ b/app/src/organisms/ChildNavigation/index.tsx
@@ -83,7 +83,10 @@ export function ChildNavigation({
       {onClickButton != null && buttonText != null ? (
         <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
           {secondaryButtonProps != null ? (
-            <SmallButton {...secondaryButtonProps} />
+            <SmallButton
+              data-testid="ChildNavigation_Secondary_Button"
+              {...secondaryButtonProps}
+            />
           ) : null}
 
           <SmallButton

--- a/app/src/organisms/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { when } from 'vitest-when'
 import { it, describe, beforeEach, vi, expect } from 'vitest'
-import { act, fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import {
   useCreateProtocolAnalysisMutation,
   useCreateRunMutation,

--- a/app/src/organisms/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { when } from 'vitest-when'
 import { it, describe, beforeEach, vi, expect } from 'vitest'
-import { fireEvent, screen } from '@testing-library/react'
+import { act, fireEvent, screen } from '@testing-library/react'
 import {
   useCreateProtocolAnalysisMutation,
   useCreateRunMutation,
@@ -55,6 +55,7 @@ describe('ProtocolSetupParameters', () => {
       .calledWith(expect.anything())
       .thenReturn({ createRun: mockCreateRun } as any)
   })
+
   it('renders the parameters labels and mock data', () => {
     render(props)
     screen.getByText('Parameters')
@@ -63,27 +64,39 @@ describe('ProtocolSetupParameters', () => {
     screen.getByText('Dry Run')
     screen.getByText('a dry run description')
   })
+
   it('renders the ChooseEnum component when a str param is selected', () => {
     render(props)
     fireEvent.click(screen.getByText('Default Module Offsets'))
     screen.getByText('mock ChooseEnum')
   })
+
   it('renders the other setting when boolean param is selected', () => {
     render(props)
     expect(screen.getAllByText('On')).toHaveLength(2)
     fireEvent.click(screen.getByText('Dry Run'))
     expect(screen.getAllByText('On')).toHaveLength(3)
   })
+
   it('renders the back icon and calls useHistory', () => {
     render(props)
     fireEvent.click(screen.getAllByRole('button')[0])
     expect(mockGoBack).toHaveBeenCalled()
   })
+
   it('renders the confirm values button and clicking on it creates a run', () => {
     render(props)
     fireEvent.click(screen.getByRole('button', { name: 'Confirm values' }))
     expect(mockCreateRun).toHaveBeenCalled()
   })
+
+  it('should restore default values button is disabled when tapping confirm values button', async () => {
+    render(props)
+    const resetButton = screen.getByTestId('ChildNavigation_Secondary_Button')
+    fireEvent.click(screen.getByText('Confirm values'))
+    expect(resetButton).toBeDisabled()
+  })
+
   it('renders the reset values modal', () => {
     render(props)
     fireEvent.click(

--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -151,6 +151,7 @@ export function ProtocolSetupParameters({
         secondaryButtonProps={{
           buttonType: 'tertiaryLowLight',
           buttonText: t('restore_defaults'),
+          disabled: isLoading || startSetup,
           onClick: () => showResetValuesModal(true),
         }}
       />


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
currently restore default values button is tappable when tapping confirm values button.
This PR makes restore default values button is disabled during confirming values.

close RQA-2639
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
set up a RTP protocol, change a runtime parameter and tap confirm values.
then try to tap restore default values button and check that the restore default values modal doesn't show up.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add disabled to secondary button in protocol setup parameters
- add a test case for this 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
