### PR TITLE
fix(protocol-designer): default tiprack selection refreshing

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/PipetteTipsTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/PipetteTipsTile.tsx
@@ -182,12 +182,10 @@ function PipetteTipsField(props: PipetteTipsFieldProps): JSX.Element | null {
   const selectedValues = pipettesByMount[mount].tiprackDefURI ?? []
 
   React.useEffect(() => {
-    if (selectedValues.length === 0) {
-      setValue(`pipettesByMount.${mount}.tiprackDefURI`, [
-        tiprackOptions[0]?.value ?? '',
-      ])
-    }
-  }, [selectedValues, setValue, tiprackOptions])
+    setValue(`pipettesByMount.${mount}.tiprackDefURI`, [
+      tiprackOptions[0]?.value ?? '',
+    ])
+  }, [])
 
   return (
     <Flex

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/CreateFileWizard.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/CreateFileWizard.test.tsx
@@ -90,7 +90,8 @@ describe('CreateFileWizard', () => {
     next = screen.getByRole('button', { name: 'Next' })
     fireEvent.click(next)
     screen.getByText('Step 3 / 6')
-    //  select 10uL tipracks
+    //  un-select default 10uL tiprack then select again
+    fireEvent.click(screen.getByLabelText('EquipmentOption_flex_10uL tipracks'))
     fireEvent.click(screen.getByLabelText('EquipmentOption_flex_10uL tipracks'))
     next = screen.getByRole('button', { name: 'Next' })
     fireEvent.click(next)

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/PipetteTipsTile.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/PipetteTipsTile.test.tsx
@@ -51,6 +51,7 @@ const mockWizardTileProps: Partial<WizardTileProps> = {
   proceed: vi.fn(),
   watch: vi.fn((name: keyof typeof values) => values[name]) as any,
   getValues: vi.fn(() => values) as any,
+  setValue: vi.fn(),
 }
 
 const fixtureTipRack10ul = {

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -262,7 +262,10 @@ export function CreateFileWizard(): JSX.Element | null {
         pipettes.flatMap(pipette => pipette.tiprackDefURI)
       )
       const FLEX_MIDDLE_SLOTS = ['C2', 'B2', 'A2']
-      const OT2_MIDDLE_SLOTS = ['2', '5', '8', '11']
+      const hasOt2TC = modules.find(
+        module => module.type === THERMOCYCLER_MODULE_TYPE
+      )
+      const OT2_MIDDLE_SLOTS = hasOt2TC ? ['2', '5'] : ['2', '5', '8', '11']
       newTiprackModels.forEach((tiprackDefURI, index) => {
         dispatch(
           labwareIngredActions.createContainer({


### PR DESCRIPTION
closes AUTH-382 AUTH-383

# Overview

Fixes 2 bugs related to tipracks:
1. if you select a bunch of tipracks then go back and change the pipette, the tipracks wouldn't be reset so this PR resets the tipracks selected whenever you rerender the tiprack selection page
2. if you have 3 or more default tipracks with the thermocycler for the OT-2, 2 tipracks would be placed in the TC's slots 8 and 11. this PR fixes that

# Test Plan

Create an ot-2 protocol and select 2 tipracks for the pipette. Then go back and select a different pipette and see that the tipracks selected is reset to the 1st one. Then select 2 more tipracks so you have a total of 3 selected. On the modules page of the wizard, add a Thermocycler GEN1 or GEN2. Create the protocol. Go to the deck map and see that slots 2, 4 and 1 are occupied for the tipracks.

# Changelog

- add branching logic to accommodate tiprack slots when the TC is selected for ot-2
- reset the tipracks selected in the pipette tip tile

# Review requests

see test plan

# Risk assessment

low