### PR TITLE
fix(app): fix slot validation on ODD location conflict check to account for thermocycler occupying 2 slots

### DIFF
--- a/app/src/pages/Protocols/hooks/index.ts
+++ b/app/src/pages/Protocols/hooks/index.ts
@@ -142,7 +142,7 @@ export const useRequiredProtocolHardwareFromAnalysis = (
         hasSlotConflict: deckConfig.some(
           ({ cutoutId, cutoutFixtureId }) =>
             cutoutId === getCutoutIdForSlotName(location.slotName, deckDef) &&
-            cutoutFixtureId !== getCutoutFixtureIdsForModuleModel(model)[0]
+            !getCutoutFixtureIdsForModuleModel(model).includes(cutoutFixtureId)
         ),
       }
     })


### PR DESCRIPTION

# Overview

Slot conflict checking did not account for the fact that the thermocycler (and any future multi-slot fixture) was composed of multiple fixtures. This means that the expected fixture (thermocycler front) was not returned, because thermocycler rear occupies the first slot in the list.

# Test Plan
Upload a protocol requiring a thermocycler to a Flex, ensure that from the main protocol list view page and the protocol dashboard do not list a location conflict.

# Risk assessment
low