### PR TITLE
chore(api-client): run api-client tests in ci

### DIFF
--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -59,8 +59,8 @@ jobs:
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
           make setup-js
-      - name: 'run react-api-client unit tests'
-        run: make -C react-api-client test-cov
+      - name: 'run api-client unit tests'
+        run: make -C api-client test-cov
       - name: 'Upload coverage report'
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   js-unit-test:
-    name: 'react-api-client unit tests'
+    name: 'api-client and react-api-client unit tests'
     timeout-minutes: 30
     runs-on: 'ubuntu-22.04'
     steps:
@@ -59,7 +59,7 @@ jobs:
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
           make setup-js
-      - name: 'run api-client unit tests'
+      - name: 'run api-client and react-api-client unit tests'
         run: make -C api-client test-cov
       - name: 'Upload coverage report'
         uses: codecov/codecov-action@v3

--- a/api-client/Makefile
+++ b/api-client/Makefile
@@ -4,6 +4,12 @@
 # TODO(mc, 2021-02-12): this may be unnecessary by using `yarn run` instead
 SHELL := bash
 
+# These variables can be overriden when make is invoked to customize the
+# behavior of jest
+tests ?=
+cov_opts ?= --coverage=true
+test_opts ?=
+
 # standard targets
 #####################################################################
 
@@ -20,4 +26,8 @@ build:
 
 .PHONY: test
 test:
-	$(MAKE) -C .. test-js-api-client
+	$(MAKE) -C .. test-js-api-client tests="$(tests)" test_opts="$(test_opts)"
+
+.PHONY: test-cov
+test-cov:
+	make -C .. test-js-api-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"


### PR DESCRIPTION
# Overview

we haven't been running (the minimal) api-client tests in CI. this changes that. `make -C api-client test` runs both api-client and react-api-client tests.

# Test Plan

verified that api-client tests are running in CI

# Changelog

 - Changes workflow to run api-client tests in CI

# Review requests

check that api-client tests are running in CI

# Risk assessment

low
