### PR TITLE
fix(app): fix scrollbar style on LPC results table on ODD

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
+++ b/app/src/organisms/LabwarePositionCheck/ResultsSummary.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { useSelector } from 'react-redux'
 import isEqual from 'lodash/isEqual'
 import { useTranslation } from 'react-i18next'
@@ -25,6 +25,7 @@ import {
   JUSTIFY_SPACE_BETWEEN,
   LocationIcon,
   MODULE_ICON_NAME_BY_TYPE,
+  OVERFLOW_AUTO,
   PrimaryButton,
   RESPONSIVENESS,
   SPACING,
@@ -155,7 +156,17 @@ export const ResultsSummary = (
       <Flex
         flexDirection={DIRECTION_COLUMN}
         maxHeight="20rem"
-        overflowY="scroll"
+        css={css`
+          overflow-y: ${OVERFLOW_AUTO};
+          &::-webkit-scrollbar {
+            width: 0.75rem;
+            background-color: transparent;
+          }
+          &::-webkit-scrollbar-thumb {
+            background: ${COLORS.grey50};
+            border-radius: 11px;
+          }
+        `}
       >
         <Header>{t('new_labware_offset_data')}</Header>
         {isLabwareOffsetCodeSnippetsOn ? (


### PR DESCRIPTION
closes [RQA-2529](https://opentrons.atlassian.net/browse/RQA-2529)

# Overview

Only show scrollbar if content exceeds container. Style scrollbar to be consistent with other designs.

# Test Plan

1. start a protocol with many labware on ODD
2. launch and run LPC
3. verify that offset table content scrollbar is styled according to designs
4. repeat 1-3 with a protocol with few labware and verify that no scrollbar renders

# Changelog

- style y overflow on ResultsSummary of LPC

# Review requests

@koji per testing

# Risk assessment

low

[RQA-2529]: https://opentrons.atlassian.net/browse/RQA-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ