### PR TITLE
chore: bump API version to 2.18 in conf.py

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -99,7 +99,7 @@ extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 # use rst_prolog to hold the subsitution
 # update the apiLevel value whenever a new minor version is released
 rst_prolog = f"""
-.. |apiLevel| replace:: 2.17
+.. |apiLevel| replace:: 2.18
 .. |release| replace:: {release}
 """
 

--- a/api/docs/v2/versioning.rst
+++ b/api/docs/v2/versioning.rst
@@ -68,7 +68,7 @@ The maximum supported API version for your robot is listed in the Opentrons App 
 
 If you upload a protocol that specifies a higher API level than the maximum supported, your robot won't be able to analyze or run your protocol. You can increase the maximum supported version by updating your robot software and Opentrons App. 
 
-Opentrons robots running the latest software (7.2.0) support the following version ranges: 
+Opentrons robots running the latest software (7.3.0) support the following version ranges: 
 
     * **Flex:** version 2.15–|apiLevel|.
     * **OT-2:** versions 2.0–|apiLevel|.


### PR DESCRIPTION
# Overview

This is a manual process now! Didn't forget this time. `|apiLevel|` will now be replaced with `2.18`.

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-bump-version-218/v2/versioning.html#maximum-supported-versions) <- mostly observe the text replacement in the max supported version ranges.

# Changelog

- new API version
- new robot software version!

# Risk assessment

nil