### PR TITLE
refactor(api): Adjust tip state error message

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2100,7 +2100,7 @@ class OT3API(
         real_mount = OT3Mount.from_mount(mount)
         status = await self.get_tip_presence_status(real_mount, follow_singular_sensor)
         if status != expected:
-            raise FailedTipStateCheck(expected, status.value)
+            raise FailedTipStateCheck(expected, status)
 
     async def _force_pick_up_tip(
         self, mount: OT3Mount, pipette_spec: TipActionSpec

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -697,9 +697,10 @@ class EarlyLiquidSenseTrigger(RuntimeError):
 class FailedTipStateCheck(RuntimeError):
     """Error raised if the tip ejector state does not match the expected value."""
 
-    def __init__(self, tip_state_type: TipStateType, actual_state: int) -> None:
+    def __init__(
+        self, expected_state: TipStateType, actual_state: TipStateType
+    ) -> None:
         """Initialize FailedTipStateCheck error."""
         super().__init__(
-            f"Failed to correctly determine tip state for tip {str(tip_state_type)} "
-            f"received {bool(actual_state)} but expected {bool(tip_state_type.value)}"
+            f"Expected tip state {expected_state}, but received {actual_state}."
         )


### PR DESCRIPTION
# Overview

This adjusts an error message for clarity. Before:

> Failed to correctly determine tip state for tip PRESENT received False but expected True

After:

> Expected tip state PRESENT, but received ABSENT.

The original message confused me because the hardware *did* correctly determine tip state—it just determined it to be something bad.

This is a user-facing message at the moment, but it will soon not be because of EXEC-427. Still, might as well tidy it up.

# Test plan

Untested at the moment since it's a small change. I'll be testing this incidentally as part of EXEC-427.

# Review requests

None in particular.

# Risk assessment

Low.