### PR TITLE
refactor(robot-server): Deduplicate command models between /runs and /maintenance_runs

### DIFF
--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -1,12 +1,10 @@
 """Router for /maintenance_runs commands endpoints."""
 import textwrap
-from datetime import datetime
 from typing import Optional, Union
 from typing_extensions import Final, Literal
 
 from anyio import move_on_after
 from fastapi import APIRouter, Depends, Query, status
-from pydantic import BaseModel, Field
 
 from opentrons.protocol_engine import (
     ProtocolEngine,
@@ -16,13 +14,18 @@ from opentrons.protocol_engine.errors import CommandDoesNotExistError
 
 from robot_server.errors.error_responses import ErrorDetails, ErrorBody
 from robot_server.service.json_api import (
-    RequestModel,
     SimpleBody,
     MultiBody,
     MultiBodyMeta,
     PydanticResponse,
 )
 from robot_server.robot.control.dependencies import require_estop_in_good_state
+from robot_server.runs.command_models import (
+    RequestModelWithCommandCreate,
+    CommandCollectionLinks,
+    CommandLink,
+    CommandLinkMeta,
+)
 
 from ..maintenance_run_models import (
     MaintenanceRunCommandSummary,
@@ -42,17 +45,6 @@ _DEFAULT_COMMAND_LIST_LENGTH: Final = 20
 commands_router = APIRouter()
 
 
-class RequestModelWithCommandCreate(RequestModel[pe_commands.CommandCreate]):
-    """Equivalent to RequestModel[CommandCreate].
-
-    This works around a Pydantic v<2 bug where RequestModel[CommandCreate]
-    doesn't parse using the CommandCreate union discriminator.
-    https://github.com/pydantic/pydantic/issues/3782
-    """
-
-    data: pe_commands.CommandCreate
-
-
 class CommandNotFound(ErrorDetails):
     """An error if a given run command is not found."""
 
@@ -65,35 +57,6 @@ class CommandNotAllowed(ErrorDetails):
 
     id: Literal["CommandNotAllowed"] = "CommandNotAllowed"
     title: str = "Setup Command Not Allowed"
-
-
-class CommandLinkMeta(BaseModel):
-    """Metadata about a command resource referenced in `links`."""
-
-    runId: str = Field(..., description="The ID of the command's run.")
-    commandId: str = Field(..., description="The ID of the command.")
-    index: int = Field(..., description="Index of the command in the overall list.")
-    key: str = Field(..., description="Value of the current command's `key` field.")
-    createdAt: datetime = Field(
-        ...,
-        description="When the current command was created.",
-    )
-
-
-class CommandLink(BaseModel):
-    """A link to a command resource."""
-
-    href: str = Field(..., description="The path to a command")
-    meta: CommandLinkMeta = Field(..., description="Information about the command.")
-
-
-class CommandCollectionLinks(BaseModel):
-    """Links returned along with a collection of commands."""
-
-    current: Optional[CommandLink] = Field(
-        None,
-        description="Path to the currently running or next queued command.",
-    )
 
 
 async def get_current_run_engine_from_url(

--- a/robot-server/robot_server/runs/command_models.py
+++ b/robot-server/robot_server/runs/command_models.py
@@ -1,0 +1,53 @@
+"""Request and response models for dealing with run commands.
+
+These are shared between the `/runs` and `/maintenance_runs` endpoints.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from opentrons.protocol_engine import commands as pe_commands
+
+from robot_server.service.json_api.request import RequestModel
+
+
+class RequestModelWithCommandCreate(RequestModel[pe_commands.CommandCreate]):
+    """Equivalent to RequestModel[CommandCreate].
+
+    This works around a Pydantic v<2 bug where RequestModel[CommandCreate]
+    doesn't parse using the CommandCreate union discriminator.
+    https://github.com/pydantic/pydantic/issues/3782
+    """
+
+    data: pe_commands.CommandCreate
+
+
+class CommandLinkMeta(BaseModel):
+    """Metadata about a command resource referenced in `links`."""
+
+    runId: str = Field(..., description="The ID of the command's run.")
+    commandId: str = Field(..., description="The ID of the command.")
+    index: int = Field(..., description="Index of the command in the overall list.")
+    key: str = Field(..., description="Value of the current command's `key` field.")
+    createdAt: datetime = Field(
+        ...,
+        description="When the current command was created.",
+    )
+
+
+class CommandLink(BaseModel):
+    """A link to a command resource."""
+
+    href: str = Field(..., description="The path to a command")
+    meta: CommandLinkMeta = Field(..., description="Information about the command.")
+
+
+class CommandCollectionLinks(BaseModel):
+    """Links returned along with a collection of commands."""
+
+    current: Optional[CommandLink] = Field(
+        None,
+        description="Path to the currently running or next queued command.",
+    )

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -108,7 +108,7 @@ async def get_current_run_engine_from_url(
     description=textwrap.dedent(
         """
         Add a single command to the run. You can add commands to a run
-        for two reasons:
+        for three reasons:
 
         - Setup commands (`data.source == "setup"`)
         - Protocol commands (`data.source == "protocol"`)

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -27,14 +27,16 @@ from robot_server.maintenance_runs.maintenance_run_models import (
     MaintenanceRunNotFoundError,
 )
 from robot_server.maintenance_runs.router.commands_router import (
-    CommandCollectionLinks,
-    CommandLink,
-    CommandLinkMeta,
-    RequestModelWithCommandCreate,
     create_run_command,
     get_run_command,
     get_run_commands,
     get_current_run_engine_from_url,
+)
+from robot_server.runs.command_models import (
+    RequestModelWithCommandCreate,
+    CommandCollectionLinks,
+    CommandLink,
+    CommandLinkMeta,
 )
 
 

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -16,15 +16,17 @@ from opentrons.protocol_engine import (
 from robot_server.errors.error_responses import ApiError
 from robot_server.service.json_api import MultiBodyMeta
 
+from robot_server.runs.command_models import (
+    RequestModelWithCommandCreate,
+    CommandCollectionLinks,
+    CommandLink,
+    CommandLinkMeta,
+)
 from robot_server.runs.run_store import RunStore, CommandNotFoundError
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.run_data_manager import RunDataManager
 from robot_server.runs.run_models import RunCommandSummary, RunNotFoundError
 from robot_server.runs.router.commands_router import (
-    CommandCollectionLinks,
-    CommandLink,
-    CommandLinkMeta,
-    RequestModelWithCommandCreate,
     create_run_command,
     get_run_command,
     get_run_commands,


### PR DESCRIPTION
# Overview

The `/runs/{id}/commands` and `/maintenance_runs/{id}/commands` endpoints were using identical request and response models. This PR shares them. This goes towards EXEC-458.

# Test plan

None needed.

# Risk assessment

Low.