### PR TITLE
fix(protocol-designer): make checked box icon ot-checkbox

### DIFF
--- a/components/src/forms/DeprecatedCheckboxField.tsx
+++ b/components/src/forms/DeprecatedCheckboxField.tsx
@@ -62,7 +62,7 @@ export function DeprecatedCheckboxField(
             props.isIndeterminate
               ? 'minus-box'
               : props.value
-              ? 'checkbox-marked'
+              ? 'ot-checkbox'
               : 'checkbox-blank-outline'
           }
           width="100%"

--- a/protocol-designer/src/components/lists/TitledStepList.tsx
+++ b/protocol-designer/src/components/lists/TitledStepList.tsx
@@ -87,7 +87,7 @@ export function TitledStepList(props: Props): JSX.Element {
   )
 
   const multiSelectIconName = props.selected
-    ? 'checkbox-marked'
+    ? 'ot-checkbox'
     : 'checkbox-blank-outline'
 
   return (

--- a/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
@@ -128,11 +128,11 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
     iconInfo = (
       <Icon
         aria-label={`EquipmentOption_${
-          isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'
+          isSelected ? 'ot-checkbox' : 'checkbox-blank-outline'
         }`}
         color={isSelected ? COLORS.blue50 : COLORS.grey50}
         size="1.5rem"
-        name={isSelected ? 'checkbox-marked' : 'checkbox-blank-outline'}
+        name={isSelected ? 'ot-checkbox' : 'checkbox-blank-outline'}
       />
     )
   } else if (showCheckbox && disabled) {

--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/EquipmentOption.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/EquipmentOption.test.tsx
@@ -67,9 +67,9 @@ describe('EquipmentOption', () => {
     }
     render(props)
     screen.getByText('mockText')
-    expect(
-      screen.getByLabelText('EquipmentOption_checkbox-marked')
-    ).toHaveStyle(`color: ${COLORS.blue50}`)
+    expect(screen.getByLabelText('EquipmentOption_ot-checkbox')).toHaveStyle(
+      `color: ${COLORS.blue50}`
+    )
     expect(screen.getByLabelText('EquipmentOption_flex_mockText')).toHaveStyle(
       `border: ${BORDERS.activeLineBorder}`
     )

--- a/protocol-designer/src/components/steplist/MultiSelectToolbar/index.tsx
+++ b/protocol-designer/src/components/steplist/MultiSelectToolbar/index.tsx
@@ -159,7 +159,7 @@ export const MultiSelectToolbar = (props: Props): JSX.Element => {
   } = useConditionalConfirm(onDeleteClickAction, true)
 
   const selectProps: ClickableIconProps = {
-    iconName: isAllStepsSelected ? 'checkbox-marked' : 'minus-box',
+    iconName: isAllStepsSelected ? 'ot-checkbox' : 'minus-box',
     tooltipText: isAllStepsSelected ? 'Deselect All' : 'Select All',
     onClick: confirmSelect,
   }


### PR DESCRIPTION
closes RQA-2707

# Overview

fix the checked box icon

# Test Plan

verify that the 3 screenshots from the ticket are fixed which includes:
1. the create file wizard pipette tip and module selection
2. the gripper checkbox in the move labware form
3. batch edit (to access batch edit and see all features, create 2 form steps then press Shift + click on a step in the timeline)

# Changelog

change all mentions of `checkbox-marked` to `ot-checkbox`

# Review requests

see test plan

# Risk assessment

low
