### PR TITLE
fix(protocol-designer): allow wasteChute selection when staging area in d3

### DIFF
--- a/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
+++ b/protocol-designer/src/components/modals/CreateFileWizard/__tests__/utils.test.tsx
@@ -136,6 +136,21 @@ describe('getNumSlotsAvailable', () => {
     const result = getNumSlotsAvailable(null, mockAdditionalEquipment)
     expect(result).toBe(1)
   })
+  it('shoult return 1 when it is for the waste chute and all slots are occupied with the staging area in slot d3', () => {
+    const mockAdditionalEquipment: AdditionalEquipment[] = [
+      'trashBin',
+      'trashBin',
+      'stagingArea_cutoutA3',
+      'stagingArea_cutoutB3',
+      'stagingArea_cutoutC3',
+      'stagingArea_cutoutD3',
+      'trashBin',
+      'gripper',
+      'trashBin',
+    ]
+    const result = getNumSlotsAvailable(null, mockAdditionalEquipment, true)
+    expect(result).toBe(1)
+  })
   it('should return 8 even when there is a magnetic block', () => {
     const mockModules = {
       0: {

--- a/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
+++ b/protocol-designer/src/components/modals/CreateFileWizard/utils.ts
@@ -68,7 +68,9 @@ const TOTAL_MODULE_SLOTS = 8
 
 export const getNumSlotsAvailable = (
   modules: FormState['modules'],
-  additionalEquipment: FormState['additionalEquipment']
+  additionalEquipment: FormState['additionalEquipment'],
+  //  special-casing the wasteChute available slots when there is a staging area in slot 3
+  isWasteChute?: boolean
 ): number => {
   const additionalEquipmentLength = additionalEquipment.length
   const hasTC = Object.values(modules || {}).some(
@@ -97,6 +99,9 @@ export const getNumSlotsAvailable = (
 
   let filteredAdditionalEquipmentLength = additionalEquipmentLength
   if (hasWasteChute && isStagingAreaInD3) {
+    filteredAdditionalEquipmentLength = filteredAdditionalEquipmentLength - 1
+  }
+  if (isWasteChute && isStagingAreaInD3) {
     filteredAdditionalEquipmentLength = filteredAdditionalEquipmentLength - 1
   }
   if (hasGripper) {
@@ -132,7 +137,11 @@ export const getTrashOptionDisabled = (
 ): boolean => {
   const { additionalEquipment, modules, trashType } = props
   const hasNoSlotsAvailable =
-    getNumSlotsAvailable(modules, additionalEquipment) === 0
+    getNumSlotsAvailable(
+      modules,
+      additionalEquipment,
+      trashType === 'wasteChute'
+    ) === 0
   return hasNoSlotsAvailable && !additionalEquipment.includes(trashType)
 }
 


### PR DESCRIPTION
closes RQA-2790

# Overview

Fixes a bug where the waste chute option was incorrectly disabled

# Test Plan

follow the steps in the ticket but basically:

create flex protocol and add a staging area in slot D3. Then add a TC, a heater-shaker, and temperature modules until all the modules are disabled (except for the magnetic block). See that the waste chute is still enabled and is clickable. 


# Changelog

- refined logic for when the slot is available and special cased the waste chute
- added a test case

# Review requests

see test plan

# Risk assessment

low