### PR TITLE
fix(labware-library): direct Protocol Library links to new library

### DIFF
--- a/labware-library/cypress/e2e/navigation.cy.js
+++ b/labware-library/cypress/e2e/navigation.cy.js
@@ -15,7 +15,7 @@ describe('Desktop Navigation', () => {
     cy.get("div[class*='_subdomain_nav_wrapper_']")
       .contains('Protocol Library')
       .should('have.prop', 'href')
-      .and('equal', 'https://protocols.opentrons.com/')
+      .and('equal', 'https://library.opentrons.com/')
     cy.get("div[class*='_subdomain_nav_wrapper_']")
       .contains('Protocol Designer')
       .should('have.prop', 'href')

--- a/labware-library/src/components/website-navigation/SubdomainNav.tsx
+++ b/labware-library/src/components/website-navigation/SubdomainNav.tsx
@@ -36,7 +36,7 @@ export const SUBDOMAIN_NAV_LINKS: Links = [
   },
   {
     name: 'Protocol Library',
-    url: 'https://protocols.opentrons.com/',
+    url: 'https://library.opentrons.com/',
     linkout: true,
     gtm: {
       action: 'click',

--- a/labware-library/src/components/website-navigation/nav-data.ts
+++ b/labware-library/src/components/website-navigation/nav-data.ts
@@ -150,7 +150,7 @@ export const protocolLinkProps: ProtocolLinks = {
   },
   library: {
     name: 'Protocol Library',
-    url: 'https://protocols.opentrons.com',
+    url: 'https://library.opentrons.com',
     description: 'Explore our open source database of protocols',
     gtm: { action: 'click', category: 'l-header', label: 'protocol-library' },
   },


### PR DESCRIPTION
closes [AUTH-79](https://opentrons.atlassian.net/browse/AUTH-79)

# Overview

direct main navigation and 'Protocols' menu Protocol Library links to new protocol library ([https://library.opentrons.com/](https://library.opentrons.com/))

# Test Plan

- build Labware Library off this branch
- click the Protocol Library links in main navigation and under 'Protocols' menu
- confirm that you are directed to new Protocol Library at [https://library.opentrons.com/](https://library.opentrons.com/)
<img width="874" alt="Screenshot 2024-06-03 at 12 09 53 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/5c3eb3d6-ee84-49eb-a8b8-eb7c4c7114de">

# Changelog

- update Protocol Library link URLs

# Review requests

js

# Risk assessment

low

[AUTH-79]: https://opentrons.atlassian.net/browse/AUTH-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ