### PR TITLE
fix(step-generation): properly emit configureNozzleLayout command

### DIFF
--- a/step-generation/src/__tests__/replaceTip.test.ts
+++ b/step-generation/src/__tests__/replaceTip.test.ts
@@ -17,6 +17,7 @@ import {
   dropTipInPlaceHelper,
   moveToAddressableAreaHelper,
   DEFAULT_PIPETTE,
+  PIPETTE_96,
 } from '../fixtures'
 import { replaceTip } from '../commandCreators/atomic/replaceTip'
 import { FIXED_TRASH_ID } from '../constants'
@@ -127,6 +128,49 @@ describe('replaceTip', () => {
       expect(res.commands).toEqual([
         ...dropTipHelper(p300SingleId),
         pickUpTipHelper('B1'),
+      ])
+    })
+    it('96-channel full tip and emits the configure nozzle layout command before picking up tip', () => {
+      const initialTestRobotState = merge({}, initialRobotState, {
+        tipState: {
+          tipracks: {
+            [tiprack1Id]: {
+              A1: false,
+            },
+          },
+          pipettes: {
+            [PIPETTE_96]: true,
+          },
+        },
+        pipettes: {
+          [PIPETTE_96]: { nozzles: 'ALL' },
+        },
+      })
+      const result = replaceTip(
+        {
+          pipette: PIPETTE_96,
+          dropTipLocation: FIXED_TRASH_ID,
+          tipRack: tiprackURI1,
+          nozzles: COLUMN,
+        },
+        invariantContext,
+        initialTestRobotState
+      )
+      const res = getSuccessResult(result)
+      expect(res.commands).toEqual([
+        ...dropTipHelper(PIPETTE_96),
+        {
+          commandType: 'configureNozzleLayout',
+          key: expect.any(String),
+          params: {
+            pipetteId: PIPETTE_96,
+            configurationParams: {
+              primaryNozzle: 'A12',
+              style: COLUMN,
+            },
+          },
+        },
+        pickUpTipHelper('A2', { pipetteId: PIPETTE_96 }),
       ])
     })
     it('Single-channel: used all tips in first rack, move to second rack', () => {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -24,7 +24,6 @@ import {
 import {
   aspirate,
   configureForVolume,
-  configureNozzleLayout,
   delay,
   dropTip,
   moveToWell,
@@ -486,20 +485,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       const dropTipAfterDispenseAirGap =
         airGapAfterDispenseCommands.length > 0 ? dropTipCommand : []
 
-      const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
-      const configureNozzleLayoutCommand: CurriedCommandCreator[] =
-        //  only emit the command if previous nozzle state is different
-        is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
-          ? [
-              curryCommandCreator(configureNozzleLayout, {
-                nozzles: args.nozzles,
-                pipetteId: args.pipette,
-              }),
-            ]
-          : []
-
       return [
-        ...configureNozzleLayoutCommand,
         ...tipCommands,
         ...configureForVolumeCommand,
         ...mixBeforeCommands,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -22,7 +22,6 @@ import {
 import {
   aspirate,
   configureForVolume,
-  configureNozzleLayout,
   delay,
   dispense,
   dropTip,
@@ -460,20 +459,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           ]
         : []
 
-      const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
-      const configureNozzleLayoutCommand: CurriedCommandCreator[] =
-        //  only emit the command if previous nozzle state is different
-        is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
-          ? [
-              curryCommandCreator(configureNozzleLayout, {
-                nozzles: args.nozzles,
-                pipetteId: args.pipette,
-              }),
-            ]
-          : []
-
       return [
-        ...configureNozzleLayoutCommand,
         ...tipCommands,
         ...configureForVolumeCommand,
         ...mixBeforeAspirateCommands,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -11,7 +11,6 @@ import * as errorCreators from '../../errorCreators'
 import {
   aspirate,
   configureForVolume,
-  configureNozzleLayout,
   delay,
   dispense,
   replaceTip,
@@ -201,17 +200,6 @@ export const mix: CommandCreator<MixArgs> = (
       }
     }
   }
-  const stateNozzles = prevRobotState.pipettes[pipette].nozzles
-  const configureNozzleLayoutCommand: CurriedCommandCreator[] =
-    //  only emit the command if previous nozzle state is different
-    is96Channel && data.nozzles != null && data.nozzles !== stateNozzles
-      ? [
-          curryCommandCreator(configureNozzleLayout, {
-            nozzles: data.nozzles,
-            pipetteId: pipette,
-          }),
-        ]
-      : []
 
   const configureForVolumeCommand: CurriedCommandCreator[] = LOW_VOLUME_PIPETTES.includes(
     invariantContext.pipetteEntities[pipette].name
@@ -281,7 +269,6 @@ export const mix: CommandCreator<MixArgs> = (
         dispenseYOffset,
       })
       return [
-        ...configureNozzleLayoutCommand,
         ...tipCommands,
         ...configureForVolumeCommand,
         ...mixCommands,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -24,7 +24,6 @@ import {
 import {
   aspirate,
   configureForVolume,
-  configureNozzleLayout,
   delay,
   dispense,
   dropTip,
@@ -274,17 +273,6 @@ export const transfer: CommandCreator<TransferArgs> = (
             changeTipNow =
               isInitialSubtransfer || destinationWell !== prevDestWell
           }
-          const stateNozzles = prevRobotState.pipettes[args.pipette].nozzles
-          const configureNozzleLayoutCommand: CurriedCommandCreator[] =
-            //  only emit the command if previous nozzle state is different
-            is96Channel && args.nozzles != null && args.nozzles !== stateNozzles
-              ? [
-                  curryCommandCreator(configureNozzleLayout, {
-                    nozzles: args.nozzles,
-                    pipetteId: args.pipette,
-                  }),
-                ]
-              : []
 
           const configureForVolumeCommand: CurriedCommandCreator[] = LOW_VOLUME_PIPETTES.includes(
             invariantContext.pipetteEntities[args.pipette].name
@@ -603,7 +591,6 @@ export const transfer: CommandCreator<TransferArgs> = (
               : []
 
           const nextCommands = [
-            ...configureNozzleLayoutCommand,
             ...tipCommands,
             ...preWetTipCommands,
             ...configureForVolumeCommand,


### PR DESCRIPTION
closes RQA-2781

# Overview

Step-generation was incorrectly assuming that the configure nozzle layout command would be emitted always before a pick up tip but that logic needed to be moved to the `replaceTip` instead.

But the bug was that the `configureNozzleLayout` command was emitting with a tip still on the pipette which caused the protocol to fail analysis

# Test Plan

first examine the attached protocol and see that there are 6 `configureNozzleLayout` commands. upload the file to PD and re-export. Confirm that there is now only 1 `configureNozzleLayout` command

[CELL LYSIS PROTOCOL - FLEX - HS One plate -v2.json](https://github.com/Opentrons/opentrons/files/15472666/CELL.LYSIS.PROTOCOL.-.FLEX.-.HS.One.plate.-v2.json)


# Changelog

- remove emitting the command from `transfer`, `mix`, `consolidate` and `distribute` and add the logic to `replaceTip`
- add a test case

# Review requests

see test plan

# Risk assessment

low