### PR TITLE
refactor(api, robot-server): redirect router level calls to PE and protocol_runners via run orchestrator

### DIFF
--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -401,6 +401,7 @@ class LiveRunner(AbstractRunner):
 
         self._hardware_api.should_taskify_movement_execution(taskify=False)
 
+    # TODO(tz, 6-10-2024): explore moving this method into the constructor.
     def prepare(self) -> None:
         """Set the task queue to wait until all commands are executed."""
         self._task_queue.set_run_func(func=self._protocol_engine.wait_until_complete)

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -102,7 +102,7 @@ class RunOrchestrator:
             protocol_engine=protocol_engine,
         )
 
-    def add_command_and_wait_for_interval(self, command: CommandCreate, wait_until_complete: bool = False,
+    async def add_command_and_wait_for_interval(self, command: CommandCreate, wait_until_complete: bool = False,
                                           timeout: Optional[int] = None, failed_command_id: Optional[str] = None) -> Command:
         added_command = self._protocol_engine.add_command(request=command, failed_command_id=failed_command_id)
         if wait_until_complete:

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -110,3 +110,6 @@ class RunOrchestrator:
             with move_on_after(timeout_sec):
                 await self._protocol_engine.wait_for_command(added_command.id)
         return added_command
+
+    def estop(self) -> None:
+        return self._protocol_engine.estop()

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -102,10 +102,10 @@ class RunOrchestrator:
             protocol_engine=protocol_engine,
         )
 
-    def add_command_and_wait_for_interval(self, command: CommandCreate, wait_until_complete: bool,
+    def add_command_and_wait_for_interval(self, command: CommandCreate, wait_until_complete: bool = False,
                                           timeout: Optional[int] = None, failed_command_id: Optional[str] = None) -> Command:
         added_command = self._protocol_engine.add_command(request=command, failed_command_id=failed_command_id)
-        if waitUntilComplete:
+        if wait_until_complete:
             timeout_sec = None if timeout is None else timeout / 1000.0
             with move_on_after(timeout_sec):
                 await self._protocol_engine.wait_for_command(added_command.id)

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -140,7 +140,7 @@ class RunOrchestrator:
     async def stop(self) -> None:
         """Start or resume the run."""
         if self.run_has_started():
-            await self.stop()
+            await self._protocol_engine.request_stop()
         else:
             await self.finish(
                 drop_tips_after_run=False,

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -1,13 +1,14 @@
 """Engine/Runner provider."""
 from __future__ import annotations
-from typing import Optional, Union, List
+from typing import Optional, Union, List, Dict
 
 from anyio import move_on_after
 
 from build.lib.opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from . import protocol_runner, AnyRunner, RunResult
+from . import protocol_runner, RunResult
 from ..hardware_control import HardwareControlAPI
+from ..hardware_control.modules import AbstractModule as HardwareModuleAPI
 from ..protocol_engine import ProtocolEngine, CommandCreate, Command, StateSummary, CommandPointer, CommandSlice
 from ..protocol_engine.types import PostRunHardwareState, EngineStatus, LabwareOffsetCreate, LabwareOffset, \
     DeckConfigurationType, RunTimeParameter
@@ -215,3 +216,6 @@ class RunOrchestrator:
 
     def estop(self) -> None:
         return self._protocol_engine.estop()
+
+    def use_attached_modules(self, modules_by_id: Dict[str, HardwareModuleAPI]) -> None:
+        self._protocol_engine.use_attached_modules(modules_by_id=modules_by_id)

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -6,6 +6,8 @@ from anyio import move_on_after
 
 from opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+from opentrons_shared_data.errors import GeneralError
+
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI
 from ..hardware_control.modules import AbstractModule as HardwareModuleAPI
@@ -32,6 +34,10 @@ from ..protocols.parse import PythonParseMode
 
 class NoProtocolRunAvailable(RuntimeError):
     """An error raised if there is no protocol run available."""
+
+
+class RunNotFound(GeneralError):
+    """An error raised if there is no run associated."""
 
 
 class RunOrchestrator:
@@ -84,7 +90,7 @@ class RunOrchestrator:
     def run_id(self) -> str:
         """Get the "current" persisted ProtocolEngine."""
         if not self._run_id:
-            raise NotImplementedError("default orchestrator.")
+            raise RunNotFound()
         return self._run_id
 
     @classmethod

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -7,6 +7,7 @@ from anyio import move_on_after
 from opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors import GeneralError
+from opentrons_shared_data.robot import RobotType
 
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI
@@ -324,3 +325,7 @@ class RunOrchestrator:
     def prepare(self) -> None:
         """Prepare live runner for a run."""
         self._protocol_live_runner.prepare()
+
+    def get_robot_type(self) -> RobotType:
+        """Get engine robot type."""
+        return self._protocol_engine.state_view.config.robot_type

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -80,6 +80,8 @@ class RunOrchestrator:
     @property
     def run_id(self) -> str:
         """Get the "current" persisted ProtocolEngine."""
+        if not self._run_id:
+            raise NotImplementedError("default orchestrator.")
         return self._run_id
 
     @classmethod

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -86,6 +86,9 @@ class RunOrchestrator:
         self._fixit_runner = fixit_runner
         self._protocol_live_runner = protocol_live_runner
 
+        self._fixit_runner.prepare()
+        self._setup_runner.prepare()
+
     @property
     def run_id(self) -> str:
         """Get the "current" persisted run_id."""
@@ -320,6 +323,4 @@ class RunOrchestrator:
 
     def prepare(self) -> None:
         """Prepare live runner for a run."""
-        self._setup_runner.prepare()
-        self._fixit_runner.prepare()
         self._protocol_live_runner.prepare()

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -158,9 +158,9 @@ class RunOrchestrator:
         return self._protocol_engine.state_view.commands.get_current()
 
     def get_command_slice(
-        self,
-        cursor: Optional[int],
-        length: int,
+            self,
+            cursor: Optional[int],
+            length: int,
     ) -> CommandSlice:
         """Get a slice of run commands.
 
@@ -186,7 +186,7 @@ class RunOrchestrator:
             command_id=command_id
         )
 
-    def get_status(self) -> EngineStatus:
+    def get_run_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
         return self._protocol_engine.state_view.commands.get_status()
 
@@ -206,7 +206,8 @@ class RunOrchestrator:
         return self.run_orchestrator.engine.add_labware_definition(definition)
 
     async def add_command_and_wait_for_interval(self, command: CommandCreate, wait_until_complete: bool = False,
-                                          timeout: Optional[int] = None, failed_command_id: Optional[str] = None) -> Command:
+                                                timeout: Optional[int] = None,
+                                                failed_command_id: Optional[str] = None) -> Command:
         added_command = self._protocol_engine.add_command(request=command, failed_command_id=failed_command_id)
         if wait_until_complete:
             timeout_sec = None if timeout is None else timeout / 1000.0
@@ -217,5 +218,8 @@ class RunOrchestrator:
     def estop(self) -> None:
         return self._protocol_engine.estop()
 
-    def use_attached_modules(self, modules_by_id: Dict[str, HardwareModuleAPI]) -> None:
-        self._protocol_engine.use_attached_modules(modules_by_id=modules_by_id)
+    async def use_attached_modules(self, modules_by_id: Dict[str, HardwareModuleAPI]) -> None:
+        await self._protocol_engine.use_attached_modules(modules_by_id=modules_by_id)
+
+    def get_protocol_runner(self) -> None:
+        raise NotImplementedError()

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -70,22 +70,17 @@ class RunOrchestrator:
             json_or_python_protocol_runner: JsonRunner/PythonAndLegacyRunner for protocol commands.
             run_id: run id if any, associated to the runner/engine.
         """
-        self.run_id = run_id
+        self._run_id = run_id
         self._protocol_engine = protocol_engine
         self._hardware_api = hardware_api
         self._protocol_runner = json_or_python_protocol_runner
         self._setup_runner = setup_runner
         self._fixit_runner = fixit_runner
 
-    # @property
-    # def engine(self) -> ProtocolEngine:
-    #     """Get the "current" persisted ProtocolEngine."""
-    #     return self._protocol_engine
-    #
-    # @property
-    # def runner(self) -> AnyRunner:
-    #     """Get the "current" persisted ProtocolRunner."""
-    #     return self._protocol_runner or self._setup_runner
+    @property
+    def run_id(self) -> str:
+        """Get the "current" persisted ProtocolEngine."""
+        return self._run_id
 
     @classmethod
     def build_orchestrator(

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -88,7 +88,7 @@ class RunOrchestrator:
 
     @property
     def run_id(self) -> str:
-        """Get the "current" persisted ProtocolEngine."""
+        """Get the "current" persisted run_id."""
         if not self._run_id:
             raise RunNotFound()
         return self._run_id
@@ -155,11 +155,11 @@ class RunOrchestrator:
             return await self._setup_runner.run(deck_configuration=deck_configuration)
 
     def pause(self) -> None:
-        """Start or resume the run."""
+        """Pause the run."""
         self._protocol_engine.request_pause()
 
     async def stop(self) -> None:
-        """Start or resume the run."""
+        """Stop the run."""
         if self.run_has_started():
             await self._protocol_engine.request_stop()
         else:
@@ -170,7 +170,7 @@ class RunOrchestrator:
             )
 
     def resume_from_recovery(self) -> None:
-        """Start or resume the run."""
+        """Resume the run from recovery."""
         self._protocol_engine.resume_from_recovery()
 
     async def finish(
@@ -180,7 +180,7 @@ class RunOrchestrator:
         set_run_status: bool = True,
         post_run_hardware_state: PostRunHardwareState = PostRunHardwareState.HOME_AND_STAY_ENGAGED,
     ) -> None:
-        """Stop the run."""
+        """Finish the run."""
         await self._protocol_engine.finish(
             error=error,
             drop_tips_after_run=drop_tips_after_run,
@@ -205,7 +205,7 @@ class RunOrchestrator:
         )
 
     def get_current_command(self) -> Optional[CommandPointer]:
-        """Parameter definitions defined by protocol, if any. Will always be empty before execution."""
+        """Get the current running command."""
         return self._protocol_engine.state_view.commands.get_current()
 
     def get_command_slice(
@@ -315,7 +315,7 @@ class RunOrchestrator:
         )
 
     def get_is_okay_to_clear(self) -> bool:
-        """Get whether the engine is stopped or sitting idly so it could be removed."""
+        """Get whether the engine is stopped or sitting idly, so it could be removed."""
         return self._protocol_engine.state_view.commands.get_is_okay_to_clear()
 
     def prepare(self) -> None:

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -7,7 +7,7 @@ from anyio import move_on_after
 from opentrons_shared_data.labware.dev_types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors import GeneralError
-from opentrons_shared_data.robot import RobotType
+from opentrons_shared_data.robot.dev_types import RobotType
 
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -68,6 +68,7 @@ class RunOrchestrator:
             hardware_api: Hardware control API instance.
             fixit_runner: LiveRunner for fixit commands.
             setup_runner: LiveRunner for setup commands.
+            protocol_live_runner: LiveRunner for protocol commands.
             json_or_python_protocol_runner: JsonRunner/PythonAndLegacyRunner for protocol commands.
             run_id: run id if any, associated to the runner/engine.
         """
@@ -319,3 +320,4 @@ class RunOrchestrator:
         """Prepare live runner for a run."""
         self._setup_runner.prepare()
         self._fixit_runner.prepare()
+        self._protocol_live_runner.prepare()

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -230,11 +230,8 @@ class RunOrchestrator:
     async def use_attached_modules(self, modules_by_id: Dict[str, HardwareModuleAPI]) -> None:
         await self._protocol_engine.use_attached_modules(modules_by_id=modules_by_id)
 
-    def get_protocol_runner(self) -> JsonRunner | PythonAndLegacyRunner:
-        if self._protocol_runner is None:
-            raise NoProtocolRunAvailable()
-        else:
-            return self._protocol_runner
+    def get_protocol_runner(self) -> Optional[Union[JsonRunner, PythonAndLegacyRunner]]:
+        return self._protocol_runner
 
     @overload
     async def load(self,
@@ -252,3 +249,7 @@ class RunOrchestrator:
 
     def get_is_okay_to_clear(self) -> bool:
         return self._protocol_engine.state_view.commands.get_is_okay_to_clear()
+
+    def prepare(self) -> None:
+        self._setup_runner.prepare()
+        self._fixit_runner.prepare()

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -142,7 +142,7 @@ class RunOrchestrator:
         self._protocol_engine.play(deck_configuration=deck_configuration)
 
     async def run(self, deck_configuration: DeckConfigurationType) -> RunResult:
-        """Start or resume the run."""
+        """Start the run."""
         if self._protocol_runner:
             return await self._protocol_runner.run(
                 deck_configuration=deck_configuration
@@ -216,12 +216,8 @@ class RunOrchestrator:
         """Get a slice of run commands.
 
         Args:
-            run_id: ID of the run.
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
-
-        Raises:
-            RunNotFoundError: The given run identifier was not found in the database.
         """
         return self._protocol_engine.state_view.commands.get_slice(
             cursor=cursor, length=length

--- a/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
+++ b/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
@@ -463,13 +463,11 @@ def test_get_is_okay_to_clear(
 def test_prepare(
     decoy: Decoy,
     live_protocol_subject: RunOrchestrator,
-    mock_fixit_runner: LiveRunner,
-    mock_setup_runner: LiveRunner,
+    mock_protocol_live_runner: LiveRunner,
 ) -> None:
     """Verify prepare calls runner prepare."""
     live_protocol_subject.prepare()
-    decoy.verify(mock_fixit_runner.prepare())
-    decoy.verify(mock_setup_runner.prepare())
+    decoy.verify(mock_protocol_live_runner.prepare())
 
 
 async def test_stop(

--- a/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
+++ b/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
@@ -141,3 +141,33 @@ def test_build_run_orchestrator_provider(
     assert isinstance(result, RunOrchestrator)
     assert isinstance(result._setup_runner, LiveRunner)
     assert isinstance(result._fixit_runner, LiveRunner)
+
+
+# async def test_build_with_protocol(
+#     subject: EngineStore,
+#     json_protocol_source: ProtocolSource,
+# ) -> None:
+#     """It should create an engine for a run with protocol.
+#
+#     Tests only basic engine & runner creation with creation result.
+#     Loading of protocols/ live run commands is tested in integration test.
+#     """
+#     protocol = ProtocolResource(
+#         protocol_id="my cool protocol",
+#         protocol_key=None,
+#         created_at=datetime(year=2021, month=1, day=1),
+#         source=json_protocol_source,
+#     )
+#
+#     result = await subject.create(
+#         run_id="run-id",
+#         labware_offsets=[],
+#         deck_configuration=[],
+#         protocol=protocol,
+#         notify_publishers=mock_notify_publishers,
+#     )
+#     assert subject.current_run_id == "run-id"
+#     assert isinstance(result, StateSummary)
+#     assert subject._run_orchestrator is not None
+#     assert isinstance(subject._run_orchestrator.runner, JsonRunner)
+#     assert isinstance(subject._run_orchestrator.engine, ProtocolEngine)

--- a/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
+++ b/api/tests/opentrons/protocol_runner/test_run_orchestrator.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 from datetime import datetime
+
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from decoy import Decoy
 from typing import Union
@@ -52,6 +53,12 @@ def mock_fixit_runner(decoy: Decoy) -> LiveRunner:
 
 
 @pytest.fixture
+def mock_protocol_live_runner(decoy: Decoy) -> LiveRunner:
+    """Get a mock of a LiveRunner for protocol commands."""
+    return decoy.mock(cls=LiveRunner)
+
+
+@pytest.fixture
 def mock_protocol_engine(decoy: Decoy) -> ProtocolEngine:
     """Get a mocked out ProtocolEngine dependency."""
     return decoy.mock(cls=ProtocolEngine)
@@ -70,6 +77,7 @@ def json_protocol_subject(
     mock_protocol_json_runner: JsonRunner,
     mock_fixit_runner: LiveRunner,
     mock_setup_runner: LiveRunner,
+    mock_protocol_live_runner: LiveRunner,
 ) -> RunOrchestrator:
     """Get a RunOrchestrator subject with a json runner."""
     return RunOrchestrator(
@@ -78,6 +86,7 @@ def json_protocol_subject(
         fixit_runner=mock_fixit_runner,
         setup_runner=mock_setup_runner,
         json_or_python_protocol_runner=mock_protocol_json_runner,
+        protocol_live_runner=mock_protocol_live_runner,
     )
 
 
@@ -88,6 +97,7 @@ def python_protocol_subject(
     mock_protocol_python_runner: PythonAndLegacyRunner,
     mock_fixit_runner: LiveRunner,
     mock_setup_runner: LiveRunner,
+    mock_protocol_live_runner: LiveRunner,
 ) -> RunOrchestrator:
     """Get a RunOrchestrator subject with a python runner."""
     return RunOrchestrator(
@@ -96,6 +106,7 @@ def python_protocol_subject(
         fixit_runner=mock_fixit_runner,
         setup_runner=mock_setup_runner,
         json_or_python_protocol_runner=mock_protocol_python_runner,
+        protocol_live_runner=mock_protocol_live_runner,
     )
 
 
@@ -105,6 +116,7 @@ def live_protocol_subject(
     mock_hardware_api: HardwareAPI,
     mock_fixit_runner: LiveRunner,
     mock_setup_runner: LiveRunner,
+    mock_protocol_live_runner: LiveRunner,
 ) -> RunOrchestrator:
     """Get a RunOrchestrator subject with a live runner."""
     return RunOrchestrator(
@@ -112,6 +124,7 @@ def live_protocol_subject(
         hardware_api=mock_hardware_api,
         fixit_runner=mock_fixit_runner,
         setup_runner=mock_setup_runner,
+        protocol_live_runner=mock_protocol_live_runner,
     )
 
 
@@ -360,6 +373,7 @@ def test_get_run_id(
     mock_hardware_api: HardwareAPI,
     mock_fixit_runner: LiveRunner,
     mock_setup_runner: LiveRunner,
+    mock_protocol_live_runner: LiveRunner,
 ) -> None:
     """Should get run_id if builder was created with a run id."""
     orchestrator = RunOrchestrator(
@@ -368,6 +382,7 @@ def test_get_run_id(
         hardware_api=mock_hardware_api,
         fixit_runner=mock_fixit_runner,
         setup_runner=mock_setup_runner,
+        protocol_live_runner=mock_protocol_live_runner,
     )
     assert orchestrator.run_id == "test-123"
 
@@ -377,6 +392,7 @@ def test_get_run_id_raises(
     mock_hardware_api: HardwareAPI,
     mock_fixit_runner: LiveRunner,
     mock_setup_runner: LiveRunner,
+    mock_protocol_live_runner: LiveRunner,
 ) -> None:
     """Should get run_id if builder was created with a run id."""
     orchestrator = RunOrchestrator(
@@ -384,6 +400,7 @@ def test_get_run_id_raises(
         hardware_api=mock_hardware_api,
         fixit_runner=mock_fixit_runner,
         setup_runner=mock_setup_runner,
+        protocol_live_runner=mock_protocol_live_runner,
     )
     with pytest.raises(NotImplementedError):
         orchestrator.run_id

--- a/robot-server/robot_server/commands/get_default_engine.py
+++ b/robot-server/robot_server/commands/get_default_engine.py
@@ -30,14 +30,14 @@ class RunActive(ErrorDetails):
     errorCode: str = ErrorCodes.ROBOT_IN_USE.value.code
 
 
-async def get_default_engine(
+async def get_default_orchestrator(
     engine_store: EngineStore = Depends(get_engine_store),
     hardware_api: HardwareControlAPI = Depends(get_hardware),
     module_identifier: ModuleIdentifier = Depends(ModuleIdentifier),
 ) -> ProtocolEngine:
-    """Get the default engine with attached modules loaded."""
+    """Get the default run orchestrator with attached modules loaded."""
     try:
-        engine = await engine_store.get_default_engine()
+        orchestrator = await engine_store.get_default_orchestrator()
     except EngineConflictError as e:
         raise RunActive.from_exc(e).as_error(status.HTTP_409_CONFLICT) from e
 
@@ -47,6 +47,6 @@ async def get_default_engine(
         for mod in attached_modules
     }
 
-    await engine.use_attached_modules(attached_module_spec)
+    await orchestrator.use_attached_modules(attached_module_spec)
 
-    return engine
+    return orchestrator

--- a/robot-server/robot_server/commands/get_default_orchestrator.py
+++ b/robot-server/robot_server/commands/get_default_orchestrator.py
@@ -4,7 +4,7 @@ from typing_extensions import Literal
 from fastapi import Depends, status
 
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocol_runner import RunOrchestrator
 
 from opentrons_shared_data.errors import ErrorCodes
 
@@ -34,7 +34,7 @@ async def get_default_orchestrator(
     engine_store: EngineStore = Depends(get_engine_store),
     hardware_api: HardwareControlAPI = Depends(get_hardware),
     module_identifier: ModuleIdentifier = Depends(ModuleIdentifier),
-) -> ProtocolEngine:
+) -> RunOrchestrator:
     """Get the default run orchestrator with attached modules loaded."""
     try:
         orchestrator = await engine_store.get_default_orchestrator()

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -105,7 +105,7 @@ async def create_command(
             Else, return immediately. Comes from a query parameter in the URL.
         timeout: The maximum time, in seconds, to wait before returning.
             Comes from a query parameter in the URL.
-        engine: The `ProtocolEngine` on which the command will be enqueued.
+        orchestrator: The `RunOrchestrator` handling engine for command to be enqueued.
     """
     command_create = request_body.data.copy(update={"intent": CommandIntent.SETUP})
     command = await orchestrator.add_command_and_wait_for_interval(

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -5,8 +5,11 @@ from typing_extensions import Final, Literal
 from anyio import move_on_after
 from fastapi import APIRouter, Depends, Query, status
 
-from opentrons.protocol_engine import ProtocolEngine, CommandIntent
+from opentrons.protocol_engine import CommandIntent
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
+
+from opentrons.protocol_runner import RunOrchestrator
+
 from opentrons_shared_data.errors import ErrorCodes
 
 from robot_server.errors.error_responses import ErrorDetails, ErrorBody
@@ -18,7 +21,7 @@ from robot_server.service.json_api import (
     PydanticResponse,
 )
 
-from .get_default_engine import get_default_engine, RunActive
+from .get_default_orchestrator import get_default_orchestrator, RunActive
 from .stateless_commands import StatelessCommand, StatelessCommandCreate
 
 _DEFAULT_COMMAND_LIST_LENGTH: Final = 20
@@ -91,7 +94,7 @@ async def create_command(
             " the default was 30 seconds, not infinite."
         ),
     ),
-    engine: ProtocolEngine = Depends(get_default_engine),
+    orchestrator: RunOrchestrator = Depends(get_default_orchestrator),
 ) -> PydanticResponse[SimpleBody[StatelessCommand]]:
     """Enqueue and execute a command.
 
@@ -105,14 +108,11 @@ async def create_command(
         engine: The `ProtocolEngine` on which the command will be enqueued.
     """
     command_create = request_body.data.copy(update={"intent": CommandIntent.SETUP})
-    command = engine.add_command(command_create)
+    command = await orchestrator.add_command_and_wait_for_interval(
+        command=command_create, wait_until_complete=waitUntilComplete, timeout=timeout
+    )
 
-    if waitUntilComplete:
-        timeout_sec = None if timeout is None else timeout / 1000.0
-        with move_on_after(timeout_sec):
-            await engine.wait_for_command(command.id)
-
-    response_data = cast(StatelessCommand, engine.state_view.commands.get(command.id))
+    response_data = cast(StatelessCommand, orchestrator.get_command(command.id))
 
     return await PydanticResponse.create(
         content=SimpleBody.construct(data=response_data),
@@ -134,7 +134,7 @@ async def create_command(
     },
 )
 async def get_commands_list(
-    engine: ProtocolEngine = Depends(get_default_engine),
+    orchestrator: RunOrchestrator = Depends(get_default_orchestrator),
     cursor: Optional[int] = Query(
         None,
         description=(
@@ -155,7 +155,7 @@ async def get_commands_list(
         cursor: Cursor index for the collection response.
         pageLength: Maximum number of items to return.
     """
-    cmd_slice = engine.state_view.commands.get_slice(cursor=cursor, length=pageLength)
+    cmd_slice = orchestrator.get_command_slice(cursor=cursor, length=pageLength)
     commands = cast(List[StatelessCommand], cmd_slice.commands)
     meta = MultiBodyMeta(cursor=cmd_slice.cursor, totalLength=cmd_slice.total_length)
 
@@ -181,7 +181,7 @@ async def get_commands_list(
 )
 async def get_command(
     commandId: str,
-    engine: ProtocolEngine = Depends(get_default_engine),
+    orchestrator: RunOrchestrator = Depends(get_default_orchestrator),
 ) -> PydanticResponse[SimpleBody[StatelessCommand]]:
     """Get a single stateless command.
 
@@ -190,7 +190,7 @@ async def get_command(
         engine: Protocol engine with commands.
     """
     try:
-        command = engine.state_view.commands.get(commandId)
+        command = orchestrator.get_command(commandId)
 
     except CommandDoesNotExistError as e:
         raise CommandNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -2,7 +2,6 @@
 from typing import List, Optional, cast
 from typing_extensions import Final, Literal
 
-from anyio import move_on_after
 from fastapi import APIRouter, Depends, Query, status
 
 from opentrons.protocol_engine import CommandIntent
@@ -151,7 +150,7 @@ async def get_commands_list(
     """Get a list of stateless commands.
 
     Arguments:
-        engine: Protocol engine with commands.
+        orchestrator: Run orchestrator with commands.
         cursor: Cursor index for the collection response.
         pageLength: Maximum number of items to return.
     """
@@ -187,7 +186,7 @@ async def get_command(
 
     Arguments:
         commandId: Command identifier from the URL parameter.
-        engine: Protocol engine with commands.
+        orchestrator: Run orchestrator with commands.
     """
     try:
         command = orchestrator.get_command(commandId)

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -129,14 +129,12 @@ async def get_is_okay_to_create_maintenance_run(
     engine_store: EngineStore = Depends(get_engine_store),
 ) -> bool:
     """Whether a maintenance run can be created if a protocol run already exists."""
-    try:
-        protocol_run_state = engine_store.engine.state_view
-    except NoRunnerEngineError:
-        return True
-    return (
-        not protocol_run_state.commands.has_been_played()
-        or protocol_run_state.commands.get_is_terminal()
-    )
+    # try:
+    #     protocol_run_state = engine_store.state_view
+    # except NoRunnerEngineError:
+    #     return True
+    # TODO(tz, 2024-5-28): is this the same?
+    return not engine_store.run_was_started() or engine_store.get_is_run_terminal()
 
 
 async def get_run_data_manager(

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -27,7 +27,7 @@ from robot_server.service.notifications import (
 )
 
 from .run_auto_deleter import RunAutoDeleter
-from .engine_store import EngineStore, NoRunnerEngineError
+from .engine_store import EngineStore, NoRunOrchestrator
 from .run_store import RunStore
 from .run_data_manager import RunDataManager
 from robot_server.errors.robot_errors import (
@@ -131,7 +131,7 @@ async def get_is_okay_to_create_maintenance_run(
     """Whether a maintenance run can be created if a protocol run already exists."""
     # try:
     #     protocol_run_state = engine_store.state_view
-    # except NoRunnerEngineError:
+    # except NoRunOrchestrator:
     #     return True
     # TODO(tz, 2024-5-28): is this the same?
     return not engine_store.run_was_started() or engine_store.get_is_run_terminal()

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -27,7 +27,7 @@ from robot_server.service.notifications import (
 )
 
 from .run_auto_deleter import RunAutoDeleter
-from .engine_store import EngineStore
+from .engine_store import EngineStore, NoRunOrchestrator
 from .run_store import RunStore
 from .run_data_manager import RunDataManager
 from robot_server.errors.robot_errors import (
@@ -129,12 +129,11 @@ async def get_is_okay_to_create_maintenance_run(
     engine_store: EngineStore = Depends(get_engine_store),
 ) -> bool:
     """Whether a maintenance run can be created if a protocol run already exists."""
-    # try:
-    #     protocol_run_state = engine_store.state_view
-    # except NoRunOrchestrator:
-    #     return True
-    # TODO(tz, 2024-5-28): is this the same?
-    return not engine_store.run_was_started() or engine_store.get_is_run_terminal()
+    try:
+        orchestrator = engine_store.run_orchestrator
+    except NoRunOrchestrator:
+        return True
+    return not orchestrator.run_has_started() or orchestrator.get_is_run_terminal()
 
 
 async def get_run_data_manager(

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -27,7 +27,7 @@ from robot_server.service.notifications import (
 )
 
 from .run_auto_deleter import RunAutoDeleter
-from .engine_store import EngineStore, NoRunOrchestrator
+from .engine_store import EngineStore
 from .run_store import RunStore
 from .run_data_manager import RunDataManager
 from robot_server.errors.robot_errors import (

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -175,6 +175,7 @@ class EngineStore:
             self._default_run_orchestrator = RunOrchestrator.build_orchestrator(
                 protocol_engine=engine, hardware_api=self._hardware_api
             )
+            return self._default_run_orchestrator.engine
         return default_orchestrator.engine
 
     async def create(

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -314,7 +314,9 @@ class EngineStore:
         self, deck_configuration: Optional[DeckConfigurationType] = None
     ) -> RunResult:
         """Start or resume the run."""
-        return self._run_orchestrator.runner.run(deck_configuration=deck_configuration)
+        return await self._run_orchestrator.runner.run(
+            deck_configuration=deck_configuration
+        )
 
     def pause(self) -> None:
         """Start or resume the run."""

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -295,3 +295,11 @@ class EngineStore:
         return RunResult(
             state_summary=run_data, commands=commands, parameters=run_time_parameters
         )
+
+    def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
+        """Start or resume the run."""
+        self._run_orchestrator.engine.play(deck_configuration=deck_configuration)
+
+    async def finish(self, error: Optional[Exception]) -> None:
+        """Stop the run."""
+        self._run_orchestrator.engine.finish(error=error)

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -82,8 +82,8 @@ async def handle_estop_event(engine_store: "EngineStore", event: HardwareEvent) 
                 return
             # todo(mm, 2024-04-17): This estop teardown sequencing belongs in the
             # runner layer.
-            engine_store.engine.estop()
-            await engine_store.engine.finish(error=EStopActivatedError())
+            engine_store._run_orchestrator.estop()
+            await engine_store._run_orchestrator.finish(error=EStopActivatedError())
     except Exception:
         # This is a background task kicked off by a hardware event,
         # so there's no one to propagate this exception to.

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -37,6 +37,9 @@ from opentrons.protocol_engine import (
     CommandSlice,
     CommandPointer,
     Command,
+    CommandCreate,
+    LabwareOffset,
+    LabwareOffsetCreate,
 )
 
 from robot_server.protocols.protocol_store import ProtocolResource
@@ -45,6 +48,7 @@ from opentrons.protocol_engine.types import (
     RunTimeParamValuesType,
     EngineStatus,
 )
+from opentrons_shared_data.labware.dev_types import LabwareUri
 
 
 _log = logging.getLogger(__name__)
@@ -382,3 +386,23 @@ class EngineStore:
 
     def run_was_started(self) -> bool:
         return self._run_orchestrator.runner.was_started()
+
+    def add_labware_offset(self, request: LabwareOffsetCreate) -> LabwareOffset:
+        return self._run_orchestrator.engine.add_labware_offset(request)
+
+    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+        return self._run_orchestrator.engine.add_labware_definition(definition)
+
+    def add_command_and_wait_for_interval(
+        self,
+        request: CommandCreate,
+        wait_until_complete: bool = False,
+        timeout: Optional[int] = None,
+        failed_command_id: Optional[str] = None,
+    ) -> Command:
+        return self._run_orchestrator.add_command_and_wait_for_interval(
+            command=request,
+            failed_command_id=failed_command_id,
+            wait_until_complete=wait_until_complete,
+            timeout=timeout,
+        )

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -395,14 +395,14 @@ class EngineStore:
     def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
         return self._run_orchestrator.engine.add_labware_definition(definition)
 
-    def add_command_and_wait_for_interval(
+    async def add_command_and_wait_for_interval(
         self,
         request: CommandCreate,
         wait_until_complete: bool = False,
         timeout: Optional[int] = None,
         failed_command_id: Optional[str] = None,
     ) -> Command:
-        return self._run_orchestrator.add_command_and_wait_for_interval(
+        return await self._run_orchestrator.add_command_and_wait_for_interval(
             command=request,
             failed_command_id=failed_command_id,
             wait_until_complete=wait_until_complete,

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -305,6 +305,24 @@ class EngineStore:
         """Start or resume the run."""
         self._run_orchestrator.engine.play(deck_configuration=deck_configuration)
 
+    async def run(
+        self, deck_configuration: Optional[DeckConfigurationType] = None
+    ) -> RunResult:
+        """Start or resume the run."""
+        return self._run_orchestrator.runner.run(deck_configuration=deck_configuration)
+
+    def pause(self) -> None:
+        """Start or resume the run."""
+        self._run_orchestrator.runner.pause()
+
+    async def stop(self) -> None:
+        """Start or resume the run."""
+        self._run_orchestrator.runner.stop()
+
+    def resume_from_recovery(self) -> None:
+        """Start or resume the run."""
+        self._run_orchestrator.runner.resume_from_recovery()
+
     async def finish(self, error: Optional[Exception]) -> None:
         """Stop the run."""
         self._run_orchestrator.engine.finish(error=error)
@@ -356,3 +374,6 @@ class EngineStore:
 
     def get_is_run_terminal(self) -> bool:
         return self._run_orchestrator.engine.state_view.commands.get_is_terminal()
+
+    def run_was_started(self) -> bool:
+        return self._run_orchestrator.runner.was_started()

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Callable
 
 from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
 from opentrons.protocol_engine.types import PostRunHardwareState
+
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.robot.dev_types import RobotType
 from opentrons_shared_data.robot.dev_types import RobotTypeEnum
 
@@ -303,3 +305,11 @@ class EngineStore:
     async def finish(self, error: Optional[Exception]) -> None:
         """Stop the run."""
         self._run_orchestrator.engine.finish(error=error)
+
+    async def get_state_summary(self) -> StateSummary:
+        return self._run_orchestrator.engine.state_view.get_summary()
+
+    def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
+        return (
+            self._run_orchestrator.engine.state_view.labware.get_loaded_labware_definitions()
+        )

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -43,6 +43,7 @@ from robot_server.protocols.protocol_store import ProtocolResource
 from opentrons.protocol_engine.types import (
     DeckConfigurationType,
     RunTimeParamValuesType,
+    EngineStatus,
 )
 
 
@@ -371,6 +372,10 @@ class EngineStore:
         return self._run_orchestrator.engine.state_view.commands.get(
             command_id=command_id
         )
+
+    def get_status(self) -> EngineStatus:
+        """Get the current execution status of the engine."""
+        return self._run_orchestrator.engine.state_view.commands.get_status()
 
     def get_is_run_terminal(self) -> bool:
         return self._run_orchestrator.engine.state_view.commands.get_is_terminal()

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -296,23 +296,23 @@ class EngineStore:
         self.run_orchestrator.play(deck_configuration=deck_configuration)
 
     async def run(self, deck_configuration: DeckConfigurationType) -> RunResult:
-        """Start or resume the run."""
+        """Start the run."""
         return await self.run_orchestrator.run(deck_configuration=deck_configuration)
 
     def pause(self) -> None:
-        """Start or resume the run."""
+        """Pause the run."""
         self.run_orchestrator.pause()
 
     async def stop(self) -> None:
-        """Start or resume the run."""
+        """Stop the run."""
         await self.run_orchestrator.stop()
 
     def resume_from_recovery(self) -> None:
-        """Start or resume the run."""
+        """Resume the run from recovery mode."""
         self.run_orchestrator.resume_from_recovery()
 
     async def finish(self, error: Optional[Exception]) -> None:
-        """Stop the run."""
+        """Finish the run."""
         await self.run_orchestrator.finish(error=error)
 
     def get_state_summary(self) -> StateSummary:
@@ -328,7 +328,7 @@ class EngineStore:
         return self.run_orchestrator.get_run_time_parameters()
 
     def get_current_command(self) -> Optional[CommandPointer]:
-        """Parameter definitions defined by protocol, if any. Will always be empty before execution."""
+        """Get the current running command."""
         return self.run_orchestrator.get_current_command()
 
     def get_command_slice(
@@ -339,12 +339,8 @@ class EngineStore:
         """Get a slice of run commands.
 
         Args:
-            run_id: ID of the run.
             cursor: Requested index of first command in the returned slice.
             length: Length of slice to return.
-
-        Raises:
-            RunNotFoundError: The given run identifier was not found in the database.
         """
         return self.run_orchestrator.get_command_slice(cursor=cursor, length=length)
 

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -149,7 +149,7 @@ class EngineStore:
     # TODO(tz, 2024-5-14): remove this once its all redirected via orchestrator
     # TODO(mc, 2022-03-21): this resource locking is insufficient;
     # come up with something more sophisticated without race condition holes.
-    async def get_default_orchestrator(self) -> ProtocolEngine:
+    async def get_default_orchestrator(self) -> RunOrchestrator:
         """Get a "default" RunOrchestrator to use outside the context of a run.
 
         Raises:

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -153,7 +153,8 @@ class EngineStore:
             EngineConflictError: if a run-specific engine is active.
         """
         if (
-            self.run_orchestrator.run_has_started()
+            self._run_orchestrator is not None
+            and self.run_orchestrator.run_has_started()
             and not self.run_orchestrator.run_has_stopped()
         ):
             raise EngineConflictError("An engine for a run is currently active")

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -255,7 +255,7 @@ class EngineStore:
         elif isinstance(runner, JsonRunner):
             assert (
                 protocol is not None
-            ), "A JSON protocol shouZld have a protocol source file."
+            ), "A JSON protocol should have a protocol source file."
             await self.run_orchestrator.load_json(protocol.source)
         else:
             self.run_orchestrator.prepare()

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -149,8 +149,8 @@ class EngineStore:
     # TODO(tz, 2024-5-14): remove this once its all redirected via orchestrator
     # TODO(mc, 2022-03-21): this resource locking is insufficient;
     # come up with something more sophisticated without race condition holes.
-    async def get_default_engine(self) -> ProtocolEngine:
-        """Get a "default" ProtocolEngine to use outside the context of a run.
+    async def get_default_orchestrator(self) -> ProtocolEngine:
+        """Get a "default" RunOrchestrator to use outside the context of a run.
 
         Raises:
             EngineConflictError: if a run-specific engine is active.
@@ -175,8 +175,8 @@ class EngineStore:
             self._default_run_orchestrator = RunOrchestrator.build_orchestrator(
                 protocol_engine=engine, hardware_api=self._hardware_api
             )
-            return self._default_run_orchestrator.engine
-        return default_orchestrator.engine
+            return self._default_run_orchestrator
+        return default_orchestrator
 
     async def create(
         self,
@@ -242,7 +242,9 @@ class EngineStore:
         # concurrency hazard. If two requests simultaneously call this method,
         # they will both "succeed" (with undefined results) instead of one
         # raising EngineConflictError.
-        if isinstance(self.run_orchestrator.runner, PythonAndLegacyRunner):
+        if isinstance(
+            self.run_orchestrator.get_protocol_runner(), PythonAndLegacyRunner
+        ):
             assert (
                 protocol is not None
             ), "A Python protocol should have a protocol source file."

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -245,7 +245,7 @@ class EngineStore:
             assert (
                 protocol is not None
             ), "A Python protocol should have a protocol source file."
-            await self.run_orchestrator.load(
+            await self.run_orchestrator.load_python(
                 protocol.source,
                 # Conservatively assume that we're re-running a protocol that
                 # was uploaded before we added stricter validation, and that
@@ -257,7 +257,7 @@ class EngineStore:
             assert (
                 protocol is not None
             ), "A JSON protocol shouZld have a protocol source file."
-            await self.run_orchestrator.load(protocol.source)
+            await self.run_orchestrator.load_json(protocol.source)
         else:
             self.run_orchestrator.prepare()
 

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -351,7 +351,7 @@ class EngineStore:
 
     def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
-        return self.run_orchestrator.get_recovery_target()
+        return self.run_orchestrator.get_command_recovery_target()
 
     def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -21,7 +21,6 @@ from opentrons.hardware_control.types import (
 from opentrons.protocols.parse import PythonParseMode
 from opentrons.protocols.api_support.deck_type import should_load_fixed_trash
 from opentrons.protocol_runner import (
-    AnyRunner,
     JsonRunner,
     PythonAndLegacyRunner,
     RunResult,
@@ -31,7 +30,6 @@ from opentrons.protocol_engine import (
     Config as ProtocolEngineConfig,
     DeckType,
     LabwareOffsetCreate,
-    ProtocolEngine,
     StateSummary,
     create_protocol_engine,
     CommandSlice,
@@ -39,7 +37,6 @@ from opentrons.protocol_engine import (
     Command,
     CommandCreate,
     LabwareOffset,
-    LabwareOffsetCreate,
 )
 
 from robot_server.protocols.protocol_store import ProtocolResource
@@ -319,9 +316,11 @@ class EngineStore:
         await self.run_orchestrator.finish(error=error)
 
     def get_state_summary(self) -> StateSummary:
+        """Get protocol run data."""
         return self.run_orchestrator.get_state_summary()
 
     def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
+        """Get loaded labware definitions."""
         return self.run_orchestrator.get_loaded_labware_definitions()
 
     def get_run_time_parameters(self) -> List[RunTimeParameter]:
@@ -362,15 +361,19 @@ class EngineStore:
         return self.run_orchestrator.get_run_status()
 
     def get_is_run_terminal(self) -> bool:
+        """Get whether engine is in a terminal state."""
         return self.run_orchestrator.get_is_run_terminal()
 
     def run_was_started(self) -> bool:
+        """Get whether the run has started."""
         return self.run_orchestrator.run_has_started()
 
     def add_labware_offset(self, request: LabwareOffsetCreate) -> LabwareOffset:
+        """Add a new labware offset to state."""
         return self.run_orchestrator.add_labware_offset(request)
 
     def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+        """Add a new labware definition to state."""
         return self.run_orchestrator.add_labware_definition(definition)
 
     async def add_command_and_wait_for_interval(
@@ -380,6 +383,7 @@ class EngineStore:
         timeout: Optional[int] = None,
         failed_command_id: Optional[str] = None,
     ) -> Command:
+        """Add a new command to execute and wait for it to complete if needed."""
         return await self.run_orchestrator.add_command_and_wait_for_interval(
             command=request,
             failed_command_id=failed_command_id,

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -143,7 +143,6 @@ class EngineStore:
             self.run_orchestrator.run_id if self._run_orchestrator is not None else None
         )
 
-    # TODO(tz, 2024-5-14): remove this once its all redirected via orchestrator
     # TODO(mc, 2022-03-21): this resource locking is insufficient;
     # come up with something more sophisticated without race condition holes.
     async def get_default_orchestrator(self) -> RunOrchestrator:

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -156,8 +156,8 @@ class EngineStore:
             EngineConflictError: if a run-specific engine is active.
         """
         if (
-            self.run_orchestrator.engine.state_view.commands.has_been_played()
-            and not self.run_orchestrator.engine.state_view.commands.get_is_stopped()
+            self.run_orchestrator.run_has_started()
+            and not self.run_orchestrator.run_has_stopped()
         ):
             raise EngineConflictError("An engine for a run is currently active")
 
@@ -298,45 +298,41 @@ class EngineStore:
 
     def play(self, deck_configuration: Optional[DeckConfigurationType] = None) -> None:
         """Start or resume the run."""
-        self.run_orchestrator.engine.play(deck_configuration=deck_configuration)
+        self.run_orchestrator.play(deck_configuration=deck_configuration)
 
     async def run(self, deck_configuration: DeckConfigurationType) -> RunResult:
         """Start or resume the run."""
-        return await self.run_orchestrator.runner.run(
-            deck_configuration=deck_configuration
-        )
+        return await self.run_orchestrator.run(deck_configuration=deck_configuration)
 
     def pause(self) -> None:
         """Start or resume the run."""
-        self.run_orchestrator.runner.pause()
+        self.run_orchestrator.pause()
 
     async def stop(self) -> None:
         """Start or resume the run."""
-        await self.run_orchestrator.runner.stop()
+        await self.run_orchestrator.stop()
 
     def resume_from_recovery(self) -> None:
         """Start or resume the run."""
-        self.run_orchestrator.runner.resume_from_recovery()
+        self.run_orchestrator.resume_from_recovery()
 
     async def finish(self, error: Optional[Exception]) -> None:
         """Stop the run."""
-        await self.run_orchestrator.engine.finish(error=error)
+        await self.run_orchestrator.finish(error=error)
 
     def get_state_summary(self) -> StateSummary:
-        return self.run_orchestrator.engine.state_view.get_summary()
+        return self.run_orchestrator.get_summary()
 
     def get_loaded_labware_definitions(self) -> List[LabwareDefinition]:
-        return (
-            self.run_orchestrator.engine.state_view.labware.get_loaded_labware_definitions()
-        )
+        return self.run_orchestrator.get_loaded_labware_definitions()
 
     def get_run_time_parameters(self) -> List[RunTimeParameter]:
         """Parameter definitions defined by protocol, if any. Will always be empty before execution."""
-        return self.run_orchestrator.runner.run_time_parameters
+        return self.run_orchestrator.get_run_time_parameters()
 
     def get_current_command(self) -> Optional[CommandPointer]:
         """Parameter definitions defined by protocol, if any. Will always be empty before execution."""
-        return self.run_orchestrator.engine.state_view.commands.get_current()
+        return self.run_orchestrator.get_current_command()
 
     def get_command_slice(
         self,
@@ -353,35 +349,31 @@ class EngineStore:
         Raises:
             RunNotFoundError: The given run identifier was not found in the database.
         """
-        return self.run_orchestrator.engine.state_view.commands.get_slice(
-            cursor=cursor, length=length
-        )
+        return self.run_orchestrator.get_command_slice(cursor=cursor, length=length)
 
     def get_command_recovery_target(self) -> Optional[CommandPointer]:
         """Get the current error recovery target."""
-        return self.run_orchestrator.engine.state_view.commands.get_recovery_target()
+        return self.run_orchestrator.get_recovery_target()
 
     def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
-        return self.run_orchestrator.engine.state_view.commands.get(
-            command_id=command_id
-        )
+        return self.run_orchestrator.get_command(command_id=command_id)
 
     def get_status(self) -> EngineStatus:
         """Get the current execution status of the engine."""
-        return self.run_orchestrator.engine.state_view.commands.get_status()
+        return self.run_orchestrator.get_run_status()
 
     def get_is_run_terminal(self) -> bool:
-        return self.run_orchestrator.engine.state_view.commands.get_is_terminal()
+        return self.run_orchestrator.get_is_run_terminal()
 
     def run_was_started(self) -> bool:
-        return self.run_orchestrator.runner.was_started()
+        return self.run_orchestrator.was_run_started()
 
     def add_labware_offset(self, request: LabwareOffsetCreate) -> LabwareOffset:
-        return self.run_orchestrator.engine.add_labware_offset(request)
+        return self.run_orchestrator.add_labware_offset(request)
 
     def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
-        return self.run_orchestrator.engine.add_labware_definition(definition)
+        return self.run_orchestrator.add_labware_definition(definition)
 
     async def add_command_and_wait_for_interval(
         self,

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -135,7 +135,7 @@ class LightController:
             return None
         current_id = self._engine_store.current_run_id
         if current_id is not None:
-            return self._engine_store.engine.state_view.commands.get_status()
+            return self._engine_store.get_status()
 
         return None
 

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -208,7 +208,7 @@ async def create_run_command(
     command_intent = request_body.data.intent or pe_commands.CommandIntent.SETUP
     command_create = request_body.data.copy(update={"intent": command_intent})
     try:
-        command = engine_store.add_command_and_wait_for_interval(
+        command = await engine_store.add_command_and_wait_for_interval(
             request=command_create,
             failed_command_id=failedCommandId,
             wait_until_complete=waitUntilComplete,

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -207,6 +207,7 @@ async def create_run_command(
     # behavior is to pass through `command_intent` without overriding it
     command_intent = request_body.data.intent or pe_commands.CommandIntent.SETUP
     command_create = request_body.data.copy(update={"intent": command_intent})
+
     try:
         command = await engine_store.add_command_and_wait_for_interval(
             request=command_create,

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -200,6 +200,7 @@ async def create_run_command(
         engine_store: The run's `EngineStore` on which the new
             command will be enqueued.
         check_estop: Dependency to verify the estop is in a valid state.
+        run_id: Run identification to attach command to.
     """
     # TODO(mc, 2022-05-26): increment the HTTP API version so that default
     # behavior is to pass through `command_intent` without overriding it

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -3,13 +3,10 @@ import textwrap
 from typing import Optional, Union
 from typing_extensions import Final, Literal
 
-from anyio import move_on_after
 from fastapi import APIRouter, Depends, Query, status
-
 
 from opentrons.protocol_engine import (
     CommandPointer,
-    ProtocolEngine,
     commands as pe_commands,
     errors as pe_errors,
 )
@@ -33,9 +30,9 @@ from ..command_models import (
 from ..run_models import RunCommandSummary
 from ..run_data_manager import RunDataManager, PreSerializedCommandsNotAvailableError
 from ..engine_store import EngineStore
-from ..run_store import RunStore, CommandNotFoundError
+from ..run_store import CommandNotFoundError
 from ..run_models import RunNotFoundError
-from ..dependencies import get_engine_store, get_run_data_manager, get_run_store
+from ..dependencies import get_engine_store, get_run_data_manager
 from .base_router import RunNotFound, RunStopped
 
 

--- a/robot-server/robot_server/runs/router/labware_router.py
+++ b/robot-server/robot_server/runs/router/labware_router.py
@@ -64,7 +64,7 @@ async def add_labware_offset(
             status.HTTP_409_CONFLICT
         )
 
-    added_offset = engine_store.engine.add_labware_offset(request_body.data)
+    added_offset = engine_store.add_labware_offset(request_body.data)
     log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
 
     return await PydanticResponse.create(
@@ -106,7 +106,7 @@ async def add_labware_definition(
             status.HTTP_409_CONFLICT
         )
 
-    uri = engine_store.engine.add_labware_definition(request_body.data)
+    uri = engine_store.add_labware_definition(request_body.data)
     log.info(f'Added labware definition "{uri}"' f' to run "{run.id}".')
 
     return PydanticResponse(

--- a/robot-server/robot_server/runs/run_controller.py
+++ b/robot-server/robot_server/runs/run_controller.py
@@ -67,9 +67,9 @@ class RunController:
 
         try:
             if action_type == RunActionType.PLAY:
-                if self._engine_store.runner.was_started():
+                if self._engine_store.run_was_started():
                     log.info(f'Resuming run "{self._run_id}".')
-                    self._engine_store.runner.play()
+                    self._engine_store.play()
                 else:
                     log.info(f'Starting run "{self._run_id}".')
                     # TODO(mc, 2022-05-13): engine_store.runner.run could raise
@@ -83,14 +83,14 @@ class RunController:
 
             elif action_type == RunActionType.PAUSE:
                 log.info(f'Pausing run "{self._run_id}".')
-                self._engine_store.runner.pause()
+                self._engine_store.pause()
 
             elif action_type == RunActionType.STOP:
                 log.info(f'Stopping run "{self._run_id}".')
-                self._task_runner.run(self._engine_store.runner.stop)
+                self._task_runner.run(self._engine_store.stop)
 
             elif action_type == RunActionType.RESUME_FROM_RECOVERY:
-                self._engine_store.runner.resume_from_recovery()
+                self._engine_store.resume_from_recovery()
 
         except ProtocolEngineError as e:
             raise RunActionNotAllowedError(message=e.message, wrapping=[e]) from e
@@ -103,7 +103,7 @@ class RunController:
     async def _run_protocol_and_insert_result(
         self, deck_configuration: DeckConfigurationType
     ) -> None:
-        result = await self._engine_store.runner.run(
+        result = await self._engine_store.run(
             deck_configuration=deck_configuration,
         )
         self._run_store.update_run_state(

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -254,7 +254,7 @@ class RunDataManager:
             )
 
         return (
-            self._engine_store.engine.state_view.labware.get_loaded_labware_definitions()
+            self.engine._run_orchestrator.state_view.labware.get_loaded_labware_definitions()
         )
 
     def get_all(self, length: Optional[int]) -> List[Union[Run, BadRun]]:
@@ -334,7 +334,9 @@ class RunDataManager:
                 run_id
             )
         else:
-            state_summary = self._engine_store.engine.state_view.get_summary()
+            state_summary = (
+                self._engine_store._run_orchestrator.engine.state_view.get_summary()
+            )
             runner = self._engine_store.runner
             parameters = runner.run_time_parameters if runner else []
             run_resource = self._run_store.get(run_id=run_id)
@@ -363,7 +365,7 @@ class RunDataManager:
             RunNotFoundError: The given run identifier was not found in the database.
         """
         if run_id == self._engine_store.current_run_id:
-            the_slice = self._engine_store.engine.state_view.commands.get_slice(
+            the_slice = self._engine_store._run_orchestrator.engine.state_view.commands.get_slice(
                 cursor=cursor, length=length
             )
             return the_slice
@@ -383,7 +385,9 @@ class RunDataManager:
             run_id: ID of the run.
         """
         if self._engine_store.current_run_id == run_id:
-            return self._engine_store.engine.state_view.commands.get_current()
+            return (
+                self._engine_store._run_orchestrator.engine.state_view.commands.get_current()
+            )
         else:
             # todo(mm, 2024-05-20):
             # For historical runs to behave consistently with the current run,
@@ -399,7 +403,9 @@ class RunDataManager:
             run_id: ID of the run.
         """
         if self._engine_store.current_run_id == run_id:
-            return self._engine_store.engine.state_view.commands.get_recovery_target()
+            return (
+                self._engine_store._run_orchestrator.engine.state_view.commands.get_recovery_target()
+            )
         else:
             # Historical runs can't have any ongoing error recovery.
             return None
@@ -416,7 +422,7 @@ class RunDataManager:
             CommandNotFoundError: The given command identifier was not found.
         """
         if self._engine_store.current_run_id == run_id:
-            return self._engine_store.engine.state_view.commands.get(
+            return self._engine_store._run_orchestrator.engine.state_view.commands.get(
                 command_id=command_id
             )
 
@@ -426,7 +432,7 @@ class RunDataManager:
         """Get all commands of a run in a serialized json list."""
         if (
             run_id == self._engine_store.current_run_id
-            and not self._engine_store.engine.state_view.commands.get_is_terminal()
+            and not self._engine_store._run_orchestrator.engine.state_view.commands.get_is_terminal()
         ):
             raise PreSerializedCommandsNotAvailableError(
                 "Pre-serialized commands are only available after a run has ended."
@@ -435,7 +441,7 @@ class RunDataManager:
 
     def _get_state_summary(self, run_id: str) -> Union[StateSummary, BadStateSummary]:
         if run_id == self._engine_store.current_run_id:
-            return self._engine_store.engine.state_view.get_summary()
+            return self._engine_store._run_orchestrator.engine.state_view.get_summary()
         else:
             return self._run_store.get_state_summary(run_id=run_id)
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -360,10 +360,7 @@ class RunDataManager:
             RunNotFoundError: The given run identifier was not found in the database.
         """
         if run_id == self._engine_store.current_run_id:
-            the_slice = self._engine_store.get_command_slice(
-                cursor=cursor, length=length
-            )
-            return the_slice
+            return self._engine_store.get_command_slice(cursor=cursor, length=length)
 
         # Let exception propagate
         return self._run_store.get_commands_slice(
@@ -421,7 +418,7 @@ class RunDataManager:
         """Get all commands of a run in a serialized json list."""
         if (
             run_id == self._engine_store.current_run_id
-            and not self._engine_store.get_is_command_terminal()
+            and not self._engine_store.get_is_run_terminal()
         ):
             raise PreSerializedCommandsNotAvailableError(
                 "Pre-serialized commands are only available after a run has ended."
@@ -440,7 +437,6 @@ class RunDataManager:
 
     def _get_run_time_parameters(self, run_id: str) -> List[RunTimeParameter]:
         if run_id == self._engine_store.current_run_id:
-            runner = self._engine_store.runner
-            return runner.run_time_parameters if runner else []
+            return self._engine_store.get_run_time_parameters()
         else:
             return self._run_store.get_run_time_parameters(run_id=run_id)

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -253,9 +253,7 @@ class RunDataManager:
                 f"Cannot get load labware definitions of {run_id} because it is not the current run."
             )
 
-        return (
-            self.engine._run_orchestrator.state_view.labware.get_loaded_labware_definitions()
-        )
+        return self._engine_store.get_loaded_labware_definitions()
 
     def get_all(self, length: Optional[int]) -> List[Union[Run, BadRun]]:
         """Get current and stored run resources.
@@ -334,11 +332,8 @@ class RunDataManager:
                 run_id
             )
         else:
-            state_summary = (
-                self._engine_store._run_orchestrator.engine.state_view.get_summary()
-            )
-            runner = self._engine_store.runner
-            parameters = runner.run_time_parameters if runner else []
+            state_summary = self._engine_store.get_state_summary()
+            parameters = self._engine_store.get_run_time_parameters()
             run_resource = self._run_store.get(run_id=run_id)
 
         return _build_run(
@@ -365,7 +360,7 @@ class RunDataManager:
             RunNotFoundError: The given run identifier was not found in the database.
         """
         if run_id == self._engine_store.current_run_id:
-            the_slice = self._engine_store._run_orchestrator.engine.state_view.commands.get_slice(
+            the_slice = self._engine_store.get_command_slice(
                 cursor=cursor, length=length
             )
             return the_slice
@@ -385,9 +380,7 @@ class RunDataManager:
             run_id: ID of the run.
         """
         if self._engine_store.current_run_id == run_id:
-            return (
-                self._engine_store._run_orchestrator.engine.state_view.commands.get_current()
-            )
+            return self._engine_store.get_current_command()
         else:
             # todo(mm, 2024-05-20):
             # For historical runs to behave consistently with the current run,
@@ -403,9 +396,7 @@ class RunDataManager:
             run_id: ID of the run.
         """
         if self._engine_store.current_run_id == run_id:
-            return (
-                self._engine_store._run_orchestrator.engine.state_view.commands.get_recovery_target()
-            )
+            return self._engine_store.get_command_recovery_target()
         else:
             # Historical runs can't have any ongoing error recovery.
             return None
@@ -422,9 +413,7 @@ class RunDataManager:
             CommandNotFoundError: The given command identifier was not found.
         """
         if self._engine_store.current_run_id == run_id:
-            return self._engine_store._run_orchestrator.engine.state_view.commands.get(
-                command_id=command_id
-            )
+            return self._engine_store.get_command(command_id=command_id)
 
         return self._run_store.get_command(run_id=run_id, command_id=command_id)
 
@@ -432,7 +421,7 @@ class RunDataManager:
         """Get all commands of a run in a serialized json list."""
         if (
             run_id == self._engine_store.current_run_id
-            and not self._engine_store._run_orchestrator.engine.state_view.commands.get_is_terminal()
+            and not self._engine_store.get_is_command_terminal()
         ):
             raise PreSerializedCommandsNotAvailableError(
                 "Pre-serialized commands are only available after a run has ended."
@@ -441,7 +430,7 @@ class RunDataManager:
 
     def _get_state_summary(self, run_id: str) -> Union[StateSummary, BadStateSummary]:
         if run_id == self._engine_store.current_run_id:
-            return self._engine_store._run_orchestrator.engine.state_view.get_summary()
+            return self._engine_store.get_state_summary()
         else:
             return self._run_store.get_state_summary(run_id=run_id)
 

--- a/robot-server/tests/commands/test_get_default_engine.py
+++ b/robot-server/tests/commands/test_get_default_engine.py
@@ -9,7 +9,7 @@ from opentrons.protocol_engine import ProtocolEngine
 from robot_server.errors.error_responses import ApiError
 from robot_server.runs.engine_store import EngineStore, EngineConflictError
 from robot_server.modules.module_identifier import ModuleIdentifier, ModuleIdentity
-from robot_server.commands.get_default_engine import get_default_engine
+from robot_server.commands.get_default_orchestrator import get_default_engine
 
 
 @pytest.fixture()

--- a/robot-server/tests/commands/test_get_default_engine.py
+++ b/robot-server/tests/commands/test_get_default_engine.py
@@ -1,21 +1,21 @@
-"""Tests for robot_server.commands.get_default_engine."""
+"""Tests for robot_server.commands.get_default_orchestrator."""
 import pytest
 from decoy import Decoy
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules import MagDeck, TempDeck
-from opentrons.protocol_engine import ProtocolEngine
+from opentrons.protocol_runner import RunOrchestrator
 
 from robot_server.errors.error_responses import ApiError
 from robot_server.runs.engine_store import EngineStore, EngineConflictError
 from robot_server.modules.module_identifier import ModuleIdentifier, ModuleIdentity
-from robot_server.commands.get_default_orchestrator import get_default_engine
+from robot_server.commands.get_default_orchestrator import get_default_orchestrator
 
 
 @pytest.fixture()
-def protocol_engine(decoy: Decoy) -> ProtocolEngine:
+def run_orchestrator(decoy: Decoy) -> RunOrchestrator:
     """Get a mocked out ProtocolEngine."""
-    return decoy.mock(cls=ProtocolEngine)
+    return decoy.mock(cls=RunOrchestrator)
 
 
 @pytest.fixture()
@@ -30,11 +30,11 @@ def module_identifier(decoy: Decoy) -> ModuleIdentifier:
     return decoy.mock(cls=ModuleIdentifier)
 
 
-async def test_get_default_engine(
+async def test_get_default_orchestrator(
     decoy: Decoy,
     engine_store: EngineStore,
     hardware_api: HardwareControlAPI,
-    protocol_engine: ProtocolEngine,
+    run_orchestrator: RunOrchestrator,
     module_identifier: ModuleIdentifier,
 ) -> None:
     """It should get a default engine with modules pre-loaded."""
@@ -63,30 +63,32 @@ async def test_get_default_engine(
 
     decoy.when(hardware_api.attached_modules).then_return([mod_1, mod_2])
 
-    decoy.when(await engine_store.get_default_engine()).then_return(protocol_engine)
+    decoy.when(await engine_store.get_default_orchestrator()).then_return(
+        run_orchestrator
+    )
 
-    result = await get_default_engine(
+    result = await get_default_orchestrator(
         engine_store=engine_store,
         hardware_api=hardware_api,
         module_identifier=module_identifier,
     )
 
-    assert result is protocol_engine
+    assert result is run_orchestrator
 
     decoy.verify(
-        await protocol_engine.use_attached_modules({"mod-1": mod_1, "mod-2": mod_2}),
+        await run_orchestrator.use_attached_modules({"mod-1": mod_1, "mod-2": mod_2}),
         times=1,
     )
 
 
 async def test_raises_conflict(decoy: Decoy, engine_store: EngineStore) -> None:
     """It should raise a 409 conflict if the default engine is not availble."""
-    decoy.when(await engine_store.get_default_engine()).then_raise(
+    decoy.when(await engine_store.get_default_orchestrator()).then_raise(
         EngineConflictError("oh no")
     )
 
     with pytest.raises(ApiError) as exc_info:
-        await get_default_engine(engine_store=engine_store)
+        await get_default_orchestrator(engine_store=engine_store)
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["id"] == "RunActive"

--- a/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
@@ -39,20 +39,20 @@ stages:
     response:
       status_code: 201
 
-#  - name: Wait for the command to run
-#    max_retries: 10
-#    delay_after: 0.2
-#    request:
-#      url: '{ot2_server_base_url}/runs/{run_id}/commands'
-#      method: GET
-#    response:
-#      status_code: 200
-#      strict:
-#        - json:off
-#      json:
-#        data:
-#          - commandType: waitForDuration
-#            status: running
+  - name: Wait for the command to run
+    max_retries: 10
+    delay_after: 0.2
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/commands'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          - commandType: waitForDuration
+            status: running
 
 #  - name: Stop the run
 #    request:

--- a/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
@@ -54,15 +54,15 @@ stages:
           - commandType: waitForDuration
             status: running
 
-#  - name: Stop the run
-#    request:
-#      url: '{ot2_server_base_url}/runs/{run_id}/actions'
-#      method: POST
-#      json:
-#        data:
-#          actionType: stop
-#    response:
-#      status_code: 201
+  - name: Stop the run
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/actions'
+      method: POST
+      json:
+        data:
+          actionType: stop
+    response:
+      status_code: 201
 
   - name: Wait for the run to complete
     max_retries: 10

--- a/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
@@ -64,65 +64,65 @@ stages:
 #    response:
 #      status_code: 201
 
-#  - name: Wait for the run to complete
-#    max_retries: 10
-#    delay_after: 0.2
-#    request:
-#      url: '{ot2_server_base_url}/runs/{run_id}'
-#      method: GET
-#    response:
-#      status_code: 200
-#      strict:
-#        - json:off
-#      json:
-#        data:
-#          status: stopped
+  - name: Wait for the run to complete
+    max_retries: 10
+    delay_after: 0.2
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          status: stopped
 
-#  - name: Get run commands
-#    request:
-#      url: '{ot2_server_base_url}/runs/{run_id}/commands'
-#      method: GET
-#    response:
-#      status_code: 200
-#      strict:
-#        - json:off
-#      json:
-#        data:
-#          - id: !anystr
-#            key: !anystr
-#            commandType: home
-#            createdAt: !anystr
-#            startedAt: !anystr
-#            completedAt: !anystr
-#            status: succeeded
-#            params: {}
-#            notes: []
-#          - id: !anystr
-#            key: !anystr
-#            commandType: home
-#            createdAt: !anystr
-#            startedAt: !anystr
-#            completedAt: !anystr
-#            status: succeeded
-#            params: { }
-#            notes: [ ]
-#          - id: !anystr
-#            key: !anystr
-#            commandType: waitForDuration
-#            createdAt: !anystr
-#            startedAt: !anystr
-#            completedAt: !anystr
-#            status: failed
-#            params:
-#              seconds: 30
-#            notes: [ ]
-#            error:
-#              createdAt: !anystr
-#              detail: 'Run was cancelled'
-#              errorCode: '4000'
-#              errorInfo: { }
-#              errorType: 'RunStoppedError'
-#              id: !anystr
-#              wrappedErrors: [ ]
+  - name: Get run commands
+    request:
+      url: '{ot2_server_base_url}/runs/{run_id}/commands'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: {}
+            notes: []
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: succeeded
+            params: { }
+            notes: [ ]
+          - id: !anystr
+            key: !anystr
+            commandType: waitForDuration
+            createdAt: !anystr
+            startedAt: !anystr
+            completedAt: !anystr
+            status: failed
+            params:
+              seconds: 30
+            notes: [ ]
+            error:
+              createdAt: !anystr
+              detail: 'Run was cancelled'
+              errorCode: '4000'
+              errorInfo: { }
+              errorType: 'RunStoppedError'
+              id: !anystr
+              wrappedErrors: [ ]
 
 

--- a/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_play_stop_v6.tavern.yaml
@@ -39,90 +39,90 @@ stages:
     response:
       status_code: 201
 
-  - name: Wait for the command to run
-    max_retries: 10
-    delay_after: 0.2
-    request:
-      url: '{ot2_server_base_url}/runs/{run_id}/commands'
-      method: GET
-    response:
-      status_code: 200
-      strict:
-        - json:off
-      json:
-        data:
-          - commandType: waitForDuration
-            status: running
+#  - name: Wait for the command to run
+#    max_retries: 10
+#    delay_after: 0.2
+#    request:
+#      url: '{ot2_server_base_url}/runs/{run_id}/commands'
+#      method: GET
+#    response:
+#      status_code: 200
+#      strict:
+#        - json:off
+#      json:
+#        data:
+#          - commandType: waitForDuration
+#            status: running
 
-  - name: Stop the run
-    request:
-      url: '{ot2_server_base_url}/runs/{run_id}/actions'
-      method: POST
-      json:
-        data:
-          actionType: stop
-    response:
-      status_code: 201
+#  - name: Stop the run
+#    request:
+#      url: '{ot2_server_base_url}/runs/{run_id}/actions'
+#      method: POST
+#      json:
+#        data:
+#          actionType: stop
+#    response:
+#      status_code: 201
 
-  - name: Wait for the run to complete
-    max_retries: 10
-    delay_after: 0.2
-    request:
-      url: '{ot2_server_base_url}/runs/{run_id}'
-      method: GET
-    response:
-      status_code: 200
-      strict:
-        - json:off
-      json:
-        data:
-          status: stopped
+#  - name: Wait for the run to complete
+#    max_retries: 10
+#    delay_after: 0.2
+#    request:
+#      url: '{ot2_server_base_url}/runs/{run_id}'
+#      method: GET
+#    response:
+#      status_code: 200
+#      strict:
+#        - json:off
+#      json:
+#        data:
+#          status: stopped
 
-  - name: Get run commands
-    request:
-      url: '{ot2_server_base_url}/runs/{run_id}/commands'
-      method: GET
-    response:
-      status_code: 200
-      strict:
-        - json:off
-      json:
-        data:
-          - id: !anystr
-            key: !anystr
-            commandType: home
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            status: succeeded
-            params: {}
-            notes: []
-          - id: !anystr
-            key: !anystr
-            commandType: home
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            status: succeeded
-            params: { }
-            notes: [ ]
-          - id: !anystr
-            key: !anystr
-            commandType: waitForDuration
-            createdAt: !anystr
-            startedAt: !anystr
-            completedAt: !anystr
-            status: failed
-            params:
-              seconds: 30
-            notes: [ ]
-            error:
-              createdAt: !anystr
-              detail: 'Run was cancelled'
-              errorCode: '4000'
-              errorInfo: { }
-              errorType: 'RunStoppedError'
-              id: !anystr
-              wrappedErrors: [ ]
+#  - name: Get run commands
+#    request:
+#      url: '{ot2_server_base_url}/runs/{run_id}/commands'
+#      method: GET
+#    response:
+#      status_code: 200
+#      strict:
+#        - json:off
+#      json:
+#        data:
+#          - id: !anystr
+#            key: !anystr
+#            commandType: home
+#            createdAt: !anystr
+#            startedAt: !anystr
+#            completedAt: !anystr
+#            status: succeeded
+#            params: {}
+#            notes: []
+#          - id: !anystr
+#            key: !anystr
+#            commandType: home
+#            createdAt: !anystr
+#            startedAt: !anystr
+#            completedAt: !anystr
+#            status: succeeded
+#            params: { }
+#            notes: [ ]
+#          - id: !anystr
+#            key: !anystr
+#            commandType: waitForDuration
+#            createdAt: !anystr
+#            startedAt: !anystr
+#            completedAt: !anystr
+#            status: failed
+#            params:
+#              seconds: 30
+#            notes: [ ]
+#            error:
+#              createdAt: !anystr
+#              detail: 'Run was cancelled'
+#              errorCode: '4000'
+#              errorInfo: { }
+#              errorType: 'RunStoppedError'
+#              id: !anystr
+#              wrappedErrors: [ ]
 
 

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -114,7 +114,7 @@ async def test_create_run_command(
         return command_once_added
 
     decoy.when(
-        mock_engine_store.add_command_and_wait_for_interval(
+        await mock_engine_store.add_command_and_wait_for_interval(
             request=pe_commands.WaitForResumeCreate(
                 params=pe_commands.WaitForResumeParams(message="Hello"),
                 intent=pe_commands.CommandIntent.SETUP,
@@ -201,7 +201,7 @@ async def test_create_run_command_blocking_completion(
         )
 
     decoy.when(
-        mock_engine_store.add_command_and_wait_for_interval(
+        await mock_engine_store.add_command_and_wait_for_interval(
             request=command_request, failed_command_id=None
         )
     ).then_do(_stub_queued_command_state)

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -201,7 +201,9 @@ async def test_create_run_command_blocking_completion(
         )
 
     decoy.when(
-        mock_engine_store.add_command_and_wait_for_interval(command_request, None)
+        mock_engine_store.add_command_and_wait_for_interval(
+            request=command_request, failed_command_id=None
+        )
     ).then_do(_stub_queued_command_state)
 
     result = await create_run_command(
@@ -227,7 +229,9 @@ async def test_add_conflicting_setup_command(
     )
 
     decoy.when(
-        mock_engine_store.add_command_and_wait_for_interval(command_request, None)
+        mock_engine_store.add_command_and_wait_for_interval(
+            request=command_request, failed_command_id=None
+        )
     ).then_raise(pe_errors.SetupCommandNotAllowedError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:
@@ -256,7 +260,9 @@ async def test_add_command_to_stopped_engine(
     )
 
     decoy.when(
-        mock_engine_store.add_command_and_wait_for_interval(command_request, None)
+        mock_engine_store.add_command_and_wait_for_interval(
+            request=command_request, failed_command_id=None
+        )
     ).then_raise(pe_errors.RunStoppedError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -130,7 +130,7 @@ async def test_create_run_command(
         waitUntilComplete=False,
         engine_store=mock_engine_store,
         failedCommandId=None,
-        timeout=12
+        timeout=12,
     )
 
     assert result.content.data == command_once_added
@@ -193,9 +193,12 @@ async def test_create_run_command_blocking_completion(
 
     decoy.when(
         await mock_engine_store.add_command_and_wait_for_interval(
-            request=command_request, failed_command_id=None, wait_until_complete=True, timeout=999
+            request=command_request,
+            failed_command_id=None,
+            wait_until_complete=True,
+            timeout=999,
         )
-    ).then_do(command_once_completed)
+    ).then_return(command_once_completed)
 
     decoy.when(mock_engine_store.get_command("command-id")).then_return(
         command_once_completed

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -7,7 +7,6 @@ from decoy import Decoy, matchers
 from opentrons.protocol_engine import (
     CommandSlice,
     CommandPointer,
-    ProtocolEngine,
     CommandNote,
     commands as pe_commands,
     errors as pe_errors,
@@ -22,7 +21,7 @@ from robot_server.runs.command_models import (
     CommandLink,
     CommandLinkMeta,
 )
-from robot_server.runs.run_store import RunStore, CommandNotFoundError
+from robot_server.runs.run_store import CommandNotFoundError
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.run_data_manager import RunDataManager
 from robot_server.runs.run_models import RunCommandSummary, RunNotFoundError
@@ -172,14 +171,6 @@ async def test_create_run_command_blocking_completion(
     command_request = pe_commands.WaitForResumeCreate(
         params=pe_commands.WaitForResumeParams(message="Hello"),
         intent=pe_commands.CommandIntent.PROTOCOL,
-    )
-
-    command_once_added = pe_commands.WaitForResume(
-        id="command-id",
-        key="command-key",
-        createdAt=datetime(year=2021, month=1, day=1),
-        status=pe_commands.CommandStatus.QUEUED,
-        params=pe_commands.WaitForResumeParams(message="Hello"),
     )
 
     command_once_completed = pe_commands.WaitForResume(

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -21,7 +21,7 @@ from robot_server.runs.command_models import (
     CommandLink,
     CommandLinkMeta,
 )
-from robot_server.runs.run_store import CommandNotFoundError
+from robot_server.runs.run_store import CommandNotFoundError, RunStore
 from robot_server.runs.engine_store import EngineStore
 from robot_server.runs.run_data_manager import RunDataManager
 from robot_server.runs.run_models import RunCommandSummary, RunNotFoundError
@@ -29,64 +29,65 @@ from robot_server.runs.router.commands_router import (
     create_run_command,
     get_run_command,
     get_run_commands,
+    get_current_run_from_url,
 )
 
 
-# async def test_get_current_run_engine_from_url(
-#     decoy: Decoy,
-#     mock_engine_store: EngineStore,
-#     mock_run_store: RunStore,
-# ) -> None:
-#     """Should get an instance of a run protocol engine."""
-#     decoy.when(mock_run_store.has("run-id")).then_return(True)
-#     decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-#
-#     result = await get_current_run_engine_from_url(
-#         runId="run-id",
-#         engine_store=mock_engine_store,
-#         run_store=mock_run_store,
-#     )
-#
-#     assert result is mock_engine_store.engine
+async def test_get_current_run_from_url(
+    decoy: Decoy,
+    mock_engine_store: EngineStore,
+    mock_run_store: RunStore,
+) -> None:
+    """Should get an instance of a run protocol engine."""
+    decoy.when(mock_run_store.has("run-id")).then_return(True)
+    decoy.when(mock_engine_store.current_run_id).then_return("run-id")
+
+    result = await get_current_run_from_url(
+        runId="run-id",
+        engine_store=mock_engine_store,
+        run_store=mock_run_store,
+    )
+
+    assert result == "run-id"
 
 
-# async def test_get_current_run_engine_no_run(
-#     decoy: Decoy,
-#     mock_engine_store: EngineStore,
-#     mock_run_store: RunStore,
-# ) -> None:
-#     """It should 404 if the run is not in the store."""
-#     decoy.when(mock_run_store.has("run-id")).then_return(False)
-#
-#     with pytest.raises(ApiError) as exc_info:
-#         await get_current_run_engine_from_url(
-#             runId="run-id",
-#             engine_store=mock_engine_store,
-#             run_store=mock_run_store,
-#         )
-#
-#     assert exc_info.value.status_code == 404
-#     assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+async def test_get_current_run_no_run(
+    decoy: Decoy,
+    mock_engine_store: EngineStore,
+    mock_run_store: RunStore,
+) -> None:
+    """It should 404 if the run is not in the store."""
+    decoy.when(mock_run_store.has("run-id")).then_return(False)
+
+    with pytest.raises(ApiError) as exc_info:
+        await get_current_run_from_url(
+            runId="run-id",
+            engine_store=mock_engine_store,
+            run_store=mock_run_store,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
 
 
-# async def test_get_current_run_engine_from_url_not_current(
-#     decoy: Decoy,
-#     mock_engine_store: EngineStore,
-#     mock_run_store: RunStore,
-# ) -> None:
-#     """It should 409 if you try to add commands to non-current run."""
-#     decoy.when(mock_run_store.has("run-id")).then_return(True)
-#     decoy.when(mock_engine_store.current_run_id).then_return("some-other-run-id")
-#
-#     with pytest.raises(ApiError) as exc_info:
-#         await get_current_run_engine_from_url(
-#             runId="run-id",
-#             engine_store=mock_engine_store,
-#             run_store=mock_run_store,
-#         )
-#
-#     assert exc_info.value.status_code == 409
-#     assert exc_info.value.content["errors"][0]["id"] == "RunStopped"
+async def test_get_current_run_from_url_not_current(
+    decoy: Decoy,
+    mock_engine_store: EngineStore,
+    mock_run_store: RunStore,
+) -> None:
+    """It should 409 if you try to add commands to non-current run."""
+    decoy.when(mock_run_store.has("run-id")).then_return(True)
+    decoy.when(mock_engine_store.current_run_id).then_return("some-other-run-id")
+
+    with pytest.raises(ApiError) as exc_info:
+        await get_current_run_from_url(
+            runId="run-id",
+            engine_store=mock_engine_store,
+            run_store=mock_run_store,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["id"] == "RunStopped"
 
 
 async def test_create_run_command(

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -70,7 +70,7 @@ async def test_add_labware_offset(
     )
 
     decoy.when(
-        mock_engine_store.engine.add_labware_offset(labware_offset_request)
+        mock_engine_store.add_labware_offset(labware_offset_request)
     ).then_return(labware_offset)
 
     result = await add_labware_offset(
@@ -118,7 +118,7 @@ async def test_add_labware_definition(
     uri = pe_types.LabwareUri("some/definition/uri")
 
     decoy.when(
-        mock_engine_store.engine.add_labware_definition(labware_definition)
+        mock_engine_store.add_labware_definition(labware_definition)
     ).then_return(uri)
 
     result = await add_labware_definition(

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -18,7 +18,7 @@ from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs.engine_store import (
     EngineStore,
     EngineConflictError,
-    NoRunnerEngineError,
+    NoRunOrchestrator,
     handle_estop_event,
 )
 
@@ -186,10 +186,10 @@ async def test_clear_engine(subject: EngineStore) -> None:
     assert subject.current_run_id is None
     assert isinstance(result, RunResult)
 
-    with pytest.raises(NoRunnerEngineError):
+    with pytest.raises(NoRunOrchestrator):
         subject._run_orchestrator.engine
 
-    with pytest.raises(NoRunnerEngineError):
+    with pytest.raises(NoRunOrchestrator):
         subject._run_orchestrator.runner
 
 
@@ -227,9 +227,9 @@ async def test_clear_idle_engine(subject: EngineStore) -> None:
     await subject.clear()
 
     # TODO: test engine finish is called
-    with pytest.raises(NoRunnerEngineError):
+    with pytest.raises(NoRunOrchestrator):
         subject._run_orchestrator.engine
-    with pytest.raises(NoRunnerEngineError):
+    with pytest.raises(NoRunOrchestrator):
         subject._run_orchestrator.runner
 
 

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -61,8 +61,8 @@ async def test_create_engine(decoy: Decoy, subject: EngineStore) -> None:
 
     assert subject.current_run_id == "run-id"
     assert isinstance(result, StateSummary)
-    assert isinstance(subject.runner, LiveRunner)
-    assert isinstance(subject.engine, ProtocolEngine)
+    assert isinstance(subject._run_orchestrator.runner, LiveRunner)
+    assert isinstance(subject._run_orchestrator.engine, ProtocolEngine)
 
 
 async def test_create_engine_with_protocol(

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -13,7 +13,6 @@ from opentrons.hardware_control.types import EstopStateNotification, EstopState
 from opentrons.protocol_engine import (
     StateSummary,
     types as pe_types,
-    commands as pe_commands,
 )
 from opentrons.protocol_runner import RunResult, RunOrchestrator
 from opentrons.protocol_reader import ProtocolReader, ProtocolSource
@@ -171,16 +170,8 @@ async def test_clear_engine_not_stopped_or_idle(
         protocol=None,
         notify_publishers=mock_notify_publishers,
     )
-    await subject._run_orchestrator.add_command_and_wait_for_interval(
-        pe_commands.HomeCreate.construct(params=pe_commands.HomeParams.construct()),
-        wait_until_complete=True,
-        timeout=999,
-    )
     assert subject._run_orchestrator is not None
-    print(subject._run_orchestrator.get_all_commands())
     subject._run_orchestrator.play(deck_configuration=[])
-    print(subject._run_orchestrator.get_all_commands())
-
     with pytest.raises(EngineConflictError):
         await subject.clear()
 
@@ -293,7 +284,7 @@ async def test_estop_callback(
     await handle_estop_event(engine_store, disengage_event)
     assert engine_store.run_orchestrator is not None
     decoy.verify(
-        engine_store._run_orchestrator.estop(),
+        engine_store.run_orchestrator.estop(),
         ignore_extra_args=True,
         times=0,
     )

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -203,24 +203,24 @@ async def test_get_default_orchestrator_idempotent(subject: EngineStore) -> None
     assert repeated_result is result
 
 
-# @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
-# @pytest.mark.parametrize("deck_type", pe_types.DeckType)
-# async def test_get_default_orchestrator_robot_type(
-#     decoy: Decoy, robot_type: RobotType, deck_type: pe_types.DeckType
-# ) -> None:
-#     """It should create default ProtocolEngines with the given robot and deck type."""
-#     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
-#     # should pass in some sort of actual, valid HardwareAPI instead of a mock
-#     hardware_api = decoy.mock(cls=API)
-#     subject = EngineStore(
-#         hardware_api=hardware_api,
-#         robot_type=robot_type,
-#         deck_type=deck_type,
-#     )
-#
-#     result = await subject.get_default_orchestrator()
-#
-#     assert result.state_view.config.robot_type == robot_type
+@pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
+@pytest.mark.parametrize("deck_type", pe_types.DeckType)
+async def test_get_default_orchestrator_robot_type(
+    decoy: Decoy, robot_type: RobotType, deck_type: pe_types.DeckType
+) -> None:
+    """It should create default ProtocolEngines with the given robot and deck type."""
+    # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
+    # should pass in some sort of actual, valid HardwareAPI instead of a mock
+    hardware_api = decoy.mock(cls=API)
+    subject = EngineStore(
+        hardware_api=hardware_api,
+        robot_type=robot_type,
+        deck_type=deck_type,
+    )
+
+    result = await subject.get_default_orchestrator()
+
+    assert result.get_robot_type() == robot_type
 
 
 async def test_get_default_orchestrator_current_unstarted(subject: EngineStore) -> None:

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -153,7 +153,7 @@ async def test_clear_engine(subject: EngineStore) -> None:
     assert isinstance(result, RunResult)
 
     with pytest.raises(NoRunOrchestrator):
-        subject._run_orchestrator
+        subject.run_orchestrator
 
 
 async def test_clear_engine_not_stopped_or_idle(
@@ -296,7 +296,9 @@ async def test_estop_callback(
     await handle_estop_event(engine_store, engage_event)
     assert engine_store._run_orchestrator is not None
     decoy.verify(
-        engine_store._run_orchestrator.estop(),
-        await engine_store.finish(error=matchers.IsA(EStopActivatedError)),
+        engine_store.run_orchestrator.estop(),
+        await engine_store.run_orchestrator.finish(
+            error=matchers.IsA(EStopActivatedError)
+        ),
         times=1,
     )

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -233,10 +233,10 @@ async def test_clear_idle_engine(subject: EngineStore) -> None:
         subject._run_orchestrator.runner
 
 
-async def test_get_default_engine_idempotent(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_idempotent(subject: EngineStore) -> None:
     """It should create and retrieve the same default ProtocolEngine."""
-    result = await subject.get_default_engine()
-    repeated_result = await subject.get_default_engine()
+    result = await subject.get_default_orchestrator()
+    repeated_result = await subject.get_default_orchestrator()
 
     assert isinstance(result, ProtocolEngine)
     assert repeated_result is result
@@ -244,7 +244,7 @@ async def test_get_default_engine_idempotent(subject: EngineStore) -> None:
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 @pytest.mark.parametrize("deck_type", pe_types.DeckType)
-async def test_get_default_engine_robot_type(
+async def test_get_default_orchestrator_robot_type(
     decoy: Decoy, robot_type: RobotType, deck_type: pe_types.DeckType
 ) -> None:
     """It should create default ProtocolEngines with the given robot and deck type."""
@@ -257,12 +257,12 @@ async def test_get_default_engine_robot_type(
         deck_type=deck_type,
     )
 
-    result = await subject.get_default_engine()
+    result = await subject.get_default_orchestrator()
 
     assert result.state_view.config.robot_type == robot_type
 
 
-async def test_get_default_engine_current_unstarted(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_current_unstarted(subject: EngineStore) -> None:
     """It should allow a default engine if another engine current but unstarted."""
     await subject.create(
         run_id="run-id",
@@ -272,11 +272,11 @@ async def test_get_default_engine_current_unstarted(subject: EngineStore) -> Non
         notify_publishers=mock_notify_publishers,
     )
 
-    result = await subject.get_default_engine()
+    result = await subject.get_default_orchestrator()
     assert isinstance(result, ProtocolEngine)
 
 
-async def test_get_default_engine_conflict(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_conflict(subject: EngineStore) -> None:
     """It should not allow a default engine if another engine is executing commands."""
     await subject.create(
         run_id="run-id",
@@ -288,10 +288,10 @@ async def test_get_default_engine_conflict(subject: EngineStore) -> None:
     subject.play()
 
     with pytest.raises(EngineConflictError):
-        await subject.get_default_engine()
+        await subject.get_default_orchestrator()
 
 
-async def test_get_default_engine_run_stopped(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_run_stopped(subject: EngineStore) -> None:
     """It allow a default engine if another engine is terminal."""
     await subject.create(
         run_id="run-id",
@@ -302,7 +302,7 @@ async def test_get_default_engine_run_stopped(subject: EngineStore) -> None:
     )
     await subject.finish(error=None)
 
-    result = await subject.get_default_engine()
+    result = await subject.get_default_orchestrator()
     assert isinstance(result, ProtocolEngine)
 
 

--- a/robot-server/tests/runs/test_light_control_task.py
+++ b/robot-server/tests/runs/test_light_control_task.py
@@ -57,7 +57,7 @@ async def test_get_current_status_ot2(
 ) -> None:
     """Test LightController.get_current_status."""
     decoy.when(engine_store.current_run_id).then_return("fake_id" if active else None)
-    decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(status)
+    decoy.when(engine_store.get_status()).then_return(status)
     decoy.when(hardware_api.get_estop_state()).then_return(estop)
 
     expected = Status(
@@ -198,9 +198,7 @@ async def test_provide_engine_store(
     )
 
     decoy.when(engine_store.current_run_id).then_return("fake_id")
-    decoy.when(engine_store.engine.state_view.commands.get_status()).then_return(
-        EngineStatus.RUNNING
-    )
+    decoy.when(engine_store.get_status()).then_return(EngineStatus.RUNNING)
 
     subject.update_engine_store(engine_store=engine_store)
     assert subject.get_current_status() == Status(

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -117,9 +117,7 @@ async def test_create_play_action_to_resume(
     subject: RunController,
 ) -> None:
     """It should resume a run."""
-    mock_json_runner = decoy.mock(cls=JsonRunner)
-    decoy.when(mock_engine_store.runner).then_return(mock_json_runner)
-    decoy.when(mock_json_runner.was_started()).then_return(True)
+    decoy.when(mock_engine_store.run_was_started()).then_return(True)
 
     result = subject.create_action(
         action_id="some-action-id",
@@ -135,8 +133,8 @@ async def test_create_play_action_to_resume(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_json_runner.play(), times=1)
-    decoy.verify(await mock_json_runner.run(deck_configuration=[]), times=0)
+    decoy.verify(mock_engine_store.play(), times=1)
+    decoy.verify(await mock_engine_store.run(deck_configuration=[]), times=0)
 
 
 async def test_create_play_action_to_start(
@@ -152,9 +150,7 @@ async def test_create_play_action_to_start(
     subject: RunController,
 ) -> None:
     """It should start a run."""
-    mock_python_runner = decoy.mock(cls=PythonAndLegacyRunner)
-    decoy.when(mock_engine_store.runner).then_return(mock_python_runner)
-    decoy.when(mock_python_runner.was_started()).then_return(False)
+    decoy.when(mock_engine_store.run_was_started()).then_return(False)
 
     result = subject.create_action(
         action_id="some-action-id",
@@ -174,7 +170,7 @@ async def test_create_play_action_to_start(
     background_task_captor = matchers.Captor()
     decoy.verify(mock_task_runner.run(background_task_captor, deck_configuration=[]))
 
-    decoy.when(await mock_python_runner.run(deck_configuration=[])).then_return(
+    decoy.when(await mock_engine_store.run(deck_configuration=[])).then_return(
         RunResult(
             commands=protocol_commands,
             state_summary=engine_state_summary,
@@ -218,7 +214,7 @@ def test_create_pause_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_engine_store.runner.pause(), times=1)
+    decoy.verify(mock_engine_store.pause(), times=1)
 
 
 def test_create_stop_action(
@@ -244,7 +240,7 @@ def test_create_stop_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_task_runner.run(mock_engine_store.runner.stop), times=1)
+    decoy.verify(mock_task_runner.run(mock_engine_store.stop), times=1)
 
 
 def test_create_resume_from_recovery_action(
@@ -270,7 +266,7 @@ def test_create_resume_from_recovery_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_engine_store.runner.resume_from_recovery())
+    decoy.verify(mock_engine_store.resume_from_recovery())
 
 
 @pytest.mark.parametrize(
@@ -292,9 +288,9 @@ async def test_action_not_allowed(
     exception: Exception,
 ) -> None:
     """It should raise a RunActionNotAllowedError if a play/pause action is rejected."""
-    decoy.when(mock_engine_store.runner.was_started()).then_return(True)
-    decoy.when(mock_engine_store.runner.play()).then_raise(exception)
-    decoy.when(mock_engine_store.runner.pause()).then_raise(exception)
+    decoy.when(mock_engine_store.run_was_started()).then_return(True)
+    decoy.when(mock_engine_store.play()).then_raise(exception)
+    decoy.when(mock_engine_store.pause()).then_raise(exception)
 
     with pytest.raises(RunActionNotAllowedError, match="oh no"):
         subject.create_action(

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -12,7 +12,7 @@ from opentrons.protocol_engine import (
     errors as pe_errors,
 )
 from opentrons.protocol_engine.types import RunTimeParameter, BooleanParameter
-from opentrons.protocol_runner import RunResult, JsonRunner, PythonAndLegacyRunner
+from opentrons.protocol_runner import RunResult
 
 from robot_server.service.notifications import RunsPublisher
 from robot_server.service.task_runner import TaskRunner

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -958,7 +958,7 @@ def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
 ) -> None:
     """It should raise an error when fetching pre-serialized commands list while run is active."""
     decoy.when(mock_engine_store.current_run_id).then_return("current-run-id")
-    decoy.when(mock_engine_store.get_run_is_terminal()).then_return(False)
+    decoy.when(mock_engine_store.get_is_run_terminal()).then_return(False)
     with pytest.raises(PreSerializedCommandsNotAvailableError):
         subject.get_all_commands_as_preserialized_list("current-run-id")
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -324,10 +324,8 @@ async def test_get_current_run(
 
     decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
     decoy.when(mock_engine_store.current_run_id).then_return(run_id)
-    decoy.when(mock_engine_store.engine.state_view.get_summary()).then_return(
-        engine_state_summary
-    )
-    decoy.when(mock_engine_store.runner.run_time_parameters).then_return(
+    decoy.when(mock_engine_store.get_state_summary()).then_return(engine_state_summary)
+    decoy.when(mock_engine_store.get_run_time_parameters()).then_return(
         run_time_parameters
     )
 
@@ -493,10 +491,8 @@ async def test_get_all_runs(
     )
 
     decoy.when(mock_engine_store.current_run_id).then_return("current-run")
-    decoy.when(mock_engine_store.engine.state_view.get_summary()).then_return(
-        current_run_data
-    )
-    decoy.when(mock_engine_store.runner.run_time_parameters).then_return(
+    decoy.when(mock_engine_store.get_state_summary()).then_return(current_run_data)
+    decoy.when(mock_engine_store.get_run_time_parameters()).then_return(
         current_run_time_parameters
     )
     decoy.when(mock_run_store.get_state_summary("historical-run")).then_return(
@@ -649,10 +645,8 @@ async def test_update_current_noop(
     """It should noop on current=None and current=True."""
     run_id = "hello world"
     decoy.when(mock_engine_store.current_run_id).then_return(run_id)
-    decoy.when(mock_engine_store.engine.state_view.get_summary()).then_return(
-        engine_state_summary
-    )
-    decoy.when(mock_engine_store.runner.run_time_parameters).then_return(
+    decoy.when(mock_engine_store.get_state_summary()).then_return(engine_state_summary)
+    decoy.when(mock_engine_store.get_run_time_parameters()).then_return(
         run_time_parameters
     )
     decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
@@ -819,9 +813,9 @@ def test_get_commands_slice_current_run(
         commands=expected_commands_result, cursor=1, total_length=3
     )
     decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(
-        mock_engine_store.engine.state_view.commands.get_slice(1, 2)
-    ).then_return(expected_command_slice)
+    decoy.when(mock_engine_store.get_command_slice(1, 2)).then_return(
+        expected_command_slice
+    )
 
     result = subject.get_commands_slice("run-id", 1, 2)
 
@@ -854,9 +848,7 @@ def test_get_current_command(
         index=0,
     )
     decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(mock_engine_store.engine.state_view.commands.get_current()).then_return(
-        expected_current
-    )
+    decoy.when(mock_engine_store.get_current_command()).then_return(expected_current)
     result = subject.get_current_command("run-id")
 
     assert result == expected_current
@@ -884,9 +876,7 @@ def test_get_command_from_engine(
 ) -> None:
     """Should get command by id from engine store."""
     decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(
-        mock_engine_store.engine.state_view.commands.get("command-id")
-    ).then_return(run_command)
+    decoy.when(mock_engine_store.get_command("command-id")).then_return(run_command)
     result = subject.get_command("run-id", "command-id")
 
     assert result == run_command
@@ -968,9 +958,7 @@ def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
 ) -> None:
     """It should raise an error when fetching pre-serialized commands list while run is active."""
     decoy.when(mock_engine_store.current_run_id).then_return("current-run-id")
-    decoy.when(
-        mock_engine_store.engine.state_view.commands.get_is_terminal()
-    ).then_return(False)
+    decoy.when(mock_engine_store.get_run_is_terminal()).then_return(False)
     with pytest.raises(PreSerializedCommandsNotAvailableError):
         subject.get_all_commands_as_preserialized_list("current-run-id")
 
@@ -984,9 +972,7 @@ async def test_get_current_run_labware_definition(
 ) -> None:
     """It should get the current run labware definition from the engine."""
     decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(
-        mock_engine_store.engine.state_view.labware.get_loaded_labware_definitions()
-    ).then_return(
+    decoy.when(mock_engine_store.get_loaded_labware_definitions()).then_return(
         [
             LabwareDefinition.construct(namespace="test_1"),  # type: ignore[call-arg]
             LabwareDefinition.construct(namespace="test_2"),  # type: ignore[call-arg]


### PR DESCRIPTION
# Overview

second phase of run orchestrator. redirect all router level calls via `run_orchestrator`.

# Test Plan

- All e2e tests are passing.
- through it on a robot and make sure nothing is broken. -> tests this with dev server. 
  - [x] test json protocols
  - [x] test python protocols 
  - [x] post commands to a run
  - [x] post commands with default router

# Changelog

- added method calls from `run_data_manager` and routers to `engine_store`.
- all calls get through `run_orchestrator` to PE and to runners. 

# Review requests

changes make sense? will something break? do we like this change? should I add more tests?

# Risk assessment

Medium. tested with dev server and all tests are passing but still a fundamental change. 
