### PR TITLE
ci(ai-client): continuous dev deployment on edge merge

### DIFF
--- a/.github/workflows/opentrons-ai-client-dev-continuos-deploy.yaml
+++ b/.github/workflows/opentrons-ai-client-dev-continuos-deploy.yaml
@@ -1,0 +1,66 @@
+# Run tests, build the app, and deploy it cross platform
+
+name: 'OpentronsAI edge continuous deployment to dev'
+
+on:
+  push:
+    branches:
+      - edge
+    paths:
+      - 'opentrons-ai-client/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  js-unit-test:
+    runs-on: 'ubuntu-22.04'
+    permissions:
+      id-token: write
+      contents: read
+    name: 'OpentronsAI edge continuous deployment to dev'
+    timeout-minutes: 10
+    steps:
+      - uses: 'actions/checkout@v3'
+      - uses: 'actions/setup-node@v3'
+        with:
+          node-version: '18.19.0'
+      - name: 'install udev'
+        run: |
+          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update && sudo apt-get install libudev-dev
+      - name: 'set complex environment variables'
+        id: 'set-vars'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { buildComplexEnvVars } = require(`${process.env.GITHUB_WORKSPACE}/.github/workflows/utils.js`)
+            buildComplexEnvVars(core, context)
+      - name: 'cache yarn cache'
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ github.workspace }}/.npm-cache/_prebuild
+            ${{ github.workspace }}/.yarn-cache
+          key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+      - name: 'setup-js'
+        run: |
+          npm config set cache ${{ github.workspace }}/.npm-cache
+          yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
+          make setup-js
+      - name: build
+        run: |
+          make -C opentrons-ai-client build
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.DEV_AI_ROLE_ARN }}
+          aws-region: ${{ secrets.DEV_AI_REGION }}
+      - name: 'deploy to dev'
+        run: |
+          make -C opentrons-ai-client dev-deploy

--- a/.github/workflows/opentrons-ai-client-dev-continuos-deploy.yaml
+++ b/.github/workflows/opentrons-ai-client-dev-continuos-deploy.yaml
@@ -1,5 +1,3 @@
-# Run tests, build the app, and deploy it cross platform
-
 name: 'OpentronsAI edge continuous deployment to dev'
 
 on:

--- a/.github/workflows/opentrons-ai-client-dev-continuos-deploy.yaml
+++ b/.github/workflows/opentrons-ai-client-dev-continuos-deploy.yaml
@@ -51,7 +51,7 @@ jobs:
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
-      - name: build
+      - name: 'build'
         run: |
           make -C opentrons-ai-client build
       - name: Configure AWS Credentials

--- a/opentrons-ai-client/Makefile
+++ b/opentrons-ai-client/Makefile
@@ -61,3 +61,7 @@ test:
 .PHONY: test-cov
 test-cov:
 	make -C .. test-js-ai-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+
+.PHONY: dev-deploy
+dev-deploy:
+	aws s3 sync ./dist s3://dev-opentrons-ai-front-end/ --delete


### PR DESCRIPTION
# Overview

When anything in `opentrons-ai-client` changes and is push (merge) to `edge`, build and deploy.

## Notes

- did not parameterize as we are not sure yet if we even will like this or how we will deploy to higher environments
- the future holds end to end tests but we may use DataDog monitors and synthetic test 

## Tasks

- [x] secrets added to the repository