### PR TITLE
refactor(api): extract RTP definitions and set values during runner load

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -602,7 +602,9 @@ def _run_file_non_pe(
     try:
         # TODO (spp, 2024-03-18): use true run-time param overrides once enabled
         #  for cli protocol simulation/ execution
-        execute_apiv2.run_protocol(protocol, context, run_time_param_overrides=None)
+        execute_apiv2.run_protocol(
+            protocol, context, run_time_parameters_with_overrides=None
+        )
     finally:
         context.cleanup()
 

--- a/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
+++ b/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
@@ -21,12 +21,14 @@ from opentrons.protocol_api import (
     ProtocolContext,
     ParameterContext,
     create_protocol_context,
+    Parameters,
 )
 from opentrons.protocol_api.core.engine import ENGINE_CORE_API_VERSION
 from opentrons.protocol_api.core.legacy.load_info import LoadInfo
 
 from opentrons.protocols.parse import PythonParseMode, parse
 from opentrons.protocols.execution.execute import run_protocol
+from opentrons.protocols.execution.execute_python import exec_add_parameters
 from opentrons.protocols.types import Protocol, PythonProtocol
 
 
@@ -148,10 +150,22 @@ class PythonProtocolExecutor:
     async def execute(
         protocol: Protocol,
         context: ProtocolContext,
-        parameter_context: Optional[ParameterContext],
-        run_time_param_values: Optional[RunTimeParamValuesType],
+        run_time_parameters_with_overrides: Optional[Parameters],
     ) -> None:
         """Execute a PAPIv2 protocol with a given ProtocolContext in a child thread."""
         await to_thread.run_sync(
-            run_protocol, protocol, context, parameter_context, run_time_param_values
+            run_protocol, protocol, context, run_time_parameters_with_overrides
+        )
+
+    @staticmethod
+    def extract_run_parameters(
+        protocol: PythonProtocol,
+        parameter_context: ParameterContext,
+        run_time_param_overrides: Optional[RunTimeParamValuesType],
+    ) -> Optional[Parameters]:
+        """Extract the parameters defined in the protocol, overridden with values for the run."""
+        return exec_add_parameters(
+            protocol=protocol,
+            parameter_context=parameter_context,
+            run_time_param_overrides=run_time_param_overrides,
         )

--- a/api/src/opentrons/protocols/execution/execute.py
+++ b/api/src/opentrons/protocols/execution/execute.py
@@ -28,12 +28,11 @@ def run_protocol(
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute
     :param context: The protocol context to use.
     :param run_time_parameters_with_overrides: Run time parameters defined in the protocol,
-        updated with the run's RTP override values.
+        updated with the run's RTP override values. When we are running either simulate
+        or execute, this will be None (until RTP is supported in cli commands)
     """
     if isinstance(protocol, PythonProtocol):
         if protocol.api_level >= APIVersion(2, 0):
-            # If this is None here then we're either running simulate or execute, in any case we don't need to report
-            # this in analysis which is the reason we'd pass it to this function
             exec_run(
                 proto=protocol,
                 context=context,

--- a/api/src/opentrons/protocols/execution/execute.py
+++ b/api/src/opentrons/protocols/execution/execute.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from opentrons.protocol_api import ProtocolContext
 from opentrons.protocol_api._parameters import Parameters
-from opentrons.protocols.execution.execute_python import run_python
+from opentrons.protocols.execution.execute_python import exec_run
 from opentrons.protocols.execution.json_dispatchers import (
     pipette_command_map,
     temperature_module_command_map,
@@ -34,7 +34,7 @@ def run_protocol(
         if protocol.api_level >= APIVersion(2, 0):
             # If this is None here then we're either running simulate or execute, in any case we don't need to report
             # this in analysis which is the reason we'd pass it to this function
-            run_python(
+            exec_run(
                 proto=protocol,
                 context=context,
                 run_time_parameters_with_overrides=run_time_parameters_with_overrides,

--- a/api/src/opentrons/protocols/execution/execute.py
+++ b/api/src/opentrons/protocols/execution/execute.py
@@ -1,8 +1,8 @@
 import logging
 from typing import Optional
 
-from opentrons.protocol_api import ProtocolContext, ParameterContext
-from opentrons.protocol_engine.types import RunTimeParamValuesType
+from opentrons.protocol_api import ProtocolContext
+from opentrons.protocol_api._parameters import Parameters
 from opentrons.protocols.execution.execute_python import run_python
 from opentrons.protocols.execution.json_dispatchers import (
     pipette_command_map,
@@ -21,27 +21,23 @@ MODULE_LOG = logging.getLogger(__name__)
 def run_protocol(
     protocol: Protocol,
     context: ProtocolContext,
-    parameter_context: Optional[ParameterContext] = None,
-    run_time_param_overrides: Optional[RunTimeParamValuesType] = None,
+    run_time_parameters_with_overrides: Optional[Parameters] = None,
 ) -> None:
     """Run a protocol.
 
     :param protocol: The :py:class:`.protocols.types.Protocol` to execute
     :param context: The protocol context to use.
-    :param parameter_context: The parameter context to use.
-    :param run_time_param_overrides: Any parameter values that are potentially overriding the defaults
+    :param run_time_parameters_with_overrides: Run time parameters defined in the protocol,
+        updated with the run's RTP override values.
     """
     if isinstance(protocol, PythonProtocol):
         if protocol.api_level >= APIVersion(2, 0):
             # If this is None here then we're either running simulate or execute, in any case we don't need to report
             # this in analysis which is the reason we'd pass it to this function
-            if parameter_context is None:
-                parameter_context = ParameterContext(protocol.api_level)
             run_python(
                 proto=protocol,
                 context=context,
-                parameter_context=parameter_context,
-                run_time_param_overrides=run_time_param_overrides,
+                run_time_parameters_with_overrides=run_time_parameters_with_overrides,
             )
         else:
             raise RuntimeError(f"Unsupported python API version: {protocol.api_level}")

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -85,34 +85,57 @@ def _parse_and_set_parameters(
     return parameter_context.export_parameters_for_protocol()
 
 
+def _get_filename(
+    protocol: PythonProtocol,
+) -> str:
+    # TODO(mm, 2023-10-11): This coupling to opentrons.protocols.parse is fragile.
+    # Can we get the correct filename directly from proto.contents?
+    if protocol.filename and protocol.filename.endswith("zip"):
+        # The ".zip" extension needs to match what opentrons.protocols.parse recognizes as a bundle,
+        # and the "protocol.ot2.py" fallback needs to match what opentrons.protocol.py sets as the
+        # AST filename.
+        return "protocol.ot2.py"
+    else:
+        # "<protocol>" needs to match what opentrons.protocols.parse sets as the fallback
+        # AST filename.
+        return protocol.filename or "<protocol>"
+
+
+def exec_add_parameters(
+    protocol: PythonProtocol,
+    parameter_context: ParameterContext,
+    run_time_param_overrides: Optional[RunTimeParamValuesType],
+) -> Optional[Parameters]:
+    """Exec the add_parameters function and get the final run time parameters with overrides."""
+    new_globs: Dict[Any, Any] = {}
+    exec(protocol.contents, new_globs)
+    filename = _get_filename(protocol)
+
+    return (
+        _parse_and_set_parameters(
+            parameter_context=parameter_context,
+            run_time_param_overrides=run_time_param_overrides,
+            new_globs=new_globs,
+            filename=filename,
+        )
+        if new_globs.get("add_parameters")
+        else None
+    )
+
+
 def run_python(
     proto: PythonProtocol,
     context: ProtocolContext,
-    parameter_context: ParameterContext,
-    run_time_param_overrides: Optional[RunTimeParamValuesType] = None,
+    run_time_parameters_with_overrides: Optional[Parameters] = None,
 ) -> None:
     new_globs: Dict[Any, Any] = {}
     exec(proto.contents, new_globs)
     # If the protocol is written correctly, it will have defined a function
     # like run(context: ProtocolContext). If so, that function is now in the
     # current scope.
-
-    # TODO(mm, 2023-10-11): This coupling to opentrons.protocols.parse is fragile.
-    # Can we get the correct filename directly from proto.contents?
-    if proto.filename and proto.filename.endswith("zip"):
-        # The ".zip" extension needs to match what opentrons.protocols.parse recognizes as a bundle,
-        # and the "protocol.ot2.py" fallback needs to match what opentrons.protocol.py sets as the
-        # AST filename.
-        filename = "protocol.ot2.py"
-    else:
-        # "<protocol>" needs to match what opentrons.protocols.parse sets as the fallback
-        # AST filename.
-        filename = proto.filename or "<protocol>"
-
-    if new_globs.get("add_parameters"):
-        context._params = _parse_and_set_parameters(
-            parameter_context, run_time_param_overrides, new_globs, filename
-        )
+    filename = _get_filename(proto)
+    if run_time_parameters_with_overrides:
+        context._params = run_time_parameters_with_overrides
 
     try:
         _runfunc_ok(new_globs.get("run"))

--- a/api/src/opentrons/protocols/execution/execute_python.py
+++ b/api/src/opentrons/protocols/execution/execute_python.py
@@ -123,7 +123,7 @@ def exec_add_parameters(
     )
 
 
-def run_python(
+def exec_run(
     proto: PythonProtocol,
     context: ProtocolContext,
     run_time_parameters_with_overrides: Optional[Parameters] = None,

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -874,7 +874,9 @@ def _run_file_non_pe(
         try:
             # TODO (spp, 2024-03-18): use true run-time param overrides once enabled
             #  for cli protocol simulation/ execution
-            execute.run_protocol(protocol, context, run_time_param_overrides=None)
+            execute.run_protocol(
+                protocol, context, run_time_parameters_with_overrides=None
+            )
             if (
                 isinstance(protocol, PythonProtocol)
                 and protocol.api_level >= APIVersion(2, 0)

--- a/api/tests/opentrons/data/testosaur_with_rtp.py
+++ b/api/tests/opentrons/data/testosaur_with_rtp.py
@@ -1,0 +1,44 @@
+from opentrons import protocol_api
+
+metadata = {
+    "protocolName": "Testosaur with RTP",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": 'A variant on "Dinosaur" for testing with Run time parameters',
+    "source": "Opentrons Repository",
+    "apiLevel": "2.18",
+}
+
+
+def add_parameters(parameters: protocol_api.ParameterContext) -> None:
+    parameters.add_int(
+        display_name="Sample count",
+        variable_name="sample_count",
+        default=3,
+        minimum=1,
+        maximum=6,
+        description="How many samples to process.",
+    )
+    parameters.add_str(
+        display_name="Mount",
+        variable_name="mount",
+        choices=[
+            {"display_name": "Left Mount", "value": "left"},
+            {"display_name": "Right Mount", "value": "right"},
+        ],
+        default="left",
+        description="What mount to use.",
+    )
+
+
+def run(ctx: protocol_api.ProtocolContext) -> None:
+    tip_rack = ctx.load_labware("opentrons_96_tiprack_300ul", 8)
+    source = ctx.load_labware("nest_12_reservoir_15ml", 1)
+    dest = ctx.load_labware("corning_96_wellplate_360ul_flat", 2)
+
+    pipette = ctx.load_instrument("p300_single_gen2", ctx.params.mount, [tip_rack])  # type: ignore[attr-defined]
+
+    for i in range(ctx.params.sample_count):  # type: ignore[attr-defined]
+        pipette.pick_up_tip()
+        pipette.aspirate(50, source.wells_by_name()["A1"])
+        pipette.dispense(50, dest.wells()[i])
+        pipette.return_tip()

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -604,8 +604,7 @@ async def test_load_legacy_python(
         await python_protocol_executor.execute(
             protocol=legacy_protocol,
             context=protocol_context,
-            parameter_context=python_runner_subject._parameter_context,
-            run_time_param_values=None,
+            run_time_parameters_with_overrides=None,
         ),
     )
 
@@ -746,8 +745,7 @@ async def test_load_legacy_json(
         await python_protocol_executor.execute(
             protocol=legacy_protocol,
             context=protocol_context,
-            parameter_context=python_runner_subject._parameter_context,
-            run_time_param_values=None,
+            run_time_parameters_with_overrides=None,
         ),
     )
 

--- a/api/tests/opentrons/protocols/execution/test_execute_python.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_python.py
@@ -1,4 +1,7 @@
 import pytest
+
+from opentrons import APIVersion
+from opentrons.protocol_api import ParameterContext
 from opentrons.protocols.execution import execute, execute_python
 from opentrons.protocols.parse import parse
 
@@ -93,3 +96,17 @@ metadata={"apiLevel": "2.0"};
         execute.run_protocol(protocol, context=ctx)
     assert "[line 5]" in str(e.value)
     assert "Exception [line 5]: hi" in str(e.value)
+
+
+@pytest.mark.ot2_only
+@pytest.mark.parametrize("protocol_file", ["testosaur_with_rtp.py"])
+def test_rtp_extraction(protocol, protocol_file) -> None:
+    """It should set the RTP definitions in protocol with override values from run."""
+    proto = parse(protocol.text, protocol.filename)
+    parameter_context = ParameterContext(api_version=APIVersion(2, 18))
+    run_time_param_overrides = {"sample_count": 2}
+    assert execute_python.exec_add_parameters(  # type: ignore
+        protocol=proto,
+        parameter_context=parameter_context,
+        run_time_param_overrides=run_time_param_overrides,
+    ).get_all() == {"sample_count": 2, "mount": "left"}

--- a/api/tests/opentrons/protocols/execution/test_execute_python.py
+++ b/api/tests/opentrons/protocols/execution/test_execute_python.py
@@ -1,7 +1,7 @@
 import pytest
 
-from opentrons import APIVersion
 from opentrons.protocol_api import ParameterContext
+from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.execution import execute, execute_python
 from opentrons.protocols.parse import parse
 


### PR DESCRIPTION
Addresses AUTH-282

# Overview

First part of the two-part changes required to make RTP values be available earlier during analysis.
This PR moves extraction of RTP definitions and setting the values of the params to run load stage. This makes sure that the final RTP values are available to the runner before the run is played.

# Test Plan

Mainly need to make sure that current protocol execution hasn't changed from any client perspective. Unit and integration tests passing should be enough.

# Review requests

- usual code review and make sure I am not missing anything related to the python protocol execution pipeline

# Risk assessment

Low. Refactor
