### PR TITLE
fix(app,components): fix add a new case to info screen for labware

### DIFF
--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -8,6 +8,7 @@ import {
   DIRECTION_ROW,
   Flex,
   Icon,
+  InfoScreen,
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SPACING,
@@ -55,36 +56,42 @@ export const ProtocolLabwareDetails = (
       : []
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} width="100%">
-      <Flex flexDirection={DIRECTION_ROW}>
-        <StyledText
-          as="label"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          marginBottom={SPACING.spacing8}
-          data-testid="ProtocolLabwareDetails_labware_name"
-          width="66%"
-        >
-          {t('labware_name')}
-        </StyledText>
-        <StyledText
-          as="label"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          data-testid="ProtocolLabwareDetails_quantity"
-        >
-          {t('quantity')}
-        </StyledText>
-      </Flex>
-      {labwareDetails?.map((labware, index) => (
-        <ProtocolLabwareDetailItem
-          key={index}
-          namespace={labware.params.namespace}
-          displayName={labware.result?.definition?.metadata?.displayName}
-          quantity={labware.quantity}
-          labware={{ definition: labware.result?.definition }}
-          data-testid={`ProtocolLabwareDetails_item_${index}`}
-        />
-      ))}
-    </Flex>
+    <>
+      {labwareDetails.length > 0 ? (
+        <Flex flexDirection={DIRECTION_COLUMN} width="100%">
+          <Flex flexDirection={DIRECTION_ROW}>
+            <StyledText
+              as="label"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              marginBottom={SPACING.spacing8}
+              data-testid="ProtocolLabwareDetails_labware_name"
+              width="66%"
+            >
+              {t('labware_name')}
+            </StyledText>
+            <StyledText
+              as="label"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              data-testid="ProtocolLabwareDetails_quantity"
+            >
+              {t('quantity')}
+            </StyledText>
+          </Flex>
+          {labwareDetails?.map((labware, index) => (
+            <ProtocolLabwareDetailItem
+              key={index}
+              namespace={labware.params.namespace}
+              displayName={labware.result?.definition?.metadata?.displayName}
+              quantity={labware.quantity}
+              labware={{ definition: labware.result?.definition }}
+              data-testid={`ProtocolLabwareDetails_item_${index}`}
+            />
+          ))}
+        </Flex>
+      ) : (
+        <InfoScreen contentType="labware" />
+      )}
+    </>
   )
 }
 

--- a/app/src/organisms/ProtocolDetails/__tests__/ProtocolLabwareDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/ProtocolLabwareDetails.test.tsx
@@ -1,11 +1,20 @@
 import * as React from 'react'
 import { screen } from '@testing-library/react'
-import { describe, it, beforeEach } from 'vitest'
+import { describe, it, beforeEach, vi } from 'vitest'
+import { InfoScreen } from '@opentrons/components'
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
 import { ProtocolLabwareDetails } from '../ProtocolLabwareDetails'
 
 import type { LoadLabwareRunTimeCommand } from '@opentrons/shared-data'
+
+vi.mock('@opentrons/components', async importOriginal => {
+  const actual = await importOriginal<typeof InfoScreen>()
+  return {
+    ...actual,
+    InfoScreen: vi.fn(),
+  }
+})
 
 const mockRequiredLabwareDetails = [
   {
@@ -70,6 +79,7 @@ describe('ProtocolLabwareDetails', () => {
     props = {
       requiredLabwareDetails: mockRequiredLabwareDetails,
     }
+    vi.mocked(InfoScreen).mockReturnValue(<div>mock InfoScreen</div>)
   })
 
   it('should render an opentrons labware', () => {
@@ -135,5 +145,13 @@ describe('ProtocolLabwareDetails', () => {
     screen.getByText('NEST 96 Well Plate 100 µL PCR Full Skirt')
     screen.getByText('Quantity')
     screen.getByText('2')
+  })
+
+  it('should render mock infoscreen when no labware', () => {
+    props = {
+      requiredLabwareDetails: [],
+    }
+    render(props)
+    screen.getByText('mock InfoScreen')
   })
 })

--- a/components/src/molecules/ParametersTable/InfoScreen.tsx
+++ b/components/src/molecules/ParametersTable/InfoScreen.tsx
@@ -8,7 +8,7 @@ import { Flex } from '../../primitives'
 import { ALIGN_CENTER, DIRECTION_COLUMN } from '../../styles'
 
 interface InfoScreenProps {
-  contentType: 'parameters' | 'moduleControls' | 'runNotStarted'
+  contentType: 'parameters' | 'moduleControls' | 'runNotStarted' | 'labware'
   t?: any
 }
 
@@ -29,6 +29,9 @@ export function InfoScreen({ contentType, t }: InfoScreenProps): JSX.Element {
       break
     case 'runNotStarted':
       bodyText = t != null ? t('run_never_started') : 'Run was never started'
+      break
+    case 'labware':
+      bodyText = 'No labware specified in this protocol'
       break
     default:
       bodyText = contentType

--- a/components/src/molecules/ParametersTable/__tests__/InfoScreen.test.tsx
+++ b/components/src/molecules/ParametersTable/__tests__/InfoScreen.test.tsx
@@ -34,6 +34,24 @@ describe('InfoScreen', () => {
     screen.getByText('Connect modules to see controls')
   })
 
+  it('should render text and icon with proper color - run not started', () => {
+    props = {
+      contentType: 'runNotStarted',
+    }
+    render(props)
+    screen.getByLabelText('alert')
+    screen.getByText('Run was never started')
+  })
+
+  it('should render text and icon with proper color - labware', () => {
+    props = {
+      contentType: 'labware',
+    }
+    render(props)
+    screen.getByLabelText('alert')
+    screen.getByText('No labware specified in this protocol')
+  })
+
   it('should have proper styles', () => {
     render(props)
     expect(screen.getByTestId('InfoScreen_parameters')).toHaveStyle(


### PR DESCRIPTION
fix add a new case to info screen for

close RQA-2648

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
fix add a new case to info screen for Labware.

For InfoScreen, we are passing `t`, but in my understanding it never works since there is no information that we can retrieve by a key.

I think we should remove `t` since ui components should not include i18n.
What do you think about this? @ncdiehl11  @jerader 

### [before]
<img width="1223" alt="missing labware empty state" src="https://github.com/Opentrons/opentrons/assets/474225/7a802148-1183-4fbc-84c8-3cd3e776734c">

### [after]
<img width="938" alt="Screenshot 2024-04-29 at 5 43 55 PM" src="https://github.com/Opentrons/opentrons/assets/474225/8422d3db-a6e3-4993-af9d-311fd16e3b83">


close RQA-2648
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
