### PR TITLE
fix(protocol-designer): disable load liquid save if no liquid selected

### DIFF
--- a/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
+++ b/protocol-designer/src/components/LiquidPlacementForm/LiquidPlacementForm.tsx
@@ -237,7 +237,13 @@ export const LiquidPlacementForm = (): JSX.Element | null => {
           </OutlineButton>
           <DeprecatedPrimaryButton
             type="submit"
-            disabled={volumeErrors != null || volume == null || volume === ''}
+            disabled={
+              volumeErrors != null ||
+              volume == null ||
+              volume === '' ||
+              selectedLiquidId == null ||
+              selectedLiquidId === ''
+            }
           >
             {t('button:save')}
           </DeprecatedPrimaryButton>


### PR DESCRIPTION
Closes RQA-2728

# Overview

When loading a liquid into labware wells in LiquidPlacementForm, we need to disable 'Save' if the volume is 0, null, or '', OR the selected liquid is null or ''.

# Test Plan

- Create OT-2 or Flex PD protocol 
- Create a liquid
- Load a labware
- Select the labware's 'Name and Liquids' to add a liquid
- Select any wells of the labware
- Enter a non-zero volume, but leave the 'Liquid' dropdown empty
- Verify that the 'Save' button is disabled

<img width="1349" alt="Screenshot 2024-05-20 at 10 48 01 AM" src="https://github.com/Opentrons/opentrons/assets/47604184/f1ce5b13-a448-4e0e-8c4d-3445ba518720">


# Changelog

- check for null or empty string value for `selectedLiquidId` in `LiquidPlacementForm` save button disabled prop

# Risk assessment
low