### PR TITLE
fix(robot-server): initialize fw update status_cache so we dont hang on bootup when client queries fw updates.

### DIFF
--- a/robot-server/robot_server/subsystems/firmware_update_manager.py
+++ b/robot-server/robot_server/subsystems/firmware_update_manager.py
@@ -139,12 +139,13 @@ class _UpdateProcess:
         created_at: datetime,
         update_id: str,
         complete_callback: Callable[[], Awaitable[None]],
+        status_cache: Optional[UpdateProgress] = None,
     ) -> None:
         """Build an _UpdateProcess. Should only be done by the manager."""
         self._status_queue = Queue()
         self._hw_handle = hw_handle
         self._subsystem = subsystem
-        self._status_cache = None
+        self._status_cache = status_cache
         self._status_cache_lock = Lock()
         self._created_at = created_at
         self._update_id = update_id
@@ -346,7 +347,12 @@ class FirmwareUpdateManager:
                     log.exception(f"Double pop for update on {subsystem}")
 
         self._all_updates_by_id[update_id] = _UpdateProcess(
-            self._hardware_handle, hw_subsystem, creation_time, update_id, _complete
+            self._hardware_handle,
+            hw_subsystem,
+            creation_time,
+            update_id,
+            _complete,
+            UpdateProgress(UpdateState.queued, 0, None),
         )
         self._running_updates_by_subsystem[hw_subsystem] = self._all_updates_by_id[
             update_id


### PR DESCRIPTION
# Overview

The "instrument firmware update needed" modal was shown on bootup when a firmware update was required. This modal has a "Update Firmware" button that, when pressed, initiates the update for the attached instrument. However, since the updates have already been started internally, pressing the button does nothing until the first update is finished.

The main issue is that the `/subsystem/updates/all` request would hang until the first update was finished for ~2m, this happens because the `start_update_process` function called during bootup would hang waiting on `provide_latest_progress` which itself is waiting on to get a status report on `self._status_queue.get()` which blocks. Since the `start_update_process` acquires the `_management_lock`, once we call `all_ongoing_processes` from the client query we lock until an update is finished.

The problem is the "waiting to get the progress" of a specific update process from the hardware controller layer. The `start_update_process` function "queues" the firmware updates by creating the `_UpdateProcess` and then running the `_update_task` with `TaskRunner.run` in the background. This does not guarantee that the update will pass, but, as far as the robot server is concerned the update has been "queued".

So what this PR proposes is, when creating the `_UpdateProcess` in the `_emplace` method, that we initialize the `status_cache: UpdateProgress` with a default `queued` state. This way we don't block waiting on the response from the hardware controller, and the `/subsystem/updates/all` request can return.


Closes: [RQA-2574](https://opentrons.atlassian.net/browse/RQA-2574)

# Test Plan

- [x] Make sure that firmware updates are automatically initiated when the robot boots up
- [x] Make sure that firmware updates are started from the ODD during the attachment flow
- [x] Make sure that firmware updates required modal is displayed when an instrument is attached outside the attach flow
- [x] Make sure that firmware update required modal is NOT shown when the robot boots up and an instrument needs an update, instead we should see the "Updating x Module Firmware..." modal.

# Changelog

- add status_cache arg to _UpdateProcess class so we can have an UpdateProgress state when creating the update

# Review requests

- Does this approach make sense?
- Any implications I might be missing?

# Risk assessment
Low, but will need additional testing as this touches firmware updates

[RQA-2574]: https://opentrons.atlassian.net/browse/RQA-2574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ