### PR TITLE
fix(app): disable module calibration if heating or cooling

### DIFF
--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -26,6 +26,7 @@
   "location_occupied": "A {{fixture}} is currently specified here on the deck configuration",
   "module_calibrating": "Stand back, {{moduleName}} is calibrating",
   "module_calibration": "Module calibration",
+  "module_heating_or_cooling": "Module cannot proceed to module calibration while heating or cooling",
   "module_secured": "The module must be fully secured in its caddy and secured in the deck slot.",
   "module_too_hot": "Module is too hot to proceed to module calibration",
   "move_gantry_to_front": "Move gantry to front",

--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -26,7 +26,7 @@
   "location_occupied": "A {{fixture}} is currently specified here on the deck configuration",
   "module_calibrating": "Stand back, {{moduleName}} is calibrating",
   "module_calibration": "Module calibration",
-  "module_heating_or_cooling": "Module cannot proceed to module calibration while heating or cooling",
+  "module_heating_or_cooling": "Module calibration cannot proceed while heating or cooling",
   "module_secured": "The module must be fully secured in its caddy and secured in the deck slot.",
   "module_too_hot": "Module is too hot to proceed to module calibration",
   "move_gantry_to_front": "Move gantry to front",

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -69,6 +69,9 @@ export const ModuleOverflowMenu = (
     isDisabled = true
   }
 
+  const isHeatingOrCooling =
+    module.data.status === 'heating' || module.data.status === 'cooling'
+
   const { menuOverflowItemsByModuleType } = useModuleOverflowMenu(
     module,
     handleAboutClick,
@@ -78,6 +81,18 @@ export const ModuleOverflowMenu = (
     isDisabled,
     isIncompatibleWithOT3
   )
+
+  const isCalibrateDisabled = !isPipetteReady || isTooHot || isHeatingOrCooling
+  let calibrateDisabledReason
+  if (!isPipetteReady) {
+    calibrateDisabledReason = t('calibrate_pipette')
+  } else if (isTooHot) {
+    calibrateDisabledReason = t('module_too_hot')
+  } else if (isHeatingOrCooling) {
+    calibrateDisabledReason = t('module_heating_or_cooling')
+  } else {
+    calibrateDisabledReason = null
+  }
 
   return (
     <Flex position={POSITION_RELATIVE}>
@@ -89,7 +104,7 @@ export const ModuleOverflowMenu = (
           <>
             <MenuItem
               onClick={handleCalibrateClick}
-              disabled={!isPipetteReady || isTooHot}
+              disabled={isCalibrateDisabled}
               {...targetProps}
             >
               {i18n.format(
@@ -99,9 +114,9 @@ export const ModuleOverflowMenu = (
                 'capitalize'
               )}
             </MenuItem>
-            {!isPipetteReady || isTooHot ? (
+            {isCalibrateDisabled ? (
               <Tooltip tooltipProps={tooltipProps}>
-                {t(!isPipetteReady ? 'calibrate_pipette' : 'module_too_hot')}
+                {calibrateDisabledReason}
               </Tooltip>
             ) : null}
           </>

--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -3,7 +3,12 @@ import { useTranslation } from 'react-i18next'
 
 import { Flex, POSITION_RELATIVE, useHoverTooltip } from '@opentrons/components'
 
-import { MODULE_MODELS_OT2_ONLY } from '@opentrons/shared-data'
+import {
+  HEATERSHAKER_MODULE_TYPE,
+  MODULE_MODELS_OT2_ONLY,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
 import { MenuList } from '../../atoms/MenuList'
 import { Tooltip } from '../../atoms/Tooltip'
 import { MenuItem } from '../../atoms/MenuList/MenuItem'
@@ -69,8 +74,22 @@ export const ModuleOverflowMenu = (
     isDisabled = true
   }
 
-  const isHeatingOrCooling =
-    module.data.status === 'heating' || module.data.status === 'cooling'
+  let isHeatingOrCooling
+  switch (module.moduleType) {
+    case TEMPERATURE_MODULE_TYPE:
+      isHeatingOrCooling = module.data.status !== 'idle'
+      break
+    case HEATERSHAKER_MODULE_TYPE:
+      isHeatingOrCooling = module.data.temperatureStatus !== 'idle'
+      break
+    case THERMOCYCLER_MODULE_TYPE:
+      isHeatingOrCooling =
+        module.data.lidTemperatureStatus !== 'idle' ||
+        module.data.status !== 'idle'
+      break
+    default:
+      isHeatingOrCooling = false
+  }
 
   const { menuOverflowItemsByModuleType } = useModuleOverflowMenu(
     module,

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -556,6 +556,25 @@ describe('ModuleOverflowMenu', () => {
     expect(calibrate).toBeDisabled()
   })
 
+  it('renders a disabled calibrate button if module temperature status errors', () => {
+    vi.mocked(useIsFlex).mockReturnValue(true)
+    const mockHeatingModule = {
+      ...mockHeaterShaker,
+      data: {
+        ...mockHeaterShaker.data,
+        temperatureStatus: 'error' as TemperatureStatus,
+      },
+    }
+    props = {
+      ...props,
+      module: mockHeatingModule,
+    }
+    render(props)
+
+    const calibrate = screen.getByRole('button', { name: 'Calibrate' })
+    expect(calibrate).toBeDisabled()
+  })
+
   it('a mock function should be called when clicking Calibrate if pipette is ready', () => {
     vi.mocked(useIsFlex).mockReturnValue(true)
     props = {

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -19,6 +19,8 @@ import {
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
 
+import type { HeaterShakerStatus } from '@opentrons/api-client'
+
 vi.mock('../../Devices/hooks')
 vi.mock('../../RunTimeControl/hooks')
 vi.mock('../../ProtocolUpload/hooks')
@@ -528,6 +530,25 @@ describe('ModuleOverflowMenu', () => {
       ...props,
       module: mockHeaterShaker,
       isTooHot: true,
+    }
+    render(props)
+
+    const calibrate = screen.getByRole('button', { name: 'Calibrate' })
+    expect(calibrate).toBeDisabled()
+  })
+
+  it('renders a disabled calibrate button if module is heating or cooling', () => {
+    vi.mocked(useIsFlex).mockReturnValue(true)
+    const mockHeatingModule = {
+      ...mockHeaterShaker,
+      data: {
+        ...mockHeaterShaker.data,
+        status: 'heating' as HeaterShakerStatus,
+      },
+    }
+    props = {
+      ...props,
+      module: mockHeatingModule,
     }
     render(props)
 

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -19,7 +19,7 @@ import {
 import { useCurrentRunId } from '../../ProtocolUpload/hooks'
 import { ModuleOverflowMenu } from '../ModuleOverflowMenu'
 
-import type { HeaterShakerStatus } from '@opentrons/api-client'
+import type { TemperatureStatus } from '@opentrons/api-client'
 
 vi.mock('../../Devices/hooks')
 vi.mock('../../RunTimeControl/hooks')
@@ -543,7 +543,7 @@ describe('ModuleOverflowMenu', () => {
       ...mockHeaterShaker,
       data: {
         ...mockHeaterShaker.data,
-        status: 'heating' as HeaterShakerStatus,
+        temperatureStatus: 'heating' as TemperatureStatus,
       },
     }
     props = {


### PR DESCRIPTION
closes [RQA-2630](https://opentrons.atlassian.net/browse/RQA-2630)

# Overview

If a temperature module, thermocycler, or heater shaker is not idle (heating, cooling, holding at target, or error), we should disable calibration.

Disabled reason precedence:
1. pipette calibration required before module calibration
2. module too hot to calibrate
3. module in process of heating/cooling

# Test Plan

- start heating/cooling a temperature module/heater shaker module/thermocycler block or lid from module card overflow menu
- click module overflow menu again
- observe that (re)calibrate option is disabled and tooltip gives appropriate information

<img width="432" alt="Screenshot 2024-05-01 at 11 10 06 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/6f6be1ac-9b8e-4188-9b0c-6511ba02c543">

# Changelog

- in module overflow menu component, check module status for heating or cooling
- add heating/cooling condition to disabled boolean for (re)calibrate
- display tooltip according to disabled reason
- add test coverage

# Review requests

js

# Risk assessment

low

[RQA-2630]: https://opentrons.atlassian.net/browse/RQA-2630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ