### PR TITLE
feat(protocol-designer): add flowRate and zHeight fields to multiDispense

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
@@ -8,21 +8,26 @@ import {
   DeprecatedCheckboxField,
   DropdownField,
   Options,
+  Flex,
+  DIRECTION_COLUMN,
+  SPACING,
 } from '@opentrons/components'
 import { getMaxDisposalVolumeForMultidispense } from '../../../steplist/formLevel/handleFormChange/utils'
 import { selectors as stepFormSelectors } from '../../../step-forms'
 import { selectors as uiLabwareSelectors } from '../../../ui/labware'
 import { getBlowoutLocationOptionsForForm } from '../utils'
 import { TextField } from './TextField'
+import { FlowRateField } from './FlowRateField'
+import { BlowoutZOffsetField } from './BlowoutZOffsetField'
 
-import type { FieldProps, FieldPropsByName } from '../types'
 import type { PathOption, StepType } from '../../../form-types'
+import type { FieldProps, FieldPropsByName } from '../types'
 
 import styles from '../StepEditForm.module.css'
 
 interface DropdownFormFieldProps extends FieldProps {
-  className?: string
   options: Options
+  className?: string
 }
 const DropdownFormField = (props: DropdownFormFieldProps): JSX.Element => {
   return (
@@ -103,7 +108,6 @@ export const DisposalVolumeField = (
   )
 
   const { value, updateValue } = propsForFields.disposalVolume_checkbox
-
   return (
     <FormGroup label={t('form:step_edit_form.multiDispenseOptionsLabel')}>
       <>
@@ -123,12 +127,27 @@ export const DisposalVolumeField = (
         </div>
         {value ? (
           <div className={styles.checkbox_row}>
-            <div className={styles.sub_label_no_checkbox}>Blowout</div>
-            <DropdownFormField
-              {...propsForFields.blowout_location}
-              className={styles.large_field}
-              options={disposalDestinationOptions}
-            />
+            <div className={styles.sub_label_no_checkbox}>{t('blowout')}</div>
+            <Flex flexDireciton={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+              <DropdownFormField
+                {...propsForFields.blowout_location}
+                className={styles.large_field}
+                options={disposalDestinationOptions}
+              />
+              <FlowRateField
+                {...propsForFields.blowout_flowRate}
+                pipetteId={pipette}
+                flowRateType="blowout"
+                volume={propsForFields.volume?.value ?? 0}
+                tiprack={propsForFields.tipRack.value}
+              />
+              <BlowoutZOffsetField
+                {...propsForFields.blowout_z_offset}
+                sourceLabwareId={propsForFields.aspirate_labware.value}
+                destLabwareId={propsForFields.dispense_labware.value}
+                blowoutLabwareId={propsForFields.blowout_location.value}
+              />
+            </Flex>
           </div>
         ) : null}
       </>

--- a/protocol-designer/src/localization/en/application.json
+++ b/protocol-designer/src/localization/en/application.json
@@ -1,6 +1,7 @@
 {
   "are_you_sure": "Are you sure you want to remove liquids from all selected wells?",
   "are_you_sure_delete_well": "Are you sure you want to delete well {{well}}?",
+  "blowout": "Blowout",
   "exit_batch_edit": "exit batch edit",
   "go_back": "Go back",
   "labware": "labware",


### PR DESCRIPTION
closes AUTH-391

# Overview

Totally forgot to extend functionality here! This PR adds the `zHeight` and `flowRate` fields to the blowout in multi dispense

# Test Plan

Create a flex protocol with the default pipette and add a 96 well plate to the deck. Add a transfer step with 10uL volume and aspirate from 1 well and dispense into 2 in the same labware. At the bottom of the form, change the path to the multi dispense path and observe the multi dispense settings. The blowout should have a blowout location, blowout flow rate and a blowout z height position.

Here is the image of the settings on the form: (please note that things don't really align but this is a rare setting i think and we will be updating designs in the next pd release!)

<img width="1049" alt="Screenshot 2024-05-08 at 13 21 52" src="https://github.com/Opentrons/opentrons/assets/66035149/2bfaa53c-6ac7-49fe-bfc9-179c80215c54">

# Changelog

- add the new fields to blowout in multi dispense
- add string to i18n

# Review requests

see test plan

# Risk assessment

low
