### PR TITLE
fix(protocol-designer): disabled color logic and pause step item ui

### DIFF
--- a/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
+++ b/protocol-designer/src/components/LiquidsPage/LiquidEditForm.tsx
@@ -97,7 +97,7 @@ export function LiquidEditForm(props: LiquidEditFormProps): JSX.Element {
 
   const {
     handleSubmit,
-    formState: { errors, isDirty, touchedFields },
+    formState: { errors, touchedFields },
     control,
     watch,
     setValue,
@@ -117,6 +117,7 @@ export function LiquidEditForm(props: LiquidEditFormProps): JSX.Element {
       serialize: values.serialize || false,
     })
   }
+
   return (
     <Card className={styles.form_card}>
       <form onSubmit={handleSubmit(handleLiquidEdits)}>
@@ -215,7 +216,10 @@ export function LiquidEditForm(props: LiquidEditFormProps): JSX.Element {
           </DeprecatedPrimaryButton>
           <DeprecatedPrimaryButton
             disabled={
-              !isDirty || errors.name != null || errors.displayColor != null
+              !touchedFields.name ||
+              errors.name != null ||
+              name === '' ||
+              errors.displayColor != null
             }
             type="submit"
           >

--- a/protocol-designer/src/components/steplist/PauseStepItems.tsx
+++ b/protocol-designer/src/components/steplist/PauseStepItems.tsx
@@ -15,6 +15,7 @@ export function PauseStepItems(props: Props): JSX.Element | null {
   }
   const { message, wait } = pauseArgs
   const { hours, minutes, seconds } = pauseArgs.meta
+
   return (
     <>
       {wait !== true ? (
@@ -41,9 +42,9 @@ export function PauseStepItems(props: Props): JSX.Element | null {
           </li>
         </>
       )}
-      {message && (
+      {message != null && message !== '' ? (
         <li className={styles.substep_content}>&quot;{message}&quot;</li>
-      )}
+      ) : null}
     </>
   )
 }


### PR DESCRIPTION
closes RQA-2710 RQA-2720

# Overview

Fixes a few bugs found in RC-B:
1. submit button disabled reason for adding a color 
2. removing the empty quotes from the pause step item

# Test Plan

- create a flex or ot-2 protocol.
- Add a color and first add a description followed by a name. see that the submit button is disabled until a name is added
- go to the deck map and add a pause with no message. create the pause step and see on the timeline that the pause step item does not show empty quotes

# Changelog

- refine logic for showing the message for a pause step item
- refine disabled logic for when the submit button is disabled for the liquid

# Review requests

see test plan

# Risk assessment

low