### PR TITLE
docs(api): add missing equals sign in tutorial code snippets

### DIFF
--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -262,7 +262,7 @@ In each row, you first need to add solution. This will be similar to what you di
 
 .. code-block:: python
             
-        left_pipette.transfer(100, reservoir["A2"], row[0], mix_after(3, 50))
+        left_pipette.transfer(100, reservoir["A2"], row[0], mix_after=(3, 50))
 
 As before, the first argument specifies to transfer 100 µL. The second argument is the source, column 2 of the reservoir. The third argument is the destination, the element at index 0 of the current ``row``. Since Python lists are zero-indexed, but columns on labware start numbering at 1, this will be well A1 on the first time through the loop, B1 the second time, and so on. The fourth argument specifies to mix 3 times with 50 µL of fluid each time.
 
@@ -275,7 +275,7 @@ Finally, it’s time to dilute the solution down the row. One approach would be 
 
 .. code-block:: python
 
-        left_pipette.transfer(100, row[:11], row[1:], mix_after(3, 50))
+        left_pipette.transfer(100, row[:11], row[1:], mix_after=(3, 50))
 
 There’s some Python shorthand here, so let’s unpack it. You can get a range of indices from a list using the colon ``:`` operator, and omitting it at either end means “from the beginning” or “until the end” of the list. So the source is ``row[:11]``, from the beginning of the row until its 11th item. And the destination is ``row[1:]``, from index 1 (column 2!) until the end. Since both of these lists have 11 items, ``transfer()`` will *step through them in parallel*, and they’re constructed so when the source is 0, the destination is 1; when the source is 1, the destination is 2; and so on. This condenses all of the subsequent transfers down the row into a single line of code.
 


### PR DESCRIPTION

# Overview

We got a report that there was a syntax error on the Python API Tutorial page.

# Test Plan

Compared to sample protocol files, which are correct and simulate.

# Changelog

`=`

# Risk assessment

none