### PR TITLE
fix(app): update specific analysis keys passed through CommandText with terminal run record

### DIFF
--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -83,7 +83,11 @@ export const RunPreviewComponent = (
       ? nullCheckedCommandsFromQuery
       : robotSideAnalysis.commands) ?? []
   // pass relevant data from run rather than analysis so that CommandText utilities can properly hash the entities' IDs
-  const analysis =
+  // TODO (nd:05/02/2024): update name and types for CommandText (and children/utilities) use of analysis. These children
+  // and utilities need only a subset of data provided by analysis, and there should be an overlap of these required data
+  // between a completed analysis and a run record, so we shouldn't pass down a franken-analysis, but rather a new interface
+  // with just the required data coming from the analysis OR the run.
+  const protocolDataFromAnalysisOrRun =
     isRunTerminal && runRecord?.data != null
       ? {
           ...robotSideAnalysis,
@@ -171,7 +175,7 @@ export const RunPreviewComponent = (
                   <CommandIcon command={command} color={iconColor} />
                   <CommandText
                     command={command}
-                    robotSideAnalysis={analysis}
+                    robotSideAnalysis={protocolDataFromAnalysisOrRun}
                     robotType={robotType}
                     color={COLORS.black90}
                   />

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -83,10 +83,8 @@ export const RunPreviewComponent = (
       ? nullCheckedCommandsFromQuery
       : robotSideAnalysis.commands) ?? []
   // pass relevant data from run rather than analysis so that CommandText utilities can properly hash the entities' IDs
-  // TODO (nd:05/02/2024): update name and types for CommandText (and children/utilities) use of analysis. These children
-  // and utilities need only a subset of data provided by analysis, and there should be an overlap of these required data
-  // between a completed analysis and a run record, so we shouldn't pass down a franken-analysis, but rather a new interface
-  // with just the required data coming from the analysis OR the run.
+  // TODO (nd:05/02/2024, AUTH-380): update name and types for CommandText (and children/utilities) use of analysis.
+  // We should ideally pass only subset of analysis/run data required by these children and utilities
   const protocolDataFromAnalysisOrRun =
     isRunTerminal && runRecord?.data != null
       ? {

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -18,12 +18,12 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useRunQuery } from '@opentrons/react-api-client'
 
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import {
   useNotifyLastRunCommand,
   useNotifyAllCommandsAsPreSerializedList,
+  useNotifyRunQuery,
 } from '../../resources/runs'
 import { CommandText } from '../CommandText'
 import { Divider } from '../../atoms/structure'
@@ -52,7 +52,7 @@ export const RunPreviewComponent = (
   const { t } = useTranslation('run_details')
   const robotSideAnalysis = useMostRecentCompletedAnalysis(runId)
   const runStatus = useRunStatus(runId)
-  const { data: runRecord } = useRunQuery(runId)
+  const { data: runRecord } = useNotifyRunQuery(runId)
   const isRunTerminal =
     runStatus != null
       ? (RUN_STATUSES_TERMINAL as RunStatus[]).includes(runStatus)


### PR DESCRIPTION
closes [RQA-2645](https://opentrons.atlassian.net/browse/RQA-2645)
closes [RQA-2647](https://opentrons.atlassian.net/browse/RQA-2647)

# Overview

We now grab commands for terminal runs from the run record rather than the most recent completed analysis to give a more accurate representation of the commands actually executed during a run. However, this introduced some unintended downstream bugs in `CommandText` and its utilities for hashing commands by labware, pipette, and module IDs— the run commands' IDs no longer match those contained in the analysis's labware, pipette, and module values.

To address this, here, I overwrite those properties in the robot-side analysis that is passed to `CommandText` and all of its children/utilities so that the command param IDs can be properly hashed.

# Test Plan

- run a protocol, like flex_MOAM_218.py linked [here](https://opentrons.atlassian.net/browse/RQA-2645)
- observe that the running protocol command text is formatted properly
- allow the run to finish or cancel the run
- observe that the terminal protocol commands go only up to the last command actually executed, and the text formatted properly, including all labware display names and locations

# Changelog

- overwrite labware, modules, and pipettes data on analysis if run is terminal and run record data is not null

# Review requests

@shlokamin per working on previous fix

# Risk assessment

medium

[RQA-2645]: https://opentrons.atlassian.net/browse/RQA-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2647]: https://opentrons.atlassian.net/browse/RQA-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ