### PR TITLE
chore: release notes for 7.3.0

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -24,6 +24,7 @@ Welcome to the v7.3.0 release of the Opentrons robot software!
 ### Bug Fixes
 
 - Fixed an edge case where capitalizing part of a labware load name could cause unexpected behavior or collisions.
+- Fixed user-installed Python packages (`pip install ...`) on the OT-2 not being found by `import` statements.
 
 ---
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,27 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons Robot Software Changes in 7.3.0
+
+Welcome to the v7.3.0 release of the Opentrons robot software!
+
+### New Features
+
+- Runtime parameters: read, write, and use parameters in Python protocol runs.
+
+### Improved Features
+
+- Automatic tip tracking is now available for all nozzle configurations.
+- It's now possible to use more than two of the same type of module.
+- Flex no longer shows unnecessary pipette calibration warnings.
+- Python protocols can once again set labware offsets outside of Labware Position Check.
+
+### Bug Fixes
+
+- Fixed an edge case where capitalizing part of a labware load name could cause unexpected behavior or collisions.
+
+---
+
 ## Opentrons Robot Software Changes in 7.2.2
 
 Welcome to the v7.2.2 release of the Opentrons robot software!

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -17,7 +17,6 @@ Welcome to the v7.3.0 release of the Opentrons robot software!
 ### Improved Features
 
 - Automatic tip tracking is now available for all nozzle configurations.
-- It's now possible to use more than two of the same type of module.
 - Flex no longer shows unnecessary pipette calibration warnings.
 - Python protocols can once again set labware offsets outside of Labware Position Check.
 

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -21,10 +21,14 @@ Welcome to the v7.3.0 release of the Opentrons robot software!
 - Flex no longer shows unnecessary pipette calibration warnings.
 - Python protocols can once again set labware offsets outside of Labware Position Check.
 
+### Changed Features
+
+- Calling `GET /runs/{id}/commands` for a JSON protocol no longer returns a full list of queued commands. Use protocol analysis to get a full list of commands.
+
 ### Bug Fixes
 
 - Fixed an edge case where capitalizing part of a labware load name could cause unexpected behavior or collisions.
-- Fixed user-installed Python packages (`pip install ...`) on the OT-2 not being found by `import` statements.
+- Fixed Python packages installed  on the OT-2 with `pip` not being found by `import` statements.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -33,6 +33,7 @@ Modules in Deck Configuration
 ### Bug Fixes
 
 - All run log steps now appear in the same font size.
+- Fixed Python protocols not having custom labware definitions available to them when they're uploaded to a Flex over a USB connection.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -30,6 +30,10 @@ Modules in Deck Configuration
 
 - Lists of robots are now sorted alphabetically.
 
+### Removals
+
+- Removed the "Use older protocol analysis method" advanced setting for OT-2. If you need this type of analysis, use `opentrons_simulate` on the command line.
+
 ### Bug Fixes
 
 - All run log steps now appear in the same font size.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,36 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons App Changes in 7.3.0
+
+Welcome to the v7.3.0 release of the Opentrons App! This release adds support for Python protocols with runtime parameters, letting you change the behavior of a protocol each time you run it.
+
+Note: After updating, the app will prompt you to reanalyze all previously imported protocols. This is a one-time step and should not affect protocol behavior.
+
+### New Features
+
+Runtime Parameters
+
+- Available runtime parameters are shown on the protocol details screen.
+- Both the Opentrons App and touchscreen let you enter new parameter values during run setup.
+- The app highlights changed parameter values so you can confirm them before starting the run.
+
+Modules in Deck Configuration
+
+- You can now specify what slots modules occupy on Flex in deck configuration.
+- When moving, Flex will avoid modules specified in deck configuration but not loaded in the protocol.
+- Deck configuration must be compatible with the protocol's requirements before you start a run.
+
+### Improved Features
+
+- Lists of robots are now sorted alphabetically.
+
+### Bug Fixes
+
+- All run log steps now appear in the same font size.
+
+---
+
 ## Opentrons App Changes in 7.2.2
 
 Welcome to the v7.2.2 release of the Opentrons App!

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -19,6 +19,7 @@ Runtime Parameters
 - Available runtime parameters are shown on the protocol details screen.
 - Both the Opentrons App and touchscreen let you enter new parameter values during run setup.
 - The app highlights changed parameter values so you can confirm them before starting the run.
+- The run preview (before the run) and run log (after the run) reflect changes to steps based on your chosen parameter values.
 
 Modules in Deck Configuration
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -33,7 +33,7 @@ Modules in Deck Configuration
 ### Bug Fixes
 
 - All run log steps now appear in the same font size.
-- Fixed Python protocols not having custom labware definitions available to them when they're uploaded to a Flex over a USB connection.
+- The app now properly sends custom labware definitions, along with the corresponding Python protocol, to Flex robots connected via USB.
 
 ---
 


### PR DESCRIPTION

# Overview

Release notes for version 7.3.0 of the robot software.

# Test Plan

We'll check these out when the first 7.3.0 alpha is cut. Let's double check that our new markdown parser is behaving.

# Changelog

Notes in the usual two spots.

# Review requests

- RTP in API notes is pretty weak now. What else should we highlight?
- Any other noteworthy features not mentioned?

# Risk assessment

none