### PR TITLE
refactor(app, api-client, shared-data): Set command intent to "fixit"

### DIFF
--- a/api-client/src/runs/commands/types.ts
+++ b/api-client/src/runs/commands/types.ts
@@ -43,6 +43,7 @@ export interface CommandsAsPreSerializedListData {
 export interface CreateCommandParams {
   waitUntilComplete?: boolean
   timeout?: number
+  failedCommandId?: string
 }
 
 export interface RunCommandError {

--- a/app/src/resources/runs/__tests__/util.test.ts
+++ b/app/src/resources/runs/__tests__/util.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { formatTimeWithUtcLabel } from '../utils'
+import { formatTimeWithUtcLabel, setCommandIntent } from '../utils'
+
+import type { CreateCommand } from '@opentrons/shared-data'
 
 describe('formatTimeWithUtc', () => {
   it('return formatted time with UTC', () => {
@@ -19,5 +21,22 @@ describe('formatTimeWithUtc', () => {
   it('return unknown if time is null', () => {
     const result = formatTimeWithUtcLabel(null)
     expect(result).toEqual('unknown')
+  })
+})
+
+const mockCommand = {
+  commandType: 'home',
+  params: {},
+  intent: 'protocol',
+} as CreateCommand
+
+describe('setCommandIntent', () => {
+  it('explicitly sets the command intent to "fixit" if a failedCommandId is specified', () => {
+    const commandWithFixitIntent = setCommandIntent(mockCommand, 'MOCK_ID')
+    expect(commandWithFixitIntent.intent).toEqual('fixit')
+  })
+  it('does not modify the command intent if no failedCommandId is specified', () => {
+    const command = setCommandIntent(mockCommand)
+    expect(command.intent).toEqual('protocol')
   })
 })

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -1,11 +1,12 @@
-import * as React from 'react'
 import { format } from 'date-fns'
+
+import type * as React from 'react'
+import type { UseMutateAsyncFunction } from 'react-query'
 import type { CommandData } from '@opentrons/api-client'
 import type { CreateCommand } from '@opentrons/shared-data'
+import type { CreateLiveCommandMutateParams } from '@opentrons/react-api-client/src/runs/useCreateLiveCommandMutation'
+import type { ModulePrepCommandsType } from '../../organisms/Devices/getModulePrepCommands'
 import type { CreateMaintenanceCommand, CreateRunCommand } from './hooks'
-import type { UseMutateAsyncFunction } from 'react-query'
-import { CreateLiveCommandMutateParams } from '@opentrons/react-api-client/src/runs/useCreateLiveCommandMutation'
-import { ModulePrepCommandsType } from '../../organisms/Devices/getModulePrepCommands'
 
 export const chainRunCommandsRecursive = (
   commands: CreateCommand[],
@@ -150,4 +151,19 @@ export const formatTimeWithUtcLabel = (time: string | null): string => {
   return typeof time === 'string' && dateIsValid(time)
     ? `${format(new Date(time), 'M/d/yy HH:mm')} ${UTC_LABEL}`
     : `${time} ${UTC_LABEL}`
+}
+
+// Visit the command, setting the command intent to "fixit" if a failedCommandId is supplied.
+export const setCommandIntent = (
+  command: CreateCommand,
+  failedCommandId?: string
+): CreateCommand => {
+  const isCommandWithFixitIntent = failedCommandId != null
+  if (isCommandWithFixitIntent) {
+    return {
+      ...command,
+      intent: 'fixit',
+    }
+  }
+  return command
 }

--- a/app/src/resources/runs/utils.ts
+++ b/app/src/resources/runs/utils.ts
@@ -13,9 +13,11 @@ export const chainRunCommandsRecursive = (
   continuePastCommandFailure: boolean = true,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 ): Promise<CommandData[]> => {
-  if (commands.length < 1)
+  if (commands.length < 1) {
     return Promise.reject(new Error('no commands to execute'))
+  }
   setIsLoading(true)
+
   return createRunCommand({
     command: commands[0],
     waitUntilComplete: true,
@@ -57,9 +59,11 @@ export const chainLiveCommandsRecursive = (
   continuePastCommandFailure: boolean = true,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 ): Promise<CommandData[]> => {
-  if (commands.length < 1)
+  if (commands.length < 1) {
     return Promise.reject(new Error('no commands to execute'))
+  }
   setIsLoading(true)
+
   return createLiveCommand({
     command: commands[0],
     waitUntilComplete: true,
@@ -98,9 +102,11 @@ export const chainMaintenanceCommandsRecursive = (
   continuePastCommandFailure: boolean = true,
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
 ): Promise<CommandData[]> => {
-  if (commands.length < 1)
+  if (commands.length < 1) {
     return Promise.reject(new Error('no commands to execute'))
+  }
   setIsLoading(true)
+
   return createMaintenanceCommand({
     maintenanceRunId: maintenanceRunId,
     command: commands[0],

--- a/react-api-client/src/runs/useCreateCommandMutation.ts
+++ b/react-api-client/src/runs/useCreateCommandMutation.ts
@@ -1,11 +1,7 @@
 import { useMutation, useQueryClient } from 'react-query'
 import { createCommand } from '@opentrons/api-client'
 import { useHost } from '../api'
-import type {
-  UseMutationResult,
-  UseMutationOptions,
-  UseMutateAsyncFunction,
-} from 'react-query'
+import type { UseMutationResult, UseMutateAsyncFunction } from 'react-query'
 import type {
   CommandData,
   HostConfig,
@@ -32,21 +28,16 @@ export type UseCreateCommandMutationResult = UseMutationResult<
   >
 }
 
-export type UseCreateCommandMutationOptions = UseMutationOptions<
-  CommandData,
-  unknown,
-  CreateCommandMutateParams
->
-
 export function useCreateCommandMutation(): UseCreateCommandMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
   const mutation = useMutation<CommandData, unknown, CreateCommandMutateParams>(
-    ({ runId, command, waitUntilComplete, timeout }) =>
-      createCommand(host as HostConfig, runId, command, {
-        waitUntilComplete,
-        timeout,
+    params => {
+      const { runId, command, ...rest } = params
+
+      return createCommand(host as HostConfig, runId, command, {
+        ...rest,
       }).then(response => {
         queryClient
           .invalidateQueries([host, 'runs'])
@@ -55,6 +46,7 @@ export function useCreateCommandMutation(): UseCreateCommandMutationResult {
           )
         return response.data
       })
+    }
   )
 
   return {

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -38,6 +38,7 @@ export interface CommandNote {
   source: string
 }
 export type CommandStatus = 'queued' | 'running' | 'succeeded' | 'failed'
+export type CommandIntent = 'protocol' | 'setup' | 'fixit'
 export interface CommonCommandRunTimeInfo {
   key?: string
   id: string
@@ -46,10 +47,11 @@ export interface CommonCommandRunTimeInfo {
   createdAt: string
   startedAt: string | null
   completedAt: string | null
-  intent?: 'protocol' | 'setup'
+  intent?: CommandIntent
   notes?: CommandNote[] | null
 }
 export interface CommonCommandCreateInfo {
+  intent?: CommandIntent
   key?: string
   meta?: { [key: string]: any }
 }

--- a/shared-data/protocol/types/schemaV6/command/index.ts
+++ b/shared-data/protocol/types/schemaV6/command/index.ts
@@ -6,6 +6,7 @@ import type { GantryRunTimeCommand, GantryCreateCommand } from './gantry'
 import type { ModuleRunTimeCommand, ModuleCreateCommand } from './module'
 import type { SetupRunTimeCommand, SetupCreateCommand } from './setup'
 import type { TimingRunTimeCommand, TimingCreateCommand } from './timing'
+import type { CommandIntent } from '../../../../command'
 
 export * from './pipetting'
 export * from './gantry'
@@ -26,7 +27,7 @@ export interface CommonCommandRunTimeInfo {
   createdAt: string
   startedAt: string | null
   completedAt: string | null
-  intent?: 'protocol' | 'setup'
+  intent?: CommandIntent
 }
 export interface CommonCommandCreateInfo {
   key?: string


### PR DESCRIPTION
Closes [EXEC-431](https://opentrons.atlassian.net/browse/EXEC-431)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Before we can POST fixit commands during Error Recovery flows, we need to refactor `useChainRunCommands` to support sending the params necessary to POST a fixit command. In addition to a normal `CreateCommand`, this requires sending:
-  A `failedCommandId`
- An explicit `fixit` intent

Because the FE never explicitly sets `intent` in the app until now, it feels correct to keep the `intent: fixit` logic abstracted when creating a new command from the app. Open to thoughts/comments/concerns. 
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- We're covered by new tests and there are no effective changes. However, [here is a branch](https://github.com/Opentrons/opentrons/tree/CHAIN-FIXIT) with a working 'home' command during ER when you click "resume". You'll have to enable the backend & frontend FFs for this to work.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
# Review requests
Are the `shared-data` types changes correct?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-431]: https://opentrons.atlassian.net/browse/EXEC-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ