### PR TITLE
feat(protocol-designer): default dispense height is 1mm from the bottom

### DIFF
--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -105,7 +105,9 @@ describe('Protocol fixtures migrate and match snapshots', () => {
         if (migrationModal) {
           if (migrationModal === 'v8.1') {
             cy.get('div')
-              .contains('The default dispense height is now 1mm from the bottom of the well')
+              .contains(
+                'The default dispense height is now 1mm from the bottom of the well'
+              )
               .should('exist')
             cy.get('button').contains('ok', { matchCase: false }).click()
           } else if (migrationModal === 'newLabwareDefs') {

--- a/protocol-designer/cypress/integration/migrations.spec.js
+++ b/protocol-designer/cypress/integration/migrations.spec.js
@@ -26,7 +26,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       expectedExportFixture:
         '../../fixtures/protocol/8/doItAllV3MigratedToV8.json',
       unusedPipettes: false,
-      migrationModal: 'v8',
+      migrationModal: 'v8.1',
     },
     {
       title: 'doItAllV4 (schema 4, PD version 4.0.0) -> PD 8.1.x, schema 8',
@@ -34,7 +34,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       expectedExportFixture:
         '../../fixtures/protocol/8/doItAllV4MigratedToV8.json',
       unusedPipettes: false,
-      migrationModal: 'v8',
+      migrationModal: 'v8.1',
     },
     {
       title:
@@ -43,7 +43,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
       expectedExportFixture:
         '../../fixtures/protocol/8/doItAllV7MigratedToV8.json',
       unusedPipettes: false,
-      migrationModal: 'v8',
+      migrationModal: 'v8.1',
     },
     {
       title:
@@ -103,9 +103,9 @@ describe('Protocol fixtures migrate and match snapshots', () => {
         })
 
         if (migrationModal) {
-          if (migrationModal === 'v8') {
+          if (migrationModal === 'v8.1') {
             cy.get('div')
-              .contains('Protocol Designer no longer supports aspirate or mix')
+              .contains('The default dispense height is now 1mm from the bottom of the well')
               .should('exist')
             cy.get('button').contains('ok', { matchCase: false }).click()
           } else if (migrationModal === 'newLabwareDefs') {

--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:16:50 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -4016,7 +4016,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4070,7 +4070,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4124,7 +4124,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4178,7 +4178,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4232,7 +4232,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4286,7 +4286,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4340,7 +4340,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4394,7 +4394,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4448,7 +4448,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4502,7 +4502,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4556,7 +4556,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4610,7 +4610,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4664,7 +4664,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4718,7 +4718,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4772,7 +4772,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4826,7 +4826,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4888,7 +4888,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 57
       }
@@ -4918,7 +4918,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 57
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -180,7 +180,7 @@
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "100",
           "blowout_checkbox": false,
-          "blowout_location": "4824b094-5999-4549-9e6b-7098a9b30a8b:trashBin",
+          "blowout_location": "134504e1-b212-41cf-966d-2560deb5b693:trashBin",
           "preWetTip": false,
           "aspirate_airGap_checkbox": false,
           "aspirate_airGap_volume": "0",
@@ -192,7 +192,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_delay_mmFromBottom": null,
-          "dropTip_location": "4824b094-5999-4549-9e6b-7098a9b30a8b:trashBin",
+          "dropTip_location": "134504e1-b212-41cf-966d-2560deb5b693:trashBin",
           "nozzles": null,
           "dispense_x_position": 0,
           "dispense_y_position": 0,
@@ -212,7 +212,7 @@
           "mix_wellOrder_first": "t2b",
           "mix_wellOrder_second": "l2r",
           "blowout_checkbox": false,
-          "blowout_location": "4824b094-5999-4549-9e6b-7098a9b30a8b:trashBin",
+          "blowout_location": "134504e1-b212-41cf-966d-2560deb5b693:trashBin",
           "mix_mmFromBottom": 0.5,
           "pipette": "6d1e53c3-2db3-451b-ad60-3fe13781a193",
           "volume": "10",
@@ -225,7 +225,7 @@
           "dispense_delay_seconds": "1",
           "mix_touchTip_checkbox": false,
           "mix_touchTip_mmFromBottom": null,
-          "dropTip_location": "4824b094-5999-4549-9e6b-7098a9b30a8b:trashBin",
+          "dropTip_location": "134504e1-b212-41cf-966d-2560deb5b693:trashBin",
           "nozzles": null,
           "tipRack": "23ed35de-5bfd-4bb0-8f54-da99a2804ed9:opentrons/opentrons_flex_96_filtertiprack_50ul/1",
           "mix_x_position": 0,
@@ -4016,7 +4016,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4070,7 +4070,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4124,7 +4124,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4178,7 +4178,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4232,7 +4232,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4286,7 +4286,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4340,7 +4340,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4394,7 +4394,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4448,7 +4448,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4502,7 +4502,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4556,7 +4556,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4610,7 +4610,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4664,7 +4664,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4718,7 +4718,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4772,7 +4772,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4826,7 +4826,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4873,7 +4873,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 35
       }
@@ -4903,7 +4903,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
         },
         "flowRate": 35
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },
@@ -4016,7 +4016,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4070,7 +4070,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4124,7 +4124,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4178,7 +4178,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4232,7 +4232,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4286,7 +4286,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4340,7 +4340,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4394,7 +4394,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4448,7 +4448,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4502,7 +4502,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4556,7 +4556,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4610,7 +4610,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4664,7 +4664,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4718,7 +4718,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4772,7 +4772,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4826,7 +4826,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 478
       }
@@ -4873,7 +4873,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 35
       }
@@ -4888,7 +4888,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 57
       }
@@ -4903,7 +4903,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 35
       }
@@ -4918,7 +4918,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 57
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -3582,7 +3582,7 @@
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3635,7 +3635,7 @@
         "wellName": "B1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3688,7 +3688,7 @@
         "wellName": "C1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3741,7 +3741,7 @@
         "wellName": "D1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3794,7 +3794,7 @@
         "wellName": "E1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3847,7 +3847,7 @@
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3900,7 +3900,7 @@
         "wellName": "G1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }
@@ -3953,7 +3953,7 @@
         "wellName": "H1",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 716
       }

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 12:14:18 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },
@@ -3656,7 +3656,7 @@
         "wellName": "B3",
         "wellLocation": {
           "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
+          "offset": { "z": 1, "x": 0, "y": 0 }
         },
         "flowRate": 57
       }

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -18,7 +18,7 @@
       "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
-        "dispense_mmFromBottom": 0.5,
+        "dispense_mmFromBottom": 1,
         "touchTip_mmFromTop": -1,
         "blowout_mmFromTop": 0
       },

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -96,6 +96,23 @@ export const getToV8MigrationMessage = (props: ModalProps): ModalContents => {
   }
 }
 
+export const getToV8_1MigrationMessage = (props: ModalProps): ModalContents => {
+  const { t } = props
+
+  return {
+    title: t('migrations.header', { pd: PD }),
+    body: (
+      <div className={styles.migration_message}>
+        <p>
+          <p>{t('migrations.toV8_1Migration.body1')}</p>
+        </p>
+        <p>{t('migrations.toV8_1Migration.body2')}</p>
+        <p>{t('migrations.toV8_1Migration.body3')}</p>
+      </div>
+    ),
+  }
+}
+
 export const getToV3MigrationMessage = (props: ModalProps): ModalContents => {
   const { t } = props
 
@@ -152,9 +169,12 @@ export const getMigrationMessage = (
   ) {
     return getNoBehaviorChangeMessage({ t })
   }
-  if (migrationsRan.includes('8.0.0')) {
+  if (migrationsRan.includes('8.1.0')) {
+    return getToV8_1MigrationMessage({ t })
+  } else if (migrationsRan.includes('8.0.0')) {
     return getToV8MigrationMessage({ t })
   }
+
   return getGenericDidMigrateMessage({ t })
 }
 

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -58,7 +58,7 @@ export const INITIAL_DECK_SETUP_STEP_ID = '__INITIAL_DECK_SETUP_STEP__'
 export const DEFAULT_CHANGE_TIP_OPTION: 'always' = 'always'
 // TODO: Ian 2019-06-13 don't keep these as hard-coded static values (see #3587)
 export const DEFAULT_MM_FROM_BOTTOM_ASPIRATE = 1
-export const DEFAULT_MM_FROM_BOTTOM_DISPENSE = 0.5
+export const DEFAULT_MM_FROM_BOTTOM_DISPENSE = 1
 // NOTE: in the negative Z direction, to go down from top
 export const DEFAULT_MM_TOUCH_TIP_OFFSET_FROM_TOP = -1
 export const DEFAULT_MM_BLOWOUT_OFFSET_FROM_TOP = 0

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -272,6 +272,11 @@
       "body2": "We have added new features since the last time this protocol was updated, but have not made any changes to existing protocol behavior. Because of this we do not expect any changes in how the robot will execute this protocol. To be safe we will still recommend keeping a separate copy of the file you just imported.",
       "body3": "As always, please contact us with any questions or feedback."
     },
+    "toV8_1Migration": {
+      "body1": "Your protocol will be automatically updated to the latest version.",
+      "body2": "The default dispense height is now 1mm from the bottom of the well. If your protocol contains any dispense commands without a custom height, it will be automatically updated.",
+      "body3": "As always, please contact us with any questions or feedback."
+    },
     "toV8Migration": {
       "body1": "Your protocol will be automatically updated to the latest version.",
       "body2": "{{pd}} no longer supports aspirate or mix actions in a trash bin. If your protocol contains these actions, an error icon will appear next to them in the Protocol Timeline. To resolve the error, choose another location for aspirating or mixing.",


### PR DESCRIPTION
closes AUTH-332 AUTH-377

# Overview

Several people from FAS have mentioned that users don't like that the default dispense height in PD is 0.5mm from the bottom. This PR updates it to be 1 mm from the bottom. So if a user does not change the default height at all it will say 1mm. 

Additionally, the migration modal is updated to include info about this change in behavior.

![screenshot_2024-05-01_at_11 34 56_720](https://github.com/Opentrons/opentrons/assets/66035149/d700bbbd-7b1d-4fc8-958f-0d94e44d4822)

# Test Plan

Create a flex or ot-2 protocol and add a transfer step and a mix step. Export the protocol. See that the z-offset for the dispense steps is 1. 

# Changelog

- update the constant
- add new migration modal and text
- update cypress tests

# Review requests

see test plan

# Risk assessment

low