### PR TITLE
chore(mypy): fix cache cleanup

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -61,7 +61,7 @@ twine_repository_url ?= $(pypi_test_upload_url)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'src/**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_sdist_cmd = $(clean_cmd) dist/*.tar.gz
 clean_all_cmd = $(clean_cmd) dist

--- a/api/Makefile
+++ b/api/Makefile
@@ -61,7 +61,8 @@ twine_repository_url ?= $(pypi_test_upload_url)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info'
+clean_cache_cmd = $(SHX) rm -rf '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_sdist_cmd = $(clean_cmd) dist/*.tar.gz
 clean_all_cmd = $(clean_cmd) dist
@@ -85,6 +86,7 @@ setup-ot2:
 .PHONY: clean
 clean: docs-clean
 	$(clean_all_cmd)
+	$(clean_cache_cmd)
 
 .PHONY: teardown
 teardown:

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -53,7 +53,8 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info'
+clean_cache_cmd = $(SHX) rm -rf '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 
 .PHONY: all
 all: clean wheel
@@ -69,7 +70,8 @@ teardown:
 
 .PHONY: clean
 clean:
-	-$(clean_cmd)
+	$(clean_cmd)
+	$(clean_cache_cmd)
 
 dist/opentrons_hardware-%-py2.py3-none-any.whl: export OPENTRONS_PROJECT=$(project_rs_default)
 dist/opentrons_hardware-%-py2.py3-none-any.whl: setup.py $(ot_sources)

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -52,7 +52,8 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info'
+clean_cache_cmd = $(SHX) rm -rf '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_sdist_cmd = $(clean_cmd) dist/*.tar.gz
 clean_all_cmd = $(clean_cmd) dist
@@ -92,6 +93,7 @@ setup-ot2:
 .PHONY: clean
 clean:
 	$(clean_all_cmd)
+	$(clean_cache_cmd)
 
 .PHONY: teardown
 teardown:

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -52,7 +52,7 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'robot_server/**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_sdist_cmd = $(clean_cmd) dist/*.tar.gz
 clean_all_cmd = $(clean_cmd) dist

--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -49,7 +49,8 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info'
+clean_cache_cmd = $(SHX) rm -rf '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_sdist_cmd = $(clean_cmd) dist/*.tar.gz
 clean_all_cmd = $(clean_cmd) dist
@@ -65,6 +66,7 @@ setup:
 .PHONY: clean
 clean:
 	$(clean_all_cmd)
+	$(clean_cache_cmd)
 
 .PHONY: teardown
 teardown:

--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -49,7 +49,7 @@ ot_sources := $(ot_py_sources)
 
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
-clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' 'server_utils/**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_sdist_cmd = $(clean_cmd) dist/*.tar.gz
 clean_all_cmd = $(clean_cmd) dist

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -50,7 +50,7 @@ tests ?= tests
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
 
-clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc' 'opentrons_shared_data/**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc' '**/.mypy_cache'
 
 .PHONY: all
 all: clean sdist wheel

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -50,7 +50,8 @@ tests ?= tests
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
 twine_repository_url ?= $(pypi_test_upload_url)
 
-clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info' ' **/__pycache__' '**/*.pyc' '**/.mypy_cache'
+clean_cmd = $(SHX) rm -rf build $(BUILD_DIR) .coverage coverage.xml '*.egg-info'
+clean_cache_cmd	 = $(SHX) rm -rf '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 
 .PHONY: all
 all: clean sdist wheel
@@ -74,6 +75,7 @@ teardown-py:
 .PHONY: clean
 clean:
 	$(clean_cmd)
+	$(clean_cache_cmd)
 
 .PHONY: wheel
 wheel: export OPENTRONS_PROJECT=$(project_rs_default)


### PR DESCRIPTION
# Overview
We haven't been properly clearing the mypy cache for some python directories when we do `make clean-py` because we were using the wrong paths. 

It seems like we don't clear pytest caches in most directories in the cleanup rules, is that intentional? 