### PR TITLE
fix(app): fix background color on magnetic module slideout data

### DIFF
--- a/app/src/organisms/ModuleCard/MagneticModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/MagneticModuleSlideout.tsx
@@ -164,13 +164,14 @@ export const MagneticModuleSlideout = (
         {t('height_ranges', { gen: info.version })}
       </StyledText>
       <Flex
-        backgroundColor={COLORS.grey10}
+        backgroundColor={COLORS.grey20}
         flexDirection={DIRECTION_ROW}
         justifyContent={JUSTIFY_SPACE_BETWEEN}
         fontWeight={TYPOGRAPHY.fontWeightRegular}
         fontSize={TYPOGRAPHY.fontSizeP}
         padding={SPACING.spacing16}
         borderRadius={BORDERS.borderRadius4}
+        data-testid={`MagneticModuleSlideout_body_data_${module.serialNumber}`}
       >
         <Flex
           flexDirection={DIRECTION_COLUMN}

--- a/app/src/organisms/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { COLORS } from '@opentrons/components'
 
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
@@ -96,5 +97,13 @@ describe('MagneticModuleSlideout', () => {
       },
     })
     expect(button).not.toBeEnabled()
+  })
+
+  it('renders the correct background color in magnetic module data', () => {
+    render(props)
+    const magneticModuleInfo = screen.getByTestId(
+      'MagneticModuleSlideout_body_data_def456'
+    )
+    expect(magneticModuleInfo).toHaveStyle(`background-color: ${COLORS.grey20}`)
   })
 })


### PR DESCRIPTION
closes [RQA-2515](https://opentrons.atlassian.net/browse/RQA-2515)

# Overview

According to designs, the background for magnetic module slideout height range table should be grey20, not grey10.
<img width="330" alt="Screenshot 2024-05-09 at 1 56 17 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/fa69ea61-3ab1-46a1-ab5f-77752cca8593">

# Test Plan

- connect to robot with magnetic module attached
- click overflow menu on magnetic module card
- select set module height
- verify that background color is grey20 (#E9E9E9)

# Changelog

- update background color
- add test for style

# Review requests

js

# Risk assessment

low

[RQA-2515]: https://opentrons.atlassian.net/browse/RQA-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ