### PR TITLE
fix(app): instead filter magnetic blocks (not magnetic modules) out of the required modules

### DIFF
--- a/app/src/pages/ProtocolDetails/Hardware.tsx
+++ b/app/src/pages/ProtocolDetails/Hardware.tsx
@@ -19,6 +19,8 @@ import {
   getModuleType,
   getFixtureDisplayName,
   GRIPPER_V1_2,
+  MAGNETIC_BLOCK_FIXTURES,
+  MAGNETIC_BLOCK_TYPE,
 } from '@opentrons/shared-data'
 
 import {
@@ -119,6 +121,16 @@ function HardwareItem({
       <LocationIcon slotName={getCutoutDisplayName(hardware.location.cutout)} />
     )
   }
+  const isMagneticBlockFixture =
+    hardware.hardwareType === 'fixture' &&
+    hardware.cutoutFixtureId != null &&
+    MAGNETIC_BLOCK_FIXTURES.includes(hardware.cutoutFixtureId)
+  let iconModuleType = null
+  if (hardware.hardwareType === 'module') {
+    iconModuleType = getModuleType(hardware.moduleModel)
+  } else if (isMagneticBlockFixture) {
+    iconModuleType = MAGNETIC_BLOCK_TYPE
+  }
   return (
     <TableRow>
       <TableDatum>
@@ -126,19 +138,16 @@ function HardwareItem({
       </TableDatum>
       <TableDatum>
         <Flex paddingLeft={SPACING.spacing24}>
-          {hardware.hardwareType === 'module' && (
+          {iconModuleType != null ? (
             <Flex
               alignItems={ALIGN_CENTER}
               height="2rem"
               paddingBottom={SPACING.spacing4}
               paddingRight={SPACING.spacing8}
             >
-              <ModuleIcon
-                moduleType={getModuleType(hardware.moduleModel)}
-                size="1.75rem"
-              />
+              <ModuleIcon moduleType={iconModuleType} size="1.75rem" />
             </Flex>
-          )}
+          ) : null}
           <StyledText as="p">{hardwareName}</StyledText>
         </Flex>
       </TableDatum>

--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -14,8 +14,8 @@ import {
   getCutoutFixturesForModuleModel,
   FLEX_MODULE_ADDRESSABLE_AREAS,
   getModuleType,
-  MAGNETIC_MODULE_TYPE,
   FLEX_USB_MODULE_ADDRESSABLE_AREAS,
+  MAGNETIC_BLOCK_TYPE,
 } from '@opentrons/shared-data'
 import { getLabwareSetupItemGroups } from '../utils'
 import { getProtocolUsesGripper } from '../../../organisms/ProtocolSetupInstruments/utils'
@@ -111,7 +111,8 @@ export const useRequiredProtocolHardwareFromAnalysis = (
     : []
 
   const requiredModules: ProtocolModule[] = analysis.modules
-    .filter(m => getModuleType(m.model) !== MAGNETIC_MODULE_TYPE)
+    // remove magnetic blocks, they're handled by required fixtures
+    .filter(m => getModuleType(m.model) !== MAGNETIC_BLOCK_TYPE)
     .map(({ location, model }) => {
       const cutoutIdForSlotName = getCutoutIdForSlotName(
         location.slotName,


### PR DESCRIPTION
# Overview

Fix bug where we were accidentally filtering magnetic modules instead of magnetic blocks from the
required modules list from analysis.

Closes [RQA-2754](https://opentrons.atlassian.net/browse/RQA-2754)

# Review requests

send a protocol that requires the magnetic block to a Flex. From the Protocol detail page of the ODD, there should only be one listing for that required magnetic block in the hardware list. There should also be no incorrect location conflicts.

# Risk assessment
low

[RQA-2754]: https://opentrons.atlassian.net/browse/RQA-2754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ