### PR TITLE
fix(protocol-designer): set default z value for TipPositionModal

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -54,7 +54,6 @@ export const TipPositionModal = (
     closeModal,
   } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
-  console.log(specs)
   const zSpec = specs.z
   const ySpec = specs.y
   const xSpec = specs.x

--- a/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/TipPositionField/TipPositionModal.tsx
@@ -54,6 +54,7 @@ export const TipPositionModal = (
     closeModal,
   } = props
   const [targetProps, tooltipProps] = useHoverTooltip()
+  console.log(specs)
   const zSpec = specs.z
   const ySpec = specs.y
   const xSpec = specs.x
@@ -72,7 +73,7 @@ export const TipPositionModal = (
   })
 
   const [zValue, setZValue] = React.useState<string | null>(
-    zSpec?.value == null ? null : String(zSpec?.value)
+    zSpec?.value == null ? String(defaultMmFromBottom) : String(zSpec?.value)
   )
   const [yValue, setYValue] = React.useState<string | null>(
     ySpec?.value == null ? null : String(ySpec?.value)


### PR DESCRIPTION
Closes RQA-2750

# Overview

If selecting a custom offset for TipPositionModal on a transfer step, the Z field should populate with the default offset from bottom rather than empty.

# Test Plan

- Setup a PD protocol on Flex or OT-2
- Create a transfer step
- Select a custom tip position for aspirate/dispense
- Click 'custom'
- Verify that the z field is the expected default (1mm) rather than empty

# Changelog

- set initial z value in useState on TipPositionModal

# Risk assessment

low