### PR TITLE
fix(protocol-designer): offset tip in blowout location vizualization

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
@@ -7,6 +7,7 @@ import WELL_CROSS_SECTION_IMAGE from '../../../../images/well_cross_section.svg'
 import styles from './TipPositionInput.module.css'
 
 const WELL_HEIGHT_PIXELS = 145
+const TIP_X_OFFSET_PIXELS = 20
 const PIXEL_DECIMALS = 2
 interface TipPositionZAxisVizProps {
   wellDepthMm: number
@@ -30,7 +31,7 @@ export function TipPositionZAxisViz(
       <img
         src={PIPETTE_TIP_IMAGE}
         className={styles.pipette_tip_image}
-        style={{ bottom: `${bottomPx}px` }}
+        style={{ bottom: `${bottomPx}px`, right: `${TIP_X_OFFSET_PIXELS}px` }}
       />
       {props.wellDepthMm !== null && (
         <span className={styles.well_height_label}>{props.wellDepthMm}mm</span>

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionZAxisViz.tsx
@@ -7,7 +7,7 @@ import WELL_CROSS_SECTION_IMAGE from '../../../../images/well_cross_section.svg'
 import styles from './TipPositionInput.module.css'
 
 const WELL_HEIGHT_PIXELS = 145
-const TIP_X_OFFSET_PIXELS = 20
+const TIP_X_OFFSET_PIXELS = 22
 const PIXEL_DECIMALS = 2
 interface TipPositionZAxisVizProps {
   wellDepthMm: number


### PR DESCRIPTION
Closes [RQA-2747](https://opentrons.atlassian.net/browse/RQA-2747)

# Overview

Add constant tip offset in x-direction for blowout location vizualization in well

# Test Plan

- create transfer step and select blowout location option
- verify that tip appears centered on visualizer

<img width="603" alt="Screenshot 2024-05-20 at 4 18 55 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/af108222-901f-484c-8abc-b4f3cea74761">


# Changelog
- add constant x offset for tip position

# Review requests

@jerader 

# Risk assessment
low

[RQA-2747]: https://opentrons.atlassian.net/browse/RQA-2747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ