### PR TITLE
fix(app): show InfoScreen under RunPreview for a run canceled before start

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -59,6 +59,7 @@
   "load_module_protocol_setup": "Load {{module}} in Slot {{slot_name}}",
   "load_pipette_protocol_setup": "Load {{pipette_name}} in {{mount_name}} Mount",
   "loading_protocol": "Loading Protocol",
+  "loading_data": "Loading data...",
   "location": "location",
   "module_controls": "Module Controls",
   "module_slot_number": "Slot {{slot_number}}",

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -61,7 +61,6 @@ export const RunPreviewComponent = (
   // we only ever want one request done for terminal runs because this is a heavy request
   const {
     data: commandsFromQueryResponse,
-    isLoading: isRunCommandsLoading,
   } = useNotifyAllCommandsAsPreSerializedList(
     runId,
     { cursor: 0, pageLength: MAX_COMMANDS },
@@ -72,8 +71,7 @@ export const RunPreviewComponent = (
     }
   )
   const commandsFromQuery = commandsFromQueryResponse?.data
-  const nullCheckedCommandsFromQuery =
-    commandsFromQuery == null ? robotSideAnalysis?.commands : commandsFromQuery
+  const nullCheckedCommandsFromQuery = commandsFromQuery ?? []
   const viewPortRef = React.useRef<HTMLDivElement | null>(null)
   const currentRunCommandKey = useNotifyLastRunCommand(runId, {
     refetchInterval: LIVE_RUN_COMMANDS_POLL_MS,
@@ -84,7 +82,7 @@ export const RunPreviewComponent = (
   ] = React.useState<boolean>(true)
   if (robotSideAnalysis == null) return null
   const commands =
-    (isRunTerminal && !isRunCommandsLoading
+    (isRunTerminal
       ? nullCheckedCommandsFromQuery
       : robotSideAnalysis.commands) ?? []
   // pass relevant data from run rather than analysis so that CommandText utilities can properly hash the entities' IDs

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -12,6 +12,7 @@ import {
   DISPLAY_FLEX,
   DISPLAY_NONE,
   Flex,
+  InfoScreen,
   POSITION_FIXED,
   PrimaryButton,
   SPACING,
@@ -58,7 +59,10 @@ export const RunPreviewComponent = (
       ? (RUN_STATUSES_TERMINAL as RunStatus[]).includes(runStatus)
       : false
   // we only ever want one request done for terminal runs because this is a heavy request
-  const commandsFromQuery = useNotifyAllCommandsAsPreSerializedList(
+  const {
+    data: commandsFromQueryResponse,
+    isLoading: isRunCommandsLoading,
+  } = useNotifyAllCommandsAsPreSerializedList(
     runId,
     { cursor: 0, pageLength: MAX_COMMANDS },
     {
@@ -66,7 +70,8 @@ export const RunPreviewComponent = (
       cacheTime: Infinity,
       enabled: isRunTerminal,
     }
-  ).data?.data
+  )
+  const commandsFromQuery = commandsFromQueryResponse?.data
   const nullCheckedCommandsFromQuery =
     commandsFromQuery == null ? robotSideAnalysis?.commands : commandsFromQuery
   const viewPortRef = React.useRef<HTMLDivElement | null>(null)
@@ -79,7 +84,7 @@ export const RunPreviewComponent = (
   ] = React.useState<boolean>(true)
   if (robotSideAnalysis == null) return null
   const commands =
-    (isRunTerminal
+    (isRunTerminal && !isRunCommandsLoading
       ? nullCheckedCommandsFromQuery
       : robotSideAnalysis.commands) ?? []
   // pass relevant data from run rather than analysis so that CommandText utilities can properly hash the entities' IDs
@@ -100,7 +105,11 @@ export const RunPreviewComponent = (
     c => c.key === currentRunCommandKey
   )
 
-  return (
+  return commands.length === 0 ? (
+    <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
+      <InfoScreen contentType="runNotStarted" />
+    </Flex>
+  ) : (
     <Flex
       ref={viewPortRef}
       flexDirection={DIRECTION_COLUMN}
@@ -110,99 +119,101 @@ export const RunPreviewComponent = (
       gridGap={SPACING.spacing8}
       padding={SPACING.spacing16}
     >
-      <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
-        <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
-          {t('run_preview')}
+      <>
+        <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
+          <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
+            {t('run_preview')}
+          </StyledText>
+          <StyledText as="label" color={COLORS.grey50}>
+            {t('steps_total', { count: commands.length })}
+          </StyledText>
+        </Flex>
+        <StyledText as="p" marginBottom={SPACING.spacing8}>
+          {t('preview_of_protocol_steps')}
         </StyledText>
-        <StyledText as="label" color={COLORS.grey50}>
-          {t('steps_total', { count: commands.length })}
-        </StyledText>
-      </Flex>
-      <StyledText as="p" marginBottom={SPACING.spacing8}>
-        {t('preview_of_protocol_steps')}
-      </StyledText>
-      <Divider marginX={`calc(-1 * ${SPACING.spacing16})`} />
-      <ViewportList
-        viewportRef={viewPortRef}
-        ref={ref}
-        items={commands}
-        onViewportIndexesChange={([
-          lowestVisibleIndex,
-          highestVisibleIndex,
-        ]) => {
-          if (currentRunCommandIndex >= 0) {
-            setIsCurrentCommandVisible(
-              currentRunCommandIndex >= lowestVisibleIndex &&
-                currentRunCommandIndex <= highestVisibleIndex
-            )
-          }
-        }}
-        initialIndex={currentRunCommandIndex}
-      >
-        {(command, index) => {
-          const isCurrent = index === currentRunCommandIndex
-          const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
-          const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
-          return (
-            <Flex
-              key={command.id}
-              alignItems={ALIGN_CENTER}
-              gridGap={SPACING.spacing8}
-            >
-              <StyledText
-                minWidth={SPACING.spacing16}
-                fontSize={TYPOGRAPHY.fontSizeCaption}
-              >
-                {index + 1}
-              </StyledText>
+        <Divider marginX={`calc(-1 * ${SPACING.spacing16})`} />
+        <ViewportList
+          viewportRef={viewPortRef}
+          ref={ref}
+          items={commands}
+          onViewportIndexesChange={([
+            lowestVisibleIndex,
+            highestVisibleIndex,
+          ]) => {
+            if (currentRunCommandIndex >= 0) {
+              setIsCurrentCommandVisible(
+                currentRunCommandIndex >= lowestVisibleIndex &&
+                  currentRunCommandIndex <= highestVisibleIndex
+              )
+            }
+          }}
+          initialIndex={currentRunCommandIndex}
+        >
+          {(command, index) => {
+            const isCurrent = index === currentRunCommandIndex
+            const backgroundColor = isCurrent ? COLORS.blue30 : COLORS.grey20
+            const iconColor = isCurrent ? COLORS.blue60 : COLORS.grey50
+            return (
               <Flex
-                flexDirection={DIRECTION_COLUMN}
-                gridGap={SPACING.spacing4}
-                width="100%"
-                backgroundColor={
-                  index === jumpedIndex ? '#F5E3FF' : backgroundColor
-                }
-                color={COLORS.black90}
-                borderRadius={BORDERS.borderRadius4}
-                padding={SPACING.spacing8}
-                css={css`
-                  transition: background-color ${COLOR_FADE_MS}ms ease-out,
-                    border-color ${COLOR_FADE_MS}ms ease-out;
-                `}
+                key={command.id}
+                alignItems={ALIGN_CENTER}
+                gridGap={SPACING.spacing8}
               >
-                <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
-                  <CommandIcon command={command} color={iconColor} />
-                  <CommandText
-                    command={command}
-                    robotSideAnalysis={protocolDataFromAnalysisOrRun}
-                    robotType={robotType}
-                    color={COLORS.black90}
-                  />
+                <StyledText
+                  minWidth={SPACING.spacing16}
+                  fontSize={TYPOGRAPHY.fontSizeCaption}
+                >
+                  {index + 1}
+                </StyledText>
+                <Flex
+                  flexDirection={DIRECTION_COLUMN}
+                  gridGap={SPACING.spacing4}
+                  width="100%"
+                  backgroundColor={
+                    index === jumpedIndex ? '#F5E3FF' : backgroundColor
+                  }
+                  color={COLORS.black90}
+                  borderRadius={BORDERS.borderRadius4}
+                  padding={SPACING.spacing8}
+                  css={css`
+                    transition: background-color ${COLOR_FADE_MS}ms ease-out,
+                      border-color ${COLOR_FADE_MS}ms ease-out;
+                  `}
+                >
+                  <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing8}>
+                    <CommandIcon command={command} color={iconColor} />
+                    <CommandText
+                      command={command}
+                      robotSideAnalysis={protocolDataFromAnalysisOrRun}
+                      robotType={robotType}
+                      color={COLORS.black90}
+                    />
+                  </Flex>
                 </Flex>
               </Flex>
-            </Flex>
-          )
-        }}
-      </ViewportList>
-      {currentRunCommandIndex >= 0 ? (
-        <PrimaryButton
-          position={POSITION_FIXED}
-          bottom={SPACING.spacing40}
-          left={`calc(calc(100% + ${NAV_BAR_WIDTH})/2)`} // add width of half of nav bar to center within run tab
-          transform="translate(-50%)"
-          borderRadius={SPACING.spacing32}
-          display={isCurrentCommandVisible ? DISPLAY_NONE : DISPLAY_FLEX}
-          onClick={makeHandleScrollToStep(currentRunCommandIndex)}
-          id="RunLog_jumpToCurrentStep"
-        >
-          {t('view_current_step')}
-        </PrimaryButton>
-      ) : null}
-      {currentRunCommandIndex === commands.length - 1 ? (
-        <StyledText as="h6" color={COLORS.grey60}>
-          {t('end_of_protocol')}
-        </StyledText>
-      ) : null}
+            )
+          }}
+        </ViewportList>
+        {currentRunCommandIndex >= 0 ? (
+          <PrimaryButton
+            position={POSITION_FIXED}
+            bottom={SPACING.spacing40}
+            left={`calc(calc(100% + ${NAV_BAR_WIDTH})/2)`} // add width of half of nav bar to center within run tab
+            transform="translate(-50%)"
+            borderRadius={SPACING.spacing32}
+            display={isCurrentCommandVisible ? DISPLAY_NONE : DISPLAY_FLEX}
+            onClick={makeHandleScrollToStep(currentRunCommandIndex)}
+            id="RunLog_jumpToCurrentStep"
+          >
+            {t('view_current_step')}
+          </PrimaryButton>
+        ) : null}
+        {currentRunCommandIndex === commands.length - 1 ? (
+          <StyledText as="h6" color={COLORS.grey60}>
+            {t('end_of_protocol')}
+          </StyledText>
+        ) : null}
+      </>
     </Flex>
   )
 }

--- a/app/src/organisms/RunPreview/index.tsx
+++ b/app/src/organisms/RunPreview/index.tsx
@@ -61,6 +61,7 @@ export const RunPreviewComponent = (
   // we only ever want one request done for terminal runs because this is a heavy request
   const {
     data: commandsFromQueryResponse,
+    isLoading: isRunCommandDataLoading,
   } = useNotifyAllCommandsAsPreSerializedList(
     runId,
     { cursor: 0, pageLength: MAX_COMMANDS },
@@ -102,7 +103,7 @@ export const RunPreviewComponent = (
       ? commands.findIndex(c => c.key === currentRunCommandKey)
       : 0
 
-  if (commands == null) {
+  if (isRunCommandDataLoading || commands == null) {
     return (
       <Flex flexDirection={DIRECTION_COLUMN} padding={SPACING.spacing16}>
         <StyledText alignSelf={ALIGN_CENTER} color={COLORS.grey50}>

--- a/react-api-client/src/runs/useAllCommandsAsPreSerializedList.ts
+++ b/react-api-client/src/runs/useAllCommandsAsPreSerializedList.ts
@@ -28,8 +28,28 @@ export function useAllCommandsAsPreSerializedList<TError = Error>(
     enabled: host !== null && runId != null && options.enabled !== false,
   }
   const { cursor, pageLength } = nullCheckedParams
+  // reduce hostKey into a new object to make nullish values play nicely with react-query key hash
+  const hostKey =
+    host != null
+      ? Object.entries(host).reduce<Object>((acc, current) => {
+          const [key, val] = current
+          if (val != null) {
+            return { ...acc, [key]: val }
+          } else {
+            return { ...acc, [key]: 'no value' }
+          }
+        }, {})
+      : {}
+
   const query = useQuery<CommandsData, TError>(
-    [host, 'runs', runId, 'getCommandsAsPreSerializedList', cursor, pageLength],
+    [
+      hostKey,
+      'runs',
+      runId,
+      'getCommandsAsPreSerializedList',
+      cursor,
+      pageLength,
+    ],
     () => {
       return getCommandsAsPreSerializedList(
         host as HostConfig,


### PR DESCRIPTION
Closes RQA-2717

# Overview

Show a 'Run was never started' InfoScreen under RunPreview for a terminal run that was never started (has 0 commands)

# Test Plan

- Begin protocol setup
- Cancel run before starting
- Verify that 'Run was never started' info screen shows
<img width="894" alt="Screenshot 2024-05-14 at 11 52 24 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/4109e03c-059d-4ab7-af61-4fa4ca6c7372">

# Changelog

- show appropriate info screen if no commands exist on the run (consistent with parameters tab)
- fallback to analysis commands while commands from `runs/{runId}/commandsAsPreSerializedList` are loading so we don't get weird json as a step

# Review requests

auth js

# Risk assessment

low