### PR TITLE
fix(app, app-shell, app-shell-odd): block initial HTTP request until successful MQTT subscription

### DIFF
--- a/app-shell-odd/src/notifications/deserialize.ts
+++ b/app-shell-odd/src/notifications/deserialize.ts
@@ -31,6 +31,10 @@ export function sendDeserialized(
   } catch {} // Prevents shell erroring during app shutdown event.
 }
 
+export function sendDeserializedRefetch(topic: NotifyTopic): void {
+  sendDeserialized(topic, { refetch: true })
+}
+
 export function sendDeserializedGenericError(topic: NotifyTopic): void {
   sendDeserialized(topic, FAILURE_STATUSES.ECONNFAILED)
 }

--- a/app-shell/src/notifications/deserialize.ts
+++ b/app-shell/src/notifications/deserialize.ts
@@ -33,6 +33,14 @@ export function sendDeserialized({
   } catch {} // Prevents shell erroring during app shutdown event.
 }
 
+export function sendDeserializedRefetch(ip: string, topic: NotifyTopic): void {
+  sendDeserialized({
+    ip,
+    topic,
+    message: { refetch: true },
+  })
+}
+
 export function sendDeserializedGenericError(
   ip: string,
   topic: NotifyTopic

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -47,7 +47,7 @@ describe('useNotifyService', () => {
     vi.clearAllMocks()
   })
 
-  it('should trigger a subscribe action on a successful initial mount', () => {
+  it('should trigger an HTTP refetch and subscribe action on a successful initial mount', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
@@ -55,6 +55,7 @@ describe('useNotifyService', () => {
         options: MOCK_OPTIONS,
       } as any)
     )
+    expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
     expect(mockDispatch).toHaveBeenCalledWith(
       notifySubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
     )

--- a/app/src/resources/__tests__/useNotifyService.test.ts
+++ b/app/src/resources/__tests__/useNotifyService.test.ts
@@ -47,7 +47,7 @@ describe('useNotifyService', () => {
     vi.clearAllMocks()
   })
 
-  it('should trigger an HTTP refetch and subscribe action on a successful initial mount', () => {
+  it('should trigger a subscribe action on a successful initial mount', () => {
     renderHook(() =>
       useNotifyService({
         topic: MOCK_TOPIC,
@@ -55,7 +55,6 @@ describe('useNotifyService', () => {
         options: MOCK_OPTIONS,
       } as any)
     )
-    expect(mockHTTPRefetch).toHaveBeenCalledWith('once')
     expect(mockDispatch).toHaveBeenCalledWith(
       notifySubscribeAction(MOCK_HOST_CONFIG.hostname, MOCK_TOPIC)
     )

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -51,8 +51,6 @@ export function useNotifyService<TData, TError = Error>({
 
   React.useEffect(() => {
     if (shouldUseNotifications) {
-      // Always fetch on initial mount.
-      setRefetch('once')
       appShellListener({
         hostname,
         topic,

--- a/app/src/resources/useNotifyService.ts
+++ b/app/src/resources/useNotifyService.ts
@@ -51,6 +51,8 @@ export function useNotifyService<TData, TError = Error>({
 
   React.useEffect(() => {
     if (shouldUseNotifications) {
+      // Always fetch on initial mount to keep latency as low as possible.
+      setRefetch('once')
       appShellListener({
         hostname,
         topic,


### PR DESCRIPTION
Closes [EXEC-429](https://opentrons.atlassian.net/browse/EXEC-429)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Currently, the desktop app/ODD attempt to address the ["missed update problem"](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/917110846/Old+proposal#Nuance%3A-Avoiding-missed-first-updates) in the following way: while we subscribe to a topic, we simultaneously GET whatever equivalent HTTP resource we just subscribed to. However, there's definitely a world (albeit a very small one) in which we receive the HTTP response, a server update occurs, the server publishes, and _then_ we successfully subscribe to a topic. In this world, we've missed the update event. 

Solve for this by simply blocking the initial HTTP GET until we subscribe. While the subscribe handshake could theoretically take a maximum of 2 seconds (at which point we forcefully timeout the subscribe action and fallback to polling), in practice it's more like <~250ms (wall-clock request to response). We already handle failed connections and don't go through this handshake if we can't connect to the client to begin with, so the "wait 2 second until sub failure" scenario shouldn't realistically happen. 

### Edge vs. 7.3.0?

After discussing with @SyntaxColoring, we believe it's best not to include the fix in 7.3.0, since there's always the possibility we cause a worse problem than we solve (although I feel good that this isn't the case). The worst case scenario is the client very very rarely doesn't receive an update notification as expected. 

In practice, this problem has yet to be reported by QA or identified by a dev, so I think it's better to hold off. I'm willing to be convinced otherwise, though. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verified behavior works as expected. We block until the subscription ACK, then we send the initial request. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed an edge-case in which a client could not receive MQTT updates. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Medium(ish). See subsection in overview.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-429]: https://opentrons.atlassian.net/browse/EXEC-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ