### PR TITLE
fix(protocol-designer): properly disable up arrow for MoaM

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
@@ -163,7 +163,7 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
           {...tempTargetProps}
           data-testid="EquipmentOption_upArrow"
           onClick={
-            numMultiples === 7
+            isDisabled || numMultiples === 7
               ? undefined
               : () => {
                   multiples.setValue(numMultiples + 1)
@@ -176,7 +176,7 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
         <Flex
           data-testid="EquipmentOption_downArrow"
           onClick={
-            numMultiples === 0
+            isDisabled || numMultiples === 0
               ? undefined
               : () => {
                   multiples.setValue(numMultiples - 1)

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/EquipmentOption.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/EquipmentOption.test.tsx
@@ -91,4 +91,35 @@ describe('EquipmentOption', () => {
     expect(props.multiples?.setValue).toHaveBeenCalled()
     screen.getByTestId('EquipmentOption_downArrow')
   })
+  it('renders the equipment option with multiples allowed cta disabled from isDisabled', () => {
+    props = {
+      ...props,
+      multiples: {
+        numItems: 1,
+        maxItems: 4,
+        setValue: vi.fn(),
+        isDisabled: true,
+      },
+    }
+    render(props)
+    fireEvent.click(screen.getByTestId('EquipmentOption_upArrow'))
+    expect(props.multiples?.setValue).not.toHaveBeenCalled()
+  })
+  it('renders the equipment option with multiples allowed cta disabled from hitting max number', () => {
+    props = {
+      ...props,
+      multiples: {
+        numItems: 1,
+        maxItems: 7,
+        setValue: vi.fn(),
+        isDisabled: false,
+      },
+    }
+    render(props)
+    screen.getByText('1')
+    for (let i = 1; i < 7; i++) {
+      fireEvent.click(screen.getByTestId('EquipmentOption_upArrow'))
+    }
+    expect(props.multiples?.setValue).toHaveBeenCalledTimes(6)
+  })
 })


### PR DESCRIPTION
closes RQA-2704

# Overview

As described in the bug ticket, even when the arrow was disabled, the CTA was not disabled. This PR fixes it

# Test Plan

create a flex protocol and add 2 staging area slots. Then add as many temperature moduels as you can. It should be disabled after 5 temperature modules.

# Changelog

- fix logic for disabling the CTA
- add test coverage

# Review requests

see test plan

# Risk assessment

low