### PR TITLE
feat(api): add new pick up tip function

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -65,7 +65,7 @@ from .robot_calibration import (
     RobotCalibration,
 )
 from .protocols import HardwareControlInterface
-from .instruments.ot2.pipette_handler import PipetteHandlerProvider
+from .instruments.ot2.pipette_handler import PipetteHandlerProvider, PickUpTipSpec
 from .instruments.ot2.instrument_calibration import load_pipette_offset
 from .motion_utilities import (
     target_position_from_absolute,
@@ -1152,6 +1152,30 @@ class API(
                 mount, back_left_nozzle, front_right_nozzle, starting_nozzle
             )
 
+    async def tip_pickup_moves(
+        self,
+        mount: top_types.Mount,
+        spec: PickUpTipSpec,
+    ) -> None:
+        for press in spec.presses:
+            with self._backend.save_current():
+                self._backend.set_active_current(press.current)
+                target_down = target_position_from_relative(
+                    mount, press.relative_down, self._current_position
+                )
+                await self._move(target_down, speed=press.speed)
+            target_up = target_position_from_relative(
+                mount, press.relative_up, self._current_position
+            )
+            await self._move(target_up)
+        # neighboring tips tend to get stuck in the space between
+        # the volume chamber and the drop-tip sleeve on p1000.
+        # This extra shake ensures those tips are removed
+        for rel_point, speed in spec.shake_off_list:
+            await self.move_rel(mount, rel_point, speed=speed)
+
+        await self.retract(mount, spec.retract_target)
+
     async def pick_up_tip(
         self,
         mount: top_types.Mount,
@@ -1176,25 +1200,9 @@ class API(
             home_flagged_axes=False,
         )
 
-        for press in spec.presses:
-            with self._backend.save_current():
-                self._backend.set_active_current(press.current)
-                target_down = target_position_from_relative(
-                    mount, press.relative_down, self._current_position
-                )
-                await self._move(target_down, speed=press.speed)
-            target_up = target_position_from_relative(
-                mount, press.relative_up, self._current_position
-            )
-            await self._move(target_up)
+        await self.tip_pickup_moves(mount, spec)
         _add_tip_to_instrs()
-        # neighboring tips tend to get stuck in the space between
-        # the volume chamber and the drop-tip sleeve on p1000.
-        # This extra shake ensures those tips are removed
-        for rel_point, speed in spec.shake_off_list:
-            await self.move_rel(mount, rel_point, speed=speed)
 
-        await self.retract(mount, spec.retract_target)
         if prep_after:
             await self.prepare_for_aspirate(mount)
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1796,12 +1796,14 @@ class OT3API(
         self._gripper_handler.check_ready_for_jaw_move("hold_jaw_width")
         await self._hold_jaw_width(jaw_width_mm)
 
-    async def execute_pick_up_tip(
+    async def tip_pickup_moves(
         self,
         mount: OT3Mount,
         presses: Optional[int] = None,
         increment: Optional[float] = None,
     ) -> None:
+        """This is a slightly more barebones variation of pick_up_tip. This is only the motor routine
+        directly involved in tip pickup, and leaves any state updates and plunger moves to the caller."""
         realmount = OT3Mount.from_mount(mount)
         instrument = self._pipette_handler.get_pipette(realmount)
         if (
@@ -2204,7 +2206,7 @@ class OT3API(
 
         await self._move_to_plunger_bottom(realmount, rate=1.0)
 
-        await self.execute_pick_up_tip(realmount, presses, increment)
+        await self.tip_pickup_moves(realmount, presses, increment)
 
         add_tip_to_instr()
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1796,6 +1796,49 @@ class OT3API(
         self._gripper_handler.check_ready_for_jaw_move("hold_jaw_width")
         await self._hold_jaw_width(jaw_width_mm)
 
+    async def execute_pick_up_tip(
+        self,
+        mount: OT3Mount,
+        presses: Optional[int] = None,
+        increment: Optional[float] = None,
+    ) -> None:
+        realmount = OT3Mount.from_mount(mount)
+        instrument = self._pipette_handler.get_pipette(realmount)
+        if (
+            self.gantry_load == GantryLoad.HIGH_THROUGHPUT
+            and instrument.nozzle_manager.current_configuration.configuration
+            == NozzleConfigurationType.FULL
+        ):
+            spec = self._pipette_handler.plan_ht_pick_up_tip(
+                instrument.nozzle_manager.current_configuration.tip_count
+            )
+            if spec.z_distance_to_tiprack:
+                await self.move_rel(
+                    realmount, top_types.Point(z=spec.z_distance_to_tiprack)
+                )
+            await self._tip_motor_action(realmount, spec.tip_action_moves)
+        else:
+            spec = self._pipette_handler.plan_lt_pick_up_tip(
+                realmount,
+                instrument.nozzle_manager.current_configuration.tip_count,
+                presses,
+                increment,
+            )
+            await self._force_pick_up_tip(realmount, spec)
+
+        # neighboring tips tend to get stuck in the space between
+        # the volume chamber and the drop-tip sleeve on p1000.
+        # This extra shake ensures those tips are removed
+        for rel_point, speed in spec.shake_off_moves:
+            await self.move_rel(realmount, rel_point, speed=speed)
+
+        # fixme: really only need this during labware position check so user
+        # can verify if a tip is properly attached
+        if spec.ending_z_retract_distance:
+            await self.move_rel(
+                realmount, top_types.Point(z=spec.ending_z_retract_distance)
+            )
+
     async def _move_to_plunger_bottom(
         self,
         mount: OT3Mount,
@@ -2160,40 +2203,8 @@ class OT3API(
                 self._backend._update_tip_state(realmount, True)
 
         await self._move_to_plunger_bottom(realmount, rate=1.0)
-        if (
-            self.gantry_load == GantryLoad.HIGH_THROUGHPUT
-            and instrument.nozzle_manager.current_configuration.configuration
-            == NozzleConfigurationType.FULL
-        ):
-            spec = self._pipette_handler.plan_ht_pick_up_tip(
-                instrument.nozzle_manager.current_configuration.tip_count
-            )
-            if spec.z_distance_to_tiprack:
-                await self.move_rel(
-                    realmount, top_types.Point(z=spec.z_distance_to_tiprack)
-                )
-            await self._tip_motor_action(realmount, spec.tip_action_moves)
-        else:
-            spec = self._pipette_handler.plan_lt_pick_up_tip(
-                realmount,
-                instrument.nozzle_manager.current_configuration.tip_count,
-                presses,
-                increment,
-            )
-            await self._force_pick_up_tip(realmount, spec)
 
-        # neighboring tips tend to get stuck in the space between
-        # the volume chamber and the drop-tip sleeve on p1000.
-        # This extra shake ensures those tips are removed
-        for rel_point, speed in spec.shake_off_moves:
-            await self.move_rel(realmount, rel_point, speed=speed)
-
-        # fixme: really only need this during labware position check so user
-        # can verify if a tip is properly attached
-        if spec.ending_z_retract_distance:
-            await self.move_rel(
-                realmount, top_types.Point(z=spec.ending_z_retract_distance)
-            )
+        await self.execute_pick_up_tip(realmount, presses, increment)
 
         add_tip_to_instr()
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1806,6 +1806,10 @@ class OT3API(
         directly involved in tip pickup, and leaves any state updates and plunger moves to the caller."""
         realmount = OT3Mount.from_mount(mount)
         instrument = self._pipette_handler.get_pipette(realmount)
+
+        if isinstance(self._backend, OT3Simulator):
+            self._backend._update_tip_state(realmount, True)
+
         if (
             self.gantry_load == GantryLoad.HIGH_THROUGHPUT
             and instrument.nozzle_manager.current_configuration.configuration

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1807,9 +1807,6 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
         instrument = self._pipette_handler.get_pipette(realmount)
 
-        if isinstance(self._backend, OT3Simulator):
-            self._backend._update_tip_state(realmount, True)
-
         if (
             self.gantry_load == GantryLoad.HIGH_THROUGHPUT
             and instrument.nozzle_manager.current_configuration.configuration
@@ -1837,6 +1834,9 @@ class OT3API(
         # This extra shake ensures those tips are removed
         for rel_point, speed in spec.shake_off_moves:
             await self.move_rel(realmount, rel_point, speed=speed)
+
+        if isinstance(self._backend, OT3Simulator):
+            self._backend._update_tip_state(realmount, True)
 
         # fixme: really only need this during labware position check so user
         # can verify if a tip is properly attached
@@ -2205,8 +2205,6 @@ class OT3API(
         def add_tip_to_instr() -> None:
             instrument.add_tip(tip_length=tip_length)
             instrument.set_current_volume(0)
-            if isinstance(self._backend, OT3Simulator):
-                self._backend._update_tip_state(realmount, True)
 
         await self._move_to_plunger_bottom(realmount, rate=1.0)
 

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -540,6 +540,19 @@ async def test_no_pipette(sim_and_instr):
         assert not hw_api._current_volume[types.Mount.RIGHT]
 
 
+async def test_execute_pick_up_tip(dummy_instruments_ot3, ot3_api_obj):
+    """Make sure that execute_pick_up_tip does not add a tip to the instrument."""
+    hw_api = await ot3_api_obj(
+        attached_instruments=dummy_instruments_ot3[0], loop=asyncio.get_running_loop()
+    )
+    mount = types.Mount.LEFT
+    await hw_api.home()
+    await hw_api.cache_instruments()
+
+    await hw_api.execute_pick_up_tip(mount)
+    assert not hw_api.hardware_instruments[mount].has_tip
+
+
 async def test_pick_up_tip(is_robot, sim_and_instr):
     sim_builder, (dummy_instruments, _) = sim_and_instr
     hw_api = await sim_builder(

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -651,9 +651,9 @@ async def test_pickup_moves(
         mock_move_to_plunger_bottom.reset_mock()
         mock_move_rel.reset_mock()
 
-        #  make sure that execute_pick_up_tip has the same set of moves,
+        #  make sure that tip_pickup_moves has the same set of moves,
         #  except no calls to move_to_plunger_bottom
-        await ot3_hardware.execute_pick_up_tip(Mount.LEFT, 40.0)
+        await ot3_hardware.tip_pickup_moves(Mount.LEFT, 40.0)
         move_call_list = [call.args for call in mock_move_rel.call_args_list]
         if gantry_load == GantryLoad.HIGH_THROUGHPUT:
             assert move_call_list == [


### PR DESCRIPTION
## Overview
This is a follow-up to https://github.com/Opentrons/opentrons/pull/15143.

In order to support error recovery, we should restructure some of our api functions so that they _only_ do the motor routines necessary to do what they say to do, without any additional movements or information caching. This creates a new function that makes that change to `pick_up_tip`, while still leaving the original function in place.

## Changelog
- create an `execute_pick_up_tip` function that leaves out both of the pipette plunger moves at the beginning and end, and does not add the tip
- add some tests
- have `pick_up_tip` call this new function

## Review Requests
Is giving this new function a different signature between `api` and `ot3api` a no-no?