### PR TITLE
fix(protocol-designer): missing labware modal logic

### DIFF
--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -117,6 +117,14 @@ export const getMagnetModuleHasLabware: Selector<boolean> = createSelector(
   }
 )
 
+/** Returns boolean if heater-shaker module has labware */
+export const getHeaterShakerModuleHasLabware: Selector<boolean> = createSelector(
+  getInitialDeckSetup,
+  initialDeckSetup => {
+    return getModuleHasLabware(initialDeckSetup, HEATERSHAKER_MODULE_TYPE)
+  }
+)
+
 /** Returns all moduleIds and if they have labware for MoaM */
 export const getTemperatureModulesHaveLabware: Selector<
   ModuleAndLabware[]

--- a/protocol-designer/src/ui/steps/actions/__tests__/addAndSelectStepWithHints.test.ts
+++ b/protocol-designer/src/ui/steps/actions/__tests__/addAndSelectStepWithHints.test.ts
@@ -26,6 +26,9 @@ beforeEach(() => {
     false
   )
   vi.mocked(uiModuleSelectors.getTemperatureModuleIds).mockReturnValue(null)
+  vi.mocked(uiModuleSelectors.getHeaterShakerModuleHasLabware).mockReturnValue(
+    false
+  )
   vi.mocked(uiModuleSelectors.getSingleThermocyclerModuleId).mockReturnValue(
     null
   )
@@ -92,6 +95,7 @@ describe('addAndSelectStepWithHints', () => {
           getSingleTemperatureModuleId: null,
           getSingleThermocyclerModuleId: null,
           getTemperatureModuleIds: [],
+          getHeaterShakerModuleHasLabware: false,
         },
       },
       {
@@ -105,12 +109,13 @@ describe('addAndSelectStepWithHints', () => {
           getThermocyclerModuleHasLabware: false,
           getSingleTemperatureModuleId: 'something',
           getSingleThermocyclerModuleId: null,
-          getTemperatureModuleIds: ['mockId'],
+          getTemperatureModuleIds: [],
+          getHeaterShakerModuleHasLabware: false,
         },
       },
       {
-        testName: 'temperature step, when thermocycler has no labware',
-        stepType: 'temperature' as StepType,
+        testName: 'thermocycler step, when thermocycler has no labware',
+        stepType: 'thermocycler' as StepType,
         selectorValues: {
           getMagnetModuleHasLabware: false,
           getTemperatureModulesHaveLabware: [],
@@ -118,6 +123,20 @@ describe('addAndSelectStepWithHints', () => {
           getSingleTemperatureModuleId: null,
           getSingleThermocyclerModuleId: 'something',
           getTemperatureModuleIds: [],
+          getHeaterShakerModuleHasLabware: false,
+        },
+      },
+      {
+        testName: 'heaterShaker step, when heaterShaker has no labware',
+        stepType: 'heaterShaker' as StepType,
+        selectorValues: {
+          getMagnetModuleHasLabware: false,
+          getTemperatureModulesHaveLabware: [],
+          getThermocyclerModuleHasLabware: false,
+          getSingleTemperatureModuleId: null,
+          getSingleThermocyclerModuleId: 'something',
+          getTemperatureModuleIds: [],
+          getHeaterShakerModuleHasLabware: false,
         },
       },
     ].forEach(({ testName, stepType, selectorValues }) => {
@@ -128,6 +147,9 @@ describe('addAndSelectStepWithHints', () => {
         vi.mocked(
           uiModuleSelectors.getTemperatureModulesHaveLabware
         ).mockReturnValue(selectorValues.getTemperatureModulesHaveLabware)
+        vi.mocked(
+          uiModuleSelectors.getHeaterShakerModuleHasLabware
+        ).mockReturnValue(selectorValues.getHeaterShakerModuleHasLabware)
         vi.mocked(
           uiModuleSelectors.getThermocyclerModuleHasLabware
         ).mockReturnValue(selectorValues.getThermocyclerModuleHasLabware)

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -49,9 +49,10 @@ export const addAndSelectStepWithHints: (arg: {
   const temperatureModuleOnDeck = uiModuleSelectors.getTemperatureModuleIds(
     state
   )
-  const thermocyclerModuleOnDeck = uiModuleSelectors.getSingleThermocyclerModuleId(
+  const heaterShakerModuleHasLabware = uiModuleSelectors.getHeaterShakerModuleHasLabware(
     state
   )
+
   const tempHasNoLabware = temperatureModulesHaveLabware.some(
     module => !module.hasLabware
   )
@@ -59,19 +60,25 @@ export const addAndSelectStepWithHints: (arg: {
   const stepNeedsLiquid = ['mix', 'moveLiquid'].includes(payload.stepType)
   const stepMagnetNeedsLabware = ['magnet'].includes(payload.stepType)
   const stepTemperatureNeedsLabware = ['temperature'].includes(payload.stepType)
+  const stepThermocyclerNeedsLabware = ['thermocycler'].includes(
+    payload.stepType
+  )
+  const stepHeaterShakerNeedsLabware = ['heaterShaker'].includes(
+    payload.stepType
+  )
+
   const stepModuleMissingLabware =
     (stepMagnetNeedsLabware && !magnetModuleHasLabware) ||
-    (stepTemperatureNeedsLabware &&
-      thermocyclerModuleOnDeck &&
-      !thermocyclerModuleHasLabware) ||
-    (temperatureModuleOnDeck?.length === 1 && tempHasNoLabware)
+    (stepThermocyclerNeedsLabware && !thermocyclerModuleHasLabware) ||
+    (temperatureModuleOnDeck?.length === 0 && stepTemperatureNeedsLabware) ||
+    (stepHeaterShakerNeedsLabware && !heaterShakerModuleHasLabware)
 
   if (stepNeedsLiquid && !deckHasLiquid) {
     dispatch(tutorialActions.addHint('add_liquids_and_labware'))
   }
   if (stepModuleMissingLabware) {
     dispatch(tutorialActions.addHint('module_without_labware'))
-  } else if (temperatureModuleOnDeck && tempHasNoLabware) {
+  } else if (temperatureModuleOnDeck != null && tempHasNoLabware) {
     dispatch(tutorialActions.addHint('multiple_modules_without_labware'))
   }
 }


### PR DESCRIPTION
closes RQA-2769

# Overview

The missing labware modal hint was popping up incorrectly and upon investigation, the logic was both wrong now and in production and it wasn't extended for the heater-shaker -- oops. This PR fixes it and adds test coverage

# Test Plan

Follow the steps in the ticket. Basically, add a temperature module and a thermocycler to a flex or ot-2 protocol. Add an adapter or labware to the temperature module. Add a temperature module step. See that the "missing labware" modal does not pop up. It should, however, pop up for the thermocycler if you add a thermocycler step.

# Changelog

- fix logic for thermocycler and temperature module, add logic for heater-shaker
- add new heater-shaker selector
- fix test

# Review requests

see test plan

# Risk assessment

low