### PR TITLE
fix(protocol-designer): air-gap in substep-highlight

### DIFF
--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -321,12 +321,10 @@ function transferLikeSubsteps(args: {
       1,
       null
     )
-    console.log('substepRows', substepRows)
     const mergedRows: StepItemSourceDestRow[] = mergeSubstepRowsSingleChannel({
       substepRows,
       showDispenseVol,
     })
-    console.log('mergedRows', mergedRows)
     return {
       substepType: 'sourceDest',
       multichannel: false,

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -112,8 +112,12 @@ export const mergeSubstepRowsSingleChannel = (args: {
   showDispenseVol: boolean
 }): StepItemSourceDestRow[] => {
   const { substepRows, showDispenseVol } = args
+  //  TODO(jr, 5/2/24): filtering out air gap steps for now since a refactor would be required
+  //  to figure out if the air gap is for the aspirate or dispense labware. Otherwise, a white screen
+  //  was happening with an air gap step trying to happen in an aspirate labware well that did not exist
+  const filteredSubstepRows = substepRows.filter(row => !row.isAirGap)
   return steplistUtils.mergeWhen(
-    substepRows,
+    filteredSubstepRows,
     (
       currentRow,
       nextRow // NOTE: if aspirate then dispense rows are adjacent, collapse them into one row
@@ -160,8 +164,12 @@ export const mergeSubstepRowsMultiChannel = (args: {
   showDispenseVol: boolean
 }): StepItemSourceDestRow[][] => {
   const { substepRows, channels, isMixStep, showDispenseVol } = args
+  //  TODO(jr, 5/2/24): filtering out air gap steps for now since a refactor would be required
+  //  to figure out if the air gap is for the aspirate or dispense labware. Otherwise, a white screen
+  //  was happening with an air gap step trying to happen in an aspirate labware well that did not exist
+  const filteredSubstepRows = substepRows.filter(row => !row.isAirGap)
   return steplistUtils.mergeWhen(
-    substepRows,
+    filteredSubstepRows,
     (
       currentMultiRow: SubstepTimelineFrame,
       nextMultiRow: SubstepTimelineFrame
@@ -313,10 +321,12 @@ function transferLikeSubsteps(args: {
       1,
       null
     )
+    console.log('substepRows', substepRows)
     const mergedRows: StepItemSourceDestRow[] = mergeSubstepRowsSingleChannel({
       substepRows,
       showDispenseVol,
     })
+    console.log('mergedRows', mergedRows)
     return {
       substepType: 'sourceDest',
       multichannel: false,

--- a/protocol-designer/src/steplist/substepTimeline.ts
+++ b/protocol-designer/src/steplist/substepTimeline.ts
@@ -64,11 +64,23 @@ const _createNextTimelineFrame = (args: {
     volume: args.volume,
     activeTips: _getNewActiveTips(args.nextFrame.commands.slice(0, args.index)),
   }
+  const command = args.command
+  const isAirGapCommand =
+    'meta' in command && command.meta != null && 'isAirGap' in command.meta
+
   const newTimelineFrame =
     args.command.commandType === 'aspirate' ||
     args.command.commandType === 'aspirateInPlace'
-      ? { ..._newTimelineFrameKeys, source: args.wellInfo }
-      : { ..._newTimelineFrameKeys, dest: args.wellInfo }
+      ? {
+          ..._newTimelineFrameKeys,
+          source: args.wellInfo,
+          isAirGap: isAirGapCommand,
+        }
+      : {
+          ..._newTimelineFrameKeys,
+          dest: args.wellInfo,
+          isAirGap: isAirGapCommand,
+        }
   return newTimelineFrame
 }
 

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -231,6 +231,7 @@ describe('generateSubstepItem', () => {
                 preIngreds: {},
                 well: 'C1',
               },
+              isAirGap: false,
             },
           ],
         },
@@ -269,6 +270,7 @@ describe('generateSubstepItem', () => {
                 preIngreds: {},
                 well: 'A1',
               },
+              isAirGap: false,
               source: {
                 postIngreds: {},
                 preIngreds: {},
@@ -323,6 +325,7 @@ describe('generateSubstepItem', () => {
                 labwareId: tiprackId,
                 wellName: 'A1',
               },
+              isAirGap: false,
               source: { well: 'A1', preIngreds: {}, postIngreds: {} },
               dest: {
                 well: 'A1',
@@ -343,6 +346,7 @@ describe('generateSubstepItem', () => {
                 labwareId: tiprackId,
                 wellName: 'A1',
               },
+              isAirGap: false,
               dest: {
                 postIngreds: {
                   __air__: {
@@ -434,6 +438,7 @@ describe('generateSubstepItem', () => {
             preIngreds: {},
             well: 'A1',
           },
+          isAirGap: false,
           source: {
             postIngreds: {},
             preIngreds: {},
@@ -460,6 +465,7 @@ describe('generateSubstepItem', () => {
             },
             well: 'A1',
           },
+          isAirGap: false,
           source: {
             postIngreds: {
               __air__: {
@@ -490,6 +496,7 @@ describe('generateSubstepItem', () => {
             preIngreds: {},
             well: 'A2',
           },
+          isAirGap: false,
           source: {
             postIngreds: {},
             preIngreds: {},
@@ -516,6 +523,7 @@ describe('generateSubstepItem', () => {
             },
             well: 'A2',
           },
+          isAirGap: false,
           source: {
             postIngreds: {
               __air__: {

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -48,6 +48,7 @@ export interface SourceDestData {
   postIngreds: WellIngredientVolumeData
 }
 export interface SubstepTimelineFrame {
+  isAirGap?: boolean
   substepIndex?: number
   activeTips: TipLocation | null | undefined
   source?: SourceDestData

--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -204,7 +204,7 @@ function _getSelectedWellsForSubstep(
 
   if (
     'sourceLabware' in stepArgs &&
-    stepArgs.sourceLabware &&
+    stepArgs.sourceLabware != null &&
     stepArgs.sourceLabware === labwareId
   ) {
     wells.push(...getWells('source'))
@@ -212,7 +212,7 @@ function _getSelectedWellsForSubstep(
 
   if (
     'destLabware' in stepArgs &&
-    stepArgs.destLabware &&
+    stepArgs.destLabware != null &&
     stepArgs.destLabware === labwareId
   ) {
     wells.push(...getWells('dest'))

--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -202,13 +202,19 @@ function _getSelectedWellsForSubstep(
 
   // source + dest steps
 
-  // @ts-expect-error(sa, 2021-6-22): `sourceLabware` is missing in `MixArgs`
-  if (stepArgs.sourceLabware && stepArgs.sourceLabware === labwareId) {
+  if (
+    'sourceLabware' in stepArgs &&
+    stepArgs.sourceLabware &&
+    stepArgs.sourceLabware === labwareId
+  ) {
     wells.push(...getWells('source'))
   }
 
-  // @ts-expect-error(sa, 2021-6-22): property `destLabware` is missing in `MixArgs`
-  if (stepArgs.destLabware && stepArgs.destLabware === labwareId) {
+  if (
+    'destLabware' in stepArgs &&
+    stepArgs.destLabware &&
+    stepArgs.destLabware === labwareId
+  ) {
     wells.push(...getWells('dest'))
   }
 


### PR DESCRIPTION
closes AUTH-298

# Overview

This is a gnarly bug that i'm pretty sure has existed since the conception of air gap. Basically, before the vitest migration, `Well.tsx` is `components` directory had a null protection where if well was null then it returned null. When we removed that null protection in the vitest migration, users began to notice the whitescreen outlined in the ticket.

This issue was that when you hover over the air gap step,  the highlighted step wasn't working correctly (highlighting only the aspirate labware and not the dispense labware). The protocol that causes the whitescreen is unique in that the aspirate labware is a 24 well aluminum block and the dispense labware is a 96 well plate. When the air gap after dispense was happening in well F1, the whitescreen occurred because the 24 well aluminum block does not have well F1.

The work around for now (just a temporary fix) is to filter out the air gap substeps. We can add them back if customers want it. BUT in order to add the air gap substeps back, we would need knowledge of if the air gap is happening in the aspirate or dispense labware which it currently does not know, so it would be a pretty hefty refactor I think.

# Test Plan

First on edge, upload the attached protocol in the ticket and open the 4th step (a transfer step). Expand the substeps and highlight through each of the items. Once you reach the air gap in F1, you should get a white screen (Also well. G1 and H1 should white screen too)

Now on this branch, upload the same protocol and do the same steps, you shouldn't get a whitescreen

# Changelog

- add isAirGap to substep type and filter out the air gap aspirate commands for not as a temp fix

# Review requests

see test plan

# Risk assessment

low