### PR TITLE
refactor(api): remove legacy from names of variables and classes that are not actually legacy

### DIFF
--- a/api/src/opentrons/protocol_runner/create_simulating_runner.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_runner.py
@@ -12,7 +12,7 @@ from opentrons.protocol_reader.protocol_source import ProtocolConfig
 
 from opentrons_shared_data.robot.dev_types import RobotType
 
-from .legacy_wrappers import LegacySimulatingContextCreator
+from .python_protocol_wrappers import SimulatingContextCreator
 from .protocol_runner import create_protocol_runner, AbstractRunner
 
 
@@ -62,7 +62,7 @@ async def create_simulating_runner(
         load_fixed_trash=should_load_fixed_trash(protocol_config),
     )
 
-    simulating_legacy_context_creator = LegacySimulatingContextCreator(
+    simulating_context_creator = SimulatingContextCreator(
         hardware_api=simulating_hardware_api,
         protocol_engine=protocol_engine,
     )
@@ -71,7 +71,7 @@ async def create_simulating_runner(
         protocol_config=protocol_config,
         protocol_engine=protocol_engine,
         hardware_api=simulating_hardware_api,
-        legacy_context_creator=simulating_legacy_context_creator,
+        protocol_context_creator=simulating_context_creator,
     )
 
 

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -17,10 +17,10 @@ from opentrons.legacy_commands import types as legacy_command_types
 from opentrons.protocol_api import InstrumentContext
 from opentrons.protocol_api.core.legacy.deck import FIXED_TRASH_ID
 from opentrons.protocol_api.core.legacy.load_info import (
-    LoadInfo,
-    LabwareLoadInfo,
-    InstrumentLoadInfo,
-    ModuleLoadInfo,
+    LoadInfo as LegacyLoadInfo,
+    LabwareLoadInfo as LegacyLabwareLoadInfo,
+    InstrumentLoadInfo as LegacyInstrumentLoadInfo,
+    ModuleLoadInfo as LegacyModuleLoadInfo,
 )
 from opentrons.protocol_engine import (
     ProtocolEngineError,
@@ -283,13 +283,13 @@ class LegacyCommandMapper:
 
         return results
 
-    def map_equipment_load(self, load_info: LoadInfo) -> List[pe_actions.Action]:
+    def map_equipment_load(self, load_info: LegacyLoadInfo) -> List[pe_actions.Action]:
         """Map a labware, instrument (pipette), or module load to a PE command."""
-        if isinstance(load_info, LabwareLoadInfo):
+        if isinstance(load_info, LegacyLabwareLoadInfo):
             return self._map_labware_load(load_info)
-        elif isinstance(load_info, InstrumentLoadInfo):
+        elif isinstance(load_info, LegacyInstrumentLoadInfo):
             return self._map_instrument_load(load_info)
-        elif isinstance(load_info, ModuleLoadInfo):
+        elif isinstance(load_info, LegacyModuleLoadInfo):
             return self._map_module_load(load_info)
 
     def _build_initial_command(
@@ -592,7 +592,7 @@ class LegacyCommandMapper:
             return custom_create, custom_running
 
     def _map_labware_load(
-        self, labware_load_info: LabwareLoadInfo
+        self, labware_load_info: LegacyLabwareLoadInfo
     ) -> List[pe_actions.Action]:
         """Map a legacy labware load to a ProtocolEngine command."""
         now = ModelUtils.get_timestamp()
@@ -660,7 +660,7 @@ class LegacyCommandMapper:
 
     def _map_instrument_load(
         self,
-        instrument_load_info: InstrumentLoadInfo,
+        instrument_load_info: LegacyInstrumentLoadInfo,
     ) -> List[pe_actions.Action]:
         """Map a legacy instrument (pipette) load to a ProtocolEngine command.
 
@@ -719,7 +719,7 @@ class LegacyCommandMapper:
         return [queue_action, run_action, succeed_action]
 
     def _map_module_load(
-        self, module_load_info: ModuleLoadInfo
+        self, module_load_info: LegacyModuleLoadInfo
     ) -> List[pe_actions.Action]:
         """Map a legacy module load to a Protocol Engine command."""
         now = ModelUtils.get_timestamp()

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -65,7 +65,7 @@ class LegacyContextCommandError(ProtocolEngineError):
             )
 
 
-_LEGACY_TO_PE_MODULE: Dict[HardwareModuleModel, pe_types.ModuleModel] = {
+_HARDWARE_TO_PE_MODULE: Dict[HardwareModuleModel, pe_types.ModuleModel] = {
     MagneticModuleModel.MAGNETIC_V1: pe_types.ModuleModel.MAGNETIC_MODULE_V1,
     MagneticModuleModel.MAGNETIC_V2: pe_types.ModuleModel.MAGNETIC_MODULE_V2,
     TemperatureModuleModel.TEMPERATURE_V1: pe_types.ModuleModel.TEMPERATURE_MODULE_V1,
@@ -727,8 +727,8 @@ class LegacyCommandMapper:
         count = self._command_count["LOAD_MODULE"]
         command_id = f"commands.LOAD_MODULE-{count}"
         module_id = f"module-{count}"
-        requested_model = _LEGACY_TO_PE_MODULE[module_load_info.requested_model]
-        loaded_model = _LEGACY_TO_PE_MODULE[module_load_info.loaded_model]
+        requested_model = _HARDWARE_TO_PE_MODULE[module_load_info.requested_model]
+        loaded_model = _HARDWARE_TO_PE_MODULE[module_load_info.loaded_model]
 
         # This will fetch a V2 definition only. PAPI < v2.3 use V1 definitions.
         # When running a < v2.3 protocol, there will be a mismatch of definitions used

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -7,10 +7,10 @@ from typing import List, Optional
 
 from opentrons.legacy_commands.types import CommandMessage as LegacyCommand
 from opentrons.legacy_broker import LegacyBroker
+from opentrons.protocol_api.core.legacy.load_info import LoadInfo
 from opentrons.protocol_engine import AbstractPlugin, actions as pe_actions
 from opentrons.util.broker import ReadOnlyBroker
 
-from .legacy_wrappers import LegacyLoadInfo
 from .legacy_command_mapper import LegacyCommandMapper
 from .thread_async_queue import ThreadAsyncQueue
 
@@ -37,7 +37,7 @@ class LegacyContextPlugin(AbstractPlugin):
     def __init__(
         self,
         broker: LegacyBroker,
-        equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
+        equipment_broker: ReadOnlyBroker[LoadInfo],
         legacy_command_mapper: Optional[LegacyCommandMapper] = None,
     ) -> None:
         """Initialize the plugin with its dependencies."""
@@ -129,7 +129,7 @@ class LegacyContextPlugin(AbstractPlugin):
         pe_actions = self._legacy_command_mapper.map_command(command=command)
         self._actions_to_dispatch.put(pe_actions)
 
-    def _handle_equipment_loaded(self, load_info: LegacyLoadInfo) -> None:
+    def _handle_equipment_loaded(self, load_info: LoadInfo) -> None:
         """Handle an equipment load reported by the APIv2 protocol.
 
         Used as a broker callback, so this will run in the APIv2 protocol's thread.

--- a/api/src/opentrons/protocol_runner/legacy_context_plugin.py
+++ b/api/src/opentrons/protocol_runner/legacy_context_plugin.py
@@ -122,7 +122,7 @@ class LegacyContextPlugin(AbstractPlugin):
         pass
 
     def _handle_legacy_command(self, command: LegacyCommand) -> None:
-        """Handle a command reported by the APIv2 protocol.
+        """Handle a command reported by the legacy APIv2 protocol.
 
         Used as a broker callback, so this will run in the APIv2 protocol's thread.
         """
@@ -130,7 +130,7 @@ class LegacyContextPlugin(AbstractPlugin):
         self._actions_to_dispatch.put(pe_actions)
 
     def _handle_equipment_loaded(self, load_info: LoadInfo) -> None:
-        """Handle an equipment load reported by the APIv2 protocol.
+        """Handle an equipment load reported by the legacy APIv2 protocol.
 
         Used as a broker callback, so this will run in the APIv2 protocol's thread.
         """

--- a/api/src/opentrons/protocol_runner/legacy_wrappers.py
+++ b/api/src/opentrons/protocol_runner/legacy_wrappers.py
@@ -1,23 +1,16 @@
-"""Wrappers for the legacy, Protocol API v2 execution pipeline."""
+"""Wrappers for Protocol API v2 execution pipeline."""
 import asyncio
 from typing import Dict, Iterable, Optional, cast
 
 from anyio import to_thread
 
 from opentrons_shared_data.labware.dev_types import (
-    LabwareDefinition as LegacyLabwareDefinition,
+    LabwareDefinition as LabwareDefinitionTypedDict,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.hardware_control.modules.types import (
-    ModuleModel as LegacyModuleModel,
-    TemperatureModuleModel as LegacyTemperatureModuleModel,
-    MagneticModuleModel as LegacyMagneticModuleModel,
-    ThermocyclerModuleModel as LegacyThermocyclerModuleModel,
-    HeaterShakerModuleModel as LegacyHeaterShakerModuleModel,
-)
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.protocol_engine import ProtocolEngine
 from opentrons.protocol_engine.types import RunTimeParamValuesType
@@ -25,32 +18,20 @@ from opentrons.protocol_reader import ProtocolSource, ProtocolFileRole
 from opentrons.util.broker import Broker
 
 from opentrons.protocol_api import (
-    ProtocolContext as LegacyProtocolContext,
-    InstrumentContext as LegacyPipetteContext,
-    ModuleContext as LegacyModuleContext,
-    Labware as LegacyLabware,
-    Well as LegacyWell,
+    ProtocolContext,
     ParameterContext,
     create_protocol_context,
 )
 from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
-from opentrons.protocol_api.core.legacy.load_info import (
-    LoadInfo as LegacyLoadInfo,
-    InstrumentLoadInfo as LegacyInstrumentLoadInfo,
-    LabwareLoadInfo as LegacyLabwareLoadInfo,
-    ModuleLoadInfo as LegacyModuleLoadInfo,
-)
+from opentrons.protocol_api.core.legacy.load_info import LoadInfo as LegacyLoadInfo
 
 from opentrons.protocols.parse import PythonParseMode, parse
 from opentrons.protocols.execution.execute import run_protocol
-from opentrons.protocols.types import (
-    Protocol as LegacyProtocol,
-    JsonProtocol as LegacyJsonProtocol,
-    PythonProtocol as LegacyPythonProtocol,
-)
+from opentrons.protocols.types import Protocol, PythonProtocol
+
 
 # The earliest Python Protocol API version ("apiLevel") where the protocol's simulation
-# and execution will be handled by Protocol Engine, rather than the legacy machinery.
+# and execution will be handled by Protocol Engine, rather than the previous direct hardware calls from protocol api.
 #
 # Note that even when simulation and execution are handled by the legacy machinery,
 # Protocol Engine still has some involvement for analyzing the simulation and
@@ -71,16 +52,16 @@ class LegacyFileReader:
         protocol_source: ProtocolSource,
         labware_definitions: Iterable[LabwareDefinition],
         python_parse_mode: PythonParseMode,
-    ) -> LegacyProtocol:
+    ) -> Protocol:
         """Read a PAPIv2 protocol into a data structure."""
         protocol_file_path = protocol_source.main_file
         protocol_contents = protocol_file_path.read_text(encoding="utf-8")
-        legacy_labware_definitions: Dict[str, LegacyLabwareDefinition] = {
+        extra_labware: Dict[str, LabwareDefinitionTypedDict] = {
             uri_from_details(
                 namespace=lw.namespace,
                 load_name=lw.parameters.loadName,
                 version=lw.version,
-            ): cast(LegacyLabwareDefinition, lw.dict(exclude_none=True))
+            ): cast(LabwareDefinitionTypedDict, lw.dict(exclude_none=True))
             for lw in labware_definitions
         }
         data_file_paths = [
@@ -92,7 +73,7 @@ class LegacyFileReader:
         return parse(
             protocol_file=protocol_contents,
             filename=protocol_file_path.name,
-            extra_labware=legacy_labware_definitions,
+            extra_labware=extra_labware,
             extra_data={
                 data_path.name: data_path.read_bytes() for data_path in data_file_paths
             },
@@ -100,8 +81,6 @@ class LegacyFileReader:
         )
 
 
-# TODO (spp, 2023-04-05): Remove 'legacy' wording since this is the context we are using
-#  for all python protocols.
 class LegacyContextCreator:
     """Interface to construct Protocol API v2 contexts."""
 
@@ -125,21 +104,17 @@ class LegacyContextCreator:
 
     def create(
         self,
-        protocol: LegacyProtocol,
+        protocol: Protocol,
         broker: Optional[LegacyBroker],
         equipment_broker: Optional[Broker[LegacyLoadInfo]],
-    ) -> LegacyProtocolContext:
+    ) -> ProtocolContext:
         """Create a Protocol API v2 context."""
         extra_labware = (
-            protocol.extra_labware
-            if isinstance(protocol, LegacyPythonProtocol)
-            else None
+            protocol.extra_labware if isinstance(protocol, PythonProtocol) else None
         )
 
         bundled_data = (
-            protocol.bundled_data
-            if isinstance(protocol, LegacyPythonProtocol)
-            else None
+            protocol.bundled_data if isinstance(protocol, PythonProtocol) else None
         )
 
         return create_protocol_context(
@@ -171,8 +146,8 @@ class LegacyExecutor:
 
     @staticmethod
     async def execute(
-        protocol: LegacyProtocol,
-        context: LegacyProtocolContext,
+        protocol: Protocol,
+        context: ProtocolContext,
         parameter_context: Optional[ParameterContext],
         run_time_param_values: Optional[RunTimeParamValuesType],
     ) -> None:
@@ -180,29 +155,3 @@ class LegacyExecutor:
         await to_thread.run_sync(
             run_protocol, protocol, context, parameter_context, run_time_param_values
         )
-
-
-__all__ = [
-    # Re-exports of user-facing Python Protocol APIv2 stuff:
-    # TODO(mc, 2022-08-22): remove, no longer "legacy", so re-exports unnecessary
-    "LegacyProtocolContext",
-    "LegacyLabware",
-    "LegacyWell",
-    "LegacyPipetteContext",
-    "LegacyModuleContext",
-    # Re-exports of internal stuff:
-    "LegacyProtocol",
-    "LegacyJsonProtocol",
-    "LegacyPythonProtocol",
-    "LegacyLoadInfo",
-    "LegacyLabwareLoadInfo",
-    "LegacyInstrumentLoadInfo",
-    "LegacyModuleLoadInfo",
-    "LegacyModuleModel",
-    "LegacyMagneticModuleModel",
-    "LegacyTemperatureModuleModel",
-    "LegacyThermocyclerModuleModel",
-    "LegacyHeaterShakerModuleModel",
-    # legacy typed dicts
-    "LegacyLabwareDefinition",
-]

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -29,12 +29,12 @@ from .task_queue import TaskQueue
 from .json_file_reader import JsonFileReader
 from .json_translator import JsonTranslator
 from .legacy_context_plugin import LegacyContextPlugin
-from .legacy_wrappers import (
+from .python_protocol_wrappers import (
     LEGACY_PYTHON_API_VERSION_CUTOFF,
     LEGACY_JSON_SCHEMA_VERSION_CUTOFF,
-    LegacyFileReader,
-    LegacyContextCreator,
-    LegacyExecutor,
+    PythonProtocolFileReader,
+    ProtocolContextCreator,
+    PythonProtocolExecutor,
 )
 from ..protocol_engine.errors import ProtocolCommandFailedError
 from ..protocol_engine.types import (
@@ -136,21 +136,26 @@ class PythonAndLegacyRunner(AbstractRunner):
         protocol_engine: ProtocolEngine,
         hardware_api: HardwareControlAPI,
         task_queue: Optional[TaskQueue] = None,
-        legacy_file_reader: Optional[LegacyFileReader] = None,
-        legacy_context_creator: Optional[LegacyContextCreator] = None,
-        legacy_executor: Optional[LegacyExecutor] = None,
+        python_protocol_file_reader: Optional[PythonProtocolFileReader] = None,
+        protocol_context_creator: Optional[ProtocolContextCreator] = None,
+        python_protocol_executor: Optional[PythonProtocolExecutor] = None,
         post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
         drop_tips_after_run: bool = True,
     ) -> None:
         """Initialize the PythonAndLegacyRunner with its dependencies."""
         super().__init__(protocol_engine)
         self._hardware_api = hardware_api
-        self._legacy_file_reader = legacy_file_reader or LegacyFileReader()
-        self._legacy_context_creator = legacy_context_creator or LegacyContextCreator(
-            hardware_api=hardware_api,
-            protocol_engine=protocol_engine,
+        self._protocol_file_reader = (
+            python_protocol_file_reader or PythonProtocolFileReader()
         )
-        self._legacy_executor = legacy_executor or LegacyExecutor()
+        self._protocol_context_creator = (
+            protocol_context_creator
+            or ProtocolContextCreator(
+                hardware_api=hardware_api,
+                protocol_engine=protocol_engine,
+            )
+        )
+        self._protocol_executor = python_protocol_executor or PythonProtocolExecutor()
         # TODO(mc, 2022-01-11): replace task queue with specific implementations
         # of runner interface
         self._task_queue = task_queue or TaskQueue()
@@ -185,7 +190,7 @@ class PythonAndLegacyRunner(AbstractRunner):
 
         # fixme(mm, 2022-12-23): This does I/O and compute-bound parsing that will block
         # the event loop. Jira RSS-165.
-        protocol = self._legacy_file_reader.read(
+        protocol = self._protocol_file_reader.read(
             protocol_source, labware_definitions, python_parse_mode
         )
         self._parameter_context = ParameterContext(api_version=protocol.api_level)
@@ -202,7 +207,7 @@ class PythonAndLegacyRunner(AbstractRunner):
         else:
             self._hardware_api.should_taskify_movement_execution(taskify=False)
 
-        context = self._legacy_context_creator.create(
+        context = self._protocol_context_creator.create(
             protocol=protocol,
             broker=self._broker,
             equipment_broker=equipment_broker,
@@ -216,7 +221,7 @@ class PythonAndLegacyRunner(AbstractRunner):
             await self._protocol_engine.add_and_execute_command(
                 request=initial_home_command
             )
-            await self._legacy_executor.execute(
+            await self._protocol_executor.execute(
                 protocol=protocol,
                 context=context,
                 parameter_context=self._parameter_context,
@@ -417,9 +422,9 @@ def create_protocol_runner(
     task_queue: Optional[TaskQueue] = None,
     json_file_reader: Optional[JsonFileReader] = None,
     json_translator: Optional[JsonTranslator] = None,
-    legacy_file_reader: Optional[LegacyFileReader] = None,
-    legacy_context_creator: Optional[LegacyContextCreator] = None,
-    legacy_executor: Optional[LegacyExecutor] = None,
+    python_protocol_file_reader: Optional[PythonProtocolFileReader] = None,
+    protocol_context_creator: Optional[ProtocolContextCreator] = None,
+    python_protocol_executor: Optional[PythonProtocolExecutor] = None,
     post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
     drop_tips_after_run: bool = True,
 ) -> AnyRunner:
@@ -443,9 +448,9 @@ def create_protocol_runner(
                 protocol_engine=protocol_engine,
                 hardware_api=hardware_api,
                 task_queue=task_queue,
-                legacy_file_reader=legacy_file_reader,
-                legacy_context_creator=legacy_context_creator,
-                legacy_executor=legacy_executor,
+                python_protocol_file_reader=python_protocol_file_reader,
+                protocol_context_creator=protocol_context_creator,
+                python_protocol_executor=python_protocol_executor,
                 post_run_hardware_state=post_run_hardware_state,
                 drop_tips_after_run=drop_tips_after_run,
             )

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -10,6 +10,7 @@ from opentrons.hardware_control import HardwareControlAPI
 from opentrons import protocol_reader
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.protocol_api import ParameterContext
+from opentrons.protocol_api.core.legacy.load_info import LoadInfo
 from opentrons.protocol_reader import (
     ProtocolSource,
     JsonProtocolConfig,
@@ -34,7 +35,6 @@ from .legacy_wrappers import (
     LegacyFileReader,
     LegacyContextCreator,
     LegacyExecutor,
-    LegacyLoadInfo,
 )
 from ..protocol_engine.errors import ProtocolCommandFailedError
 from ..protocol_engine.types import (
@@ -192,7 +192,7 @@ class PythonAndLegacyRunner(AbstractRunner):
         equipment_broker = None
 
         if protocol.api_level < LEGACY_PYTHON_API_VERSION_CUTOFF:
-            equipment_broker = Broker[LegacyLoadInfo]()
+            equipment_broker = Broker[LoadInfo]()
             self._protocol_engine.add_plugin(
                 LegacyContextPlugin(
                     broker=self._broker, equipment_broker=equipment_broker

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -32,7 +32,7 @@ from .legacy_context_plugin import LegacyContextPlugin
 from .python_protocol_wrappers import (
     LEGACY_PYTHON_API_VERSION_CUTOFF,
     LEGACY_JSON_SCHEMA_VERSION_CUTOFF,
-    PythonProtocolFileReader,
+    PythonAndLegacyFileReader,
     ProtocolContextCreator,
     PythonProtocolExecutor,
 )
@@ -136,7 +136,7 @@ class PythonAndLegacyRunner(AbstractRunner):
         protocol_engine: ProtocolEngine,
         hardware_api: HardwareControlAPI,
         task_queue: Optional[TaskQueue] = None,
-        python_protocol_file_reader: Optional[PythonProtocolFileReader] = None,
+        python_and_legacy_file_reader: Optional[PythonAndLegacyFileReader] = None,
         protocol_context_creator: Optional[ProtocolContextCreator] = None,
         python_protocol_executor: Optional[PythonProtocolExecutor] = None,
         post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
@@ -146,7 +146,7 @@ class PythonAndLegacyRunner(AbstractRunner):
         super().__init__(protocol_engine)
         self._hardware_api = hardware_api
         self._protocol_file_reader = (
-            python_protocol_file_reader or PythonProtocolFileReader()
+            python_and_legacy_file_reader or PythonAndLegacyFileReader()
         )
         self._protocol_context_creator = (
             protocol_context_creator
@@ -422,7 +422,7 @@ def create_protocol_runner(
     task_queue: Optional[TaskQueue] = None,
     json_file_reader: Optional[JsonFileReader] = None,
     json_translator: Optional[JsonTranslator] = None,
-    python_protocol_file_reader: Optional[PythonProtocolFileReader] = None,
+    python_and_legacy_file_reader: Optional[PythonAndLegacyFileReader] = None,
     protocol_context_creator: Optional[ProtocolContextCreator] = None,
     python_protocol_executor: Optional[PythonProtocolExecutor] = None,
     post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
@@ -448,7 +448,7 @@ def create_protocol_runner(
                 protocol_engine=protocol_engine,
                 hardware_api=hardware_api,
                 task_queue=task_queue,
-                python_protocol_file_reader=python_protocol_file_reader,
+                python_and_legacy_file_reader=python_and_legacy_file_reader,
                 protocol_context_creator=protocol_context_creator,
                 python_protocol_executor=python_protocol_executor,
                 post_run_hardware_state=post_run_hardware_state,

--- a/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
+++ b/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
@@ -44,7 +44,7 @@ LEGACY_PYTHON_API_VERSION_CUTOFF = ENGINE_CORE_API_VERSION
 LEGACY_JSON_SCHEMA_VERSION_CUTOFF = 6
 
 
-class PythonProtocolFileReader:
+class PythonAndLegacyFileReader:
     """Interface to read Protocol API v2 protocols prior to execution."""
 
     @staticmethod

--- a/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
+++ b/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
@@ -23,7 +23,7 @@ from opentrons.protocol_api import (
     create_protocol_context,
 )
 from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
-from opentrons.protocol_api.core.legacy.load_info import LoadInfo as LegacyLoadInfo
+from opentrons.protocol_api.core.legacy.load_info import LoadInfo
 
 from opentrons.protocols.parse import PythonParseMode, parse
 from opentrons.protocols.execution.execute import run_protocol
@@ -44,7 +44,7 @@ LEGACY_PYTHON_API_VERSION_CUTOFF = ENGINE_CORE_API_VERSION
 LEGACY_JSON_SCHEMA_VERSION_CUTOFF = 6
 
 
-class LegacyFileReader:
+class PythonProtocolFileReader:
     """Interface to read Protocol API v2 protocols prior to execution."""
 
     @staticmethod
@@ -81,7 +81,7 @@ class LegacyFileReader:
         )
 
 
-class LegacyContextCreator:
+class ProtocolContextCreator:
     """Interface to construct Protocol API v2 contexts."""
 
     _USE_SIMULATING_CORE = False
@@ -106,7 +106,7 @@ class LegacyContextCreator:
         self,
         protocol: Protocol,
         broker: Optional[LegacyBroker],
-        equipment_broker: Optional[Broker[LegacyLoadInfo]],
+        equipment_broker: Optional[Broker[LoadInfo]],
     ) -> ProtocolContext:
         """Create a Protocol API v2 context."""
         extra_labware = (
@@ -131,7 +131,7 @@ class LegacyContextCreator:
         )
 
 
-class LegacySimulatingContextCreator(LegacyContextCreator):
+class SimulatingContextCreator(ProtocolContextCreator):
     """Interface to construct PAPIv2 contexts using simulating implementations.
 
     Avoids some calls to the hardware API for performance.
@@ -141,7 +141,7 @@ class LegacySimulatingContextCreator(LegacyContextCreator):
     _USE_SIMULATING_CORE = True
 
 
-class LegacyExecutor:
+class PythonProtocolExecutor:
     """Interface to execute Protocol API v2 protocols in a child thread."""
 
     @staticmethod

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -10,9 +10,9 @@ from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.legacy_commands.types import CommentMessage, PauseMessage, CommandMessage
 from opentrons.protocol_api.core.legacy.load_info import (
-    LabwareLoadInfo,
-    InstrumentLoadInfo,
-    ModuleLoadInfo,
+    LabwareLoadInfo as LegacyLabwareLoadInfo,
+    InstrumentLoadInfo as LegacyInstrumentLoadInfo,
+    ModuleLoadInfo as LegacyModuleLoadInfo,
 )
 from opentrons.protocol_engine import (
     DeckSlotLocation,
@@ -270,7 +270,7 @@ def test_command_stack() -> None:
 
 def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     """It should correctly map a labware load."""
-    input = LabwareLoadInfo(
+    input = LegacyLabwareLoadInfo(
         labware_definition=minimal_labware_def,
         labware_namespace="some_namespace",
         labware_load_name="some_load_name",
@@ -334,7 +334,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
 def test_map_instrument_load(decoy: Decoy) -> None:
     """It should correctly map an instrument load."""
     pipette_dict = cast(PipetteDict, {"pipette_id": "fizzbuzz"})
-    input = InstrumentLoadInfo(
+    input = LegacyInstrumentLoadInfo(
         instrument_load_name="p1000_single_gen2",
         mount=Mount.LEFT,
         pipette_dict=pipette_dict,
@@ -395,7 +395,7 @@ def test_map_module_load(
 ) -> None:
     """It should correctly map a module load."""
     test_definition = ModuleDefinition.parse_obj(minimal_module_def)
-    input = ModuleLoadInfo(
+    input = LegacyModuleLoadInfo(
         requested_model=TemperatureModuleModel.TEMPERATURE_V1,
         loaded_model=TemperatureModuleModel.TEMPERATURE_V2,
         deck_slot=DeckSlotName.SLOT_1,
@@ -454,7 +454,7 @@ def test_map_module_load(
 
 def test_map_module_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     """It should correctly map a labware load on module."""
-    load_input = LabwareLoadInfo(
+    load_input = LegacyLabwareLoadInfo(
         labware_definition=minimal_labware_def,
         labware_namespace="some_namespace",
         labware_load_name="some_load_name",

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -7,7 +7,13 @@ import pytest
 from decoy import matchers, Decoy
 
 from opentrons.hardware_control.dev_types import PipetteDict
+from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.legacy_commands.types import CommentMessage, PauseMessage, CommandMessage
+from opentrons.protocol_api.core.legacy.load_info import (
+    LabwareLoadInfo,
+    InstrumentLoadInfo,
+    ModuleLoadInfo,
+)
 from opentrons.protocol_engine import (
     DeckSlotLocation,
     ModuleLocation,
@@ -28,12 +34,6 @@ from opentrons.protocol_runner.legacy_command_mapper import (
     LegacyContextCommandError,
     LegacyCommandMapper,
     LegacyCommandParams,
-)
-from opentrons.protocol_runner.legacy_wrappers import (
-    LegacyInstrumentLoadInfo,
-    LegacyLabwareLoadInfo,
-    LegacyModuleLoadInfo,
-    LegacyTemperatureModuleModel,
 )
 from opentrons_shared_data.labware.dev_types import LabwareDefinition
 from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
@@ -270,7 +270,7 @@ def test_command_stack() -> None:
 
 def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     """It should correctly map a labware load."""
-    input = LegacyLabwareLoadInfo(
+    input = LabwareLoadInfo(
         labware_definition=minimal_labware_def,
         labware_namespace="some_namespace",
         labware_load_name="some_load_name",
@@ -334,7 +334,7 @@ def test_map_labware_load(minimal_labware_def: LabwareDefinition) -> None:
 def test_map_instrument_load(decoy: Decoy) -> None:
     """It should correctly map an instrument load."""
     pipette_dict = cast(PipetteDict, {"pipette_id": "fizzbuzz"})
-    input = LegacyInstrumentLoadInfo(
+    input = InstrumentLoadInfo(
         instrument_load_name="p1000_single_gen2",
         mount=Mount.LEFT,
         pipette_dict=pipette_dict,
@@ -395,9 +395,9 @@ def test_map_module_load(
 ) -> None:
     """It should correctly map a module load."""
     test_definition = ModuleDefinition.parse_obj(minimal_module_def)
-    input = LegacyModuleLoadInfo(
-        requested_model=LegacyTemperatureModuleModel.TEMPERATURE_V1,
-        loaded_model=LegacyTemperatureModuleModel.TEMPERATURE_V2,
+    input = ModuleLoadInfo(
+        requested_model=TemperatureModuleModel.TEMPERATURE_V1,
+        loaded_model=TemperatureModuleModel.TEMPERATURE_V2,
         deck_slot=DeckSlotName.SLOT_1,
         configuration="conf",
         module_serial="module-serial",
@@ -454,7 +454,7 @@ def test_map_module_load(
 
 def test_map_module_labware_load(minimal_labware_def: LabwareDefinition) -> None:
     """It should correctly map a labware load on module."""
-    load_input = LegacyLabwareLoadInfo(
+    load_input = LabwareLoadInfo(
         labware_definition=minimal_labware_def,
         labware_namespace="some_namespace",
         labware_load_name="some_load_name",

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -17,12 +17,10 @@ from opentrons.protocol_engine import (
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.util.broker import ReadOnlyBroker
 
+from opentrons.protocol_api.core.legacy.load_info import LoadInfo, LabwareLoadInfo
+
 from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandMapper
 from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
-from opentrons.protocol_runner.legacy_wrappers import (
-    LegacyLoadInfo,
-    LegacyLabwareLoadInfo,
-)
 
 from opentrons.types import DeckSlotName
 
@@ -38,9 +36,9 @@ def mock_legacy_broker(decoy: Decoy) -> LegacyBroker:
 
 
 @pytest.fixture
-def mock_equipment_broker(decoy: Decoy) -> ReadOnlyBroker[LegacyLoadInfo]:
+def mock_equipment_broker(decoy: Decoy) -> ReadOnlyBroker[LoadInfo]:
     """Get a mocked out `equipment_broker: Broker` dependency."""
-    return decoy.mock(cls=ReadOnlyBroker[LegacyLoadInfo])
+    return decoy.mock(cls=ReadOnlyBroker[LoadInfo])
 
 
 @pytest.fixture
@@ -64,7 +62,7 @@ def mock_action_dispatcher(decoy: Decoy) -> pe_actions.ActionDispatcher:
 @pytest.fixture
 def subject(
     mock_legacy_broker: LegacyBroker,
-    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LoadInfo],
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_state_view: StateView,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
@@ -92,7 +90,7 @@ class _ContextManager:
 async def test_broker_subscribe_unsubscribe(
     decoy: Decoy,
     mock_legacy_broker: LegacyBroker,
-    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LoadInfo],
     subject: LegacyContextPlugin,
 ) -> None:
     """It should subscribe to the brokers on setup and unsubscribe on teardown."""
@@ -125,7 +123,7 @@ async def test_broker_subscribe_unsubscribe(
 async def test_command_broker_messages(
     decoy: Decoy,
     mock_legacy_broker: LegacyBroker,
-    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LoadInfo],
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
     subject: LegacyContextPlugin,
@@ -181,7 +179,7 @@ async def test_command_broker_messages(
 async def test_equipment_broker_messages(
     decoy: Decoy,
     mock_legacy_broker: LegacyBroker,
-    mock_equipment_broker: ReadOnlyBroker[LegacyLoadInfo],
+    mock_equipment_broker: ReadOnlyBroker[LoadInfo],
     mock_legacy_command_mapper: LegacyCommandMapper,
     mock_action_dispatcher: pe_actions.ActionDispatcher,
     subject: LegacyContextPlugin,
@@ -199,9 +197,9 @@ async def test_equipment_broker_messages(
 
     subject.setup()
 
-    handler: Callable[[LegacyLabwareLoadInfo], None] = labware_handler_captor.value
+    handler: Callable[[LabwareLoadInfo], None] = labware_handler_captor.value
 
-    load_info = LegacyLabwareLoadInfo(
+    load_info = LabwareLoadInfo(
         labware_definition=minimal_labware_def,
         labware_namespace="some_namespace",
         labware_load_name="some_load_name",

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -48,7 +48,7 @@ from opentrons.protocol_runner.json_file_reader import JsonFileReader
 from opentrons.protocol_runner.json_translator import JsonTranslator
 from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 from opentrons.protocol_runner.python_protocol_wrappers import (
-    PythonProtocolFileReader,
+    PythonAndLegacyFileReader,
     ProtocolContextCreator,
     PythonProtocolExecutor,
 )
@@ -85,9 +85,9 @@ def json_translator(decoy: Decoy) -> JsonTranslator:
 
 
 @pytest.fixture
-def python_protocol_file_reader(decoy: Decoy) -> PythonProtocolFileReader:
-    """Get a mocked out PythonProtocolFileReader dependency."""
-    return decoy.mock(cls=PythonProtocolFileReader)
+def python_and_legacy_file_reader(decoy: Decoy) -> PythonAndLegacyFileReader:
+    """Get a mocked out PythonAndLegacyFileReader dependency."""
+    return decoy.mock(cls=PythonAndLegacyFileReader)
 
 
 @pytest.fixture
@@ -137,7 +137,7 @@ def python_runner_subject(
     protocol_engine: ProtocolEngine,
     hardware_api: HardwareAPI,
     task_queue: TaskQueue,
-    python_protocol_file_reader: PythonProtocolFileReader,
+    python_and_legacy_file_reader: PythonAndLegacyFileReader,
     protocol_context_creator: ProtocolContextCreator,
     python_protocol_executor: PythonProtocolExecutor,
 ) -> PythonAndLegacyRunner:
@@ -146,7 +146,7 @@ def python_runner_subject(
         protocol_engine=protocol_engine,
         hardware_api=hardware_api,
         task_queue=task_queue,
-        python_protocol_file_reader=python_protocol_file_reader,
+        python_and_legacy_file_reader=python_and_legacy_file_reader,
         protocol_context_creator=protocol_context_creator,
         python_protocol_executor=python_protocol_executor,
     )
@@ -183,7 +183,7 @@ def test_create_protocol_runner(
     task_queue: TaskQueue,
     json_file_reader: JsonFileReader,
     json_translator: JsonTranslator,
-    python_protocol_file_reader: PythonProtocolFileReader,
+    python_and_legacy_file_reader: PythonAndLegacyFileReader,
     protocol_context_creator: ProtocolContextCreator,
     python_protocol_executor: PythonProtocolExecutor,
     config: Optional[Union[JsonProtocolConfig, PythonProtocolConfig]],
@@ -522,7 +522,7 @@ async def test_load_json_runner(
 
 async def test_load_legacy_python(
     decoy: Decoy,
-    python_protocol_file_reader: PythonProtocolFileReader,
+    python_and_legacy_file_reader: PythonAndLegacyFileReader,
     protocol_context_creator: ProtocolContextCreator,
     python_protocol_executor: PythonProtocolExecutor,
     task_queue: TaskQueue,
@@ -563,7 +563,7 @@ async def test_load_legacy_python(
         await protocol_reader.extract_labware_definitions(legacy_protocol_source)
     ).then_return([labware_definition])
     decoy.when(
-        python_protocol_file_reader.read(
+        python_and_legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[labware_definition],
             python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
@@ -612,7 +612,7 @@ async def test_load_legacy_python(
 
 async def test_load_python_with_pe_papi_core(
     decoy: Decoy,
-    python_protocol_file_reader: PythonProtocolFileReader,
+    python_and_legacy_file_reader: PythonAndLegacyFileReader,
     protocol_context_creator: ProtocolContextCreator,
     protocol_engine: ProtocolEngine,
     python_runner_subject: PythonAndLegacyRunner,
@@ -647,7 +647,7 @@ async def test_load_python_with_pe_papi_core(
         await protocol_reader.extract_labware_definitions(protocol_source)
     ).then_return([])
     decoy.when(
-        python_protocol_file_reader.read(
+        python_and_legacy_file_reader.read(
             protocol_source=protocol_source,
             labware_definitions=[],
             python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
@@ -672,7 +672,7 @@ async def test_load_python_with_pe_papi_core(
 
 async def test_load_legacy_json(
     decoy: Decoy,
-    python_protocol_file_reader: PythonProtocolFileReader,
+    python_and_legacy_file_reader: PythonAndLegacyFileReader,
     protocol_context_creator: ProtocolContextCreator,
     python_protocol_executor: PythonProtocolExecutor,
     task_queue: TaskQueue,
@@ -708,7 +708,7 @@ async def test_load_legacy_json(
         await protocol_reader.extract_labware_definitions(legacy_protocol_source)
     ).then_return([labware_definition])
     decoy.when(
-        python_protocol_file_reader.read(
+        python_and_legacy_file_reader.read(
             protocol_source=legacy_protocol_source,
             labware_definitions=[labware_definition],
             python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -8,15 +8,20 @@ from pathlib import Path
 from typing import List, cast, Optional, Union, Type
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+from opentrons_shared_data.labware.dev_types import (
+    LabwareDefinition as LabwareDefinitionTypedDict,
+)
 from opentrons_shared_data.protocol.models import ProtocolSchemaV6, ProtocolSchemaV7
 from opentrons_shared_data.protocol.dev_types import (
     JsonProtocol as LegacyJsonProtocolDict,
 )
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.legacy_broker import LegacyBroker
+from opentrons.protocol_api import ProtocolContext
 from opentrons.protocol_engine.types import PostRunHardwareState
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.parse import PythonParseMode
+from opentrons.protocols.types import PythonProtocol, JsonProtocol
 from opentrons.util.broker import Broker
 
 from opentrons import protocol_reader
@@ -46,10 +51,6 @@ from opentrons.protocol_runner.legacy_wrappers import (
     LegacyFileReader,
     LegacyContextCreator,
     LegacyExecutor,
-    LegacyPythonProtocol,
-    LegacyJsonProtocol,
-    LegacyProtocolContext,
-    LegacyLabwareDefinition,
 )
 
 
@@ -541,9 +542,9 @@ async def test_load_legacy_python(
         content_hash="abc123",
     )
 
-    extra_labware = {"definition-uri": cast(LegacyLabwareDefinition, {})}
+    extra_labware = {"definition-uri": cast(LabwareDefinitionTypedDict, {})}
 
-    legacy_protocol = LegacyPythonProtocol(
+    legacy_protocol = PythonProtocol(
         text="",
         contents="",
         filename="protocol.py",
@@ -556,7 +557,7 @@ async def test_load_legacy_python(
         extra_labware=extra_labware,
     )
 
-    legacy_context = decoy.mock(cls=LegacyProtocolContext)
+    legacy_context = decoy.mock(cls=ProtocolContext)
 
     decoy.when(
         await protocol_reader.extract_labware_definitions(legacy_protocol_source)
@@ -627,7 +628,7 @@ async def test_load_python_with_pe_papi_core(
         content_hash="abc123",
     )
 
-    legacy_protocol = LegacyPythonProtocol(
+    legacy_protocol = PythonProtocol(
         text="",
         contents="",
         filename="protocol.py",
@@ -640,7 +641,7 @@ async def test_load_python_with_pe_papi_core(
         extra_labware=None,
     )
 
-    legacy_context = decoy.mock(cls=LegacyProtocolContext)
+    legacy_context = decoy.mock(cls=ProtocolContext)
 
     decoy.when(
         await protocol_reader.extract_labware_definitions(legacy_protocol_source)
@@ -691,7 +692,7 @@ async def test_load_legacy_json(
         content_hash="abc123",
     )
 
-    legacy_protocol = LegacyJsonProtocol(
+    legacy_protocol = JsonProtocol(
         text="{}",
         contents=cast(LegacyJsonProtocolDict, {}),
         filename="protocol.json",
@@ -701,7 +702,7 @@ async def test_load_legacy_json(
         metadata={"protocolName": "A Very Impressive Protocol"},
     )
 
-    legacy_context = decoy.mock(cls=LegacyProtocolContext)
+    legacy_context = decoy.mock(cls=ProtocolContext)
 
     decoy.when(
         await protocol_reader.extract_labware_definitions(legacy_protocol_source)

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -133,7 +133,7 @@ def json_runner_subject(
 
 
 @pytest.fixture
-def legacy_python_runner_subject(
+def python_runner_subject(
     protocol_engine: ProtocolEngine,
     hardware_api: HardwareAPI,
     task_queue: TaskQueue,
@@ -207,7 +207,7 @@ def test_create_protocol_runner(
     "subject",
     [
         (lazy_fixture("json_runner_subject")),
-        (lazy_fixture("legacy_python_runner_subject")),
+        (lazy_fixture("python_runner_subject")),
         (lazy_fixture("live_runner_subject")),
     ],
 )
@@ -227,7 +227,7 @@ def test_play_starts_run(
     "subject",
     [
         (lazy_fixture("json_runner_subject")),
-        (lazy_fixture("legacy_python_runner_subject")),
+        (lazy_fixture("python_runner_subject")),
         (lazy_fixture("live_runner_subject")),
     ],
 )
@@ -246,7 +246,7 @@ def test_pause(
     "subject",
     [
         (lazy_fixture("json_runner_subject")),
-        (lazy_fixture("legacy_python_runner_subject")),
+        (lazy_fixture("python_runner_subject")),
         (lazy_fixture("live_runner_subject")),
     ],
 )
@@ -269,7 +269,7 @@ async def test_stop(
     "subject",
     [
         (lazy_fixture("json_runner_subject")),
-        (lazy_fixture("legacy_python_runner_subject")),
+        (lazy_fixture("python_runner_subject")),
         (lazy_fixture("live_runner_subject")),
     ],
 )
@@ -298,7 +298,7 @@ async def test_stop_when_run_never_started(
     "subject",
     [
         (lazy_fixture("json_runner_subject")),
-        (lazy_fixture("legacy_python_runner_subject")),
+        (lazy_fixture("python_runner_subject")),
         (lazy_fixture("live_runner_subject")),
     ],
 )
@@ -527,7 +527,7 @@ async def test_load_legacy_python(
     python_protocol_executor: PythonProtocolExecutor,
     task_queue: TaskQueue,
     protocol_engine: ProtocolEngine,
-    legacy_python_runner_subject: PythonAndLegacyRunner,
+    python_runner_subject: PythonAndLegacyRunner,
 ) -> None:
     """It should load a legacy context-based Python protocol."""
     labware_definition = LabwareDefinition.construct()  # type: ignore[call-arg]
@@ -578,7 +578,7 @@ async def test_load_legacy_python(
         )
     ).then_return(protocol_context)
 
-    await legacy_python_runner_subject.load(
+    await python_runner_subject.load(
         legacy_protocol_source,
         python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         run_time_param_values=None,
@@ -592,7 +592,7 @@ async def test_load_legacy_python(
         task_queue.set_run_func(run_func_captor),
     )
 
-    assert broker_captor.value is legacy_python_runner_subject.broker
+    assert broker_captor.value is python_runner_subject.broker
 
     # Verify that the run func calls the right things:
     run_func = run_func_captor.value
@@ -604,7 +604,7 @@ async def test_load_legacy_python(
         await python_protocol_executor.execute(
             protocol=legacy_protocol,
             context=protocol_context,
-            parameter_context=legacy_python_runner_subject._parameter_context,
+            parameter_context=python_runner_subject._parameter_context,
             run_time_param_values=None,
         ),
     )
@@ -615,7 +615,7 @@ async def test_load_python_with_pe_papi_core(
     python_protocol_file_reader: PythonProtocolFileReader,
     protocol_context_creator: ProtocolContextCreator,
     protocol_engine: ProtocolEngine,
-    legacy_python_runner_subject: PythonAndLegacyRunner,
+    python_runner_subject: PythonAndLegacyRunner,
 ) -> None:
     """It should load a legacy context-based Python protocol."""
     protocol_source = ProtocolSource(
@@ -660,14 +660,14 @@ async def test_load_python_with_pe_papi_core(
         )
     ).then_return(protocol_context)
 
-    await legacy_python_runner_subject.load(
+    await python_runner_subject.load(
         protocol_source,
         python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         run_time_param_values=None,
     )
 
     decoy.verify(protocol_engine.add_plugin(matchers.IsA(LegacyContextPlugin)), times=0)
-    assert broker_captor.value is legacy_python_runner_subject.broker
+    assert broker_captor.value is python_runner_subject.broker
 
 
 async def test_load_legacy_json(
@@ -677,7 +677,7 @@ async def test_load_legacy_json(
     python_protocol_executor: PythonProtocolExecutor,
     task_queue: TaskQueue,
     protocol_engine: ProtocolEngine,
-    legacy_python_runner_subject: PythonAndLegacyRunner,
+    python_runner_subject: PythonAndLegacyRunner,
 ) -> None:
     """It should load a legacy context-based JSON protocol."""
     labware_definition = LabwareDefinition.construct()  # type: ignore[call-arg]
@@ -722,7 +722,7 @@ async def test_load_legacy_json(
         )
     ).then_return(protocol_context)
 
-    await legacy_python_runner_subject.load(
+    await python_runner_subject.load(
         legacy_protocol_source,
         python_parse_mode=PythonParseMode.ALLOW_LEGACY_METADATA_AND_REQUIREMENTS,
         run_time_param_values=None,
@@ -746,7 +746,7 @@ async def test_load_legacy_json(
         await python_protocol_executor.execute(
             protocol=legacy_protocol,
             context=protocol_context,
-            parameter_context=legacy_python_runner_subject._parameter_context,
+            parameter_context=python_runner_subject._parameter_context,
             run_time_param_values=None,
         ),
     )
@@ -757,16 +757,16 @@ async def test_run_python_runner(
     hardware_api: HardwareAPI,
     protocol_engine: ProtocolEngine,
     task_queue: TaskQueue,
-    legacy_python_runner_subject: PythonAndLegacyRunner,
+    python_runner_subject: PythonAndLegacyRunner,
 ) -> None:
     """It should run a protocol to completion."""
     decoy.when(protocol_engine.state_view.commands.has_been_played()).then_return(
         False, True
     )
 
-    assert legacy_python_runner_subject.was_started() is False
-    await legacy_python_runner_subject.run(deck_configuration=[])
-    assert legacy_python_runner_subject.was_started() is True
+    assert python_runner_subject.was_started() is False
+    await python_runner_subject.run(deck_configuration=[])
+    assert python_runner_subject.was_started() is True
 
     decoy.verify(
         protocol_engine.play(deck_configuration=[]),


### PR DESCRIPTION
# Overview

Sometime ago, a number of classes in our `protocol_runner` folder were marked as legacy with the thought that we'd move to a new major API version and those would no longer be the actively developed parts of our protocol reading and execution.

However this proved not to be the cases, and for the past couple years these have continued to be marked as legacy despite the fact that they are being actively used now and for the foreseeable future. Furthermore, there are a number of folders, classes and variables that are marked legacy which _are_ actually legacy parts of our system, further increasing confusion of what is current and what is deprecated/no longer in active development.

This PR renames everything in the `protocol_runner` that was prematurely marked as legacy, and additionally gets rid of a bunch of re-exports that were further naming things that are no longer legacy.

# Test Plan

Pure refactor PR, so existing unit and integration tests cover everything.

# Changelog

- a bunch of internal renaming, but the most outward facing changes are renaming `legacy_wrappers.py` to `python_protocol_wrappers.py`, `LegacyFileReader` to `PythonProtocolFileReader`, `LegacyContextCreator` to `ProtocolContextCreator`, and `LegacyExecutor` to `PythonProtocolExecutor`

# Review requests

Is there anything I either missed or incorrectly labelled as no longer legacy but which in fact is. I also removed the export renaming of `LoadInfo` since the fact that it's legacy is shown by the fact its in the correctly named `legacy` folder of `protocol_api`, but if this is a step too far I can revert those changes.

# Risk assessment

Low, refactor only PR.