### PR TITLE
fix(opentrons-ai-client): use babel plugins in correct environments

### DIFF
--- a/opentrons-ai-client/babel.config.cjs
+++ b/opentrons-ai-client/babel.config.cjs
@@ -7,6 +7,9 @@ module.exports = {
     production: {
       plugins: ['babel-plugin-styled-components', 'babel-plugin-unassert'],
     },
+    staging: {
+      plugins: ['babel-plugin-styled-components'],
+    },
     development: {
       plugins: ['babel-plugin-styled-components'],
     },

--- a/opentrons-ai-client/vite.config.ts
+++ b/opentrons-ai-client/vite.config.ts
@@ -1,6 +1,11 @@
 import path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import postCssImport from 'postcss-import'
+import postCssApply from 'postcss-apply'
+import postColorModFunction from 'postcss-color-mod-function'
+import postCssPresetEnv from 'postcss-preset-env'
+import lostCss from 'lost'
 
 export default defineConfig({
   // this makes imports relative rather than absolute
@@ -25,7 +30,13 @@ export default defineConfig({
   },
   css: {
     postcss: {
-      plugins: [],
+      plugins: [
+        postCssImport({ root: 'src/' }),
+        postCssApply(),
+        postColorModFunction(),
+        postCssPresetEnv({ stage: 0 }),
+        lostCss(),
+      ],
     },
   },
   define: {


### PR DESCRIPTION
# Overview

This PR updates our build configs to use a babel plugin for styled components in the staging env, and adds some css plugins for stuff used in the components library. This *should* fix the whitescreen issue we were seeing in staging and prod.


# Risk assessment

Low