### PR TITLE
fix(api): encode unknown gcode inputs in tc control script

### DIFF
--- a/api/src/opentrons/hardware_control/scripts/tc_control.py
+++ b/api/src/opentrons/hardware_control/scripts/tc_control.py
@@ -15,6 +15,9 @@ gcode_shortcuts = {
     _MOVE_LID: "M240.D",  # move lid stepper motor
     "ol": "M126",  # open lid
     "cl": "M127",  # close lid
+    "sw": "M901.D",  # status of all switches
+    "lt": "M141.D",  # get lid temperature
+    "pt": "M105.D"  # get plate temperature
 }
 
 
@@ -68,7 +71,7 @@ async def comms_loop(dev: Serial) -> bool:
         await handle_gcode_shortcut(dev, command)
     else:
         try:
-            dev.write(f"{command}\n")
+            dev.write(f"{command}\n".encode())
             print(await message_return(dev))
         except TypeError:
             print("Invalid input.")

--- a/api/src/opentrons/hardware_control/scripts/tc_control.py
+++ b/api/src/opentrons/hardware_control/scripts/tc_control.py
@@ -17,7 +17,7 @@ gcode_shortcuts = {
     "cl": "M127",  # close lid
     "sw": "M901.D",  # status of all switches
     "lt": "M141.D",  # get lid temperature
-    "pt": "M105.D"  # get plate temperature
+    "pt": "M105.D",  # get plate temperature
 }
 
 


### PR DESCRIPTION
## Overview
In the `tc_control.py` script, a bug got past me where the script doesn't correctly encode a gcode string before sending it off to the thermocycler. This just fixes that and adds a couple more shortcuts that are useful for general thermocycler debugging.