### PR TITLE
test: add developer validation version of smoke test protocol

### DIFF
--- a/app-testing/files/protocols/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py
+++ b/app-testing/files/protocols/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py
@@ -346,7 +346,7 @@ def add_parameters(parameters: protocol_api.Parameters):
 
     parameters.add_bool(
         variable_name="prefer_gripper_disposal",
-        display_name="I love to refill tip racks",
+        display_name="I LOVE TO REFILL TIP RACKS",
         description="Prefer to use the gripper to dispose of labware, instead of manual moves off deck",
         default=False,
     )
@@ -466,8 +466,10 @@ def run(ctx: protocol_api.ProtocolContext) -> None:
 
                 if i == 1:
                     pipette_96_channel.drop_tip(waste_chute)
-                else:
+                elif i == 2:
                     pipette_96_channel.drop_tip()
+                else:
+                    pipette_96_channel.drop_tip(trash_bin)
 
             dispose_with_preferred_method(tip_rack_2)
 

--- a/app-testing/files/protocols/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py
+++ b/app-testing/files/protocols/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py
@@ -107,7 +107,7 @@ class AllMoveSequences:
     from_module_move_sequence: MoveSequence
 
     @classmethod
-    def dev_default(cls, all_modules: typing.List[ValidModuleLocations]) -> "AllMoveSequences":
+    def dev_configuration(cls, all_modules: typing.List[ValidModuleLocations]) -> "AllMoveSequences":
         module_to_move_to = all_modules[0]
         return cls(
             from_deck_move_sequence=MoveSequence(
@@ -137,7 +137,7 @@ class AllMoveSequences:
         )
 
     @classmethod
-    def full_default(cls, all_modules: typing.List[ValidModuleLocations]) -> "AllMoveSequences":
+    def full_configuration(cls, all_modules: typing.List[ValidModuleLocations]) -> "AllMoveSequences":
         return cls(
             from_deck_move_sequence=MoveSequence(
                 to_deck_moves=["B2"],
@@ -174,7 +174,7 @@ class ModuleTemperatureConfiguration:
     temperature_module: float
 
     @classmethod
-    def full_default(cls) -> "ModuleTemperatureConfiguration":
+    def full_configuration(cls) -> "ModuleTemperatureConfiguration":
         return cls(
             thermocycler_block=60.0,
             thermocycler_lid=80.0,
@@ -183,7 +183,7 @@ class ModuleTemperatureConfiguration:
         )
 
     @classmethod
-    def dev_default(cls) -> "ModuleTemperatureConfiguration":
+    def dev_configuration(cls) -> "ModuleTemperatureConfiguration":
         return cls(
             thermocycler_block=50.0,
             thermocycler_lid=50.0,
@@ -219,8 +219,8 @@ class TestConfiguration:
             test_set_offset=True,
             partial_tip_pickup_column_count=12,
             prefer_move_off_deck=prefer_move_off_deck,
-            module_temps=ModuleTemperatureConfiguration.full_default(),
-            moves=AllMoveSequences.full_default(all_modules),
+            module_temps=ModuleTemperatureConfiguration.full_configuration(),
+            moves=AllMoveSequences.full_configuration(all_modules),
         )
 
     @classmethod
@@ -234,8 +234,8 @@ class TestConfiguration:
             test_set_offset=False,
             partial_tip_pickup_column_count=2,
             prefer_move_off_deck=prefer_move_off_deck,
-            module_temps=ModuleTemperatureConfiguration.dev_default(),
-            moves=AllMoveSequences.dev_default(all_modules),
+            module_temps=ModuleTemperatureConfiguration.dev_configuration(),
+            moves=AllMoveSequences.dev_configuration(all_modules),
         )
 
     @classmethod
@@ -246,19 +246,19 @@ class TestConfiguration:
             protocol_api.ThermocyclerContext | protocol_api.MagneticBlockContext | protocol_api.Labware
         ],
     ) -> "TestConfiguration":
-        test_type = parameters.test_type
+        test_configuration = parameters.test_configuration
         prefer_move_off_deck = parameters.prefer_move_off_deck
         reservoir_name = parameters.reservoir_name
         well_plate_name = parameters.well_plate_name
 
-        if test_type == "full":
+        if test_configuration == "full":
             return cls._get_full_config(
                 prefer_move_off_deck=prefer_move_off_deck,
                 reservoir_name=reservoir_name,
                 well_plate_name=well_plate_name,
                 all_modules=where_to_put_labware_on_modules,
             )
-        elif test_type == "dev":
+        elif test_configuration == "dev":
             return cls._get_dev_config(
                 prefer_move_off_deck=prefer_move_off_deck,
                 reservoir_name=reservoir_name,
@@ -266,7 +266,7 @@ class TestConfiguration:
                 all_modules=where_to_put_labware_on_modules,
             )
         else:
-            raise ValueError(f"Invalid test type: {test_type}")
+            raise ValueError(f"Invalid test configuration: {test_configuration}")
 
 
 #################
@@ -296,7 +296,7 @@ PIPETTE_96_CHANNEL_NAME = "flex_96channel_1000"
 
 def add_parameters(parameters: protocol_api.Parameters):
 
-    test_type_choices = [
+    test_configuration_choices = [
         {"display_name": "Full Smoke Test", "value": "full"},
         {"display_name": "Developer Validation", "value": "dev"},
     ]
@@ -313,11 +313,11 @@ def add_parameters(parameters: protocol_api.Parameters):
     ]
 
     parameters.add_str(
-        variable_name="test_type",
-        display_name="Test Type",
-        description="Type of testing to perform",
+        variable_name="test_configuration",
+        display_name="Test Configuration",
+        description="Configuration of QA test to perform",
         default="full",
-        choices=test_type_choices,
+        choices=test_configuration_choices,
     )
 
     parameters.add_str(

--- a/app-testing/files/protocols/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py
+++ b/app-testing/files/protocols/Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py
@@ -108,18 +108,14 @@ class AllMoveSequences:
     moves: typing.List[MoveSequence]
 
     @classmethod
-    def abbreviated_moves(
-        cls, all_modules: typing.List[ValidModuleLocations]
-    ) -> "AllMoveSequences":
+    def abbreviated_moves(cls, all_modules: typing.List[ValidModuleLocations]) -> "AllMoveSequences":
         module_to_move_to = all_modules[0]
         return cls(
             [MoveSequence(move_tos=["B2", module_to_move_to, "D4", "C3"], starting_location="C2", reset_to_start_after_each_move=False)],
         )
 
     @classmethod
-    def all_moves(
-        cls, all_modules: typing.List[ValidModuleLocations]
-    ) -> "AllMoveSequences":
+    def all_moves(cls, all_modules: typing.List[ValidModuleLocations]) -> "AllMoveSequences":
         return cls(
             [
                 # Covers
@@ -157,7 +153,9 @@ class AllMoveSequences:
             ],
         )
 
-    def do_moves(self, ctx: protocol_api.ProtocolContext, labware: protocol_api.Labware, original_labware_location: DeckSlots | ValidModuleLocations):
+    def do_moves(
+        self, ctx: protocol_api.ProtocolContext, labware: protocol_api.Labware, original_labware_location: DeckSlots | ValidModuleLocations
+    ):
         for move_sequence in self.moves:
             move_sequence.do_moves(ctx, labware)
 
@@ -624,11 +622,7 @@ def run(ctx: protocol_api.ProtocolContext) -> None:
     ### THE ORDER OF THESE FUNCTION CALLS MATTER. CHANGING THEM WILL CAUSE THE PROTOCOL NOT TO WORK ###
     ###################################################################################################
     test_pipetting()
-    test_config.gripper_moves.do_moves(
-        ctx=ctx,
-        labware=dest_pcr_plate,
-        original_labware_location="C2"
-    )
+    test_config.gripper_moves.do_moves(ctx=ctx, labware=dest_pcr_plate, original_labware_location="C2")
     test_module_usage()
     test_manual_moves()
     if test_config.test_set_offset:


### PR DESCRIPTION
# Overview

Closes RQA-2801

Add the ability to define different configurations of our smoke test protocol to allow developers an easy-to-run preconfigured version of our test. 

All a developer needs to do is select the `Developer Validation` configuration for the `Test Configuration` runtime parameter

# Test Plan

- [ ] Get someone to run it on a Flex and help me tune the protocol

# Changelog

- Defined some dataclasses inside the test protocol to pull out the configuration properties of the protocol
- Defined a `dev_configuration` and `full_configuration`
  - dev is for devs
  - full is for QA  

# Review requests

Is there a better way to handle this configuration logic than just inline in the protocol file? This should really be some kind of importable package but that seems like a decently large lift

# Risk assessment

None
