### PR TITLE
fix(api): validation casing for mixed tip use between single and eight channels

### DIFF
--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -268,9 +268,12 @@ class TipView(HasState[TipState]):
                 return None
             else:
                 # In the case of an 8ch pipette where a column has mixed state tips we may simply progress to the next column in our search
-                if len(nozzle_map.full_instrument_map_store) == 8:
+                if (
+                    nozzle_map is not None
+                    and len(nozzle_map.full_instrument_map_store) == 8
+                ):
                     return None
-                
+
                 # In the case of a 96ch we can attempt to index in by singular rows and columns assuming that indexed direction is safe
                 # The tip cluster list is ordered: Each row from a column in order by columns
                 tip_cluster_final_column = []

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -267,6 +267,11 @@ class TipView(HasState[TipState]):
             elif all(wells[well] == TipRackWellState.USED for well in tip_cluster):
                 return None
             else:
+                # In the case of an 8ch pipette where a column has mixed state tips we may simply progress to the next column in our search
+                if len(nozzle_map.full_instrument_map_store) == 8:
+                    return None
+                
+                # In the case of a 96ch we can attempt to index in by singular rows and columns assuming that indexed direction is safe
                 # The tip cluster list is ordered: Each row from a column in order by columns
                 tip_cluster_final_column = []
                 for i in range(active_rows):


### PR DESCRIPTION

# Overview
Closes RQA-2780
An edge case was found where the automatic tip tracking would not correctly identify the next valid column for an 8ch pickup after a sequence of single channel pickups.

# Test Plan
The following protocol should pass analysis and perform identically on apiLevel 2.17 and 2.18.
```
requirements = {
	"robotType": "Flex",
	"apiLevel": "2.18"
}

def run(ctx):
	tips = ctx.load_labware('opentrons_flex_96_tiprack_1000ul', 'B3')
	tips2 = ctx.load_labware('opentrons_flex_96_tiprack_1000ul', 'C3')
	p1000 = ctx.load_instrument('flex_8channel_1000', 'right', tip_racks=[tips, tips2]) 
	p1000_single = ctx.load_instrument('flex_1channel_1000', 'left', tip_racks=[tips, tips2])
	trash = ctx.load_trash_bin("A3")

	p1000_single.pick_up_tip()
	p1000_single.drop_tip()
	p1000_single.pick_up_tip()
	p1000_single.drop_tip()

	for i in range(22):
		p1000.pick_up_tip()
		p1000.drop_tip()
```


# Changelog

# Review requests

# Risk assessment
 Low
