### PR TITLE
docs(api): Versioning page updates for Python API 2.18

### DIFF
--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -84,6 +84,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 +-------------+------------------------------+
 | API Version | Introduced in Robot Software |
 +=============+==============================+
+|     2.18    |          7.3.0               |
++-------------+------------------------------+
 |     2.17    |          7.2.0               |
 +-------------+------------------------------+
 |     2.16    |          7.1.0               |
@@ -127,6 +129,14 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 Changes in API Versions
 =======================
+
+Version 2.18
+------------
+
+- Define customizable parameters with the new ``add_parameters()`` function, and access their values on the :py:obj:`.ProtocolContext.params` object during a protocol run. See :ref:`runtime-parameters` and related pages for more information.
+- Move the pipette to positions relative to the top of a trash container. See :ref:`position-relative-trash`. The default behavior of :py:meth:`.drop_tip` also accounts for this new possibility.
+- :py:meth:`.set_offset` has been restored to the API with new behavior that applies to labware type–location pairs.
+- Automatic tip tracking is now available for all nozzle configurations.
 
 Version 2.17
 ------------


### PR DESCRIPTION
# Overview

Summarize all of the changes in Python API 2.18 on the Versioning documentation page.

Closes RTC-463

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-versioning-2.18/v2/versioning.html)

# Changelog

- add row to version table
- feature bullets

# Review requests

any glaring omissions?

# Risk assessment

nil