### PR TITLE
fix(protocol-designer): format export modal mesasge for repeat modules and 96-channel

### DIFF
--- a/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
+++ b/protocol-designer/src/components/FileSidebar/FileSidebar.tsx
@@ -31,7 +31,6 @@ import styles from './FileSidebar.module.css'
 
 import type {
   CreateCommand,
-  ModuleType,
   ProtocolFile,
   RobotType,
 } from '@opentrons/shared-data'
@@ -44,7 +43,6 @@ import type {
 } from '../../step-forms'
 import type { ThunkDispatch } from '../../types'
 import { createPortal } from 'react-dom'
-import { e } from 'vitest/dist/reporters-1evA5lom'
 
 export interface AdditionalEquipment {
   [additionalEquipmentId: string]: {

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -230,7 +230,7 @@ describe('FileSidebar', () => {
       'One or more modules specified in your protocol in Slot(s) A1,B1 are not currently used in any step. In order to run this protocol you will need to power up and connect the modules to your robot.'
     )
   })
-  it.only('renders the formatted unused pipettes and modules warning sorted by count', () => {
+  it('renders the formatted unused pipettes and modules warning sorted by count', () => {
     vi.mocked(getInitialDeckSetup).mockReturnValue({
       modules: {
         moduleId1: {
@@ -280,7 +280,6 @@ describe('FileSidebar', () => {
     })
     render()
     fireEvent.click(screen.getByRole('button', { name: 'Export' }))
-    screen.debug()
     screen.getByText(
       'The mock display name pipette and Temperature modules, Thermocycler module, and Heater-Shaker module in your protocol are not currently used in any step. In order to run this protocol you will need to attach this pipette as well as power up and connect the module to your robot.'
     )

--- a/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
+++ b/protocol-designer/src/components/FileSidebar/__tests__/FileSidebar.test.tsx
@@ -230,4 +230,59 @@ describe('FileSidebar', () => {
       'One or more modules specified in your protocol in Slot(s) A1,B1 are not currently used in any step. In order to run this protocol you will need to power up and connect the modules to your robot.'
     )
   })
+  it.only('renders the formatted unused pipettes and modules warning sorted by count', () => {
+    vi.mocked(getInitialDeckSetup).mockReturnValue({
+      modules: {
+        moduleId1: {
+          slot: 'A1',
+          moduleState: {} as any,
+          id: 'moduleId',
+          type: 'thermocyclerModuleType',
+          model: 'thermocyclerModuleV2',
+        },
+        moduleId2: {
+          slot: 'C3',
+          moduleState: {} as any,
+          id: 'moduleId1',
+          type: 'temperatureModuleType',
+          model: 'temperatureModuleV2',
+        },
+        moduleId3: {
+          slot: 'D3',
+          moduleState: {} as any,
+          id: 'moduleId2',
+          type: 'temperatureModuleType',
+          model: 'temperatureModuleV2',
+        },
+        moduleId4: {
+          slot: 'C1',
+          moduleState: {} as any,
+          id: 'moduleId3',
+          type: 'heaterShakerModuleType',
+          model: 'heaterShakerModuleV1',
+        },
+      },
+      pipettes: {
+        pipetteId: {
+          mount: 'left',
+          name: 'p1000_96',
+          id: 'pipetteId',
+          tiprackLabwareDef: [fixtureTiprack300ul as LabwareDefinition2],
+          tiprackDefURI: ['mockDefUri'],
+          spec: {
+            displayName: 'mock display name',
+            channels: 96,
+          } as any,
+        },
+      },
+      additionalEquipmentOnDeck: {},
+      labware: {},
+    })
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'Export' }))
+    screen.debug()
+    screen.getByText(
+      'The mock display name pipette and Temperature modules, Thermocycler module, and Heater-Shaker module in your protocol are not currently used in any step. In order to run this protocol you will need to attach this pipette as well as power up and connect the module to your robot.'
+    )
+  })
 })


### PR DESCRIPTION
Closes RQA-2762

# Overview

Consolidate modules of the same type into a single plural noun rather than 'and'-joined repeated modules. Remove mount side for 96-channel pipette.

# Test Plan

- Add combinations of modules to a protocol
- Add a move labware step so that the export modal will show the text we are fixing here
- Select `Export`
- Verify that the modal text looks like the following:
<img width="623" alt="Screenshot 2024-05-22 at 12 53 44 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/06515886-d83b-4e4e-bc20-85c557327f16">
<img width="619" alt="Screenshot 2024-05-22 at 12 53 23 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/adcb9d0a-8e9e-405f-a683-505feacb7420">
<img width="627" alt="Screenshot 2024-05-22 at 12 53 03 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/06d20d5e-f19c-406f-a371-e7a2103b98db">


# Changelog

- group modules of the same type into a single plural noun
- comma-join a list of more than 2 module types

# Risk assessment

low