### PR TITLE
fix(app): disable exit button after successful pipette attach/detach

### DIFF
--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -233,6 +233,7 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
         <SecondaryButton
           marginRight={SPACING.spacing8}
           onClick={toCalibrationDashboard}
+          disabled={isDisabled}
         >
           {t('calibrate_pipette_offset')}
         </SecondaryButton>

--- a/app/src/organisms/ChangePipette/ConfirmPipette.tsx
+++ b/app/src/organisms/ChangePipette/ConfirmPipette.tsx
@@ -58,6 +58,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
     actualPipette,
     setConfirmPipetteLevel,
     confirmPipetteLevel,
+    isDisabled,
   } = props
   const { t } = useTranslation('change_pipette')
 
@@ -141,6 +142,7 @@ export function ConfirmPipette(props: ConfirmPipetteProps): JSX.Element {
           <SuccessAndExitButtons
             {...props}
             confirmPipetteLevel={confirmPipetteLevel}
+            isDisabled={isDisabled}
           />
         ) : null}
       </>
@@ -221,6 +223,7 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
     toCalibrationDashboard,
     success,
     wrongWantedPipette,
+    isDisabled,
   } = props
   const { t } = useTranslation('change_pipette')
   return (
@@ -234,7 +237,11 @@ function SuccessAndExitButtons(props: ConfirmPipetteProps): JSX.Element {
           {t('calibrate_pipette_offset')}
         </SecondaryButton>
       ) : null}
-      <PrimaryButton textTransform={TEXT_TRANSFORM_CAPITALIZE} onClick={exit}>
+      <PrimaryButton
+        textTransform={TEXT_TRANSFORM_CAPITALIZE}
+        onClick={exit}
+        disabled={isDisabled}
+      >
         {t('shared:exit')}
       </PrimaryButton>
     </>

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -435,6 +435,9 @@ describe('ConfirmPipette', () => {
     }
     const { getByRole } = render(props)
     expect(getByRole('button', { name: 'exit' })).toBeDisabled()
+    expect(
+      getByRole('button', { name: 'Calibrate pipette offset' })
+    ).toBeDisabled()
   })
   it('should render buttons as disabled on failure when robot is in motion/isDisabled is true', () => {
     props = {

--- a/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
+++ b/app/src/organisms/ChangePipette/__tests__/ConfirmPipette.test.tsx
@@ -427,7 +427,16 @@ describe('ConfirmPipette', () => {
     fireEvent.click(pocBtn)
     expect(props.toCalibrationDashboard).toBeCalled()
   })
-  it('should render buttons as disabled when robot is in motion/isDisabled is true', () => {
+  it('should render buttons as disabled on success when robot is in motion/isDisabled is true', () => {
+    props = {
+      ...props,
+      success: true,
+      isDisabled: true,
+    }
+    const { getByRole } = render(props)
+    expect(getByRole('button', { name: 'exit' })).toBeDisabled()
+  })
+  it('should render buttons as disabled on failure when robot is in motion/isDisabled is true', () => {
     props = {
       ...props,
       success: false,


### PR DESCRIPTION
Closes [RQA-2731](https://opentrons.atlassian.net/browse/RQA-2731)

# Overview

On OT-2, after a pipette is attached or detached successfully, the exit button should only be clickable once, so that many home commands are not emitted in rapid succession with each click.

https://github.com/Opentrons/opentrons/assets/47604184/60913798-92a5-4693-9668-22b96df7e60b


https://github.com/Opentrons/opentrons/assets/47604184/d7a0d0c4-a44a-4969-bd2e-d46b1d68b2e5




# Test Plan

- start attach flow for an OT-2 pipette
- after completing steps successfully, click "Exit" button
- observe that button immediately becomes disabled after clicking
- repeat above with detach flow

# Changelog

- pass down `isDisabled` prop to success exit button

# Review requests

js

# Risk assessment

low

[RQA-2731]: https://opentrons.atlassian.net/browse/RQA-2731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ