### PR TITLE
docs(api): fix type specification for `add_parameters()`

### DIFF
--- a/api/docs/v2/parameters/defining.rst
+++ b/api/docs/v2/parameters/defining.rst
@@ -62,7 +62,7 @@ The examples on this page assume the following definition, which uses the argume
 
 .. code-block::
 
-    def add_parameters(parameters: protocol_api.ProtocolContext.Parameters):
+    def add_parameters(parameters: protocol_api.Parameters):
 
 Within this function definition, call methods on ``parameters`` to define parameters. The next section demonstrates how each type of parameter has its own method.
 


### PR DESCRIPTION

# Overview

I got the type specification for the object of `add_parameters()` wrong. 

# Test Plan

Simulated a protocol that uses the `def add_parameters(…` line verbatim on 7.3.0-b1.

# Changelog

1-line diff

# Risk assessment

none