### PR TITLE
fix(system-server): sanitize the filename in the upload_splash endpoint for OEM Mode.

### DIFF
--- a/system-server/system_server/system/oem_mode/router.py
+++ b/system-server/system_server/system/oem_mode/router.py
@@ -12,13 +12,14 @@ from fastapi import (
     File,
     HTTPException,
 )
+from pathlib import Path
 
 from .models import EnableOEMMode
 from ...settings import SystemServerSettings, get_settings, save_settings
 
 
 # regex to sanitize the filename
-FILENAME_REGEX = re.compile(r'[^a-zA-Z0-9.]')
+FILENAME_REGEX = re.compile(r"[^a-zA-Z0-9-.]")
 
 
 oem_mode_router = APIRouter()
@@ -121,7 +122,8 @@ async def upload_splash_image(
             os.unlink(settings.oem_mode_splash_custom)
 
         # sanitize the filename
-        filename = FILENAME_REGEX.sub("_", file.filename)
+        sanatized_filename = FILENAME_REGEX.sub("_", file.filename)
+        filename = f"{Path(sanatized_filename).stem}.{content_type}"
 
         # file is valid, save to final location
         filepath = f"{settings.persistence_directory}/{filename}"


### PR DESCRIPTION
# Overview

Bash does not like spaces or weird characters when loading the custom logo in OEM Mode, so let's sanitize the filename by removing all non-alphanumeric characters.

Fixes: [RQA-2668](https://opentrons.atlassian.net/browse/RQA-2668)

# Test Plan

- [x] Make sure that all non-alphanumeric characters are stripped from the filename
- [x] Make sure that the image from the bug ticket  `Userspace - Pfizer (max width).png` displays correctly on bootup.

# Changelog

- replace all non-alphanumeric characters except for period with underscore (_) when processing the image filename

# Review requests
# Risk assessment
Low

[RQA-2668]: https://opentrons.atlassian.net/browse/RQA-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ