### PR TITLE
fix(hardware): fix sensor moves that aren't using the buffer

### DIFF
--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -71,30 +71,17 @@ pressure_output_file_heading = [
 # FIXME we should organize all of these functions to use the sensor drivers.
 # FIXME we should restrict some of these functions by instrument type.
 
-
-def _build_pass_step(
+def _fix_pass_step_for_buffer(
+    move_group: MoveGroupStep,
     movers: List[NodeId],
     distance: Dict[NodeId, float],
     speed: Dict[NodeId, float],
     stop_condition: MoveStopCondition = MoveStopCondition.sync_line,
-    sensor_to_use: Optional[SensorId] = None,
+    sensor_to_use: Optional[SensorId] = None
 ) -> MoveGroupStep:
     pipette_nodes = [
         i for i in movers if i in [NodeId.pipette_left, NodeId.pipette_right]
     ]
-
-    move_group = create_step(
-        distance={ax: float64(abs(distance[ax])) for ax in movers},
-        velocity={
-            ax: float64(speed[ax] * copysign(1.0, distance[ax])) for ax in movers
-        },
-        acceleration={},
-        # use any node present to calculate duration of the move, assuming the durations
-        #   will be the same
-        duration=float64(abs(distance[movers[0]] / speed[movers[0]])),
-        present_nodes=movers,
-        stop_condition=stop_condition,
-    )
     pipette_move = create_step(
         distance={ax: float64(abs(distance[ax])) for ax in movers},
         velocity={
@@ -110,6 +97,27 @@ def _build_pass_step(
     )
     for node in pipette_nodes:
         move_group[node] = pipette_move[node]
+    return move_group
+
+def _build_pass_step(
+    movers: List[NodeId],
+    distance: Dict[NodeId, float],
+    speed: Dict[NodeId, float],
+    stop_condition: MoveStopCondition = MoveStopCondition.sync_line,
+    sensor_to_use: Optional[SensorId] = None,
+) -> MoveGroupStep:
+    move_group = create_step(
+        distance={ax: float64(abs(distance[ax])) for ax in movers},
+        velocity={
+            ax: float64(speed[ax] * copysign(1.0, distance[ax])) for ax in movers
+        },
+        acceleration={},
+        # use any node present to calculate duration of the move, assuming the durations
+        #   will be the same
+        duration=float64(abs(distance[movers[0]] / speed[movers[0]])),
+        present_nodes=movers,
+        stop_condition=stop_condition,
+    )
     return move_group
 
 
@@ -323,6 +331,15 @@ async def liquid_probe(
         stop_condition=MoveStopCondition.sync_line,
         sensor_to_use=sensor_id,
     )
+    if sync_buffer_output:
+        sensor_group = _fix_pass_step_for_buffer(
+            sensor_group,
+            movers=[head_node, tool],
+            distance={head_node: max_z_distance, tool: max_z_distance},
+            speed={head_node: mount_speed, tool: plunger_speed},
+            stop_condition=MoveStopCondition.sync_line,
+            sensor_to_use=sensor_id
+        )
 
     sensor_runner = MoveGroupRunner(move_groups=[[sensor_group]])
     if csv_output:

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -71,13 +71,14 @@ pressure_output_file_heading = [
 # FIXME we should organize all of these functions to use the sensor drivers.
 # FIXME we should restrict some of these functions by instrument type.
 
+
 def _fix_pass_step_for_buffer(
     move_group: MoveGroupStep,
     movers: List[NodeId],
     distance: Dict[NodeId, float],
     speed: Dict[NodeId, float],
     stop_condition: MoveStopCondition = MoveStopCondition.sync_line,
-    sensor_to_use: Optional[SensorId] = None
+    sensor_to_use: Optional[SensorId] = None,
 ) -> MoveGroupStep:
     pipette_nodes = [
         i for i in movers if i in [NodeId.pipette_left, NodeId.pipette_right]
@@ -98,6 +99,7 @@ def _fix_pass_step_for_buffer(
     for node in pipette_nodes:
         move_group[node] = pipette_move[node]
     return move_group
+
 
 def _build_pass_step(
     movers: List[NodeId],
@@ -338,7 +340,7 @@ async def liquid_probe(
             distance={head_node: max_z_distance, tool: max_z_distance},
             speed={head_node: mount_speed, tool: plunger_speed},
             stop_condition=MoveStopCondition.sync_line,
-            sensor_to_use=sensor_id
+            sensor_to_use=sensor_id,
         )
 
     sensor_runner = MoveGroupRunner(move_groups=[[sensor_group]])

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -1,10 +1,12 @@
 """Test the tool-sensor coordination code."""
 import logging
 from mock import patch, ANY, AsyncMock, call
+import os
 import pytest
 from contextlib import asynccontextmanager
 from typing import Iterator, List, Tuple, AsyncIterator, Any, Dict
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
+    AddLinearMoveRequest,
     ExecuteMoveGroupRequest,
     MoveCompleted,
     ReadFromSensorResponse,
@@ -48,6 +50,7 @@ from opentrons_hardware.firmware_bindings.constants import (
     SensorType,
     SensorThresholdMode,
     SensorOutputBinding,
+    MoveStopCondition,
 )
 from opentrons_hardware.sensors.scheduler import SensorScheduler
 from opentrons_hardware.sensors.sensor_driver import SensorDriver
@@ -191,6 +194,109 @@ async def test_liquid_probe(
     assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(
         sensor=sensor_info,
         data=SensorDataType.build(threshold_pascals * 65536, sensor_info.sensor_type),
+        mode=SensorThresholdMode.absolute,
+    )
+
+
+@pytest.mark.parametrize(
+    "csv_output, sync_buffer_output, can_bus_only_output, move_stop_condition",
+    [
+        (True, False, False, MoveStopCondition.sync_line),
+        (True, True, False, MoveStopCondition.sensor_report),
+        (False, False, True, MoveStopCondition.sync_line),
+    ],
+)
+async def test_liquid_probe_output_options(
+    mock_messenger: AsyncMock,
+    mock_bind_output: AsyncMock,
+    message_send_loopback: CanLoopback,
+    mock_sensor_threshold: AsyncMock,
+    csv_output: bool,
+    sync_buffer_output: bool,
+    can_bus_only_output: bool,
+    move_stop_condition: MoveStopCondition,
+) -> None:
+    """Test that liquid_probe targets the right nodes."""
+    sensor_info = SensorInformation(
+        sensor_type=SensorType.pressure,
+        sensor_id=SensorId.S0,
+        node_id=NodeId.pipette_left,
+    )
+    test_csv_file: str = os.path.join(os.getcwd(), "test.csv")
+
+    def move_responder(
+        node_id: NodeId, message: MessageDefinition
+    ) -> List[Tuple[NodeId, MessageDefinition, NodeId]]:
+        message.payload.serialize()
+        if isinstance(message, ExecuteMoveGroupRequest):
+            ack_payload = EmptyPayload()
+            ack_payload.message_index = message.payload.message_index
+            return [
+                (
+                    NodeId.host,
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            group_id=UInt8Field(0),
+                            seq_id=UInt8Field(0),
+                            current_position_um=UInt32Field(14000),
+                            encoder_position_um=Int32Field(14000),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(2),
+                        )
+                    ),
+                    NodeId.head_l,
+                ),
+                (
+                    NodeId.host,
+                    MoveCompleted(
+                        payload=MoveCompletedPayload(
+                            group_id=UInt8Field(0),
+                            seq_id=UInt8Field(0),
+                            current_position_um=UInt32Field(14000),
+                            encoder_position_um=Int32Field(14000),
+                            position_flags=MotorPositionFlagsField(0),
+                            ack_id=UInt8Field(2),
+                        )
+                    ),
+                    NodeId.pipette_left,
+                ),
+            ]
+        else:
+            if (
+                isinstance(message, AddLinearMoveRequest)
+                and node_id == NodeId.pipette_left
+            ):
+                assert (
+                    message.payload.request_stop_condition.value == move_stop_condition
+                )
+            return []
+
+    message_send_loopback.add_responder(move_responder)
+    try:
+        position = await liquid_probe(
+            messenger=mock_messenger,
+            tool=NodeId.pipette_left,
+            head_node=NodeId.head_l,
+            max_z_distance=40,
+            mount_speed=10,
+            plunger_speed=8,
+            threshold_pascals=14,
+            csv_output=csv_output,
+            sync_buffer_output=sync_buffer_output,
+            can_bus_only_output=can_bus_only_output,
+            data_files={SensorId.S0: test_csv_file},
+            auto_zero_sensor=True,
+            num_baseline_reads=8,
+            sensor_id=SensorId.S0,
+        )
+    finally:
+        if os.path.isfile(test_csv_file):
+            # clean up the test file this creates if it exists
+            os.remove(test_csv_file)
+    assert position[NodeId.head_l].positions_only()[0] == 14
+    assert mock_sensor_threshold.call_args_list[0][0][0] == SensorThresholdInformation(
+        sensor=sensor_info,
+        data=SensorDataType.build(14 * 65536, sensor_info.sensor_type),
         mode=SensorThresholdMode.absolute,
     )
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
When we were working on the sensor buffer based moves we accidently broke other sensor based moves by changing the move stop condition. 
In the buffer moves we trigger the sync differently because we're doing it from the motor-interrupt and then clearing it from the python side
but the other that are normally expecting to check against the move stop condition of the sync line were never finishing because the sync line wasn't getting sent.

this PR fixes the issue by only changing the move stop condition when we're using the buffer based moves


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
