### PR TITLE
fix(app): ensure terminal run preview shows detail for load liquid commands

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Liquid,
   LoadedLabware,
   LoadedModule,
   LoadedPipette,
@@ -46,6 +47,7 @@ export interface LegacyGoodRunData {
   pipettes: LoadedPipette[]
   labware: LoadedLabware[]
   modules: LoadedModule[]
+  liquids: Liquid[]
   protocolId?: string
   labwareOffsets?: LabwareOffset[]
   runTimeParameters: RunTimeParameter[]

--- a/app/src/organisms/InterventionModal/__fixtures__/index.ts
+++ b/app/src/organisms/InterventionModal/__fixtures__/index.ts
@@ -8,6 +8,7 @@ import {
 import type { RunData } from '@opentrons/api-client'
 import type {
   LabwareDefinitionsByUri,
+  Liquid,
   LoadedLabware,
   LoadedModule,
 } from '@opentrons/shared-data'
@@ -176,6 +177,12 @@ export const mockThermocyclerModule: LoadedModule = {
   serialNumber: 'dummySerialTC',
 }
 
+export const mockLiquid: Liquid = {
+  id: 'mockLiquid',
+  displayName: 'mock liquid',
+  description: 'this is my mock liquid description',
+}
+
 export const mockRunData: RunData = {
   id: 'mockRunData',
   createdAt: '',
@@ -188,6 +195,7 @@ export const mockRunData: RunData = {
   pipettes: [],
   labware: [mockLabwareOnModule, mockLabwareOnSlot, mockLabwareOffDeck],
   modules: [mockModule],
+  liquids: [mockLiquid],
   runTimeParameters: [],
 }
 

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -92,6 +92,7 @@ export const RunPreviewComponent = (
           labware: runRecord.data.labware ?? [],
           modules: runRecord.data.modules ?? [],
           pipettes: runRecord.data.pipettes ?? [],
+          liquids: runRecord.data.liquids ?? [],
           commands: commands,
         }
       : robotSideAnalysis

--- a/app/src/organisms/RunTimeControl/__fixtures__/index.ts
+++ b/app/src/organisms/RunTimeControl/__fixtures__/index.ts
@@ -41,6 +41,7 @@ export const mockPausedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -66,6 +67,7 @@ export const mockPauseRequestedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -96,6 +98,7 @@ export const mockRunningRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -136,6 +139,7 @@ export const mockFailedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -171,6 +175,7 @@ export const mockStopRequestedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -206,6 +211,7 @@ export const mockStoppedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -236,6 +242,7 @@ export const mockSucceededRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -250,6 +257,7 @@ export const mockIdleUnstartedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -280,6 +288,7 @@ export const mockIdleStartedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 

--- a/react-api-client/src/runs/__fixtures__/runs.ts
+++ b/react-api-client/src/runs/__fixtures__/runs.ts
@@ -32,6 +32,7 @@ export const mockPausedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -62,6 +63,7 @@ export const mockRunningRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 


### PR DESCRIPTION
closes [RQA-2645](https://opentrons.atlassian.net/browse/RQA-2645)
closes [RQA-2647](https://opentrons.atlassian.net/browse/RQA-2647)

# Overview

After a terminal run, we access the run record's data for commands, labware, pipettes, and modules. We need to extend this to liquids so that the liquid's ID from its load command matches that on the analysis-like object passed to command text.

# Test Plan

- Run a protocol that loads at least one liquid (example linked as `rtp_tests.py` [here](https://opentrons.atlassian.net/browse/RQA-2645))
- Verify that run log before and during run shows full detail for load liquid command
- Cancel or finish run and verify that run log still shows full detail for load liquid command 

Before fix (see command 4):

<img width="519" alt="Screenshot 2024-05-07 at 3 05 37 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/41c2e2dd-161a-457f-9120-c5c2e6a303b8">


After fix (see command 4):

<img width="522" alt="Screenshot 2024-05-07 at 3 05 13 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/72182f03-65b9-43ff-bad8-0370d0864906">

# Changelog

- pull liquids from run record for terminal run to pass to `CommandText` in `RunPreview`
- update `Run` interface to include `liquids` to reflect actual robot server response shape
- update `Run` fixtures to include `liquids` key

# Review requests

auth js

# Risk assessment

low

[RQA-2645]: https://opentrons.atlassian.net/browse/RQA-2645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-2647]: https://opentrons.atlassian.net/browse/RQA-2647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ