### PR TITLE
fix(shared-data): defaults should match valuesByApiLevel for p50 3_6 lowVolume

### DIFF
--- a/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_6.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p50/lowVolumeDefault/3_6.json
@@ -4,15 +4,15 @@
     "t50": {
       "uiMaxFlowRate": 26.7,
       "defaultAspirateFlowRate": {
-        "default": 35,
+        "default": 26.7,
         "valuesByApiLevel": { "2.14": 26.7 }
       },
       "defaultDispenseFlowRate": {
-        "default": 57,
+        "default": 26.7,
         "valuesByApiLevel": { "2.14": 26.7 }
       },
       "defaultBlowOutFlowRate": {
-        "default": 57,
+        "default": 26.7,
         "valuesByApiLevel": { "2.14": 26.7 }
       },
       "defaultFlowAcceleration": 1200.0,


### PR DESCRIPTION
closes RQA-2785

# Overview

Somehow i forgot to change the `defaults` for the p50 3_6 pipette version to match the `uiMaxFlowRate` and `valuesByApiLevel`. I double checked and this is the only model with the issue.

# Test Plan

Just confirm that the `defaults` matches the `valuesByApiLevel`

# Changelog

- change pipette definition

# Review requests

see test plan

# Risk assessment

low