### PR TITLE
fix(api): skip command key hash generation only if command intent is SETUP

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/hash_command_params.py
+++ b/api/src/opentrons/protocol_engine/commands/hash_command_params.py
@@ -28,7 +28,7 @@ def hash_protocol_command_params(
         The command hash, if the command is a protocol command.
         `None` if the command is a setup command.
     """
-    if create.intent != CommandIntent.PROTOCOL:
+    if create.intent == CommandIntent.SETUP:
         return None
     # We avoid Python's built-in hash() function because it's not stable across
     # runs of the Python interpreter. (Jira RSS-215.)

--- a/robot-server/tests/integration/http_api/test_command_key_hash_matching.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_command_key_hash_matching.tavern.yaml
@@ -1,0 +1,119 @@
+test_name: Test that command keys in analysis and protocol run match for a deterministic protocol running using protocol engine
+
+marks:
+  - usefixtures:
+      - ot2_server_base_url
+
+stages:
+  - name: Upload a protocol
+    request:
+      url: '{ot2_server_base_url}/protocols'
+      method: POST
+      files:
+        files: 'tests/integration/protocols/basic_transfer_with_run_time_parameters.py'
+    response:
+      save:
+        json:
+          protocol_id: data.id
+          analysis_id: data.analysisSummaries[0].id
+      strict:
+        - json:off
+      status_code: 201
+
+  - name: Save command keys from protocol analysis
+    max_retries: 5
+    delay_after: 1
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}/analyses/{analysis_id}'
+    response:
+      save:
+        json:
+          analysis_data: data
+          home_cmd_key: data.commands[0].key
+          plate_load_key: data.commands[1].key
+          pipette_load_key: data.commands[3].key
+          pick_up_tip_key: data.commands[4].key
+          drop_tip_key: data.commands[7].key
+      strict:
+        - json:off
+      json:
+        data:
+          id: '{analysis_id}'
+          commands:
+            - commandType: loadPipette
+
+  - name: Create run from protocol
+    request:
+      url: '{ot2_server_base_url}/runs'
+      method: POST
+      json:
+        data:
+          protocolId: '{protocol_id}'
+    response:
+      status_code: 201
+      save:
+        json:
+          original_run_data: data
+          run_id: data.id
+
+  - name: Play the run
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/actions'
+      method: POST
+      json:
+        data:
+          actionType: play
+    response:
+      status_code: 201
+
+  - name: Wait for the protocol to complete
+    max_retries: 5
+    delay_after: 1
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          status: succeeded
+
+  - name: Verify commands have keys identical to their counterparts in analysis
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/commands'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        links:
+          current:
+            href: !anystr
+            meta:
+              runId: !anystr
+              commandId: !anystr
+              index: 7
+              key: !anystr
+              createdAt: !anystr
+        meta:
+          cursor: 0
+          totalLength: 8
+        data:
+          - id: !anystr
+            key: '{home_cmd_key}'
+            commandType: home
+          - id: !anystr
+            key: '{plate_load_key}'
+            commandType: loadLabware
+          - id: !anystr
+            key: '{pipette_load_key}'
+            commandType: loadPipette
+          - id: !anystr
+            key: '{pick_up_tip_key}'
+            commandType: pickUpTip
+          - id: !anystr
+            key: '{drop_tip_key}'
+            commandType: dropTip


### PR DESCRIPTION
Fixes RQA-2640

# Overview

In a previous PR we made a change from skipping hash generation if `CommandCreate.intent == CommandIntent.SETUP` to if `CommandCreate.intent != CommandIntent.PROTOCOL`. But a command can have a null intent when it is a protocol command; we only expect setup commands to have an explicit SETUP intent. So we were accidentally skipping key hash generation for python protocols, which was resulting in the app not being able to match run commands with their analysis counterparts.

This PR fixes that and also adds an integration test so we don't accidentally break this functionality again.

# Review requests

- want to make sure that there wasn't an important reason for making the original change that I'm missing. But since all tests are still passing I'm guessing there wasn't any functional change that required a change in the original `if` statement.

# Risk assessment

Low. Bug fix.
