### PR TITLE
fix(protocol-designer): duplicate labware thunk refinement for offdeck

### DIFF
--- a/protocol-designer/src/labware-ingred/actions/thunks.ts
+++ b/protocol-designer/src/labware-ingred/actions/thunks.ts
@@ -131,7 +131,7 @@ export const duplicateLabware: (
     robotType,
     labwareDef
   )
-  if (duplicateSlot == null) {
+  if (duplicateSlot == null && !templateLabwareIdIsOffDeck) {
     console.error('no slots available, cannot duplicate labware')
   }
   const allNicknamesById = uiLabwareSelectors.getLabwareNicknamesById(state)
@@ -140,15 +140,29 @@ export const duplicateLabware: (
     Object.keys(allNicknamesById).map((id: string) => allNicknamesById[id]), // NOTE: flow won't do Object.values here >:(
     templateNickname
   )
+  const duplicateLabwareId = uuid() + ':' + templateLabwareDefURI
 
-  if (templateLabwareDefURI && duplicateSlot != null) {
+  if (templateLabwareDefURI) {
+    if (templateLabwareIdIsOffDeck) {
+      dispatch({
+        type: 'DUPLICATE_LABWARE',
+        payload: {
+          duplicateLabwareNickname,
+          templateLabwareId,
+          duplicateLabwareId,
+          slot: 'offDeck',
+        },
+      })
+    }
+  }
+  if (duplicateSlot != null && !templateLabwareIdIsOffDeck) {
     dispatch({
       type: 'DUPLICATE_LABWARE',
       payload: {
         duplicateLabwareNickname,
         templateLabwareId,
-        duplicateLabwareId: uuid() + ':' + templateLabwareDefURI,
-        slot: templateLabwareIdIsOffDeck ? 'offDeck' : duplicateSlot,
+        duplicateLabwareId,
+        slot: duplicateSlot,
       },
     })
   }


### PR DESCRIPTION
closes RQA-2792


# Overview

the duplicate labware logic didn't work for offdeck labware sometimes (when there is no available slot on the deck)

# Test Plan

Create a flex or ot-2 protocol and fill the deck up with labware. Then add an off-deck labware and make sure the duplicate button works as expected

# Changelog

- fix the thunk logic for duplicating labware

# Review requests

see test plan

# Risk assessment

low