### PR TITLE
fix(api): pass the calibrated jaw max offset value when we resetting instrument

### DIFF
--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -331,9 +331,7 @@ def _reload_gripper(
                     new_config,
                     cal_offset,
                     attached_instr._gripper_id,
-                    attached_instr._jaw_max_offset
-                    if attached_instr.has_jaw_width_calibration
-                    else None,
+                    attached_instr._jaw_max_offset,
                 ),
                 False,
             )

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -52,6 +52,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         config: GripperDefinition,
         gripper_cal_offset: GripperCalibrationOffset,
         gripper_id: str,
+        jaw_max_offset: Optional[float] = None,
     ) -> None:
         self._config = config
         self._model = config.model
@@ -83,7 +84,7 @@ class Gripper(AbstractInstrument[GripperDefinition]):
         self._log.info(
             f"loaded: {self._model}, gripper offset: {self._calibration_offset}"
         )
-        self._jaw_max_offset: Optional[float] = None
+        self._jaw_max_offset = jaw_max_offset
 
     @property
     def grip_force_profile(self) -> GripForceProfile:
@@ -330,6 +331,9 @@ def _reload_gripper(
                     new_config,
                     cal_offset,
                     attached_instr._gripper_id,
+                    attached_instr._jaw_max_offset
+                    if attached_instr.has_jaw_width_calibration
+                    else None,
                 ),
                 False,
             )

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper.py
@@ -33,7 +33,7 @@ from opentrons_shared_data.gripper import (
     Geometry,
 )
 
-RECONFIG_KEYS = {"quirks"}
+RECONFIG_KEYS = {"quirks", "grip_force_profile"}
 
 MAX_ACCEPTABLE_JAW_DISPLACEMENT: Final = 20
 
@@ -326,12 +326,13 @@ def _reload_gripper(
                 changed.add(k)
         if changed.intersection(RECONFIG_KEYS):
             # Something has changed that requires reconfig
+            # we shoud recalibrate the jaw as well
             return (
                 Gripper(
                     new_config,
                     cal_offset,
                     attached_instr._gripper_id,
-                    attached_instr._jaw_max_offset,
+                    None,
                 ),
                 False,
             )

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -51,6 +51,9 @@ class GripperHandler:
             og_gripper.config,
             load_gripper_calibration_offset(og_gripper.gripper_id),
             og_gripper.gripper_id,
+            og_gripper._jaw_max_offset
+            if og_gripper.has_jaw_width_calibration
+            else None,
         )
         self._gripper = new_gripper
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/gripper_handler.py
@@ -51,9 +51,7 @@ class GripperHandler:
             og_gripper.config,
             load_gripper_calibration_offset(og_gripper.gripper_id),
             og_gripper.gripper_id,
-            og_gripper._jaw_max_offset
-            if og_gripper.has_jaw_width_calibration
-            else None,
+            og_gripper._jaw_max_offset,
         )
         self._gripper = new_gripper
 

--- a/api/tests/opentrons/hardware_control/test_gripper.py
+++ b/api/tests/opentrons/hardware_control/test_gripper.py
@@ -74,6 +74,7 @@ def test_reload_instrument_cal_ot3(fake_offset: "GripperCalibrationOffset") -> N
         fake_gripper_conf,
         fake_offset,
         "fakeid123",
+        jaw_max_offset=15,
     )
     # if only calibration is changed
     new_cal = instrument_calibration.GripperCalibrationOffset(
@@ -87,8 +88,35 @@ def test_reload_instrument_cal_ot3(fake_offset: "GripperCalibrationOffset") -> N
 
     # it's the same gripper
     assert new_gripper == old_gripper
+    # jaw offset should persists as well
+    assert new_gripper._jaw_max_offset == old_gripper._jaw_max_offset
     # we said upstream could skip
     assert skip
+
+
+@pytest.mark.ot3_only
+def test_reload_instrument_cal_ot3_conf_changed(
+    fake_offset: "GripperCalibrationOffset",
+) -> None:
+    old_gripper = gripper.Gripper(
+        fake_gripper_conf,
+        fake_offset,
+        "fakeid123",
+        jaw_max_offset=15,
+    )
+    new_conf = fake_gripper_conf.copy(
+        update={"grip_force_profile": {"default_grip_force": 1}}
+    )
+    assert new_conf != old_gripper.config
+
+    new_gripper, skip = gripper._reload_gripper(new_conf, old_gripper, fake_offset)
+
+    # it's not the same gripper
+    assert new_gripper != old_gripper
+    # do not pass in the old jaw max offse
+    assert not new_gripper._jaw_max_offset
+    # we said upstream could skip
+    assert not skip
 
 
 @pytest.mark.ot3_only

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1957,3 +1957,18 @@ async def test_stop_only_home_necessary_axes(
     await ot3_hardware.stop(home_after=True)
     if jaw_state == GripperJawState.GRIPPING:
         mock_home.assert_called_once_with(skip=[Axis.G])
+
+
+async def test_gripper_max_offset_persists_after_reset(
+    ot3_hardware: ThreadManager[OT3API],
+) -> None:
+    gripper_config = gc.load(GripperModel.v1)
+    instr_data = AttachedGripper(config=gripper_config, id="test")
+    await ot3_hardware.cache_gripper(instr_data)
+    ot3_hardware._gripper_handler.get_gripper()._jaw_max_offset = 10
+
+    await ot3_hardware.reset()
+    reset_gripper = ot3_hardware._gripper_handler.get_gripper()
+    assert reset_gripper._config == gripper_config
+    assert reset_gripper._gripper_id == "test"
+    assert reset_gripper._jaw_max_offset == 10

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -1957,18 +1957,3 @@ async def test_stop_only_home_necessary_axes(
     await ot3_hardware.stop(home_after=True)
     if jaw_state == GripperJawState.GRIPPING:
         mock_home.assert_called_once_with(skip=[Axis.G])
-
-
-async def test_gripper_max_offset_persists_after_reset(
-    ot3_hardware: ThreadManager[OT3API],
-) -> None:
-    gripper_config = gc.load(GripperModel.v1)
-    instr_data = AttachedGripper(config=gripper_config, id="test")
-    await ot3_hardware.cache_gripper(instr_data)
-    ot3_hardware._gripper_handler.get_gripper()._jaw_max_offset = 10
-
-    await ot3_hardware.reset()
-    reset_gripper = ot3_hardware._gripper_handler.get_gripper()
-    assert reset_gripper._config == gripper_config
-    assert reset_gripper._gripper_id == "test"
-    assert reset_gripper._jaw_max_offset == 10


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
We really only need to calibrate the gripper's max jaw offset once every time we attach a new gripper. This means that when we call `ot3api.reset()`, which is pretty often because it's called by `ot3api.stop()`, we should just reuse the calibrated value so we don't see the jaw opening and closing all the time.

<!--
Describe any requests for your reviewers here.
-->
