### PR TITLE
refactor(app, api-client, react-api-client): unify analysis and run record for CommandText use

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Liquid,
   LoadedLabware,
   LoadedModule,
   LoadedPipette,
@@ -45,6 +46,7 @@ export interface LegacyGoodRunData {
   errors: RunError[]
   pipettes: LoadedPipette[]
   labware: LoadedLabware[]
+  liquids: Liquid[]
   modules: LoadedModule[]
   protocolId?: string
   labwareOffsets?: LabwareOffset[]

--- a/app/src/organisms/CommandText/LoadCommandText.tsx
+++ b/app/src/organisms/CommandText/LoadCommandText.tsx
@@ -6,12 +6,6 @@ import {
   LoadLabwareRunTimeCommand,
   getPipetteNameSpecs,
 } from '@opentrons/shared-data'
-
-import type {
-  RunTimeCommand,
-  CompletedProtocolAnalysis,
-  RobotType,
-} from '@opentrons/shared-data'
 import {
   getLabwareName,
   getPipetteNameOnMount,
@@ -20,15 +14,18 @@ import {
   getLiquidDisplayName,
 } from './utils'
 
+import type { RunTimeCommand, RobotType } from '@opentrons/shared-data'
+import type { CommandTextData } from './types'
+
 interface LoadCommandTextProps {
   command: RunTimeCommand
-  robotSideAnalysis: CompletedProtocolAnalysis
+  protocolData: CommandTextData
   robotType: RobotType
 }
 
 export const LoadCommandText = ({
   command,
-  robotSideAnalysis,
+  protocolData,
   robotType,
 }: LoadCommandTextProps): JSX.Element | null => {
   const { t } = useTranslation('run_details')
@@ -36,7 +33,7 @@ export const LoadCommandText = ({
   switch (command.commandType) {
     case 'loadPipette': {
       const pipetteModel = getPipetteNameOnMount(
-        robotSideAnalysis,
+        protocolData,
         command.params.mount
       )
       return t('load_pipette_protocol_setup', {
@@ -64,7 +61,7 @@ export const LoadCommandText = ({
         'moduleId' in command.params.location
       ) {
         const moduleModel = getModuleModel(
-          robotSideAnalysis,
+          protocolData,
           command.params.location.moduleId
         )
         const moduleName =
@@ -80,7 +77,7 @@ export const LoadCommandText = ({
               : 1,
           labware: command.result?.definition.metadata.displayName,
           slot_name: getModuleDisplayLocation(
-            robotSideAnalysis,
+            protocolData,
             command.params.location.moduleId
           ),
           module_name: moduleName,
@@ -91,7 +88,7 @@ export const LoadCommandText = ({
       ) {
         const labwareId = command.params.location.labwareId
         const labwareName = command.result?.definition.metadata.displayName
-        const matchingAdapter = robotSideAnalysis.commands.find(
+        const matchingAdapter = protocolData.commands.find(
           (command): command is LoadLabwareRunTimeCommand =>
             command.commandType === 'loadLabware' &&
             command.result?.labwareId === labwareId
@@ -112,7 +109,7 @@ export const LoadCommandText = ({
           })
         } else if (adapterLoc != null && 'moduleId' in adapterLoc) {
           const moduleModel = getModuleModel(
-            robotSideAnalysis,
+            protocolData,
             adapterLoc?.moduleId ?? ''
           )
           const moduleName =
@@ -122,7 +119,7 @@ export const LoadCommandText = ({
             adapter_name: adapterName,
             module_name: moduleName,
             slot_name: getModuleDisplayLocation(
-              robotSideAnalysis,
+              protocolData,
               adapterLoc?.moduleId ?? ''
             ),
           })
@@ -148,8 +145,8 @@ export const LoadCommandText = ({
     case 'loadLiquid': {
       const { liquidId, labwareId } = command.params
       return t('load_liquids_info_protocol_setup', {
-        liquid: getLiquidDisplayName(robotSideAnalysis, liquidId),
-        labware: getLabwareName(robotSideAnalysis, labwareId),
+        liquid: getLiquidDisplayName(protocolData, liquidId),
+        labware: getLabwareName(protocolData, labwareId),
       })
     }
     default: {

--- a/app/src/organisms/CommandText/LoadCommandText.tsx
+++ b/app/src/organisms/CommandText/LoadCommandText.tsx
@@ -19,13 +19,13 @@ import type { CommandTextData } from './types'
 
 interface LoadCommandTextProps {
   command: RunTimeCommand
-  protocolData: CommandTextData
+  commandTextData: CommandTextData
   robotType: RobotType
 }
 
 export const LoadCommandText = ({
   command,
-  protocolData,
+  commandTextData,
   robotType,
 }: LoadCommandTextProps): JSX.Element | null => {
   const { t } = useTranslation('run_details')
@@ -33,7 +33,7 @@ export const LoadCommandText = ({
   switch (command.commandType) {
     case 'loadPipette': {
       const pipetteModel = getPipetteNameOnMount(
-        protocolData,
+        commandTextData,
         command.params.mount
       )
       return t('load_pipette_protocol_setup', {
@@ -61,7 +61,7 @@ export const LoadCommandText = ({
         'moduleId' in command.params.location
       ) {
         const moduleModel = getModuleModel(
-          protocolData,
+          commandTextData,
           command.params.location.moduleId
         )
         const moduleName =
@@ -77,7 +77,7 @@ export const LoadCommandText = ({
               : 1,
           labware: command.result?.definition.metadata.displayName,
           slot_name: getModuleDisplayLocation(
-            protocolData,
+            commandTextData,
             command.params.location.moduleId
           ),
           module_name: moduleName,
@@ -88,7 +88,7 @@ export const LoadCommandText = ({
       ) {
         const labwareId = command.params.location.labwareId
         const labwareName = command.result?.definition.metadata.displayName
-        const matchingAdapter = protocolData.commands.find(
+        const matchingAdapter = commandTextData.commands.find(
           (command): command is LoadLabwareRunTimeCommand =>
             command.commandType === 'loadLabware' &&
             command.result?.labwareId === labwareId
@@ -109,7 +109,7 @@ export const LoadCommandText = ({
           })
         } else if (adapterLoc != null && 'moduleId' in adapterLoc) {
           const moduleModel = getModuleModel(
-            protocolData,
+            commandTextData,
             adapterLoc?.moduleId ?? ''
           )
           const moduleName =
@@ -119,7 +119,7 @@ export const LoadCommandText = ({
             adapter_name: adapterName,
             module_name: moduleName,
             slot_name: getModuleDisplayLocation(
-              protocolData,
+              commandTextData,
               adapterLoc?.moduleId ?? ''
             ),
           })
@@ -145,8 +145,8 @@ export const LoadCommandText = ({
     case 'loadLiquid': {
       const { liquidId, labwareId } = command.params
       return t('load_liquids_info_protocol_setup', {
-        liquid: getLiquidDisplayName(protocolData, liquidId),
-        labware: getLabwareName(protocolData, labwareId),
+        liquid: getLiquidDisplayName(commandTextData, liquidId),
+        labware: getLabwareName(commandTextData, labwareId),
       })
     }
     default: {

--- a/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
+++ b/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
@@ -4,29 +4,30 @@ import { getLabwareName } from './utils'
 import { getLabwareDisplayLocation } from './utils/getLabwareDisplayLocation'
 import { getFinalLabwareLocation } from './utils/getFinalLabwareLocation'
 import type {
-  CompletedProtocolAnalysis,
   MoveLabwareRunTimeCommand,
   RobotType,
 } from '@opentrons/shared-data'
+import type { CommandTextData } from './types'
+
 interface MoveLabwareCommandTextProps {
   command: MoveLabwareRunTimeCommand
-  robotSideAnalysis: CompletedProtocolAnalysis
+  protocolData: CommandTextData
   robotType: RobotType
 }
 export function MoveLabwareCommandText(
   props: MoveLabwareCommandTextProps
 ): JSX.Element {
   const { t } = useTranslation('protocol_command_text')
-  const { command, robotSideAnalysis, robotType } = props
+  const { command, protocolData, robotType } = props
   const { labwareId, newLocation, strategy } = command.params
 
-  const allPreviousCommands = robotSideAnalysis.commands.slice(
+  const allPreviousCommands = protocolData.commands.slice(
     0,
-    robotSideAnalysis.commands.findIndex(c => c.id === command.id)
+    protocolData.commands.findIndex(c => c.id === command.id)
   )
   const oldLocation = getFinalLabwareLocation(labwareId, allPreviousCommands)
   const newDisplayLocation = getLabwareDisplayLocation(
-    robotSideAnalysis,
+    protocolData,
     newLocation,
     t,
     robotType
@@ -40,28 +41,18 @@ export function MoveLabwareCommandText(
 
   return strategy === 'usingGripper'
     ? t('move_labware_using_gripper', {
-        labware: getLabwareName(robotSideAnalysis, labwareId),
+        labware: getLabwareName(protocolData, labwareId),
         old_location:
           oldLocation != null
-            ? getLabwareDisplayLocation(
-                robotSideAnalysis,
-                oldLocation,
-                t,
-                robotType
-              )
+            ? getLabwareDisplayLocation(protocolData, oldLocation, t, robotType)
             : '',
         new_location: location,
       })
     : t('move_labware_manually', {
-        labware: getLabwareName(robotSideAnalysis, labwareId),
+        labware: getLabwareName(protocolData, labwareId),
         old_location:
           oldLocation != null
-            ? getLabwareDisplayLocation(
-                robotSideAnalysis,
-                oldLocation,
-                t,
-                robotType
-              )
+            ? getLabwareDisplayLocation(protocolData, oldLocation, t, robotType)
             : '',
         new_location: location,
       })

--- a/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
+++ b/app/src/organisms/CommandText/MoveLabwareCommandText.tsx
@@ -11,23 +11,23 @@ import type { CommandTextData } from './types'
 
 interface MoveLabwareCommandTextProps {
   command: MoveLabwareRunTimeCommand
-  protocolData: CommandTextData
+  commandTextData: CommandTextData
   robotType: RobotType
 }
 export function MoveLabwareCommandText(
   props: MoveLabwareCommandTextProps
 ): JSX.Element {
   const { t } = useTranslation('protocol_command_text')
-  const { command, protocolData, robotType } = props
+  const { command, commandTextData, robotType } = props
   const { labwareId, newLocation, strategy } = command.params
 
-  const allPreviousCommands = protocolData.commands.slice(
+  const allPreviousCommands = commandTextData.commands.slice(
     0,
-    protocolData.commands.findIndex(c => c.id === command.id)
+    commandTextData.commands.findIndex(c => c.id === command.id)
   )
   const oldLocation = getFinalLabwareLocation(labwareId, allPreviousCommands)
   const newDisplayLocation = getLabwareDisplayLocation(
-    protocolData,
+    commandTextData,
     newLocation,
     t,
     robotType
@@ -41,18 +41,28 @@ export function MoveLabwareCommandText(
 
   return strategy === 'usingGripper'
     ? t('move_labware_using_gripper', {
-        labware: getLabwareName(protocolData, labwareId),
+        labware: getLabwareName(commandTextData, labwareId),
         old_location:
           oldLocation != null
-            ? getLabwareDisplayLocation(protocolData, oldLocation, t, robotType)
+            ? getLabwareDisplayLocation(
+                commandTextData,
+                oldLocation,
+                t,
+                robotType
+              )
             : '',
         new_location: location,
       })
     : t('move_labware_manually', {
-        labware: getLabwareName(protocolData, labwareId),
+        labware: getLabwareName(commandTextData, labwareId),
         old_location:
           oldLocation != null
-            ? getLabwareDisplayLocation(protocolData, oldLocation, t, robotType)
+            ? getLabwareDisplayLocation(
+                commandTextData,
+                oldLocation,
+                t,
+                robotType
+              )
             : '',
         new_location: location,
       })

--- a/app/src/organisms/CommandText/PipettingCommandText.tsx
+++ b/app/src/organisms/CommandText/PipettingCommandText.tsx
@@ -113,8 +113,9 @@ export const PipettingCommandText = ({
       const pipetteId = command.params.pipetteId
       const pipetteName:
         | PipetteName
-        | undefined = commandTextData.pipettes.find(pip => pip.id === pipetteId)
-        ?.pipetteName
+        | undefined = commandTextData.pipettes.find(
+        pipette => pipette.id === pipetteId
+      )?.pipetteName
 
       return t('pickup_tip', {
         well_range: getWellRange(

--- a/app/src/organisms/CommandText/PipettingCommandText.tsx
+++ b/app/src/organisms/CommandText/PipettingCommandText.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { getLabwareDefURI, RobotType } from '@opentrons/shared-data'
+import { getLabwareDefURI } from '@opentrons/shared-data'
 
 import { getLabwareDefinitionsFromCommands } from '../LabwarePositionCheck/utils/labware'
 import { getLoadedLabware } from './utils/accessors'
@@ -13,18 +13,19 @@ import {
 import type {
   PipetteName,
   PipettingRunTimeCommand,
+  RobotType,
 } from '@opentrons/shared-data'
 import type { CommandTextData } from './types'
 
 interface PipettingCommandTextProps {
   command: PipettingRunTimeCommand
-  protocolData: CommandTextData
+  commandTextData: CommandTextData
   robotType: RobotType
 }
 
 export const PipettingCommandText = ({
   command,
-  protocolData,
+  commandTextData,
   robotType,
 }: PipettingCommandTextProps): JSX.Element | null => {
   const { t } = useTranslation('protocol_command_text')
@@ -33,9 +34,9 @@ export const PipettingCommandText = ({
     'labwareId' in command.params ? command.params.labwareId : ''
   const wellName = 'wellName' in command.params ? command.params.wellName : ''
 
-  const allPreviousCommands = protocolData.commands.slice(
+  const allPreviousCommands = commandTextData.commands.slice(
     0,
-    protocolData.commands.findIndex(c => c.id === command.id)
+    commandTextData.commands.findIndex(c => c.id === command.id)
   )
   const labwareLocation = getFinalLabwareLocation(
     labwareId,
@@ -43,14 +44,19 @@ export const PipettingCommandText = ({
   )
   const displayLocation =
     labwareLocation != null
-      ? getLabwareDisplayLocation(protocolData, labwareLocation, t, robotType)
+      ? getLabwareDisplayLocation(
+          commandTextData,
+          labwareLocation,
+          t,
+          robotType
+        )
       : ''
   switch (command.commandType) {
     case 'aspirate': {
       const { volume, flowRate } = command.params
       return t('aspirate', {
         well_name: wellName,
-        labware: getLabwareName(protocolData, labwareId),
+        labware: getLabwareName(commandTextData, labwareId),
         labware_location: displayLocation,
         volume: volume,
         flow_rate: flowRate,
@@ -61,7 +67,7 @@ export const PipettingCommandText = ({
       return pushOut
         ? t('dispense_push_out', {
             well_name: wellName,
-            labware: getLabwareName(protocolData, labwareId),
+            labware: getLabwareName(commandTextData, labwareId),
             labware_location: displayLocation,
             volume: volume,
             flow_rate: flowRate,
@@ -69,7 +75,7 @@ export const PipettingCommandText = ({
           })
         : t('dispense', {
             well_name: wellName,
-            labware: getLabwareName(protocolData, labwareId),
+            labware: getLabwareName(commandTextData, labwareId),
             labware_location: displayLocation,
             volume: volume,
             flow_rate: flowRate,
@@ -79,15 +85,15 @@ export const PipettingCommandText = ({
       const { flowRate } = command.params
       return t('blowout', {
         well_name: wellName,
-        labware: getLabwareName(protocolData, labwareId),
+        labware: getLabwareName(commandTextData, labwareId),
         labware_location: displayLocation,
         flow_rate: flowRate,
       })
     }
     case 'dropTip': {
-      const loadedLabware = getLoadedLabware(protocolData, labwareId)
+      const loadedLabware = getLoadedLabware(commandTextData, labwareId)
       const labwareDefinitions = getLabwareDefinitionsFromCommands(
-        protocolData.commands
+        commandTextData.commands
       )
       const labwareDef = labwareDefinitions.find(
         lw => getLabwareDefURI(lw) === loadedLabware?.definitionUri
@@ -95,19 +101,20 @@ export const PipettingCommandText = ({
       return labwareDef?.parameters.isTiprack
         ? t('return_tip', {
             well_name: wellName,
-            labware: getLabwareName(protocolData, labwareId),
+            labware: getLabwareName(commandTextData, labwareId),
             labware_location: displayLocation,
           })
         : t('drop_tip', {
             well_name: wellName,
-            labware: getLabwareName(protocolData, labwareId),
+            labware: getLabwareName(commandTextData, labwareId),
           })
     }
     case 'pickUpTip': {
       const pipetteId = command.params.pipetteId
-      const pipetteName: PipetteName | undefined = protocolData.pipettes.find(
-        pip => pip.id === pipetteId
-      )?.pipetteName
+      const pipetteName:
+        | PipetteName
+        | undefined = commandTextData.pipettes.find(pip => pip.id === pipetteId)
+        ?.pipetteName
 
       return t('pickup_tip', {
         well_range: getWellRange(
@@ -116,7 +123,7 @@ export const PipettingCommandText = ({
           wellName,
           pipetteName
         ),
-        labware: getLabwareName(protocolData, labwareId),
+        labware: getLabwareName(commandTextData, labwareId),
         labware_location: displayLocation,
       })
     }

--- a/app/src/organisms/CommandText/__fixtures__/index.ts
+++ b/app/src/organisms/CommandText/__fixtures__/index.ts
@@ -1,4 +1,13 @@
 import robotSideAnalysis from './mockRobotSideAnalysis.json'
 import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 export const mockRobotSideAnalysis: CompletedProtocolAnalysis = robotSideAnalysis as CompletedProtocolAnalysis
+
+export const mockCommandTextData: CommandTextData = {
+  commands: mockRobotSideAnalysis.commands,
+  pipettes: mockRobotSideAnalysis.pipettes,
+  labware: mockRobotSideAnalysis.labware,
+  modules: mockRobotSideAnalysis.modules,
+  liquids: mockRobotSideAnalysis.liquids,
+}

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -30,6 +30,7 @@ import type {
   PrepareToAspirateRunTimeCommand,
   RunTimeCommand,
 } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 describe('CommandText', () => {
   it('renders correct text for aspirate', () => {
@@ -40,7 +41,7 @@ describe('CommandText', () => {
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -59,7 +60,7 @@ describe('CommandText', () => {
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -85,7 +86,7 @@ describe('CommandText', () => {
     if (pushOutDispenseCommand != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={pushOutDispenseCommand}
         />,
@@ -99,7 +100,7 @@ describe('CommandText', () => {
   it('renders correct text for dispenseInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -128,7 +129,7 @@ describe('CommandText', () => {
     if (blowoutCommand != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={blowoutCommand}
         />,
@@ -142,7 +143,7 @@ describe('CommandText', () => {
   it('renders correct text for blowOutInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -161,7 +162,7 @@ describe('CommandText', () => {
   it('renders correct text for aspirateInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -190,7 +191,7 @@ describe('CommandText', () => {
     if (moveToWellCommand != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={moveToWellCommand}
         />,
@@ -217,7 +218,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -231,7 +232,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for Waste Chutes', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -251,7 +252,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for Fixed Trash', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -271,7 +272,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for Trash Bins', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -291,7 +292,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableAreaForDropTip for Trash Bin', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -312,7 +313,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for slots', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -340,7 +341,7 @@ describe('CommandText', () => {
 
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={command}
       />,
@@ -358,7 +359,7 @@ describe('CommandText', () => {
 
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={command}
       />,
@@ -374,7 +375,7 @@ describe('CommandText', () => {
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -386,7 +387,7 @@ describe('CommandText', () => {
   it('renders correct text for dropTip into a labware', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -407,7 +408,7 @@ describe('CommandText', () => {
   it('renders correct text for dropTipInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -430,7 +431,7 @@ describe('CommandText', () => {
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -449,7 +450,7 @@ describe('CommandText', () => {
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -466,7 +467,7 @@ describe('CommandText', () => {
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          robotSideAnalysis={mockRobotSideAnalysis}
+          protocolData={mockRobotSideAnalysis as CommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -482,7 +483,7 @@ describe('CommandText', () => {
     const loadLabwareCommand = loadLabwareCommands[0]
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadLabwareCommand}
       />,
@@ -497,7 +498,7 @@ describe('CommandText', () => {
     const loadTipRackCommand = loadLabwareCommands[2]
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadTipRackCommand}
       />,
@@ -512,7 +513,7 @@ describe('CommandText', () => {
     const loadOnModuleCommand = loadLabwareCommands[3]
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadOnModuleCommand}
       />,
@@ -550,7 +551,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -574,7 +575,7 @@ describe('CommandText', () => {
     } as LoadLabwareRunTimeCommand
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadOffDeckCommand}
       />,
@@ -615,7 +616,7 @@ describe('CommandText', () => {
     }
     const { getByText } = renderWithProviders(
       <CommandText
-        robotSideAnalysis={analysisWithLiquids}
+        protocolData={analysisWithLiquids as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadLiquidCommand}
       />,
@@ -638,7 +639,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -662,7 +663,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -685,7 +686,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -709,7 +710,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -735,7 +736,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -759,7 +760,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -786,7 +787,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -817,7 +818,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         isOnDevice={true}
       />,
@@ -847,7 +848,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -872,7 +873,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -895,7 +896,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -918,7 +919,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -971,7 +972,7 @@ describe('CommandText', () => {
                 completedAt: null,
               } as RunTimeCommand
             }
-            robotSideAnalysis={mockRobotSideAnalysis}
+            protocolData={mockRobotSideAnalysis as CommandTextData}
             robotType={FLEX_ROBOT_TYPE}
           />,
           {
@@ -997,7 +998,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1020,7 +1021,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1043,7 +1044,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1066,7 +1067,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1089,7 +1090,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1112,7 +1113,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1135,7 +1136,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1158,7 +1159,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1181,7 +1182,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1208,7 +1209,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1237,7 +1238,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1266,7 +1267,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1295,7 +1296,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1326,7 +1327,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1355,7 +1356,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        robotSideAnalysis={mockRobotSideAnalysis}
+        protocolData={mockRobotSideAnalysis as CommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {

--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -11,12 +11,14 @@ import {
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
 import { CommandText } from '../'
-import { mockRobotSideAnalysis } from '../__fixtures__'
+import { mockCommandTextData } from '../__fixtures__'
+import { getCommandTextData } from '../utils/getCommandTextData'
 
 import type {
   AspirateInPlaceRunTimeCommand,
   BlowoutInPlaceRunTimeCommand,
   BlowoutRunTimeCommand,
+  CompletedProtocolAnalysis,
   ConfigureForVolumeRunTimeCommand,
   DispenseInPlaceRunTimeCommand,
   DispenseRunTimeCommand,
@@ -30,18 +32,17 @@ import type {
   PrepareToAspirateRunTimeCommand,
   RunTimeCommand,
 } from '@opentrons/shared-data'
-import type { CommandTextData } from '../types'
 
 describe('CommandText', () => {
   it('renders correct text for aspirate', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'aspirate'
     )
     expect(command).not.toBeUndefined()
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -53,14 +54,14 @@ describe('CommandText', () => {
     }
   })
   it('renders correct text for dispense without pushOut', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'dispense'
     )
     expect(command).not.toBeUndefined()
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -72,7 +73,7 @@ describe('CommandText', () => {
     }
   })
   it('renders correct text for dispense with pushOut', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'dispense'
     )
     const pushOutDispenseCommand = {
@@ -86,7 +87,7 @@ describe('CommandText', () => {
     if (pushOutDispenseCommand != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={pushOutDispenseCommand}
         />,
@@ -100,7 +101,7 @@ describe('CommandText', () => {
   it('renders correct text for dispenseInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -118,7 +119,7 @@ describe('CommandText', () => {
     getByText('Dispensing 50 µL in place at 300 µL/sec')
   })
   it('renders correct text for blowout', () => {
-    const dispenseCommand = mockRobotSideAnalysis.commands.find(
+    const dispenseCommand = mockCommandTextData.commands.find(
       c => c.commandType === 'dispense'
     )
     const blowoutCommand = {
@@ -129,7 +130,7 @@ describe('CommandText', () => {
     if (blowoutCommand != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={blowoutCommand}
         />,
@@ -143,7 +144,7 @@ describe('CommandText', () => {
   it('renders correct text for blowOutInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -162,7 +163,7 @@ describe('CommandText', () => {
   it('renders correct text for aspirateInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -180,7 +181,7 @@ describe('CommandText', () => {
     getByText('Aspirating 10 µL in place at 300 µL/sec')
   })
   it('renders correct text for moveToWell', () => {
-    const dispenseCommand = mockRobotSideAnalysis.commands.find(
+    const dispenseCommand = mockCommandTextData.commands.find(
       c => c.commandType === 'aspirate'
     )
     const moveToWellCommand = {
@@ -191,7 +192,7 @@ describe('CommandText', () => {
     if (moveToWellCommand != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={moveToWellCommand}
         />,
@@ -207,7 +208,7 @@ describe('CommandText', () => {
           commandType: 'moveLabware',
           params: {
             strategy: 'usingGripper',
-            labwareId: mockRobotSideAnalysis.labware[2].id,
+            labwareId: mockCommandTextData.labware[2].id,
             newLocation: { addressableAreaName: '5' },
           },
           id: 'def456',
@@ -218,7 +219,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -232,7 +233,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for Waste Chutes', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -252,7 +253,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for Fixed Trash', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -272,7 +273,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for Trash Bins', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -292,7 +293,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableAreaForDropTip for Trash Bin', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -313,7 +314,7 @@ describe('CommandText', () => {
   it('renders correct text for moveToAddressableArea for slots', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={OT2_ROBOT_TYPE}
         command={
           {
@@ -341,7 +342,7 @@ describe('CommandText', () => {
 
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={command}
       />,
@@ -359,7 +360,7 @@ describe('CommandText', () => {
 
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={command}
       />,
@@ -368,14 +369,14 @@ describe('CommandText', () => {
     getByText('Preparing P300 Single-Channel GEN1 to aspirate')
   })
   it('renders correct text for dropTip', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'dropTip'
     )
     expect(command).not.toBeUndefined()
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -387,7 +388,7 @@ describe('CommandText', () => {
   it('renders correct text for dropTip into a labware', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -408,7 +409,7 @@ describe('CommandText', () => {
   it('renders correct text for dropTipInPlace', () => {
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={
           {
@@ -424,14 +425,14 @@ describe('CommandText', () => {
     getByText('Dropping tip in place')
   })
   it('renders correct text for pickUpTip', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'pickUpTip'
     )
     expect(command).not.toBeUndefined()
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -443,14 +444,14 @@ describe('CommandText', () => {
     }
   })
   it('renders correct text for loadPipette', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'loadPipette'
     )
     expect(command).not.toBeNull()
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -460,14 +461,14 @@ describe('CommandText', () => {
     }
   })
   it('renders correct text for loadModule', () => {
-    const command = mockRobotSideAnalysis.commands.find(
+    const command = mockCommandTextData.commands.find(
       c => c.commandType === 'loadModule'
     )
     expect(command).not.toBeNull()
     if (command != null) {
       const { getByText } = renderWithProviders(
         <CommandText
-          protocolData={mockRobotSideAnalysis as CommandTextData}
+          commandTextData={mockCommandTextData}
           robotType={FLEX_ROBOT_TYPE}
           command={command}
         />,
@@ -477,13 +478,13 @@ describe('CommandText', () => {
     }
   })
   it('renders correct text for loadLabware that is category adapter in slot', () => {
-    const loadLabwareCommands = mockRobotSideAnalysis.commands.filter(
+    const loadLabwareCommands = mockCommandTextData.commands.filter(
       c => c.commandType === 'loadLabware'
     )
     const loadLabwareCommand = loadLabwareCommands[0]
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadLabwareCommand}
       />,
@@ -492,13 +493,13 @@ describe('CommandText', () => {
     getByText('Load Opentrons 96 Flat Bottom Adapter in Slot 2')
   })
   it('renders correct text for loadLabware in slot', () => {
-    const loadLabwareCommands = mockRobotSideAnalysis.commands.filter(
+    const loadLabwareCommands = mockCommandTextData.commands.filter(
       c => c.commandType === 'loadLabware'
     )
     const loadTipRackCommand = loadLabwareCommands[2]
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadTipRackCommand}
       />,
@@ -507,13 +508,13 @@ describe('CommandText', () => {
     getByText('Load Opentrons 96 Tip Rack 300 µL in Slot 9')
   })
   it('renders correct text for loadLabware in module', () => {
-    const loadLabwareCommands = mockRobotSideAnalysis.commands.filter(
+    const loadLabwareCommands = mockCommandTextData.commands.filter(
       c => c.commandType === 'loadLabware'
     )
     const loadOnModuleCommand = loadLabwareCommands[3]
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadOnModuleCommand}
       />,
@@ -551,7 +552,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -563,7 +564,7 @@ describe('CommandText', () => {
     )
   })
   it('renders correct text for loadLabware off deck', () => {
-    const loadLabwareCommands = mockRobotSideAnalysis.commands.filter(
+    const loadLabwareCommands = mockCommandTextData.commands.filter(
       c => c.commandType === 'loadLabware'
     )
     const loadOffDeckCommand = {
@@ -575,7 +576,7 @@ describe('CommandText', () => {
     } as LoadLabwareRunTimeCommand
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         command={loadOffDeckCommand}
       />,
@@ -584,7 +585,7 @@ describe('CommandText', () => {
     getByText('Load NEST 96 Well Plate 100 µL PCR Full Skirt off deck')
   })
   it('renders correct text for loadLiquid', () => {
-    const loadLabwareCommands = mockRobotSideAnalysis.commands.filter(
+    const loadLabwareCommands = mockCommandTextData.commands.filter(
       c => c.commandType === 'loadLabware'
     )
     const liquidId = 'zxcvbn'
@@ -595,7 +596,7 @@ describe('CommandText', () => {
       params: { liquidId, labwareId },
     } as LoadLiquidRunTimeCommand
     const analysisWithLiquids = {
-      ...mockRobotSideAnalysis,
+      ...mockCommandTextData,
       liquids: [
         {
           id: 'zxcvbn',
@@ -616,7 +617,9 @@ describe('CommandText', () => {
     }
     const { getByText } = renderWithProviders(
       <CommandText
-        protocolData={analysisWithLiquids as CommandTextData}
+        commandTextData={getCommandTextData(
+          analysisWithLiquids as CompletedProtocolAnalysis
+        )}
         robotType={FLEX_ROBOT_TYPE}
         command={loadLiquidCommand}
       />,
@@ -639,7 +642,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -663,7 +666,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -686,7 +689,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -710,7 +713,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -736,7 +739,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -760,7 +763,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -787,7 +790,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -818,7 +821,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
         isOnDevice={true}
       />,
@@ -848,7 +851,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -873,7 +876,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -896,7 +899,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -919,7 +922,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -972,7 +975,7 @@ describe('CommandText', () => {
                 completedAt: null,
               } as RunTimeCommand
             }
-            protocolData={mockRobotSideAnalysis as CommandTextData}
+            commandTextData={mockCommandTextData}
             robotType={FLEX_ROBOT_TYPE}
           />,
           {
@@ -998,7 +1001,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1021,7 +1024,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1044,7 +1047,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1067,7 +1070,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1090,7 +1093,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1113,7 +1116,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1136,7 +1139,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1159,7 +1162,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1182,7 +1185,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1209,7 +1212,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1227,7 +1230,7 @@ describe('CommandText', () => {
           commandType: 'moveLabware',
           params: {
             strategy: 'manualMoveWithPause',
-            labwareId: mockRobotSideAnalysis.labware[2].id,
+            labwareId: mockCommandTextData.labware[2].id,
             newLocation: 'offDeck',
           },
           id: 'def456',
@@ -1238,7 +1241,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1256,7 +1259,7 @@ describe('CommandText', () => {
           commandType: 'moveLabware',
           params: {
             strategy: 'manualMoveWithPause',
-            labwareId: mockRobotSideAnalysis.labware[3].id,
+            labwareId: mockCommandTextData.labware[3].id,
             newLocation: { slotName: 'A3' },
           },
           id: 'def456',
@@ -1267,7 +1270,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1285,7 +1288,7 @@ describe('CommandText', () => {
           commandType: 'moveLabware',
           params: {
             strategy: 'usingGripper',
-            labwareId: mockRobotSideAnalysis.labware[2].id,
+            labwareId: mockCommandTextData.labware[2].id,
             newLocation: 'offDeck',
           },
           id: 'def456',
@@ -1296,7 +1299,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1314,7 +1317,7 @@ describe('CommandText', () => {
           commandType: 'moveLabware',
           params: {
             strategy: 'usingGripper',
-            labwareId: mockRobotSideAnalysis.labware[2].id,
+            labwareId: mockCommandTextData.labware[2].id,
             newLocation: {
               addressableAreaName: GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
             },
@@ -1327,7 +1330,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {
@@ -1345,8 +1348,8 @@ describe('CommandText', () => {
           commandType: 'moveLabware',
           params: {
             strategy: 'usingGripper',
-            labwareId: mockRobotSideAnalysis.labware[3].id,
-            newLocation: { moduleId: mockRobotSideAnalysis.modules[0].id },
+            labwareId: mockCommandTextData.labware[3].id,
+            newLocation: { moduleId: mockCommandTextData.modules[0].id },
           },
           id: 'def456',
           result: { offsetId: 'fake_offset_id' },
@@ -1356,7 +1359,7 @@ describe('CommandText', () => {
           startedAt: null,
           completedAt: null,
         }}
-        protocolData={mockRobotSideAnalysis as CommandTextData}
+        commandTextData={mockCommandTextData}
         robotType={FLEX_ROBOT_TYPE}
       />,
       {

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -49,14 +49,14 @@ const SIMPLE_TRANSLATION_KEY_BY_COMMAND_TYPE: {
 
 interface Props extends StyleProps {
   command: RunTimeCommand
-  protocolData: CommandTextData
+  commandTextData: CommandTextData
   robotType: RobotType
   isOnDevice?: boolean
 }
 export function CommandText(props: Props): JSX.Element | null {
   const {
     command,
-    protocolData,
+    commandTextData,
     robotType,
     isOnDevice = false,
     ...styleProps
@@ -75,7 +75,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'pickUpTip': {
       return (
         <StyledText as="p" {...styleProps}>
-          <PipettingCommandText {...{ command, protocolData, robotType }} />
+          <PipettingCommandText {...{ command, commandTextData, robotType }} />
         </StyledText>
       )
     }
@@ -85,7 +85,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'loadLiquid': {
       return (
         <StyledText as="p" {...styleProps}>
-          <LoadCommandText {...{ command, protocolData, robotType }} />
+          <LoadCommandText {...{ command, commandTextData, robotType }} />
         </StyledText>
       )
     }
@@ -168,9 +168,9 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveToWell': {
       const { wellName, labwareId } = command.params
-      const allPreviousCommands = protocolData.commands.slice(
+      const allPreviousCommands = commandTextData.commands.slice(
         0,
-        protocolData.commands.findIndex(c => c.id === command.id)
+        commandTextData.commands.findIndex(c => c.id === command.id)
       )
       const labwareLocation = getFinalLabwareLocation(
         labwareId,
@@ -179,7 +179,7 @@ export function CommandText(props: Props): JSX.Element | null {
       const displayLocation =
         labwareLocation != null
           ? getLabwareDisplayLocation(
-              protocolData,
+              commandTextData,
               labwareLocation,
               t,
               robotType
@@ -189,7 +189,7 @@ export function CommandText(props: Props): JSX.Element | null {
         <StyledText as="p" {...styleProps}>
           {t('move_to_well', {
             well_name: wellName,
-            labware: getLabwareName(protocolData, labwareId),
+            labware: getLabwareName(commandTextData, labwareId),
             labware_location: displayLocation,
           })}
         </StyledText>
@@ -198,13 +198,15 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'moveLabware': {
       return (
         <StyledText as="p" {...styleProps}>
-          <MoveLabwareCommandText {...{ command, protocolData, robotType }} />
+          <MoveLabwareCommandText
+            {...{ command, commandTextData, robotType }}
+          />
         </StyledText>
       )
     }
     case 'configureForVolume': {
       const { volume, pipetteId } = command.params
-      const pipetteName = protocolData.pipettes.find(
+      const pipetteName = commandTextData.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
 
@@ -222,7 +224,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'configureNozzleLayout': {
       const { configurationParams, pipetteId } = command.params
-      const pipetteName = protocolData.pipettes.find(
+      const pipetteName = commandTextData.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
 
@@ -241,7 +243,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'prepareToAspirate': {
       const { pipetteId } = command.params
-      const pipetteName = protocolData.pipettes.find(
+      const pipetteName = commandTextData.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
 
@@ -258,7 +260,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveToAddressableArea': {
       const addressableAreaDisplayName = getAddressableAreaDisplayName(
-        protocolData,
+        commandTextData,
         command.id,
         t
       )
@@ -273,7 +275,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveToAddressableAreaForDropTip': {
       const addressableAreaDisplayName = getAddressableAreaDisplayName(
-        protocolData,
+        commandTextData,
         command.id,
         t
       )

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -20,12 +20,9 @@ import { PipettingCommandText } from './PipettingCommandText'
 import { TemperatureCommandText } from './TemperatureCommandText'
 import { MoveLabwareCommandText } from './MoveLabwareCommandText'
 
-import type {
-  CompletedProtocolAnalysis,
-  RobotType,
-  RunTimeCommand,
-} from '@opentrons/shared-data'
+import type { RobotType, RunTimeCommand } from '@opentrons/shared-data'
 import type { StyleProps } from '@opentrons/components'
+import type { CommandTextData } from './types'
 
 const SIMPLE_TRANSLATION_KEY_BY_COMMAND_TYPE: {
   [commandType in RunTimeCommand['commandType']]?: string
@@ -52,14 +49,14 @@ const SIMPLE_TRANSLATION_KEY_BY_COMMAND_TYPE: {
 
 interface Props extends StyleProps {
   command: RunTimeCommand
-  robotSideAnalysis: CompletedProtocolAnalysis
+  protocolData: CommandTextData
   robotType: RobotType
   isOnDevice?: boolean
 }
 export function CommandText(props: Props): JSX.Element | null {
   const {
     command,
-    robotSideAnalysis,
+    protocolData,
     robotType,
     isOnDevice = false,
     ...styleProps
@@ -78,9 +75,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'pickUpTip': {
       return (
         <StyledText as="p" {...styleProps}>
-          <PipettingCommandText
-            {...{ command, robotSideAnalysis, robotType }}
-          />
+          <PipettingCommandText {...{ command, protocolData, robotType }} />
         </StyledText>
       )
     }
@@ -90,7 +85,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'loadLiquid': {
       return (
         <StyledText as="p" {...styleProps}>
-          <LoadCommandText {...{ command, robotSideAnalysis, robotType }} />
+          <LoadCommandText {...{ command, protocolData, robotType }} />
         </StyledText>
       )
     }
@@ -173,9 +168,9 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveToWell': {
       const { wellName, labwareId } = command.params
-      const allPreviousCommands = robotSideAnalysis.commands.slice(
+      const allPreviousCommands = protocolData.commands.slice(
         0,
-        robotSideAnalysis.commands.findIndex(c => c.id === command.id)
+        protocolData.commands.findIndex(c => c.id === command.id)
       )
       const labwareLocation = getFinalLabwareLocation(
         labwareId,
@@ -184,7 +179,7 @@ export function CommandText(props: Props): JSX.Element | null {
       const displayLocation =
         labwareLocation != null
           ? getLabwareDisplayLocation(
-              robotSideAnalysis,
+              protocolData,
               labwareLocation,
               t,
               robotType
@@ -194,7 +189,7 @@ export function CommandText(props: Props): JSX.Element | null {
         <StyledText as="p" {...styleProps}>
           {t('move_to_well', {
             well_name: wellName,
-            labware: getLabwareName(robotSideAnalysis, labwareId),
+            labware: getLabwareName(protocolData, labwareId),
             labware_location: displayLocation,
           })}
         </StyledText>
@@ -203,15 +198,13 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'moveLabware': {
       return (
         <StyledText as="p" {...styleProps}>
-          <MoveLabwareCommandText
-            {...{ command, robotSideAnalysis, robotType }}
-          />
+          <MoveLabwareCommandText {...{ command, protocolData, robotType }} />
         </StyledText>
       )
     }
     case 'configureForVolume': {
       const { volume, pipetteId } = command.params
-      const pipetteName = robotSideAnalysis.pipettes.find(
+      const pipetteName = protocolData.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
 
@@ -229,7 +222,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'configureNozzleLayout': {
       const { configurationParams, pipetteId } = command.params
-      const pipetteName = robotSideAnalysis.pipettes.find(
+      const pipetteName = protocolData.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
 
@@ -248,7 +241,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'prepareToAspirate': {
       const { pipetteId } = command.params
-      const pipetteName = robotSideAnalysis.pipettes.find(
+      const pipetteName = protocolData.pipettes.find(
         pip => pip.id === pipetteId
       )?.pipetteName
 
@@ -265,7 +258,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveToAddressableArea': {
       const addressableAreaDisplayName = getAddressableAreaDisplayName(
-        robotSideAnalysis,
+        protocolData,
         command.id,
         t
       )
@@ -280,7 +273,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveToAddressableAreaForDropTip': {
       const addressableAreaDisplayName = getAddressableAreaDisplayName(
-        robotSideAnalysis,
+        protocolData,
         command.id,
         t
       )

--- a/app/src/organisms/CommandText/types.ts
+++ b/app/src/organisms/CommandText/types.ts
@@ -1,0 +1,6 @@
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+
+export type CommandTextData = Pick<
+  CompletedProtocolAnalysis,
+  'pipettes' | 'labware' | 'modules' | 'liquids' | 'commands'
+>

--- a/app/src/organisms/CommandText/utils/accessors.ts
+++ b/app/src/organisms/CommandText/utils/accessors.ts
@@ -5,9 +5,10 @@ import type {
   LoadedModule,
   LoadedPipette,
 } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 export function getLoadedLabware(
-  protocolData: CompletedProtocolAnalysis | RunData,
+  protocolData: CompletedProtocolAnalysis | RunData | CommandTextData,
   labwareId: string
 ): LoadedLabware | undefined {
   // NOTE: old analysis contains a object dictionary of labware entities by id, this case is supported for backwards compatibility purposes
@@ -16,16 +17,16 @@ export function getLoadedLabware(
     : protocolData.labware[labwareId]
 }
 export function getLoadedPipette(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   mount: string
 ): LoadedPipette | undefined {
   // NOTE: old analysis contains a object dictionary of pipette entities by id, this case is supported for backwards compatibility purposes
-  return Array.isArray(analysis.pipettes)
-    ? analysis.pipettes.find(l => l.mount === mount)
-    : analysis.pipettes[mount]
+  return Array.isArray(protocolData.pipettes)
+    ? protocolData.pipettes.find(l => l.mount === mount)
+    : protocolData.pipettes[mount]
 }
 export function getLoadedModule(
-  protocolData: CompletedProtocolAnalysis | RunData,
+  protocolData: CompletedProtocolAnalysis | RunData | CommandTextData,
   moduleId: string
 ): LoadedModule | undefined {
   // NOTE: old analysis contains a object dictionary of module entities by id, this case is supported for backwards compatibility purposes

--- a/app/src/organisms/CommandText/utils/accessors.ts
+++ b/app/src/organisms/CommandText/utils/accessors.ts
@@ -8,29 +8,29 @@ import type {
 import type { CommandTextData } from '../types'
 
 export function getLoadedLabware(
-  protocolData: CompletedProtocolAnalysis | RunData | CommandTextData,
+  commandTextData: CompletedProtocolAnalysis | RunData | CommandTextData,
   labwareId: string
 ): LoadedLabware | undefined {
   // NOTE: old analysis contains a object dictionary of labware entities by id, this case is supported for backwards compatibility purposes
-  return Array.isArray(protocolData.labware)
-    ? protocolData.labware.find(l => l.id === labwareId)
-    : protocolData.labware[labwareId]
+  return Array.isArray(commandTextData.labware)
+    ? commandTextData.labware.find(l => l.id === labwareId)
+    : commandTextData.labware[labwareId]
 }
 export function getLoadedPipette(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   mount: string
 ): LoadedPipette | undefined {
   // NOTE: old analysis contains a object dictionary of pipette entities by id, this case is supported for backwards compatibility purposes
-  return Array.isArray(protocolData.pipettes)
-    ? protocolData.pipettes.find(l => l.mount === mount)
-    : protocolData.pipettes[mount]
+  return Array.isArray(commandTextData.pipettes)
+    ? commandTextData.pipettes.find(l => l.mount === mount)
+    : commandTextData.pipettes[mount]
 }
 export function getLoadedModule(
-  protocolData: CompletedProtocolAnalysis | RunData | CommandTextData,
+  commandTextData: CompletedProtocolAnalysis | RunData | CommandTextData,
   moduleId: string
 ): LoadedModule | undefined {
   // NOTE: old analysis contains a object dictionary of module entities by id, this case is supported for backwards compatibility purposes
-  return Array.isArray(protocolData.modules)
-    ? protocolData.modules.find(l => l.id === moduleId)
-    : protocolData.modules[moduleId]
+  return Array.isArray(commandTextData.modules)
+    ? commandTextData.modules.find(l => l.id === moduleId)
+    : commandTextData.modules[moduleId]
 }

--- a/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
+++ b/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
@@ -6,11 +6,11 @@ import type { TFunction } from 'i18next'
 import type { CommandTextData } from '../types'
 
 export function getAddressableAreaDisplayName(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   commandId: string,
   t: TFunction
 ): string {
-  const addressableAreaCommand = (protocolData?.commands ?? []).find(
+  const addressableAreaCommand = (commandTextData?.commands ?? []).find(
     command => command.id === commandId
   )
 

--- a/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
+++ b/app/src/organisms/CommandText/utils/getAddressableAreaDisplayName.ts
@@ -1,16 +1,16 @@
 import type {
   AddressableAreaName,
-  CompletedProtocolAnalysis,
   MoveToAddressableAreaParams,
 } from '@opentrons/shared-data'
 import type { TFunction } from 'i18next'
+import type { CommandTextData } from '../types'
 
 export function getAddressableAreaDisplayName(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   commandId: string,
   t: TFunction
 ): string {
-  const addressableAreaCommand = (analysis?.commands ?? []).find(
+  const addressableAreaCommand = (protocolData?.commands ?? []).find(
     command => command.id === commandId
   )
 

--- a/app/src/organisms/CommandText/utils/getCommandTextData.ts
+++ b/app/src/organisms/CommandText/utils/getCommandTextData.ts
@@ -1,0 +1,16 @@
+import type { LegacyGoodRunData } from '@opentrons/api-client'
+import type {
+  CompletedProtocolAnalysis,
+  RunTimeCommand,
+} from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
+
+export function getCommandTextData(
+  protocolData: CompletedProtocolAnalysis | LegacyGoodRunData,
+  protocolCommands?: RunTimeCommand[]
+): CommandTextData {
+  const { pipettes, labware, modules, liquids } = protocolData
+  const commands =
+    'commands' in protocolData ? protocolData.commands : protocolCommands ?? []
+  return { commands, pipettes, labware, modules, liquids }
+}

--- a/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
@@ -9,14 +9,12 @@ import {
 import { getModuleDisplayLocation } from './getModuleDisplayLocation'
 import { getModuleModel } from './getModuleModel'
 import { getLabwareDefinitionsFromCommands } from '../../LabwarePositionCheck/utils/labware'
-import type {
-  CompletedProtocolAnalysis,
-  RobotType,
-} from '@opentrons/shared-data/'
+import type { RobotType } from '@opentrons/shared-data'
 import type { TFunction } from 'i18next'
+import type { CommandTextData } from '../types'
 
 export function getLabwareDisplayLocation(
-  robotSideAnalysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   location: LabwareLocation,
   t: TFunction,
   robotType: RobotType,
@@ -33,15 +31,12 @@ export function getLabwareDisplayLocation(
       ? location.addressableAreaName
       : t('slot', { slot_name: location.addressableAreaName })
   } else if ('moduleId' in location) {
-    const moduleModel = getModuleModel(robotSideAnalysis, location.moduleId)
+    const moduleModel = getModuleModel(protocolData, location.moduleId)
     if (moduleModel == null) {
       console.warn('labware is located on an unknown module model')
       return ''
     } else {
-      const slotName = getModuleDisplayLocation(
-        robotSideAnalysis,
-        location.moduleId
-      )
+      const slotName = getModuleDisplayLocation(protocolData, location.moduleId)
       return isOnDevice
         ? `${getModuleDisplayName(moduleModel)}, ${slotName}`
         : t('module_in_slot', {
@@ -54,12 +49,10 @@ export function getLabwareDisplayLocation(
           })
     }
   } else if ('labwareId' in location) {
-    const adapter = robotSideAnalysis.labware.find(
+    const adapter = protocolData.labware.find(
       lw => lw.id === location.labwareId
     )
-    const allDefs = getLabwareDefinitionsFromCommands(
-      robotSideAnalysis.commands
-    )
+    const allDefs = getLabwareDefinitionsFromCommands(protocolData.commands)
     const adapterDef = allDefs.find(
       def => getLabwareDefURI(def) === adapter?.definitionUri
     )
@@ -83,7 +76,7 @@ export function getLabwareDisplayLocation(
       })
     } else if ('moduleId' in adapter.location) {
       const moduleIdUnderAdapter = adapter.location.moduleId
-      const moduleModel = robotSideAnalysis.modules.find(
+      const moduleModel = protocolData.modules.find(
         module => module.id === moduleIdUnderAdapter
       )?.model
       if (moduleModel == null) {
@@ -91,7 +84,7 @@ export function getLabwareDisplayLocation(
         return ''
       }
       const slotName = getModuleDisplayLocation(
-        robotSideAnalysis,
+        protocolData,
         adapter.location.moduleId
       )
       return t('adapter_in_mod_in_slot', {

--- a/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareDisplayLocation.ts
@@ -14,7 +14,7 @@ import type { TFunction } from 'i18next'
 import type { CommandTextData } from '../types'
 
 export function getLabwareDisplayLocation(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   location: LabwareLocation,
   t: TFunction,
   robotType: RobotType,
@@ -31,12 +31,15 @@ export function getLabwareDisplayLocation(
       ? location.addressableAreaName
       : t('slot', { slot_name: location.addressableAreaName })
   } else if ('moduleId' in location) {
-    const moduleModel = getModuleModel(protocolData, location.moduleId)
+    const moduleModel = getModuleModel(commandTextData, location.moduleId)
     if (moduleModel == null) {
       console.warn('labware is located on an unknown module model')
       return ''
     } else {
-      const slotName = getModuleDisplayLocation(protocolData, location.moduleId)
+      const slotName = getModuleDisplayLocation(
+        commandTextData,
+        location.moduleId
+      )
       return isOnDevice
         ? `${getModuleDisplayName(moduleModel)}, ${slotName}`
         : t('module_in_slot', {
@@ -49,10 +52,10 @@ export function getLabwareDisplayLocation(
           })
     }
   } else if ('labwareId' in location) {
-    const adapter = protocolData.labware.find(
+    const adapter = commandTextData.labware.find(
       lw => lw.id === location.labwareId
     )
-    const allDefs = getLabwareDefinitionsFromCommands(protocolData.commands)
+    const allDefs = getLabwareDefinitionsFromCommands(commandTextData.commands)
     const adapterDef = allDefs.find(
       def => getLabwareDefURI(def) === adapter?.definitionUri
     )
@@ -76,7 +79,7 @@ export function getLabwareDisplayLocation(
       })
     } else if ('moduleId' in adapter.location) {
       const moduleIdUnderAdapter = adapter.location.moduleId
-      const moduleModel = protocolData.modules.find(
+      const moduleModel = commandTextData.modules.find(
         module => module.id === moduleIdUnderAdapter
       )?.model
       if (moduleModel == null) {
@@ -84,7 +87,7 @@ export function getLabwareDisplayLocation(
         return ''
       }
       const slotName = getModuleDisplayLocation(
-        protocolData,
+        commandTextData,
         adapter.location.moduleId
       )
       return t('adapter_in_mod_in_slot', {

--- a/app/src/organisms/CommandText/utils/getLabwareName.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareName.ts
@@ -1,11 +1,8 @@
 import { getLoadedLabware } from './accessors'
 
-import {
-  CompletedProtocolAnalysis,
-  getLabwareDefURI,
-  getLabwareDisplayName,
-} from '@opentrons/shared-data'
+import { getLabwareDefURI, getLabwareDisplayName } from '@opentrons/shared-data'
 import { getLabwareDefinitionsFromCommands } from '../../LabwarePositionCheck/utils/labware'
+import type { CommandTextData } from '../types'
 
 const FIXED_TRASH_DEF_URIS = [
   'opentrons/opentrons_1_trash_850ml_fixed/1',
@@ -13,10 +10,10 @@ const FIXED_TRASH_DEF_URIS = [
   'opentrons/opentrons_1_trash_3200ml_fixed/1',
 ]
 export function getLabwareName(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   labwareId: string
 ): string {
-  const loadedLabware = getLoadedLabware(analysis, labwareId)
+  const loadedLabware = getLoadedLabware(protocolData, labwareId)
   if (loadedLabware == null) {
     return ''
   } else if (FIXED_TRASH_DEF_URIS.includes(loadedLabware.definitionUri)) {
@@ -25,7 +22,7 @@ export function getLabwareName(
     return loadedLabware.displayName
   } else {
     const labwareDef = getLabwareDefinitionsFromCommands(
-      analysis.commands
+      protocolData.commands
     ).find(def => getLabwareDefURI(def) === loadedLabware.definitionUri)
     return labwareDef != null ? getLabwareDisplayName(labwareDef) : ''
   }

--- a/app/src/organisms/CommandText/utils/getLabwareName.ts
+++ b/app/src/organisms/CommandText/utils/getLabwareName.ts
@@ -10,10 +10,10 @@ const FIXED_TRASH_DEF_URIS = [
   'opentrons/opentrons_1_trash_3200ml_fixed/1',
 ]
 export function getLabwareName(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   labwareId: string
 ): string {
-  const loadedLabware = getLoadedLabware(protocolData, labwareId)
+  const loadedLabware = getLoadedLabware(commandTextData, labwareId)
   if (loadedLabware == null) {
     return ''
   } else if (FIXED_TRASH_DEF_URIS.includes(loadedLabware.definitionUri)) {
@@ -22,7 +22,7 @@ export function getLabwareName(
     return loadedLabware.displayName
   } else {
     const labwareDef = getLabwareDefinitionsFromCommands(
-      protocolData.commands
+      commandTextData.commands
     ).find(def => getLabwareDefURI(def) === loadedLabware.definitionUri)
     return labwareDef != null ? getLabwareDisplayName(labwareDef) : ''
   }

--- a/app/src/organisms/CommandText/utils/getLiquidDisplayName.ts
+++ b/app/src/organisms/CommandText/utils/getLiquidDisplayName.ts
@@ -1,10 +1,10 @@
 import type { CommandTextData } from '../types'
 
 export function getLiquidDisplayName(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   liquidId: string
 ): CommandTextData['liquids'][number]['displayName'] {
-  const liquidDisplayName = (protocolData?.liquids ?? []).find(
+  const liquidDisplayName = (commandTextData?.liquids ?? []).find(
     liquid => liquid.id === liquidId
   )?.displayName
   return liquidDisplayName ?? ''

--- a/app/src/organisms/CommandText/utils/getLiquidDisplayName.ts
+++ b/app/src/organisms/CommandText/utils/getLiquidDisplayName.ts
@@ -1,10 +1,10 @@
-import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 export function getLiquidDisplayName(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   liquidId: string
-): CompletedProtocolAnalysis['liquids'][number]['displayName'] {
-  const liquidDisplayName = (analysis?.liquids ?? []).find(
+): CommandTextData['liquids'][number]['displayName'] {
+  const liquidDisplayName = (protocolData?.liquids ?? []).find(
     liquid => liquid.id === liquidId
   )?.displayName
   return liquidDisplayName ?? ''

--- a/app/src/organisms/CommandText/utils/getModuleDisplayLocation.ts
+++ b/app/src/organisms/CommandText/utils/getModuleDisplayLocation.ts
@@ -1,11 +1,11 @@
 import { getLoadedModule } from './accessors'
 
-import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 export function getModuleDisplayLocation(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   moduleId: string
 ): string {
-  const loadedModule = getLoadedModule(analysis, moduleId)
+  const loadedModule = getLoadedModule(protocolData, moduleId)
   return loadedModule != null ? loadedModule.location.slotName : ''
 }

--- a/app/src/organisms/CommandText/utils/getModuleDisplayLocation.ts
+++ b/app/src/organisms/CommandText/utils/getModuleDisplayLocation.ts
@@ -3,9 +3,9 @@ import { getLoadedModule } from './accessors'
 import type { CommandTextData } from '../types'
 
 export function getModuleDisplayLocation(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   moduleId: string
 ): string {
-  const loadedModule = getLoadedModule(protocolData, moduleId)
+  const loadedModule = getLoadedModule(commandTextData, moduleId)
   return loadedModule != null ? loadedModule.location.slotName : ''
 }

--- a/app/src/organisms/CommandText/utils/getModuleModel.ts
+++ b/app/src/organisms/CommandText/utils/getModuleModel.ts
@@ -4,9 +4,9 @@ import type { ModuleModel } from '@opentrons/shared-data'
 import type { CommandTextData } from '../types'
 
 export function getModuleModel(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   moduleId: string
 ): ModuleModel | null {
-  const loadedModule = getLoadedModule(protocolData, moduleId)
+  const loadedModule = getLoadedModule(commandTextData, moduleId)
   return loadedModule != null ? loadedModule.model : null
 }

--- a/app/src/organisms/CommandText/utils/getModuleModel.ts
+++ b/app/src/organisms/CommandText/utils/getModuleModel.ts
@@ -1,14 +1,12 @@
 import { getLoadedModule } from './accessors'
 
-import type {
-  ModuleModel,
-  CompletedProtocolAnalysis,
-} from '@opentrons/shared-data'
+import type { ModuleModel } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 export function getModuleModel(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   moduleId: string
 ): ModuleModel | null {
-  const loadedModule = getLoadedModule(analysis, moduleId)
+  const loadedModule = getLoadedModule(protocolData, moduleId)
   return loadedModule != null ? loadedModule.model : null
 }

--- a/app/src/organisms/CommandText/utils/getPipetteNameOnMount.ts
+++ b/app/src/organisms/CommandText/utils/getPipetteNameOnMount.ts
@@ -1,14 +1,12 @@
 import { getLoadedPipette } from './accessors'
 
-import type {
-  CompletedProtocolAnalysis,
-  PipetteName,
-} from '@opentrons/shared-data'
+import type { PipetteName } from '@opentrons/shared-data'
+import type { CommandTextData } from '../types'
 
 export function getPipetteNameOnMount(
-  analysis: CompletedProtocolAnalysis,
+  protocolData: CommandTextData,
   mount: string
 ): PipetteName | null {
-  const loadedPipette = getLoadedPipette(analysis, mount)
+  const loadedPipette = getLoadedPipette(protocolData, mount)
   return loadedPipette != null ? loadedPipette.pipetteName : null
 }

--- a/app/src/organisms/CommandText/utils/getPipetteNameOnMount.ts
+++ b/app/src/organisms/CommandText/utils/getPipetteNameOnMount.ts
@@ -4,9 +4,9 @@ import type { PipetteName } from '@opentrons/shared-data'
 import type { CommandTextData } from '../types'
 
 export function getPipetteNameOnMount(
-  protocolData: CommandTextData,
+  commandTextData: CommandTextData,
   mount: string
 ): PipetteName | null {
-  const loadedPipette = getLoadedPipette(protocolData, mount)
+  const loadedPipette = getLoadedPipette(commandTextData, mount)
   return loadedPipette != null ? loadedPipette.pipetteName : null
 }

--- a/app/src/organisms/InterventionModal/__fixtures__/index.ts
+++ b/app/src/organisms/InterventionModal/__fixtures__/index.ts
@@ -8,6 +8,7 @@ import {
 import type { RunData } from '@opentrons/api-client'
 import type {
   LabwareDefinitionsByUri,
+  Liquid,
   LoadedLabware,
   LoadedModule,
 } from '@opentrons/shared-data'
@@ -176,6 +177,12 @@ export const mockThermocyclerModule: LoadedModule = {
   serialNumber: 'dummySerialTC',
 }
 
+export const mockLiquid: Liquid = {
+  id: 'mockLiquid',
+  displayName: 'mock liquid',
+  description: 'this is my mock liquid',
+}
+
 export const mockRunData: RunData = {
   id: 'mockRunData',
   createdAt: '',
@@ -188,6 +195,7 @@ export const mockRunData: RunData = {
   pipettes: [],
   labware: [mockLabwareOnModule, mockLabwareOnSlot, mockLabwareOffDeck],
   modules: [mockModule],
+  liquids: [mockLiquid],
   runTimeParameters: [],
 }
 

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -31,6 +31,7 @@ import type {
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { RunCommandSummary, RunStatus } from '@opentrons/api-client'
+import type { CommandTextData } from '../../CommandText/types'
 import type { TrackProtocolRunEvent } from '../../Devices/hooks'
 import type { RobotAnalyticsData } from '../../../redux/analytics/types'
 
@@ -233,7 +234,7 @@ export function CurrentRunningProtocolCommand({
         {robotSideAnalysis != null && currentCommand != null ? (
           <CommandText
             command={currentCommand}
-            robotSideAnalysis={robotSideAnalysis}
+            protocolData={robotSideAnalysis as CommandTextData}
             robotType={robotType}
             isOnDevice={true}
           />

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -21,6 +21,7 @@ import { RUN_STATUS_RUNNING, RUN_STATUS_IDLE } from '@opentrons/api-client'
 
 import { CommandText } from '../../CommandText'
 import { RunTimer } from '../../Devices/ProtocolRun/RunTimer'
+import { getCommandTextData } from '../../CommandText/utils/getCommandTextData'
 import { PlayPauseButton } from './PlayPauseButton'
 import { StopButton } from './StopButton'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '../../../redux/analytics'
@@ -31,7 +32,6 @@ import type {
   RunTimeCommand,
 } from '@opentrons/shared-data'
 import type { RunCommandSummary, RunStatus } from '@opentrons/api-client'
-import type { CommandTextData } from '../../CommandText/types'
 import type { TrackProtocolRunEvent } from '../../Devices/hooks'
 import type { RobotAnalyticsData } from '../../../redux/analytics/types'
 
@@ -234,7 +234,7 @@ export function CurrentRunningProtocolCommand({
         {robotSideAnalysis != null && currentCommand != null ? (
           <CommandText
             command={currentCommand}
-            protocolData={robotSideAnalysis as CommandTextData}
+            commandTextData={getCommandTextData(robotSideAnalysis)}
             robotType={robotType}
             isOnDevice={true}
           />

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
@@ -23,6 +23,7 @@ import { RUN_STATUS_RUNNING, RUN_STATUS_IDLE } from '@opentrons/api-client'
 
 import { CommandText } from '../../CommandText'
 import { CommandIcon } from '../../RunPreview/CommandIcon'
+import { getCommandTextData } from '../../CommandText/utils/getCommandTextData'
 import { PlayPauseButton } from './PlayPauseButton'
 import { StopButton } from './StopButton'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '../../../redux/analytics'
@@ -34,7 +35,6 @@ import type {
 import type { RunStatus } from '@opentrons/api-client'
 import type { TrackProtocolRunEvent } from '../../Devices/hooks'
 import type { RobotAnalyticsData } from '../../../redux/analytics/types'
-import type { CommandTextData } from '../../CommandText/types'
 
 const TITLE_TEXT_STYLE = css`
   color: ${COLORS.grey60};
@@ -235,7 +235,7 @@ export function RunningProtocolCommandList({
                     <CommandIcon command={command} size="2rem" />
                     <CommandText
                       command={command}
-                      protocolData={robotSideAnalysis as CommandTextData}
+                      commandTextData={getCommandTextData(robotSideAnalysis)}
                       robotType={robotType}
                       css={COMMAND_ROW_STYLE}
                       isOnDevice={true}

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
@@ -34,6 +34,7 @@ import type {
 import type { RunStatus } from '@opentrons/api-client'
 import type { TrackProtocolRunEvent } from '../../Devices/hooks'
 import type { RobotAnalyticsData } from '../../../redux/analytics/types'
+import type { CommandTextData } from '../../CommandText/types'
 
 const TITLE_TEXT_STYLE = css`
   color: ${COLORS.grey60};
@@ -234,7 +235,7 @@ export function RunningProtocolCommandList({
                     <CommandIcon command={command} size="2rem" />
                     <CommandText
                       command={command}
-                      robotSideAnalysis={robotSideAnalysis}
+                      protocolData={robotSideAnalysis as CommandTextData}
                       robotType={robotType}
                       css={COMMAND_ROW_STYLE}
                       isOnDevice={true}

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -33,6 +33,7 @@ import { useRunStatus } from '../RunTimeControl/hooks'
 
 import type { RunStatus } from '@opentrons/api-client'
 import type { RobotType } from '@opentrons/shared-data'
+import type { CommandTextData } from '../CommandText/types'
 
 const COLOR_FADE_MS = 500
 const LIVE_RUN_COMMANDS_POLL_MS = 3000
@@ -82,16 +83,13 @@ export const RunPreviewComponent = (
     (isRunTerminal
       ? nullCheckedCommandsFromQuery
       : robotSideAnalysis.commands) ?? []
-  // pass relevant data from run rather than analysis so that CommandText utilities can properly hash the entities' IDs
-  // TODO (nd:05/02/2024, AUTH-380): update name and types for CommandText (and children/utilities) use of analysis.
-  // We should ideally pass only subset of analysis/run data required by these children and utilities
   const protocolDataFromAnalysisOrRun =
     isRunTerminal && runRecord?.data != null
       ? {
-          ...robotSideAnalysis,
           labware: runRecord.data.labware ?? [],
           modules: runRecord.data.modules ?? [],
           pipettes: runRecord.data.pipettes ?? [],
+          liquids: runRecord.data.liquids ?? [],
           commands: commands,
         }
       : robotSideAnalysis
@@ -173,7 +171,9 @@ export const RunPreviewComponent = (
                   <CommandIcon command={command} color={iconColor} />
                   <CommandText
                     command={command}
-                    robotSideAnalysis={protocolDataFromAnalysisOrRun}
+                    protocolData={
+                      protocolDataFromAnalysisOrRun as CommandTextData
+                    }
                     robotType={robotType}
                     color={COLORS.black90}
                   />

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -30,10 +30,10 @@ import { Divider } from '../../atoms/structure'
 import { NAV_BAR_WIDTH } from '../../App/constants'
 import { CommandIcon } from './CommandIcon'
 import { useRunStatus } from '../RunTimeControl/hooks'
+import { getCommandTextData } from '../CommandText/utils/getCommandTextData'
 
 import type { RunStatus } from '@opentrons/api-client'
 import type { RobotType } from '@opentrons/shared-data'
-import type { CommandTextData } from '../CommandText/types'
 
 const COLOR_FADE_MS = 500
 const LIVE_RUN_COMMANDS_POLL_MS = 3000
@@ -83,16 +83,10 @@ export const RunPreviewComponent = (
     (isRunTerminal
       ? nullCheckedCommandsFromQuery
       : robotSideAnalysis.commands) ?? []
-  const protocolDataFromAnalysisOrRun =
+  const commandTextData =
     isRunTerminal && runRecord?.data != null
-      ? {
-          labware: runRecord.data.labware ?? [],
-          modules: runRecord.data.modules ?? [],
-          pipettes: runRecord.data.pipettes ?? [],
-          liquids: runRecord.data.liquids ?? [],
-          commands: commands,
-        }
-      : robotSideAnalysis
+      ? getCommandTextData(runRecord.data, nullCheckedCommandsFromQuery)
+      : getCommandTextData(robotSideAnalysis)
   const currentRunCommandIndex = commands.findIndex(
     c => c.key === currentRunCommandKey
   )
@@ -171,9 +165,7 @@ export const RunPreviewComponent = (
                   <CommandIcon command={command} color={iconColor} />
                   <CommandText
                     command={command}
-                    protocolData={
-                      protocolDataFromAnalysisOrRun as CommandTextData
-                    }
+                    commandTextData={commandTextData}
                     robotType={robotType}
                     color={COLORS.black90}
                   />

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -43,9 +43,9 @@ import { useDownloadRunLog, useRobotType } from '../Devices/hooks'
 import { InterventionTicks } from './InterventionTicks'
 import { isInterventionCommand } from '../InterventionModal/utils'
 import { useNotifyRunQuery } from '../../resources/runs'
+import { getCommandTextData } from '../CommandText/utils/getCommandTextData'
 
 import type { RunStatus } from '@opentrons/api-client'
-import type { CommandTextData } from '../CommandText/types'
 
 const TERMINAL_RUN_STATUSES: RunStatus[] = [
   RUN_STATUS_STOPPED,
@@ -139,7 +139,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   ) {
     currentStepContents = (
       <CommandText
-        protocolData={analysis as CommandTextData}
+        commandTextData={getCommandTextData(analysis)}
         command={analysisCommands[lastRunAnalysisCommandIndex]}
         robotType={robotType}
       />
@@ -151,7 +151,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   ) {
     currentStepContents = (
       <CommandText
-        protocolData={analysis as CommandTextData}
+        commandTextData={getCommandTextData(analysis)}
         command={runCommandDetails.data}
         robotType={robotType}
       />

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -45,6 +45,7 @@ import { isInterventionCommand } from '../InterventionModal/utils'
 import { useNotifyRunQuery } from '../../resources/runs'
 
 import type { RunStatus } from '@opentrons/api-client'
+import type { CommandTextData } from '../CommandText/types'
 
 const TERMINAL_RUN_STATUSES: RunStatus[] = [
   RUN_STATUS_STOPPED,
@@ -138,7 +139,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   ) {
     currentStepContents = (
       <CommandText
-        robotSideAnalysis={analysis}
+        protocolData={analysis as CommandTextData}
         command={analysisCommands[lastRunAnalysisCommandIndex]}
         robotType={robotType}
       />
@@ -150,7 +151,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   ) {
     currentStepContents = (
       <CommandText
-        robotSideAnalysis={analysis}
+        protocolData={analysis as CommandTextData}
         command={runCommandDetails.data}
         robotType={robotType}
       />

--- a/app/src/organisms/RunTimeControl/__fixtures__/index.ts
+++ b/app/src/organisms/RunTimeControl/__fixtures__/index.ts
@@ -41,6 +41,7 @@ export const mockPausedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -66,6 +67,7 @@ export const mockPauseRequestedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -96,6 +98,7 @@ export const mockRunningRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -136,6 +139,7 @@ export const mockFailedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -171,6 +175,7 @@ export const mockStopRequestedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -206,6 +211,7 @@ export const mockStoppedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -236,6 +242,7 @@ export const mockSucceededRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -250,6 +257,7 @@ export const mockIdleUnstartedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -280,6 +288,7 @@ export const mockIdleStartedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 

--- a/react-api-client/src/runs/__fixtures__/runs.ts
+++ b/react-api-client/src/runs/__fixtures__/runs.ts
@@ -32,6 +32,7 @@ export const mockPausedRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 
@@ -62,6 +63,7 @@ export const mockRunningRun: RunData = {
   pipettes: [],
   labware: [],
   modules: [],
+  liquids: [],
   runTimeParameters: [],
 }
 


### PR DESCRIPTION
closes [AUTH-380](https://opentrons.atlassian.net/browse/AUTH-380)

# Overview

After a run is terminal, we access the run record rather than the most recently completed analysis in the command list in the run preview (or more aptly, run postview). This PR refactors the data sent to CommandText and ultimately many of its children and utilities to include only the necessary data from the run record if the run is terminal, or the most recent analysis if the run has not started or is in progress.

# Test Plan

- Run a protocol that loads at least one liquid (example linked as `rtp_tests.py` [here](https://opentrons.atlassian.net/browse/RQA-2645))
- Verify that run log before and during run shows full detail for load liquid command
- Cancel or finish run and verify that run log still shows full detail for load liquid command 

# Changelog

add new interface `CommandTextData` specifying the following subset of the union of `CompletedProtocolAnalysis` and `LegacyGoodRunData`
- pipettes
- labware
- modules
- liquids
- commands

implement this new interface in `CommandText`, its child components covering all possible command types, and its utilities that lookup entity data from their respective load commands

# Review requests

auth js

# Risk assessment

low-medium

[AUTH-380]: https://opentrons.atlassian.net/browse/AUTH-380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ