### PR TITLE
fix(opentrons-ai-server): prompt formatted via llama-index 

### DIFF
--- a/opentrons-ai-server/api/domain/openai_predict.py
+++ b/opentrons-ai-server/api/domain/openai_predict.py
@@ -85,7 +85,7 @@ class OpenAIPredict:
 
         program = OpenAIPydanticProgram.from_defaults(
             output_cls=atomic_descr,
-            prompt_template_str=prompt_template_str.format(protocol_description=protocol_description),
+            prompt_template_str=prompt_template_str,
             verbose=False,
             llm=li_OpenAI(model=self.settings.openai_model_name, api_key=self.settings.openai_api_key.get_secret_value()),
         )


### PR DESCRIPTION
input prompt is formatted using python and passed to llama index parameter. This shouldnt happen since this is already tackled by llama-index package.

Closes: AUTH-464 

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Paste the following text into input textbox and get some response.

```
simulate this protocol from opentrons import protocol_api

metadata metadata = { 'protocolName': 'Aspiration and Dispense', 'author': 'Your Name your.email@example.com', 'description': 'A simple protocol to aspirate from a test tube and dispense into a PCR plate using a Gen2 20µl pipette', 'apiLevel': '2.15' }

def run(protocol: protocol_api.ProtocolContext): # labware tip_rack = protocol.load_labware('opentrons_96_tiprack_20ul', '1') test_tube_rack = protocol.load_labware('opentrons_24_tuberack_generic_2ml_screwcap', '2') pcr_plate = protocol.load_labware('nest_96_wellplate_100ul_pcr_full_skirt', '3')

pipettes
pipette = protocol.load_instrument('p20_single_gen2', 'right', tip_racks=[tip_rack])

reagents and locations
test_tube = test_tube_rack.wells_by_name()['A1'] pcr_well = pcr_plate.wells_by_name()['A1']

protocol steps
pipette.pick_up_tip() pipette.aspirate(10, test_tube) # aspirate 10µl from the test tube pipette.dispense(10, pcr_well) # dispense 10µl into the PCR plate well pipette.drop_tip()
```








<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
Low

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
