### PR TITLE
refactor(api): Allow commands to return errors instead of raising them

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -1,7 +1,7 @@
 """Aspirate command request, result, and implementation models."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import (
     PipetteIdMixin,
@@ -12,6 +12,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -120,7 +121,7 @@ class AspirateImplementation(
         )
 
 
-class Aspirate(BaseCommand[AspirateParams, AspirateResult, Never]):
+class Aspirate(BaseCommand[AspirateParams, AspirateResult, ErrorOccurrence]):
     """Aspirate command model."""
 
     commandType: AspirateCommandType = "aspirate"

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -12,7 +12,7 @@ from .pipetting_common import (
     FlowRateMixin,
     BaseLiquidHandlingResult,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from ..errors.exceptions import PipetteNotReadyToAspirateError
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class AspirateInPlaceResult(BaseLiquidHandlingResult):
 
 
 class AspirateInPlaceImplementation(
-    AbstractCommandImpl[AspirateInPlaceParams, AspirateInPlaceResult]
+    AbstractCommandImpl[AspirateInPlaceParams, SuccessData[AspirateInPlaceResult, None]]
 ):
     """AspirateInPlace command implementation."""
 
@@ -53,7 +53,9 @@ class AspirateInPlaceImplementation(
         self._hardware_api = hardware_api
         self._command_note_adder = command_note_adder
 
-    async def execute(self, params: AspirateInPlaceParams) -> AspirateInPlaceResult:
+    async def execute(
+        self, params: AspirateInPlaceParams
+    ) -> SuccessData[AspirateInPlaceResult, None]:
         """Aspirate without moving the pipette.
 
         Raises:
@@ -77,10 +79,10 @@ class AspirateInPlaceImplementation(
             command_note_adder=self._command_note_adder,
         )
 
-        return AspirateInPlaceResult(volume=volume)
+        return SuccessData(public=AspirateInPlaceResult(volume=volume), private=None)
 
 
-class AspirateInPlace(BaseCommand[AspirateInPlaceParams, AspirateInPlaceResult]):
+class AspirateInPlace(BaseCommand[AspirateInPlaceParams, AspirateInPlaceResult, Never]):
     """AspirateInPlace command model."""
 
     commandType: AspirateInPlaceCommandType = "aspirateInPlace"

--- a/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate_in_place.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -13,6 +13,7 @@ from .pipetting_common import (
     BaseLiquidHandlingResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from ..errors.exceptions import PipetteNotReadyToAspirateError
 
 if TYPE_CHECKING:
@@ -82,7 +83,9 @@ class AspirateInPlaceImplementation(
         return SuccessData(public=AspirateInPlaceResult(volume=volume), private=None)
 
 
-class AspirateInPlace(BaseCommand[AspirateInPlaceParams, AspirateInPlaceResult, Never]):
+class AspirateInPlace(
+    BaseCommand[AspirateInPlaceParams, AspirateInPlaceResult, ErrorOccurrence]
+):
     """AspirateInPlace command model."""
 
     commandType: AspirateInPlaceCommandType = "aspirateInPlace"

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -1,7 +1,7 @@
 """Blow-out command request, result, and implementation models."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from ..types import DeckPoint
 from .pipetting_common import (
@@ -10,7 +10,7 @@ from .pipetting_common import (
     WellLocationMixin,
     DestinationPositionResult,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -34,7 +34,9 @@ class BlowOutResult(DestinationPositionResult):
     pass
 
 
-class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
+class BlowOutImplementation(
+    AbstractCommandImpl[BlowOutParams, SuccessData[BlowOutResult, None]]
+):
     """BlowOut command implementation."""
 
     def __init__(
@@ -50,7 +52,7 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
         self._state_view = state_view
         self._hardware_api = hardware_api
 
-    async def execute(self, params: BlowOutParams) -> BlowOutResult:
+    async def execute(self, params: BlowOutParams) -> SuccessData[BlowOutResult, None]:
         """Move to and blow-out the requested well."""
         x, y, z = await self._movement.move_to_well(
             pipette_id=params.pipetteId,
@@ -63,10 +65,12 @@ class BlowOutImplementation(AbstractCommandImpl[BlowOutParams, BlowOutResult]):
             pipette_id=params.pipetteId, flow_rate=params.flowRate
         )
 
-        return BlowOutResult(position=DeckPoint(x=x, y=y, z=z))
+        return SuccessData(
+            public=BlowOutResult(position=DeckPoint(x=x, y=y, z=z)), private=None
+        )
 
 
-class BlowOut(BaseCommand[BlowOutParams, BlowOutResult]):
+class BlowOut(BaseCommand[BlowOutParams, BlowOutResult, Never]):
     """Blow-out command model."""
 
     commandType: BlowOutCommandType = "blowout"

--- a/api/src/opentrons/protocol_engine/commands/blow_out.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out.py
@@ -1,7 +1,7 @@
 """Blow-out command request, result, and implementation models."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import DeckPoint
 from .pipetting_common import (
@@ -11,6 +11,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -70,7 +71,7 @@ class BlowOutImplementation(
         )
 
 
-class BlowOut(BaseCommand[BlowOutParams, BlowOutResult, Never]):
+class BlowOut(BaseCommand[BlowOutParams, BlowOutResult, ErrorOccurrence]):
     """Blow-out command model."""
 
     commandType: BlowOutCommandType = "blowout"

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 from pydantic import BaseModel
 
 from .pipetting_common import (
     PipetteIdMixin,
     FlowRateMixin,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -35,7 +35,7 @@ class BlowOutInPlaceResult(BaseModel):
 
 
 class BlowOutInPlaceImplementation(
-    AbstractCommandImpl[BlowOutInPlaceParams, BlowOutInPlaceResult]
+    AbstractCommandImpl[BlowOutInPlaceParams, SuccessData[BlowOutInPlaceResult, None]]
 ):
     """BlowOutInPlace command implementation."""
 
@@ -50,16 +50,18 @@ class BlowOutInPlaceImplementation(
         self._state_view = state_view
         self._hardware_api = hardware_api
 
-    async def execute(self, params: BlowOutInPlaceParams) -> BlowOutInPlaceResult:
+    async def execute(
+        self, params: BlowOutInPlaceParams
+    ) -> SuccessData[BlowOutInPlaceResult, None]:
         """Blow-out without moving the pipette."""
         await self._pipetting.blow_out_in_place(
             pipette_id=params.pipetteId, flow_rate=params.flowRate
         )
 
-        return BlowOutInPlaceResult()
+        return SuccessData(public=BlowOutInPlaceResult(), private=None)
 
 
-class BlowOutInPlace(BaseCommand[BlowOutInPlaceParams, BlowOutInPlaceResult]):
+class BlowOutInPlace(BaseCommand[BlowOutInPlaceParams, BlowOutInPlaceResult, Never]):
     """BlowOutInPlace command model."""
 
     commandType: BlowOutInPlaceCommandType = "blowOutInPlace"

--- a/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/blow_out_in_place.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 from pydantic import BaseModel
 
 from .pipetting_common import (
@@ -10,6 +10,7 @@ from .pipetting_common import (
     FlowRateMixin,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -61,7 +62,9 @@ class BlowOutInPlaceImplementation(
         return SuccessData(public=BlowOutInPlaceResult(), private=None)
 
 
-class BlowOutInPlace(BaseCommand[BlowOutInPlaceParams, BlowOutInPlaceResult, Never]):
+class BlowOutInPlace(
+    BaseCommand[BlowOutInPlaceParams, BlowOutInPlaceResult, ErrorOccurrence]
+):
     """BlowOutInPlace command model."""
 
     commandType: BlowOutInPlaceCommandType = "blowOutInPlace"

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_gripper.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_gripper.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from typing import Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from pydantic import BaseModel, Field
 
@@ -14,6 +14,7 @@ from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
 )
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 from opentrons.protocol_engine.types import Vec3f
 from opentrons.protocol_engine.resources import ensure_ot3_hardware
 
@@ -139,7 +140,7 @@ class CalibrateGripperImplementation(
 
 
 class CalibrateGripper(
-    BaseCommand[CalibrateGripperParams, CalibrateGripperResult, Never]
+    BaseCommand[CalibrateGripperParams, CalibrateGripperResult, ErrorOccurrence]
 ):
     """A `calibrateGripper` command."""
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
@@ -2,16 +2,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
-from opentrons.protocol_engine.commands.command import (
-    AbstractCommandImpl,
-    BaseCommand,
-    BaseCommandCreate,
-)
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 # Work around type-only circular dependencies.
 if TYPE_CHECKING:
@@ -52,7 +48,7 @@ class CalibrateModuleResult(BaseModel):
 
 
 class CalibrateModuleImplementation(
-    AbstractCommandImpl[CalibrateModuleParams, CalibrateModuleResult]
+    AbstractCommandImpl[CalibrateModuleParams, SuccessData[CalibrateModuleResult, None]]
 ):
     """CalibrateModule command implementation."""
 
@@ -65,7 +61,9 @@ class CalibrateModuleImplementation(
         self._state_view = state_view
         self._hardware_api = hardware_api
 
-    async def execute(self, params: CalibrateModuleParams) -> CalibrateModuleResult:
+    async def execute(
+        self, params: CalibrateModuleParams
+    ) -> SuccessData[CalibrateModuleResult, None]:
         """Execute calibrate-module command."""
         ot3_api = ensure_ot3_hardware(
             self._hardware_api,
@@ -85,15 +83,18 @@ class CalibrateModuleImplementation(
             ot3_api, ot3_mount, slot.slotName.id, module_serial, nominal_position
         )
 
-        return CalibrateModuleResult(
-            moduleOffset=ModuleOffsetVector(
-                x=module_offset.x, y=module_offset.y, z=module_offset.z
+        return SuccessData(
+            public=CalibrateModuleResult(
+                moduleOffset=ModuleOffsetVector(
+                    x=module_offset.x, y=module_offset.y, z=module_offset.z
+                ),
+                location=slot,
             ),
-            location=slot,
+            private=None,
         )
 
 
-class CalibrateModule(BaseCommand[CalibrateModuleParams, CalibrateModuleResult]):
+class CalibrateModule(BaseCommand[CalibrateModuleParams, CalibrateModuleResult, Never]):
     """Calibrate-module command model."""
 
     commandType: CalibrateModuleCommandType = "calibration/calibrateModule"

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_module.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 # Work around type-only circular dependencies.
 if TYPE_CHECKING:
@@ -94,7 +95,9 @@ class CalibrateModuleImplementation(
         )
 
 
-class CalibrateModule(BaseCommand[CalibrateModuleParams, CalibrateModuleResult, Never]):
+class CalibrateModule(
+    BaseCommand[CalibrateModuleParams, CalibrateModuleResult, ErrorOccurrence]
+):
     """Calibrate-module command model."""
 
     commandType: CalibrateModuleCommandType = "calibration/calibrateModule"

--- a/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/calibrate_pipette.py
@@ -1,9 +1,10 @@
 """Calibrate-pipette command for OT3 hardware. request, result, and implementation models."""
 from typing import Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 from ...types import InstrumentOffsetVector
 
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
@@ -76,7 +77,7 @@ class CalibratePipetteImplementation(
 
 
 class CalibratePipette(
-    BaseCommand[CalibratePipetteParams, CalibratePipetteResult, Never]
+    BaseCommand[CalibratePipetteParams, CalibratePipetteResult, ErrorOccurrence]
 ):
     """Calibrate-pipette command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 
 import enum
 from typing import TYPE_CHECKING, Type, Optional
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType, Point, Mount
 from opentrons.hardware_control.types import Axis, CriticalPoint
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 
 if TYPE_CHECKING:
@@ -116,7 +117,11 @@ class MoveToMaintenancePositionImplementation(
 
 
 class MoveToMaintenancePosition(
-    BaseCommand[MoveToMaintenancePositionParams, MoveToMaintenancePositionResult, Never]
+    BaseCommand[
+        MoveToMaintenancePositionParams,
+        MoveToMaintenancePositionResult,
+        ErrorOccurrence,
+    ]
 ):
     """Calibration set up position command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -3,17 +3,13 @@ from __future__ import annotations
 
 import enum
 from typing import TYPE_CHECKING, Type, Optional
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from pydantic import BaseModel, Field
 
 from opentrons.types import MountType, Point, Mount
 from opentrons.hardware_control.types import Axis, CriticalPoint
-from opentrons.protocol_engine.commands.command import (
-    AbstractCommandImpl,
-    BaseCommand,
-    BaseCommandCreate,
-)
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 
 if TYPE_CHECKING:
@@ -59,7 +55,8 @@ class MoveToMaintenancePositionResult(BaseModel):
 
 class MoveToMaintenancePositionImplementation(
     AbstractCommandImpl[
-        MoveToMaintenancePositionParams, MoveToMaintenancePositionResult
+        MoveToMaintenancePositionParams,
+        SuccessData[MoveToMaintenancePositionResult, None],
     ]
 ):
     """Calibration set up position command implementation."""
@@ -75,7 +72,7 @@ class MoveToMaintenancePositionImplementation(
 
     async def execute(
         self, params: MoveToMaintenancePositionParams
-    ) -> MoveToMaintenancePositionResult:
+    ) -> SuccessData[MoveToMaintenancePositionResult, None]:
         """Move the requested mount to a maintenance deck slot."""
         ot3_api = ensure_ot3_hardware(
             self._hardware_api,
@@ -115,11 +112,11 @@ class MoveToMaintenancePositionImplementation(
                 )
                 await ot3_api.disengage_axes([Axis.Z_L, Axis.Z_R])
 
-        return MoveToMaintenancePositionResult()
+        return SuccessData(public=MoveToMaintenancePositionResult(), private=None)
 
 
 class MoveToMaintenancePosition(
-    BaseCommand[MoveToMaintenancePositionParams, MoveToMaintenancePositionResult]
+    BaseCommand[MoveToMaintenancePositionParams, MoveToMaintenancePositionResult, Never]
 ):
     """Calibration set up position command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import (
@@ -11,7 +12,6 @@ from typing import (
     Generic,
     Optional,
     TypeVar,
-    Tuple,
     List,
     Type,
     Union,
@@ -35,6 +35,8 @@ _ParamsT = TypeVar("_ParamsT", bound=BaseModel)
 _ParamsT_contra = TypeVar("_ParamsT_contra", bound=BaseModel, contravariant=True)
 _ResultT = TypeVar("_ResultT", bound=BaseModel)
 _ResultT_co = TypeVar("_ResultT_co", bound=BaseModel, covariant=True)
+_ErrorT = TypeVar("_ErrorT", bound=ErrorOccurrence)
+_ErrorT_co = TypeVar("_ErrorT_co", bound=ErrorOccurrence, covariant=True)
 _PrivateResultT_co = TypeVar("_PrivateResultT_co", covariant=True)
 
 
@@ -60,7 +62,11 @@ class CommandIntent(str, Enum):
     FIXIT = "fixit"
 
 
-class BaseCommandCreate(GenericModel, Generic[_ParamsT]):
+class BaseCommandCreate(
+    GenericModel,
+    # These type parameters need to be invariant because our fields are mutable.
+    Generic[_ParamsT],
+):
     """Base class for command creation requests.
 
     You shouldn't use this class directly; instead, use or define
@@ -99,7 +105,37 @@ class BaseCommandCreate(GenericModel, Generic[_ParamsT]):
     )
 
 
-class BaseCommand(GenericModel, Generic[_ParamsT, _ResultT]):
+@dataclass(frozen=True)
+class SuccessData(Generic[_ResultT_co, _PrivateResultT_co]):
+    """Data from the successful completion of a command."""
+
+    public: _ResultT_co
+    """Public result data. Exposed over HTTP and stored in databases."""
+
+    private: _PrivateResultT_co
+    """Additional result data, only given to `opentrons.protocol_engine` internals."""
+
+
+@dataclass(frozen=True)
+class DefinedErrorData(Generic[_ErrorT_co, _PrivateResultT_co]):
+    """Data from a command that failed with a defined error.
+
+    This should only be used for "defined" errors, not any error.
+    See `AbstractCommandImpl.execute()`.
+    """
+
+    public: _ErrorT_co
+    """Public error data. Exposed over HTTP and stored in databases."""
+
+    private: _PrivateResultT_co
+    """Additional error data, only given to `opentrons.protocol_engine` internals."""
+
+
+class BaseCommand(
+    GenericModel,
+    # These type parameters need to be invariant because our fields are mutable.
+    Generic[_ParamsT, _ResultT, _ErrorT],
+):
     """Base command model.
 
     You shouldn't use this class directly; instead, use or define
@@ -134,7 +170,12 @@ class BaseCommand(GenericModel, Generic[_ParamsT, _ResultT]):
         None,
         description="Command execution result data, if succeeded",
     )
-    error: Optional[ErrorOccurrence] = Field(
+    error: Union[
+        _ErrorT,
+        # ErrorOccurrence here is for undefined errors not captured by _ErrorT.
+        ErrorOccurrence,
+        None,
+    ] = Field(
         None,
         description="Reference to error occurrence, if execution failed",
     )
@@ -169,27 +210,46 @@ class BaseCommand(GenericModel, Generic[_ParamsT, _ResultT]):
         ),
     )
 
-    _ImplementationCls: Union[
-        Type[AbstractCommandImpl[_ParamsT, _ResultT]],
-        Type[AbstractCommandWithPrivateResultImpl[_ParamsT, _ResultT, object]],
+    _ImplementationCls: Type[
+        AbstractCommandImpl[
+            _ParamsT,
+            Union[
+                SuccessData[
+                    # Our _ImplementationCls must return public result data that can fit
+                    # in our `result` field:
+                    _ResultT,
+                    # But we don't care (here) what kind of private result data it returns:
+                    object,
+                ],
+                DefinedErrorData[
+                    # Likewise, for our `error` field:
+                    _ErrorT,
+                    object,
+                ],
+            ],
+        ]
     ]
+
+
+_ExecuteReturnT_co = TypeVar(
+    "_ExecuteReturnT_co",
+    bound=Union[
+        SuccessData[BaseModel, object],
+        DefinedErrorData[ErrorOccurrence, object],
+    ],
+    covariant=True,
+)
 
 
 class AbstractCommandImpl(
     ABC,
-    Generic[_ParamsT_contra, _ResultT_co],
+    Generic[_ParamsT_contra, _ExecuteReturnT_co],
 ):
     """Abstract command creation and execution implementation.
 
     A given command request should map to a specific command implementation,
-    which defines how to:
-
-    - Create a command resource from the request model
-    - Execute the command, mapping data from execution into the result model
-
-    This class should be used as the base class for new commands by default. You should only
-    use AbstractCommandWithPrivateResultImpl if you actually need private results to send to
-    the rest of the engine wihtout being published outside of it.
+    which defines how to execute the command and map data from execution into the
+    result model.
     """
 
     def __init__(
@@ -211,50 +271,16 @@ class AbstractCommandImpl(
         pass
 
     @abstractmethod
-    async def execute(self, params: _ParamsT_contra) -> _ResultT_co:
-        """Execute the command, mapping data from execution into a response model."""
-        ...
+    async def execute(self, params: _ParamsT_contra) -> _ExecuteReturnT_co:
+        """Execute the command, mapping data from execution into a response model.
 
+        This should either:
 
-class AbstractCommandWithPrivateResultImpl(
-    ABC,
-    Generic[_ParamsT_contra, _ResultT_co, _PrivateResultT_co],
-):
-    """Abstract command creation and execution implementation if the command has private results.
-
-    A given command request should map to a specific command implementation,
-    which defines how to:
-
-    - Create a command resource from the request model
-    - Execute the command, mapping data from execution into the result model
-
-    This class should be used instead of AbstractCommandImpl as a base class if your command needs
-    to send data to result handlers that should not be published outside of the engine.
-
-    Note that this class needs an extra type-parameter for the private result.
-    """
-
-    def __init__(
-        self,
-        state_view: StateView,
-        hardware_api: HardwareControlAPI,
-        equipment: execution.EquipmentHandler,
-        movement: execution.MovementHandler,
-        gantry_mover: execution.GantryMover,
-        labware_movement: execution.LabwareMovementHandler,
-        pipetting: execution.PipettingHandler,
-        tip_handler: execution.TipHandler,
-        run_control: execution.RunControlHandler,
-        rail_lights: execution.RailLightsHandler,
-        status_bar: execution.StatusBarHandler,
-        command_note_adder: CommandNoteAdder,
-    ) -> None:
-        """Initialize the command implementation with execution handlers."""
-        pass
-
-    @abstractmethod
-    async def execute(
-        self, params: _ParamsT_contra
-    ) -> Tuple[_ResultT_co, _PrivateResultT_co]:
-        """Execute the command, mapping data from execution into a response model."""
+        - Return a `SuccessData`, if the command completed normally.
+        - Return a `DefinedErrorData`, if the command failed with a "defined error."
+          Defined errors are errors that are documented as part of the robot's public
+          API.
+        - Raise an exception, if the command failed with any other error
+          (in other words, an undefined error).
+        """
         ...

--- a/api/src/opentrons/protocol_engine/commands/comment.py
+++ b/api/src/opentrons/protocol_engine/commands/comment.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 CommentCommandType = Literal["comment"]
 
@@ -35,7 +36,7 @@ class CommentImplementation(
         return SuccessData(public=CommentResult(), private=None)
 
 
-class Comment(BaseCommand[CommentParams, CommentResult, Never]):
+class Comment(BaseCommand[CommentParams, CommentResult, ErrorOccurrence]):
     """Comment command model."""
 
     commandType: CommentCommandType = "comment"

--- a/api/src/opentrons/protocol_engine/commands/comment.py
+++ b/api/src/opentrons/protocol_engine/commands/comment.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 CommentCommandType = Literal["comment"]
 
@@ -22,18 +22,20 @@ class CommentResult(BaseModel):
     """Result data from the execution of a Comment command."""
 
 
-class CommentImplementation(AbstractCommandImpl[CommentParams, CommentResult]):
+class CommentImplementation(
+    AbstractCommandImpl[CommentParams, SuccessData[CommentResult, None]]
+):
     """Comment command implementation."""
 
     def __init__(self, **kwargs: object) -> None:
         pass
 
-    async def execute(self, params: CommentParams) -> CommentResult:
+    async def execute(self, params: CommentParams) -> SuccessData[CommentResult, None]:
         """No operation taken other than capturing message in command."""
-        return CommentResult()
+        return SuccessData(public=CommentResult(), private=None)
 
 
-class Comment(BaseCommand[CommentParams, CommentResult]):
+class Comment(BaseCommand[CommentParams, CommentResult, Never]):
     """Comment command model."""
 
     commandType: CommentCommandType = "comment"

--- a/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_for_volume.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import PipetteIdMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from .configuring_common import PipetteConfigUpdateResultMixin
 
 if TYPE_CHECKING:
@@ -69,7 +70,7 @@ class ConfigureForVolumeImplementation(
 
 
 class ConfigureForVolume(
-    BaseCommand[ConfigureForVolumeParams, ConfigureForVolumeResult, Never]
+    BaseCommand[ConfigureForVolumeParams, ConfigureForVolumeResult, ErrorOccurrence]
 ):
     """Configure for volume command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -1,17 +1,13 @@
 """Configure nozzle layout command request, result, and implementation models."""
 from __future__ import annotations
 from pydantic import BaseModel
-from typing import TYPE_CHECKING, Optional, Type, Tuple, Union
-from typing_extensions import Literal
+from typing import TYPE_CHECKING, Optional, Type, Union
+from typing_extensions import Literal, Never
 
 from .pipetting_common import (
     PipetteIdMixin,
 )
-from .command import (
-    AbstractCommandWithPrivateResultImpl,
-    BaseCommand,
-    BaseCommandCreate,
-)
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from .configuring_common import (
     PipetteNozzleLayoutResultMixin,
 )
@@ -55,10 +51,9 @@ class ConfigureNozzleLayoutResult(BaseModel):
 
 
 class ConfigureNozzleLayoutImplementation(
-    AbstractCommandWithPrivateResultImpl[
+    AbstractCommandImpl[
         ConfigureNozzleLayoutParams,
-        ConfigureNozzleLayoutResult,
-        ConfigureNozzleLayoutPrivateResult,
+        SuccessData[ConfigureNozzleLayoutResult, ConfigureNozzleLayoutPrivateResult],
     ]
 ):
     """Configure nozzle layout command implementation."""
@@ -71,7 +66,7 @@ class ConfigureNozzleLayoutImplementation(
 
     async def execute(
         self, params: ConfigureNozzleLayoutParams
-    ) -> Tuple[ConfigureNozzleLayoutResult, ConfigureNozzleLayoutPrivateResult]:
+    ) -> SuccessData[ConfigureNozzleLayoutResult, ConfigureNozzleLayoutPrivateResult]:
         """Check that requested pipette can support the requested nozzle layout."""
         primary_nozzle = params.configurationParams.dict().get("primaryNozzle")
         front_right_nozzle = params.configurationParams.dict().get("frontRightNozzle")
@@ -87,14 +82,17 @@ class ConfigureNozzleLayoutImplementation(
             **nozzle_params,
         )
 
-        return ConfigureNozzleLayoutResult(), ConfigureNozzleLayoutPrivateResult(
-            pipette_id=params.pipetteId,
-            nozzle_map=nozzle_map,
+        return SuccessData(
+            public=ConfigureNozzleLayoutResult(),
+            private=ConfigureNozzleLayoutPrivateResult(
+                pipette_id=params.pipetteId,
+                nozzle_map=nozzle_map,
+            ),
         )
 
 
 class ConfigureNozzleLayout(
-    BaseCommand[ConfigureNozzleLayoutParams, ConfigureNozzleLayoutResult]
+    BaseCommand[ConfigureNozzleLayoutParams, ConfigureNozzleLayoutResult, Never]
 ):
     """Configure nozzle layout command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
+++ b/api/src/opentrons/protocol_engine/commands/configure_nozzle_layout.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type, Union
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import (
     PipetteIdMixin,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from .configuring_common import (
     PipetteNozzleLayoutResultMixin,
 )
@@ -92,7 +93,9 @@ class ConfigureNozzleLayoutImplementation(
 
 
 class ConfigureNozzleLayout(
-    BaseCommand[ConfigureNozzleLayoutParams, ConfigureNozzleLayoutResult, Never]
+    BaseCommand[
+        ConfigureNozzleLayoutParams, ConfigureNozzleLayoutResult, ErrorOccurrence
+    ]
 ):
     """Configure nozzle layout command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/custom.py
+++ b/api/src/opentrons/protocol_engine/commands/custom.py
@@ -12,9 +12,10 @@ put your own disambiguation identifier in the payload.
 """
 from pydantic import BaseModel, Extra
 from typing import Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 
 CustomCommandType = Literal["custom"]
@@ -51,7 +52,7 @@ class CustomImplementation(
         return SuccessData(public=CustomResult.construct(), private=None)
 
 
-class Custom(BaseCommand[CustomParams, CustomResult, Never]):
+class Custom(BaseCommand[CustomParams, CustomResult, ErrorOccurrence]):
     """Custom command model."""
 
     commandType: CustomCommandType = "custom"

--- a/api/src/opentrons/protocol_engine/commands/custom.py
+++ b/api/src/opentrons/protocol_engine/commands/custom.py
@@ -12,9 +12,9 @@ put your own disambiguation identifier in the payload.
 """
 from pydantic import BaseModel, Extra
 from typing import Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 
 CustomCommandType = Literal["custom"]
@@ -38,18 +38,20 @@ class CustomResult(BaseModel):
         extra = Extra.allow
 
 
-class CustomImplementation(AbstractCommandImpl[CustomParams, CustomResult]):
+class CustomImplementation(
+    AbstractCommandImpl[CustomParams, SuccessData[CustomResult, None]]
+):
     """Custom command implementation."""
 
     # TODO(mm, 2022-11-09): figure out how a plugin can specify a custom command
     # implementation. For now, always no-op, so we can use custom commands as containers
     # for legacy RPC (pre-ProtocolEngine) payloads.
-    async def execute(self, params: CustomParams) -> CustomResult:
+    async def execute(self, params: CustomParams) -> SuccessData[CustomResult, None]:
         """A custom command does nothing when executed directly."""
-        return CustomResult.construct()
+        return SuccessData(public=CustomResult.construct(), private=None)
 
 
-class Custom(BaseCommand[CustomParams, CustomResult]):
+class Custom(BaseCommand[CustomParams, CustomResult, Never]):
     """Custom command model."""
 
     commandType: CustomCommandType = "custom"

--- a/api/src/opentrons/protocol_engine/commands/dispense.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense.py
@@ -1,7 +1,7 @@
 """Dispense command request, result, and implementation models."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from pydantic import Field
 
@@ -15,6 +15,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler, PipettingHandler
@@ -77,7 +78,7 @@ class DispenseImplementation(
         )
 
 
-class Dispense(BaseCommand[DispenseParams, DispenseResult, Never]):
+class Dispense(BaseCommand[DispenseParams, DispenseResult, ErrorOccurrence]):
     """Dispense command model."""
 
     commandType: DispenseCommandType = "dispense"

--- a/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/dispense_in_place.py
@@ -1,7 +1,7 @@
 """Dispense-in-place command request, result, and implementation models."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from pydantic import Field
 
@@ -12,6 +12,7 @@ from .pipetting_common import (
     BaseLiquidHandlingResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import PipettingHandler
@@ -56,7 +57,9 @@ class DispenseInPlaceImplementation(
         return SuccessData(public=DispenseInPlaceResult(volume=volume), private=None)
 
 
-class DispenseInPlace(BaseCommand[DispenseInPlaceParams, DispenseInPlaceResult, Never]):
+class DispenseInPlace(
+    BaseCommand[DispenseInPlaceParams, DispenseInPlaceResult, ErrorOccurrence]
+):
     """DispenseInPlace command model."""
 
     commandType: DispenseInPlaceCommandType = "dispenseInPlace"

--- a/api/src/opentrons/protocol_engine/commands/drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import DropTipWellLocation, DeckPoint
 from .pipetting_common import PipetteIdMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -111,7 +112,7 @@ class DropTipImplementation(
         )
 
 
-class DropTip(BaseCommand[DropTipParams, DropTipResult, Never]):
+class DropTip(BaseCommand[DropTipParams, DropTipResult, ErrorOccurrence]):
     """Drop tip command model."""
 
     commandType: DropTipCommandType = "dropTip"

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import PipetteIdMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import TipHandler
@@ -56,7 +57,9 @@ class DropTipInPlaceImplementation(
         return SuccessData(public=DropTipInPlaceResult(), private=None)
 
 
-class DropTipInPlace(BaseCommand[DropTipInPlaceParams, DropTipInPlaceResult, Never]):
+class DropTipInPlace(
+    BaseCommand[DropTipInPlaceParams, DropTipInPlaceResult, ErrorOccurrence]
+):
     """Drop tip in place command model."""
 
     commandType: DropTipInPlaceCommandType = "dropTipInPlace"

--- a/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/drop_tip_in_place.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from .pipetting_common import PipetteIdMixin
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import TipHandler
@@ -34,7 +34,7 @@ class DropTipInPlaceResult(BaseModel):
 
 
 class DropTipInPlaceImplementation(
-    AbstractCommandImpl[DropTipInPlaceParams, DropTipInPlaceResult]
+    AbstractCommandImpl[DropTipInPlaceParams, SuccessData[DropTipInPlaceResult, None]]
 ):
     """Drop tip in place command implementation."""
 
@@ -45,16 +45,18 @@ class DropTipInPlaceImplementation(
     ) -> None:
         self._tip_handler = tip_handler
 
-    async def execute(self, params: DropTipInPlaceParams) -> DropTipInPlaceResult:
+    async def execute(
+        self, params: DropTipInPlaceParams
+    ) -> SuccessData[DropTipInPlaceResult, None]:
         """Drop a tip using the requested pipette."""
         await self._tip_handler.drop_tip(
             pipette_id=params.pipetteId, home_after=params.homeAfter
         )
 
-        return DropTipInPlaceResult()
+        return SuccessData(public=DropTipInPlaceResult(), private=None)
 
 
-class DropTipInPlace(BaseCommand[DropTipInPlaceParams, DropTipInPlaceResult]):
+class DropTipInPlace(BaseCommand[DropTipInPlaceParams, DropTipInPlaceResult, Never]):
     """Drop tip in place command model."""
 
     commandType: DropTipInPlaceCommandType = "dropTipInPlace"

--- a/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from .pipetting_common import PipetteIdMixin
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 from ..types import TipPresenceStatus
 
@@ -37,7 +37,7 @@ class GetTipPresenceResult(BaseModel):
 
 
 class GetTipPresenceImplementation(
-    AbstractCommandImpl[GetTipPresenceParams, GetTipPresenceResult]
+    AbstractCommandImpl[GetTipPresenceParams, SuccessData[GetTipPresenceResult, None]]
 ):
     """GetTipPresence command implementation."""
 
@@ -48,7 +48,9 @@ class GetTipPresenceImplementation(
     ) -> None:
         self._tip_handler = tip_handler
 
-    async def execute(self, params: GetTipPresenceParams) -> GetTipPresenceResult:
+    async def execute(
+        self, params: GetTipPresenceParams
+    ) -> SuccessData[GetTipPresenceResult, None]:
         """Verify if tip presence is as expected for the requested pipette."""
         pipette_id = params.pipetteId
 
@@ -56,10 +58,10 @@ class GetTipPresenceImplementation(
             pipette_id=pipette_id,
         )
 
-        return GetTipPresenceResult(status=result)
+        return SuccessData(public=GetTipPresenceResult(status=result), private=None)
 
 
-class GetTipPresence(BaseCommand[GetTipPresenceParams, GetTipPresenceResult]):
+class GetTipPresence(BaseCommand[GetTipPresenceParams, GetTipPresenceResult, Never]):
     """GetTipPresence command model."""
 
     commandType: GetTipPresenceCommandType = "getTipPresence"

--- a/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/get_tip_presence.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import PipetteIdMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 from ..types import TipPresenceStatus
 
@@ -61,7 +62,9 @@ class GetTipPresenceImplementation(
         return SuccessData(public=GetTipPresenceResult(status=result), private=None)
 
 
-class GetTipPresence(BaseCommand[GetTipPresenceParams, GetTipPresenceResult, Never]):
+class GetTipPresence(
+    BaseCommand[GetTipPresenceParams, GetTipPresenceResult, ErrorOccurrence]
+):
     """GetTipPresence command model."""
 
     commandType: GetTipPresenceCommandType = "getTipPresence"

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
@@ -1,11 +1,11 @@
 """Command models to close the Heater-Shaker Module's labware latch."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -26,7 +26,9 @@ class CloseLabwareLatchResult(BaseModel):
 
 
 class CloseLabwareLatchImpl(
-    AbstractCommandImpl[CloseLabwareLatchParams, CloseLabwareLatchResult]
+    AbstractCommandImpl[
+        CloseLabwareLatchParams, SuccessData[CloseLabwareLatchResult, None]
+    ]
 ):
     """Execution implementation of a Heater-Shaker's close labware latch command."""
 
@@ -39,7 +41,9 @@ class CloseLabwareLatchImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: CloseLabwareLatchParams) -> CloseLabwareLatchResult:
+    async def execute(
+        self, params: CloseLabwareLatchParams
+    ) -> SuccessData[CloseLabwareLatchResult, None]:
         """Close a Heater-Shaker's labware latch."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
@@ -54,10 +58,12 @@ class CloseLabwareLatchImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.close_labware_latch()
 
-        return CloseLabwareLatchResult()
+        return SuccessData(public=CloseLabwareLatchResult(), private=None)
 
 
-class CloseLabwareLatch(BaseCommand[CloseLabwareLatchParams, CloseLabwareLatchResult]):
+class CloseLabwareLatch(
+    BaseCommand[CloseLabwareLatchParams, CloseLabwareLatchResult, Never]
+):
     """A command to close a Heater-Shaker's latch."""
 
     commandType: CloseLabwareLatchCommandType = "heaterShaker/closeLabwareLatch"

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/close_labware_latch.py
@@ -1,11 +1,12 @@
 """Command models to close the Heater-Shaker Module's labware latch."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -62,7 +63,7 @@ class CloseLabwareLatchImpl(
 
 
 class CloseLabwareLatch(
-    BaseCommand[CloseLabwareLatchParams, CloseLabwareLatchResult, Never]
+    BaseCommand[CloseLabwareLatchParams, CloseLabwareLatchResult, ErrorOccurrence]
 ):
     """A command to close a Heater-Shaker's latch."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -1,11 +1,11 @@
 """Command models to stop heating Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -26,7 +26,9 @@ class DeactivateHeaterResult(BaseModel):
 
 
 class DeactivateHeaterImpl(
-    AbstractCommandImpl[DeactivateHeaterParams, DeactivateHeaterResult]
+    AbstractCommandImpl[
+        DeactivateHeaterParams, SuccessData[DeactivateHeaterResult, None]
+    ]
 ):
     """Execution implementation of a Heater-Shaker's deactivate heater command."""
 
@@ -39,7 +41,9 @@ class DeactivateHeaterImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: DeactivateHeaterParams) -> DeactivateHeaterResult:
+    async def execute(
+        self, params: DeactivateHeaterParams
+    ) -> SuccessData[DeactivateHeaterResult, None]:
         """Unset a Heater-Shaker's target temperature."""
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
@@ -53,10 +57,12 @@ class DeactivateHeaterImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.deactivate_heater()
 
-        return DeactivateHeaterResult()
+        return SuccessData(public=DeactivateHeaterResult(), private=None)
 
 
-class DeactivateHeater(BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult]):
+class DeactivateHeater(
+    BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult, Never]
+):
     """A command to unset a Heater-Shaker's target temperature."""
 
     commandType: DeactivateHeaterCommandType = "heaterShaker/deactivateHeater"

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_heater.py
@@ -1,11 +1,12 @@
 """Command models to stop heating Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -61,7 +62,7 @@ class DeactivateHeaterImpl(
 
 
 class DeactivateHeater(
-    BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult, Never]
+    BaseCommand[DeactivateHeaterParams, DeactivateHeaterResult, ErrorOccurrence]
 ):
     """A command to unset a Heater-Shaker's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
@@ -1,11 +1,11 @@
 """Command models to deactivate shaker for the Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -25,7 +25,9 @@ class DeactivateShakerResult(BaseModel):
 
 
 class DeactivateShakerImpl(
-    AbstractCommandImpl[DeactivateShakerParams, DeactivateShakerResult]
+    AbstractCommandImpl[
+        DeactivateShakerParams, SuccessData[DeactivateShakerResult, None]
+    ]
 ):
     """Execution implementation of a Heater-Shaker's deactivate shaker command."""
 
@@ -38,7 +40,9 @@ class DeactivateShakerImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: DeactivateShakerParams) -> DeactivateShakerResult:
+    async def execute(
+        self, params: DeactivateShakerParams
+    ) -> SuccessData[DeactivateShakerResult, None]:
         """Deactivate shaker for a Heater-Shaker."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
@@ -55,10 +59,12 @@ class DeactivateShakerImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.deactivate_shaker()
 
-        return DeactivateShakerResult()
+        return SuccessData(public=DeactivateShakerResult(), private=None)
 
 
-class DeactivateShaker(BaseCommand[DeactivateShakerParams, DeactivateShakerResult]):
+class DeactivateShaker(
+    BaseCommand[DeactivateShakerParams, DeactivateShakerResult, Never]
+):
     """A command to deactivate shaker for a Heater-Shaker."""
 
     commandType: DeactivateShakerCommandType = "heaterShaker/deactivateShaker"

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/deactivate_shaker.py
@@ -1,11 +1,12 @@
 """Command models to deactivate shaker for the Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -63,7 +64,7 @@ class DeactivateShakerImpl(
 
 
 class DeactivateShaker(
-    BaseCommand[DeactivateShakerParams, DeactivateShakerResult, Never]
+    BaseCommand[DeactivateShakerParams, DeactivateShakerResult, ErrorOccurrence]
 ):
     """A command to deactivate shaker for a Heater-Shaker."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/open_labware_latch.py
@@ -1,10 +1,11 @@
 """Command models to open the Heater-Shaker Module's labware latch."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -87,7 +88,7 @@ class OpenLabwareLatchImpl(
 
 
 class OpenLabwareLatch(
-    BaseCommand[OpenLabwareLatchParams, OpenLabwareLatchResult, Never]
+    BaseCommand[OpenLabwareLatchParams, OpenLabwareLatchResult, ErrorOccurrence]
 ):
     """A command to open a Heater-Shaker's labware latch."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -1,10 +1,10 @@
 """Command models to set and wait for a shake speed for a Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -33,7 +33,9 @@ class SetAndWaitForShakeSpeedResult(BaseModel):
 
 
 class SetAndWaitForShakeSpeedImpl(
-    AbstractCommandImpl[SetAndWaitForShakeSpeedParams, SetAndWaitForShakeSpeedResult]
+    AbstractCommandImpl[
+        SetAndWaitForShakeSpeedParams, SuccessData[SetAndWaitForShakeSpeedResult, None]
+    ]
 ):
     """Execution implementation of Heater-Shaker's set and wait shake speed command."""
 
@@ -51,7 +53,7 @@ class SetAndWaitForShakeSpeedImpl(
     async def execute(
         self,
         params: SetAndWaitForShakeSpeedParams,
-    ) -> SetAndWaitForShakeSpeedResult:
+    ) -> SuccessData[SetAndWaitForShakeSpeedResult, None]:
         """Set and wait for a Heater-Shaker's target shake speed."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
@@ -83,11 +85,16 @@ class SetAndWaitForShakeSpeedImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.set_speed(rpm=validated_speed)
 
-        return SetAndWaitForShakeSpeedResult(pipetteRetracted=pipette_should_retract)
+        return SuccessData(
+            public=SetAndWaitForShakeSpeedResult(
+                pipetteRetracted=pipette_should_retract
+            ),
+            private=None,
+        )
 
 
 class SetAndWaitForShakeSpeed(
-    BaseCommand[SetAndWaitForShakeSpeedParams, SetAndWaitForShakeSpeedResult]
+    BaseCommand[SetAndWaitForShakeSpeedParams, SetAndWaitForShakeSpeedResult, Never]
 ):
     """A command to set and wait for a Heater-Shaker's shake speed."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_and_wait_for_shake_speed.py
@@ -1,10 +1,11 @@
 """Command models to set and wait for a shake speed for a Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -94,7 +95,9 @@ class SetAndWaitForShakeSpeedImpl(
 
 
 class SetAndWaitForShakeSpeed(
-    BaseCommand[SetAndWaitForShakeSpeedParams, SetAndWaitForShakeSpeedResult, Never]
+    BaseCommand[
+        SetAndWaitForShakeSpeedParams, SetAndWaitForShakeSpeedResult, ErrorOccurrence
+    ]
 ):
     """A command to set and wait for a Heater-Shaker's shake speed."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -1,11 +1,11 @@
 """Command models to start heating a Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -27,7 +27,9 @@ class SetTargetTemperatureResult(BaseModel):
 
 
 class SetTargetTemperatureImpl(
-    AbstractCommandImpl[SetTargetTemperatureParams, SetTargetTemperatureResult]
+    AbstractCommandImpl[
+        SetTargetTemperatureParams, SuccessData[SetTargetTemperatureResult, None]
+    ]
 ):
     """Execution implementation of a Heater-Shaker's set temperature command."""
 
@@ -43,7 +45,7 @@ class SetTargetTemperatureImpl(
     async def execute(
         self,
         params: SetTargetTemperatureParams,
-    ) -> SetTargetTemperatureResult:
+    ) -> SuccessData[SetTargetTemperatureResult, None]:
         """Set a Heater-Shaker's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
@@ -61,11 +63,11 @@ class SetTargetTemperatureImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.start_set_temperature(validated_temp)
 
-        return SetTargetTemperatureResult()
+        return SuccessData(public=SetTargetTemperatureResult(), private=None)
 
 
 class SetTargetTemperature(
-    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult]
+    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult, Never]
 ):
     """A command to set a Heater-Shaker's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/set_target_temperature.py
@@ -1,11 +1,12 @@
 """Command models to start heating a Heater-Shaker Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -67,7 +68,7 @@ class SetTargetTemperatureImpl(
 
 
 class SetTargetTemperature(
-    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult, Never]
+    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult, ErrorOccurrence]
 ):
     """A command to set a Heater-Shaker's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
@@ -1,11 +1,12 @@
 """Command models to wait for a Heater-Shaker Module's target temperature."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -75,7 +76,7 @@ class WaitForTemperatureImpl(
 
 
 class WaitForTemperature(
-    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult, Never]
+    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult, ErrorOccurrence]
 ):
     """A command to wait for a Heater-Shaker's target temperature to be reached."""
 

--- a/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/heater_shaker/wait_for_temperature.py
@@ -1,11 +1,11 @@
 """Command models to wait for a Heater-Shaker Module's target temperature."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -35,7 +35,9 @@ class WaitForTemperatureResult(BaseModel):
 
 
 class WaitForTemperatureImpl(
-    AbstractCommandImpl[WaitForTemperatureParams, WaitForTemperatureResult]
+    AbstractCommandImpl[
+        WaitForTemperatureParams, SuccessData[WaitForTemperatureResult, None]
+    ]
 ):
     """Execution implementation of a Heater-Shaker's wait for temperature command."""
 
@@ -50,7 +52,7 @@ class WaitForTemperatureImpl(
 
     async def execute(
         self, params: WaitForTemperatureParams
-    ) -> WaitForTemperatureResult:
+    ) -> SuccessData[WaitForTemperatureResult, None]:
         """Wait for a Heater-Shaker's target temperature to be reached."""
         hs_module_substate = self._state_view.modules.get_heater_shaker_module_substate(
             module_id=params.moduleId
@@ -69,11 +71,11 @@ class WaitForTemperatureImpl(
         if hs_hardware_module is not None:
             await hs_hardware_module.await_temperature(awaiting_temperature=target_temp)
 
-        return WaitForTemperatureResult()
+        return SuccessData(public=WaitForTemperatureResult(), private=None)
 
 
 class WaitForTemperature(
-    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult]
+    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult, Never]
 ):
     """A command to wait for a Heater-Shaker's target temperature to be reached."""
 

--- a/api/src/opentrons/protocol_engine/commands/home.py
+++ b/api/src/opentrons/protocol_engine/commands/home.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, List, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from opentrons.types import MountType
 from ..types import MotorAxis
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -60,7 +61,7 @@ class HomeImplementation(
         return SuccessData(public=HomeResult(), private=None)
 
 
-class Home(BaseCommand[HomeParams, HomeResult, Never]):
+class Home(BaseCommand[HomeParams, HomeResult, ErrorOccurrence]):
     """Command to send some (or all) motors to their home positions.
 
     Homing a motor re-establishes positional accuracy the first time a motor

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
@@ -16,6 +16,7 @@ from ..types import (
 )
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -156,7 +157,7 @@ class LoadLabwareImplementation(
         )
 
 
-class LoadLabware(BaseCommand[LoadLabwareParams, LoadLabwareResult, Never]):
+class LoadLabware(BaseCommand[LoadLabwareParams, LoadLabwareResult, ErrorOccurrence]):
     """Load labware command resource model."""
 
     commandType: LoadLabwareCommandType = "loadLabware"

--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import Optional, Type, Dict, TYPE_CHECKING
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -35,13 +35,17 @@ class LoadLiquidResult(BaseModel):
     pass
 
 
-class LoadLiquidImplementation(AbstractCommandImpl[LoadLiquidParams, LoadLiquidResult]):
+class LoadLiquidImplementation(
+    AbstractCommandImpl[LoadLiquidParams, SuccessData[LoadLiquidResult, None]]
+):
     """Load liquid command implementation."""
 
     def __init__(self, state_view: StateView, **kwargs: object) -> None:
         self._state_view = state_view
 
-    async def execute(self, params: LoadLiquidParams) -> LoadLiquidResult:
+    async def execute(
+        self, params: LoadLiquidParams
+    ) -> SuccessData[LoadLiquidResult, None]:
         """Load data necessary for a liquid."""
         self._state_view.liquid.validate_liquid_id(params.liquidId)
 
@@ -49,10 +53,10 @@ class LoadLiquidImplementation(AbstractCommandImpl[LoadLiquidParams, LoadLiquidR
             labware_id=params.labwareId, wells=params.volumeByWell
         )
 
-        return LoadLiquidResult()
+        return SuccessData(public=LoadLiquidResult(), private=None)
 
 
-class LoadLiquid(BaseCommand[LoadLiquidParams, LoadLiquidResult]):
+class LoadLiquid(BaseCommand[LoadLiquidParams, LoadLiquidResult, Never]):
     """Load liquid command resource model."""
 
     commandType: LoadLiquidCommandType = "loadLiquid"

--- a/api/src/opentrons/protocol_engine/commands/load_liquid.py
+++ b/api/src/opentrons/protocol_engine/commands/load_liquid.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import Optional, Type, Dict, TYPE_CHECKING
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -56,7 +57,7 @@ class LoadLiquidImplementation(
         return SuccessData(public=LoadLiquidResult(), private=None)
 
 
-class LoadLiquid(BaseCommand[LoadLiquidParams, LoadLiquidResult, Never]):
+class LoadLiquid(BaseCommand[LoadLiquidParams, LoadLiquidResult, ErrorOccurrence]):
     """Load liquid command resource model."""
 
     commandType: LoadLiquidCommandType = "loadLiquid"

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -1,10 +1,11 @@
 """Implementation, request models, and response models for the load module command."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 from pydantic import BaseModel, Field
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from ..types import (
     DeckSlotLocation,
     ModuleType,
@@ -185,7 +186,7 @@ class LoadModuleImplementation(
                 )
 
 
-class LoadModule(BaseCommand[LoadModuleParams, LoadModuleResult, Never]):
+class LoadModule(BaseCommand[LoadModuleParams, LoadModuleResult, ErrorOccurrence]):
     """The model for a load module command."""
 
     commandType: LoadModuleCommandType = "loadModule"

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -9,12 +9,13 @@ from opentrons_shared_data.robot import user_facing_robot_type
 from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons.types import MountType
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from .configuring_common import PipetteConfigUpdateResultMixin
 from ..errors import InvalidSpecificationForRobotTypeError, InvalidLoadPipetteSpecsError
 
@@ -120,7 +121,7 @@ class LoadPipetteImplementation(
         )
 
 
-class LoadPipette(BaseCommand[LoadPipetteParams, LoadPipetteResult, Never]):
+class LoadPipette(BaseCommand[LoadPipetteParams, LoadPipetteResult, ErrorOccurrence]):
     """Load pipette command model."""
 
     commandType: LoadPipetteCommandType = "loadPipette"

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.execution import EquipmentHandler
@@ -36,7 +36,9 @@ class DisengageResult(BaseModel):
     pass
 
 
-class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResult]):
+class DisengageImplementation(
+    AbstractCommandImpl[DisengageParams, SuccessData[DisengageResult, None]]
+):
     """The implementation of a Magnetic Module disengage command."""
 
     def __init__(
@@ -48,7 +50,9 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: DisengageParams) -> DisengageResult:
+    async def execute(
+        self, params: DisengageParams
+    ) -> SuccessData[DisengageResult, None]:
         """Execute a Magnetic Module disengage command.
 
         Raises:
@@ -70,10 +74,10 @@ class DisengageImplementation(AbstractCommandImpl[DisengageParams, DisengageResu
         if hardware_module is not None:  # Not virtualizing modules.
             await hardware_module.deactivate()
 
-        return DisengageResult()
+        return SuccessData(public=DisengageResult(), private=None)
 
 
-class Disengage(BaseCommand[DisengageParams, DisengageResult]):
+class Disengage(BaseCommand[DisengageParams, DisengageResult, Never]):
     """A command to disengage a Magnetic Module's magnets."""
 
     commandType: DisengageCommandType = "magneticModule/disengage"

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/disengage.py
@@ -4,11 +4,12 @@
 from __future__ import annotations
 
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.execution import EquipmentHandler
@@ -77,7 +78,7 @@ class DisengageImplementation(
         return SuccessData(public=DisengageResult(), private=None)
 
 
-class Disengage(BaseCommand[DisengageParams, DisengageResult, Never]):
+class Disengage(BaseCommand[DisengageParams, DisengageResult, ErrorOccurrence]):
     """A command to disengage a Magnetic Module's magnets."""
 
     commandType: DisengageCommandType = "magneticModule/disengage"

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -1,11 +1,12 @@
 """Magnetic Module engage command request, result, and implementation models."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.execution import EquipmentHandler
@@ -97,7 +98,7 @@ class EngageImplementation(
         return SuccessData(public=EngageResult(), private=None)
 
 
-class Engage(BaseCommand[EngageParams, EngageResult, Never]):
+class Engage(BaseCommand[EngageParams, EngageResult, ErrorOccurrence]):
     """A command to engage a Magnetic Module's magnets."""
 
     commandType: EngageCommandType = "magneticModule/engage"

--- a/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
+++ b/api/src/opentrons/protocol_engine/commands/magnetic_module/engage.py
@@ -1,11 +1,11 @@
 """Magnetic Module engage command request, result, and implementation models."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.execution import EquipmentHandler
@@ -52,7 +52,9 @@ class EngageResult(BaseModel):
     pass
 
 
-class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
+class EngageImplementation(
+    AbstractCommandImpl[EngageParams, SuccessData[EngageResult, None]]
+):
     """The implementation of a Magnetic Module engage command."""
 
     def __init__(
@@ -64,7 +66,7 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: EngageParams) -> EngageResult:
+    async def execute(self, params: EngageParams) -> SuccessData[EngageResult, None]:
         """Execute a Magnetic Module engage command.
 
         Raises:
@@ -92,10 +94,10 @@ class EngageImplementation(AbstractCommandImpl[EngageParams, EngageResult]):
         if hardware_module is not None:  # Not virtualizing modules.
             await hardware_module.engage(height=hardware_height)
 
-        return EngageResult()
+        return SuccessData(public=EngageResult(), private=None)
 
 
-class Engage(BaseCommand[EngageParams, EngageResult]):
+class Engage(BaseCommand[EngageParams, EngageResult, Never]):
     """A command to engage a Magnetic Module's magnets."""
 
     commandType: EngageCommandType = "magneticModule/engage"

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from opentrons.types import Point
 from ..types import (
@@ -18,6 +18,7 @@ from ..types import (
 from ..errors import LabwareMovementNotAllowedError, NotSupportedOnRobotType
 from ..resources import labware_validation, fixture_validation
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from opentrons_shared_data.gripper.constants import GRIPPER_PADDLE_WIDTH
 
 if TYPE_CHECKING:
@@ -217,7 +218,7 @@ class MoveLabwareImplementation(
         )
 
 
-class MoveLabware(BaseCommand[MoveLabwareParams, MoveLabwareResult, Never]):
+class MoveLabware(BaseCommand[MoveLabwareParams, MoveLabwareResult, ErrorOccurrence]):
     """A ``moveLabware`` command."""
 
     commandType: MoveLabwareCommandType = "moveLabware"

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from ..types import MovementAxis, DeckPoint
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from .pipetting_common import DestinationPositionResult
 
 if TYPE_CHECKING:
@@ -36,14 +36,16 @@ class MoveRelativeResult(DestinationPositionResult):
 
 
 class MoveRelativeImplementation(
-    AbstractCommandImpl[MoveRelativeParams, MoveRelativeResult]
+    AbstractCommandImpl[MoveRelativeParams, SuccessData[MoveRelativeResult, None]]
 ):
     """Move relative command implementation."""
 
     def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
         self._movement = movement
 
-    async def execute(self, params: MoveRelativeParams) -> MoveRelativeResult:
+    async def execute(
+        self, params: MoveRelativeParams
+    ) -> SuccessData[MoveRelativeResult, None]:
         """Move (jog) a given pipette a relative distance."""
         x, y, z = await self._movement.move_relative(
             pipette_id=params.pipetteId,
@@ -51,10 +53,12 @@ class MoveRelativeImplementation(
             distance=params.distance,
         )
 
-        return MoveRelativeResult(position=DeckPoint(x=x, y=y, z=z))
+        return SuccessData(
+            public=MoveRelativeResult(position=DeckPoint(x=x, y=y, z=z)), private=None
+        )
 
 
-class MoveRelative(BaseCommand[MoveRelativeParams, MoveRelativeResult]):
+class MoveRelative(BaseCommand[MoveRelativeParams, MoveRelativeResult, Never]):
     """Command to move (jog) a given pipette a relative distance."""
 
     commandType: MoveRelativeCommandType = "moveRelative"

--- a/api/src/opentrons/protocol_engine/commands/move_relative.py
+++ b/api/src/opentrons/protocol_engine/commands/move_relative.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import MovementAxis, DeckPoint
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from .pipetting_common import DestinationPositionResult
 
 if TYPE_CHECKING:
@@ -58,7 +59,9 @@ class MoveRelativeImplementation(
         )
 
 
-class MoveRelative(BaseCommand[MoveRelativeParams, MoveRelativeResult, Never]):
+class MoveRelative(
+    BaseCommand[MoveRelativeParams, MoveRelativeResult, ErrorOccurrence]
+):
     """Command to move (jog) a given pipette a relative distance."""
 
     commandType: MoveRelativeCommandType = "moveRelative"

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..errors import LocationNotAccessibleByPipetteError
 from ..types import DeckPoint, AddressableOffsetVector
@@ -13,6 +13,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -113,7 +114,9 @@ class MoveToAddressableAreaImplementation(
 
 
 class MoveToAddressableArea(
-    BaseCommand[MoveToAddressableAreaParams, MoveToAddressableAreaResult, Never]
+    BaseCommand[
+        MoveToAddressableAreaParams, MoveToAddressableAreaResult, ErrorOccurrence
+    ]
 ):
     """Move to addressable area command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from ..errors import LocationNotAccessibleByPipetteError
 from ..types import DeckPoint, AddressableOffsetVector
@@ -12,7 +12,7 @@ from .pipetting_common import (
     MovementMixin,
     DestinationPositionResult,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -71,7 +71,9 @@ class MoveToAddressableAreaResult(DestinationPositionResult):
 
 
 class MoveToAddressableAreaImplementation(
-    AbstractCommandImpl[MoveToAddressableAreaParams, MoveToAddressableAreaResult]
+    AbstractCommandImpl[
+        MoveToAddressableAreaParams, SuccessData[MoveToAddressableAreaResult, None]
+    ]
 ):
     """Move to addressable area command implementation."""
 
@@ -83,7 +85,7 @@ class MoveToAddressableAreaImplementation(
 
     async def execute(
         self, params: MoveToAddressableAreaParams
-    ) -> MoveToAddressableAreaResult:
+    ) -> SuccessData[MoveToAddressableAreaResult, None]:
         """Move the requested pipette to the requested addressable area."""
         self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
             params.addressableAreaName
@@ -104,11 +106,14 @@ class MoveToAddressableAreaImplementation(
             stay_at_highest_possible_z=params.stayAtHighestPossibleZ,
         )
 
-        return MoveToAddressableAreaResult(position=DeckPoint(x=x, y=y, z=z))
+        return SuccessData(
+            public=MoveToAddressableAreaResult(position=DeckPoint(x=x, y=y, z=z)),
+            private=None,
+        )
 
 
 class MoveToAddressableArea(
-    BaseCommand[MoveToAddressableAreaParams, MoveToAddressableAreaResult]
+    BaseCommand[MoveToAddressableAreaParams, MoveToAddressableAreaResult, Never]
 ):
     """Move to addressable area command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from ..errors import LocationNotAccessibleByPipetteError
 from ..types import DeckPoint, AddressableOffsetVector
@@ -12,7 +12,7 @@ from .pipetting_common import (
     MovementMixin,
     DestinationPositionResult,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -83,7 +83,8 @@ class MoveToAddressableAreaForDropTipResult(DestinationPositionResult):
 
 class MoveToAddressableAreaForDropTipImplementation(
     AbstractCommandImpl[
-        MoveToAddressableAreaForDropTipParams, MoveToAddressableAreaForDropTipResult
+        MoveToAddressableAreaForDropTipParams,
+        SuccessData[MoveToAddressableAreaForDropTipResult, None],
     ]
 ):
     """Move to addressable area for drop tip command implementation."""
@@ -96,7 +97,7 @@ class MoveToAddressableAreaForDropTipImplementation(
 
     async def execute(
         self, params: MoveToAddressableAreaForDropTipParams
-    ) -> MoveToAddressableAreaForDropTipResult:
+    ) -> SuccessData[MoveToAddressableAreaForDropTipResult, None]:
         """Move the requested pipette to the requested addressable area in preperation of a drop tip."""
         self._state_view.addressable_areas.raise_if_area_not_in_deck_configuration(
             params.addressableAreaName
@@ -125,12 +126,19 @@ class MoveToAddressableAreaForDropTipImplementation(
             ignore_tip_configuration=params.ignoreTipConfiguration,
         )
 
-        return MoveToAddressableAreaForDropTipResult(position=DeckPoint(x=x, y=y, z=z))
+        return SuccessData(
+            public=MoveToAddressableAreaForDropTipResult(
+                position=DeckPoint(x=x, y=y, z=z)
+            ),
+            private=None,
+        )
 
 
 class MoveToAddressableAreaForDropTip(
     BaseCommand[
-        MoveToAddressableAreaForDropTipParams, MoveToAddressableAreaForDropTipResult
+        MoveToAddressableAreaForDropTipParams,
+        MoveToAddressableAreaForDropTipResult,
+        Never,
     ]
 ):
     """Move to addressable area for drop tip command model."""

--- a/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_addressable_area_for_drop_tip.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..errors import LocationNotAccessibleByPipetteError
 from ..types import DeckPoint, AddressableOffsetVector
@@ -13,6 +13,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -138,7 +139,7 @@ class MoveToAddressableAreaForDropTip(
     BaseCommand[
         MoveToAddressableAreaForDropTipParams,
         MoveToAddressableAreaForDropTipResult,
-        Never,
+        ErrorOccurrence,
     ]
 ):
     """Move to addressable area for drop tip command model."""

--- a/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_coordinates.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 from pydantic import Field
 from typing import Optional, Type, TYPE_CHECKING
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import DeckPoint
 from .pipetting_common import PipetteIdMixin, MovementMixin, DestinationPositionResult
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -64,7 +65,7 @@ class MoveToCoordinatesImplementation(
 
 
 class MoveToCoordinates(
-    BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult, Never]
+    BaseCommand[MoveToCoordinatesParams, MoveToCoordinatesResult, ErrorOccurrence]
 ):
     """Move to well command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/move_to_well.py
+++ b/api/src/opentrons/protocol_engine/commands/move_to_well.py
@@ -1,7 +1,7 @@
 """Move to well command request, result, and implementation models."""
 from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import DeckPoint
 from .pipetting_common import (
@@ -11,6 +11,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -57,7 +58,7 @@ class MoveToWellImplementation(
         )
 
 
-class MoveToWell(BaseCommand[MoveToWellParams, MoveToWellResult, Never]):
+class MoveToWell(BaseCommand[MoveToWellParams, MoveToWellResult, ErrorOccurrence]):
     """Move to well command model."""
 
     commandType: MoveToWellCommandType = "moveToWell"

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import DeckPoint
 from .pipetting_common import (
@@ -11,6 +11,7 @@ from .pipetting_common import (
     DestinationPositionResult,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -98,7 +99,7 @@ class PickUpTipImplementation(
         )
 
 
-class PickUpTip(BaseCommand[PickUpTipParams, PickUpTipResult, Never]):
+class PickUpTip(BaseCommand[PickUpTipParams, PickUpTipResult, ErrorOccurrence]):
     """Pick up tip command model."""
 
     commandType: PickUpTipCommandType = "pickUpTip"

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import (
     PipetteIdMixin,
 )
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution.pipetting import PipettingHandler
@@ -50,7 +51,7 @@ class PrepareToAspirateImplementation(
 
 
 class PrepareToAspirate(
-    BaseCommand[PrepareToAspirateParams, PrepareToAspirateResult, Never]
+    BaseCommand[PrepareToAspirateParams, PrepareToAspirateResult, ErrorOccurrence]
 ):
     """Prepare for aspirate command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/prepare_to_aspirate.py
@@ -3,16 +3,12 @@
 from __future__ import annotations
 from pydantic import BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from .pipetting_common import (
     PipetteIdMixin,
 )
-from .command import (
-    AbstractCommandImpl,
-    BaseCommand,
-    BaseCommandCreate,
-)
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution.pipetting import PipettingHandler
@@ -34,8 +30,7 @@ class PrepareToAspirateResult(BaseModel):
 
 class PrepareToAspirateImplementation(
     AbstractCommandImpl[
-        PrepareToAspirateParams,
-        PrepareToAspirateResult,
+        PrepareToAspirateParams, SuccessData[PrepareToAspirateResult, None]
     ]
 ):
     """Prepare for aspirate command implementation."""
@@ -43,16 +38,20 @@ class PrepareToAspirateImplementation(
     def __init__(self, pipetting: PipettingHandler, **kwargs: object) -> None:
         self._pipetting_handler = pipetting
 
-    async def execute(self, params: PrepareToAspirateParams) -> PrepareToAspirateResult:
+    async def execute(
+        self, params: PrepareToAspirateParams
+    ) -> SuccessData[PrepareToAspirateResult, None]:
         """Prepare the pipette to aspirate."""
         await self._pipetting_handler.prepare_for_aspirate(
             pipette_id=params.pipetteId,
         )
 
-        return PrepareToAspirateResult()
+        return SuccessData(public=PrepareToAspirateResult(), private=None)
 
 
-class PrepareToAspirate(BaseCommand[PrepareToAspirateParams, PrepareToAspirateResult]):
+class PrepareToAspirate(
+    BaseCommand[PrepareToAspirateParams, PrepareToAspirateResult, Never]
+):
     """Prepare for aspirate command model."""
 
     commandType: PrepareToAspirateCommandType = "prepareToAspirate"

--- a/api/src/opentrons/protocol_engine/commands/reload_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/reload_labware.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -72,7 +73,9 @@ class ReloadLabwareImplementation(
         )
 
 
-class ReloadLabware(BaseCommand[ReloadLabwareParams, ReloadLabwareResult, Never]):
+class ReloadLabware(
+    BaseCommand[ReloadLabwareParams, ReloadLabwareResult, ErrorOccurrence]
+):
     """Reload labware command resource model."""
 
     commandType: ReloadLabwareCommandType = "reloadLabware"

--- a/api/src/opentrons/protocol_engine/commands/reload_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/reload_labware.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..state import StateView
@@ -45,7 +45,7 @@ class ReloadLabwareResult(BaseModel):
 
 
 class ReloadLabwareImplementation(
-    AbstractCommandImpl[ReloadLabwareParams, ReloadLabwareResult]
+    AbstractCommandImpl[ReloadLabwareParams, SuccessData[ReloadLabwareResult, None]]
 ):
     """Reload labware command implementation."""
 
@@ -55,19 +55,24 @@ class ReloadLabwareImplementation(
         self._equipment = equipment
         self._state_view = state_view
 
-    async def execute(self, params: ReloadLabwareParams) -> ReloadLabwareResult:
+    async def execute(
+        self, params: ReloadLabwareParams
+    ) -> SuccessData[ReloadLabwareResult, None]:
         """Reload the definition and calibration data for a specific labware."""
         reloaded_labware = await self._equipment.reload_labware(
             labware_id=params.labwareId,
         )
 
-        return ReloadLabwareResult(
-            labwareId=params.labwareId,
-            offsetId=reloaded_labware.offsetId,
+        return SuccessData(
+            public=ReloadLabwareResult(
+                labwareId=params.labwareId,
+                offsetId=reloaded_labware.offsetId,
+            ),
+            private=None,
         )
 
 
-class ReloadLabware(BaseCommand[ReloadLabwareParams, ReloadLabwareResult]):
+class ReloadLabware(BaseCommand[ReloadLabwareParams, ReloadLabwareResult, Never]):
     """Reload labware command resource model."""
 
     commandType: ReloadLabwareCommandType = "reloadLabware"

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from ..types import MotorAxis
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -37,20 +37,22 @@ class RetractAxisResult(BaseModel):
 
 
 class RetractAxisImplementation(
-    AbstractCommandImpl[RetractAxisParams, RetractAxisResult]
+    AbstractCommandImpl[RetractAxisParams, SuccessData[RetractAxisResult, None]]
 ):
     """Retract Axis command implementation."""
 
     def __init__(self, movement: MovementHandler, **kwargs: object) -> None:
         self._movement = movement
 
-    async def execute(self, params: RetractAxisParams) -> RetractAxisResult:
+    async def execute(
+        self, params: RetractAxisParams
+    ) -> SuccessData[RetractAxisResult, None]:
         """Retract the specified axis."""
         await self._movement.retract_axis(axis=params.axis)
-        return RetractAxisResult()
+        return SuccessData(public=RetractAxisResult(), private=None)
 
 
-class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult]):
+class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult, Never]):
     """Command to retract the specified axis to its home position."""
 
     commandType: RetractAxisCommandType = "retractAxis"

--- a/api/src/opentrons/protocol_engine/commands/retract_axis.py
+++ b/api/src/opentrons/protocol_engine/commands/retract_axis.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import MotorAxis
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler
@@ -52,7 +53,7 @@ class RetractAxisImplementation(
         return SuccessData(public=RetractAxisResult(), private=None)
 
 
-class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult, Never]):
+class RetractAxis(BaseCommand[RetractAxisParams, RetractAxisResult, ErrorOccurrence]):
     """Command to retract the specified axis to its home position."""
 
     commandType: RetractAxisCommandType = "retractAxis"

--- a/api/src/opentrons/protocol_engine/commands/save_position.py
+++ b/api/src/opentrons/protocol_engine/commands/save_position.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..types import DeckPoint
 from ..resources import ModelUtils
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import GantryMover
@@ -79,7 +80,9 @@ class SavePositionImplementation(
         )
 
 
-class SavePosition(BaseCommand[SavePositionParams, SavePositionResult, Never]):
+class SavePosition(
+    BaseCommand[SavePositionParams, SavePositionResult, ErrorOccurrence]
+):
     """Save Position command model."""
 
     commandType: SavePositionCommandType = "savePosition"

--- a/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
+++ b/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import RailLightsHandler
@@ -43,7 +44,9 @@ class SetRailLightsImplementation(
         return SuccessData(public=SetRailLightsResult(), private=None)
 
 
-class SetRailLights(BaseCommand[SetRailLightsParams, SetRailLightsResult, Never]):
+class SetRailLights(
+    BaseCommand[SetRailLightsParams, SetRailLightsResult, ErrorOccurrence]
+):
     """setRailLights command model."""
 
     commandType: SetRailLightsCommandType = "setRailLights"

--- a/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
+++ b/api/src/opentrons/protocol_engine/commands/set_rail_lights.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import RailLightsHandler
@@ -28,20 +28,22 @@ class SetRailLightsResult(BaseModel):
 
 
 class SetRailLightsImplementation(
-    AbstractCommandImpl[SetRailLightsParams, SetRailLightsResult]
+    AbstractCommandImpl[SetRailLightsParams, SuccessData[SetRailLightsResult, None]]
 ):
     """setRailLights command implementation."""
 
     def __init__(self, rail_lights: RailLightsHandler, **kwargs: object) -> None:
         self._rail_lights = rail_lights
 
-    async def execute(self, params: SetRailLightsParams) -> SetRailLightsResult:
+    async def execute(
+        self, params: SetRailLightsParams
+    ) -> SuccessData[SetRailLightsResult, None]:
         """Dispatch a set lights command setting the state of the rail lights."""
         await self._rail_lights.set_rail_lights(params.on)
-        return SetRailLightsResult()
+        return SuccessData(public=SetRailLightsResult(), private=None)
 
 
-class SetRailLights(BaseCommand[SetRailLightsParams, SetRailLightsResult]):
+class SetRailLights(BaseCommand[SetRailLightsParams, SetRailLightsResult, Never]):
     """setRailLights command model."""
 
     commandType: SetRailLightsCommandType = "setRailLights"

--- a/api/src/opentrons/protocol_engine/commands/set_status_bar.py
+++ b/api/src/opentrons/protocol_engine/commands/set_status_bar.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 import enum
 
 from opentrons.hardware_control.types import StatusBarState
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import StatusBarHandler
@@ -65,7 +66,9 @@ class SetStatusBarImplementation(
         return SuccessData(public=SetStatusBarResult(), private=None)
 
 
-class SetStatusBar(BaseCommand[SetStatusBarParams, SetStatusBarResult, Never]):
+class SetStatusBar(
+    BaseCommand[SetStatusBarParams, SetStatusBarResult, ErrorOccurrence]
+):
     """setStatusBar command model."""
 
     commandType: SetStatusBarCommandType = "setStatusBar"

--- a/api/src/opentrons/protocol_engine/commands/set_status_bar.py
+++ b/api/src/opentrons/protocol_engine/commands/set_status_bar.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 import enum
 
 from opentrons.hardware_control.types import StatusBarState
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import StatusBarHandler
@@ -48,22 +48,24 @@ class SetStatusBarResult(BaseModel):
 
 
 class SetStatusBarImplementation(
-    AbstractCommandImpl[SetStatusBarParams, SetStatusBarResult]
+    AbstractCommandImpl[SetStatusBarParams, SuccessData[SetStatusBarResult, None]]
 ):
     """setStatusBar command implementation."""
 
     def __init__(self, status_bar: StatusBarHandler, **kwargs: object) -> None:
         self._status_bar = status_bar
 
-    async def execute(self, params: SetStatusBarParams) -> SetStatusBarResult:
+    async def execute(
+        self, params: SetStatusBarParams
+    ) -> SuccessData[SetStatusBarResult, None]:
         """Execute the setStatusBar command."""
         if not self._status_bar.status_bar_should_not_be_changed():
             state = _animation_to_status_bar_state(params.animation)
             await self._status_bar.set_status_bar(state)
-        return SetStatusBarResult()
+        return SuccessData(public=SetStatusBarResult(), private=None)
 
 
-class SetStatusBar(BaseCommand[SetStatusBarParams, SetStatusBarResult]):
+class SetStatusBar(BaseCommand[SetStatusBarParams, SetStatusBarResult, Never]):
     """setStatusBar command model."""
 
     commandType: SetStatusBarCommandType = "setStatusBar"

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -1,11 +1,12 @@
 """Command models to deactivate a Temperature Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -60,7 +61,9 @@ class DeactivateTemperatureImpl(
 
 
 class DeactivateTemperature(
-    BaseCommand[DeactivateTemperatureParams, DeactivateTemperatureResult, Never]
+    BaseCommand[
+        DeactivateTemperatureParams, DeactivateTemperatureResult, ErrorOccurrence
+    ]
 ):
     """A command to deactivate a Temperature Module."""
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/deactivate.py
@@ -1,11 +1,11 @@
 """Command models to deactivate a Temperature Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -25,7 +25,9 @@ class DeactivateTemperatureResult(BaseModel):
 
 
 class DeactivateTemperatureImpl(
-    AbstractCommandImpl[DeactivateTemperatureParams, DeactivateTemperatureResult]
+    AbstractCommandImpl[
+        DeactivateTemperatureParams, SuccessData[DeactivateTemperatureResult, None]
+    ]
 ):
     """Execution implementation of a Temperature Module's deactivate command."""
 
@@ -40,7 +42,7 @@ class DeactivateTemperatureImpl(
 
     async def execute(
         self, params: DeactivateTemperatureParams
-    ) -> DeactivateTemperatureResult:
+    ) -> SuccessData[DeactivateTemperatureResult, None]:
         """Deactivate a Temperature Module."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(
@@ -54,11 +56,11 @@ class DeactivateTemperatureImpl(
 
         if temp_hardware_module is not None:
             await temp_hardware_module.deactivate()
-        return DeactivateTemperatureResult()
+        return SuccessData(public=DeactivateTemperatureResult(), private=None)
 
 
 class DeactivateTemperature(
-    BaseCommand[DeactivateTemperatureParams, DeactivateTemperatureResult]
+    BaseCommand[DeactivateTemperatureParams, DeactivateTemperatureResult, Never]
 ):
     """A command to deactivate a Temperature Module."""
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -1,11 +1,12 @@
 """Command models to start heating a Temperature Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -73,7 +74,7 @@ class SetTargetTemperatureImpl(
 
 
 class SetTargetTemperature(
-    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult, Never]
+    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult, ErrorOccurrence]
 ):
     """A command to set a Temperature Module's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/set_target_temperature.py
@@ -1,11 +1,11 @@
 """Command models to start heating a Temperature Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -32,7 +32,9 @@ class SetTargetTemperatureResult(BaseModel):
 
 
 class SetTargetTemperatureImpl(
-    AbstractCommandImpl[SetTargetTemperatureParams, SetTargetTemperatureResult]
+    AbstractCommandImpl[
+        SetTargetTemperatureParams, SuccessData[SetTargetTemperatureResult, None]
+    ]
 ):
     """Execution implementation of a Temperature Module's set temperature command."""
 
@@ -47,7 +49,7 @@ class SetTargetTemperatureImpl(
 
     async def execute(
         self, params: SetTargetTemperatureParams
-    ) -> SetTargetTemperatureResult:
+    ) -> SuccessData[SetTargetTemperatureResult, None]:
         """Set a Temperature Module's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(
@@ -64,11 +66,14 @@ class SetTargetTemperatureImpl(
 
         if temp_hardware_module is not None:
             await temp_hardware_module.start_set_temperature(celsius=validated_temp)
-        return SetTargetTemperatureResult(targetTemperature=validated_temp)
+        return SuccessData(
+            public=SetTargetTemperatureResult(targetTemperature=validated_temp),
+            private=None,
+        )
 
 
 class SetTargetTemperature(
-    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult]
+    BaseCommand[SetTargetTemperatureParams, SetTargetTemperatureResult, Never]
 ):
     """A command to set a Temperature Module's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
@@ -1,11 +1,12 @@
 """Command models to wait for target temperature of a Temperature Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -77,7 +78,7 @@ class WaitForTemperatureImpl(
 
 
 class WaitForTemperature(
-    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult, Never]
+    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult, ErrorOccurrence]
 ):
     """A command to wait for a Temperature Module's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/temperature_module/wait_for_temperature.py
@@ -1,11 +1,11 @@
 """Command models to wait for target temperature of a Temperature Module."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -34,7 +34,9 @@ class WaitForTemperatureResult(BaseModel):
 
 
 class WaitForTemperatureImpl(
-    AbstractCommandImpl[WaitForTemperatureParams, WaitForTemperatureResult]
+    AbstractCommandImpl[
+        WaitForTemperatureParams, SuccessData[WaitForTemperatureResult, None]
+    ]
 ):
     """Execution implementation of Temperature Module's wait for temperature command."""
 
@@ -49,7 +51,7 @@ class WaitForTemperatureImpl(
 
     async def execute(
         self, params: WaitForTemperatureParams
-    ) -> WaitForTemperatureResult:
+    ) -> SuccessData[WaitForTemperatureResult, None]:
         """Wait for a Temperature Module's target temperature."""
         # Allow propagation of ModuleNotLoadedError and WrongModuleTypeError.
         module_substate = self._state_view.modules.get_temperature_module_substate(
@@ -71,11 +73,11 @@ class WaitForTemperatureImpl(
             await temp_hardware_module.await_temperature(
                 awaiting_temperature=target_temp
             )
-        return WaitForTemperatureResult()
+        return SuccessData(public=WaitForTemperatureResult(), private=None)
 
 
 class WaitForTemperature(
-    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult]
+    BaseCommand[WaitForTemperatureParams, WaitForTemperatureResult, Never]
 ):
     """A command to wait for a Temperature Module's target temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
@@ -1,11 +1,11 @@
 """Command models to close a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from opentrons.protocol_engine.types import MotorAxis
 
 if TYPE_CHECKING:
@@ -26,7 +26,9 @@ class CloseLidResult(BaseModel):
     """Result data from closing a Thermocycler's lid."""
 
 
-class CloseLidImpl(AbstractCommandImpl[CloseLidParams, CloseLidResult]):
+class CloseLidImpl(
+    AbstractCommandImpl[CloseLidParams, SuccessData[CloseLidResult, None]]
+):
     """Execution implementation of a Thermocycler's close lid command."""
 
     def __init__(
@@ -40,7 +42,9 @@ class CloseLidImpl(AbstractCommandImpl[CloseLidParams, CloseLidResult]):
         self._equipment = equipment
         self._movement = movement
 
-    async def execute(self, params: CloseLidParams) -> CloseLidResult:
+    async def execute(
+        self, params: CloseLidParams
+    ) -> SuccessData[CloseLidResult, None]:
         """Close a Thermocycler's lid."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -60,10 +64,10 @@ class CloseLidImpl(AbstractCommandImpl[CloseLidParams, CloseLidResult]):
         if thermocycler_hardware is not None:
             await thermocycler_hardware.close()
 
-        return CloseLidResult()
+        return SuccessData(public=CloseLidResult(), private=None)
 
 
-class CloseLid(BaseCommand[CloseLidParams, CloseLidResult]):
+class CloseLid(BaseCommand[CloseLidParams, CloseLidResult, Never]):
     """A command to close a Thermocycler's lid."""
 
     commandType: CloseLidCommandType = "thermocycler/closeLid"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/close_lid.py
@@ -1,11 +1,12 @@
 """Command models to close a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 from opentrons.protocol_engine.types import MotorAxis
 
 if TYPE_CHECKING:
@@ -67,7 +68,7 @@ class CloseLidImpl(
         return SuccessData(public=CloseLidResult(), private=None)
 
 
-class CloseLid(BaseCommand[CloseLidParams, CloseLidResult, Never]):
+class CloseLid(BaseCommand[CloseLidParams, CloseLidResult, ErrorOccurrence]):
     """A command to close a Thermocycler's lid."""
 
     commandType: CloseLidCommandType = "thermocycler/closeLid"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
@@ -1,11 +1,11 @@
 """Command models to stop heating a Thermocycler's block."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -26,7 +26,7 @@ class DeactivateBlockResult(BaseModel):
 
 
 class DeactivateBlockImpl(
-    AbstractCommandImpl[DeactivateBlockParams, DeactivateBlockResult]
+    AbstractCommandImpl[DeactivateBlockParams, SuccessData[DeactivateBlockResult, None]]
 ):
     """Execution implementation of a Thermocycler's deactivate block command."""
 
@@ -39,7 +39,9 @@ class DeactivateBlockImpl(
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: DeactivateBlockParams) -> DeactivateBlockResult:
+    async def execute(
+        self, params: DeactivateBlockParams
+    ) -> SuccessData[DeactivateBlockResult, None]:
         """Unset a Thermocycler's target block temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -51,10 +53,10 @@ class DeactivateBlockImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.deactivate_block()
 
-        return DeactivateBlockResult()
+        return SuccessData(public=DeactivateBlockResult(), private=None)
 
 
-class DeactivateBlock(BaseCommand[DeactivateBlockParams, DeactivateBlockResult]):
+class DeactivateBlock(BaseCommand[DeactivateBlockParams, DeactivateBlockResult, Never]):
     """A command to unset a Thermocycler's target block temperature."""
 
     commandType: DeactivateBlockCommandType = "thermocycler/deactivateBlock"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_block.py
@@ -1,11 +1,12 @@
 """Command models to stop heating a Thermocycler's block."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -56,7 +57,9 @@ class DeactivateBlockImpl(
         return SuccessData(public=DeactivateBlockResult(), private=None)
 
 
-class DeactivateBlock(BaseCommand[DeactivateBlockParams, DeactivateBlockResult, Never]):
+class DeactivateBlock(
+    BaseCommand[DeactivateBlockParams, DeactivateBlockResult, ErrorOccurrence]
+):
     """A command to unset a Thermocycler's target block temperature."""
 
     commandType: DeactivateBlockCommandType = "thermocycler/deactivateBlock"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
@@ -1,11 +1,12 @@
 """Command models to stop heating a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -56,7 +57,9 @@ class DeactivateLidImpl(
         return SuccessData(public=DeactivateLidResult(), private=None)
 
 
-class DeactivateLid(BaseCommand[DeactivateLidParams, DeactivateLidResult, Never]):
+class DeactivateLid(
+    BaseCommand[DeactivateLidParams, DeactivateLidResult, ErrorOccurrence]
+):
     """A command to unset a Thermocycler's target lid temperature."""
 
     commandType: DeactivateLidCommandType = "thermocycler/deactivateLid"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/deactivate_lid.py
@@ -1,11 +1,11 @@
 """Command models to stop heating a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -25,7 +25,9 @@ class DeactivateLidResult(BaseModel):
     """Result data from unsetting a Thermocycler's target lid temperature."""
 
 
-class DeactivateLidImpl(AbstractCommandImpl[DeactivateLidParams, DeactivateLidResult]):
+class DeactivateLidImpl(
+    AbstractCommandImpl[DeactivateLidParams, SuccessData[DeactivateLidResult, None]]
+):
     """Execution implementation of a Thermocycler's deactivate lid command."""
 
     def __init__(
@@ -37,7 +39,9 @@ class DeactivateLidImpl(AbstractCommandImpl[DeactivateLidParams, DeactivateLidRe
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: DeactivateLidParams) -> DeactivateLidResult:
+    async def execute(
+        self, params: DeactivateLidParams
+    ) -> SuccessData[DeactivateLidResult, None]:
         """Unset a Thermocycler's target lid temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -49,10 +53,10 @@ class DeactivateLidImpl(AbstractCommandImpl[DeactivateLidParams, DeactivateLidRe
         if thermocycler_hardware is not None:
             await thermocycler_hardware.deactivate_lid()
 
-        return DeactivateLidResult()
+        return SuccessData(public=DeactivateLidResult(), private=None)
 
 
-class DeactivateLid(BaseCommand[DeactivateLidParams, DeactivateLidResult]):
+class DeactivateLid(BaseCommand[DeactivateLidParams, DeactivateLidResult, Never]):
     """A command to unset a Thermocycler's target lid temperature."""
 
     commandType: DeactivateLidCommandType = "thermocycler/deactivateLid"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -1,11 +1,11 @@
 """Command models to open a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from opentrons.protocol_engine.types import MotorAxis
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ class OpenLidResult(BaseModel):
     """Result data from opening a Thermocycler's lid."""
 
 
-class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
+class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, None]]):
     """Execution implementation of a Thermocycler's open lid command."""
 
     def __init__(
@@ -40,7 +40,7 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
         self._equipment = equipment
         self._movement = movement
 
-    async def execute(self, params: OpenLidParams) -> OpenLidResult:
+    async def execute(self, params: OpenLidParams) -> SuccessData[OpenLidResult, None]:
         """Open a Thermocycler's lid."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -60,10 +60,10 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, OpenLidResult]):
         if thermocycler_hardware is not None:
             await thermocycler_hardware.open()
 
-        return OpenLidResult()
+        return SuccessData(public=OpenLidResult(), private=None)
 
 
-class OpenLid(BaseCommand[OpenLidParams, OpenLidResult]):
+class OpenLid(BaseCommand[OpenLidParams, OpenLidResult, Never]):
     """A command to open a Thermocycler's lid."""
 
     commandType: OpenLidCommandType = "thermocycler/openLid"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/open_lid.py
@@ -1,11 +1,12 @@
 """Command models to open a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 from opentrons.protocol_engine.types import MotorAxis
 
 if TYPE_CHECKING:
@@ -63,7 +64,7 @@ class OpenLidImpl(AbstractCommandImpl[OpenLidParams, SuccessData[OpenLidResult, 
         return SuccessData(public=OpenLidResult(), private=None)
 
 
-class OpenLid(BaseCommand[OpenLidParams, OpenLidResult, Never]):
+class OpenLid(BaseCommand[OpenLidParams, OpenLidResult, ErrorOccurrence]):
     """A command to open a Thermocycler's lid."""
 
     commandType: OpenLidCommandType = "thermocycler/openLid"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
@@ -1,13 +1,13 @@
 """Command models to execute a Thermocycler profile."""
 from __future__ import annotations
 from typing import List, Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
 from opentrons.hardware_control.modules.types import ThermocyclerStep
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -45,7 +45,9 @@ class RunProfileResult(BaseModel):
     """Result data from running a Thermocycler profile."""
 
 
-class RunProfileImpl(AbstractCommandImpl[RunProfileParams, RunProfileResult]):
+class RunProfileImpl(
+    AbstractCommandImpl[RunProfileParams, SuccessData[RunProfileResult, None]]
+):
     """Execution implementation of a Thermocycler's run profile command."""
 
     def __init__(
@@ -57,7 +59,9 @@ class RunProfileImpl(AbstractCommandImpl[RunProfileParams, RunProfileResult]):
         self._state_view = state_view
         self._equipment = equipment
 
-    async def execute(self, params: RunProfileParams) -> RunProfileResult:
+    async def execute(
+        self, params: RunProfileParams
+    ) -> SuccessData[RunProfileResult, None]:
         """Run a Thermocycler profile."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -91,10 +95,10 @@ class RunProfileImpl(AbstractCommandImpl[RunProfileParams, RunProfileResult]):
                 steps=steps, repetitions=1, volume=target_volume
             )
 
-        return RunProfileResult()
+        return SuccessData(public=RunProfileResult(), private=None)
 
 
-class RunProfile(BaseCommand[RunProfileParams, RunProfileResult]):
+class RunProfile(BaseCommand[RunProfileParams, RunProfileResult, Never]):
     """A command to execute a Thermocycler profile run."""
 
     commandType: RunProfileCommandType = "thermocycler/runProfile"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/run_profile.py
@@ -1,13 +1,14 @@
 """Command models to execute a Thermocycler profile."""
 from __future__ import annotations
 from typing import List, Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from opentrons.hardware_control.modules.types import ThermocyclerStep
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -98,7 +99,7 @@ class RunProfileImpl(
         return SuccessData(public=RunProfileResult(), private=None)
 
 
-class RunProfile(BaseCommand[RunProfileParams, RunProfileResult, Never]):
+class RunProfile(BaseCommand[RunProfileParams, RunProfileResult, ErrorOccurrence]):
     """A command to execute a Thermocycler profile run."""
 
     commandType: RunProfileCommandType = "thermocycler/runProfile"

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -1,11 +1,12 @@
 """Command models to start heating a Thermocycler's block."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -101,7 +102,11 @@ class SetTargetBlockTemperatureImpl(
 
 
 class SetTargetBlockTemperature(
-    BaseCommand[SetTargetBlockTemperatureParams, SetTargetBlockTemperatureResult, Never]
+    BaseCommand[
+        SetTargetBlockTemperatureParams,
+        SetTargetBlockTemperatureResult,
+        ErrorOccurrence,
+    ]
 ):
     """A command to set a Thermocycler's target block temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_block_temperature.py
@@ -1,11 +1,11 @@
 """Command models to start heating a Thermocycler's block."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -45,7 +45,7 @@ class SetTargetBlockTemperatureResult(BaseModel):
 class SetTargetBlockTemperatureImpl(
     AbstractCommandImpl[
         SetTargetBlockTemperatureParams,
-        SetTargetBlockTemperatureResult,
+        SuccessData[SetTargetBlockTemperatureResult, None],
     ]
 ):
     """Execution implementation of a Thermocycler's set block temperature command."""
@@ -62,7 +62,7 @@ class SetTargetBlockTemperatureImpl(
     async def execute(
         self,
         params: SetTargetBlockTemperatureParams,
-    ) -> SetTargetBlockTemperatureResult:
+    ) -> SuccessData[SetTargetBlockTemperatureResult, None]:
         """Set a Thermocycler's target block temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -92,13 +92,16 @@ class SetTargetBlockTemperatureImpl(
                 target_temperature, volume=target_volume, hold_time_seconds=hold_time
             )
 
-        return SetTargetBlockTemperatureResult(
-            targetBlockTemperature=target_temperature
+        return SuccessData(
+            public=SetTargetBlockTemperatureResult(
+                targetBlockTemperature=target_temperature
+            ),
+            private=None,
         )
 
 
 class SetTargetBlockTemperature(
-    BaseCommand[SetTargetBlockTemperatureParams, SetTargetBlockTemperatureResult]
+    BaseCommand[SetTargetBlockTemperatureParams, SetTargetBlockTemperatureResult, Never]
 ):
     """A command to set a Thermocycler's target block temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -1,11 +1,11 @@
 """Command models to start heating a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -32,7 +32,9 @@ class SetTargetLidTemperatureResult(BaseModel):
 
 
 class SetTargetLidTemperatureImpl(
-    AbstractCommandImpl[SetTargetLidTemperatureParams, SetTargetLidTemperatureResult]
+    AbstractCommandImpl[
+        SetTargetLidTemperatureParams, SuccessData[SetTargetLidTemperatureResult, None]
+    ]
 ):
     """Execution implementation of a Thermocycler's set lid temperature command."""
 
@@ -48,7 +50,7 @@ class SetTargetLidTemperatureImpl(
     async def execute(
         self,
         params: SetTargetLidTemperatureParams,
-    ) -> SetTargetLidTemperatureResult:
+    ) -> SuccessData[SetTargetLidTemperatureResult, None]:
         """Set a Thermocycler's target lid temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -63,11 +65,16 @@ class SetTargetLidTemperatureImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.set_target_lid_temperature(target_temperature)
 
-        return SetTargetLidTemperatureResult(targetLidTemperature=target_temperature)
+        return SuccessData(
+            public=SetTargetLidTemperatureResult(
+                targetLidTemperature=target_temperature
+            ),
+            private=None,
+        )
 
 
 class SetTargetLidTemperature(
-    BaseCommand[SetTargetLidTemperatureParams, SetTargetLidTemperatureResult]
+    BaseCommand[SetTargetLidTemperatureParams, SetTargetLidTemperatureResult, Never]
 ):
     """A command to set a Thermocycler's target lid temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/set_target_lid_temperature.py
@@ -1,11 +1,12 @@
 """Command models to start heating a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -74,7 +75,9 @@ class SetTargetLidTemperatureImpl(
 
 
 class SetTargetLidTemperature(
-    BaseCommand[SetTargetLidTemperatureParams, SetTargetLidTemperatureResult, Never]
+    BaseCommand[
+        SetTargetLidTemperatureParams, SetTargetLidTemperatureResult, ErrorOccurrence
+    ]
 ):
     """A command to set a Thermocycler's target lid temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
@@ -1,11 +1,11 @@
 """Command models to wait for heating a Thermocycler's block."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -27,8 +27,7 @@ class WaitForBlockTemperatureResult(BaseModel):
 
 class WaitForBlockTemperatureImpl(
     AbstractCommandImpl[
-        WaitForBlockTemperatureParams,
-        WaitForBlockTemperatureResult,
+        WaitForBlockTemperatureParams, SuccessData[WaitForBlockTemperatureResult, None]
     ]
 ):
     """Execution implementation of Thermocycler's wait for block temperature command."""
@@ -45,7 +44,7 @@ class WaitForBlockTemperatureImpl(
     async def execute(
         self,
         params: WaitForBlockTemperatureParams,
-    ) -> WaitForBlockTemperatureResult:
+    ) -> SuccessData[WaitForBlockTemperatureResult, None]:
         """Wait for a Thermocycler's target block temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -61,11 +60,11 @@ class WaitForBlockTemperatureImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.wait_for_block_target()
 
-        return WaitForBlockTemperatureResult()
+        return SuccessData(public=WaitForBlockTemperatureResult(), private=None)
 
 
 class WaitForBlockTemperature(
-    BaseCommand[WaitForBlockTemperatureParams, WaitForBlockTemperatureResult]
+    BaseCommand[WaitForBlockTemperatureParams, WaitForBlockTemperatureResult, Never]
 ):
     """A command to wait for a Thermocycler's target block temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_block_temperature.py
@@ -1,11 +1,12 @@
 """Command models to wait for heating a Thermocycler's block."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -64,7 +65,9 @@ class WaitForBlockTemperatureImpl(
 
 
 class WaitForBlockTemperature(
-    BaseCommand[WaitForBlockTemperatureParams, WaitForBlockTemperatureResult, Never]
+    BaseCommand[
+        WaitForBlockTemperatureParams, WaitForBlockTemperatureResult, ErrorOccurrence
+    ]
 ):
     """A command to wait for a Thermocycler's target block temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
@@ -1,11 +1,12 @@
 """Command models to wait for heating a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Never, Type
+from typing_extensions import Literal, Type
 
 from pydantic import BaseModel, Field
 
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -64,7 +65,9 @@ class WaitForLidTemperatureImpl(
 
 
 class WaitForLidTemperature(
-    BaseCommand[WaitForLidTemperatureParams, WaitForLidTemperatureResult, Never]
+    BaseCommand[
+        WaitForLidTemperatureParams, WaitForLidTemperatureResult, ErrorOccurrence
+    ]
 ):
     """A command to wait for a Thermocycler's lid temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
+++ b/api/src/opentrons/protocol_engine/commands/thermocycler/wait_for_lid_temperature.py
@@ -1,11 +1,11 @@
 """Command models to wait for heating a Thermocycler's lid."""
 from __future__ import annotations
 from typing import Optional, TYPE_CHECKING
-from typing_extensions import Literal, Type
+from typing_extensions import Literal, Never, Type
 
 from pydantic import BaseModel, Field
 
-from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from opentrons.protocol_engine.state import StateView
@@ -27,8 +27,7 @@ class WaitForLidTemperatureResult(BaseModel):
 
 class WaitForLidTemperatureImpl(
     AbstractCommandImpl[
-        WaitForLidTemperatureParams,
-        WaitForLidTemperatureResult,
+        WaitForLidTemperatureParams, SuccessData[WaitForLidTemperatureResult, None]
     ]
 ):
     """Execution implementation of Thermocycler's wait for lid temperature command."""
@@ -45,7 +44,7 @@ class WaitForLidTemperatureImpl(
     async def execute(
         self,
         params: WaitForLidTemperatureParams,
-    ) -> WaitForLidTemperatureResult:
+    ) -> SuccessData[WaitForLidTemperatureResult, None]:
         """Wait for a Thermocycler's lid temperature."""
         thermocycler_state = self._state_view.modules.get_thermocycler_module_substate(
             params.moduleId
@@ -61,11 +60,11 @@ class WaitForLidTemperatureImpl(
         if thermocycler_hardware is not None:
             await thermocycler_hardware.wait_for_lid_target()
 
-        return WaitForLidTemperatureResult()
+        return SuccessData(public=WaitForLidTemperatureResult(), private=None)
 
 
 class WaitForLidTemperature(
-    BaseCommand[WaitForLidTemperatureParams, WaitForLidTemperatureResult]
+    BaseCommand[WaitForLidTemperatureParams, WaitForLidTemperatureResult, Never]
 ):
     """A command to wait for a Thermocycler's lid temperature."""
 

--- a/api/src/opentrons/protocol_engine/commands/touch_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/touch_tip.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 from pydantic import Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from ..errors import TouchTipDisabledError, LabwareIsTipRackError
 from ..types import DeckPoint
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 from .pipetting_common import (
     PipetteIdMixin,
     WellLocationMixin,
@@ -108,7 +109,7 @@ class TouchTipImplementation(
         )
 
 
-class TouchTip(BaseCommand[TouchTipParams, TouchTipResult, Never]):
+class TouchTip(BaseCommand[TouchTipParams, TouchTipResult, ErrorOccurrence]):
     """Touch up tip command model."""
 
     commandType: TouchTipCommandType = "touchTip"

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
 from .pipetting_common import PipetteIdMixin
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 from ..types import TipPresenceStatus, InstrumentSensorId
 
@@ -35,7 +35,9 @@ class VerifyTipPresenceResult(BaseModel):
 
 
 class VerifyTipPresenceImplementation(
-    AbstractCommandImpl[VerifyTipPresenceParams, VerifyTipPresenceResult]
+    AbstractCommandImpl[
+        VerifyTipPresenceParams, SuccessData[VerifyTipPresenceResult, None]
+    ]
 ):
     """VerifyTipPresence command implementation."""
 
@@ -46,7 +48,9 @@ class VerifyTipPresenceImplementation(
     ) -> None:
         self._tip_handler = tip_handler
 
-    async def execute(self, params: VerifyTipPresenceParams) -> VerifyTipPresenceResult:
+    async def execute(
+        self, params: VerifyTipPresenceParams
+    ) -> SuccessData[VerifyTipPresenceResult, None]:
         """Verify if tip presence is as expected for the requested pipette."""
         pipette_id = params.pipetteId
         expected_state = params.expectedState
@@ -62,10 +66,12 @@ class VerifyTipPresenceImplementation(
             follow_singular_sensor=follow_singular_sensor,
         )
 
-        return VerifyTipPresenceResult()
+        return SuccessData(public=VerifyTipPresenceResult(), private=None)
 
 
-class VerifyTipPresence(BaseCommand[VerifyTipPresenceParams, VerifyTipPresenceResult]):
+class VerifyTipPresence(
+    BaseCommand[VerifyTipPresenceParams, VerifyTipPresenceResult, Never]
+):
     """VerifyTipPresence command model."""
 
     commandType: VerifyTipPresenceCommandType = "verifyTipPresence"

--- a/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
+++ b/api/src/opentrons/protocol_engine/commands/verify_tip_presence.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 
 from pydantic import Field, BaseModel
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .pipetting_common import PipetteIdMixin
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 from ..types import TipPresenceStatus, InstrumentSensorId
 
@@ -70,7 +71,7 @@ class VerifyTipPresenceImplementation(
 
 
 class VerifyTipPresence(
-    BaseCommand[VerifyTipPresenceParams, VerifyTipPresenceResult, Never]
+    BaseCommand[VerifyTipPresenceParams, VerifyTipPresenceResult, ErrorOccurrence]
 ):
     """VerifyTipPresence command model."""
 

--- a/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import RunControlHandler
@@ -43,7 +44,9 @@ class WaitForDurationImplementation(
         return SuccessData(public=WaitForDurationResult(), private=None)
 
 
-class WaitForDuration(BaseCommand[WaitForDurationParams, WaitForDurationResult, Never]):
+class WaitForDuration(
+    BaseCommand[WaitForDurationParams, WaitForDurationResult, ErrorOccurrence]
+):
     """Wait for duration command model."""
 
     commandType: WaitForDurationCommandType = "waitForDuration"

--- a/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_duration.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import RunControlHandler
@@ -28,20 +28,22 @@ class WaitForDurationResult(BaseModel):
 
 
 class WaitForDurationImplementation(
-    AbstractCommandImpl[WaitForDurationParams, WaitForDurationResult]
+    AbstractCommandImpl[WaitForDurationParams, SuccessData[WaitForDurationResult, None]]
 ):
     """Wait for duration command implementation."""
 
     def __init__(self, run_control: RunControlHandler, **kwargs: object) -> None:
         self._run_control = run_control
 
-    async def execute(self, params: WaitForDurationParams) -> WaitForDurationResult:
+    async def execute(
+        self, params: WaitForDurationParams
+    ) -> SuccessData[WaitForDurationResult, None]:
         """Wait for a duration of time."""
         await self._run_control.wait_for_duration(params.seconds)
-        return WaitForDurationResult()
+        return SuccessData(public=WaitForDurationResult(), private=None)
 
 
-class WaitForDuration(BaseCommand[WaitForDurationParams, WaitForDurationResult]):
+class WaitForDuration(BaseCommand[WaitForDurationParams, WaitForDurationResult, Never]):
     """Wait for duration command model."""
 
     commandType: WaitForDurationCommandType = "waitForDuration"

--- a/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal, Never
+from typing_extensions import Literal
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..errors.error_occurrence import ErrorOccurrence
 
 if TYPE_CHECKING:
     from ..execution import RunControlHandler
@@ -44,7 +45,9 @@ class WaitForResumeImplementation(
         return SuccessData(public=WaitForResumeResult(), private=None)
 
 
-class WaitForResume(BaseCommand[WaitForResumeParams, WaitForResumeResult, Never]):
+class WaitForResume(
+    BaseCommand[WaitForResumeParams, WaitForResumeResult, ErrorOccurrence]
+):
     """Wait for resume command model."""
 
     commandType: WaitForResumeCommandType = "waitForResume"

--- a/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
+++ b/api/src/opentrons/protocol_engine/commands/wait_for_resume.py
@@ -2,9 +2,9 @@
 from __future__ import annotations
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
-from typing_extensions import Literal
+from typing_extensions import Literal, Never
 
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate
+from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
     from ..execution import RunControlHandler
@@ -29,20 +29,22 @@ class WaitForResumeResult(BaseModel):
 
 
 class WaitForResumeImplementation(
-    AbstractCommandImpl[WaitForResumeParams, WaitForResumeResult]
+    AbstractCommandImpl[WaitForResumeParams, SuccessData[WaitForResumeResult, None]]
 ):
     """Wait for resume command implementation."""
 
     def __init__(self, run_control: RunControlHandler, **kwargs: object) -> None:
         self._run_control = run_control
 
-    async def execute(self, params: WaitForResumeParams) -> WaitForResumeResult:
+    async def execute(
+        self, params: WaitForResumeParams
+    ) -> SuccessData[WaitForResumeResult, None]:
         """Dispatch a PauseAction to the store to pause the protocol."""
         await self._run_control.wait_for_resume()
-        return WaitForResumeResult()
+        return SuccessData(public=WaitForResumeResult(), private=None)
 
 
-class WaitForResume(BaseCommand[WaitForResumeParams, WaitForResumeResult]):
+class WaitForResume(BaseCommand[WaitForResumeParams, WaitForResumeResult, Never]):
     """Wait for resume command model."""
 
     commandType: WaitForResumeCommandType = "waitForResume"

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -2,6 +2,7 @@
 import asyncio
 from logging import getLogger
 from typing import Optional, List, Protocol
+from typing_extensions import assert_never
 
 from opentrons.hardware_control import HardwareControlAPI
 
@@ -11,16 +12,12 @@ from opentrons_shared_data.errors.exceptions import (
     PythonException,
 )
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 
 from ..state import StateStore
 from ..resources import ModelUtils
-from ..commands import (
-    CommandStatus,
-    AbstractCommandImpl,
-    CommandResult,
-    CommandPrivateResult,
-)
+from ..commands import CommandStatus
 from ..actions import (
     ActionDispatcher,
     RunCommandAction,
@@ -142,17 +139,17 @@ class CommandExecutor:
         )
         running_command = self._state_store.commands.get(queued_command.id)
 
+        log.debug(
+            f"Executing {running_command.id}, {running_command.commandType}, {running_command.params}"
+        )
         try:
-            log.debug(
-                f"Executing {running_command.id}, {running_command.commandType}, {running_command.params}"
+            result = await command_impl.execute(
+                running_command.params  # type: ignore[arg-type]
             )
-            if isinstance(command_impl, AbstractCommandImpl):
-                result: CommandResult = await command_impl.execute(running_command.params)  # type: ignore[arg-type]
-                private_result: Optional[CommandPrivateResult] = None
-            else:
-                result, private_result = await command_impl.execute(running_command.params)  # type: ignore[arg-type]
 
         except (Exception, asyncio.CancelledError) as error:
+            # The command encountered an undefined error.
+
             log.warning(f"Execution of {running_command.id} failed", exc_info=error)
             # TODO(mc, 2022-11-14): mark command as stopped rather than failed
             # https://opentrons.atlassian.net/browse/RCORE-390
@@ -184,16 +181,23 @@ class CommandExecutor:
                     ),
                 )
             )
+
         else:
-            update = {
-                "result": result,
-                "status": CommandStatus.SUCCEEDED,
-                "completedAt": self._model_utils.get_timestamp(),
-                "notes": note_tracker.get_notes(),
-            }
-            succeeded_command = running_command.copy(update=update)
-            self._action_dispatcher.dispatch(
-                SucceedCommandAction(
-                    command=succeeded_command, private_result=private_result
-                ),
-            )
+            if isinstance(result, SuccessData):
+                update = {
+                    "result": result.public,
+                    "status": CommandStatus.SUCCEEDED,
+                    "completedAt": self._model_utils.get_timestamp(),
+                    "notes": note_tracker.get_notes(),
+                }
+                succeeded_command = running_command.copy(update=update)
+                self._action_dispatcher.dispatch(
+                    SucceedCommandAction(
+                        command=succeeded_command, private_result=result.private
+                    ),
+                )
+            else:
+                # The command encountered a defined error.
+                # TODO(mm, 2024-05-10): Once commands start returning DefinedErrorData,
+                # handle it here by dispatching a FailCommandAction.
+                assert_never(result)

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_gripper.py
@@ -26,6 +26,7 @@ from opentrons.protocol_engine.commands.calibration.calibrate_gripper import (
     CalibrateGripperParams,
     CalibrateGripperParamsJaw,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.errors import HardwareNotSupportedError
 from opentrons.protocol_engine.types import Vec3f
 
@@ -69,7 +70,10 @@ async def test_calibrate_gripper(
     ).then_return(Point(1.1, 2.2, 3.3))
 
     result = await subject.execute(params)
-    assert result == CalibrateGripperResult(jawOffset=Vec3f(x=1.1, y=2.2, z=3.3))
+    assert result == SuccessData(
+        public=CalibrateGripperResult(jawOffset=Vec3f(x=1.1, y=2.2, z=3.3)),
+        private=None,
+    )
 
 
 @pytest.mark.ot3_only
@@ -101,8 +105,8 @@ async def test_calibrate_gripper_saves_calibration(
         )
     ).then_return(expected_calibration_data)
     result = await subject.execute(params)
-    assert result.jawOffset == Vec3f(x=1.1, y=2.2, z=3.3)
-    assert result.savedCalibration == expected_calibration_data
+    assert result.public.jawOffset == Vec3f(x=1.1, y=2.2, z=3.3)
+    assert result.public.savedCalibration == expected_calibration_data
 
 
 @pytest.mark.ot3_only

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_module.py
@@ -12,6 +12,7 @@ from opentrons.protocol_engine.commands.calibration.calibrate_module import (
     CalibrateModuleImplementation,
     CalibrateModuleParams,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.errors.exceptions import HardwareNotSupportedError
 from opentrons.protocol_engine.state.state import StateView
 from opentrons.protocol_engine.types import (
@@ -85,13 +86,16 @@ async def test_calibrate_module_implementation(
 
     result = await subject.execute(params)
 
-    assert result == CalibrateModuleResult(
-        moduleOffset=ModuleOffsetVector(
-            x=3,
-            y=4,
-            z=6,
+    assert result == SuccessData(
+        public=CalibrateModuleResult(
+            moduleOffset=ModuleOffsetVector(
+                x=3,
+                y=4,
+                z=6,
+            ),
+            location=location,
         ),
-        location=location,
+        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_calibrate_pipette.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.commands.calibration.calibrate_pipette import (
     CalibratePipetteImplementation,
     CalibratePipetteParams,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.errors.exceptions import HardwareNotSupportedError
 from opentrons.protocol_engine.types import InstrumentOffsetVector
 
@@ -59,8 +60,11 @@ async def test_calibrate_pipette_implementation(
         times=1,
     )
 
-    assert result == CalibratePipetteResult(
-        pipetteOffset=InstrumentOffsetVector(x=3, y=4, z=6)
+    assert result == SuccessData(
+        public=CalibratePipetteResult(
+            pipetteOffset=InstrumentOffsetVector(x=3, y=4, z=6)
+        ),
+        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -5,12 +5,14 @@ from typing import TYPE_CHECKING
 import pytest
 from decoy import Decoy
 
+
 from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position import (
     MoveToMaintenancePositionParams,
     MoveToMaintenancePositionImplementation,
     MoveToMaintenancePositionResult,
     MaintenancePosition,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import MountType, Mount, Point
@@ -54,7 +56,7 @@ async def test_calibration_move_to_location_implementatio_for_attach_instrument(
     decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
-    assert result == MoveToMaintenancePositionResult()
+    assert result == SuccessData(public=MoveToMaintenancePositionResult(), private=None)
 
     hw_mount = mount_type.to_hw_mount()
     decoy.verify(
@@ -98,7 +100,7 @@ async def test_calibration_move_to_location_implementatio_for_attach_plate(
     decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
-    assert result == MoveToMaintenancePositionResult()
+    assert result == SuccessData(public=MoveToMaintenancePositionResult(), private=None)
 
     decoy.verify(
         await ot3_hardware_api.prepare_for_mount_movement(Mount.LEFT),
@@ -141,7 +143,7 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
 
     result = await subject.execute(params=params)
-    assert result == MoveToMaintenancePositionResult()
+    assert result == SuccessData(public=MoveToMaintenancePositionResult(), private=None)
 
     decoy.verify(
         await ot3_hardware_api.prepare_for_mount_movement(Mount.LEFT),

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_labware_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_close_labware_latch.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.close_labware_latch import (
     CloseLabwareLatchImpl,
 )
@@ -43,7 +44,9 @@ async def test_close_labware_latch(
 
     result = await subject.execute(data)
     decoy.verify(await heater_shaker_hardware.close_labware_latch(), times=1)
-    assert result == heater_shaker.CloseLabwareLatchResult()
+    assert result == SuccessData(
+        public=heater_shaker.CloseLabwareLatchResult(), private=None
+    )
 
 
 async def test_close_labware_latch_virtual(
@@ -73,4 +76,6 @@ async def test_close_labware_latch_virtual(
 
     result = await subject.execute(data)
 
-    assert result == heater_shaker.CloseLabwareLatchResult()
+    assert result == SuccessData(
+        public=heater_shaker.CloseLabwareLatchResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_heater.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.deactivate_heater import (
     DeactivateHeaterImpl,
 )
@@ -44,4 +45,6 @@ async def test_deactivate_heater(
 
     result = await subject.execute(data)
     decoy.verify(await hs_hardware.deactivate_heater(), times=1)
-    assert result == heater_shaker.DeactivateHeaterResult()
+    assert result == SuccessData(
+        public=heater_shaker.DeactivateHeaterResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_shaker.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_deactivate_shaker.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.deactivate_shaker import (
     DeactivateShakerImpl,
 )
@@ -44,7 +45,9 @@ async def test_deactivate_shaker(
 
     result = await subject.execute(data)
     decoy.verify(await hs_hardware.deactivate_shaker(), times=1)
-    assert result == heater_shaker.DeactivateShakerResult()
+    assert result == SuccessData(
+        public=heater_shaker.DeactivateShakerResult(), private=None
+    )
 
 
 async def test_deactivate_shaker_virtual(
@@ -74,4 +77,6 @@ async def test_deactivate_shaker_virtual(
     ).then_return(None)
 
     result = await subject.execute(data)
-    assert result == heater_shaker.DeactivateShakerResult()
+    assert result == SuccessData(
+        public=heater_shaker.DeactivateShakerResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_open_labware_latch.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.open_labware_latch import (
     OpenLabwareLatchImpl,
 )
@@ -62,4 +63,6 @@ async def test_open_labware_latch(
         ),
         await hs_hardware.open_labware_latch(),
     )
-    assert result == heater_shaker.OpenLabwareLatchResult(pipetteRetracted=True)
+    assert result == SuccessData(
+        public=heater_shaker.OpenLabwareLatchResult(pipetteRetracted=True), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_and_wait_for_shake_speed.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.set_and_wait_for_shake_speed import (
     SetAndWaitForShakeSpeedImpl,
 )
@@ -68,4 +69,7 @@ async def test_set_and_wait_for_shake_speed(
         ),
         await hs_hardware.set_speed(rpm=1234),
     )
-    assert result == heater_shaker.SetAndWaitForShakeSpeedResult(pipetteRetracted=True)
+    assert result == SuccessData(
+        public=heater_shaker.SetAndWaitForShakeSpeedResult(pipetteRetracted=True),
+        private=None,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_set_target_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.set_target_temperature import (
     SetTargetTemperatureImpl,
 )
@@ -53,4 +54,6 @@ async def test_set_target_temperature(
 
     result = await subject.execute(data)
     decoy.verify(await hs_hardware.start_set_temperature(celsius=45.6), times=1)
-    assert result == heater_shaker.SetTargetTemperatureResult()
+    assert result == SuccessData(
+        public=heater_shaker.SetTargetTemperatureResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_wait_for_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/heater_shaker/test_wait_for_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import heater_shaker
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.heater_shaker.wait_for_temperature import (
     WaitForTemperatureImpl,
 )
@@ -48,4 +49,6 @@ async def test_wait_for_temperature(
     decoy.verify(
         await hs_hardware.await_temperature(awaiting_temperature=123.45), times=1
     )
-    assert result == heater_shaker.WaitForTemperatureResult()
+    assert result == SuccessData(
+        public=heater_shaker.WaitForTemperatureResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_disengage.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleSubState,
     MagneticModuleId,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.magnetic_module import (
     DisengageParams,
     DisengageResult,
@@ -45,4 +46,4 @@ async def test_magnetic_module_disengage_implementation(
     result = await subject.execute(params=params)
 
     decoy.verify(await magnetic_module_hw.deactivate(), times=1)
-    assert result == DisengageResult()
+    assert result == SuccessData(public=DisengageResult(), private=None)

--- a/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
+++ b/api/tests/opentrons/protocol_engine/commands/magnetic_module/test_engage.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine.state.module_substates import (
     MagneticModuleSubState,
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.magnetic_module import (
     EngageParams,
     EngageResult,
@@ -50,4 +51,4 @@ async def test_magnetic_module_engage_implementation(
     result = await subject.execute(params=params)
 
     decoy.verify(await magnetic_module_hw.engage(9001), times=1)
-    assert result == EngageResult()
+    assert result == SuccessData(public=EngageResult(), private=None)

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_deactivate.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import temperature_module
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.temperature_module.deactivate import (
     DeactivateTemperatureImpl,
 )
@@ -43,5 +44,6 @@ async def test_await_temperature(
 
     result = await subject.execute(data)
     decoy.verify(await tempdeck_hardware.deactivate(), times=1)
-    assert result == temperature_module.DeactivateTemperatureResult()
-    assert isinstance(result, temperature_module.DeactivateTemperatureResult)
+    assert result == SuccessData(
+        public=temperature_module.DeactivateTemperatureResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_set_target_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import temperature_module
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.temperature_module.set_target_temperature import (
     SetTargetTemperatureImpl,
 )
@@ -49,4 +50,7 @@ async def test_set_target_temperature(
 
     result = await subject.execute(data)
     decoy.verify(await tempdeck_hardware.start_set_temperature(celsius=1), times=1)
-    assert result == temperature_module.SetTargetTemperatureResult(targetTemperature=1)
+    assert result == SuccessData(
+        public=temperature_module.SetTargetTemperatureResult(targetTemperature=1),
+        private=None,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/temperature_module/test_wait_for_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/temperature_module/test_wait_for_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import temperature_module
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.temperature_module.wait_for_temperature import (
     WaitForTemperatureImpl,
 )
@@ -46,7 +47,9 @@ async def test_wait_for_temperature(
     decoy.verify(
         await tempdeck_hardware.await_temperature(awaiting_temperature=123), times=1
     )
-    assert result == temperature_module.WaitForTemperatureResult()
+    assert result == SuccessData(
+        public=temperature_module.WaitForTemperatureResult(), private=None
+    )
 
 
 async def test_wait_for_temperature_requested_celsius(
@@ -86,4 +89,6 @@ async def test_wait_for_temperature_requested_celsius(
     decoy.verify(
         await tempdeck_hardware.await_temperature(awaiting_temperature=12), times=1
     )
-    assert result == temperature_module.WaitForTemperatureResult()
+    assert result == SuccessData(
+        public=temperature_module.WaitForTemperatureResult(), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.commands.aspirate import (
     AspirateResult,
     AspirateImplementation,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 
 from opentrons.protocol_engine.state import StateView
 
@@ -84,7 +85,10 @@ async def test_aspirate_implementation_no_prep(
 
     result = await subject.execute(data)
 
-    assert result == AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3))
+    assert result == SuccessData(
+        public=AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3)),
+        private=None,
+    )
 
 
 async def test_aspirate_implementation_with_prep(
@@ -140,7 +144,10 @@ async def test_aspirate_implementation_with_prep(
 
     result = await subject.execute(data)
 
-    assert result == AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3))
+    assert result == SuccessData(
+        public=AspirateResult(volume=50, position=DeckPoint(x=1, y=2, z=3)),
+        private=None,
+    )
 
     decoy.verify(
         await movement.move_to_well(

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate_in_place.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.commands.aspirate_in_place import (
     AspirateInPlaceResult,
     AspirateInPlaceImplementation,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.errors.exceptions import PipetteNotReadyToAspirateError
 from opentrons.protocol_engine.notes import CommandNoteAdder
 
@@ -84,7 +85,7 @@ async def test_aspirate_in_place_implementation(
 
     result = await subject.execute(params=data)
 
-    assert result == AspirateInPlaceResult(volume=123)
+    assert result == SuccessData(public=AspirateInPlaceResult(volume=123), private=None)
 
 
 async def test_handle_aspirate_in_place_request_not_ready_to_aspirate(

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine.commands import (
     BlowOutImplementation,
     BlowOutParams,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
@@ -52,7 +53,9 @@ async def test_blow_out_implementation(
 
     result = await subject.execute(data)
 
-    assert result == BlowOutResult(position=DeckPoint(x=1, y=2, z=3))
+    assert result == SuccessData(
+        public=BlowOutResult(position=DeckPoint(x=1, y=2, z=3)), private=None
+    )
 
     decoy.verify(
         await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234),

--- a/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_blow_out_in_place.py
@@ -7,7 +7,7 @@ from opentrons.protocol_engine.commands.blow_out_in_place import (
     BlowOutInPlaceResult,
     BlowOutInPlaceImplementation,
 )
-
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
@@ -36,7 +36,7 @@ async def test_blow_out_in_place_implementation(
 
     result = await subject.execute(data)
 
-    assert result == BlowOutInPlaceResult()
+    assert result == SuccessData(public=BlowOutInPlaceResult(), private=None)
 
     decoy.verify(
         await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234)

--- a/api/tests/opentrons/protocol_engine/commands/test_comment.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_comment.py
@@ -4,6 +4,7 @@ from opentrons.protocol_engine.commands.comment import (
     CommentResult,
     CommentImplementation,
 )
+from opentrons.protocol_engine.commands.command import SuccessData
 
 
 async def test_comment_implementation() -> None:
@@ -14,4 +15,4 @@ async def test_comment_implementation() -> None:
 
     result = await subject.execute(data)
 
-    assert result == CommentResult()
+    assert result == SuccessData(public=CommentResult(), private=None)

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
 )
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.configure_for_volume import (
     ConfigureForVolumeParams,
     ConfigureForVolumeResult,
@@ -65,9 +66,11 @@ async def test_configure_for_volume_implementation(
         )
     )
 
-    result, private_result = await subject.execute(data)
+    result = await subject.execute(data)
 
-    assert result == ConfigureForVolumeResult()
-    assert private_result == ConfigureForVolumePrivateResult(
-        pipette_id="pipette-id", serial_number="some number", config=config
+    assert result == SuccessData(
+        public=ConfigureForVolumeResult(),
+        private=ConfigureForVolumePrivateResult(
+            pipette_id="pipette-id", serial_number="some number", config=config
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_nozzle_layout.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine.execution import (
 from opentrons.types import Point
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 
-
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.configure_nozzle_layout import (
     ConfigureNozzleLayoutParams,
     ConfigureNozzleLayoutResult,
@@ -124,10 +124,12 @@ async def test_configure_nozzle_layout_implementation(
         )
     ).then_return(expected_nozzlemap)
 
-    result, private_result = await subject.execute(requested_nozzle_layout)
+    result = await subject.execute(requested_nozzle_layout)
 
-    assert result == ConfigureNozzleLayoutResult()
-    assert private_result == ConfigureNozzleLayoutPrivateResult(
-        pipette_id="pipette-id",
-        nozzle_map=expected_nozzlemap,
+    assert result == SuccessData(
+        public=ConfigureNozzleLayoutResult(),
+        private=ConfigureNozzleLayoutPrivateResult(
+            pipette_id="pipette-id",
+            nozzle_map=expected_nozzlemap,
+        ),
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense.py
@@ -5,6 +5,7 @@ from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset, Deck
 from opentrons.protocol_engine.execution import MovementHandler, PipettingHandler
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.dispense import (
     DispenseParams,
     DispenseResult,
@@ -50,4 +51,7 @@ async def test_dispense_implementation(
 
     result = await subject.execute(data)
 
-    assert result == DispenseResult(volume=42, position=DeckPoint(x=1, y=2, z=3))
+    assert result == SuccessData(
+        public=DispenseResult(volume=42, position=DeckPoint(x=1, y=2, z=3)),
+        private=None,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_dispense_in_place.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine.execution import PipettingHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.dispense_in_place import (
     DispenseInPlaceParams,
     DispenseInPlaceResult,
@@ -31,4 +32,4 @@ async def test_dispense_in_place_implementation(
 
     result = await subject.execute(data)
 
-    assert result == DispenseInPlaceResult(volume=42)
+    assert result == SuccessData(public=DispenseInPlaceResult(volume=42), private=None)

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip.py
@@ -13,6 +13,7 @@ from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.execution import MovementHandler, TipHandler
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.drop_tip import (
     DropTipParams,
     DropTipResult,
@@ -110,7 +111,9 @@ async def test_drop_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == DropTipResult(position=DeckPoint(x=111, y=222, z=333))
+    assert result == SuccessData(
+        public=DropTipResult(position=DeckPoint(x=111, y=222, z=333)), private=None
+    )
 
     decoy.verify(
         await mock_tip_handler.drop_tip(pipette_id="abc", home_after=True),
@@ -170,4 +173,6 @@ async def test_drop_tip_with_alternating_locations(
     ).then_return(Point(x=111, y=222, z=333))
 
     result = await subject.execute(params)
-    assert result == DropTipResult(position=DeckPoint(x=111, y=222, z=333))
+    assert result == SuccessData(
+        public=DropTipResult(position=DeckPoint(x=111, y=222, z=333)), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_drop_tip_in_place.py
@@ -4,6 +4,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine.execution import TipHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.drop_tip_in_place import (
     DropTipInPlaceParams,
     DropTipInPlaceResult,
@@ -28,7 +29,7 @@ async def test_drop_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == DropTipInPlaceResult()
+    assert result == SuccessData(public=DropTipInPlaceResult(), private=None)
 
     decoy.verify(
         await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),

--- a/api/tests/opentrons/protocol_engine/commands/test_get_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_get_tip_presence.py
@@ -5,6 +5,7 @@ import pytest
 from opentrons.protocol_engine.execution import TipHandler
 from opentrons.protocol_engine.types import TipPresenceStatus
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.get_tip_presence import (
     GetTipPresenceParams,
     GetTipPresenceResult,
@@ -39,4 +40,6 @@ async def test_get_tip_presence_implementation(
 
     result = await subject.execute(data)
 
-    assert result == GetTipPresenceResult(status=status)
+    assert result == SuccessData(
+        public=GetTipPresenceResult(status=status), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_home.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_home.py
@@ -5,6 +5,7 @@ from opentrons.protocol_engine.types import MotorAxis
 from opentrons.types import MountType
 from opentrons.protocol_engine.execution import MovementHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.home import (
     HomeParams,
     HomeResult,
@@ -20,7 +21,7 @@ async def test_home_implementation(decoy: Decoy, movement: MovementHandler) -> N
 
     result = await subject.execute(data)
 
-    assert result == HomeResult()
+    assert result == SuccessData(public=HomeResult(), private=None)
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]))
 
 
@@ -32,7 +33,7 @@ async def test_home_all_implementation(decoy: Decoy, movement: MovementHandler) 
 
     result = await subject.execute(data)
 
-    assert result == HomeResult()
+    assert result == SuccessData(public=HomeResult(), private=None)
     decoy.verify(await movement.home(axes=None))
 
 
@@ -51,7 +52,7 @@ async def test_home_with_invalid_position(
     )
 
     result = await subject.execute(data)
-    assert result == HomeResult()
+    assert result == SuccessData(public=HomeResult(), private=None)
 
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]), times=1)
     decoy.reset()
@@ -60,6 +61,6 @@ async def test_home_with_invalid_position(
         await movement.check_for_valid_position(mount=MountType.LEFT)
     ).then_return(True)
     result = await subject.execute(data)
-    assert result == HomeResult()
+    assert result == SuccessData(public=HomeResult(), private=None)
 
     decoy.verify(await movement.home(axes=[MotorAxis.X, MotorAxis.Y]), times=0)

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -20,6 +20,7 @@ from opentrons.protocol_engine.execution import LoadedLabwareData, EquipmentHand
 from opentrons.protocol_engine.resources import labware_validation
 from opentrons.protocol_engine.state import StateView
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.load_labware import (
     LoadLabwareParams,
     LoadLabwareResult,
@@ -80,10 +81,13 @@ async def test_load_labware_implementation(
 
     result = await subject.execute(data)
 
-    assert result == LoadLabwareResult(
-        labwareId="labware-id",
-        definition=well_plate_def,
-        offsetId="labware-offset-id",
+    assert result == SuccessData(
+        public=LoadLabwareResult(
+            labwareId="labware-id",
+            definition=well_plate_def,
+            offsetId="labware-offset-id",
+        ),
+        private=None,
     )
 
 
@@ -153,10 +157,13 @@ async def test_load_labware_on_labware(
 
     result = await subject.execute(data)
 
-    assert result == LoadLabwareResult(
-        labwareId="labware-id",
-        definition=well_plate_def,
-        offsetId="labware-offset-id",
+    assert result == SuccessData(
+        public=LoadLabwareResult(
+            labwareId="labware-id",
+            definition=well_plate_def,
+            offsetId="labware-offset-id",
+        ),
+        private=None,
     )
 
     decoy.verify(

--- a/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_liquid.py
@@ -2,6 +2,7 @@
 import pytest
 from decoy import Decoy
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands import (
     LoadLiquidResult,
     LoadLiquidImplementation,
@@ -35,7 +36,7 @@ async def test_load_liquid_implementation(
     )
     result = await subject.execute(data)
 
-    assert result == LoadLiquidResult()
+    assert result == SuccessData(public=LoadLiquidResult(), private=None)
 
     decoy.verify(mock_state_view.liquid.validate_liquid_id("liquid-id"))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine.execution import EquipmentHandler, LoadedModuleDa
 from opentrons.protocol_engine import ModuleModel as EngineModuleModel
 from opentrons.hardware_control.modules import ModuleType
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.load_module import (
     LoadModuleParams,
     LoadModuleResult,
@@ -84,11 +85,14 @@ async def test_load_module_implementation(
     )
 
     result = await subject.execute(data)
-    assert result == LoadModuleResult(
-        moduleId="module-id",
-        serialNumber="mod-serial",
-        model=ModuleModel.TEMPERATURE_MODULE_V2,
-        definition=tempdeck_v2_def,
+    assert result == SuccessData(
+        public=LoadModuleResult(
+            moduleId="module-id",
+            serialNumber="mod-serial",
+            model=ModuleModel.TEMPERATURE_MODULE_V2,
+            definition=tempdeck_v2_def,
+        ),
+        private=None,
     )
 
 
@@ -137,11 +141,14 @@ async def test_load_module_implementation_mag_block(
     )
 
     result = await subject.execute(data)
-    assert result == LoadModuleResult(
-        moduleId="module-id",
-        serialNumber=None,
-        model=ModuleModel.MAGNETIC_BLOCK_V1,
-        definition=mag_block_v1_def,
+    assert result == SuccessData(
+        public=LoadModuleResult(
+            moduleId="module-id",
+            serialNumber=None,
+            model=ModuleModel.MAGNETIC_BLOCK_V1,
+            definition=mag_block_v1_def,
+        ),
+        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -13,6 +13,7 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
 )
 from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.load_pipette import (
     LoadPipetteParams,
     LoadPipetteResult,
@@ -66,11 +67,13 @@ async def test_load_pipette_implementation(
         )
     )
 
-    result, private_result = await subject.execute(data)
+    result = await subject.execute(data)
 
-    assert result == LoadPipetteResult(pipetteId="some id")
-    assert private_result == LoadPipettePrivateResult(
-        pipette_id="some id", serial_number="some-serial-number", config=config_data
+    assert result == SuccessData(
+        public=LoadPipetteResult(pipetteId="some id"),
+        private=LoadPipettePrivateResult(
+            pipette_id="some id", serial_number="some-serial-number", config=config_data
+        ),
     )
 
 
@@ -117,11 +120,13 @@ async def test_load_pipette_implementation_96_channel(
         )
     )
 
-    result, private_result = await subject.execute(data)
+    result = await subject.execute(data)
 
-    assert result == LoadPipetteResult(pipetteId="pipette-id")
-    assert private_result == LoadPipettePrivateResult(
-        pipette_id="pipette-id", serial_number="some id", config=config_data
+    assert result == SuccessData(
+        public=LoadPipetteResult(pipetteId="pipette-id"),
+        private=LoadPipettePrivateResult(
+            pipette_id="pipette-id", serial_number="some id", config=config_data
+        ),
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -22,6 +22,7 @@ from opentrons.protocol_engine.types import (
     AddressableAreaLocation,
 )
 from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_labware import (
     MoveLabwareParams,
     MoveLabwareResult,
@@ -99,8 +100,11 @@ async def test_manual_move_labware_implementation(
     decoy.verify(
         state_view.labware.raise_if_labware_has_labware_on_top("my-cool-labware-id")
     )
-    assert result == MoveLabwareResult(
-        offsetId="wowzers-a-new-offset-id",
+    assert result == SuccessData(
+        public=MoveLabwareResult(
+            offsetId="wowzers-a-new-offset-id",
+        ),
+        private=None,
     )
 
 
@@ -162,8 +166,11 @@ async def test_move_labware_implementation_on_labware(
             "my-even-cooler-labware-id",
         ),
     )
-    assert result == MoveLabwareResult(
-        offsetId="wowzers-a-new-offset-id",
+    assert result == SuccessData(
+        public=MoveLabwareResult(
+            offsetId="wowzers-a-new-offset-id",
+        ),
+        private=None,
     )
 
 
@@ -246,8 +253,11 @@ async def test_gripper_move_labware_implementation(
             post_drop_slide_offset=None,
         ),
     )
-    assert result == MoveLabwareResult(
-        offsetId="wowzers-a-new-offset-id",
+    assert result == SuccessData(
+        public=MoveLabwareResult(
+            offsetId="wowzers-a-new-offset-id",
+        ),
+        private=None,
     )
 
 
@@ -333,8 +343,11 @@ async def test_gripper_move_to_waste_chute_implementation(
             post_drop_slide_offset=expected_slide_offset,
         ),
     )
-    assert result == MoveLabwareResult(
-        offsetId="wowzers-a-new-offset-id",
+    assert result == SuccessData(
+        public=MoveLabwareResult(
+            offsetId="wowzers-a-new-offset-id",
+        ),
+        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_relative.py
@@ -5,6 +5,7 @@ from opentrons.protocol_engine.types import DeckPoint, MovementAxis
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_relative import (
     MoveRelativeParams,
     MoveRelativeResult,
@@ -34,4 +35,6 @@ async def test_move_relative_implementation(
 
     result = await subject.execute(data)
 
-    assert result == MoveRelativeResult(position=DeckPoint(x=1, y=2, z=3))
+    assert result == SuccessData(
+        public=MoveRelativeResult(position=DeckPoint(x=1, y=2, z=3)), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area.py
@@ -6,6 +6,7 @@ from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_to_addressable_area import (
     MoveToAddressableAreaParams,
     MoveToAddressableAreaResult,
@@ -47,4 +48,7 @@ async def test_move_to_addressable_area_implementation(
 
     result = await subject.execute(data)
 
-    assert result == MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7))
+    assert result == SuccessData(
+        public=MoveToAddressableAreaResult(position=DeckPoint(x=9, y=8, z=7)),
+        private=None,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_addressable_area_for_drop_tip.py
@@ -6,6 +6,7 @@ from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_to_addressable_area_for_drop_tip import (
     MoveToAddressableAreaForDropTipParams,
     MoveToAddressableAreaForDropTipResult,
@@ -54,6 +55,7 @@ async def test_move_to_addressable_area_for_drop_tip_implementation(
 
     result = await subject.execute(data)
 
-    assert result == MoveToAddressableAreaForDropTipResult(
-        position=DeckPoint(x=9, y=8, z=7)
+    assert result == SuccessData(
+        public=MoveToAddressableAreaForDropTipResult(position=DeckPoint(x=9, y=8, z=7)),
+        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_coordinates.py
@@ -7,6 +7,7 @@ from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.types import DeckPoint
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_to_coordinates import (
     MoveToCoordinatesParams,
     MoveToCoordinatesResult,
@@ -54,4 +55,7 @@ async def test_move_to_coordinates_implementation(
 
     result = await subject.execute(params=params)
 
-    assert result == MoveToCoordinatesResult(position=DeckPoint(x=4.44, y=5.55, z=6.66))
+    assert result == SuccessData(
+        public=MoveToCoordinatesResult(position=DeckPoint(x=4.44, y=5.55, z=6.66)),
+        private=None,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_to_well.py
@@ -5,6 +5,7 @@ from opentrons.protocol_engine import WellLocation, WellOffset, DeckPoint
 from opentrons.protocol_engine.execution import MovementHandler
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.move_to_well import (
     MoveToWellParams,
     MoveToWellResult,
@@ -43,4 +44,6 @@ async def test_move_to_well_implementation(
 
     result = await subject.execute(data)
 
-    assert result == MoveToWellResult(position=DeckPoint(x=9, y=8, z=7))
+    assert result == SuccessData(
+        public=MoveToWellResult(position=DeckPoint(x=9, y=8, z=7)), private=None
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_pick_up_tip.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine.types import TipGeometry
 from opentrons.protocol_engine.state import StateView
 from opentrons.protocol_engine.execution import MovementHandler, TipHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.pick_up_tip import (
     PickUpTipParams,
     PickUpTipResult,
@@ -77,9 +78,12 @@ async def test_pick_up_tip_implementation(
         )
     )
 
-    assert result == PickUpTipResult(
-        tipLength=42,
-        tipVolume=300,
-        tipDiameter=5,
-        position=DeckPoint(x=111, y=222, z=333),
+    assert result == SuccessData(
+        public=PickUpTipResult(
+            tipLength=42,
+            tipVolume=300,
+            tipDiameter=5,
+            position=DeckPoint(x=111, y=222, z=333),
+        ),
+        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_prepare_to_aspirate.py
@@ -6,6 +6,7 @@ from opentrons.protocol_engine.execution import (
     PipettingHandler,
 )
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.prepare_to_aspirate import (
     PrepareToAspirateParams,
     PrepareToAspirateImplementation,
@@ -26,4 +27,4 @@ async def test_prepare_to_aspirate_implmenetation(
     )
 
     result = await subject.execute(data)
-    assert isinstance(result, PrepareToAspirateResult)
+    assert result == SuccessData(public=PrepareToAspirateResult(), private=None)

--- a/api/tests/opentrons/protocol_engine/commands/test_reload_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_reload_labware.py
@@ -18,6 +18,7 @@ from opentrons.protocol_engine.execution import ReloadedLabwareData, EquipmentHa
 from opentrons.protocol_engine.resources import labware_validation
 from opentrons.protocol_engine.state import StateView
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.reload_labware import (
     ReloadLabwareParams,
     ReloadLabwareResult,
@@ -56,9 +57,12 @@ async def test_reload_labware_implementation(
 
     result = await subject.execute(data)
 
-    assert result == ReloadLabwareResult(
-        labwareId="my-labware-id",
-        offsetId="labware-offset-id",
+    assert result == SuccessData(
+        public=ReloadLabwareResult(
+            labwareId="my-labware-id",
+            offsetId="labware-offset-id",
+        ),
+        private=None,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_retract_axis.py
@@ -4,6 +4,7 @@ from decoy import Decoy
 from opentrons.protocol_engine.types import MotorAxis
 from opentrons.protocol_engine.execution import MovementHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.retract_axis import (
     RetractAxisParams,
     RetractAxisResult,
@@ -21,5 +22,5 @@ async def test_retract_axis_implementation(
     data = RetractAxisParams(axis=MotorAxis.Y)
     result = await subject.execute(data)
 
-    assert result == RetractAxisResult()
+    assert result == SuccessData(public=RetractAxisResult(), private=None)
     decoy.verify(await movement.retract_axis(axis=MotorAxis.Y))

--- a/api/tests/opentrons/protocol_engine/commands/test_save_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_save_position.py
@@ -7,6 +7,7 @@ from opentrons.protocol_engine.execution import GantryMover
 from opentrons.protocol_engine.resources import ModelUtils
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.save_position import (
     SavePositionParams,
     SavePositionResult,
@@ -45,7 +46,10 @@ async def test_save_position_implementation(
 
     result = await subject.execute(params)
 
-    assert result == SavePositionResult(
-        positionId="456",
-        position=DeckPoint(x=1, y=2, z=3),
+    assert result == SuccessData(
+        public=SavePositionResult(
+            positionId="456",
+            position=DeckPoint(x=1, y=2, z=3),
+        ),
+        private=None,
     )

--- a/api/tests/opentrons/protocol_engine/commands/test_set_rail_lights.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_set_rail_lights.py
@@ -5,6 +5,7 @@ from opentrons.protocol_engine.execution import (
     RailLightsHandler,
 )
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.set_rail_lights import (
     SetRailLightsParams,
     SetRailLightsResult,
@@ -25,6 +26,6 @@ async def test_set_rail_lights_implementation(
 
     result = await subject.execute(data)
 
-    assert result == SetRailLightsResult()
+    assert result == SuccessData(public=SetRailLightsResult(), private=None)
 
     decoy.verify(await rail_lights.set_rail_lights(True), times=1)

--- a/api/tests/opentrons/protocol_engine/commands/test_set_status_bar.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_set_status_bar.py
@@ -3,6 +3,7 @@
 import pytest
 from decoy import Decoy
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.set_status_bar import (
     SetStatusBarParams,
     SetStatusBarResult,
@@ -34,7 +35,7 @@ async def test_status_bar_busy(
 
     result = await subject.execute(params=data)
 
-    assert result == SetStatusBarResult()
+    assert result == SuccessData(public=SetStatusBarResult(), private=None)
 
     decoy.verify(await status_bar.set_status_bar(status=StatusBarState.OFF), times=0)
 
@@ -62,6 +63,6 @@ async def test_set_status_bar_animation(
     data = SetStatusBarParams(animation=animation)
 
     result = await subject.execute(params=data)
-    assert result == SetStatusBarResult()
+    assert result == SuccessData(public=SetStatusBarResult(), private=None)
 
     decoy.verify(await status_bar.set_status_bar(status=expected_state), times=1)

--- a/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_touch_tip.py
@@ -9,6 +9,7 @@ from opentrons.protocol_engine.execution import MovementHandler, GantryMover
 from opentrons.protocol_engine.state import StateView
 from opentrons.types import Point
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.touch_tip import (
     TouchTipParams,
     TouchTipResult,
@@ -120,7 +121,9 @@ async def test_touch_tip_implementation(
 
     result = await subject.execute(params)
 
-    assert result == TouchTipResult(position=DeckPoint(x=4, y=5, z=6))
+    assert result == SuccessData(
+        public=TouchTipResult(position=DeckPoint(x=4, y=5, z=6)), private=None
+    )
 
 
 async def test_touch_tip_disabled(

--- a/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_verify_tip_presence.py
@@ -4,6 +4,7 @@ from decoy import Decoy
 from opentrons.protocol_engine.execution import TipHandler
 from opentrons.protocol_engine.types import TipPresenceStatus
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.verify_tip_presence import (
     VerifyTipPresenceParams,
     VerifyTipPresenceResult,
@@ -31,4 +32,4 @@ async def test_verify_tip_presence_implementation(
 
     result = await subject.execute(data)
 
-    assert isinstance(result, VerifyTipPresenceResult)
+    assert result == SuccessData(public=VerifyTipPresenceResult(), private=None)

--- a/api/tests/opentrons/protocol_engine/commands/test_wait_for_duration.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_wait_for_duration.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine.execution import RunControlHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.wait_for_duration import (
     WaitForDurationParams,
     WaitForDurationResult,
@@ -21,5 +22,5 @@ async def test_pause_implementation(
 
     result = await subject.execute(data)
 
-    assert result == WaitForDurationResult()
+    assert result == SuccessData(public=WaitForDurationResult(), private=None)
     decoy.verify(await run_control.wait_for_duration(42.0), times=1)

--- a/api/tests/opentrons/protocol_engine/commands/test_wait_for_resume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_wait_for_resume.py
@@ -3,6 +3,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine.execution import RunControlHandler
 
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.wait_for_resume import (
     WaitForResumeCreate,
     WaitForResumeParams,
@@ -22,7 +23,7 @@ async def test_wait_for_resume_implementation(
 
     result = await subject.execute(data)
 
-    assert result == WaitForResumeResult()
+    assert result == SuccessData(public=WaitForResumeResult(), private=None)
     decoy.verify(await run_control.wait_for_resume(), times=1)
 
 

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_close_lid.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.close_lid import (
     CloseLidImpl,
 )
@@ -54,4 +55,4 @@ async def test_close_lid(
         await tc_hardware.close(),
         times=1,
     )
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_block.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_block.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.deactivate_block import (
     DeactivateBlockImpl,
 )
@@ -44,4 +45,4 @@ async def test_deactivate_block(
     result = await subject.execute(data)
 
     decoy.verify(await tc_hardware.deactivate_block(), times=1)
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_deactivate_lid.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.deactivate_lid import (
     DeactivateLidImpl,
 )
@@ -44,4 +45,4 @@ async def test_deactivate_lid(
     result = await subject.execute(data)
 
     decoy.verify(await tc_hardware.deactivate_lid(), times=1)
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_open_lid.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler, MovementHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.open_lid import (
     OpenLidImpl,
 )
@@ -52,4 +53,4 @@ async def test_open_lid(
         await tc_hardware.open(),
         times=1,
     )
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_run_profile.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.run_profile import (
     RunProfileImpl,
 )
@@ -74,4 +75,4 @@ async def test_run_profile(
         ),
         times=1,
     )
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_block_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.set_target_block_temperature import (
     SetTargetBlockTemperatureImpl,
 )
@@ -66,4 +67,4 @@ async def test_set_target_block_temperature(
         ),
         times=1,
     )
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_set_target_lid_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.set_target_lid_temperature import (
     SetTargetLidTemperatureImpl,
 )
@@ -55,4 +56,4 @@ async def test_set_target_lid_temperature(
     result = await subject.execute(data)
 
     decoy.verify(await tc_hardware.set_target_lid_temperature(celsius=45.6), times=1)
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_block_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_block_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.wait_for_block_temperature import (
     WaitForBlockTemperatureImpl,
 )
@@ -50,4 +51,4 @@ async def test_set_target_block_temperature(
         tc_module_substate.get_target_block_temperature(),
         await tc_hardware.wait_for_block_target(),
     )
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)

--- a/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_lid_temperature.py
+++ b/api/tests/opentrons/protocol_engine/commands/thermocycler/test_wait_for_lid_temperature.py
@@ -10,6 +10,7 @@ from opentrons.protocol_engine.state.module_substates import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler
 from opentrons.protocol_engine.commands import thermocycler as tc_commands
+from opentrons.protocol_engine.commands.command import SuccessData
 from opentrons.protocol_engine.commands.thermocycler.wait_for_lid_temperature import (
     WaitForLidTemperatureImpl,
 )
@@ -50,4 +51,4 @@ async def test_set_target_block_temperature(
         tc_module_substate.get_target_lid_temperature(),
         await tc_hardware.wait_for_lid_target(),
     )
-    assert result == expected_result
+    assert result == SuccessData(public=expected_result, private=None)


### PR DESCRIPTION
# Overview

This reworks the `opentrons.protocol_engine` command boilerplate to prepare for EXEC-427.

# Test plan

CI is sufficient.

# Changelog

Formerly, command implementations had to either return a `BaseModel`, which would get put in the command's `result` field, or raise an exception, which would get converted into a `BaseModel` and then put in the command's `error` field.

This PR adds a third option: to return an error `BaseModel` directly. We want returned error `BaseModel`s to represent [*defined* errors](https://opentrons.atlassian.net/wiki/spaces/PER/pages/4126703622/Proposal+Structured+representation+of+recoverable+errors), and raised exceptions to represent *undefined* errors. This will let us enforce some parity between a command's publicly declared interface and what it will actually return.

Implementations can associate private data with an error—they return a `DefinedErrorData(public=SomeErrorBaseModel(...), private=...)` dataclass. For symmetry with this, implementations now also represent success by returning a `SuccessData(public=FooResult(...), private=...)` dataclass, instead of a `(public, private)` tuple or just returning `public` directly. Having separate dataclasses makes it cleaner for the `CommandExecutor` to distinguish between success and failure.

No commands take advantage of this yet.

# Review requests

This PR has a lot of noise because it changes the command boilerplate. The most worthwhile things to look at are:

* `command.py` and `command_executor.py` have the main changes.
* `configure_for_volume.py`/`configure_nozzle_layout.py`/`load_pipette.py` are the three commands that return a private result. It's worth looking at one of them to see how that translates into the new system.

# Risk assessment

Low.
