### PR TITLE
fix(docker): need to specify platform

### DIFF
--- a/opentrons-ai-server/Dockerfile
+++ b/opentrons-ai-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.12
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 
 COPY --from=public.ecr.aws/datadog/lambda-extension:57 /opt/. /opt/
 

--- a/opentrons-ai-server/deploy.py
+++ b/opentrons-ai-server/deploy.py
@@ -37,7 +37,7 @@ class BaseDeploymentConfig:
 @dataclass(frozen=True)
 class CrtDeploymentConfig(BaseDeploymentConfig):
     ECR_REPOSITORY: str = "crt-ecr-repo"
-    ECR_URL: str = f"{get_aws_account_id}.dkr.ecr.{get_aws_region()}.amazonaws.com"
+    ECR_URL: str = f"{get_aws_account_id()}.dkr.ecr.{get_aws_region()}.amazonaws.com"
     FUNCTION_NAME: str = "crt-api-function"
     IMAGE_NAME: str = "crt-ai-server"
 


### PR DESCRIPTION
### Forgot to specify the platform explicitly.  

> When it was built on a mac, we got the wrong platform.