### PR TITLE
fix(protocol-designer): fix diffing function in makeTimelineMiddleware

### DIFF
--- a/protocol-designer/src/timelineMiddleware/makeTimelineMiddleware.ts
+++ b/protocol-designer/src/timelineMiddleware/makeTimelineMiddleware.ts
@@ -1,3 +1,4 @@
+import isEqual from 'lodash/isEqual'
 import {
   getArgsAndErrorsByStepId,
   getOrderedStepIds,
@@ -21,7 +22,7 @@ const hasChanged = (
 ): boolean =>
   Object.keys(nextValues).some(
     (selectorKey: string) =>
-      nextValues[selectorKey] !== memoizedValues?.[selectorKey]
+      !isEqual(nextValues[selectorKey], memoizedValues?.[selectorKey])
   )
 
 const getTimelineArgs = (state: BaseState): GenerateRobotStateTimelineArgs => ({


### PR DESCRIPTION
Closes [RQA-2752](https://opentrons.atlassian.net/browse/RQA-2752)

# Overview

Undefined object values were resulting in `false` returns for `substepsNeedsRecompute`, in turn resulting in not propogating up errors from moving labware conflicts. This PR uses deep object equality checks with lodash isEqual to properly return true if our robot timeline needs recomputing.

# Test Plan

- follow steps outlined by the linked ticket above
- verify that the error message shows if move labware target slot is blocked by an initial robot state with any labware including tipracks in the target slot

# Changelog

- Use `lodash.isEqual` rather than `===` to determine object equality in `makeTimelineMiddleware` > `substepsNeedsRecompute` > `hasChanged`. This will correctly force a new robot state timeline generation.

# Review requests

auth js

# Risk assessment

medium

[RQA-2752]: https://opentrons.atlassian.net/browse/RQA-2752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ