### PR TITLE
refactor(protocol-designer): logic for when slots are occupied for staging areas

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/StagingAreaTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/StagingAreaTile.tsx
@@ -43,7 +43,10 @@ export function StagingAreaTile(props: WizardTileProps): JSX.Element | null {
     // and a cutoutFixtureId so that we don't have to string parse here to generate them
     equipment.includes('stagingArea')
   )
-  const unoccupiedStagingAreaSlots = getUnoccupiedStagingAreaSlots(modules)
+  const unoccupiedStagingAreaSlots = getUnoccupiedStagingAreaSlots(
+    modules,
+    additionalEquipment
+  )
 
   const savedStagingAreaSlots: DeckConfiguration = stagingAreaItems.flatMap(
     item => {

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
@@ -31,25 +31,47 @@ let MOCK_FORM_STATE = {
 
 describe('getUnoccupiedStagingAreaSlots', () => {
   it('should return all staging area slots when there are no modules', () => {
-    const result = getUnoccupiedStagingAreaSlots(null)
+    const result = getUnoccupiedStagingAreaSlots(null, [])
     expect(result).toStrictEqual(STANDARD_EMPTY_SLOTS)
   })
-  it('should return one staging area slot when there are modules in the way of the other slots', () => {
-    const result = getUnoccupiedStagingAreaSlots({
-      0: { model: 'magneticBlockV1', type: 'magneticBlockType', slot: 'A3' },
-      1: {
-        model: 'temperatureModuleV2',
-        type: 'temperatureModuleType',
-        slot: 'B3',
+  it('should return one staging area slot when there are only 1 num slots available', () => {
+    const result = getUnoccupiedStagingAreaSlots(
+      {
+        0: {
+          model: 'heaterShakerModuleV1',
+          type: 'heaterShakerModuleType',
+          slot: 'D1',
+        },
+        1: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'D3',
+        },
+        2: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'C1',
+        },
+        3: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'B3',
+        },
+        4: {
+          model: 'thermocyclerModuleV2',
+          type: 'thermocyclerModuleType',
+          slot: 'B1',
+        },
+        5: {
+          model: 'temperatureModuleV2',
+          type: 'temperatureModuleType',
+          slot: 'A3',
+        },
       },
-      2: {
-        model: 'temperatureModuleV2',
-        type: 'temperatureModuleType',
-        slot: 'C3',
-      },
-    })
+      []
+    )
     expect(result).toStrictEqual([
-      { cutoutId: 'cutoutD3', cutoutFixtureId: SINGLE_RIGHT_SLOT_FIXTURE },
+      { cutoutId: 'cutoutA3', cutoutFixtureId: SINGLE_RIGHT_SLOT_FIXTURE },
     ])
   })
 })

--- a/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
@@ -64,26 +64,6 @@ export const MOVABLE_TRASH_CUTOUTS = [
   },
 ]
 
-export const getUnoccupiedStagingAreaSlots = (
-  modules: FormState['modules']
-): DeckConfiguration => {
-  let unoccupiedSlots = STANDARD_EMPTY_SLOTS
-  const moduleCutoutIds =
-    modules != null
-      ? Object.values(modules).flatMap(module =>
-          module.type === THERMOCYCLER_MODULE_TYPE
-            ? [`cutout${module.slot}`, 'cutoutA1']
-            : `cutout${module.slot}`
-        )
-      : []
-
-  unoccupiedSlots = unoccupiedSlots.filter(emptySlot => {
-    return !moduleCutoutIds.includes(emptySlot.cutoutId)
-  })
-
-  return unoccupiedSlots
-}
-
 const TOTAL_MODULE_SLOTS = 8
 
 export const getNumSlotsAvailable = (
@@ -126,6 +106,19 @@ export const getNumSlotsAvailable = (
     TOTAL_MODULE_SLOTS -
     (filteredModuleLength + filteredAdditionalEquipmentLength)
   )
+}
+
+export const getUnoccupiedStagingAreaSlots = (
+  modules: FormState['modules'],
+  additionalEquipment: FormState['additionalEquipment']
+): DeckConfiguration => {
+  const numSlotsAvailable = getNumSlotsAvailable(modules, additionalEquipment)
+  let unoccupiedSlots = STANDARD_EMPTY_SLOTS
+
+  if (numSlotsAvailable < 4) {
+    unoccupiedSlots = STANDARD_EMPTY_SLOTS.slice(0, numSlotsAvailable)
+  }
+  return unoccupiedSlots
 }
 
 interface TrashOptionDisabledProps {


### PR DESCRIPTION
closes RQA-2705

# Overview

This addresses the bug that Koji found. I forgot to update the staging area slot unoccupied logic to account for the modules not being assigned a slot initially.

# Test Plan

Create a flex protocol and add a bunch of modules then go back to the staging area slots tile. See that it only allows you to add a staging area if there are enough slots.

NOTE: there is nothing notifying you why there are no available slots. I guess i could add something there, like a banner or something but I think i will leave as is unless QA or design think otherwise. This will be redesigned in PD 8.2 anyway
# Changelog

- refactor logic for getting unoccupied staging area slots
- fix test

# Review requests

see test plan

# Risk assessment

low