### PR TITLE
refactor(api-client,shared-data): Update TS types for new `isDefined` field on errors

### DIFF
--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -4,6 +4,7 @@ import type {
   LoadedModule,
   LoadedPipette,
   ModuleModel,
+  RunCommandError,
   RunTimeCommand,
   RunTimeParameter,
 } from '@opentrons/shared-data'
@@ -137,12 +138,6 @@ export interface CommandData {
   data: RunTimeCommand
 }
 
-export interface RunError {
-  id: string
-  errorType: string
-  errorInfo: { [key: string]: string }
-  wrappedErrors: RunError[]
-  errorCode: string
-  createdAt: string
-  detail: string
-}
+// Although run errors are semantically different from command errors,
+// the server currently happens to use the exact same model for both.
+export type RunError = RunCommandError

--- a/app/src/organisms/Devices/ProtocolRun/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/__tests__/RunFailedModal.test.tsx
@@ -16,6 +16,7 @@ const ROBOT_NAME = 'mockRobotName'
 const mockError: RunError = {
   id: '5097b3e6-3900-482d-abb1-0a8d8a0e515d',
   errorType: 'ModuleNotAttachedError',
+  isDefined: false,
   createdAt: '2023-08-07T20:16:57.720783+00:00',
   detail: 'No available thermocyclerModuleV2 found.',
   errorCode: '4000',

--- a/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
@@ -11,6 +11,7 @@ export const mockFailedCommand: FailedCommand = {
   error: {
     createdAt: '2024-05-24T13:55:32.595751+00:00',
     detail: 'No tip detected.',
+    isDefined: false,
     errorCode: '3003',
     errorType: 'tipPhysicallyMissing',
     errorInfo: {},

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunFailedModal.test.tsx
@@ -20,6 +20,7 @@ const mockErrors = [
   {
     id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
     errorType: 'generalError',
+    isDefined: false,
     createdAt: '2023-04-09T21:41:51.333171+00:00',
     detail: 'Error with code 4000 (lowest priority)',
     errorInfo: {},
@@ -28,6 +29,7 @@ const mockErrors = [
       {
         id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
         errorType: 'roboticsInteractionError',
+        isDefined: false,
         createdAt: '2023-04-09T21:41:51.333171+00:00',
         detail: 'Error with code 3000 (second lowest priortiy)',
         errorInfo: {},
@@ -37,6 +39,7 @@ const mockErrors = [
       {
         id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
         errorType: 'roboticsControlError',
+        isDefined: false,
         createdAt: '2023-04-09T21:41:51.333171+00:00',
         detail: 'Error with code 2000 (second highest priority)',
         errorInfo: {},
@@ -45,6 +48,7 @@ const mockErrors = [
           {
             id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
             errorType: 'hardwareCommunicationError',
+            isDefined: false,
             createdAt: '2023-04-09T21:41:51.333171+00:00',
             detail: 'Error with code 1000 (highest priority)',
             errorInfo: {},
@@ -58,6 +62,7 @@ const mockErrors = [
   {
     id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
     errorType: 'roboticsInteractionError',
+    isDefined: false,
     createdAt: '2023-04-09T21:41:51.333171+00:00',
     detail: 'Error with code 2001 (second highest priortiy)',
     errorInfo: {},

--- a/app/src/organisms/RunTimeControl/__fixtures__/index.ts
+++ b/app/src/organisms/RunTimeControl/__fixtures__/index.ts
@@ -129,6 +129,7 @@ export const mockFailedRun: RunData = {
     {
       id: '5',
       errorType: 'RuntimeError',
+      isDefined: false,
       createdAt: 'noon forty-five',
       detail: 'this run failed',
       errorInfo: {},

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -84,6 +84,7 @@ export interface RunCommandError {
   errorCode: string
   errorType: string
   id: string
+  isDefined: boolean
   errorInfo?: Record<string, unknown>
   wrappedErrors?: Array<Record<string, unknown>>
 }

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -86,5 +86,5 @@ export interface RunCommandError {
   id: string
   isDefined: boolean
   errorInfo?: Record<string, unknown>
-  wrappedErrors?: Array<Record<string, unknown>>
+  wrappedErrors?: RunCommandError[]
 }


### PR DESCRIPTION
# Overview

I forgot to do the TypeScript part in #15290, sowwwyyyyy.

# Test Plan

Just make sure CI keeps passing.

# Changelog

Update TypeScript bindings for #15290—add an `isDefined` field to command and run errors.

# Review requests

Does it make sense to alias `RunError` with `RunCommandError` like this?

# Risk assessment

No risk.
