### PR TITLE
feat(protocol-designer): remove MoaM feature flag

### DIFF
--- a/protocol-designer/src/components/EditModules.tsx
+++ b/protocol-designer/src/components/EditModules.tsx
@@ -10,7 +10,6 @@ import {
 } from '../step-forms'
 import { moveDeckItem } from '../labware-ingred/actions/actions'
 import { getRobotType } from '../file-data/selectors'
-import { getEnableMoam } from '../feature-flags/selectors'
 import { EditMultipleModulesModal } from './modals/EditModulesModal/EditMultipleModulesModal'
 import { useBlockingHint } from './Hints/useBlockingHint'
 import { MagneticModuleWarningModalContent } from './modals/EditModulesModal/MagneticModuleWarningModalContent'
@@ -35,11 +34,8 @@ export const EditModules = (props: EditModulesProps): JSX.Element => {
   const { moduleId, moduleType } = moduleToEdit
   const _initialDeckSetup = useSelector(stepFormSelectors.getInitialDeckSetup)
   const robotType = useSelector(getRobotType)
-  const moamFf = useSelector(getEnableMoam)
   const showMultipleModuleModal =
-    robotType === FLEX_ROBOT_TYPE &&
-    moduleType === TEMPERATURE_MODULE_TYPE &&
-    moamFf
+    robotType === FLEX_ROBOT_TYPE && moduleType === TEMPERATURE_MODULE_TYPE
 
   const moduleOnDeck = moduleId ? _initialDeckSetup.modules[moduleId] : null
   const [

--- a/protocol-designer/src/components/__tests__/EditModules.test.tsx
+++ b/protocol-designer/src/components/__tests__/EditModules.test.tsx
@@ -12,7 +12,6 @@ import { getDismissedHints } from '../../tutorial/selectors'
 import { EditModules } from '../EditModules'
 import { EditModulesModal } from '../modals/EditModulesModal'
 import { renderWithProviders } from '../../__testing-utils__'
-import { getEnableMoam } from '../../feature-flags/selectors'
 import { getRobotType } from '../../file-data/selectors'
 import { EditMultipleModulesModal } from '../modals/EditModulesModal/EditMultipleModulesModal'
 
@@ -23,7 +22,6 @@ vi.mock('../modals/EditModulesModal/EditMultipleModulesModal')
 vi.mock('../modals/EditModulesModal')
 vi.mock('../../tutorial/selectors')
 vi.mock('../../file-data/selectors')
-vi.mock('../../feature-flags/selectors')
 const render = (props: React.ComponentProps<typeof EditModules>) => {
   return renderWithProviders(<EditModules {...props} />, {
     i18nInstance: i18n,
@@ -66,7 +64,6 @@ describe('EditModules', () => {
     )
     vi.mocked(getDismissedHints).mockReturnValue([hintKey])
     vi.mocked(getRobotType).mockReturnValue(OT2_ROBOT_TYPE)
-    vi.mocked(getEnableMoam).mockReturnValue(true)
   })
 
   it('renders the edit modules modal for single modules', () => {

--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -37,7 +37,6 @@ import { getIsCrashablePipetteSelected } from '../../../step-forms'
 import gripperImage from '../../../images/flex_gripper.png'
 import wasteChuteImage from '../../../images/waste_chute.png'
 import trashBinImage from '../../../images/flex_trash_bin.png'
-import { getEnableMoam } from '../../../feature-flags/selectors'
 import { uuid } from '../../../utils'
 import { selectors as featureFlagSelectors } from '../../../feature-flags'
 import { CrashInfoBox, ModuleDiagram } from '../../modules'
@@ -191,7 +190,6 @@ export function ModulesAndOtherTile(props: WizardTileProps): JSX.Element {
 
 function FlexModuleFields(props: WizardTileProps): JSX.Element {
   const { watch, setValue } = props
-  const enableMoamFf = useSelector(getEnableMoam)
   const modules = watch('modules')
   const additionalEquipment = watch('additionalEquipment')
   const moduleTypesOnDeck =
@@ -261,10 +259,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
         }
 
         const handleOnClick = (): void => {
-          if (
-            (moduleType !== TEMPERATURE_MODULE_TYPE && enableMoamFf) ||
-            !enableMoamFf
-          ) {
+          if (moduleType !== TEMPERATURE_MODULE_TYPE) {
             if (isModuleOnDeck) {
               const updatedModules =
                 modules != null
@@ -302,7 +297,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
             }
             onClick={handleOnClick}
             multiples={
-              moduleType === TEMPERATURE_MODULE_TYPE && enableMoamFf
+              moduleType === TEMPERATURE_MODULE_TYPE
                 ? {
                     maxItems: MAX_TEMPERATURE_MODULES,
                     setValue: handleMultiplesClick,
@@ -316,9 +311,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
                   }
                 : undefined
             }
-            showCheckbox={
-              enableMoamFf ? moduleType !== TEMPERATURE_MODULE_TYPE : true
-            }
+            showCheckbox={moduleType !== TEMPERATURE_MODULE_TYPE}
           />
         )
       })}

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/ModulesAndOtherTile.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/ModulesAndOtherTile.test.tsx
@@ -5,10 +5,7 @@ import { fireEvent, screen, cleanup } from '@testing-library/react'
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import { renderWithProviders } from '../../../../__testing-utils__'
 import { i18n } from '../../../../localization'
-import {
-  getDisableModuleRestrictions,
-  getEnableMoam,
-} from '../../../../feature-flags/selectors'
+import { getDisableModuleRestrictions } from '../../../../feature-flags/selectors'
 import { CrashInfoBox } from '../../../modules'
 import { ModuleFields } from '../../FilePipettesModal/ModuleFields'
 import { ModulesAndOtherTile } from '../ModulesAndOtherTile'
@@ -61,7 +58,6 @@ describe('ModulesAndOtherTile', () => {
       ...props,
       ...mockWizardTileProps,
     } as WizardTileProps
-    vi.mocked(getEnableMoam).mockReturnValue(true)
     vi.mocked(CrashInfoBox).mockReturnValue(<div> mock CrashInfoBox</div>)
     vi.mocked(EquipmentOption).mockReturnValue(<div>mock EquipmentOption</div>)
     vi.mocked(getDisableModuleRestrictions).mockReturnValue(false)

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -21,8 +21,6 @@ const initialFlags: Flags = {
     process.env.OT_PD_DISABLE_MODULE_RESTRICTIONS === '1' || false,
   OT_PD_ALLOW_ALL_TIPRACKS:
     process.env.OT_PD_ALLOW_ALL_TIPRACKS === '1' || false,
-  OT_PD_ENABLE_MULTI_TIP: process.env.OT_PD_ENABLE_MULTI_TIP === '1' || false,
-  OT_PD_ENABLE_MOAM: process.env.OT_PD_ENABLE_MOAM === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -19,11 +19,3 @@ export const getAllowAllTipracks: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ALLOW_ALL_TIPRACKS ?? false
 )
-export const getEnableMultiTip: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_MULTI_TIP ?? false
-)
-export const getEnableMoam: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_MOAM ?? false
-)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -22,14 +22,14 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_OT_3',
   'OT_PD_ALLOW_96_CHANNEL',
   'OT_PD_ENABLE_FLEX_DECK_MODIFICATION',
+  'OT_PD_ENABLE_MULTI_TIP',
+  'OT_PD_ENABLE_MOAM',
 ]
 // union of feature flag string constant IDs
 export type FlagTypes =
   | 'PRERELEASE_MODE'
   | 'OT_PD_DISABLE_MODULE_RESTRICTIONS'
   | 'OT_PD_ALLOW_ALL_TIPRACKS'
-  | 'OT_PD_ENABLE_MULTI_TIP'
-  | 'OT_PD_ENABLE_MOAM'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -11,13 +11,5 @@
   "OT_PD_ALLOW_ALL_TIPRACKS": {
     "title": "Allow all tip rack options",
     "description": "Enable selection of all tip racks for each pipette."
-  },
-  "OT_PD_ENABLE_MULTI_TIP": {
-    "title": "Enable multi tiprack support",
-    "description": "Allow users to select multiple tipracks per pipette"
-  },
-  "OT_PD_ENABLE_MOAM": {
-    "title": "Enable multiples of a module",
-    "description": "Allow users to select multiples of a module"
   }
 }


### PR DESCRIPTION
closes AUTH-239

# Overview

Removes MoaM and unused multi tip feature flag

# Test Plan

go through creating a flex protocol and see that the option to select multiple temps is there. Go through creating an ot-2 protocol and see that you can't select multiple temps

# Changelog

- remove moam ff
- remove multi tiprack ff

# Review requests

see test plan

# Risk assessment

low