### PR TITLE
fix(app): update disabled style of ProtocolSetupStep description

### DIFF
--- a/app/src/pages/ProtocolSetup/index.tsx
+++ b/app/src/pages/ProtocolSetup/index.tsx
@@ -211,7 +211,11 @@ export function ProtocolSetupStep({
           >
             {title}
           </StyledText>
-          <StyledText as="h4" color={COLORS.grey60} maxWidth="35rem">
+          <StyledText
+            as="h4"
+            color={disabled ? COLORS.grey50 : COLORS.grey60}
+            maxWidth="35rem"
+          >
             {description}
           </StyledText>
         </Flex>


### PR DESCRIPTION
# Overview

Set new description text of ProtocolSetupStep to grey50 if disabled

<img width="993" alt="Screenshot 2024-05-07 at 12 12 11 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/6ad49d13-c6cf-40bf-9cae-8dffb50c0994">

# Test Plan

- start RTP protocol setup on ODD
- confirm values
- observe disabled state of parameters

# Changelog

- set `ProtocolSetupStep` description color depending on disabled state

# Review requests

auth js

# Risk assessment

low