### PR TITLE
feat(app): anonymize release notes

### DIFF
--- a/app/src/assets/localization/en/anonymous.json
+++ b/app/src/assets/localization/en/anonymous.json
@@ -25,6 +25,7 @@
   "gripper_successfully_calibrated": "Gripper successfully calibrated",
   "gripper_successfully_detached": "Gripper successfully detached",
   "gripper": "Gripper",
+  "help_us_improve_send_error_report": "Help us improve your experience by sending an error report to support",
   "ip_description_second": "Work with your network administrator to assign a static IP address to the robot.",
   "learn_uninstalling": "Learn more about uninstalling the app",
   "loosen_screws_and_detach": "Loosen screws and detach gripper",
@@ -66,6 +67,7 @@
   "update_robot_software_description": "Bypass the auto-update process and update the robot software manually.",
   "update_robot_software_link": "Launch software update page",
   "versions_sync": "Learn more about keeping the app and robot software in sync",
+  "view_latest_release_notes_at": "Please contact support for release notes.",
   "want_to_help_out": "Want to help out?",
   "welcome_title": "Welcome!",
   "why_use_lpc": "Labware Position Check is intended to correct for minor variances. Don't use Labware Position Check to compensate for large positional adjustments. Needing to set large labware offsets could indicate a problem with robot calibration."

--- a/app/src/assets/localization/en/branded.json
+++ b/app/src/assets/localization/en/branded.json
@@ -25,6 +25,7 @@
   "gripper_successfully_calibrated": "Flex Gripper successfully calibrated",
   "gripper_successfully_detached": "Flex Gripper successfully detached",
   "gripper": "Flex Gripper",
+  "help_us_improve_send_error_report": "Help us improve your experience by sending an error report to {{support_email}}",
   "ip_description_second": "Opentrons recommends working with your network administrator to assign a static IP address to the robot.",
   "learn_uninstalling": "Learn more about uninstalling the Opentrons App",
   "loosen_screws_and_detach": "Loosen screws and detach Flex Gripper",
@@ -66,6 +67,7 @@
   "update_robot_software_description": "Bypass the Opentrons App auto-update process and update the robot software manually.",
   "update_robot_software_link": "Launch Opentrons software update page",
   "versions_sync": "Learn more about keeping the Opentrons App and robot software in sync",
+  "view_latest_release_notes_at": "View latest release notes at {{url}}",
   "want_to_help_out": "Want to help out Opentrons?",
   "welcome_title": "Welcome to your Opentrons Flex!",
   "why_use_lpc": "Labware Position Check is intended to correct for minor variances. Opentrons does not recommend using Labware Position Check to compensate for large positional adjustments. Needing to set large labware offsets could indicate a problem with robot calibration."

--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -304,7 +304,6 @@
   "use_older_aspirate_description": "Aspirate with the less accurate volumetric calibrations that were used before version 3.7.0. Use this if you need consistency with pre-v3.7.0 results. This only affects GEN1 P10S, P10M, P50M, and P300S pipettes.",
   "validating_software": "Validating software...",
   "view_details": "View details",
-  "view_latest_release_notes_at": "View latest release notes at {{url}}",
   "view_network_details": "View network details",
   "view_update": "View update",
   "welcome_description": "Quickly run protocols and check on your robot's status right on your lab bench.",

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -36,7 +36,6 @@
   "get_started": "Get started",
   "github": "GitHub",
   "go_back": "Go back",
-  "help_us_improve_send_error_report": "Help us improve your experience by sending an error report to {{support_email}}",
   "instruments": "instruments",
   "loading": "Loading...",
   "next": "Next",

--- a/app/src/molecules/ReleaseNotes/index.tsx
+++ b/app/src/molecules/ReleaseNotes/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import Markdown from 'react-markdown'
 
 import { StyledText } from '@opentrons/components'
+import { useIsOEMMode } from '../../resources/robot-settings/hooks'
 
 import styles from './styles.module.css'
 
@@ -14,9 +15,11 @@ const DEFAULT_RELEASE_NOTES = 'We recommend upgrading to the latest version.'
 export function ReleaseNotes(props: ReleaseNotesProps): JSX.Element {
   const { source } = props
 
+  const isOEMMode = useIsOEMMode()
+
   return (
     <div className={styles.release_notes}>
-      {source != null ? (
+      {source != null && !isOEMMode ? (
         <Markdown
           components={{
             div: undefined,

--- a/app/src/organisms/LabwarePositionCheck/FatalErrorModal.tsx
+++ b/app/src/organisms/LabwarePositionCheck/FatalErrorModal.tsx
@@ -33,7 +33,7 @@ interface FatalErrorModalProps {
 }
 export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
   const { errorMessage, shouldUseMetalProbe, onClose } = props
-  const { t } = useTranslation(['labware_position_check', 'shared'])
+  const { t } = useTranslation(['labware_position_check', 'shared', 'branded'])
   return createPortal(
     <LegacyModalShell
       width="47rem"
@@ -70,7 +70,7 @@ export function FatalErrorModal(props: FatalErrorModalProps): JSX.Element {
           </StyledText>
         ) : null}
         <StyledText as="p" textAlign={TEXT_ALIGN_CENTER}>
-          {t('shared:help_us_improve_send_error_report', {
+          {t('branded:help_us_improve_send_error_report', {
             support_email: SUPPORT_EMAIL,
           })}
         </StyledText>

--- a/app/src/organisms/RobotSettingsDashboard/RobotSystemVersion.tsx
+++ b/app/src/organisms/RobotSettingsDashboard/RobotSystemVersion.tsx
@@ -40,6 +40,7 @@ export function RobotSystemVersion({
     'shared',
     'device_details',
     'app_settings',
+    'branded',
   ])
   const [showModal, setShowModal] = React.useState<boolean>(isUpdateAvailable)
 
@@ -76,7 +77,7 @@ export function RobotSystemVersion({
         >
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing24}>
             <StyledText as="p">
-              {t('view_latest_release_notes_at', { url: GITHUB_URL })}
+              {t('branded:view_latest_release_notes_at', { url: GITHUB_URL })}
             </StyledText>
             <Flex
               backgroundColor={COLORS.grey35}


### PR DESCRIPTION
# Overview

fall back to default "We recommend upgrading to the latest version" release notes.

closes PLAT-266

<img width="1136" alt="Screen Shot 2024-05-01 at 4 43 53 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/2f1df4fd-71f2-4f42-8d70-2cf5dc4ec8d1">
<img width="1136" alt="Screen Shot 2024-05-01 at 4 51 10 PM" src="https://github.com/Opentrons/opentrons/assets/29845468/8494fa44-088c-487c-9498-a97c7ab6b1a9">

# Test Plan

manually verified the anonymization

# Changelog

 - Anonymizes release notes

# Review requests

check the release notes

# Risk assessment

low
