### PR TITLE
docs(robot-server): Correct and unify the definition of "current"

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -520,6 +520,8 @@ class CommandView(HasState[CommandState]):
         queued_command_ids = self._state.command_history.get_queue_ids()
         total_length = self._state.command_history.length()
 
+        # TODO(mm, 2024-05-17): This looks like it's attempting to do the same thing
+        # as self.get_current(), but in a different way. Can we unify them?
         if cursor is None:
             if running_command is not None:
                 cursor = running_command.index

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -184,7 +184,10 @@ class MaintenanceRunDataManager:
         return the_slice
 
     def get_current_command(self, run_id: str) -> Optional[CurrentCommand]:
-        """Get the currently executing command, if any.
+        """Get the "current" command, if any.
+
+        See `ProtocolEngine.state_view.commands.get_current()` for the definition
+        of "current."
 
         Args:
             run_id: ID of the run.

--- a/robot-server/robot_server/runs/command_models.py
+++ b/robot-server/robot_server/runs/command_models.py
@@ -49,5 +49,9 @@ class CommandCollectionLinks(BaseModel):
 
     current: Optional[CommandLink] = Field(
         None,
-        description="Path to the currently running or next queued command.",
+        description=(
+            'Information about the "current" command.'
+            ' The "current" command is the one that\'s running right now,'
+            " or, if there is none, the one that was running most recently."
+        ),
     )

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -373,7 +373,10 @@ class RunDataManager:
         )
 
     def get_current_command(self, run_id: str) -> Optional[CurrentCommand]:
-        """Get the currently executing command, if any.
+        """Get the "current" command, if any.
+
+        See `ProtocolEngine.state_view.commands.get_current()` for the definition
+        of "current."
 
         Args:
             run_id: ID of the run.


### PR DESCRIPTION
# Overview

This tries to resolve some confusion around the `cursor` query parameter and `links.current` field in the `GET /runs/{id}/commands` and `GET /maintenance_runs/{id}/commands` endpoints.

# Test plan

None needed.

# Changelog

`links.current` is a bit confusing:

* The public OpenAPI spec says that it returns the command that's currently running or **next queued.**
* The docstring on the internal low-level Python code says that it returns the command that's currently running or **most recently completed.**
* The Python implementation appears to actually return the command that's currently running or **most recently completed.**

Compare with the `cursor` *query param* of `GET /runs/{id}/commands`, which appears consistent about returning the currently running or **most recently completed** command.

This PR changes the OpenAPI spec of `links.current` to say it's the currently running or **most recently completed** command. This unifies everything. I'm working under the premise that this reflects what we have now, and it's working fine, and we have no reason to change it.

# Review requests

Am I misreading the `StateView.get_slice()` and `StateView.get_current()` implementation logic and misunderstanding the current behavior?

If this is the current behavior, is my premise correct that it's fine and we have no reason to change it?

# Risk assessment

No risk.
