### PR TITLE
fix(protocol-designer): set numMultiples to numItems instead of 0

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/EquipmentOption.tsx
@@ -75,7 +75,9 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
   const { t } = useTranslation(['tooltip', 'shared'])
   const [equipmentTargetProps, equipmentTooltipProps] = useHoverTooltip()
   const [tempTargetProps, tempTooltipProps] = useHoverTooltip()
-  const [numMultiples, setNumMultiples] = React.useState<number>(0)
+  const [numMultiples, setNumMultiples] = React.useState<number>(
+    multiples?.numItems ?? 0
+  )
 
   const EQUIPMENT_OPTION_STYLE = css`
     background-color: ${COLORS.white};
@@ -151,6 +153,7 @@ export function EquipmentOption(props: EquipmentOptionProps): JSX.Element {
     } else if (numItems > 0) {
       downArrowStyle = ARROW_STYLE_ACTIVE
     }
+
     iconInfo = (
       <Flex
         flexDirection={DIRECTION_COLUMN}


### PR DESCRIPTION
closes RQA-2787

# Overview

This was a good catch by @DerekMaggio! Basically, the `numMultiples` was being set to 0 on render instead of remembering the actual number. So if you go back to change something, the `numMultiples` would be reset to 0, disallowing the user to select the down arrow.

# Test Plan

follow the test plan outlined in the attached ticket!

# Changelog

- set the `useState` correctly

# Review requests

see test plan

# Risk assessment

low