### PR TITLE
refactor(api): Make sure command implementations return something compatible with the command's result type

### DIFF
--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -242,9 +242,7 @@ async def test_execute(
         params: _TestCommandParams
         result: Optional[_TestCommandResult]
 
-        @property
-        def _ImplementationCls(self) -> Type[_TestCommandImpl]:
-            return TestCommandImplCls
+        _ImplementationCls: Type[_TestCommandImpl] = TestCommandImplCls
 
     command_params = _TestCommandParams()
     command_result = _TestCommandResult()
@@ -407,9 +405,7 @@ async def test_execute_raises_protocol_engine_error(
         params: _TestCommandParams
         result: Optional[_TestCommandResult]
 
-        @property
-        def _ImplementationCls(self) -> Type[_TestCommandImpl]:
-            return TestCommandImplCls
+        _ImplementationCls: Type[_TestCommandImpl] = TestCommandImplCls
 
     command_params = _TestCommandParams()
 


### PR DESCRIPTION
# Overview

This is a step towards EXEC-427.

Every command declares a `result` type, e.g `Aspirate` has `AspirateResult`. But it turns out that nothing enforces that the command's implementation returns that type—`AspirateImplementation` could return a `DispenseResult`. This has been okay in practice so far because each implementation only returns one thing, and it's not easy for them to fall out of sync. But you can imagine how it will get messy when we start introducing more structured error types. My rough plan is for `execute() -> AspirateResult` to become `execute() -> AspirateResult | AspirateErrorA | AspirateErrorB | ...`, and we will want to enforce that `AspirateErrorA | AspirateErrorB` matches the type of the `Aspirate.error` field.

# Changelog

See my inline notes.

# Test plan

* [x] Make sure CI keeps passing.
* [x] Make sure the "new field" doesn't show up in robot-server's HTTP API documentation.

# Review requests

Does this make sense?

# Risk assessment

Very low.
