### PR TITLE
chore(api): add API version 2.19

### DIFF
--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 18)
+MAX_SUPPORTED_VERSION = APIVersion(2, 19)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)


### PR DESCRIPTION
This carves out a 2.19 API version that will contain updated tip overlap data.

Closes EXEC-452
