### PR TITLE
fix(api): rip out unneeded arguments to liquid probe

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -28,11 +28,8 @@ DEFAULT_LIQUID_PROBE_SETTINGS: Final[LiquidProbeSettings] = LiquidProbeSettings(
     mount_speed=10,
     plunger_speed=5,
     sensor_threshold_pascals=40,
-    expected_liquid_height=110,
     output_option=OutputOptions.stream_to_csv,
     aspirate_while_sensing=False,
-    auto_zero_sensor=True,
-    num_baseline_reads=10,
     data_files={InstrumentProbeType.PRIMARY: "/data/pressure_sensor_data.csv"},
 )
 
@@ -341,18 +338,9 @@ def _build_default_liquid_probe(
         sensor_threshold_pascals=from_conf.get(
             "sensor_threshold_pascals", default.sensor_threshold_pascals
         ),
-        expected_liquid_height=from_conf.get(
-            "expected_liquid_height", default.expected_liquid_height
-        ),
         output_option=from_conf.get("output_option", default.output_option),
         aspirate_while_sensing=from_conf.get(
             "aspirate_while_sensing", default.aspirate_while_sensing
-        ),
-        auto_zero_sensor=from_conf.get(
-            "get_pressure_baseline", default.auto_zero_sensor
-        ),
-        num_baseline_reads=from_conf.get(
-            "num_baseline_reads", default.num_baseline_reads
         ),
         data_files=data_files,
     )

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -133,11 +133,8 @@ class LiquidProbeSettings:
     mount_speed: float
     plunger_speed: float
     sensor_threshold_pascals: float
-    expected_liquid_height: float
     output_option: OutputOptions
     aspirate_while_sensing: bool
-    auto_zero_sensor: bool
-    num_baseline_reads: int
     data_files: Optional[Dict[InstrumentProbeType, str]]
 
 

--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -148,8 +148,6 @@ class FlexBackend(Protocol):
         threshold_pascals: float,
         output_format: OutputOptions = OutputOptions.can_bus_only,
         data_files: Optional[Dict[InstrumentProbeType, str]] = None,
-        auto_zero_sensor: bool = True,
-        num_baseline_reads: int = 10,
         probe: InstrumentProbeType = InstrumentProbeType.PRIMARY,
     ) -> float:
         ...

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1360,8 +1360,6 @@ class OT3Controller(FlexBackend):
         threshold_pascals: float,
         output_option: OutputOptions = OutputOptions.can_bus_only,
         data_files: Optional[Dict[InstrumentProbeType, str]] = None,
-        auto_zero_sensor: bool = True,
-        num_baseline_reads: int = 10,
         probe: InstrumentProbeType = InstrumentProbeType.PRIMARY,
     ) -> float:
         if output_option == OutputOptions.sync_buffer_to_csv:
@@ -1404,8 +1402,6 @@ class OT3Controller(FlexBackend):
             sync_buffer_output=sync_buffer_output,
             can_bus_only_output=can_bus_only_output,
             data_files=data_files_transposed,
-            auto_zero_sensor=auto_zero_sensor,
-            num_baseline_reads=num_baseline_reads,
             sensor_id=sensor_id_for_instrument(probe),
         )
         for node, point in positions.items():

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -347,8 +347,6 @@ class OT3Simulator(FlexBackend):
         threshold_pascals: float,
         output_format: OutputOptions = OutputOptions.can_bus_only,
         data_files: Optional[Dict[InstrumentProbeType, str]] = None,
-        auto_zero_sensor: bool = True,
-        num_baseline_reads: int = 10,
         probe: InstrumentProbeType = InstrumentProbeType.PRIMARY,
     ) -> float:
         z_axis = Axis.by_mount(mount)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2624,8 +2624,6 @@ class OT3API(
             probe_settings.sensor_threshold_pascals,
             probe_settings.output_option,
             probe_settings.data_files,
-            probe_settings.auto_zero_sensor,
-            probe_settings.num_baseline_reads,
             probe=probe if probe else InstrumentProbeType.PRIMARY,
         )
         end_pos = await self.gantry_position(mount, refresh=True)

--- a/api/tests/opentrons/config/ot3_settings.py
+++ b/api/tests/opentrons/config/ot3_settings.py
@@ -123,11 +123,8 @@ ot3_dummy_settings = {
         "mount_speed": 10,
         "plunger_speed": 10,
         "sensor_threshold_pascals": 17,
-        "expected_liquid_height": 90,
         "output_option": OutputOptions.stream_to_csv,
         "aspirate_while_sensing": False,
-        "auto_zero_sensor": True,
-        "num_baseline_reads": 10,
         "data_files": {"PRIMARY": "/data/pressure_sensor_data.csv"},
     },
     "calibration": {

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -181,11 +181,8 @@ def fake_liquid_settings() -> LiquidProbeSettings:
         mount_speed=40,
         plunger_speed=10,
         sensor_threshold_pascals=15,
-        expected_liquid_height=109,
         output_option=OutputOptions.can_bus_only,
         aspirate_while_sensing=False,
-        auto_zero_sensor=False,
-        num_baseline_reads=8,
         data_files={InstrumentProbeType.PRIMARY: "fake_file_name"},
     )
 

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -118,11 +118,8 @@ def fake_liquid_settings() -> LiquidProbeSettings:
         mount_speed=40,
         plunger_speed=10,
         sensor_threshold_pascals=15,
-        expected_liquid_height=109,
         output_option=OutputOptions.can_bus_only,
         aspirate_while_sensing=False,
-        auto_zero_sensor=False,
-        num_baseline_reads=10,
         data_files={InstrumentProbeType.PRIMARY: "fake_file_name"},
     )
 
@@ -828,11 +825,8 @@ async def test_liquid_probe(
             mount_speed=40,
             plunger_speed=10,
             sensor_threshold_pascals=15,
-            expected_liquid_height=109,
             output_option=OutputOptions.can_bus_only,
             aspirate_while_sensing=True,
-            auto_zero_sensor=False,
-            num_baseline_reads=10,
             data_files={InstrumentProbeType.PRIMARY: "fake_file_name"},
         )
         await ot3_hardware.liquid_probe(mount, fake_settings_aspirate)
@@ -845,8 +839,6 @@ async def test_liquid_probe(
             fake_settings_aspirate.sensor_threshold_pascals,
             fake_settings_aspirate.output_option,
             fake_settings_aspirate.data_files,
-            fake_settings_aspirate.auto_zero_sensor,
-            fake_settings_aspirate.num_baseline_reads,
             probe=InstrumentProbeType.PRIMARY,
         )
 

--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -181,11 +181,8 @@ def _get_liquid_probe_settings(
         mount_speed=lqid_cfg["mount_speed"],
         plunger_speed=lqid_cfg["plunger_speed"],
         sensor_threshold_pascals=lqid_cfg["sensor_threshold_pascals"],
-        expected_liquid_height=110,
         output_option=OutputOptions.sync_only,
         aspirate_while_sensing=False,
-        auto_zero_sensor=True,
-        num_baseline_reads=10,
         data_files={InstrumentProbeType.PRIMARY: "/data/testing_data/pressure.csv"},
     )
 

--- a/hardware-testing/hardware_testing/liquid_sense/execute.py
+++ b/hardware-testing/hardware_testing/liquid_sense/execute.py
@@ -358,11 +358,8 @@ def _run_trial(run_args: RunArgs, tip: int, well: Well, trial: int) -> float:
             mount_speed=run_args.z_speed,
             plunger_speed=plunger_speed,
             sensor_threshold_pascals=lqid_cfg["sensor_threshold_pascals"],
-            expected_liquid_height=110,
             output_option=OutputOptions.sync_buffer_to_csv,
             aspirate_while_sensing=run_args.aspirate,
-            auto_zero_sensor=True,
-            num_baseline_reads=10,
             data_files=data_files,
         )
 

--- a/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
+++ b/hardware-testing/hardware_testing/production_qc/pipette_assembly_qc_ot3/__main__.py
@@ -1380,11 +1380,8 @@ async def _test_liquid_probe(
                 mount_speed=probe_cfg.mount_speed,
                 plunger_speed=probe_cfg.plunger_speed,
                 sensor_threshold_pascals=probe_cfg.sensor_threshold_pascals,
-                expected_liquid_height=0,  # FIXME: remove
                 output_option=OutputOptions.can_bus_only,  # FIXME: remove
-                aspirate_while_sensing=False,  # FIXME: I heard this doesn't work
-                auto_zero_sensor=True,  # TODO: when would we want to adjust this?
-                num_baseline_reads=10,  # TODO: when would we want to adjust this?
+                aspirate_while_sensing=False,
                 data_files=None,
             )
             end_z = await api.liquid_probe(mount, probe_settings, probe=probe)

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -308,14 +308,14 @@ async def liquid_probe(
     sync_buffer_output: bool = False,
     can_bus_only_output: bool = False,
     data_files: Optional[Dict[SensorId, str]] = None,
-    auto_zero_sensor: bool = True,
-    num_baseline_reads: int = 10,
     sensor_id: SensorId = SensorId.S0,
 ) -> Dict[NodeId, MotorPositionStatus]:
     """Move the mount and pipette simultaneously while reading from the pressure sensor."""
     log_files: Dict[SensorId, str] = {} if not data_files else data_files
     sensor_driver = SensorDriver()
     threshold_fixed_point = threshold_pascals * sensor_fixed_point_conversion
+    # How many samples to take to level out the sensor
+    num_baseline_reads = 20
     pressure_sensors = await _setup_pressure_sensors(
         messenger,
         sensor_id,
@@ -323,7 +323,7 @@ async def liquid_probe(
         num_baseline_reads,
         threshold_fixed_point,
         sensor_driver,
-        auto_zero_sensor,
+        True,
     )
 
     sensor_group = _build_pass_step(

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -186,8 +186,6 @@ async def test_liquid_probe(
         csv_output=False,
         sync_buffer_output=False,
         can_bus_only_output=False,
-        auto_zero_sensor=True,
-        num_baseline_reads=8,
         sensor_id=SensorId.S0,
     )
     assert position[motor_node].positions_only()[0] == 14
@@ -285,8 +283,6 @@ async def test_liquid_probe_output_options(
             sync_buffer_output=sync_buffer_output,
             can_bus_only_output=can_bus_only_output,
             data_files={SensorId.S0: test_csv_file},
-            auto_zero_sensor=True,
-            num_baseline_reads=8,
             sensor_id=SensorId.S0,
         )
     finally:


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
