### PR TITLE
refactor(app): style desktop "Applied Labware Offset Data" buttons

### DIFF
--- a/app/src/organisms/LabwareOffsetTabs/index.tsx
+++ b/app/src/organisms/LabwareOffsetTabs/index.tsx
@@ -42,7 +42,7 @@ export function LabwareOffsetTabs({
       flexDirection={DIRECTION_COLUMN}
       {...styleProps}
     >
-      <Flex>
+      <Flex gridGap={SPACING.spacing4} marginY={SPACING.spacing8}>
         <RoundTab
           isCurrent={currentTab === 'table'}
           onClick={() => setCurrentTab('table')}


### PR DESCRIPTION
Closes [RQA-2637](https://opentrons.atlassian.net/browse/RQA-2637)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Somewhere in the border radius/component refactoring work, the desktop LPC offset buttons lost their margins. This adds them back, accounting for only the places we have these tabs (instead of altering the `RoundTab` component. 

I think we could discuss snapshot testing to prevent these kinds of style bugs from happening in the future. Chatted with Shlok about this -[ it's ticketed here.](https://opentrons.atlassian.net/browse/EXEC-426)


### Current Behavior

<img width="1048" alt="Screenshot 2024-04-25 at 2 10 08 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/c60ea225-1159-4e84-b5fb-50b9f1601634">

### Fixed Behavior

<img width="897" alt="Screenshot 2024-04-29 at 9 07 10 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/1772d1ec-53d6-4762-8796-f46167d42022">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2637]: https://opentrons.atlassian.net/browse/RQA-2637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ