### PR TITLE
fix(react-api-client): filter out unknown modules in the /modules endpoint.

### DIFF
--- a/api-client/src/modules/__fixtures__/index.ts
+++ b/api-client/src/modules/__fixtures__/index.ts
@@ -93,6 +93,29 @@ export const mockModulesResponse = [
   },
 ]
 
+export const mockUnknownModuleResponse = [
+  ...mockModulesResponse,
+  {
+    name: 'unknown',
+    displayName: 'UnknownModule',
+    moduleModel: 'unknownModule',
+    port: '/dev/unknown',
+    usbPort: {
+      port: 0,
+      hub: false,
+      portGroup: 'unknown',
+      path: '',
+    },
+    serial: 'dummySerialMD',
+    model: 'unknown_v1.1',
+    revision: 'unknown_v1.1',
+    fwVersion: 'dummyVersionMD',
+    hasAvailableUpdate: false,
+    status: 'engaged',
+    data: {},
+  },
+]
+
 export const v2MockModulesResponse = [
   {
     name: 'thermocycler',

--- a/react-api-client/src/modules/__tests__/useModulesQuery.test.tsx
+++ b/react-api-client/src/modules/__tests__/useModulesQuery.test.tsx
@@ -5,6 +5,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import {
   getModules,
   mockModulesResponse,
+  mockUnknownModuleResponse,
   v2MockModulesResponse,
 } from '@opentrons/api-client'
 import { useHost } from '../../api'
@@ -19,6 +20,10 @@ vi.mock('../../api/useHost')
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
 const MODULES_RESPONSE = {
   data: mockModulesResponse,
+  meta: { totalLength: 0, cursor: 0 },
+}
+const UNKNOWN_MODULES_RESPONSE = {
+  data: mockUnknownModuleResponse,
   meta: { totalLength: 0, cursor: 0 },
 }
 const V2_MODULES_RESPONSE = { data: v2MockModulesResponse }
@@ -67,6 +72,19 @@ describe('useModulesQuery hook', () => {
       expect(result.current.data).toEqual(MODULES_RESPONSE)
     })
   })
+  it('should filter out unknown modules', async () => {
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(getModules).mockResolvedValue({
+      data: UNKNOWN_MODULES_RESPONSE,
+    } as Response<any>)
+
+    const { result } = renderHook(useModulesQuery, { wrapper })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(MODULES_RESPONSE)
+    })
+  })
+
   it('should return an empty array if an old version of modules returns', async () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(getModules).mockResolvedValue({

--- a/react-api-client/src/modules/useModulesQuery.ts
+++ b/react-api-client/src/modules/useModulesQuery.ts
@@ -3,6 +3,7 @@ import { getModules } from '@opentrons/api-client'
 import { useHost } from '../api'
 import type { UseQueryResult, UseQueryOptions } from 'react-query'
 import type { HostConfig, Modules } from '@opentrons/api-client'
+import { MODULE_MODELS } from '@opentrons/shared-data'
 
 export type UseModulesQueryOptions = UseQueryOptions<Modules>
 
@@ -26,7 +27,20 @@ export function useModulesQuery(
           }
         }
       }),
-    { enabled: host !== null, ...options }
+    {
+      enabled: host !== null,
+      // Filter unknown modules so we don't block the app, which
+      // can happen when developing new devices not yet known to the client.
+      select: resp => {
+        return {
+          ...resp,
+          data: resp.data.filter(module =>
+            MODULE_MODELS.includes(module.moduleModel)
+          ),
+        }
+      },
+      ...options,
+    }
   )
 
   return query


### PR DESCRIPTION
# Overview

The desktop app is blocked when it gets an unknown module in the `GET /modules` response, which happens when the user clicks on the `Devices` side panel in the desktop app. Since we query modules for all discovered robots, it can be confusing to know which robot the unknown module is connected to. There will sometimes be a lag between developing and supporting new modules in the desktop app. So instead of blocking the desktop app, we should filter out unknown modules in the `GET /response`.

Closes: [RABR-316](https://opentrons.atlassian.net/browse/RABR-316)

# Test Plan

- [x] Connect an unknown module (plate reader) to a robot and make sure we no longer see the "invalid module" modal.
- [x] Make sure we still handle known modules like before.

# Changelog

- Use the `select` option of react `UseQuery` to filter out unknown modules

# Review requests
# Risk assessment
low

[RABR-316]: https://opentrons.atlassian.net/browse/RABR-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ