### PR TITLE
fix(robot-server): clear ChangeNotifier's internal event immediately after waiting

### DIFF
--- a/robot-server/robot_server/service/notifications/change_notifier.py
+++ b/robot-server/robot_server/service/notifications/change_notifier.py
@@ -15,9 +15,5 @@ class ChangeNotifier:
 
     async def wait(self) -> None:
         """Wait until the next change notification."""
-        self._event.clear()
         await self._event.wait()
-
-    def clear(self) -> None:
-        """Reset the internal event flag."""
         self._event.clear()

--- a/robot-server/tests/service/notifications/test_change_notifier.py
+++ b/robot-server/tests/service/notifications/test_change_notifier.py
@@ -54,3 +54,30 @@ async def test_multiple_subscribers(_test_repetition: int) -> None:
     await asyncio.gather(task_1, task_2, task_3)
 
     assert results == [1, 2, 3]
+
+
+async def test_notify_while_busy() -> None:
+    """Test that waiters process a new notify() after they are done being busy."""
+    subject = ChangeNotifier()
+    results = []
+
+    async def _do_task() -> None:
+        results.append("TEST")
+        await asyncio.sleep(0.2)  # Simulate being busy
+
+    async def do_task() -> None:
+        while True:
+            await subject.wait()
+            await _do_task()
+
+    task = asyncio.create_task(do_task())
+
+    subject.notify()
+    await asyncio.sleep(0.0)
+
+    subject.notify()
+    await asyncio.sleep(0.5)
+
+    assert results == ["TEST", "TEST"]
+
+    task.cancel()


### PR DESCRIPTION
Closes [RQA-2677](https://opentrons.atlassian.net/browse/RQA-2677)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

ChangeNotifier is the interface for alerting robot-server of notification updates deriving from Protocol Engine. Protocol Engine `notify()`ies, and the PublisherNotifier `wait()`s. After the event flag is set() in `notify()`, the PublisherNotifier no longer waits (correctly). However, the event flag isn't cleared immediately on receiving a new event...it's cleared _after_  PublisherNotifer fires all its registered callbacks. This causes some events to be dropped if Protocol Engine tries setting the flag before PublisherNotifier has gotten around to clearing it... woops. 

The reason we haven't seen this problem earlier is because we currently don't have too many immediately back-to-back events firing with publishers that would be interested in those events, but in the specific scenario mentioned in the ticket, the following is happening:

- A play action hits PE, and PE sets the event flag via `notify()`.
- PublisherNotifier starts firing through its registered callbacks.
- The "command succeeded" & "next running command" actions hit PE very shortly after the play action, and the set event flag is set from `True` to `True` redundantly.
- PublisherNotifier finishes its callbacks then sets the event flag to `False`...dropping these new events.

The fix: simply clear the event flag immediately after waiting.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- You can test this with any protocol containing a manual move labware command + a command afterwards. Here's the [protocol I used.](https://github.com/Opentrons/opentrons/files/15226308/GripperMoveTestingWithPause.py.zip)
- Verify that the Intervention Modal derenders on the ODD immediately after the command is completed (so like 1 second after pressing the button), NOT a whole command after the command proceeding the manual move command. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed a bug in which commands after manual move commands were slow to update on the ODD.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RQA-2677]: https://opentrons.atlassian.net/browse/RQA-2677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ