### PR TITLE
fix(api): OT-2 attempting to connect modules via temporary ports

### DIFF
--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -29,9 +29,11 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 MODULE_PORT_REGEX = re.compile(
+    # add a negative lookbehind to suppress matches on OT-2 tempfiles udev creates
+    r"(?<!\.#ot_module_)"
     # capture all modules by name using alternation
-    "(" + "|".join(modules.MODULE_TYPE_BY_NAME.keys()) + ")"
-    # add a negative lookahead to suppress matches on tempfiles udev creates
+    + "(" + "|".join(modules.MODULE_TYPE_BY_NAME.keys()) + ")"
+    # add a negative lookahead to suppress matches on Flex tempfiles udev creates
     + r"\d+(?!\.tmp-c\d+:\d+)",
     re.I,
 )


### PR DESCRIPTION
Closes AUTH-379

# Overview

#14345 updated the module ports filtering to exclude any temporary ports created by udev. But the regex used for port name matching filters out only Flex port names (e.g. `ot_module_thermocycler2.tmp-c166:2`). This PR adds regex to filter out OT-2 temp ports as well (e.g. `.#ot_module_thermocycler0b494617b5e4f08ae`). 

# Test Plan

Before this PR, when you connect a module on the OT-2, you should see something like the following in the logs (doesn't affect actual module connectivity):

```
Module Added: ModuleAtPort(port='/dev/.#ot_module_thermocycler0b494617b5e4f08ae', name='thermocycler', usb_port=USBPort(name='', port_number=0, port_group='unknown', hub=False, hub_port=None, device_path=''))
Exception in Module registration
           Traceback (most recent call last):
             File "/usr/lib/python3.10/site-packages/serial/serialposix.py", line 322, in open
           FileNotFoundError: [Errno 2] No such file or directory: '/dev/.#ot_module_thermocycler0b494617b5e4f08ae'
```
With the changes in this PR, this error should never happen and the module should get connected correctly over its expected port.

Test that Flex modules' connectivity isn't affected by this either.

# Review requests

I'm still new to regex and looks like there are a few ways to write the pattern to filter out the temp port names. So let me know if there's a better regex pattern for this.

# Risk assessment

Medium. Can affect module connectivity but is easy to test and rule out any issues.
