### PR TITLE
chore: add known issue for losing LPC offsets when swapping labware type via RTP

### DIFF
--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -43,6 +43,7 @@ Modules in Deck Configuration
 ### Known Issues
 
 - Previously saved labware offset data may not be available when setting up a run via a USB connection from a Windows computer. Re-run Labware Position Check or use a Wi-Fi connection instead.
+- If you apply labware offset data for a particular type of labware, and then load a different type of labware in its place via a runtime parameter, the new labware type will have default offsets (0.0 on all axes). Re-run Labware Position Check to set offsets for the new labware.
 
 ---
 


### PR DESCRIPTION
# Overview

Letting people know they can get chicken-and-egg'd if they apply labware offsets, set RTPs that change their labware, and then reanalysis gets rid of their original offsets.

# Review requests

Is this clear? This is kind of a tricky one to wrap up in a single sentence.

# Risk assessment

zip