### PR TITLE
fix(app): remove excess padding in TestShakeSlideout

### DIFF
--- a/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TestShakeSlideout.tsx
@@ -194,7 +194,7 @@ export const TestShakeSlideout = (
       <Flex
         flexDirection={DIRECTION_COLUMN}
         fontWeight={TYPOGRAPHY.fontWeightRegular}
-        padding={`${SPACING.spacing16} ${SPACING.spacing20} ${SPACING.spacing20} ${SPACING.spacing16}`}
+        paddingBottom={SPACING.spacing24}
         width="100%"
       >
         <Flex


### PR DESCRIPTION
closes [RQA-2516](https://opentrons.atlassian.net/browse/RQA-2516)

# Overview
remove excess padding in TestShakeSlideout

<img width="335" alt="Screenshot 2024-05-09 at 10 25 50 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/73bb1ac3-0565-4bf8-8d19-4fe6ab1d989a">

# Test Plan

- connect to robot with heater shaker module
- open heater shaker module card overflow > test shake slideout 
- verify padding of latch/shake speed content

# Changelog

- fix padding

# Review requests

js

# Risk assessment

low

[RQA-2516]: https://opentrons.atlassian.net/browse/RQA-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ