### PR TITLE
fix(app): remove unnecessary padding

### DIFF
--- a/app/src/pages/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ProtocolDetails/Parameters.tsx
@@ -24,13 +24,12 @@ const Table = styled('table')`
   font-size: ${TYPOGRAPHY.fontSize22};
   width: 100%;
   border-spacing: 0 ${SPACING.spacing8};
-  margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
 const TableHeader = styled('th')`
   font-size: ${TYPOGRAPHY.fontSize20};
   font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
-  padding: ${SPACING.spacing4};
+  padding: 0 ${SPACING.spacing4} 0 ${SPACING.spacing4};
   color: ${COLORS.grey60};
 `
 

--- a/app/src/pages/ProtocolDetails/index.tsx
+++ b/app/src/pages/ProtocolDetails/index.tsx
@@ -291,7 +291,7 @@ const ProtocolSectionContent = ({
   }
   return (
     <Flex
-      marginTop={SPACING.spacing32}
+      paddingTop={SPACING.spacing32}
       justifyContent={currentOption === 'Deck' ? JUSTIFY_CENTER : undefined}
     >
       {protocolSection}


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
 remove unnecessary padding
close RQA-2650

### [before]
https://drive.google.com/file/d/1nLQ6e7v_NJ6mP1Wy8-zliq5TN263jd5-/view

### [after]
<img width="1022" alt="Screenshot 2024-05-01 at 3 01 43 PM" src="https://github.com/Opentrons/opentrons/assets/474225/0dac4d2a-66c6-415c-9c83-0b3e49c7685a">




<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
