### PR TITLE
fix(api): monitor the pressure sensor more

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -45,7 +45,7 @@ from .ot3utils import (
     motor_nodes,
     LIMIT_SWITCH_OVERTRAVEL_DISTANCE,
     map_pipette_type_to_sensor_id,
-    moving_axes_in_move_group,
+    moving_pipettes_in_move_group,
     gripper_jaw_state_from_fw,
     get_system_constraints,
     get_system_constraints_for_calibration,
@@ -667,12 +667,8 @@ class OT3Controller(FlexBackend):
             else False,
         )
 
-        mounts_moving = [
-            k
-            for k in moving_axes_in_move_group(move_group)
-            if k
-            in [NodeId.pipette_left, NodeId.pipette_right, NodeId.head_l, NodeId.head_r]
-        ]
+        mounts_moving = moving_pipettes_in_move_group(move_group)
+
         async with self._monitor_overpressure(mounts_moving):
             positions = await runner.run(can_messenger=self._messenger)
         self._handle_motor_status_response(positions)

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -670,7 +670,8 @@ class OT3Controller(FlexBackend):
         mounts_moving = [
             k
             for k in moving_axes_in_move_group(move_group)
-            if k in [NodeId.pipette_left, NodeId.pipette_right]
+            if k
+            in [NodeId.pipette_left, NodeId.pipette_right, NodeId.head_l, NodeId.head_r]
         ]
         async with self._monitor_overpressure(mounts_moving):
             positions = await runner.run(can_messenger=self._messenger)

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -667,9 +667,9 @@ class OT3Controller(FlexBackend):
             else False,
         )
 
-        mounts_moving = moving_pipettes_in_move_group(move_group)
+        pipettes_moving = moving_pipettes_in_move_group(move_group)
 
-        async with self._monitor_overpressure(mounts_moving):
+        async with self._monitor_overpressure(pipettes_moving):
             positions = await runner.run(can_messenger=self._messenger)
         self._handle_motor_status_response(positions)
 

--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -498,6 +498,20 @@ def create_gripper_jaw_hold_group(encoder_position_um: int) -> MoveGroup:
     return move_group
 
 
+def moving_pipettes_in_move_group(group: MoveGroup) -> List[NodeId]:
+    """Utility function to get which pipette nodes are moving either in z or their plunger."""
+    all_nodes = [node for step in group for node, _ in step.items()]
+    moving_nodes = moving_axes_in_move_group(group)
+    pipettes_moving: List[NodeId] = [
+        k for k in moving_nodes if k in [NodeId.pipette_left, NodeId.pipette_right]
+    ]
+    if NodeId.head_l in moving_nodes and NodeId.pipette_left in all_nodes:
+        pipettes_moving.append(NodeId.pipette_left)
+    if NodeId.head_r in moving_nodes and NodeId.pipette_right in all_nodes:
+        pipettes_moving.append(NodeId.pipette_right)
+    return pipettes_moving
+
+
 def moving_axes_in_move_group(group: MoveGroup) -> Set[NodeId]:
     """Utility function to get only the moving nodes in a move group."""
     ret: Set[NodeId] = set()


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
This will allow us to monitor the pressure sensor more, specifically it should help us catch and differentiate cases where the tip collides with the labware by monitoring it during the z movement in addition to the plunger movement. 
Should help diagnose:
RABR-319
RABR-305
RABR-304
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
