### PR TITLE
docs(api): Python requirements and simulation behavior in Tutorial

### DIFF
--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -21,7 +21,9 @@ Before You Begin
 
 You're going to write some Python code, but you don't need to be a Python expert to get started writing Opentrons protocols. You should know some basic Python syntax, like how it uses `indentation <https://docs.python.org/3/reference/lexical_analysis.html#indentation>`_ to group blocks of code, dot notation for `calling methods <https://docs.python.org/3/tutorial/classes.html#method-objects>`_, and the format of `lists <https://docs.python.org/3/tutorial/introduction.html#lists>`_ and `dictionaries <https://docs.python.org/3/tutorial/datastructures.html#dictionaries>`_. You’ll also be using `common control structures <https://docs.python.org/3/tutorial/controlflow.html#if-statements>`_ like ``if`` statements and ``for`` loops. 
 
-To run your code, make sure that you've installed `Python 3 <https://wiki.python.org/moin/BeginnersGuide/Download>`_ and the `pip package installer <https://pip.pypa.io/en/stable/getting-started/>`_. You should write your code in your favorite plaintext editor or development environment and save it in a file with a ``.py`` extension, like ``dilution-tutorial.py``.
+You should write your code in your favorite plaintext editor or development environment and save it in a file with a ``.py`` extension, like ``dilution-tutorial.py``.
+
+To run your code, make sure that you've installed `Python 3.10 <https://www.python.org/downloads/>`_ and the `pip package installer <https://pip.pypa.io/en/stable/getting-started/>`_. If you don't use Python 3.10 as your system Python, we recommend using `pyenv <https://github.com/pyenv/pyenv>`_ to manage multiple Python versions.
 
 Hardware and Labware
 --------------------
@@ -339,13 +341,7 @@ To see a text preview of the steps your Flex or OT-2 will take, use the change d
 
     opentrons_simulate dilution-tutorial.py
 
-This should generate a lot of output! As written, the protocol has about 1000 steps. If you’re curious how long that will take, you can use an experimental feature to estimate the time:
-
-.. prompt:: bash
-
-    opentrons_simulate dilution-tutorial.py -e -o nothing
-
-The ``-e`` flag estimates duration, and ``-o nothing`` suppresses printing the run log. This indicates that using a single-channel pipette for serial dilution across the whole plate will take about half an hour — plenty of time to grab a coffee while your robot pipettes for you! ☕️ 
+This should generate a lot of output! As written, the protocol has about 1000 steps. In fact, using a single-channel pipette for serial dilution across the whole plate will take about half an hour — plenty of time to grab a coffee while your robot pipettes for you! ☕️
 
 If that’s too long, you can always cancel your run partway through or modify ``for i in range(8)`` to loop through fewer rows.
 

--- a/api/docs/v2/tutorial.rst
+++ b/api/docs/v2/tutorial.rst
@@ -23,7 +23,7 @@ You're going to write some Python code, but you don't need to be a Python expert
 
 You should write your code in your favorite plaintext editor or development environment and save it in a file with a ``.py`` extension, like ``dilution-tutorial.py``.
 
-To run your code, make sure that you've installed `Python 3.10 <https://www.python.org/downloads/>`_ and the `pip package installer <https://pip.pypa.io/en/stable/getting-started/>`_. If you don't use Python 3.10 as your system Python, we recommend using `pyenv <https://github.com/pyenv/pyenv>`_ to manage multiple Python versions.
+To simulate your code, you'll need `Python 3.10 <https://www.python.org/downloads/>`_ and the `pip package installer <https://pip.pypa.io/en/stable/getting-started/>`_. Newer versions of Python aren't yet supported by the Python Protocol API. If you don't use Python 3.10 as your system Python, we recommend using `pyenv <https://github.com/pyenv/pyenv>`_ to manage multiple Python versions.
 
 Hardware and Labware
 --------------------


### PR DESCRIPTION
# Overview

Some changes to the Tutorial page to reflect the current requirements and capabilities of `opentrons_simulate`.

Notably, the duration estimator never made it out of beta and is fully broken now, so mentions of it have been removed.

# Test Plan

[Tutorial in sandbox](http://sandbox.docs.opentrons.com/docs-simulation-python-updates/v2/tutorial.html)

# Changelog

- Mention Python 3.10 and `pyenv`
- Remove instruction to use `opentrons_simulate -e`

# Risk assessment

none