### PR TITLE
fix(app): clear intervention modal if run is finishing

### DIFF
--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -42,10 +42,7 @@ import { ProgressBar } from '../../atoms/ProgressBar'
 import { useDownloadRunLog, useRobotType } from '../Devices/hooks'
 import { InterventionTicks } from './InterventionTicks'
 import { isInterventionCommand } from '../InterventionModal/utils'
-import {
-  useNotifyLastRunCommand,
-  useNotifyRunQuery,
-} from '../../resources/runs'
+import { useNotifyRunQuery } from '../../resources/runs'
 
 import type { RunStatus } from '@opentrons/api-client'
 
@@ -82,7 +79,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     pageLength: 1,
   })
   const analysisCommands = analysis?.commands ?? []
-  const lastRunCommand = useNotifyLastRunCommand(runId)
+  const lastRunCommand = allCommandsQueryData?.data[0] ?? null
   const runCommandsLength = allCommandsQueryData?.meta.totalLength
 
   const downloadIsDisabled =

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -42,7 +42,10 @@ import { ProgressBar } from '../../atoms/ProgressBar'
 import { useDownloadRunLog, useRobotType } from '../Devices/hooks'
 import { InterventionTicks } from './InterventionTicks'
 import { isInterventionCommand } from '../InterventionModal/utils'
-import { useNotifyRunQuery } from '../../resources/runs'
+import {
+  useNotifyLastRunCommand,
+  useNotifyRunQuery,
+} from '../../resources/runs'
 
 import type { RunStatus } from '@opentrons/api-client'
 
@@ -79,7 +82,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     pageLength: 1,
   })
   const analysisCommands = analysis?.commands ?? []
-  const lastRunCommand = allCommandsQueryData?.data[0] ?? null
+  const lastRunCommand = useNotifyLastRunCommand(runId)
   const runCommandsLength = allCommandsQueryData?.meta.totalLength
 
   const downloadIsDisabled =

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -25,6 +25,7 @@ import {
   RUN_STATUS_STOP_REQUESTED,
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
   RUN_STATUS_AWAITING_RECOVERY,
+  RUN_STATUS_FINISHING,
 } from '@opentrons/api-client'
 
 import { useFeatureFlag } from '../../redux/config'
@@ -203,7 +204,8 @@ export function RunningProtocol(): JSX.Element {
             {interventionModalCommandKey != null &&
             runRecord?.data != null &&
             lastRunCommand != null &&
-            isInterventionCommand(lastRunCommand) ? (
+            isInterventionCommand(lastRunCommand) &&
+            runStatus !== RUN_STATUS_FINISHING ? (
               <InterventionModal
                 robotName={robotName}
                 command={lastRunCommand}


### PR DESCRIPTION
Closes RQA-2730

# Overview

Remove InterventionModal if run is finishing. Implement useNotifyLastRunCommand in desktop RunProgressMeter

# Test Plan

- run a protocol in which the last command is an intervention command (pause, etc.)
- resume the protocol on desktop app
- verify that the modal clears when the run is finishing
- repeat the above steps on ODD

# Changelog

- introduce `useNotifyLastRunCommand` hook to `RunProgressMeter`
- check for run finishing status to remove intervention modal

# Review requests

@b-cooper per work together

# Risk assessment

low