### PR TITLE
fix(protocol-designer): submit and don't show again fixes

### DIFF
--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -83,7 +83,7 @@ export const FilePage = (): JSX.Element => {
   const saveFileMetadata = (nextFormValues: FileMetadataFields): void => {
     dispatch(actions.saveFileMetadata(nextFormValues))
   }
-
+  const [isManualDirty, setManualDirty] = React.useState<boolean>(false)
   const {
     handleSubmit,
     watch,
@@ -91,7 +91,6 @@ export const FilePage = (): JSX.Element => {
     setValue,
     formState: { isDirty },
   } = useForm<FileMetadataFields>({ defaultValues: formValues })
-
   //  to ensure that values from watch are up to date if the defaultValues
   //  change
   React.useEffect(() => {
@@ -155,6 +154,7 @@ export const FilePage = (): JSX.Element => {
                     name="protocolName"
                     value={protocolName}
                     onChange={field.onChange}
+                    onClick={() => setManualDirty(true)}
                   />
                 )}
               />
@@ -172,6 +172,7 @@ export const FilePage = (): JSX.Element => {
                     name="author"
                     value={author}
                     onChange={field.onChange}
+                    onClick={() => setManualDirty(true)}
                   />
                 )}
               />
@@ -190,6 +191,7 @@ export const FilePage = (): JSX.Element => {
                   name="description"
                   value={description}
                   onChange={field.onChange}
+                  onClick={() => setManualDirty(true)}
                 />
               )}
             />
@@ -198,9 +200,12 @@ export const FilePage = (): JSX.Element => {
             <OutlineButton
               type="submit"
               className={styles.update_button}
-              disabled={!isDirty}
+              disabled={!isDirty || !isManualDirty}
+              onClick={() => setManualDirty(false)}
             >
-              {isDirty ? t('application:update') : t('application:updated')}
+              {isManualDirty
+                ? t('application:update')
+                : t('application:updated')}
             </OutlineButton>
           </div>
         </form>

--- a/protocol-designer/src/components/Hints/index.tsx
+++ b/protocol-designer/src/components/Hints/index.tsx
@@ -21,9 +21,13 @@ const HINT_IS_ALERT: HintKey[] = ['add_liquids_and_labware']
 
 export const Hints = (): JSX.Element | null => {
   const { t } = useTranslation(['alert', 'nav', 'button'])
-  const [rememberDismissal, toggleRememberDismissal] = React.useState<boolean>(
+  const [rememberDismissal, setRememberDismissal] = React.useState<boolean>(
     false
   )
+
+  const toggleRememberDismissal = React.useCallback(() => {
+    setRememberDismissal(prevDismissal => !prevDismissal)
+  }, [])
   const hintKey = useSelector(selectors.getHint)
   const dispatch = useDispatch()
   const removeHint = (hintKey: HintKey): void => {
@@ -159,9 +163,7 @@ export const Hints = (): JSX.Element | null => {
         <DeprecatedCheckboxField
           className={styles.dont_show_again}
           label={t('hint.dont_show_again')}
-          onChange={() => {
-            toggleRememberDismissal(rememberDismissal)
-          }}
+          onChange={toggleRememberDismissal}
           value={rememberDismissal}
         />
         <OutlineButton


### PR DESCRIPTION
closes RQA-2715 RQA-2719

# Overview

Addresses 2 bugs:
1. fixes the logic for don't show again checkbox in the modals
2. fixes the update button for editing the metadata

# Test Plan

-Go to settings and click on the `Restore all hints and tips notifications` restore button (if you can't click it then its restored so no worries)
- create a flex or ot-2 protocol
- edit the metadata (author, name, etc) and see that the update button works as expected and disables when there are no new changes
- go to the deck map and see the hint modal for `Setting up your protocol`. Click on the don't show again checkbox and make sure it works as expected

# Changelog

- add a use callback for the don't show again checkbox logic
- add a manual `isDirty` state for keeping track of when the update button is disabled/not disabled 

# Review requests

see test plan

# Risk assessment

low
