### PR TITLE
feat(protocol-designer): y position tooltip and migration copy

### DIFF
--- a/protocol-designer/cypress/e2e/migrations.cy.js
+++ b/protocol-designer/cypress/e2e/migrations.cy.js
@@ -106,7 +106,7 @@ describe('Protocol fixtures migrate and match snapshots', () => {
           if (migrationModal === 'v8.1') {
             cy.get('div')
               .contains(
-                'The default dispense height is now 1mm from the bottom of the well'
+                'The default dispense height is now 1 mm from the bottom of the well'
               )
               .should('exist')
             cy.get('button').contains('ok', { matchCase: false }).click()

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -10,6 +10,8 @@ import {
   RadioGroup,
   SPACING,
   StyledText,
+  Tooltip,
+  useHoverTooltip,
 } from '@opentrons/components'
 import { getMainPagePortalEl } from '../../../portals/MainPageModalPortal'
 import { getIsTouchTipField } from '../../../../form-types'
@@ -51,11 +53,12 @@ export const TipPositionModal = (
     wellYWidthMm,
     closeModal,
   } = props
+  const [targetProps, tooltipProps] = useHoverTooltip()
   const zSpec = specs.z
   const ySpec = specs.y
   const xSpec = specs.x
 
-  const { t } = useTranslation(['modal', 'button'])
+  const { t } = useTranslation(['modal', 'button', 'tooltip'])
 
   if (zSpec == null || xSpec == null || ySpec == null) {
     console.error(
@@ -255,7 +258,11 @@ export const TipPositionModal = (
           value={xValue ?? ''}
         />
       </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing4}
+        {...targetProps}
+      >
         <StyledText as="label" paddingLeft={SPACING.spacing24}>
           {t('tip_position.field_titles.y_position')}
         </StyledText>
@@ -290,6 +297,8 @@ export const TipPositionModal = (
           value={zValue !== null ? zValue : ''}
         />
       </Flex>
+
+      <Tooltip {...tooltipProps}>{t('tooltip:y_position_value')}</Tooltip>
     </Flex>
   ) : null
 

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -261,6 +261,7 @@ export const TipPositionModal = (
       <Flex
         flexDirection={DIRECTION_COLUMN}
         gridGap={SPACING.spacing4}
+        width="max-content"
         {...targetProps}
       >
         <StyledText as="label" paddingLeft={SPACING.spacing24}>
@@ -278,6 +279,7 @@ export const TipPositionModal = (
           units="mm"
           value={yValue ?? ''}
         />
+        <Tooltip {...tooltipProps}>{t('tooltip:y_position_value')}</Tooltip>
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
         <StyledText as="label" paddingLeft={SPACING.spacing24}>
@@ -297,8 +299,6 @@ export const TipPositionModal = (
           value={zValue !== null ? zValue : ''}
         />
       </Flex>
-
-      <Tooltip {...tooltipProps}>{t('tooltip:y_position_value')}</Tooltip>
     </Flex>
   ) : null
 

--- a/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/MoveLiquidForm/SourceDestFields.tsx
@@ -145,24 +145,6 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
           </>
         )}
 
-        <CheckboxRowField
-          {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
-          label={t('step_edit_form.field.touchTip.label')}
-          className={styles.small_field}
-        >
-          <TipPositionField
-            propsForFields={propsForFields}
-            zField={`${prefix}_touchTip_mmFromBottom`}
-            labwareId={
-              formData[
-                getLabwareFieldForPositioningField(
-                  addFieldNamePrefix('touchTip_mmFromBottom')
-                )
-              ]
-            }
-          />
-        </CheckboxRowField>
-
         {prefix === 'dispense' && (
           <CheckboxRowField
             {...propsForFields.blowout_checkbox}
@@ -192,6 +174,25 @@ export const SourceDestFields = (props: SourceDestFieldsProps): JSX.Element => {
             />
           </CheckboxRowField>
         )}
+
+        <CheckboxRowField
+          {...propsForFields[addFieldNamePrefix('touchTip_checkbox')]}
+          label={t('step_edit_form.field.touchTip.label')}
+          className={styles.small_field}
+        >
+          <TipPositionField
+            propsForFields={propsForFields}
+            zField={`${prefix}_touchTip_mmFromBottom`}
+            labwareId={
+              formData[
+                getLabwareFieldForPositioningField(
+                  addFieldNamePrefix('touchTip_mmFromBottom')
+                )
+              ]
+            }
+          />
+        </CheckboxRowField>
+
         <CheckboxRowField
           {...propsForFields[addFieldNamePrefix('airGap_checkbox')]}
           label={t('step_edit_form.field.airGap.label')}

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -108,6 +108,7 @@ export const getToV8_1MigrationMessage = (props: ModalProps): ModalContents => {
         </p>
         <p>{t('migrations.toV8_1Migration.body2')}</p>
         <p>{t('migrations.toV8_1Migration.body3')}</p>
+        <p>{t('migrations.toV8_1Migration.body4')}</p>
       </div>
     ),
   }

--- a/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
+++ b/protocol-designer/src/components/modals/FileUploadMessageModal/modalContents.tsx
@@ -108,7 +108,6 @@ export const getToV8_1MigrationMessage = (props: ModalProps): ModalContents => {
         </p>
         <p>{t('migrations.toV8_1Migration.body2')}</p>
         <p>{t('migrations.toV8_1Migration.body3')}</p>
-        <p>{t('migrations.toV8_1Migration.body4')}</p>
       </div>
     ),
   }

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -274,9 +274,8 @@
     },
     "toV8_1Migration": {
       "body1": "Your protocol will be automatically updated to the latest version.",
-      "body2": "The default dispense height is now 1mm from the bottom of the well. If your protocol contains any dispense commands without a custom height, it will be automatically updated.",
-      "body3": "Additionally, we have updated the default order for advanced settings. If both a touch tip and blow out are selected, the order is now swapped and will emit a touch tip followed by a blow out",
-      "body4": "As always, please contact us with any questions or feedback."
+      "body2": "The default dispense height is now 1 mm from the bottom of the well, instead of 0.5 mm. All dispense commands without a custom height will change to use the new default height.",
+      "body3": "Additionally, blowout actions now precede touch tip actions. The new order affects all dispenses that include both actions."
     },
     "toV8Migration": {
       "body1": "Your protocol will be automatically updated to the latest version.",

--- a/protocol-designer/src/localization/en/modal.json
+++ b/protocol-designer/src/localization/en/modal.json
@@ -275,7 +275,8 @@
     "toV8_1Migration": {
       "body1": "Your protocol will be automatically updated to the latest version.",
       "body2": "The default dispense height is now 1mm from the bottom of the well. If your protocol contains any dispense commands without a custom height, it will be automatically updated.",
-      "body3": "As always, please contact us with any questions or feedback."
+      "body3": "Additionally, we have updated the default order for advanced settings. If both a touch tip and blow out are selected, the order is now swapped and will emit a touch tip followed by a blow out",
+      "body4": "As always, please contact us with any questions or feedback."
     },
     "toV8Migration": {
       "body1": "Your protocol will be automatically updated to the latest version.",

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -10,6 +10,7 @@
   "not_enough_space_for_temp": "There is not enough space on the deck to add more temperature modules",
   "not_in_beta": "ⓘ Coming Soon",
   "missing_tiprack": "Missing a tiprack? Make sure it is added to the deck",
+  "y_position_value": "A negative value moves towards the front",
 
   "step_description": {
     "heaterShaker": "Set heat, shake, or labware latch commands for the Heater-Shaker module",
@@ -41,7 +42,7 @@
       "dispense_flowRate": "The speed at which the pipette dispenses",
       "dispense_mix_checkbox": "Pipette up and down after dispensing",
       "dispense_mmFromBottom": "Adjust tip position for dispense",
-      "dispense_touchTip_checkbox": "Touch tip to each side of well after dispensing",
+      "dispense_touchTip_checkbox": "Touch tip to each side of well after dispensing and other dispense advanced setting commands",
       "dispense_touchTip_mmFromBottom": "Distance from the bottom of the well",
       "disposalVolume_checkbox": "Aspirate extra volume that is disposed of after a multi-dispense is complete. We recommend a disposal volume of at least the pipette's minimum.",
       "heaterShakerSetTimer": "Once this counter has elapsed, the module will deactivate the heater and shaker",


### PR DESCRIPTION
closes AUTH-398 AUTH-409

# Overview

Add the advanced setting change to the migration modal

<img width="629" alt="Screenshot 2024-05-20 at 12 27 25" src="https://github.com/Opentrons/opentrons/assets/66035149/6101465e-9685-4034-a979-00cb185fa487">

also add a tooltip to the z position input field indicating what a negative number is

<img width="641" alt="Screenshot 2024-05-20 at 12 31 14" src="https://github.com/Opentrons/opentrons/assets/66035149/d6f5531d-c6b3-4c55-862c-e4fbb4a24993">

# Test Plan

import the attached protocol and observe the migration modal mentioning the tooltip and blow out advanced setting changes

go to the timeline and add a transfer step, go to the tip position modal and hover over the y position input field


# Changelog

- add tooltip to modal
- edit the migration modal copy

# Review requests

see test plan

# Risk assessment

low