### PR TITLE
chore(shared-data): fix deploy to npm github action

### DIFF
--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -234,6 +234,11 @@ jobs:
         with:
           node-version: '18.19.0'
           registry-url: 'https://registry.npmjs.org'
+      - name: 'install udev for usb-detection'
+        run: |
+          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'cache yarn cache'
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
# Overview

[Oops](https://github.com/Opentrons/opentrons/actions/runs/8991222695) I forgot to explicitly install dependencies for usb detection. This PR does that so that we can successfully publish shared-data to npm


# Risk assessment

Low
