### PR TITLE
fix(api): stop-requested hanging on stop when awaiting-recovery

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -362,6 +362,9 @@ class CommandStore(HasState[CommandState], HandlesActions):
 
         elif isinstance(action, StopAction):
             if not self._state.run_result:
+                if self._state.queue_status == QueueStatus.AWAITING_RECOVERY:
+                    self._state.recovery_target_command_id = None
+
                 self._state.queue_status = QueueStatus.PAUSED
                 if action.from_estop:
                     self._state.stopped_by_estop = True


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-403.
fix bug related to stop-requested hanging when issuing a StopAction when in AwaitingRecovery state.

# Test Plan

- use ff for recoverable commands
- upload a protocol that will fail on a recoverable command.
- issue a stop action while in `awaiting-recovery`
- run should stop. 

# Review requests

is test sufficient ?

# Risk assessment

low. bug fix. 