### PR TITLE
fix(protocol-designer): clean up trash modal and new labware dropdown logic

### DIFF
--- a/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/LabwareSelectionModal.tsx
@@ -470,7 +470,7 @@ export function LabwareSelectionModal(): JSX.Element | null {
         <ul>
           {customLabwareURIs.length > 0 ? (
             <PDTitledList
-              title="Custom Labware"
+              title={t('custom_labware')}
               collapsed={selectedCategory !== CUSTOM_CATEGORY}
               onCollapseToggle={makeToggleCategory(CUSTOM_CATEGORY)}
               onClick={makeToggleCategory(CUSTOM_CATEGORY)}
@@ -530,7 +530,7 @@ export function LabwareSelectionModal(): JSX.Element | null {
             <PDTitledList
               data-testid="LabwareSelectionModal_adapterCompatibleLabware"
               key={adapterCompatibleLabware}
-              title="adapter compatible labware"
+              title={t('adapter_compatible_labware')}
               collapsed={selectedCategory !== adapterCompatibleLabware}
               onCollapseToggle={makeToggleCategory(adapterCompatibleLabware)}
               onClick={makeToggleCategory(adapterCompatibleLabware)}

--- a/protocol-designer/src/components/LabwareSelectionModal/__tests__/LabwareSelectionModal.test.tsx
+++ b/protocol-designer/src/components/LabwareSelectionModal/__tests__/LabwareSelectionModal.test.tsx
@@ -121,7 +121,7 @@ describe('LabwareSelectionModal', () => {
     })
     render()
     fireEvent.click(
-      screen.getByText(nestedTextMatcher('adapter compatible labware'))
+      screen.getByText(nestedTextMatcher('Adapter Compatible Labware'))
     )
     screen.getByText('Opentrons GEB 1000uL Tiprack')
   })

--- a/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/LabwareLocationField/index.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
+import { getModuleDisplayName } from '@opentrons/shared-data'
 import {
-  getModuleDisplayName,
-  WASTE_CHUTE_CUTOUT,
-} from '@opentrons/shared-data'
-import {
-  getAdditionalEquipmentEntities,
   getLabwareEntities,
   getModuleEntities,
 } from '../../../../step-forms/selectors'
@@ -14,7 +10,6 @@ import {
   getRobotStateAtActiveItem,
   getUnoccupiedLabwareLocationOptions,
 } from '../../../../top-selectors/labware-locations'
-import { getHasWasteChute } from '../../../labware'
 import { StepFormDropdown } from '../StepFormDropdownField'
 
 export function LabwareLocationField(
@@ -27,32 +22,18 @@ export function LabwareLocationField(
   const labwareEntities = useSelector(getLabwareEntities)
   const robotState = useSelector(getRobotStateAtActiveItem)
   const moduleEntities = useSelector(getModuleEntities)
-  const additionalEquipmentEntities = useSelector(
-    getAdditionalEquipmentEntities
-  )
-  const hasWasteChute = getHasWasteChute(additionalEquipmentEntities)
   const isLabwareOffDeck =
     labware != null ? robotState?.labware[labware]?.slot === 'offDeck' : false
-  const displayWasteChuteValue =
-    useGripper && hasWasteChute && !isLabwareOffDeck
 
   let unoccupiedLabwareLocationsOptions =
     useSelector(getUnoccupiedLabwareLocationOptions) ?? []
 
-  if (isLabwareOffDeck && hasWasteChute) {
-    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
-      option =>
-        option.value !== 'offDeck' && option.value !== WASTE_CHUTE_CUTOUT
-    )
-  } else if (useGripper || isLabwareOffDeck) {
+  if (useGripper || isLabwareOffDeck) {
     unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
       option => option.value !== 'offDeck'
     )
-  } else if (!displayWasteChuteValue) {
-    unoccupiedLabwareLocationsOptions = unoccupiedLabwareLocationsOptions.filter(
-      option => option.name !== 'Waste Chute in D3'
-    )
   }
+
   const location: string = value as string
 
   const bothFieldsSelected = labware != null && value != null

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -23,14 +23,7 @@ import {
   PipetteName,
   OT2_ROBOT_TYPE,
   getPipetteSpecsV2,
-  FLEX_ROBOT_TYPE,
-  RobotType,
 } from '@opentrons/shared-data'
-import { StepChangesConfirmModal } from '../EditPipettesModal/StepChangesConfirmModal'
-import { PipetteFields } from './PipetteFields'
-import { CrashInfoBox } from '../../modules'
-import styles from './FilePipettesModal.module.css'
-import modalStyles from '../modal.module.css'
 import {
   actions as stepFormActions,
   selectors as stepFormSelectors,
@@ -44,22 +37,28 @@ import { INITIAL_DECK_SETUP_STEP_ID } from '../../../constants'
 import { NewProtocolFields } from '../../../load-file'
 import { getRobotType } from '../../../file-data/selectors'
 import { uuid } from '../../../utils'
-import { actions as steplistActions } from '../../../steplist'
-import { selectors as featureFlagSelectors } from '../../../feature-flags'
-import { getCrashableModuleSelected } from '../CreateFileWizard/utils'
-
-import type { DeckSlot, ThunkDispatch } from '../../../types'
-import type {
-  LabwareEntities,
-  NormalizedPipette,
-} from '@opentrons/step-generation'
-import type { StepIdType } from '../../../form-types'
 import { getLabwareEntities } from '../../../step-forms/selectors'
 import {
   createContainer,
   deleteContainer,
 } from '../../../labware-ingred/actions'
+import { actions as steplistActions } from '../../../steplist'
+import { selectors as featureFlagSelectors } from '../../../feature-flags'
+import { CrashInfoBox } from '../../modules'
+import { getCrashableModuleSelected } from '../CreateFileWizard/utils'
 import { adapter96ChannelDefUri } from '../CreateFileWizard'
+import { StepChangesConfirmModal } from '../EditPipettesModal/StepChangesConfirmModal'
+import { PipetteFields } from './PipetteFields'
+
+import type {
+  LabwareEntities,
+  NormalizedPipette,
+} from '@opentrons/step-generation'
+import type { DeckSlot, ThunkDispatch } from '../../../types'
+import type { StepIdType } from '../../../form-types'
+
+import styles from './FilePipettesModal.module.css'
+import modalStyles from '../modal.module.css'
 
 export type PipetteFieldsData = Omit<
   PipetteOnDeck,

--- a/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
+++ b/protocol-designer/src/components/modals/FilePipettesModal/index.tsx
@@ -190,7 +190,7 @@ const makeUpdatePipettes = (
   newTiprackUris.forEach(tiprackDefUri => {
     if (!previousTiprackUris.has(tiprackDefUri)) {
       const adapterUnderLabwareDefURI = newPipetteArray.some(
-        pip => pip.name === 'p1000_96'
+        pipette => pipette.name === 'p1000_96'
       )
         ? adapter96ChannelDefUri
         : undefined

--- a/protocol-designer/src/components/modules/TrashModal.tsx
+++ b/protocol-designer/src/components/modules/TrashModal.tsx
@@ -87,11 +87,14 @@ const TrashModalComponent = (props: TrashModalComponentProps): JSX.Element => {
     name: 'selectedSlot',
     defaultValue: defaultValue,
   })
-  const isSlotEmpty = getSlotIsEmpty(
-    initialDeckSetup,
-    selectedSlot,
-    trashName === 'trashBin'
-  )
+  const hasTrashAlreadyInSlot = Object.values(
+    initialDeckSetup.additionalEquipmentOnDeck
+  ).find(aE => aE.name === 'trashBin' && aE.location === selectedSlot)
+
+  const isSlotEmpty =
+    getSlotIsEmpty(initialDeckSetup, selectedSlot, trashName === 'trashBin') ||
+    hasTrashAlreadyInSlot
+
   const slotFromCutout = selectedSlot.replace('cutout', '')
   const flexDeck = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
 

--- a/protocol-designer/src/localization/en/modules.json
+++ b/protocol-designer/src/localization/en/modules.json
@@ -1,4 +1,6 @@
 {
+  "adapter_compatible_labware": "Adapter Compatible Labware",
+  "custom_labware": "Custom Labware",
   "additional_equipment_display_names": {
     "gripper": "Flex Gripper",
     "stagingAreas": "Staging Area Slots",


### PR DESCRIPTION
closes RQA-2501, RQA-2143, RQA-1156, AUTH-378

# Overview

Addresses a bunch of bugs and a quality of life improvement:
1. the adapter text when adding an adapter to the deck is capitalized (Auth-378)
2. changing a pipette and tiprack updates the tiprack on the deck (RQA-1156)
3. the trash modal does not show cannot place banner when the trash is already in selected slot (RQA-2143)
4. when `use gripper` is selected, the waste chute option will show in labware location dropdown but when not selected, the waste chute + off-deck locations will show in dropdown (RQA-2501)

# Test Plan

Create a flex protocol and add a gripper and trash bin and waste chute. Open the trash edit modal and see that the `cannot place` banner is not there since the trash is the thing occupying slot A3. Go to the deck map and add an adapter. Add a labware on top of the adapter and see that the text is capitalized in the modal. Add a move labware step and if the gripper is selected, see that the waste chute location + all slots are included in the new location dropdown. If the gripper is not selected, see that the waste chute, all slots, and off-deck labware is included. Then go back to the edit file page and change the pipette and tiprack. Go back to the deckmap and see that the tiprack is udpated to the correctly selected one.

# Changelog

- add text to i18n and capitalize 
- refactor logic to delete and add new containers for the new tipracks that are selected
- add additional logic to when slot is available in the trash modal
- clean up logic for the new location dropdown for when gripper is selected and not selected

# Review requests

see test plan

# Risk assessment

low