### PR TITLE
feat(api): Prepare PipetteStore to handle overpressure errors from aspirate commands

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -6,6 +6,7 @@ from typing_extensions import Annotated
 from pydantic import Field
 
 from .command import DefinedErrorData
+from .pipetting_common import OverpressureError, OverpressureErrorInternalData
 
 from . import heater_shaker
 from . import magnetic_module
@@ -629,7 +630,7 @@ CommandPrivateResult = Union[
 ]
 
 # All `DefinedErrorData`s that implementations will actually return in practice.
-# There's just one right now, but this will eventually be a Union.
-CommandDefinedErrorData = DefinedErrorData[
-    TipPhysicallyMissingError, TipPhysicallyMissingErrorInternalData
+CommandDefinedErrorData = Union[
+    DefinedErrorData[TipPhysicallyMissingError, TipPhysicallyMissingErrorInternalData],
+    DefinedErrorData[OverpressureError, OverpressureErrorInternalData],
 ]

--- a/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
+++ b/api/src/opentrons/protocol_engine/commands/pick_up_tip.py
@@ -78,7 +78,7 @@ class TipPhysicallyMissingError(ErrorOccurrence):
     detail: str = "No tip detected."
 
 
-@dataclass
+@dataclass(frozen=True)
 class TipPhysicallyMissingErrorInternalData:
     """Internal-to-ProtocolEngine data about a TipPhysicallyMissingError."""
 

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from opentrons_shared_data.errors import ErrorCodes
 from pydantic import BaseModel, Field
-from typing import Literal, Optional, TypedDict
+from typing import Literal, Optional
 
 from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
 
@@ -123,18 +123,12 @@ class DestinationPositionResult(BaseModel):
     )
 
 
-class OverpressureErrorInfo(TypedDict):  # noqa: D101
-    # Documentation for this is on the field in OverpressureError
-    # so it shows up in robot-server's OpenAPI spec.
-    volume: float
-
-
 class OverpressureError(ErrorOccurrence):
-    """Returned when sensors detect an overpressure error.
+    """Returned when sensors detect an overpressure error while moving liquid.
 
-    This is returned by commands that move the pipette plunger. The plunger motion is
-    stopped at the point of the error. After this error, It's safe to issue subsequent
-    `aspirate`, `dispense` etc. commands to pick up from where the error happened.
+    The pipette plunger motion is stopped at the point of the error. The next thing to
+    move the plunger must be a `home` or `blowout` command; commands like `aspirate`
+    will return an error.
     """
 
     isDefined: bool = True
@@ -143,14 +137,6 @@ class OverpressureError(ErrorOccurrence):
 
     errorCode: str = ErrorCodes.PIPETTE_OVERPRESSURE.value.code
     detail: str = ErrorCodes.PIPETTE_OVERPRESSURE.value.detail
-
-    errorInfo: OverpressureErrorInfo = Field(
-        ...,
-        description=(
-            "The amount, in µL, aspirated or dispensed by this command before it"
-            " encountered the overpressure error."
-        ),
-    )
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from datetime import datetime
 from textwrap import dedent
-from typing import Any, Dict, List, Mapping, Type, Union, Optional, Sequence
+from typing import Any, Dict, List, Type, Union, Optional, Sequence
 from pydantic import BaseModel, Field
 from opentrons_shared_data.errors.codes import ErrorCodes
 from .exceptions import ProtocolEngineError
@@ -118,7 +118,7 @@ class ErrorOccurrence(BaseModel):
         ),
     )
 
-    errorInfo: Mapping[str, object] = Field(
+    errorInfo: Dict[str, str] = Field(
         default={},
         description=dedent(
             """\

--- a/api/src/opentrons/protocol_engine/errors/error_occurrence.py
+++ b/api/src/opentrons/protocol_engine/errors/error_occurrence.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from datetime import datetime
 from textwrap import dedent
-from typing import Any, Dict, List, Type, Union, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Type, Union, Optional, Sequence
 from pydantic import BaseModel, Field
 from opentrons_shared_data.errors.codes import ErrorCodes
 from .exceptions import ProtocolEngineError
@@ -118,7 +118,7 @@ class ErrorOccurrence(BaseModel):
         ),
     )
 
-    errorInfo: Dict[str, str] = Field(
+    errorInfo: Mapping[str, object] = Field(
         default={},
         description=dedent(
             """\

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -387,15 +387,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
         ):
             pipette_id = action.command.params.pipetteId
             deck_point = action.command.result.position
-
-            try:
-                loaded_pipette = self._state.pipettes_by_id[pipette_id]
-            except KeyError:
-                self._clear_deck_point()
-            else:
-                self._state.current_deck_point = CurrentDeckPoint(
-                    mount=loaded_pipette.mount, deck_point=deck_point
-                )
+            loaded_pipette = self._state.pipettes_by_id[pipette_id]
+            self._state.current_deck_point = CurrentDeckPoint(
+                mount=loaded_pipette.mount, deck_point=deck_point
+            )
         elif (
             isinstance(action, FailCommandAction)
             and isinstance(action.running_command, Aspirate)
@@ -405,14 +400,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             assert_type(action.error.private, OverpressureErrorInternalData)
             pipette_id = action.running_command.params.pipetteId
             deck_point = action.error.private.position
-            try:
-                loaded_pipette = self._state.pipettes_by_id[pipette_id]
-            except KeyError:
-                self._clear_deck_point()
-            else:
-                self._state.current_deck_point = CurrentDeckPoint(
-                    mount=loaded_pipette.mount, deck_point=deck_point
-                )
+            loaded_pipette = self._state.pipettes_by_id[pipette_id]
+            self._state.current_deck_point = CurrentDeckPoint(
+                mount=loaded_pipette.mount, deck_point=deck_point
+            )
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -447,18 +447,6 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
 
             self._state.aspirated_volume_by_id[pipette_id] = next_volume
 
-        elif (
-            isinstance(action, FailCommandAction)
-            and isinstance(action.running_command, Aspirate)
-            and isinstance(action.error, DefinedErrorData)
-            and isinstance(action.error.public, OverpressureError)
-        ):
-            pipette_id = action.running_command.params.pipetteId
-            previous_volume = self._state.aspirated_volume_by_id[pipette_id] or 0
-            next_volume = previous_volume + action.error.public.errorInfo["volume"]
-
-            self._state.aspirated_volume_by_id[pipette_id] = next_volume
-
         elif isinstance(action, SucceedCommandAction) and isinstance(
             action.command.result, (DispenseResult, DispenseInPlaceResult)
         ):

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -8,6 +8,13 @@ from opentrons_shared_data.pipette import pipette_definition
 
 from opentrons.types import DeckSlotName, MountType, Point
 from opentrons.protocol_engine import commands as cmd
+from opentrons.protocol_engine.commands.command import DefinedErrorData
+from opentrons.protocol_engine.commands.pipetting_common import (
+    OverpressureError,
+    OverpressureErrorInfo,
+    OverpressureErrorInternalData,
+)
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 from opentrons.protocol_engine.types import (
     DeckPoint,
     DeckSlotLocation,
@@ -178,6 +185,37 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
                 pipette_id="pipette-id", volume=42, flow_rate=1.23
             ),
         ),
+        FailCommandAction(
+            running_command=cmd.Aspirate(
+                params=cmd.AspirateParams(
+                    pipetteId="pipette-id",
+                    labwareId="labware-id",
+                    wellName="well-name",
+                    volume=99999,
+                    flowRate=1.23,
+                ),
+                id="command-id",
+                key="command-key",
+                createdAt=datetime.now(),
+                status=cmd.CommandStatus.RUNNING,
+            ),
+            error=DefinedErrorData(
+                public=OverpressureError(
+                    errorInfo=OverpressureErrorInfo(volume=42),
+                    id="error-id",
+                    detail="error-detail",
+                    createdAt=datetime.now(),
+                ),
+                private=OverpressureErrorInternalData(
+                    position=DeckPoint(x=0, y=0, z=0)
+                ),
+            ),
+            command_id="command-id",
+            error_id="error-id",
+            failed_at=datetime.now(),
+            notes=[],
+            type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
+        ),
         SucceedCommandAction(
             private_result=None,
             command=create_aspirate_in_place_command(
@@ -302,6 +340,43 @@ def test_blow_out_clears_volume(
                     flow_rate=1.23,
                 ),
                 private_result=None,
+            ),
+            CurrentWell(
+                pipette_id="pipette-id",
+                labware_id="aspirate-labware-id",
+                well_name="aspirate-well-name",
+            ),
+        ),
+        (
+            FailCommandAction(
+                running_command=cmd.Aspirate(
+                    params=cmd.AspirateParams(
+                        pipetteId="pipette-id",
+                        labwareId="aspirate-labware-id",
+                        wellName="aspirate-well-name",
+                        volume=99999,
+                        flowRate=1.23,
+                    ),
+                    id="command-id",
+                    key="command-key",
+                    createdAt=datetime.now(),
+                    status=cmd.CommandStatus.RUNNING,
+                ),
+                error=DefinedErrorData(
+                    public=OverpressureError(
+                        id="error-id",
+                        createdAt=datetime.now(),
+                        errorInfo=OverpressureErrorInfo(volume=1234),
+                    ),
+                    private=OverpressureErrorInternalData(
+                        position=DeckPoint(x=0, y=0, z=0)
+                    ),
+                ),
+                command_id="command-id",
+                error_id="error-id",
+                failed_at=datetime.now(),
+                notes=[],
+                type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
             ),
             CurrentWell(
                 pipette_id="pipette-id",
@@ -756,6 +831,37 @@ def test_add_pipette_config(
                 destination=DeckPoint(x=11, y=22, z=33),
             ),
             private_result=None,
+        ),
+        FailCommandAction(
+            running_command=cmd.Aspirate(
+                params=cmd.AspirateParams(
+                    pipetteId="pipette-id",
+                    labwareId="labware-id",
+                    wellName="well-name",
+                    volume=99999,
+                    flowRate=1.23,
+                ),
+                id="command-id",
+                key="command-key",
+                createdAt=datetime.now(),
+                status=cmd.CommandStatus.RUNNING,
+            ),
+            error=DefinedErrorData(
+                public=OverpressureError(
+                    errorInfo=OverpressureErrorInfo(volume=42),
+                    id="error-id",
+                    detail="error-detail",
+                    createdAt=datetime.now(),
+                ),
+                private=OverpressureErrorInternalData(
+                    position=DeckPoint(x=11, y=22, z=33)
+                ),
+            ),
+            command_id="command-id",
+            error_id="error-id",
+            failed_at=datetime.now(),
+            notes=[],
+            type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
         ),
         SucceedCommandAction(
             command=create_dispense_command(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -1,7 +1,7 @@
 """Tests for pipette state changes in the protocol_engine state store."""
 import pytest
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from opentrons_shared_data.pipette.dev_types import PipetteNameType
 from opentrons_shared_data.pipette import pipette_definition
@@ -19,6 +19,7 @@ from opentrons.protocol_engine.types import (
     TipGeometry,
 )
 from opentrons.protocol_engine.actions import (
+    FailCommandAction,
     SetPipetteMovementSpeedAction,
     SucceedCommandAction,
 )
@@ -169,16 +170,25 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
 
 
 @pytest.mark.parametrize(
-    "aspirate_command",
+    "aspirate_action",
     [
-        create_aspirate_command(pipette_id="pipette-id", volume=42, flow_rate=1.23),
-        create_aspirate_in_place_command(
-            pipette_id="pipette-id", volume=42, flow_rate=1.23
+        SucceedCommandAction(
+            private_result=None,
+            command=create_aspirate_command(
+                pipette_id="pipette-id", volume=42, flow_rate=1.23
+            ),
+        ),
+        SucceedCommandAction(
+            private_result=None,
+            command=create_aspirate_in_place_command(
+                pipette_id="pipette-id", volume=42, flow_rate=1.23
+            ),
         ),
     ],
 )
 def test_aspirate_adds_volume(
-    subject: PipetteStore, aspirate_command: cmd.Command
+    subject: PipetteStore,
+    aspirate_action: Union[SucceedCommandAction, FailCommandAction],
 ) -> None:
     """It should add volume to pipette after an aspirate."""
     load_command = create_load_pipette_command(
@@ -190,15 +200,11 @@ def test_aspirate_adds_volume(
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=load_command)
     )
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=aspirate_command)
-    )
+    subject.handle_action(aspirate_action)
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 42
 
-    subject.handle_action(
-        SucceedCommandAction(private_result=None, command=aspirate_command)
-    )
+    subject.handle_action(aspirate_action)
 
     assert subject.state.aspirated_volume_by_id["pipette-id"] == 84
 
@@ -284,81 +290,99 @@ def test_blow_out_clears_volume(
 
 
 @pytest.mark.parametrize(
-    ("command", "expected_location"),
+    ("action", "expected_location"),
     (
         (
-            create_aspirate_command(
-                pipette_id="aspirate-pipette-id",
-                labware_id="aspirate-labware-id",
-                well_name="aspirate-well-name",
-                volume=1337,
-                flow_rate=1.23,
+            SucceedCommandAction(
+                command=create_aspirate_command(
+                    pipette_id="pipette-id",
+                    labware_id="aspirate-labware-id",
+                    well_name="aspirate-well-name",
+                    volume=1337,
+                    flow_rate=1.23,
+                ),
+                private_result=None,
             ),
             CurrentWell(
-                pipette_id="aspirate-pipette-id",
+                pipette_id="pipette-id",
                 labware_id="aspirate-labware-id",
                 well_name="aspirate-well-name",
             ),
         ),
         (
-            create_dispense_command(
-                pipette_id="dispense-pipette-id",
-                labware_id="dispense-labware-id",
-                well_name="dispense-well-name",
-                volume=1337,
-                flow_rate=1.23,
+            SucceedCommandAction(
+                command=create_dispense_command(
+                    pipette_id="pipette-id",
+                    labware_id="dispense-labware-id",
+                    well_name="dispense-well-name",
+                    volume=1337,
+                    flow_rate=1.23,
+                ),
+                private_result=None,
             ),
             CurrentWell(
-                pipette_id="dispense-pipette-id",
+                pipette_id="pipette-id",
                 labware_id="dispense-labware-id",
                 well_name="dispense-well-name",
             ),
         ),
         (
-            create_pick_up_tip_command(
-                pipette_id="pick-up-tip-pipette-id",
+            SucceedCommandAction(
+                command=create_pick_up_tip_command(
+                    pipette_id="pipette-id",
+                    labware_id="pick-up-tip-labware-id",
+                    well_name="pick-up-tip-well-name",
+                ),
+                private_result=None,
+            ),
+            CurrentWell(
+                pipette_id="pipette-id",
                 labware_id="pick-up-tip-labware-id",
                 well_name="pick-up-tip-well-name",
             ),
-            CurrentWell(
-                pipette_id="pick-up-tip-pipette-id",
-                labware_id="pick-up-tip-labware-id",
-                well_name="pick-up-tip-well-name",
-            ),
         ),
         (
-            create_drop_tip_command(
-                pipette_id="drop-tip-pipette-id",
+            SucceedCommandAction(
+                command=create_drop_tip_command(
+                    pipette_id="pipette-id",
+                    labware_id="drop-tip-labware-id",
+                    well_name="drop-tip-well-name",
+                ),
+                private_result=None,
+            ),
+            CurrentWell(
+                pipette_id="pipette-id",
                 labware_id="drop-tip-labware-id",
                 well_name="drop-tip-well-name",
             ),
+        ),
+        (
+            SucceedCommandAction(
+                command=create_move_to_well_command(
+                    pipette_id="pipette-id",
+                    labware_id="move-to-well-labware-id",
+                    well_name="move-to-well-well-name",
+                ),
+                private_result=None,
+            ),
             CurrentWell(
-                pipette_id="drop-tip-pipette-id",
-                labware_id="drop-tip-labware-id",
-                well_name="drop-tip-well-name",
+                pipette_id="pipette-id",
+                labware_id="move-to-well-labware-id",
+                well_name="move-to-well-well-name",
             ),
         ),
         (
-            create_move_to_well_command(
-                pipette_id="move-to-well-pipette-id",
-                labware_id="move-to-well-labware-id",
-                well_name="move-to-well-well-name",
+            SucceedCommandAction(
+                command=create_blow_out_command(
+                    pipette_id="pipette-id",
+                    labware_id="move-to-well-labware-id",
+                    well_name="move-to-well-well-name",
+                    flow_rate=1.23,
+                ),
+                private_result=None,
             ),
             CurrentWell(
-                pipette_id="move-to-well-pipette-id",
-                labware_id="move-to-well-labware-id",
-                well_name="move-to-well-well-name",
-            ),
-        ),
-        (
-            create_blow_out_command(
-                pipette_id="move-to-well-pipette-id",
-                labware_id="move-to-well-labware-id",
-                well_name="move-to-well-well-name",
-                flow_rate=1.23,
-            ),
-            CurrentWell(
-                pipette_id="move-to-well-pipette-id",
+                pipette_id="pipette-id",
                 labware_id="move-to-well-labware-id",
                 well_name="move-to-well-well-name",
             ),
@@ -366,13 +390,13 @@ def test_blow_out_clears_volume(
     ),
 )
 def test_movement_commands_update_current_well(
-    command: cmd.Command,
+    action: Union[SucceedCommandAction, FailCommandAction],
     expected_location: CurrentWell,
     subject: PipetteStore,
 ) -> None:
     """It should save the last used pipette, labware, and well for movement commands."""
     load_pipette_command = create_load_pipette_command(
-        pipette_id=command.params.pipetteId,  # type: ignore[arg-type, union-attr]
+        pipette_id="pipette-id",
         pipette_name=PipetteNameType.P300_SINGLE,
         mount=MountType.LEFT,
     )
@@ -380,7 +404,7 @@ def test_movement_commands_update_current_well(
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=load_pipette_command)
     )
-    subject.handle_action(SucceedCommandAction(private_result=None, command=command))
+    subject.handle_action(action)
 
     assert subject.state.current_location == expected_location
 
@@ -720,67 +744,94 @@ def test_add_pipette_config(
 
 
 @pytest.mark.parametrize(
-    "command",
+    "action",
     (
-        create_aspirate_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            volume=1337,
-            flow_rate=1.23,
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_aspirate_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                volume=1337,
+                flow_rate=1.23,
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_dispense_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            volume=1337,
-            flow_rate=1.23,
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_dispense_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                volume=1337,
+                flow_rate=1.23,
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_blow_out_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            flow_rate=1.23,
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_blow_out_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                flow_rate=1.23,
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_pick_up_tip_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_pick_up_tip_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_drop_tip_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_drop_tip_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_touch_tip_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_touch_tip_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_move_to_well_command(
-            pipette_id="pipette-id",
-            labware_id="labware-id",
-            well_name="well-name",
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_move_to_well_command(
+                pipette_id="pipette-id",
+                labware_id="labware-id",
+                well_name="well-name",
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_move_to_coordinates_command(
-            pipette_id="pipette-id",
-            coordinates=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_move_to_coordinates_command(
+                pipette_id="pipette-id",
+                coordinates=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
-        create_move_relative_command(
-            pipette_id="pipette-id",
-            destination=DeckPoint(x=11, y=22, z=33),
+        SucceedCommandAction(
+            command=create_move_relative_command(
+                pipette_id="pipette-id",
+                destination=DeckPoint(x=11, y=22, z=33),
+            ),
+            private_result=None,
         ),
     ),
 )
 def test_movement_commands_update_deck_point(
-    command: cmd.Command,
+    action: Union[SucceedCommandAction, FailCommandAction],
     subject: PipetteStore,
 ) -> None:
     """It should save the last used pipette, labware, and well for movement commands."""
@@ -793,7 +844,7 @@ def test_movement_commands_update_deck_point(
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=load_pipette_command)
     )
-    subject.handle_action(SucceedCommandAction(private_result=None, command=command))
+    subject.handle_action(action)
 
     assert subject.state.current_deck_point == CurrentDeckPoint(
         mount=MountType.LEFT, deck_point=DeckPoint(x=11, y=22, z=33)


### PR DESCRIPTION
# Overview

This goes towards EXEC-376.

# Test Plan

Just unit tests for now, because there's not much to test yet. I'll come up with more meaningful tests in follow-up PRs.

# Changelog

* Make a new defined error, `overpressure`.
* When an `aspirate` command fails with an `overpressure` error:
    * *Do* update where Protocol Engine thinks the pipette is.
    * *Do not* update the amount of liquid that Protocol Engine thinks is in the tip.
    
      I suspect this is not quite what we will want in the long term. We probably want to set it to either however much liquid got aspirated before the error, or to some special "unknown" sentinel. I propose we keep it simple for this PR and revisit it after this is wired up to PAPI and the hardware API.

The `aspirate` command does not actually return this new error yet, so none of this code is reachable in practice yet.

# Review requests

* Do the documented semantics for the new `OverpressureError` sound good?

# Risk assessment

Low.
