### PR TITLE
fix(app): Allow downloading troubleshooting logs when E-stop is engaged

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
@@ -27,12 +27,10 @@ import type { IconProps } from '@opentrons/components'
 
 interface TroubleshootingProps {
   robotName: string
-  isEstopNotDisengaged: boolean
 }
 
 export function Troubleshooting({
   robotName,
-  isEstopNotDisengaged,
 }: TroubleshootingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const robot = useRobot(robotName)
@@ -127,10 +125,7 @@ export function Troubleshooting({
       </Box>
       <TertiaryButton
         disabled={
-          controlDisabled ||
-          logsAvailable == null ||
-          isDownloadingRobotLogs ||
-          isEstopNotDisengaged
+          controlDisabled || logsAvailable == null || isDownloadingRobotLogs
         }
         marginLeft={SPACING_AUTO}
         onClick={handleClick}

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/Troubleshooting.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/Troubleshooting.test.tsx
@@ -43,7 +43,6 @@ describe('RobotSettings Troubleshooting', () => {
   beforeEach(() => {
     props = {
       robotName: ROBOT_NAME,
-      isEstopNotDisengaged: false,
     }
     when(useRobot).calledWith(ROBOT_NAME).thenReturn(mockConnectableRobot)
     when(useHost).calledWith().thenReturn(HOST_CONFIG)
@@ -89,11 +88,5 @@ describe('RobotSettings Troubleshooting', () => {
     await waitFor(() => {
       expect(downloadLogsButton).not.toBeDisabled()
     })
-  })
-
-  it('should make donwload button disabled when e-stop is pressed', () => {
-    props = { ...props, isEstopNotDisengaged: true }
-    render(props)
-    expect(screen.getByRole('button', { name: 'Download logs' })).toBeDisabled()
   })
 })

--- a/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -220,10 +220,7 @@ export function RobotSettingsAdvanced({
             />
           </>
         ) : null}
-        <Troubleshooting
-          robotName={robotName}
-          isEstopNotDisengaged={isEstopNotDisengaged}
-        />
+        <Troubleshooting robotName={robotName} />
         <Divider marginY={SPACING.spacing16} />
         <DeviceReset
           updateIsExpanded={updateIsExpanded}


### PR DESCRIPTION
# Overview

Fixes EXEC-507.

# Test Plan

* [x] See test plan in EXEC-507.

# Changelog

Straightforwardly, do not disable the "Download logs" button when the E-stop is engaged.

# Review requests

* Any reason not to do this?
* For similar reasons why we're doing this, should we *also* keep the "Device reset" button enabled?
* Do we need to update any design, product, or QA resources to reflect this change?

# Risk assessment

Low.
