### PR TITLE
fix(protocol-designer): enable arrow when reaching max slots 

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
@@ -151,7 +151,6 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
     } else if (numItems > 0) {
       downArrowStyle = ARROW_STYLE_ACTIVE
     }
-    console.log('isDisabled', isDisabled, )
     iconInfo = (
       <Flex
         flexDirection={DIRECTION_COLUMN}

--- a/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
@@ -151,7 +151,7 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
     } else if (numItems > 0) {
       downArrowStyle = ARROW_STYLE_ACTIVE
     }
-
+    console.log('isDisabled', isDisabled, )
     iconInfo = (
       <Flex
         flexDirection={DIRECTION_COLUMN}
@@ -176,7 +176,7 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
         <Flex
           data-testid="EquipmentOption_downArrow"
           onClick={
-            isDisabled || numMultiples === 0
+            numMultiples === 0
               ? undefined
               : () => {
                   multiples.setValue(numMultiples - 1)

--- a/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/ModulesAndOtherTile.tsx
@@ -223,7 +223,7 @@ function FlexModuleFields(props: WizardTileProps): JSX.Element {
           getNumSlotsAvailable(modules, additionalEquipment) === 0
         //  special-casing TC since it takes up 2 slots
         if (moduleType === THERMOCYCLER_MODULE_TYPE) {
-          isDisabled = getNumSlotsAvailable(modules, additionalEquipment) === 1
+          isDisabled = getNumSlotsAvailable(modules, additionalEquipment) <= 1
         }
 
         const handleMultiplesClick = (num: number): void => {


### PR DESCRIPTION
closes RQA-2718

# Overview

When reaching max capacity on the deck, the down arrow for the multiple temp modules was disabled. This PR fixes that

# Test Plan

add 7 temperature modules to reach max capacity and then press the down arrow to delete them

# Changelog

- modify on click cta 
- fix bug with the TC disabled

# Review requests

see test plan

# Risk assessment

low