### PR TITLE
refactor(protocol-designer): dismissed warning now dismisses for duration of protocol

### DIFF
--- a/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV3MigratedToV8.json
@@ -27,7 +27,7 @@
           "opentrons/opentrons_96_tiprack_300ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {
         "0": {
           "name": "Water",

--- a/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV4MigratedToV8.json
@@ -27,7 +27,7 @@
           "opentrons/opentrons_96_tiprack_300ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {
         "0": {
           "name": "Water",

--- a/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV7MigratedToV8.json
@@ -30,7 +30,7 @@
           "opentrons/opentrons_flex_96_filtertiprack_50ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {
         "0": {
           "name": "Water",

--- a/protocol-designer/fixtures/protocol/8/doItAllV8.json
+++ b/protocol-designer/fixtures/protocol/8/doItAllV8.json
@@ -27,7 +27,7 @@
           "opentrons/opentrons_flex_96_tiprack_1000ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {
         "0": {
           "name": "h20",

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -30,7 +30,7 @@
           "opentrons/tipone_96_tiprack_200ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {
         "0": {
           "name": "samples",

--- a/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
+++ b/protocol-designer/fixtures/protocol/8/mix_8_0_0.json
@@ -25,7 +25,7 @@
       "pipetteTiprackAssignments": {
         "pipetteId": ["opentrons/opentrons_96_tiprack_10ul/1"]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {},
       "ingredLocations": {},
       "savedStepForms": {

--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -27,7 +27,7 @@
           "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {},
       "ingredLocations": {},
       "savedStepForms": {

--- a/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
+++ b/protocol-designer/fixtures/protocol/8/ninetySixChannelFullAndColumn.json
@@ -27,7 +27,7 @@
           "opentrons/opentrons_flex_96_tiprack_50ul/1"
         ]
       },
-      "dismissedWarnings": { "form": {}, "timeline": {} },
+      "dismissedWarnings": { "form": [], "timeline": [] },
       "ingredients": {},
       "ingredLocations": {
         "9bd16b50-4ae9-4cfd-8583-3378087e6a6c:opentrons/opentrons_flex_96_tiprack_50ul/1": {}

--- a/protocol-designer/src/components/alerts/Alerts.tsx
+++ b/protocol-designer/src/components/alerts/Alerts.tsx
@@ -10,7 +10,6 @@ import {
 } from '../../dismiss'
 import { selectors as stepFormSelectors } from '../../step-forms'
 import { selectors as fileDataSelectors } from '../../file-data'
-import { PRESAVED_STEP_ID } from '../../steplist'
 import {
   getVisibleFormWarnings,
   getVisibleFormErrors,
@@ -152,15 +151,12 @@ const AlertsComponent = (props: Props): JSX.Element => {
       dispatch(
         dismissActions.dismissTimelineWarning({
           type: dismissId,
-          stepId,
         })
       )
     } else {
       dispatch(
         dismissActions.dismissFormWarning({
           type: dismissId,
-          //  if stepId does not exist, assume it is a presaved step
-          stepId: stepId ?? PRESAVED_STEP_ID,
         })
       )
     }

--- a/protocol-designer/src/dismiss/__tests__/reducers.test.ts
+++ b/protocol-designer/src/dismiss/__tests__/reducers.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { _allReducers } from '../reducers'
-import { PRESAVED_STEP_ID } from '../../steplist/types'
 import type { DismissedWarningState } from '../reducers'
 
 const { dismissedWarnings } = _allReducers
@@ -8,7 +7,7 @@ const { dismissedWarnings } = _allReducers
 let initialState: DismissedWarningState
 
 beforeEach(() => {
-  initialState = { form: {}, timeline: {} }
+  initialState = { form: [], timeline: [] }
 })
 
 describe('dismissedWarnings reducer', () => {
@@ -18,12 +17,11 @@ describe('dismissedWarnings reducer', () => {
       type: 'DISMISS_FORM_WARNING',
       payload: {
         type: 'BELOW_PIPETTE_MINIMUM_VOLUME',
-        stepId: 'someStepId',
       },
     }
     expect(dismissedWarnings(state, action)).toEqual({
-      form: { someStepId: ['BELOW_PIPETTE_MINIMUM_VOLUME'] },
-      timeline: {},
+      form: ['BELOW_PIPETTE_MINIMUM_VOLUME'],
+      timeline: [],
     })
   })
 
@@ -33,14 +31,11 @@ describe('dismissedWarnings reducer', () => {
       type: 'DISMISS_FORM_WARNING',
       payload: {
         type: 'BELOW_PIPETTE_MINIMUM_VOLUME',
-        stepId: PRESAVED_STEP_ID,
       },
     }
     expect(dismissedWarnings(state, action)).toEqual({
-      form: {
-        [PRESAVED_STEP_ID]: ['BELOW_PIPETTE_MINIMUM_VOLUME'],
-      },
-      timeline: {},
+      form: ['BELOW_PIPETTE_MINIMUM_VOLUME'],
+      timeline: [],
     })
   })
 
@@ -50,12 +45,11 @@ describe('dismissedWarnings reducer', () => {
       type: 'DISMISS_TIMELINE_WARNING',
       payload: {
         type: 'ASPIRATE_MORE_THAN_WELL_CONTENTS',
-        stepId: 'someStepId',
       },
     }
     expect(dismissedWarnings(state, action)).toEqual({
-      form: {},
-      timeline: { someStepId: ['ASPIRATE_MORE_THAN_WELL_CONTENTS'] },
+      form: [],
+      timeline: ['ASPIRATE_MORE_THAN_WELL_CONTENTS'],
     })
   })
 
@@ -65,84 +59,11 @@ describe('dismissedWarnings reducer', () => {
       type: 'DISMISS_TIMELINE_WARNING',
       payload: {
         type: 'ASPIRATE_MORE_THAN_WELL_CONTENTS',
-        stepId: PRESAVED_STEP_ID,
       },
     }
     expect(dismissedWarnings(state, action)).toEqual({
-      form: {},
-      timeline: {
-        [PRESAVED_STEP_ID]: ['ASPIRATE_MORE_THAN_WELL_CONTENTS'],
-      },
-    })
-  })
-
-  it('should forget all warnings for a form upon DELETE_STEP', () => {
-    const state = {
-      form: {
-        otherStepId: ['whatever_form'],
-        someStepId: ['BELOW_PIPETTE_MINIMUM_VOLUME'],
-      },
-      timeline: {
-        otherStepId: ['whatever_timeline'],
-        someStepId: ['ASPIRATE_MORE_THAN_WELL_CONTENTS'],
-      },
-    }
-
-    const action = {
-      type: 'DELETE_STEP',
-      payload: 'someStepId',
-    }
-
-    expect(dismissedWarnings(state, action)).toEqual({
-      form: { otherStepId: ['whatever_form'] },
-      timeline: { otherStepId: ['whatever_timeline'] },
-    })
-  })
-
-  it('should forget all warnings for multiple forms upon DELETE_MULTIPLE_STEPS', () => {
-    const state = {
-      form: {
-        firstStepId: ['firstStepId form warning'],
-        secondStepId: ['secondStepId form warning'],
-        thirdStepId: ['thirdStepId form warning'],
-      },
-      timeline: {
-        firstStepId: ['firstStepId timeline warning'],
-        secondStepId: ['secondStepId timeline warning'],
-        thirdStepId: ['thirdStepId timeline warning'],
-      },
-    }
-
-    const action = {
-      type: 'DELETE_MULTIPLE_STEPS',
-      payload: ['secondStepId', 'firstStepId'],
-    }
-
-    expect(dismissedWarnings(state, action)).toEqual({
-      form: { thirdStepId: ['thirdStepId form warning'] },
-      timeline: { thirdStepId: ['thirdStepId timeline warning'] },
-    })
-  })
-
-  it('should forget all warnings for an unsaved form upon CANCEL_STEP_FORM', () => {
-    const state = {
-      form: {
-        otherStepId: ['whatever_form'],
-        [PRESAVED_STEP_ID]: ['BELOW_PIPETTE_MINIMUM_VOLUME'],
-      },
-      timeline: {
-        otherStepId: ['whatever_timeline'],
-        [PRESAVED_STEP_ID]: ['ASPIRATE_MORE_THAN_WELL_CONTENTS'],
-      },
-    }
-    const action = {
-      type: 'CANCEL_STEP_FORM',
-      payload: null,
-    }
-
-    expect(dismissedWarnings(state, action)).toEqual({
-      form: { otherStepId: ['whatever_form'] },
-      timeline: { otherStepId: ['whatever_timeline'] },
+      form: [],
+      timeline: ['ASPIRATE_MORE_THAN_WELL_CONTENTS'],
     })
   })
 
@@ -156,8 +77,8 @@ describe('dismissedWarnings reducer', () => {
             version: '5.0.1',
             data: {
               dismissedWarnings: {
-                form: { someStepId: ['whatever_form'] },
-                timeline: { someStepId: ['whatever_timeline'] },
+                form: ['whatever_form'],
+                timeline: ['whatever_timeline'],
               },
             },
           },
@@ -165,8 +86,8 @@ describe('dismissedWarnings reducer', () => {
       },
     }
     expect(dismissedWarnings(initialState, action)).toEqual({
-      form: { someStepId: ['whatever_form'] },
-      timeline: { someStepId: ['whatever_timeline'] },
+      form: ['whatever_form'],
+      timeline: ['whatever_timeline'],
     })
   })
 })

--- a/protocol-designer/src/dismiss/actions.ts
+++ b/protocol-designer/src/dismiss/actions.ts
@@ -1,10 +1,7 @@
-import type { StepIdType } from '../form-types'
-
 export interface DismissAction<ActionType> {
   type: ActionType
   payload: {
     type: string
-    stepId: StepIdType
   }
 }
 

--- a/protocol-designer/src/dismiss/reducers.ts
+++ b/protocol-designer/src/dismiss/reducers.ts
@@ -1,27 +1,29 @@
 import { combineReducers } from 'redux'
 import { handleActions } from 'redux-actions'
-import omit from 'lodash/omit'
 import { getPDMetadata } from '../file-types'
-import { PRESAVED_STEP_ID } from '../steplist/types'
 import type { Reducer } from 'redux'
-import type { DismissFormWarning, DismissTimelineWarning } from './actions'
 import type { BaseState, Action } from '../types'
 import type { LoadFileAction } from '../load-file'
-import type {
-  CancelStepFormAction,
-  DeleteStepAction,
-  DeleteMultipleStepsAction,
-} from '../steplist/actions'
 import type { StepIdType } from '../form-types'
+import type { DismissFormWarning, DismissTimelineWarning } from './actions'
+
 export type WarningType = string
-export type DismissedWarningsAllSteps = Record<
+
+export interface DismissedWarningState {
+  form: WarningType[]
+  timeline: WarningType[]
+}
+
+//  these legacy types are used for the migration 8_1_0
+type LegacyDismissedWarningsAllSteps = Record<
   StepIdType,
   WarningType[] | null | undefined
 >
-export interface DismissedWarningState {
-  form: DismissedWarningsAllSteps
-  timeline: DismissedWarningsAllSteps
+export interface LegacyDismissedWarningState {
+  form: LegacyDismissedWarningsAllSteps
+  timeline: LegacyDismissedWarningsAllSteps
 }
+
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081
 const dismissedWarnings: Reducer<DismissedWarningState, any> = handleActions(
@@ -31,13 +33,9 @@ const dismissedWarnings: Reducer<DismissedWarningState, any> = handleActions(
       action: DismissFormWarning
     ): DismissedWarningState => {
       const { type } = action.payload
-      const stepId = action.payload.stepId
       return {
         ...state,
-        form: {
-          ...state.form,
-          [stepId]: [...(state.form[stepId] || []), type],
-        },
+        form: state.form ? [...state.form, type] : [type],
       }
     },
     DISMISS_TIMELINE_WARNING: (
@@ -45,34 +43,9 @@ const dismissedWarnings: Reducer<DismissedWarningState, any> = handleActions(
       action: DismissTimelineWarning
     ): DismissedWarningState => {
       const { type } = action.payload
-      const stepId = action.payload.stepId
       return {
         ...state,
-        timeline: {
-          ...state.timeline,
-          [stepId]: [...(state.timeline[stepId] || []), type],
-        },
-      }
-    },
-    DELETE_STEP: (
-      state: DismissedWarningState,
-      action: DeleteStepAction
-    ): DismissedWarningState => {
-      // remove key for deleted step
-      const stepId = action.payload
-      return {
-        form: omit(state.form, stepId),
-        timeline: omit(state.timeline, stepId),
-      }
-    },
-    DELETE_MULTIPLE_STEPS: (
-      state: DismissedWarningState,
-      action: DeleteMultipleStepsAction
-    ): DismissedWarningState => {
-      const stepIds = action.payload
-      return {
-        form: omit(state.form, stepIds),
-        timeline: omit(state.timeline, stepIds),
+        timeline: state.timeline ? [...state.timeline, type] : [type],
       }
     },
     LOAD_FILE: (
@@ -80,17 +53,10 @@ const dismissedWarnings: Reducer<DismissedWarningState, any> = handleActions(
       action: LoadFileAction
     ): DismissedWarningState =>
       getPDMetadata(action.payload.file).dismissedWarnings,
-    CANCEL_STEP_FORM: (
-      state: DismissedWarningState,
-      action: CancelStepFormAction
-    ): DismissedWarningState => ({
-      form: omit(state.form, PRESAVED_STEP_ID),
-      timeline: omit(state.timeline, PRESAVED_STEP_ID),
-    }),
   },
   {
-    form: {},
-    timeline: {},
+    form: [],
+    timeline: [],
   }
 )
 export const _allReducers = {

--- a/protocol-designer/src/dismiss/selectors.ts
+++ b/protocol-designer/src/dismiss/selectors.ts
@@ -1,40 +1,26 @@
-import { createSelector } from 'reselect'
 import mapValues from 'lodash/mapValues'
+import { createSelector } from 'reselect'
 import { selectors as stepFormSelectors } from '../step-forms'
-import { getSelectedStepId } from '../ui/steps/selectors'
-import { PRESAVED_STEP_ID } from '../steplist/types'
 import type { FormWarning } from '../steplist'
 import type { BaseState, Selector } from '../types'
-import type {
-  RootState,
-  DismissedWarningsAllSteps,
-  WarningType,
-} from './reducers'
+import type { RootState, WarningType } from './reducers'
+
 export const rootSelector = (state: BaseState): RootState => state.dismiss
 export const getAllDismissedWarnings: Selector<any> = createSelector(
   rootSelector,
   s => s.dismissedWarnings
 )
-export const getDismissedFormWarningTypesPerStep: Selector<DismissedWarningsAllSteps> = createSelector(
-  getAllDismissedWarnings,
-  all => all.form
-)
-export const getDismissedTimelineWarningTypes: Selector<DismissedWarningsAllSteps> = createSelector(
-  getAllDismissedWarnings,
-  all => all.timeline
-)
+export const getDismissedFormWarningTypesPerStep: Selector<
+  WarningType[]
+> = createSelector(getAllDismissedWarnings, all => all.form)
+export const getDismissedTimelineWarningTypes: Selector<
+  WarningType[]
+> = createSelector(getAllDismissedWarnings, all => all.timeline)
 export const getDismissedFormWarningTypesForSelectedStep: Selector<
   WarningType[]
 > = createSelector(
   getDismissedFormWarningTypesPerStep,
-  getSelectedStepId,
-  (dismissedWarnings, stepId) => {
-    if (stepId == null) {
-      return dismissedWarnings[PRESAVED_STEP_ID] || []
-    }
-
-    return dismissedWarnings[stepId] || []
-  }
+  dismissedWarnings => dismissedWarnings
 )
 
 /** Non-dismissed form-level warnings for selected step */
@@ -44,9 +30,8 @@ export const getFormWarningsForSelectedStep: Selector<
   stepFormSelectors.getFormLevelWarningsForUnsavedForm,
   getDismissedFormWarningTypesForSelectedStep,
   (warnings, dismissedWarnings) => {
-    const dismissedTypesForStep = dismissedWarnings
     const formWarnings = warnings.filter(
-      w => !dismissedTypesForStep.includes(w.type)
+      w => !dismissedWarnings.includes(w.type)
     )
     return formWarnings
   }
@@ -61,7 +46,7 @@ export const getHasFormLevelWarningsPerStep: Selector<
       warningsPerStep,
       (warnings: FormWarning, stepId: string) =>
         (warningsPerStep[stepId] || []).filter(
-          w => !(dismissedPerStep[stepId] || []).includes(w.type)
+          w => !dismissedPerStep.includes(w.type)
         ).length > 0
     )
 )

--- a/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
+++ b/protocol-designer/src/file-data/__fixtures__/createFile/commonFields.ts
@@ -30,8 +30,8 @@ export const fileMetadata: FileMetadataFields = {
   created: 1582667312515,
 }
 export const dismissedWarnings: DismissedWarningState = {
-  form: {},
-  timeline: {},
+  form: [],
+  timeline: [],
 }
 export const ingredients: IngredientsState = {}
 export const ingredLocations: LabwareLiquidState = {}

--- a/protocol-designer/src/load-file/migration/8_1_0.ts
+++ b/protocol-designer/src/load-file/migration/8_1_0.ts
@@ -5,6 +5,7 @@ import type {
   ProtocolFile,
   PipetteName,
 } from '@opentrons/shared-data'
+import type { LegacyDismissedWarningState } from '../../dismiss/reducers'
 import type { DesignerApplicationData } from './utils/getLoadLiquidCommands'
 
 export interface DesignerApplicationDataV8 {
@@ -24,6 +25,7 @@ export interface DesignerApplicationDataV8 {
   savedStepForms: Record<string, any>
   orderedStepIds: string[]
   pipetteTiprackAssignments: Record<string, string>
+  dismissedWarnings: LegacyDismissedWarningState
 }
 
 export const migrateFile = (
@@ -45,6 +47,8 @@ export const migrateFile = (
     },
     {}
   )
+
+  const dismissedWarnings = designerApplication.data?.dismissedWarnings
 
   const pipetteTiprackAssignments =
     designerApplication.data?.pipetteTiprackAssignments
@@ -131,6 +135,19 @@ export const migrateFile = (
     {}
   )
 
+  const newDismissedWarningsForm =
+    dismissedWarnings.form != null
+      ? Object.values(dismissedWarnings.form).flatMap(
+          formType => formType as string[]
+        )
+      : []
+  const newDismissedWarningsTimeline =
+    dismissedWarnings.timeline != null
+      ? Object.values(dismissedWarnings.timeline).flatMap(
+          timelineType => timelineType as string[]
+        )
+      : []
+
   return {
     ...appData,
     designerApplication: {
@@ -142,6 +159,10 @@ export const migrateFile = (
           ...pipettingSavedStepsWithAdditionalFields,
         },
         pipetteTiprackAssignments: newTiprackAssignments,
+        dismissedWarnings: {
+          form: newDismissedWarningsForm,
+          timeline: newDismissedWarningsTimeline,
+        },
       },
     },
   }

--- a/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
+++ b/protocol-designer/src/load-file/migration/utils/getLoadLiquidCommands.ts
@@ -1,6 +1,7 @@
 import reduce from 'lodash/reduce'
 import { uuid } from '../../../utils'
 import type { LoadLiquidCreateCommand } from '@opentrons/shared-data/protocol/types/schemaV6/command/setup'
+import type { DismissedWarningState } from '../../../dismiss/reducers'
 
 export interface DesignerApplicationData {
   ingredients: Record<
@@ -19,6 +20,7 @@ export interface DesignerApplicationData {
   savedStepForms: Record<string, any>
   orderedStepIds: string[]
   pipetteTiprackAssignments: Record<string, string[]>
+  dismissedWarnings: DismissedWarningState
 }
 
 export const getLoadLiquidCommands = (

--- a/protocol-designer/src/top-selectors/timelineWarnings/index.ts
+++ b/protocol-designer/src/top-selectors/timelineWarnings/index.ts
@@ -14,7 +14,7 @@ export const getTimelineWarningsForSelectedStep: Selector<
   (dismissedWarningTypes, warningsPerStep, stepId) => {
     if (stepId == null) return []
     return (warningsPerStep[stepId] || []).filter(
-      warning => !(dismissedWarningTypes[stepId] || []).includes(warning.type)
+      warning => !dismissedWarningTypes.includes(warning.type)
     )
   }
 )
@@ -28,12 +28,9 @@ export const getHasTimelineWarningsPerStep: Selector<HasWarningsPerStep> = creat
       const warningTypesForStep = (warningsPerStep[stepId] || []).map(
         w => w.type
       )
-      const dismissedWarningTypesForStep = new Set(
-        dismissedWarningTypes[stepId] || []
-      )
       const hasUndismissedWarnings =
         warningTypesForStep.filter(
-          warningType => !dismissedWarningTypesForStep.has(warningType)
+          warningType => !dismissedWarningTypes.includes(warningType)
         ).length > 0
       return { ...stepAcc, [stepId]: hasUndismissedWarnings }
     }, {})


### PR DESCRIPTION
closes RQA-2756

# Overview

The current behavior for a dismissed warnings for both form warnings and timeline warnings is that it is tied to the step id. This means that if you dismiss a warning then duplicate the step or create a new step, the warning appears again for that step. This has been the legacy behavior for dismissed warnings.

This new behavior is instead of tying each dismissed warning to a specific step id, it is tied to the protocol itself. So if you dismiss a warning, it is dismissed forever in the protocol, even if you reimport your protocol. But if you make a new protocol, the warnings are all visible again.

# Test Plan

Create a flex or OT-2 protocol. Do not add any liquids but add a tuberack to the deck. Create a transfer step where you are aspirating and/or dispensing into the tube. See that the tuberack warning is there. DIsmiss it.

Next, duplicate that step by right clicking on the step in the timeline and selecting the duplicate button. See that the only warnings on both steps is the "no liquid" warning. But the tuberack warning should not be visible. Then, delete the "no liquid" warning and it should delete for both steps.

Create one final transfer step with the tuberack and see that both the tuberack and "no liquid" warnings are not visible.

Finally, export your protocol and reimport. go to the deckmap and timeline and see that there are no warnings.

# Changelog

- refactored the dismissed warnings reducer and selector to remove the record, keyed by the step id. 
- refactor the types to match the new shape
- refactor affected components
- fix all affected tests
- add to the migration
- fix cypress tests

# Review requests

see test plan

# Risk assessment

low