### PR TITLE
feat(hardware): added safety relay active state to HepaUVState and safety_relay_inactive error

### DIFF
--- a/hardware/opentrons_hardware/firmware_bindings/constants.py
+++ b/hardware/opentrons_hardware/firmware_bindings/constants.py
@@ -4,6 +4,7 @@ This file is used as a source for code generation, which does not run in a venv
 by default. Please do not unconditionally import things outside the python standard
 library.
 """
+
 from enum import Enum, unique
 from typing import Union, Dict, List
 
@@ -294,6 +295,7 @@ class ErrorCode(int, Enum):
     door_open = 0x0E
     reed_open = 0x0F
     motor_driver_error_detected = 0x10
+    safety_relay_inactive = 0x11
 
 
 @unique

--- a/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
+++ b/hardware/opentrons_hardware/firmware_bindings/messages/payloads.py
@@ -1,4 +1,5 @@
 """Payloads of can bus messages."""
+
 # TODO (amit, 2022-01-26): Figure out why using annotations import ruins
 #  dataclass fields interpretation.
 #  from __future__ import annotations
@@ -684,6 +685,7 @@ class GetHepaUVStatePayloadResponse(EmptyPayload):
     uv_light_on: utils.UInt8Field
     remaining_time_s: utils.UInt32Field
     uv_current_ma: utils.UInt16Field
+    safety_relay_active: utils.UInt8Field
 
 
 @dataclass(eq=False)

--- a/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/hepa_uv_settings.py
@@ -1,4 +1,5 @@
 """Utilities for controlling the hepa/uv extension module."""
+
 import logging
 import asyncio
 from typing import Optional
@@ -46,6 +47,7 @@ class HepaUVState:
     uv_duration_s: int
     remaining_time_s: int
     uv_current_ma: int
+    safety_relay_active: bool
 
 
 async def set_hepa_fan_state(
@@ -136,6 +138,7 @@ async def get_hepa_uv_state(can_messenger: CanMessenger) -> Optional[HepaUVState
                 uv_duration_s=int(message.payload.uv_duration_s.value),
                 remaining_time_s=int(message.payload.remaining_time_s.value),
                 uv_current_ma=int(message.payload.uv_current_ma.value),
+                safety_relay_active=bool(message.payload.safety_relay_active.value),
             )
 
     def _filter(arb_id: ArbitrationId) -> bool:

--- a/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_hepauv_settings.py
@@ -55,6 +55,7 @@ def create_hepa_uv_state_response(
     duration: int,
     remaining_time: int,
     uv_current: int,
+    safety_relay_active: bool,
 ) -> MessageDefinition:
     """Create a GetHepaUVStateResponse."""
     return md.GetHepaUVStateResponse(
@@ -63,6 +64,7 @@ def create_hepa_uv_state_response(
             uv_duration_s=UInt32Field(duration),
             remaining_time_s=UInt32Field(remaining_time),
             uv_current_ma=UInt16Field(uv_current),
+            safety_relay_active=UInt8Field(safety_relay_active),
         )
     )
 
@@ -162,12 +164,29 @@ async def test_get_hepa_fan_state(
     [
         (
             NodeId.host,
-            create_hepa_uv_state_response(True, 900, 300, 3300),
+            create_hepa_uv_state_response(True, 900, 300, 3300, True),
             NodeId.hepa_uv,
         ),
-        (NodeId.host, create_hepa_uv_state_response(True, 0, 0, 33000), NodeId.hepa_uv),
-        (NodeId.host, create_hepa_uv_state_response(False, 0, 0, 0), NodeId.hepa_uv),
-        (NodeId.host, create_hepa_uv_state_response(False, 900, 0, 0), NodeId.hepa_uv),
+        (
+            NodeId.host,
+            create_hepa_uv_state_response(True, 0, 0, 33000, True),
+            NodeId.hepa_uv,
+        ),
+        (
+            NodeId.host,
+            create_hepa_uv_state_response(True, 0, 0, 33000, False),
+            NodeId.hepa_uv,
+        ),
+        (
+            NodeId.host,
+            create_hepa_uv_state_response(False, 0, 0, 0, True),
+            NodeId.hepa_uv,
+        ),
+        (
+            NodeId.host,
+            create_hepa_uv_state_response(False, 900, 0, 0, False),
+            NodeId.hepa_uv,
+        ),
     ],
 )
 async def test_get_hepa_uv_state(
@@ -202,6 +221,7 @@ async def test_get_hepa_uv_state(
             int(payload.uv_duration_s.value),
             int(payload.remaining_time_s.value),
             int(payload.uv_current_ma.value),
+            bool(payload.safety_relay_active.value),
         )
         == res
     )


### PR DESCRIPTION
# Overview

As a result of the initial safety evaluation of the Flex HEPA/UV unit, we have added a safety relay between the PCBA and UV lamp ballast that monitors the Flex door switch, the placement reed switch, and the UV enable pushbutton. This safety relay will cut the supply to the UV lamp ballast if the door is opened or if the placement reed switch is not activated. Furthermore, the user must press the UV to enable the pushbutton to enable the relay after both the door switch and placement reed switch are in the correct state. All of this happens without firmware interaction.

This pull request incorporates the changes required to support the new electrical design, since most of the logic is the same, the work is concentrated on adding support for the safety relay. This pull request goes with [Opentrons/ot3-firmware#782](https://github.com/Opentrons/ot3-firmware/pull/782).

Closes: [PLAT-300](https://opentrons.atlassian.net/browse/PLAT-300) [PLAT-301](https://opentrons.atlassian.net/browse/PLAT-301) [PLAT-302](https://opentrons.atlassian.net/browse/PLAT-302)

# Test Plan

- Test on hardware once the new hepa uv units are built

# Changelog


# Review requests
# Risk assessment

[PLAT-300]: https://opentrons.atlassian.net/browse/PLAT-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-301]: https://opentrons.atlassian.net/browse/PLAT-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-302]: https://opentrons.atlassian.net/browse/PLAT-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ