### PR TITLE
fix(api): disallow hashing we using a fixit command

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/hash_command_params.py
+++ b/api/src/opentrons/protocol_engine/commands/hash_command_params.py
@@ -28,7 +28,7 @@ def hash_protocol_command_params(
         The command hash, if the command is a protocol command.
         `None` if the command is a setup command.
     """
-    if create.intent == CommandIntent.SETUP:
+    if create.intent in [CommandIntent.SETUP, CommandIntent.FIXIT]:
         return None
     # We avoid Python's built-in hash() function because it's not stable across
     # runs of the Python interpreter. (Jira RSS-215.)

--- a/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
@@ -1,4 +1,5 @@
 """Tests for hash_command_params."""
+import pytest
 
 from opentrons.protocol_engine import CommandIntent
 from opentrons.protocol_engine import commands
@@ -66,10 +67,11 @@ def test_repeated_commands() -> None:
     assert a_hash != b_hash
 
 
-def test_setup_command() -> None:
+@pytest.mark.parametrize("command_intent", [CommandIntent.SETUP, CommandIntent.FIXIT])
+def test_setup_command(command_intent: CommandIntent) -> None:
     """Setup commands should always hash to None."""
     setup_command = commands.WaitForDurationCreate(
         params=commands.WaitForDurationParams(seconds=123),
-        intent=CommandIntent.SETUP,
+        intent=command_intent,
     )
     assert hash_protocol_command_params(setup_command, None) is None

--- a/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_hash_command_params.py
@@ -68,8 +68,8 @@ def test_repeated_commands() -> None:
 
 
 @pytest.mark.parametrize("command_intent", [CommandIntent.SETUP, CommandIntent.FIXIT])
-def test_setup_command(command_intent: CommandIntent) -> None:
-    """Setup commands should always hash to None."""
+def test_setup_and_fixit_command(command_intent: CommandIntent) -> None:
+    """Setup and fixit commands should always skip hashing."""
     setup_command = commands.WaitForDurationCreate(
         params=commands.WaitForDurationParams(seconds=123),
         intent=command_intent,


### PR DESCRIPTION
# Overview

follow up for https://github.com/Opentrons/opentrons/pull/14908.
disallow hashing for fixit commands.

# Test Plan

POST a fixit command and make sure the hash is `None`.

# Risk assessment

low. set hash to `None` when using a fixit command
