### PR TITLE
fix(shared-data): P1000S v3.7 can use latest tip-overlap values

### DIFF
--- a/shared-data/js/__tests__/pipettes.test.ts
+++ b/shared-data/js/__tests__/pipettes.test.ts
@@ -63,7 +63,7 @@ describe('pipette data accessors', () => {
   })
 
   describe('getPipetteSpecsV2', () => {
-    it('returns the correct info for p1000_single_flex which should be the latest model version 3.6', () => {
+    it('returns the correct info for p1000_single_flex which should be the latest model version 3.7', () => {
       const mockP1000Specs = {
         $otSharedSchema: '#/pipette/schemas/2/pipetteGeometrySchema.json',
         availableSensors: {
@@ -84,12 +84,12 @@ describe('pipette data accessors', () => {
               '#/pipette/schemas/2/pipetteLiquidPropertiesSchema.json',
             defaultTipOverlapDictionary: {
               default: 10.5,
-              'opentrons/opentrons_flex_96_tiprack_1000ul/1': 10.5,
-              'opentrons/opentrons_flex_96_tiprack_200ul/1': 10.5,
-              'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.5,
-              'opentrons/opentrons_flex_96_filtertiprack_1000ul/1': 10.5,
-              'opentrons/opentrons_flex_96_filtertiprack_200ul/1': 10.5,
-              'opentrons/opentrons_flex_96_filtertiprack_50ul/1': 10.5,
+              'opentrons/opentrons_flex_96_tiprack_1000ul/1': 9.65,
+              'opentrons/opentrons_flex_96_tiprack_200ul/1': 9.76,
+              'opentrons/opentrons_flex_96_tiprack_50ul/1': 10.09,
+              'opentrons/opentrons_flex_96_filtertiprack_1000ul/1': 9.65,
+              'opentrons/opentrons_flex_96_filtertiprack_200ul/1': 9.76,
+              'opentrons/opentrons_flex_96_filtertiprack_50ul/1': 10.09,
             },
             defaultTipracks: [
               'opentrons/opentrons_flex_96_tiprack_1000ul/1',

--- a/shared-data/pipette/definitions/2/liquid/single_channel/p1000/default/3_7.json
+++ b/shared-data/pipette/definitions/2/liquid/single_channel/p1000/default/3_7.json
@@ -193,12 +193,12 @@
   },
   "defaultTipOverlapDictionary": {
     "default": 10.5,
-    "opentrons/opentrons_flex_96_tiprack_1000ul/1": 10.5,
-    "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.5,
-    "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.5,
-    "opentrons/opentrons_flex_96_filtertiprack_1000ul/1": 10.5,
-    "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 10.5,
-    "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 10.5
+    "opentrons/opentrons_flex_96_tiprack_1000ul/1": 9.65,
+    "opentrons/opentrons_flex_96_tiprack_200ul/1": 9.76,
+    "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.09,
+    "opentrons/opentrons_flex_96_filtertiprack_1000ul/1": 9.65,
+    "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 9.76,
+    "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 10.09
   },
   "maxVolume": 1000,
   "minVolume": 5,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Since this pipette model hasn't been shipped to customers yet, it is safe to update the tip-overlap values in the definition to match our latest data.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
