### PR TITLE
chore(app-shell): make-dev fixes

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -171,18 +171,16 @@ _dist-collect-artifacts:
 # development
 #####################################################################
 
-.PHONY: clean-dev-autoupdate
-clean-dev-autoupdate:
-	rm -f ./dev-app-update.yml
 
-dev-app-update.yml:
+.PHONY: dev-app-update-file
+dev-app-update-file:
 	cp ./dev-app-update-$(OPENTRONS_PROJECT).yml ./dev-app-update.yml
 
 
 .PHONY: dev
 dev: export NODE_ENV := development
 dev: export OPENTRONS_PROJECT := $(OPENTRONS_PROJECT)
-dev: clean-dev-autoupdate ./dev-app-update.yml
+dev: dev-app-update-file
 	vite build
 	$(electron)
 

--- a/app-shell/dev-app-update-robot-stack.yml
+++ b/app-shell/dev-app-update-robot-stack.yml
@@ -1,3 +1,3 @@
 provider: generic
-bucket: https://builds.opentrons.com/app/
+url: https://builds.opentrons.com/app/
 channel: latest

--- a/app-shell/src/update.ts
+++ b/app-shell/src/update.ts
@@ -12,14 +12,11 @@ const autoUpdater = updater.autoUpdater
 autoUpdater.logger = createLogger('update')
 autoUpdater.autoDownload = false
 
-const log = createLogger('app-shell-update')
-
 export const CURRENT_VERSION: string = autoUpdater.currentVersion.version
 
 export function registerUpdate(
   dispatch: Dispatch
 ): (action: Action) => unknown {
-  log.info(`Registered update handler, version=${CURRENT_VERSION}`)
   return function handleAction(action: Action) {
     switch (action.type) {
       case UI_INITIALIZED:

--- a/app-shell/src/update.ts
+++ b/app-shell/src/update.ts
@@ -12,11 +12,14 @@ const autoUpdater = updater.autoUpdater
 autoUpdater.logger = createLogger('update')
 autoUpdater.autoDownload = false
 
+const log = createLogger('app-shell-update')
+
 export const CURRENT_VERSION: string = autoUpdater.currentVersion.version
 
 export function registerUpdate(
   dispatch: Dispatch
 ): (action: Action) => unknown {
+  log.info(`Registered update handler, version=${CURRENT_VERSION}`)
   return function handleAction(action: Action) {
     switch (action.type) {
       case UI_INITIALIZED:


### PR DESCRIPTION
make dev for the robot-stack release kind would print errors in its logs and not prompt updates because the dev app update was malformed. Also, we weren't switching the dev-app-update correctly because it wasn't a phony target.

The log is the "undefined trying to access includes" one.

After this, `make dev` should prompt updates whether you're on `OPENTRONS_PROJECT=robot-stack` or `OPENTRONS_PROJECT=ot3` (before, it only would on `=ot3`)
