### PR TITLE
fix(step-generation): account for adapter in 4th column slot timeline error

### DIFF
--- a/protocol-designer/src/load-file/migration/8_1_0.ts
+++ b/protocol-designer/src/load-file/migration/8_1_0.ts
@@ -89,10 +89,9 @@ export const migrateFile = (
       const matchingTiprackCommand = tiprackLoadCommands.find(
         command => command.params.labwareId === item.tipRack
       )
-
       if (matchingTiprackCommand == null) {
         console.error(
-          `expected to find a tiprack loadname from tiprack ${item.tiprack} but could not `
+          `expected to find a tiprack loadname from tiprack ${item.tipRack} but could not `
         )
       }
       const matchingTiprackURI =

--- a/protocol-designer/src/load-file/migration/utils/getDefaultBlowoutFlowRate.ts
+++ b/protocol-designer/src/load-file/migration/utils/getDefaultBlowoutFlowRate.ts
@@ -31,6 +31,6 @@ export function getDefaultBlowoutFlowRate(
     matchingTipLiquidSpecs,
     `expected to find the tip liquid specs but could not with pipetteName ${pipetteName}`
   )
-  console.log(pipetteName, volume, tipLength)
+
   return matchingTipLiquidSpecs.defaultBlowOutFlowRate.default
 }

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1381,11 +1381,13 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
         ]),
       ]
 
-      const unoccupiedSlotForMovableTrash = getUnoccupiedSlotForMoveableTrash(
-        file,
-        hasWasteChuteCommands,
-        stagingAreaSlotNames
-      )
+      const unoccupiedSlotForMovableTrash = hasWasteChuteCommands
+        ? ''
+        : getUnoccupiedSlotForMoveableTrash(
+            file,
+            hasWasteChuteCommands,
+            stagingAreaSlotNames
+          )
 
       const stagingAreas = stagingAreaSlotNames.reduce((acc, slot) => {
         const stagingAreaId = `${uuid()}:stagingArea`
@@ -1460,7 +1462,6 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
       } else if (mixStepTrashBin != null) {
         trashBinId = mixStepTrashBin.dropTip_location
       }
-
       const trashCutoutId =
         trashAddressableAreaName != null
           ? getCutoutIdByAddressableArea(
@@ -1557,14 +1558,15 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
         [hardcodedTrashBinIdFlex]: {
           name: 'trashBin' as const,
           id: hardcodedTrashBinIdFlex,
-          location: getCutoutIdByAddressableArea(
-            hardcodedTrashAddressableAreaName as AddressableAreaName,
-            'trashBinAdapter',
-            FLEX_ROBOT_TYPE
-          ),
+          location: hasWasteChuteCommands
+            ? ''
+            : getCutoutIdByAddressableArea(
+                hardcodedTrashAddressableAreaName as AddressableAreaName,
+                'trashBinAdapter',
+                FLEX_ROBOT_TYPE
+              ),
         },
       }
-
       if (isFlex) {
         if (trashBin != null) {
           return {

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -41,6 +41,7 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
     yOffset,
   } = args
   const actionName = 'aspirate'
+  const labwareState = prevRobotState.labware
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
   const isFlexPipette =
@@ -75,6 +76,13 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
 
   if (COLUMN_4_SLOTS.includes(slotName)) {
     errors.push(errorCreators.pipettingIntoColumn4({ typeOfStep: actionName }))
+  } else if (labwareState[slotName] != null) {
+    const adapterSlot = labwareState[slotName].slot
+    if (COLUMN_4_SLOTS.includes(adapterSlot)) {
+      errors.push(
+        errorCreators.pipettingIntoColumn4({ typeOfStep: actionName })
+      )
+    }
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/blowout.ts
+++ b/step-generation/src/commandCreators/atomic/blowout.ts
@@ -15,6 +15,7 @@ export const blowout: CommandCreator<BlowoutParams> = (
   const actionName = 'blowout'
   const errors: CommandCreatorError[] = []
   const pipetteData = prevRobotState.pipettes[pipetteId]
+  const labwareState = prevRobotState.labware
   const slotName = getLabwareSlot(
     labwareId,
     prevRobotState.labware,
@@ -56,6 +57,13 @@ export const blowout: CommandCreator<BlowoutParams> = (
 
   if (COLUMN_4_SLOTS.includes(slotName)) {
     errors.push(errorCreators.pipettingIntoColumn4({ typeOfStep: actionName }))
+  } else if (labwareState[slotName] != null) {
+    const adapterSlot = labwareState[slotName].slot
+    if (COLUMN_4_SLOTS.includes(adapterSlot)) {
+      errors.push(
+        errorCreators.pipettingIntoColumn4({ typeOfStep: actionName })
+      )
+    }
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -38,6 +38,7 @@ export const dispense: CommandCreator<ExtendedDispenseParams> = (
     yOffset,
   } = args
   const actionName = 'dispense'
+  const labwareState = prevRobotState.labware
   const errors: CommandCreatorError[] = []
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
   const isFlexPipette =
@@ -93,6 +94,13 @@ export const dispense: CommandCreator<ExtendedDispenseParams> = (
 
   if (COLUMN_4_SLOTS.includes(slotName)) {
     errors.push(errorCreators.pipettingIntoColumn4({ typeOfStep: actionName }))
+  } else if (labwareState[slotName] != null) {
+    const adapterSlot = labwareState[slotName].slot
+    if (COLUMN_4_SLOTS.includes(adapterSlot)) {
+      errors.push(
+        errorCreators.pipettingIntoColumn4({ typeOfStep: actionName })
+      )
+    }
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -26,6 +26,7 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
   const { pipette, labware, well, offset, minimumZHeight, forceDirect } = args
   const actionName = 'moveToWell'
   const errors: CommandCreatorError[] = []
+  const labwareState = prevRobotState.labware
   // TODO(2020-07-30, IL): the below is duplicated or at least similar
   // across aspirate/dispense/blowout, we can probably DRY it up
   const pipetteSpec = invariantContext.pipetteEntities[pipette]?.spec
@@ -63,6 +64,13 @@ export const moveToWell: CommandCreator<v5MoveToWellParams> = (
     errors.push(
       errorCreators.pipettingIntoColumn4({ typeOfStep: 'move to well' })
     )
+  } else if (labwareState[slotName] != null) {
+    const adapterSlot = labwareState[slotName].slot
+    if (COLUMN_4_SLOTS.includes(adapterSlot)) {
+      errors.push(
+        errorCreators.pipettingIntoColumn4({ typeOfStep: actionName })
+      )
+    }
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/replaceTip.ts
+++ b/step-generation/src/commandCreators/atomic/replaceTip.ts
@@ -39,6 +39,13 @@ const _pickUpTip: CommandCreator<PickUpTipArgs> = (
     errors.push(
       errorCreators.pipettingIntoColumn4({ typeOfStep: 'pick up tip' })
     )
+  } else if (prevRobotState.labware[tiprackSlot] != null) {
+    const adapterSlot = prevRobotState.labware[tiprackSlot].slot
+    if (COLUMN_4_SLOTS.includes(adapterSlot)) {
+      errors.push(
+        errorCreators.pipettingIntoColumn4({ typeOfStep: 'pick up tip' })
+      )
+    }
   }
 
   if (errors.length > 0) {

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 // TODO: Ian 2019-04-18 move orderWells somewhere more general -- shared-data util?
 import min from 'lodash/min'
 import {
@@ -77,7 +76,7 @@ export function _getNextTip(args: {
     return allWellsHaveTip ? orderedWells[0] : null
   }
 
-  assert(false, `Pipette ${pipetteId} has no channels/spec, cannot _getNextTip`)
+  console.assert(false, `Pipette ${pipetteId} has no channels/spec, cannot _getNextTip`)
   return null
 }
 interface NextTiprackInfo {
@@ -110,7 +109,7 @@ export function getNextTiprack(
   // filter out unmounted or non-compatible tiprack models
   const sortedTipracksIds = sortLabwareBySlot(robotState.labware).filter(
     labwareId => {
-      assert(
+      console.assert(
         invariantContext.labwareEntities[labwareId]?.labwareDefURI,
         `cannot getNextTiprack, no labware entity for "${labwareId}"`
       )
@@ -202,7 +201,7 @@ export function getPipetteWithTipMaxVol(
   const tiprackTipVol = getTiprackVolume(chosenTipRack ?? tiprackDef[0])
 
   if (!pipetteMaxVol || !tiprackTipVol) {
-    assert(
+    console.assert(
       false,
       `getPipetteEffectiveMaxVol expected tiprackMaxVol and pipette maxVolume to be > 0, got',
       ${pipetteMaxVol}, ${tiprackTipVol}`

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -76,7 +76,10 @@ export function _getNextTip(args: {
     return allWellsHaveTip ? orderedWells[0] : null
   }
 
-  console.assert(false, `Pipette ${pipetteId} has no channels/spec, cannot _getNextTip`)
+  console.assert(
+    false,
+    `Pipette ${pipetteId} has no channels/spec, cannot _getNextTip`
+  )
   return null
 }
 interface NextTiprackInfo {


### PR DESCRIPTION
closes AUTH-381

# Overview

This Pr fixes and cleans up a few things but mainly fixes a bug where users could still pipette into the 4th column slots when the tiprack or labware is on top of an adapter. the currently logic did not account for adapters but this PR fixes that.

# Test Plan

upload the attached protocol, see that there is a timeline error stating that you are pipetting into a 4th column slot

 [240425 - DNA Extr SOP test Flex 96 channel (2) (2).json](https://github.com/Opentrons/opentrons/files/15202746/240425.-.DNA.Extr.SOP.test.Flex.96.channel.2.2.json)

# Changelog

- extend logic to adapter in step-generation
- fix a few random assert items and clean up some code

# Review requests

see test plan

# Risk assessment

low