### PR TITLE
feat(app): add Protocol Status Banner for CSV file

### DIFF
--- a/app/src/assets/localization/en/protocol_list.json
+++ b/app/src/assets/localization/en/protocol_list.json
@@ -1,5 +1,7 @@
 {
+  "csv_file_required": "CSV file required for analysis. Add the CSV during run setup.",
   "delete_protocol_message": " and its run history will be permanently deleted.",
+  "delete_this_protocol": "Delete this protocol?",
   "last_updated_at": "Updated {{date}}",
   "left_mount": "left mount",
   "loading_data": "Loading data...",
@@ -14,7 +16,6 @@
   "robot": "robot",
   "send_to_robot_overflow": "Send to {{robot_display_name}}",
   "send_to_robot": "Send protocol to {{robot_display_name}}",
-  "delete_this_protocol": "Delete this protocol?",
   "show_in_folder": "Show in folder",
   "start_setup": "Start setup",
   "this_protocol_will_be_trashed": "This protocol will be moved to this computer’s trash and may be unrecoverable.",

--- a/app/src/organisms/ProtocolStatusBanner/ProtocolStatusBanner.stories.tsx
+++ b/app/src/organisms/ProtocolStatusBanner/ProtocolStatusBanner.stories.tsx
@@ -1,0 +1,12 @@
+import { ProtocolStatusBanner as ProtocolStatusBannerComponent } from './index'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof ProtocolStatusBannerComponent> = {
+  title: 'App/Organisms/ProtocolStatusBanner',
+  component: ProtocolStatusBannerComponent,
+}
+export default meta
+
+type Story = StoryObj<typeof ProtocolStatusBannerComponent>
+
+export const ProtocolStatusBanner: Story = {}

--- a/app/src/organisms/ProtocolStatusBanner/__tests__/ProtocolStatusBanner.test.tsx
+++ b/app/src/organisms/ProtocolStatusBanner/__tests__/ProtocolStatusBanner.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+
+import { COLORS } from '@opentrons/components'
+
+import { i18n } from '../../../i18n'
+import { renderWithProviders } from '../../../__testing-utils__'
+import { ProtocolStatusBanner } from '../index'
+
+const render = () => {
+  return renderWithProviders(<ProtocolStatusBanner />, {
+    i18nInstance: i18n,
+  })
+}
+
+describe('ProtocolStatusBanner', () => {
+  it('should render text and icon', () => {
+    render()
+    screen.getByText(
+      'CSV file required for analysis. Add the CSV during run setup.'
+    )
+    screen.getByLabelText('icon_warning')
+  })
+
+  it('should render the banner with correct styling', () => {
+    render()
+    const icon = screen.getByLabelText('icon_warning')
+    expect(icon).toHaveStyle(`color: ${COLORS.yellow60}`)
+    expect(icon).toHaveStyle(`width: 1rem`)
+    expect(icon).toHaveStyle(`height: 1rem`)
+    const banner = screen.getByTestId('Banner_warning')
+    expect(banner).toHaveStyle(`background-color: ${COLORS.yellow30}`)
+  })
+})

--- a/app/src/organisms/ProtocolStatusBanner/index.tsx
+++ b/app/src/organisms/ProtocolStatusBanner/index.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { SPACING, StyledText } from '@opentrons/components'
+import { Banner } from '../../atoms/Banner'
+
+import type { IconProps } from '@opentrons/components'
+
+export function ProtocolStatusBanner(): JSX.Element {
+  const { t } = useTranslation('protocol_list')
+
+  const alertIcon: IconProps = { name: 'alert-circle' }
+  return (
+    <Banner
+      type="warning"
+      icon={alertIcon}
+      width="100%"
+      iconMarginLeft={SPACING.spacing4}
+    >
+      <StyledText>{t('csv_file_required')}</StyledText>
+    </Banner>
+  )
+}


### PR DESCRIPTION


<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
add Protocol Status Banner for CSV file
I place this component under organisms because of `ProtocolAnalysisFailure` component.
I believe we can change the place to store this component when we start working CSV file.

close AUTH-482
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- make -C components dev

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add a new component, its test and its stories
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
