### PR TITLE
fix(protocol-designer): candidate-C bug addressing and don't unnecess…

### DIFF
--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -115,7 +115,6 @@ export const FilePage = (): JSX.Element => {
     'author',
     'description',
   ])
-  console.log('!isDirty || !isManualDirty', !isDirty || !isManualDirty)
   return (
     <div className={styles.file_page}>
       <Card title={t('application:information')}>

--- a/protocol-designer/src/components/FilePage.tsx
+++ b/protocol-designer/src/components/FilePage.tsx
@@ -82,6 +82,7 @@ export const FilePage = (): JSX.Element => {
 
   const saveFileMetadata = (nextFormValues: FileMetadataFields): void => {
     dispatch(actions.saveFileMetadata(nextFormValues))
+    setManualDirty(false)
   }
   const [isManualDirty, setManualDirty] = React.useState<boolean>(false)
   const {
@@ -114,7 +115,7 @@ export const FilePage = (): JSX.Element => {
     'author',
     'description',
   ])
-
+  console.log('!isDirty || !isManualDirty', !isDirty || !isManualDirty)
   return (
     <div className={styles.file_page}>
       <Card title={t('application:information')}>
@@ -201,7 +202,6 @@ export const FilePage = (): JSX.Element => {
               type="submit"
               className={styles.update_button}
               disabled={!isDirty || !isManualDirty}
-              onClick={() => setManualDirty(false)}
             >
               {isManualDirty
                 ? t('application:update')

--- a/protocol-designer/src/components/FileSidebar/utils/getUnusedTrash.ts
+++ b/protocol-designer/src/components/FileSidebar/utils/getUnusedTrash.ts
@@ -38,13 +38,17 @@ export const getUnusedTrash = (
     wasteChute != null
       ? commands?.some(
           command =>
-            command.commandType === 'moveToAddressableArea' &&
-            WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
-              command.params.addressableAreaName as AddressableAreaName
-            )
+            (command.commandType === 'moveToAddressableArea' &&
+              WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
+                command.params.addressableAreaName as AddressableAreaName
+              )) ||
+            (command.commandType === 'moveLabware' &&
+              command.params.newLocation !== 'offDeck' &&
+              'addressableAreaName' in command.params.newLocation &&
+              command.params.newLocation.addressableAreaName ===
+                'gripperWasteChute')
         )
       : null
-
   return {
     trashBinUnused: trashBin != null && !hasTrashBinCommands,
     wasteChuteUnused: wasteChute != null && !hasWasteChuteCommands,

--- a/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/index.tsx
@@ -121,6 +121,7 @@ export function CreateFileWizard(): JSX.Element | null {
       values.pipettesByMount,
       (acc, formPipette: FormPipette, mount): PipetteFieldsData[] => {
         return formPipette?.pipetteName != null &&
+          formPipette?.pipetteName !== '' &&
           formPipette.tiprackDefURI != null &&
           (mount === 'left' || mount === 'right')
           ? [

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -27,7 +27,11 @@ export const getMigrationVersionsToRunFromVersion = (
   const allSortedVersions = Object.keys(migrationsByVersion).sort(
     semver.compare
   )
-  return takeRightWhile(allSortedVersions, v => semver.gt(v, version))
+
+  return takeRightWhile(
+    allSortedVersions,
+    v => semver.gt(v, version) && !version.includes(v)
+  )
 }
 
 const allMigrationsByVersion: MigrationsByVersion = {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1355,10 +1355,9 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
             command.params.newLocation !== 'offDeck' &&
             'addressableAreaName' in command.params.newLocation &&
             WASTE_CHUTE_ADDRESSABLE_AREAS.includes(
-              command.params.addressableAreaName
+              command.params.newLocation.addressableAreaName
             ))
       )
-
       const getStagingAreaSlotNames = (
         commandType: 'moveLabware' | 'loadLabware',
         locationKey: 'newLocation' | 'location'
@@ -1519,6 +1518,9 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
         ) {
           wasteChuteId = moveLiquidStepWasteChute.blowOut_location
         }
+        //  new wasteChuteId generated for if there are only moveLabware commands
+      } else if (hasWasteChuteCommands && moveLiquidStepWasteChute == null) {
+        wasteChuteId = `${uuid()}:wasteChute`
       }
 
       const wasteChute =


### PR DESCRIPTION
…arily migrate

closes RQA-2772 RQA-2773 RQA-2776 RQA-2777

# Overview

Addresses several things:
1. no longer unnecessarily migrate protocols when the `candidate-` string is at the end of the version
2. correctly generate a waste chute when only a move labware step is involved and not a pipetting step
3. don't create a pipette entity when the pipette name is an empty string
4. fix the cta for changing the protocol name

# Test Plan

First, for fix 3: create a flex protocol and add a pipette, add a tiprack, add the 2nd pipette then add a tiprack, then go back and select "none" for the 2nd pipette. create the protocol and see that it does no white screen

Next, edit the name of the protocol and see that it updates in the banner when you hit submit (for fix 4).

Then for fix 2, add a waste chute and a gripper and create a move labware step to move the tiprack into the waste chute with the gripper. Export the protocol and see that the "unused waste chute" modal DOES NOT show up

Import the protocol back and there SHOULD NOT be a migration modal that pops up (for fix 1). see that the waste chute is still selected in the protocol.

# Changelog

- check for move labware into the waste chute and add the fix to the `getUnusedTrash` util and the reducer
- add an extra protection when generating pipette entities
- add some logic to not migrate if the version has the main version string in it
- change the onClick to happen inside the `saveFileMetadata`

# Review requests

see test plan

# Risk assessment

low