### PR TITLE
fix(api): Parse all RTP fields strictly to fix flakiness

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -22,6 +22,7 @@ from pydantic.generics import GenericModel
 
 from opentrons.hardware_control import HardwareControlAPI
 
+from ..resources import ModelUtils
 from ..errors import ErrorOccurrence
 from ..notes import CommandNote, CommandNoteAdder
 

--- a/api/src/opentrons/protocol_engine/commands/command.py
+++ b/api/src/opentrons/protocol_engine/commands/command.py
@@ -22,7 +22,6 @@ from pydantic.generics import GenericModel
 
 from opentrons.hardware_control import HardwareControlAPI
 
-from ..resources import ModelUtils
 from ..errors import ErrorOccurrence
 from ..notes import CommandNote, CommandNoteAdder
 

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -885,12 +885,14 @@ class TipPresenceStatus(str, Enum):
 class RTPBase(BaseModel):
     """Parameters defined in a protocol."""
 
-    displayName: str = Field(..., description="Display string for the parameter.")
-    variableName: str = Field(..., description="Python variable name of the parameter.")
-    description: Optional[str] = Field(
+    displayName: StrictStr = Field(..., description="Display string for the parameter.")
+    variableName: StrictStr = Field(
+        ..., description="Python variable name of the parameter."
+    )
+    description: Optional[StrictStr] = Field(
         None, description="Detailed description of the parameter."
     )
-    suffix: Optional[str] = Field(
+    suffix: Optional[StrictStr] = Field(
         None,
         description="Units (like mL, mm/sec, etc) or a custom suffix for the parameter.",
     )

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -4,7 +4,15 @@ import re
 from datetime import datetime
 from enum import Enum
 from dataclasses import dataclass
-from pydantic import BaseModel, Field, validator
+from pydantic import (
+    BaseModel,
+    Field,
+    StrictBool,
+    StrictFloat,
+    StrictInt,
+    StrictStr,
+    validator,
+)
 from typing import Optional, Union, List, Dict, Any, NamedTuple, Tuple, FrozenSet
 from typing_extensions import Literal, TypeGuard
 
@@ -894,17 +902,17 @@ class NumberParameter(RTPBase):
     type: Literal["int", "float"] = Field(
         ..., description="String specifying whether the number is an int or float type."
     )
-    min: float = Field(
+    min: Union[StrictInt, StrictFloat] = Field(
         ..., description="Minimum value that the number param is allowed to have."
     )
-    max: float = Field(
+    max: Union[StrictInt, StrictFloat] = Field(
         ..., description="Maximum value that the number param is allowed to have."
     )
-    value: float = Field(
+    value: Union[StrictInt, StrictFloat] = Field(
         ...,
         description="The value assigned to the parameter; if not supplied by the client, will be assigned the default value.",
     )
-    default: float = Field(
+    default: Union[StrictInt, StrictFloat] = Field(
         ...,
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
@@ -916,11 +924,11 @@ class BooleanParameter(RTPBase):
     type: Literal["bool"] = Field(
         default="bool", description="String specifying the type of this parameter"
     )
-    value: bool = Field(
+    value: StrictBool = Field(
         ...,
         description="The value assigned to the parameter; if not supplied by the client, will be assigned the default value.",
     )
-    default: bool = Field(
+    default: StrictBool = Field(
         ...,
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
@@ -929,8 +937,10 @@ class BooleanParameter(RTPBase):
 class EnumChoice(BaseModel):
     """Components of choices used in RTP Enum Parameters."""
 
-    displayName: str = Field(..., description="Display string for the param's choice.")
-    value: Union[float, str] = Field(
+    displayName: StrictStr = Field(
+        ..., description="Display string for the param's choice."
+    )
+    value: Union[StrictInt, StrictFloat, StrictStr] = Field(
         ..., description="Enum value of the param's choice."
     )
 
@@ -945,11 +955,11 @@ class EnumParameter(RTPBase):
     choices: List[EnumChoice] = Field(
         ..., description="List of valid choices for this parameter."
     )
-    value: Union[float, str] = Field(
+    value: Union[StrictInt, StrictFloat, StrictStr] = Field(
         ...,
         description="The value assigned to the parameter; if not supplied by the client, will be assigned the default value.",
     )
-    default: Union[float, str] = Field(
+    default: Union[StrictInt, StrictFloat, StrictStr] = Field(
         ...,
         description="Default value of the parameter, to be used when there is no client-specified value.",
     )
@@ -958,5 +968,5 @@ class EnumParameter(RTPBase):
 RunTimeParameter = Union[NumberParameter, EnumParameter, BooleanParameter]
 
 RunTimeParamValuesType = Dict[
-    str, Union[float, bool, str]
+    StrictStr, Union[StrictInt, StrictFloat, StrictBool, StrictStr]
 ]  # update value types as more RTP types are added


### PR DESCRIPTION
# Overview

Closes AUTH-401.

# Changelog

As described in AUTH-401, there were two problems:

1. Our Pydantic models sometimes parse run-time parameter values as the wrong types. For example, parsing `true` into `Union[float, bool, str]` could return `1.0` instead of `True`. This is because of [Pydantic's type coercion](https://docs.pydantic.dev/1.10/usage/models/#data-conversion).
2. Exactly which values get wrongly parsed into exactly which wrong types is unstable; it changes depending on things like import statements in files far away. This is apparently because, although Pydantic parses unions “left to right,” the order of “left to right” can change depending on Python’s caching of generic types.
    * https://bugs.python.org/issue42317
    * https://github.com/pydantic/pydantic/issues/7022

The solution to both of these problems is to disable Pydantic's type coercion. That solves the first problem for obvious reasons. It solves the second problem because, when parsing something like a `Union[float, bool, str]`, there will no longer be any "ties" that Pydantic needs to break by using `Union` order.

(In my opinion, this is also a good practice in general, and we should do it for everything going forward.)

For all fields in all run-time parameter models, change `int` to `StrictInt`, `str` to `StrictStr`, `bool` to `StrictBool`, and `float` to `Union[StrictInt, StrictFloat]`. That last `Union` is because numbers like `123`, without a decimal point, do not parse into `StrictFloat`.

# Test plan

* [x] In robot-server, run `pipenv run pytest tests/protocols/test_protocols_router.py::test_create_protocol_analyses_with_same_rtp_values` on commits c90840de0bfe1650b363971de81561251da8f372 and 65a57e840eb5ffcaad7fd2fb0140e9d0927fc8c1. It will fail on the first one (before the fix) and succeed on the second one (after the fix).
* [ ] Continued overall testing of run-time parameters? See risk assessment. 

# Review requests

Are there any fields or models that I missed?

Also see risk assessment.

# Risk assessment

Medium?

Changes like this can break the database if we've been accidentally storing stuff wrongly, like if we've been storing `"1.23"` where we meant to store `1.23` and this PR changes that field from `float` to `StrictFloat`.

There's also some risk that the frontend has had bugs where it sends the wrong types, but the server-side type coercion has been masking them. The server will return `422` errors now.

I'll defer to AUTH people for their assessment of how likely we are to have problems like these, and how much manual testing we need to do to be confident.