### PR TITLE
fix: typo recieved -> received

### DIFF
--- a/api/docs/ot1/api.html
+++ b/api/docs/ot1/api.html
@@ -446,7 +446,7 @@ window.intercomSettings = {
                               data-gtm-label="start-guide"
                               data-gtm-action="click"
                             >OT-2 Start Guide</a>
-                            <span>You recieved your robot, here's what's next</span>
+                            <span>You received your robot, here's what's next</span>
                           </li>
                           <li onclick="closeMenu()">
                             <a

--- a/api/docs/ot1/calibration.html
+++ b/api/docs/ot1/calibration.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/containers.html
+++ b/api/docs/ot1/containers.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/examples.html
+++ b/api/docs/ot1/examples.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/firmware.html
+++ b/api/docs/ot1/firmware.html
@@ -478,7 +478,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/genindex.html
+++ b/api/docs/ot1/genindex.html
@@ -477,7 +477,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/index.html
+++ b/api/docs/ot1/index.html
@@ -478,7 +478,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/modules.html
+++ b/api/docs/ot1/modules.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/pipettes.html
+++ b/api/docs/ot1/pipettes.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/py-modindex.html
+++ b/api/docs/ot1/py-modindex.html
@@ -478,7 +478,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/robot.html
+++ b/api/docs/ot1/robot.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/search.html
+++ b/api/docs/ot1/search.html
@@ -486,7 +486,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/transfer.html
+++ b/api/docs/ot1/transfer.html
@@ -480,7 +480,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/ot1/writing.html
+++ b/api/docs/ot1/writing.html
@@ -479,7 +479,7 @@
                           data-gtm-action="click"
                           >OT-2 Start Guide</a
                         >
-                        <span>You recieved your robot, here's what's next</span>
+                        <span>You received your robot, here's what's next</span>
                       </li>
                       <li onclick="closeMenu()">
                         <a

--- a/api/docs/templates/hardware/layout.html
+++ b/api/docs/templates/hardware/layout.html
@@ -425,7 +425,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                       data-gtm-action="click"
                       >OT-2 Start Guide</a
                     >
-                    <span>You recieved your robot, here's what's next</span>
+                    <span>You received your robot, here's what's next</span>
                   </li>
                   <li onclick="closeMenu()">
                     <a

--- a/api/docs/templates/v1/layout.html
+++ b/api/docs/templates/v1/layout.html
@@ -425,7 +425,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                       data-gtm-action="click"
                       >OT-2 Start Guide</a
                     >
-                    <span>You recieved your robot, here's what's next</span>
+                    <span>You received your robot, here's what's next</span>
                   </li>
                   <li onclick="closeMenu()">
                     <a

--- a/api/docs/templates/v2/layout.html
+++ b/api/docs/templates/v2/layout.html
@@ -425,7 +425,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                       data-gtm-action="click"
                       >OT-2 Start Guide</a
                     >
-                    <span>You recieved your robot, here's what's next</span>
+                    <span>You received your robot, here's what's next</span>
                   </li>
                   <li onclick="closeMenu()">
                     <a

--- a/hardware/opentrons_hardware/hardware_control/current_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/current_settings.py
@@ -73,7 +73,7 @@ async def set_run_current(
         )
         if error != ErrorCode.ok:
             log.error(
-                f"recieved error {str(error)} trying to set run current for {str(node)}"
+                f"received error {str(error)} trying to set run current for {str(node)}"
             )
 
 
@@ -97,5 +97,5 @@ async def set_hold_current(
         )
         if error != ErrorCode.ok:
             log.error(
-                f"recieved error {str(error)} trying to set run current for {str(node)}"
+                f"received error {str(error)} trying to set run current for {str(node)}"
             )

--- a/hardware/opentrons_hardware/hardware_control/gripper_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/gripper_settings.py
@@ -64,7 +64,7 @@ async def set_reference_voltage(
         expected_nodes=[NodeId.gripper_g],
     )
     if error != ErrorCode.ok:
-        log.error(f"recieved error trying to set gripper vref {str(error)}")
+        log.error(f"received error trying to set gripper vref {str(error)}")
 
 
 async def set_pwm_param(
@@ -80,7 +80,7 @@ async def set_pwm_param(
         expected_nodes=[NodeId.gripper_g],
     )
     if error != ErrorCode.ok:
-        log.error(f"recieved error trying to set gripper pwm {str(error)}")
+        log.error(f"received error trying to set gripper pwm {str(error)}")
 
 
 async def set_error_tolerance(
@@ -100,7 +100,7 @@ async def set_error_tolerance(
         expected_nodes=[NodeId.gripper_g],
     )
     if error != ErrorCode.ok:
-        log.error(f"recieved error trying to set gripper error tolerance {str(error)}")
+        log.error(f"received error trying to set gripper error tolerance {str(error)}")
 
 
 async def set_jaw_holdoff(
@@ -119,7 +119,7 @@ async def set_jaw_holdoff(
     )
     if error != ErrorCode.ok:
         log.error(
-            f"recieved error trying to set gripper jaw holdoff value {str(error)}"
+            f"received error trying to set gripper jaw holdoff value {str(error)}"
         )
 
 

--- a/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
@@ -64,7 +64,7 @@ async def set_hepa_fan_state(
         expected_nodes=[NodeId.hepa_uv],
     )
     if error != ErrorCode.ok:
-        log.error(f"recieved error trying to set hepa fan state {str(error)}")
+        log.error(f"received error trying to set hepa fan state {str(error)}")
     return error == ErrorCode.ok
 
 
@@ -117,7 +117,7 @@ async def set_hepa_uv_state(
         expected_nodes=[NodeId.hepa_uv],
     )
     if error != ErrorCode.ok:
-        log.error(f"recieved error trying to set hepa uv light state {str(error)}")
+        log.error(f"received error trying to set hepa uv light state {str(error)}")
     return error == ErrorCode.ok
 
 

--- a/hardware/opentrons_hardware/hardware_control/limit_switches.py
+++ b/hardware/opentrons_hardware/hardware_control/limit_switches.py
@@ -35,7 +35,7 @@ def _create_listener(
             )
             return
         if message.message_id == MessageId.error_message:
-            log.error(f"recieved an error {str(message)}")
+            log.error(f"received an error {str(message)}")
             return
         elif message.message_id != MessageId.limit_sw_response:
             log.warning(f"unexpected message id: 0x{message.message_id:x}")

--- a/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
+++ b/hardware/opentrons_hardware/hardware_control/motor_enable_disable.py
@@ -38,7 +38,7 @@ async def set_enable_motor(
             expected_nodes=[node],
         )
         if error != ErrorCode.ok:
-            log.error(f"recieved error {str(error)} trying to enable {str(node)} ")
+            log.error(f"received error {str(error)} trying to enable {str(node)} ")
 
 
 async def set_disable_motor(
@@ -53,7 +53,7 @@ async def set_disable_motor(
             expected_nodes=[node],
         )
         if error != ErrorCode.ok:
-            log.error(f"recieved error {str(error)} trying to disable {str(node)} ")
+            log.error(f"received error {str(error)} trying to disable {str(node)} ")
 
 
 async def set_enable_tip_motor(
@@ -68,7 +68,7 @@ async def set_enable_tip_motor(
             expected_nodes=[node],
         )
         if error != ErrorCode.ok:
-            log.error(f"recieved error {str(error)} trying to enable {str(node)} ")
+            log.error(f"received error {str(error)} trying to enable {str(node)} ")
 
 
 async def set_disable_tip_motor(
@@ -83,7 +83,7 @@ async def set_disable_tip_motor(
             expected_nodes=[node],
         )
         if error != ErrorCode.ok:
-            log.error(f"recieved error {str(error)} trying to disable {str(node)} ")
+            log.error(f"received error {str(error)} trying to disable {str(node)} ")
 
 
 async def get_motor_enabled(

--- a/hardware/opentrons_hardware/hardware_control/tools/detector.py
+++ b/hardware/opentrons_hardware/hardware_control/tools/detector.py
@@ -44,7 +44,7 @@ async def _await_one_result(callback: WaitableCallback) -> ToolDetectionResult:
         if isinstance(response, message_definitions.PushToolsDetectedNotification):
             return _handle_detection_result(response)
         if isinstance(response, message_definitions.ErrorMessage):
-            log.error(f"Recieved error message {str(response)}")
+            log.error(f"Received error message {str(response)}")
     raise CanbusCommunicationError(message="Messenger closed before a tool was found")
 
 
@@ -78,7 +78,7 @@ async def _await_responses(
                 seen.add(node)
                 break
             elif isinstance(response, message_definitions.ErrorMessage):
-                log.error(f"Recieved error message {str(response)}")
+                log.error(f"Received error message {str(response)}")
 
 
 async def _handle_gripper_info(

--- a/hardware/opentrons_hardware/sensors/scheduler.py
+++ b/hardware/opentrons_hardware/sensors/scheduler.py
@@ -171,7 +171,7 @@ class SensorScheduler:
         )
         if error != ErrorCode.ok:
             log.error(
-                f"recieved error {str(error)} trying to write sensor info to {sensor_info.node_id.name}"
+                f"received error {str(error)} trying to write sensor info to {sensor_info.node_id.name}"
             )
 
     async def send_read(
@@ -384,7 +384,7 @@ class SensorScheduler:
                 f"{SensorDataType.build(message.payload.sensor_data, message.payload.sensor).to_float()}"
             )
         if isinstance(message, ErrorMessage):
-            log.error(f"recieved error message {str(message)}")
+            log.error(f"received error message {str(message)}")
 
     @asynccontextmanager
     async def bind_sync(
@@ -411,7 +411,7 @@ class SensorScheduler:
         )
         if error != ErrorCode.ok:
             log.error(
-                f"recieved error {str(error)} trying to bind sensor output on {str(target_sensor.node_id)}"
+                f"received error {str(error)} trying to bind sensor output on {str(target_sensor.node_id)}"
             )
 
         try:
@@ -436,7 +436,7 @@ class SensorScheduler:
             )
             if error != ErrorCode.ok:
                 log.error(
-                    f"recieved error {str(error)} trying to write unbind sensor output on {str(target_sensor.node_id)}"
+                    f"received error {str(error)} trying to write unbind sensor output on {str(target_sensor.node_id)}"
                 )
 
     @asynccontextmanager
@@ -457,7 +457,7 @@ class SensorScheduler:
                     SensorDataType.build(payload.sensor_data, payload.sensor).to_float()
                 )
             if isinstance(message, ErrorMessage):
-                log.error(f"Recieved error message {str(message)}")
+                log.error(f"Received error message {str(message)}")
 
         def _filter(arbitration_id: ArbitrationId) -> bool:
             return (
@@ -483,7 +483,7 @@ class SensorScheduler:
         )
         if error != ErrorCode.ok:
             log.error(
-                f"recieved error {str(error)} trying to bind sensor output on {str(target_sensor.node_id)}"
+                f"received error {str(error)} trying to bind sensor output on {str(target_sensor.node_id)}"
             )
 
         try:
@@ -505,7 +505,7 @@ class SensorScheduler:
             )
             if error != ErrorCode.ok:
                 log.error(
-                    f"recieved error {str(error)} trying to write unbind sensor output on {str(target_sensor.node_id)}"
+                    f"received error {str(error)} trying to write unbind sensor output on {str(target_sensor.node_id)}"
                 )
 
     @asynccontextmanager
@@ -562,7 +562,7 @@ class SensorScheduler:
             )
             if error != ErrorCode.ok:
                 log.error(
-                    f"recieved error {str(error)} trying to bind sensor output on {str(sensor.node_id)}"
+                    f"received error {str(error)} trying to bind sensor output on {str(sensor.node_id)}"
                 )
 
         try:
@@ -586,5 +586,5 @@ class SensorScheduler:
                 )
                 if error != ErrorCode.ok:
                     log.error(
-                        f"recieved error {str(error)} trying to write unbind sensor output on {str(sensor.node_id)}"
+                        f"received error {str(error)} trying to write unbind sensor output on {str(sensor.node_id)}"
                     )


### PR DESCRIPTION
# Overview

Spotted a typo in an error message and did a sweep across the whole monorepo to fix it.

Closes RTC-449

# Test Plan

Relying on CI to tell me if I broke anything.

# Changelog

Fixed the typo in these locations:
- Hardcoded nav in OT-One Python docs
- Nav templates in other Python docs
- Several hardware error messages

# Review requests

Did my best to avoid modifying any actual code. Please double check.

# Risk assessment

v low, unless we're depending on exact error strings downstream somewhere.