### PR TITLE
fix(app): properly fall back to load order module matching on map view OT2 module setup

### DIFF
--- a/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesMap.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesMap.tsx
@@ -54,7 +54,8 @@ export const SetupModulesMap = ({
   const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
     attachedModules,
     protocolModulesInfo,
-    actualDeckConfig
+    actualDeckConfig,
+    robotType
   )
 
   const modulesOnDeck = attachedProtocolModuleMatches.map(module => ({

--- a/app/src/organisms/ProtocolSetupModulesAndDeck/utils.ts
+++ b/app/src/organisms/ProtocolSetupModulesAndDeck/utils.ts
@@ -2,6 +2,8 @@ import {
   DeckConfiguration,
   FLEX_ROBOT_TYPE,
   NON_CONNECTING_MODULE_TYPES,
+  OT2_ROBOT_TYPE,
+  RobotType,
   checkModuleCompatibility,
   getCutoutFixturesForModuleModel,
   getCutoutIdsFromModuleSlotName,
@@ -16,14 +18,15 @@ export type AttachedProtocolModuleMatch = ProtocolModuleInfo & {
   attachedModuleMatch: AttachedModule | null
 }
 
-// NOTE: this is a FLEX only function
-// some logic copied from useModuleRenderInfoForProtocolById
+// NOTE: some logic copied from useModuleRenderInfoForProtocolById
 export function getAttachedProtocolModuleMatches(
   attachedModules: AttachedModule[],
   protocolModulesInfo: ProtocolModuleInfo[],
-  deckConfig: DeckConfiguration
+  deckConfig: DeckConfiguration,
+  robotType: RobotType = FLEX_ROBOT_TYPE
 ): AttachedProtocolModuleMatch[] {
-  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE) // this is only used for Flex ODD
+  const deckDef = getDeckDefFromRobotType(robotType)
+  const robotSupportsModuleConfig = robotType !== OT2_ROBOT_TYPE
   const matchedAttachedModules: AttachedModule[] = []
   const attachedProtocolModuleMatches = protocolModulesInfo.map(
     protocolModule => {
@@ -49,12 +52,14 @@ export function getAttachedProtocolModuleMatches(
                 matchedAttachedModule.serialNumber ===
                 attachedModule.serialNumber
             ) &&
-            // check deck config has module with expected serial number in expected location
-            deckConfig.some(
-              ({ cutoutId, opentronsModuleSerialNumber }) =>
-                attachedModule.serialNumber === opentronsModuleSerialNumber &&
-                moduleCutoutIds.includes(cutoutId)
-            )
+            // then if robotType supports configurable modules check the deck config has a
+            // a module with the expected serial number in the expected location
+            (!robotSupportsModuleConfig ||
+              deckConfig.some(
+                ({ cutoutId, opentronsModuleSerialNumber }) =>
+                  attachedModule.serialNumber === opentronsModuleSerialNumber &&
+                  moduleCutoutIds.includes(cutoutId)
+              ))
         ) ?? null
       if (compatibleAttachedModule !== null) {
         matchedAttachedModules.push(compatibleAttachedModule)


### PR DESCRIPTION
# Overview

Don't look to deck configuration for matching specced modules to attached modules within the module
setup step of the OT-2

Closes [RQA-2735](https://opentrons.atlassian.net/browse/RQA-2735)

# Review requests

confirm that multiples of a module works as expected in protocol setup on an OT-2

# Risk assessment
low

[RQA-2735]: https://opentrons.atlassian.net/browse/RQA-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ