### PR TITLE
refactor(api): Use a dataclass, not a BaseModel, for PipetteNozleLayoutResultMixin

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/configuring_common.py
+++ b/api/src/opentrons/protocol_engine/commands/configuring_common.py
@@ -1,6 +1,5 @@
 """Common configuration command base models."""
 
-from pydantic import BaseModel, Field
 from dataclasses import dataclass
 from opentrons.hardware_control.nozzle_manager import (
     NozzleMap,
@@ -10,18 +9,18 @@ from ..resources import pipette_data_provider
 
 @dataclass
 class PipetteConfigUpdateResultMixin:
-    """A mixin-suitable model for adding pipette config to results."""
+    """A mixin-suitable model for adding pipette config to private results."""
 
     pipette_id: str
     serial_number: str
     config: pipette_data_provider.LoadedStaticPipetteData
 
 
-class PipetteNozzleLayoutResultMixin(BaseModel):
+@dataclass
+class PipetteNozzleLayoutResultMixin:
     """A nozzle layout result for updating the pipette state."""
 
     pipette_id: str
-    nozzle_map: NozzleMap = Field(
-        ...,
-        description="A dataclass object holding information about the current nozzle configuration.",
-    )
+
+    nozzle_map: NozzleMap
+    """A dataclass object holding information about the current nozzle configuration."""


### PR DESCRIPTION
# Overview

This class is only used internally, in-memory, and never serialized to JSON. So, make it a `@dataclass` instead of a `pydantic.BaseModel` for clarity and performance.

# Test Plan

Just CI.

# Review requests

None in particular.

# Risk assessment

lo
