### PR TITLE
chore(components): Fix workaround for "excessively deep" error

### DIFF
--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -271,7 +271,7 @@ export function MoveLabwareOnDeck(
 /**
  * These animated components needs to be split out because react-spring and styled-components don't play nice
  * @see https://github.com/pmndrs/react-spring/issues/1515 */
-const AnimatedG = styled(animated.g)<any>``
+const AnimatedG = styled(animated.g as any)``
 
 interface WellProps {
   wellDef: LabwareWell


### PR DESCRIPTION
# Overview

This attempts to fix our workaround for https://github.com/pmndrs/react-spring/issues/1515. https://github.com/pmndrs/react-spring/issues/1515 causes this spurious `make check-js` error, and it sounds like our workaround doesn't consistently suppress it for some reason.

```
components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx:274:19 - error TS2589: Type instantiation is excessively deep and possibly infinite.

274 const AnimatedG = styled(animated.g)<any>``
                      ~~~~~~~~~~~~~~~~~~
```

# Test Plan

* [x] `make check-js` succeeds locally.
* [x] `make check-js` succeeds in CI.

# Changelog

Adjust our placement of `any` so that `AnimatedG`'s type is `StyledComponent<any>` instead of `StyledComponent<AnimatedComponent<"g">>`. It sort of looks like that's how our original workaround was supposed to work, but for some reason that wasn't happening? This is all magic to me. 🤷  

# Review requests

This means the uses of `AnimatedG` in this file will not be type-safe. Is this a good idea?

# Risk assessment

Low.