### PR TITLE
fix(app): wait for maintenance run deletion before closing flows

### DIFF
--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
-import { UseMutateFunction } from 'react-query'
 import {
   useConditionalConfirm,
   Flex,
@@ -35,6 +34,7 @@ import { UnmountGripper } from './UnmountGripper'
 import { Success } from './Success'
 import { ExitConfirmation } from './ExitConfirmation'
 
+import type { UseMutateFunction } from 'react-query'
 import type { GripperWizardFlowType } from './types'
 import type { AxiosError } from 'axios'
 import type {
@@ -120,11 +120,18 @@ export function GripperWizardFlows(
     if (props?.onComplete != null) props.onComplete()
     if (maintenanceRunData != null) {
       deleteMaintenanceRun(maintenanceRunData?.data.id)
+    } else {
+      closeFlow()
     }
-    closeFlow()
   }
 
-  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({})
+  const {
+    deleteMaintenanceRun,
+    isLoading: isDeleteLoading,
+  } = useDeleteMaintenanceRunMutation({
+    onSuccess: () => closeFlow(),
+    onError: () => closeFlow(),
+  })
 
   const handleCleanUpAndClose = (): void => {
     if (maintenanceRunData?.data.id == null) handleClose()
@@ -153,7 +160,10 @@ export function GripperWizardFlows(
       createMaintenanceRun={createTargetedMaintenanceRun}
       isCreateLoading={isCreateLoading}
       isRobotMoving={
-        isChainCommandMutationLoading || isCommandLoading || isExiting
+        isChainCommandMutationLoading ||
+        isCommandLoading ||
+        isExiting ||
+        isDeleteLoading
       }
       handleCleanUpAndClose={handleCleanUpAndClose}
       handleClose={handleClose}

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -5,13 +5,7 @@ import { useTranslation } from 'react-i18next'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
 import { useConditionalConfirm, COLORS } from '@opentrons/components'
-import {
-  LEFT,
-  NINETY_SIX_CHANNEL,
-  RIGHT,
-  LoadedPipette,
-  CreateCommand,
-} from '@opentrons/shared-data'
+import { LEFT, NINETY_SIX_CHANNEL, RIGHT } from '@opentrons/shared-data'
 import {
   useHost,
   useDeleteMaintenanceRunMutation,
@@ -28,6 +22,7 @@ import { getTopPortalEl } from '../../App/portal'
 import { WizardHeader } from '../../molecules/WizardHeader'
 import { FirmwareUpdateModal } from '../FirmwareUpdateModal'
 import { getIsOnDevice } from '../../redux/config'
+import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 import { useAttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
 import { usePipetteFlowWizardHeaderText } from './hooks'
 import { getPipetteWizardSteps } from './getPipetteWizardSteps'
@@ -44,10 +39,13 @@ import { Carriage } from './Carriage'
 import { MountingPlate } from './MountingPlate'
 import { UnskippableModal } from './UnskippableModal'
 
-import type { PipetteMount } from '@opentrons/shared-data'
+import type {
+  LoadedPipette,
+  CreateCommand,
+  PipetteMount,
+} from '@opentrons/shared-data'
 import type { CommandData, HostConfig } from '@opentrons/api-client'
 import type { PipetteWizardFlow, SelectablePipettes } from './types'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
 
 const RUN_REFETCH_INTERVAL = 5000
 
@@ -185,11 +183,18 @@ export const PipetteWizardFlows = (
     if (onComplete != null) onComplete()
     if (maintenanceRunData != null) {
       deleteMaintenanceRun(maintenanceRunData?.data.id)
+    } else {
+      closeFlow()
     }
-    closeFlow()
   }
 
-  const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation({})
+  const {
+    deleteMaintenanceRun,
+    isLoading: isDeleteLoading,
+  } = useDeleteMaintenanceRunMutation({
+    onSuccess: () => closeFlow(),
+    onError: () => closeFlow(),
+  })
 
   const handleCleanUpAndClose = (): void => {
     if (maintenanceRunData?.data.id == null) handleClose()
@@ -234,7 +239,7 @@ export const PipetteWizardFlows = (
       : undefined
   const calibrateBaseProps = {
     chainRunCommands: chainMaintenanceRunCommands,
-    isRobotMoving: isCommandMutationLoading,
+    isRobotMoving: isCommandMutationLoading || isDeleteLoading,
     proceed,
     maintenanceRunId,
     goBack,
@@ -255,11 +260,11 @@ export const PipetteWizardFlows = (
       proceed={handleCleanUpAndClose}
       goBack={cancelExit}
       isOnDevice={isOnDevice}
-      isRobotMoving={isCommandMutationLoading}
+      isRobotMoving={isCommandMutationLoading || isDeleteLoading}
     />
   ) : (
     <ExitModal
-      isRobotMoving={isCommandMutationLoading}
+      isRobotMoving={isCommandMutationLoading || isDeleteLoading}
       goBack={cancelExit}
       proceed={handleCleanUpAndClose}
       flowType={flowType}
@@ -383,7 +388,7 @@ export const PipetteWizardFlows = (
   }
 
   let exitWizardButton = onExit
-  if (isCommandMutationLoading) {
+  if (isCommandMutationLoading || isDeleteLoading) {
     exitWizardButton = undefined
   } else if (errorMessage != null && isExiting) {
     exitWizardButton = handleClose


### PR DESCRIPTION
fix [RABR-290](https://opentrons.atlassian.net/browse/RABR-290)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
In two previous PR's we stopped waiting for a maintenance run to get deleted before closing gripper and wizard flows. This fixed a few visual bugs where the spinner was removed before the modals closed, but caused a bug where you could try to create a new maintenance run before the previous one was deleted. This PR adds back in waiting for the delete mutation to resolve before exiting and adds logic to show the spinner while the mutation is loading.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. Ensure this fixes the bug where opening, quickly closing, and opening another gripper flow causes a 500 error since the deletion isn't complete before another is created
2. Exit out of pipette and gripper flows and ensure the loader shows from the time the home begins to the time the modal is closed

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
1. Move `closeFlow()` back to the resolve call back of `useDeleteMaintenanceRunMutation`
2. Grab `isLoading` from the same mutation and use it wherever we show a spinner

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
Quick code check - @ncdiehl11, @vegano1 and I have done some testing on this
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[RABR-290]: https://opentrons.atlassian.net/browse/RABR-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ