### PR TITLE
fix(protocol-designer): do not duplicate into adjacent h-s slot for o…

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -17,6 +17,7 @@ import {
   THERMOCYCLER_MODULE_TYPE,
   FLEX_ROBOT_TYPE,
   WASTE_CHUTE_CUTOUT,
+  getAreSlotsAdjacent,
 } from '@opentrons/shared-data'
 import { actions as stepFormActions } from '../../../step-forms'
 import { INITIAL_DECK_SETUP_STEP_ID } from '../../../constants'
@@ -267,14 +268,22 @@ export function CreateFileWizard(): JSX.Element | null {
       const hasOt2TC = modules.find(
         module => module.type === THERMOCYCLER_MODULE_TYPE
       )
+      const heaterShakerSlot = modules.find(
+        module => module.type === HEATERSHAKER_MODULE_TYPE
+      )?.slot
       const OT2_MIDDLE_SLOTS = hasOt2TC ? ['2', '5'] : ['2', '5', '8', '11']
+      const modifiedOt2Slots = OT2_MIDDLE_SLOTS.filter(slot =>
+        heaterShakerSlot != null
+          ? !getAreSlotsAdjacent(heaterShakerSlot, slot)
+          : slot
+      )
       newTiprackModels.forEach((tiprackDefURI, index) => {
         dispatch(
           labwareIngredActions.createContainer({
             slot:
               values.fields.robotType === FLEX_ROBOT_TYPE
                 ? FLEX_MIDDLE_SLOTS[index]
-                : OT2_MIDDLE_SLOTS[index],
+                : modifiedOt2Slots[index],
             labwareDefURI: tiprackDefURI,
             adapterUnderLabwareDefURI:
               values.pipettesByMount.left.pipetteName === 'p1000_96'

--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -53,11 +53,12 @@ export const createContainer: (
   const state = getState()
   const initialDeckSetup = stepFormSelectors.getInitialDeckSetup(state)
   const robotType = getRobotType(state)
-  const slot =
-    args.slot || getNextAvailableDeckSlot(initialDeckSetup, robotType)
   const labwareDef = labwareDefSelectors.getLabwareDefsByURI(state)[
     args.labwareDefURI
   ]
+  const slot =
+    args.slot ||
+    getNextAvailableDeckSlot(initialDeckSetup, robotType, labwareDef)
   const isTiprack = getIsTiprack(labwareDef)
 
   if (slot) {
@@ -122,7 +123,14 @@ export const duplicateLabware: (
   const initialDeckSetup = stepFormSelectors.getInitialDeckSetup(state)
   const templateLabwareIdIsOffDeck =
     initialDeckSetup.labware[templateLabwareId].slot === 'offDeck'
-  const duplicateSlot = getNextAvailableDeckSlot(initialDeckSetup, robotType)
+  const labwareDef = labwareDefSelectors.getLabwareDefsByURI(state)[
+    templateLabwareDefURI
+  ]
+  const duplicateSlot = getNextAvailableDeckSlot(
+    initialDeckSetup,
+    robotType,
+    labwareDef
+  )
   if (duplicateSlot == null) {
     console.error('no slots available, cannot duplicate labware')
   }


### PR DESCRIPTION
…t-2 tall labware

closes RQA-2716

# Overview

This bug has certainly existed in production since PD 6.0.0 i think. Shout out to Derek for finding it. Basically, the heater-shaker on the ot-2 has many collision warnings and any tall labware greater than 53mm can hit the heater-shaker when it is in motion. So this PR filters out the adjacent slots of the heater-shaker when duplicating the labware on the deck and the initial set up when the tipracks are auto generated.

# Test Plan

Follow the steps outlined in the ticket. Basically, you don't want the tiprack auto generating or duplicating into slot 2.

# Changelog

- add logic to special case the heater-shaker tall labware on ot-2 for create file wizard and get next available slot util

# Review requests

see test plan

# Risk assessment

low