### PR TITLE
refactor(app): format <ul> in release notes

### DIFF
--- a/app/src/molecules/ReleaseNotes/styles.module.css
+++ b/app/src/molecules/ReleaseNotes/styles.module.css
@@ -38,6 +38,8 @@
 
   & li {
     margin: 0.25rem 0;
+    font-size: var(--fs-body-2);
+    color: var(--c-font-dark); /* from legacy --font-body-2-dark */
   }
 
   & code {

--- a/app/src/molecules/ReleaseNotes/styles.module.css
+++ b/app/src/molecules/ReleaseNotes/styles.module.css
@@ -32,6 +32,8 @@
   & ol {
     margin-left: 1.25rem;
     margin-bottom: 0.25rem;
+    font-size: var(--fs-body-2);
+    color: var(--c-font-dark); /* from legacy --font-body-2-dark */
   }
 
   & li {


### PR DESCRIPTION
Closes [RQA-2674](https://opentrons.atlassian.net/browse/RQA-2674)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We recently migrated our .md renderer and tweaked some of the HTML tags. `<ul>`s didn't have the appropriate font and color applied, so let's add that. I've confirmed with @ecormany and Sue that this is what we want!

### Current Behavior

<img width="536" alt="image-20240502-144058" src="https://github.com/Opentrons/opentrons/assets/64858653/2ea1e344-3ce6-4d0b-a9f6-8d03d26861c3">

### Fixed Behavior

<img width="502" alt="Screenshot 2024-05-02 at 4 48 31 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/5b02cda6-2bd9-406b-9714-a574cbca8fbb">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Build a local version of the app `make -C app-shell dist-osx` or equivalent. 
- Run the local version, usually in the `app-shell/dist/` directory.
- Open the update modal for a robot and verify the release notes `<ul>`s are styled appropriately.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2674]: https://opentrons.atlassian.net/browse/RQA-2674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ