### PR TITLE
fix(app): ensure liquids nested in labware on adapter in module show on liquid map

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsMap.tsx
@@ -82,7 +82,7 @@ export function SetupLiquidsMap(
       labwareInAdapterInMod?.params.displayName ??
       module.nestedLabwareDisplayName
     const nestedLabwareWellFill = getWellFillFromLabwareId(
-      module.nestedLabwareId ?? '',
+      topLabwareId ?? '',
       liquids,
       labwareByLiquidId
     )


### PR DESCRIPTION
closes [RQA-2699](https://opentrons.atlassian.net/browse/RQA-2699)

# Overview

At protocol setup on desktop, when viewing liquid setup > map view, liquids are incorrectly set to null for labware nested on an adapter, which is in turn nested on a module. We need to pass the topmost nested labware to getWellFillFromLabwareId to correctly return populated well fill.

# Test Plan

- start setup on a protocol that loads liquids in a labware on top of an adapter on top of a module (like `RiboZero_Plus_8_standard_lw.py` linked [here](https://opentrons.atlassian.net/browse/RQA-2699))
- open accordion for Liquid Setup and select map view
- observe the nested labware (slot D1 if using the above linked example) can be clicked and correctly shows loaded liquids

# Changelog

- access top labware of nested adapters + labware on modules when getting well fill

# Review requests

js

# Risk assessment

low

[RQA-2699]: https://opentrons.atlassian.net/browse/RQA-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ