### PR TITLE
fix(step-generation): liquidState tracking for 96-channel column pickup

### DIFF
--- a/step-generation/src/__tests__/dispenseUpdateLiquidState.test.ts
+++ b/step-generation/src/__tests__/dispenseUpdateLiquidState.test.ts
@@ -8,7 +8,12 @@ import merge from 'lodash/merge'
 import omit from 'lodash/omit'
 import produce from 'immer'
 import { createEmptyLiquidState, createTipLiquidState } from '../utils'
-import { makeContext, DEFAULT_PIPETTE, SOURCE_LABWARE } from '../fixtures'
+import {
+  makeContext,
+  DEFAULT_PIPETTE,
+  SOURCE_LABWARE,
+  getInitialRobotStateStandard,
+} from '../fixtures'
 
 import {
   dispenseUpdateLiquidState,
@@ -33,6 +38,10 @@ beforeEach(() => {
     useFullVolume: false,
     labwareId: SOURCE_LABWARE,
     wellName: 'A1',
+    robotStateAndWarnings: {
+      robotState: getInitialRobotStateStandard(invariantContext),
+      warnings: [],
+    },
   }
 })
 
@@ -396,6 +405,10 @@ describe('...8-channel pipette', () => {
             useFullVolume: false,
             volume: 150,
             wellName: 'A1',
+            robotStateAndWarnings: {
+              robotState: getInitialRobotStateStandard(invariantContext),
+              warnings: [],
+            },
           },
           initialLiquidState
         )

--- a/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/dispenseUpdateLiquidState.ts
@@ -1,5 +1,6 @@
 import mapValues from 'lodash/mapValues'
 import reduce from 'lodash/reduce'
+import { COLUMN } from '@opentrons/shared-data'
 import {
   splitLiquid,
   mergeLiquid,
@@ -13,7 +14,7 @@ import type {
   SourceAndDest,
   RobotStateAndWarnings,
 } from '../types'
-import { COLUMN } from '@opentrons/shared-data'
+
 type LiquidState = RobotState['liquidState']
 export interface DispenseUpdateLiquidStateArgs {
   invariantContext: InvariantContext

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import range from 'lodash/range'
 import isEmpty from 'lodash/isEmpty'
 import uniq from 'lodash/uniq'
@@ -32,7 +31,7 @@ export function forAspirate(
     params.wellName
   )
 
-  assert(
+  console.assert(
     // @ts-expect-error (sa, 2021-05-03): this assert is unnecessary
     uniq(wellsForTips).length === allWellsShared ? 1 : wellsForTips.length,
     `expected all wells to be shared, or no wells to be shared. Got: ${JSON.stringify(

--- a/step-generation/src/getNextRobotStateAndWarnings/forBlowout.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forBlowout.ts
@@ -15,5 +15,6 @@ export function forBlowout(
     wellName,
     prevLiquidState: robotState.liquidState,
     invariantContext,
+    robotStateAndWarnings,
   })
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDispense.ts
@@ -16,5 +16,6 @@ export function forDispense(
     useFullVolume: false,
     volume,
     wellName,
+    robotStateAndWarnings,
   })
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -20,6 +20,7 @@ export function forDropTip(
     labwareId,
     useFullVolume: true,
     wellName,
+    robotStateAndWarnings,
   })
   robotState.tipState.pipettes[pipetteId] = false
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/inPlaceCommandUpdates.ts
@@ -27,6 +27,7 @@ export const forDispenseInPlace = (
     prevLiquidState: robotState.liquidState,
     useFullVolume: false,
     volume,
+    robotStateAndWarnings,
   })
 }
 
@@ -42,6 +43,7 @@ export const forBlowOutInPlace = (
     pipetteId,
     prevLiquidState: robotState.liquidState,
     useFullVolume: true,
+    robotStateAndWarnings,
   })
 }
 
@@ -59,5 +61,6 @@ export const forDropTipInPlace = (
     prevLiquidState: robotState.liquidState,
     pipetteId,
     useFullVolume: true,
+    robotStateAndWarnings,
   })
 }


### PR DESCRIPTION
closes RESC-246 AUTH-373

# Overview

This PR fixes a bug in the liquid state tracking specifically for using a 96-channel column partial tip configuration. The bug was that I forgot to consider partial tip for the 96-channel in the liquid state tracking all together so the protocol in the RESC ticket was tracking liquids as if all 96 nozzles were being used instead of 1 column

# Test Plan

Upload the protocol attached to the RESC ticket on edge. The last transfer step should have a "not enough liquid in wells" warning. Upload the same protocol on this branch. The last transfer step should NOT have a "not enough liquid in wells" warning.

# Changelog

- update the dispense update liquid state component to grab the pipette's nozzle configuration. If nozzles is column then the channels is 8 instead of 96
- fix the test
- extend props to include the robot state and warnings and update all affected components

# Review requests

see test plan

# Risk assessment

low