### PR TITLE
fix(api): only add tip if pickup successful

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2159,7 +2159,9 @@ class OT3API(
                 instrument.set_current_volume(0)
                 self._backend._update_tip_state(realmount, True)
             else:
-                status = await self.get_tip_presence_status(mount, InstrumentProbeType.PRIMARY)
+                status = await self.get_tip_presence_status(
+                    mount, InstrumentProbeType.PRIMARY
+                )
                 if status == TipStateType.PRESENT:
                     instrument.add_tip(tip_length=tip_length)
                     instrument.set_current_volume(0)


### PR DESCRIPTION
## Overview
Accompanies https://opentrons.atlassian.net/browse/EXEC-432

Currently in `ot3api` during a call to `pick_up_tip`, a tip is cached to the present pipette regardless of whether the pickup succeeded. This was fine, because if the pickup failed, then the current run would end and all instrument information gathered over the course of the run would be erased.

If we want to recover from this and keep the same instances of `Pipette`, though, we should just verify the tip presence before caching information in the api. 

This will probably want to change in the future as we build out `tip_handler` and do more to accommodate partial tip pickup, but I think this is fine for now.
