### PR TITLE
build(components, shared-data): fix components and shared-data npm deploy actions

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -190,9 +190,9 @@ jobs:
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
           make setup-js
-      - name: 'build typescript'
-        run: make build-ts
-      - name: 'build library'
+      - name: 'build typescript types'
+        run: make -C components build-ts
+      - name: 'build js bundle'
         run: |
           make -C components lib
       # replace package.json stub version number with version from tag

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -235,7 +235,6 @@ jobs:
           node-version: '18.19.0'
           registry-url: 'https://registry.npmjs.org'
       - name: 'install udev for usb-detection'
-        if: startsWith(matrix.os, 'ubuntu')
         run: |
           # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -234,6 +234,12 @@ jobs:
         with:
           node-version: '18.19.0'
           registry-url: 'https://registry.npmjs.org'
+      - name: 'install udev for usb-detection'
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          # WORKAROUND: Remove microsoft debian repo due to https://github.com/microsoft/linux-package-repositories/issues/130. Remove line below after it is resolved
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update && sudo apt-get install libudev-dev
       - name: 'cache yarn cache'
         uses: actions/cache@v3
         with:

--- a/components/Makefile
+++ b/components/Makefile
@@ -31,6 +31,10 @@ lib: export NODE_ENV := production
 lib:
 	yarn vite build
 
+.PHONY: build-ts
+build-ts:
+	yarn tsc --build --emitDeclarationOnly
+
 # development
 #####################################################################
 

--- a/components/package.json
+++ b/components/package.json
@@ -5,7 +5,7 @@
   "source": "src/index.ts",
   "types": "lib/index.d.ts",
   "style": "src/index.module.css",
-  "main": "lib/opentrons-components.js",
+  "main": "lib/index.mjs",
   "module": "src/index.ts",
   "repository": {
     "type": "git",
@@ -35,8 +35,10 @@
     "classnames": "2.2.5",
     "interactjs": "^1.10.17",
     "lodash": "4.17.21",
+    "react-i18next": "13.5.0",
     "react-popper": "1.0.0",
     "react-remove-scroll": "2.4.3",
+    "react-router-dom": "5.3.4",
     "react-select": "5.4.0",
     "redux": "4.0.5",
     "styled-components": "5.3.6"

--- a/components/src/hardware-sim/DeckSlotLocation/index.tsx
+++ b/components/src/hardware-sim/DeckSlotLocation/index.tsx
@@ -20,6 +20,8 @@ interface LegacyDeckSlotLocationProps extends React.SVGProps<SVGGElement> {
   slotClipColor?: React.SVGProps<SVGPathElement>['stroke']
 }
 
+type AddressableAreaFromDeckDef = typeof ot2DeckDefV5.locations.addressableAreas[number]
+
 // dimensions of the OT-2 fixed trash, not in deck definition
 export const OT2_FIXED_TRASH_X_DIMENSION = 172.86
 export const OT2_FIXED_TRASH_Y_DIMENSION = 165.86
@@ -41,7 +43,7 @@ export function LegacyDeckSlotLocation(
   if (robotType !== OT2_ROBOT_TYPE) return null
 
   const slotDef = ot2DeckDefV5.locations.addressableAreas.find(
-    s => s.id === slotName
+    (s: AddressableAreaFromDeckDef) => s.id === slotName
   )
   if (slotDef == null) {
     console.warn(

--- a/components/src/images/labware/measurement-guide/index.ts
+++ b/components/src/images/labware/measurement-guide/index.ts
@@ -11,95 +11,141 @@ export interface DiagramProps {
 
 type Diagrams = Record<string, string[]>
 
+const FOOTPRINT_IMAGE_RELATIVE_PATH = './images/dimensions/footprint@3x.png'
+const DIMENSIONS_HEIGHT_PLATE_IMAGE_RELATIVE_PATH =
+  './images/dimensions/height-plate-and-reservoir@3x.png'
+const DIMENSIONS_HEIGHT_TIP_RACK_IMAGE_RELATIVE_PATH =
+  './images/dimensions/height-tip-rack@3x.png'
+
+const DIMENSIONS_HEIGHT_TUBE_RACK_IMAGE_RELATIVE_PATH =
+  './images/dimensions/height-tube-rack@3x.png'
+
+const DIMENSIONS_HEIGHT_TUBE_RACK_IMAGE_IRREGULAR_RELATIVE_PATH =
+  './images/dimensions/height-tube-rack-irregular@3x.png'
+
+const HEIGHT_ALUM_BLOCK_TUBES_IMAGE_RELATIVE_PATH =
+  './images/dimensions/height-alum-block-tubes@3x.png'
+
+const HEIGHT_ALUM_BLOCK_PLATE_IMAGE_RELATIVE_PATH =
+  './images/dimensions/height-alum-block-plate@3x.png'
+
+const OFFSET_RESEVOIR_IMAGE_RELATIVE_PATH =
+  './images/offset/offset-reservoir@3x.png'
+
+const SPACING_RESEVOIR_IMAGE_RELATIVE_PATH =
+  './images/spacing/spacing-reservoir@3x.png'
+
+const SPACING_RESEVOIR_MULTI_ROW_IMAGE_RELATIVE_PATH =
+  './images/spacing/spacing-reservoir-multi-row@3x.png'
+
+const OFFSET_WELL_CIRCULAR_IMAGE_RELATIVE_PATH =
+  './images/offset/offset-well-circular@3x.png'
+
+const SPACING_WELL_CIRCULAR_IMAGE_RELATIVE_PATH =
+  './images/spacing/spacing-well-circular@3x.png'
+
+const OFFSET_WELL_RECTANGULAR_IMAGE_RELATIVE_PATH =
+  './images/offset/offset-well-rectangular@3x.png'
+
+const SPACING_WELL_RECTANGULAR_IMAGE_RELATIVE_PATH =
+  './images/spacing/spacing-well-rectangular@3x.png'
+
+const DEPTH_LENGTH_TIP_RACK_IMAGE_RELATIVE_PATH =
+  './images/depth/length-tip-rack@3x.png'
+
+const SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH =
+  './images/shape/shape-circular@3x.png'
+
+const DEPTH_PLATE_FLAT_IMAGE_RELATIVE_PATH =
+  './images/depth/depth-plate-flat@3x.png'
+
+const SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH =
+  './images/shape/shape-rectangular@3x.png'
+
+const DEPTH_PLATE_ROUND_IMAGE_RELATIVE_PATH =
+  './images/depth/depth-plate-round@3x.png'
+
+const DEPTH_PLATE_V_SHAPE_IMAGE_RELATIVE_PATH =
+  './images/depth/depth-plate-v@3x.png'
+
+const DEPTH_RESEVOIR_AND_TUBES_FLAT_IMAGE_RELATIVE_PATH =
+  './images/depth/depth-reservoir-and-tubes-flat@3x.png'
+
+const DEPTH_RESEVOIR_AND_TUBES_ROUND_IMAGE_RELATIVE_PATH =
+  './images/depth/depth-reservoir-and-tubes-round@3x.png'
+
+const DEPTH_RESEVOIR_AND_TUBES_V_SHAPE_IMAGE_RELATIVE_PATH =
+  './images/depth/depth-reservoir-and-tubes-v@3x.png'
+
 const FOOTPRINT_DIAGRAMS: Diagrams = {
   wellPlate: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL(
-      './images/dimensions/height-plate-and-reservoir@3x.png',
-      import.meta.url
-    ).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(DIMENSIONS_HEIGHT_PLATE_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
   tipRack: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL('./images/dimensions/height-tip-rack@3x.png', import.meta.url).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(DIMENSIONS_HEIGHT_TIP_RACK_IMAGE_RELATIVE_PATH, import.meta.url)
+      .href,
   ],
   tubeRack: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL('./images/dimensions/height-tube-rack@3x.png', import.meta.url)
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(DIMENSIONS_HEIGHT_TUBE_RACK_IMAGE_RELATIVE_PATH, import.meta.url)
       .href,
   ],
   reservoir: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL(
-      './images/dimensions/height-plate-and-reservoir@3x.png',
-      import.meta.url
-    ).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(DIMENSIONS_HEIGHT_PLATE_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
   irregular: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
     new URL(
-      './images/dimensions/height-tube-rack-irregular@3x.png',
+      DIMENSIONS_HEIGHT_TUBE_RACK_IMAGE_IRREGULAR_RELATIVE_PATH,
       import.meta.url
     ).href,
   ],
   adapter: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL(
-      './images/dimensions/height-plate-and-reservoir@3x.png',
-      import.meta.url
-    ).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(DIMENSIONS_HEIGHT_PLATE_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
 }
 
 const ALUM_BLOCK_FOOTPRINTS: Diagrams = {
   tubeRack: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL(
-      './images/dimensions/height-alum-block-tubes@3x.png',
-      import.meta.url
-    ).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(HEIGHT_ALUM_BLOCK_TUBES_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
   wellPlate: [
-    new URL('./images/dimensions/footprint@3x.png', import.meta.url).href,
-    new URL(
-      './images/dimensions/height-alum-block-plate@3x.png',
-      import.meta.url
-    ).href,
+    new URL(FOOTPRINT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(HEIGHT_ALUM_BLOCK_PLATE_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
 }
 
 const RESERVOIR_SPACING_DIAGRAMS: Diagrams = {
   singleRow: [
-    new URL('./images/offset/offset-reservoir@3x.png', import.meta.url).href,
-    new URL('./images/spacing/spacing-reservoir@3x.png', import.meta.url).href,
+    new URL(OFFSET_RESEVOIR_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(SPACING_RESEVOIR_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
   multiRow: [
-    new URL('./images/offset/offset-reservoir@3x.png', import.meta.url).href,
-    new URL(
-      './images/spacing/spacing-reservoir-multi-row@3x.png',
-      import.meta.url
-    ).href,
+    new URL(OFFSET_RESEVOIR_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(SPACING_RESEVOIR_MULTI_ROW_IMAGE_RELATIVE_PATH, import.meta.url)
+      .href,
   ],
 }
 
 const SPACING_DIAGRAMS: Diagrams = {
   circular: [
-    new URL('./images/offset/offset-well-circular@3x.png', import.meta.url)
-      .href,
-    new URL('./images/spacing/spacing-well-circular@3x.png', import.meta.url)
-      .href,
+    new URL(OFFSET_WELL_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(SPACING_WELL_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
   rectangular: [
-    new URL('./images/offset/offset-well-rectangular@3x.png', import.meta.url)
-      .href,
-    new URL('./images/spacing/spacing-well-rectangular@3x.png', import.meta.url)
-      .href,
+    new URL(OFFSET_WELL_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
+    new URL(SPACING_WELL_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
   ],
 }
 
 const TIPRACK_MEASUREMENT_DIAGRAMS: string[] = [
-  new URL('./images/depth/length-tip-rack@3x.png', import.meta.url).href,
-  new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+  new URL(DEPTH_LENGTH_TIP_RACK_IMAGE_RELATIVE_PATH, import.meta.url).href,
+  new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
 ]
 
 type NestedDiagrams = Record<string, Record<string, string[]>>
@@ -107,32 +153,32 @@ type NestedDiagrams = Record<string, Record<string, string[]>>
 const PLATE_MEASUREMENT_DIAGRAMS: NestedDiagrams = {
   flat: {
     circular: [
-      new URL('./images/depth/depth-plate-flat@3x.png', import.meta.url).href,
-      new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+      new URL(DEPTH_PLATE_FLAT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+      new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
     rectangular: [
-      new URL('./images/depth/depth-plate-flat@3x.png', import.meta.url).href,
-      new URL('./images/shape/shape-rectangular@3x.png', import.meta.url).href,
+      new URL(DEPTH_PLATE_FLAT_IMAGE_RELATIVE_PATH, import.meta.url).href,
+      new URL(SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
   },
   u: {
     circular: [
-      new URL('./images/depth/depth-plate-round@3x.png', import.meta.url).href,
-      new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+      new URL(DEPTH_PLATE_ROUND_IMAGE_RELATIVE_PATH, import.meta.url).href,
+      new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
     rectangular: [
-      new URL('./images/depth/depth-plate-round@3x.png', import.meta.url).href,
-      new URL('./images/shape/shape-rectangular@3x.png', import.meta.url).href,
+      new URL(DEPTH_PLATE_ROUND_IMAGE_RELATIVE_PATH, import.meta.url).href,
+      new URL(SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
   },
   v: {
     circular: [
-      new URL('./images/depth/depth-plate-v@3x.png', import.meta.url).href,
-      new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+      new URL(DEPTH_PLATE_V_SHAPE_IMAGE_RELATIVE_PATH, import.meta.url).href,
+      new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
     rectangular: [
-      new URL('./images/depth/depth-plate-v@3x.png', import.meta.url).href,
-      new URL('./images/shape/shape-rectangular@3x.png', import.meta.url).href,
+      new URL(DEPTH_PLATE_V_SHAPE_IMAGE_RELATIVE_PATH, import.meta.url).href,
+      new URL(SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
   },
 }
@@ -140,49 +186,49 @@ const MEASUREMENT_DIAGRAMS: NestedDiagrams = {
   flat: {
     circular: [
       new URL(
-        './images/depth/depth-reservoir-and-tubes-flat@3x.png',
+        DEPTH_RESEVOIR_AND_TUBES_FLAT_IMAGE_RELATIVE_PATH,
         import.meta.url
       ).href,
-      new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+      new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
     rectangular: [
       new URL(
-        './images/depth/depth-reservoir-and-tubes-flat@3x.png',
+        DEPTH_RESEVOIR_AND_TUBES_FLAT_IMAGE_RELATIVE_PATH,
         import.meta.url
       ).href,
-      new URL('./images/shape/shape-rectangular@3x.png', import.meta.url).href,
+      new URL(SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
   },
   u: {
     circular: [
       new URL(
-        './images/depth/depth-reservoir-and-tubes-round@3x.png',
+        DEPTH_RESEVOIR_AND_TUBES_ROUND_IMAGE_RELATIVE_PATH,
         import.meta.url
       ).href,
-      new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+      new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
     rectangular: [
       new URL(
-        './images/depth/depth-reservoir-and-tubes-round@3x.png',
+        DEPTH_RESEVOIR_AND_TUBES_ROUND_IMAGE_RELATIVE_PATH,
         import.meta.url
       ).href,
-      new URL('./images/shape/shape-rectangular@3x.png', import.meta.url).href,
+      new URL(SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
   },
   v: {
     circular: [
       new URL(
-        './images/depth/depth-reservoir-and-tubes-v@3x.png',
+        DEPTH_RESEVOIR_AND_TUBES_V_SHAPE_IMAGE_RELATIVE_PATH,
         import.meta.url
       ).href,
-      new URL('./images/shape/shape-circular@3x.png', import.meta.url).href,
+      new URL(SHAPE_CIRCULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
     rectangular: [
       new URL(
-        './images/depth/depth-reservoir-and-tubes-v@3x.png',
+        DEPTH_RESEVOIR_AND_TUBES_V_SHAPE_IMAGE_RELATIVE_PATH,
         import.meta.url
       ).href,
-      new URL('./images/shape/shape-rectangular@3x.png', import.meta.url).href,
+      new URL(SHAPE_RECTANGULAR_IMAGE_RELATIVE_PATH, import.meta.url).href,
     ],
   },
 }

--- a/components/vite.config.ts
+++ b/components/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     // Relative to the root
     ssr: 'src/index.ts',
     outDir: 'lib',
+    // do not delete the outdir, typescript types might live there and we dont want to delete them
+    emptyOutDir: false,
     commonjsOptions: {
       transformMixedEsModules: true,
       esmExternals: true,

--- a/scripts/deploy/create-release.js
+++ b/scripts/deploy/create-release.js
@@ -123,7 +123,7 @@ async function versionDetailsFromGit(tag, allowOld) {
   }
   const allVersions = await Promise.all(allTags.map(tag => detailsFromTag(tag)))
   const sortedVersions = allVersions
-        .map(details => details[1])
+    .map(details => details[1])
     .sort(semver.compare)
     .reverse()
   const previousVersion = versionPrevious(currentVersion, sortedVersions)

--- a/scripts/deploy/create-release.js
+++ b/scripts/deploy/create-release.js
@@ -92,7 +92,7 @@ async function detailsFromTag(tag) {
 }
 
 async function tagFromDetails(project, version) {
-  return (await gitVersion()).tagFromDetails(project, version)
+  return await (await gitVersion()).tagFromDetails(project, version)
 }
 
 async function prefixForProject(project) {
@@ -113,19 +113,19 @@ async function versionDetailsFromGit(tag, allowOld) {
     }
   }
 
-  const [project, currentVersion] = detailsFromTag(tag)
+  const [project, currentVersion] = await detailsFromTag(tag)
   const prefix = await prefixForProject(project)
-  const allTags = (await monorepoGit().tags([prefix + '*'])).all
+  const allTags = (await (await monorepoGit()).tags([prefix + '*'])).all
   if (!allTags.includes(tag)) {
     throw new Error(
       `Tag ${tag} does not exist - create it before running this script`
     )
   }
-  const sortedVersions = allTags
-    .map(tag => detailsFromTag(tag)[1])
+  const allVersions = await Promise.all(allTags.map(tag => detailsFromTag(tag)))
+  const sortedVersions = allVersions
+        .map(details => details[1])
     .sort(semver.compare)
     .reverse()
-
   const previousVersion = versionPrevious(currentVersion, sortedVersions)
   return [project, currentVersion, previousVersion]
 }
@@ -144,7 +144,7 @@ async function buildChangelog(project, currentVersion, previousVersion) {
   }
   const previousTag = await tagFromDetails(project, previousVersion)
   const currentTag = await tagFromDetails(project, currentVersion)
-  const prefix = await prefixForProject(Project)
+  const prefix = await prefixForProject(project)
   const changelogStream = conventionalChangelog(
     { preset: 'angular', tagPrefix: prefix },
     {

--- a/shared-data/Makefile
+++ b/shared-data/Makefile
@@ -30,7 +30,9 @@ lib-js: export NODE_ENV := production
 lib-js:
 	NODE_OPTIONS=--openssl-legacy-provider yarn vite build
 
-
+.PHONY: build-ts
+build-ts:
+	yarn tsc --build --emitDeclarationOnly
 
 # Python targets
 

--- a/shared-data/package.json
+++ b/shared-data/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "source": "js/index.ts",
   "types": "lib/js/index.d.ts",
-  "main": "lib/opentrons-shared-data.js",
+  "main": "lib/index.mjs",
   "module": "js/index.ts",
   "dependencies": {
     "ajv": "^6.12.3",

--- a/shared-data/vite.config.ts
+++ b/shared-data/vite.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
     // Relative to the root
     ssr: 'js/index.ts',
     outDir: 'lib',
+    // do not delete the outdir, typescript types might live there and we dont want to delete them
+    emptyOutDir: false,
     commonjsOptions: {
       transformMixedEsModules: true,
       esmExternals: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
     esbuildOptions: {
       target: 'es2020',
     },
-    exclude: ['node_modules']
+    exclude: ['node_modules'],
   },
   css: {
     postcss: {


### PR DESCRIPTION
# Overview

Since the vite migration our npm publish github action has been publishing an unusable artifact for the following reasons:

1. The `main` entry path points to the old bundle name that webpack generated
2. We do not specify all dependencies required for consumers to use `@opentrons/components`, which leads to build errors when trying to import modules that don't exist
3. Image urls configured via the `new URL()` constructor do not point to an asset that is bundled into the production build. This means we get an import error when a consumer builds their project because it can't find assets we reference in our code. Ex:

```js
new URL("./images/depth/depth-plate-flat@3x.png", import.meta.url).href,
```

^this works fine in development, but in a production build we'll get an error like this: 

```
ERROR in ./node_modules/@opentrons/components/lib/index.mjs 16968:15-78
Module not found: Error: Can't resolve './images/depth/depth-plate-v@3x.png' in '/Users/shlokamin/Desktop/workspace/my-app/node_modules/@opentrons/components/lib'
```

It turns out that the way vite interprets: 

```js
const FOOTPRINT_RELATIVE_PATH = './images/dimensions/footprint@3x.png'
new URL(FOOTPRINT_RELATIVE_PATH, import.meta.url)

// versus

new URL('./images/dimensions/footprint@3x.png', import.meta.url)
```

is... different. Vite does not like the first option, but it is okay with the second option. tbh im confused as to why, since the calls to the `URL` constructor are evaluated immediately (not lazily). 

Anyways, this PR fixes these issues.

# Review Requests
Try out version [0.1.6-alpha.7](https://www.npmjs.com/package/@opentrons/components/v/0.1.6-alpha.7) of the components library and see if it works for y'all

# Risk assessment

Low/medium