### PR TITLE
fix(protocol-designer): default to correct tiprack uri

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TiprackField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TiprackField.tsx
@@ -36,6 +36,13 @@ export function TiprackField(props: TiprackFieldProps): JSX.Element {
     defaultTiprackUris.includes(option.value)
   )
 
+  React.useEffect(() => {
+    //  if default value is not included in the pipette's tiprack uris then
+    //  change it so it is
+    if (!defaultTiprackUris.includes(value as string)) {
+      updateValue(defaultTiprackUris[0])
+    }
+  }, [defaultTiprackUris, value, updateValue])
   const hasMissingTiprack = defaultTiprackUris.length > tiprackOptions.length
   return (
     <Box {...targetProps}>

--- a/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
+++ b/protocol-designer/src/step-forms/test/createPresavedStepForm.test.ts
@@ -141,7 +141,7 @@ describe('createPresavedStepForm', () => {
       pipette: 'leftPipetteId',
       nozzles: null,
       stepType: 'moveLiquid',
-      tipRack: 'defaultTipRack',
+      tipRack: null,
       // default fields
       dropTip_location: 'mockTrash',
       aspirate_airGap_checkbox: false,
@@ -228,7 +228,7 @@ describe('createPresavedStepForm', () => {
         volume: undefined,
         aspirate_flowRate: null,
         dispense_flowRate: null,
-        tipRack: 'defaultTipRack',
+        tipRack: null,
         blowout_flowRate: null,
       })
     })

--- a/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
+++ b/protocol-designer/src/step-forms/utils/createPresavedStepForm.ts
@@ -118,45 +118,6 @@ const _patchDefaultDropTipLocation = (args: {
   return null
 }
 
-const _patchDefaultTiprack = (args: {
-  initialDeckSetup: InitialDeckSetup
-  labwareEntities: LabwareEntities
-  pipetteEntities: PipetteEntities
-  savedStepForms: SavedStepFormState
-  orderedStepIds: OrderedStepIdsState
-}): FormUpdater => formData => {
-  const {
-    initialDeckSetup,
-    labwareEntities,
-    pipetteEntities,
-    savedStepForms,
-    orderedStepIds,
-  } = args
-  const defaultPipetteId = getNextDefaultPipetteId(
-    savedStepForms,
-    orderedStepIds,
-    initialDeckSetup.pipettes
-  )
-
-  const pipetteFirstTiprackDefUri =
-    pipetteEntities[defaultPipetteId].tiprackDefURI[0]
-  const formHasTipRackField = formData && 'tipRack' in formData
-
-  if (formHasTipRackField) {
-    const updatedFields = handleFormChange(
-      {
-        tipRack: pipetteFirstTiprackDefUri,
-      },
-      formData,
-      pipetteEntities,
-      labwareEntities
-    )
-    return updatedFields
-  }
-
-  return null
-}
-
 const _patchDefaultMagnetFields = (args: {
   initialDeckSetup: InitialDeckSetup
   orderedStepIds: OrderedStepIdsState
@@ -312,14 +273,6 @@ export const createPresavedStepForm = ({
     additionalEquipmentEntities,
   })
 
-  const updateDefaultTipRack = _patchDefaultTiprack({
-    initialDeckSetup,
-    labwareEntities,
-    orderedStepIds,
-    pipetteEntities,
-    savedStepForms,
-  })
-
   const updateDefaultPipette = _patchDefaultPipette({
     initialDeckSetup,
     labwareEntities,
@@ -360,7 +313,6 @@ export const createPresavedStepForm = ({
   return [
     updateDefaultPipette,
     updateDefaultDropTip,
-    updateDefaultTipRack,
     updateTemperatureModuleId,
     updateThermocyclerFields,
     updateHeaterShakerModuleId,


### PR DESCRIPTION
closes RQA-2709

# Overview

PD now selects correct default tiprack

paired with @ncdiehl11 

# Test Plan

Create an ot-2 protocol with a p10 single and 10uL tiprack and p300 single and 300uL tiprack. 
add a labware to the deck
create a transfer step for the p10 single pipette
create a transfer step for the p300 single pipette
see that the highlighted wells are in the correct labware

# Changelog

- remove the presaved tiprack logic
- replace that presaved tiprack logic to a use effect in the tiprack field

# Review requests

see test plan

# Risk assessment

low