### PR TITLE
feat(app): Update LargeButton buttonTypes

### DIFF
--- a/app/src/atoms/buttons/LargeButton.stories.tsx
+++ b/app/src/atoms/buttons/LargeButton.stories.tsx
@@ -58,3 +58,21 @@ export const PrimaryWithSubtext: Story = {
     subtext: 'Button subtext',
   },
 }
+
+export const OnColor: Story = {
+  args: {
+    buttonType: 'onColor',
+    buttonText: 'Button text',
+    disabled: false,
+    subtext: 'Button subtext',
+  },
+}
+
+export const AlertAlt: Story = {
+  args: {
+    buttonType: 'alertAlt',
+    buttonText: 'Button text',
+    disabled: false,
+    subtext: 'Button subtext',
+  },
+}

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -16,13 +16,17 @@ import {
 import { ODD_FOCUS_VISIBLE } from './constants'
 import type { IconName, StyleProps } from '@opentrons/components'
 
-type LargeButtonTypes = 'primary' | 'secondary' | 'alert'
+type LargeButtonTypes =
+  | 'primary'
+  | 'secondary'
+  | 'alert'
+  | 'onColor'
+  | 'alertAlt'
 interface LargeButtonProps extends StyleProps {
   onClick: () => void
   buttonType?: LargeButtonTypes
   buttonText: React.ReactNode
   iconName?: IconName
-  iconColorOverride?: string
   subtext?: string
   disabled?: boolean
 }
@@ -32,7 +36,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     buttonType = 'primary',
     buttonText,
     iconName,
-    iconColorOverride,
     subtext,
     disabled = false,
     ...buttonProps
@@ -43,27 +46,61 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     {
       defaultBackgroundColor: string
       activeBackgroundColor: string
+      disabledBackgroundColor: string
       defaultColor: string
+      disabledColor: string
       iconColor: string
+      disabledIconColor: string
+      border?: string
+      disabledBorder?: string
     }
   > = {
     secondary: {
       defaultColor: COLORS.black90,
+      disabledColor: COLORS.grey50,
       defaultBackgroundColor: COLORS.blue35,
       activeBackgroundColor: COLORS.blue40,
+      disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.blue50,
+      disabledIconColor: COLORS.grey50,
     },
     alert: {
       defaultColor: COLORS.red60,
+      disabledColor: COLORS.grey50,
       defaultBackgroundColor: COLORS.red35,
       activeBackgroundColor: COLORS.red40,
+      disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.red60,
+      disabledIconColor: COLORS.grey50,
     },
     primary: {
       defaultColor: COLORS.white,
+      disabledColor: COLORS.grey50,
       defaultBackgroundColor: COLORS.blue50,
       activeBackgroundColor: COLORS.blue60,
+      disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.white,
+      disabledIconColor: COLORS.grey50,
+    },
+    onColor: {
+      defaultColor: COLORS.white,
+      disabledColor: COLORS.grey40,
+      defaultBackgroundColor: COLORS.transparent,
+      activeBackgroundColor: COLORS.transparent,
+      disabledBackgroundColor: COLORS.transparent,
+      iconColor: COLORS.white,
+      disabledIconColor: COLORS.grey40,
+      border: `${BORDERS.borderRadius4} solid ${COLORS.white}`,
+      disabledBorder: `${BORDERS.borderRadius4} solid ${COLORS.grey35}`,
+    },
+    alertAlt: {
+      defaultColor: COLORS.red50,
+      disabledColor: COLORS.grey50,
+      defaultBackgroundColor: COLORS.white,
+      activeBackgroundColor: COLORS.white,
+      disabledBackgroundColor: COLORS.grey35,
+      iconColor: COLORS.red50,
+      disabledIconColor: COLORS.grey50,
     },
   }
 
@@ -77,6 +114,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     box-shadow: none;
     padding: ${SPACING.spacing24};
     line-height: ${TYPOGRAPHY.lineHeight20};
+    border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].border};
     ${TYPOGRAPHY.pSemiBold}
 
     &:focus {
@@ -85,7 +123,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       box-shadow: none;
     }
     &:hover {
-      border: none;
+      border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].border};
       box-shadow: none;
       background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
         .defaultBackgroundColor};
@@ -102,8 +140,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     }
 
     &:disabled {
-      background-color: ${COLORS.grey35};
-      color: ${COLORS.grey50};
+      color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .disabledBackgroundColor};
     }
   `
   return (
@@ -131,9 +170,8 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
           aria-label={`${iconName} icon`}
           color={
             disabled
-              ? COLORS.grey50
-              : iconColorOverride ??
-                LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
+              ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
+              : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
           }
           size="5rem"
         />

--- a/app/src/atoms/buttons/__tests__/LargeButton.test.tsx
+++ b/app/src/atoms/buttons/__tests__/LargeButton.test.tsx
@@ -45,6 +45,29 @@ describe('LargeButton', () => {
       `background-color: ${COLORS.blue35}`
     )
   })
+
+  it('renders the onColor button', () => {
+    props = {
+      ...props,
+      buttonType: 'onColor',
+    }
+    render(props)
+    expect(screen.getByRole('button')).toHaveStyle(
+      `background-color: ${COLORS.transparent}`
+    )
+  })
+
+  it('renders the alertAlt button', () => {
+    props = {
+      ...props,
+      buttonType: 'alertAlt',
+    }
+    render(props)
+    expect(screen.getByRole('button')).toHaveStyle(
+      `background-color: ${COLORS.white}`
+    )
+  })
+
   it('renders the button as disabled', () => {
     props = {
       ...props,
@@ -52,16 +75,5 @@ describe('LargeButton', () => {
     }
     render(props)
     expect(screen.getByRole('button')).toBeDisabled()
-  })
-
-  it('renders the icon override color if specified', () => {
-    props = {
-      ...props,
-      iconColorOverride: COLORS.red50,
-    }
-    render(props)
-    expect(screen.getByLabelText('play-round-corners icon')).toHaveStyle(
-      `color: ${COLORS.red50}`
-    )
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -135,6 +135,6 @@ const SplashFrame = styled(Flex)`
 `
 
 const SHARED_BUTTON_STYLE = css`
-  width: 464px;
-  height: 216px;
+  width: 29rem;
+  height: 13.5rem;
 `

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -86,15 +86,16 @@ export function RunPausedSplash({
         <LargeButton
           onClick={onCancelClick}
           buttonText={t('cancel_run')}
-          css={CANCEL_RUN_BTN_STYLE}
+          css={SHARED_BUTTON_STYLE}
           iconName={'remove'}
-          iconColorOverride={COLORS.red50}
+          buttonType="alertAlt"
         />
         <LargeButton
           onClick={onLaunchERClick}
           buttonText={t('launch_recovery_mode')}
-          css={LAUNCH_RECOVERY_BTN_STYLE}
+          css={SHARED_BUTTON_STYLE}
           iconName={'recovery'}
+          buttonType="onColor"
         />
       </Flex>
     </Flex>
@@ -133,45 +134,7 @@ const SplashFrame = styled(Flex)`
   padding-bottom: 0px;
 `
 
-const SHARED_BUTTON_STYLE = `
-width: 464px;
-height: 216px;
-`
-
-const LAUNCH_RECOVERY_BTN_STYLE = css`
-  ${SHARED_BUTTON_STYLE};
-  background-color: transparent;
-  border: 4px solid ${COLORS.white};
-
-  &:hover {
-    background-color: transparent;
-    border: 4px solid ${COLORS.white};
-  }
-  &:active {
-    background-color: transparent;
-    border: 4px solid ${COLORS.white};
-  }
-  &:focus-visible {
-    background-color: transparent;
-    border: 4px solid ${COLORS.white};
-  }
-`
-
-const CANCEL_RUN_BTN_STYLE = css`
-  ${SHARED_BUTTON_STYLE};
-  color: ${COLORS.red50};
-  background-color: ${COLORS.white};
-
-  &:hover {
-    color: ${COLORS.red50};
-    background-color: ${COLORS.white};
-  }
-  &:active {
-    color: ${COLORS.red50};
-    background-color: ${COLORS.white};
-  }
-  &:focus-visible {
-    color: ${COLORS.red50};
-    background-color: ${COLORS.white};
-  }
+const SHARED_BUTTON_STYLE = css`
+  width: 464px;
+  height: 216px;
 `


### PR DESCRIPTION
Closes [EXEC-470](https://opentrons.atlassian.net/browse/EXEC-470)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

This PR is a follow up to #15262, in which I didn't see that we actually had [Figma buttonTypes](https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery?node-id=953-17455&t=S4Evm8O0XGb03FDe-4) for the new RunPausedSplash screen. 

<img width="912" alt="Screenshot 2024-05-28 at 10 16 30 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/efe51037-7187-4f49-9092-4d85a300df01">

<img width="867" alt="Screenshot 2024-05-28 at 10 16 33 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/6c31c932-a94b-4b05-8dfd-6ef6cf8404a1">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verified via Storybook that the buttonTypes match [designs](https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery?node-id=953-17455&t=S4Evm8O0XGb03FDe-4). You'll have to change Storybook's background color (in the top navbar), since the button defaults use a lot of white.
- Confirmed that the RunPausedSplash screen still matches designs.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added new PrimaryButton types.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-470]: https://opentrons.atlassian.net/browse/EXEC-470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ