### PR TITLE
feat(api): Return overpressure errors from `aspirate` and wait for their recovery

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -153,7 +153,7 @@ class InstrumentCore(AbstractInstrument[WellCore]):
                 well_name=well_name,
                 well_location=well_location,
             )
-            self._engine_client.aspirate(
+            self._engine_client.aspirate_wait_for_recovery(
                 pipette_id=self._pipette_id,
                 labware_id=labware_id,
                 well_name=well_name,

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -433,6 +433,33 @@ class SyncClient:
 
         return cast(commands.AspirateResult, result)
 
+    def aspirate_wait_for_recovery(
+        self,
+        pipette_id: str,
+        labware_id: str,
+        well_name: str,
+        well_location: WellLocation,
+        volume: float,
+        flow_rate: float,
+    ) -> commands.Aspirate:
+        """Execute a Aspirate, wait for any error recovery, and return it.
+
+        Note that the returned command will not necessarily have a `result`.
+        """
+        request = commands.AspirateCreate(
+            params=commands.AspirateParams(
+                pipetteId=pipette_id,
+                labwareId=labware_id,
+                wellName=well_name,
+                wellLocation=well_location,
+                volume=volume,
+                flowRate=flow_rate,
+            )
+        )
+        command = self._transport.execute_command_wait_for_recovery(request=request)
+
+        return cast(commands.Aspirate, command)
+
     def aspirate_in_place(
         self,
         pipette_id: str,

--- a/api/src/opentrons/protocol_engine/commands/aspirate.py
+++ b/api/src/opentrons/protocol_engine/commands/aspirate.py
@@ -1,9 +1,12 @@
 """Aspirate command request, result, and implementation models."""
 from __future__ import annotations
-from typing import TYPE_CHECKING, Optional, Type
+from typing import TYPE_CHECKING, Optional, Type, Union
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
 from typing_extensions import Literal
 
 from .pipetting_common import (
+    OverpressureError,
+    OverpressureErrorInternalData,
     PipetteIdMixin,
     AspirateVolumeMixin,
     FlowRateMixin,
@@ -11,7 +14,13 @@ from .pipetting_common import (
     BaseLiquidHandlingResult,
     DestinationPositionResult,
 )
-from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from .command import (
+    AbstractCommandImpl,
+    BaseCommand,
+    BaseCommandCreate,
+    DefinedErrorData,
+    SuccessData,
+)
 from ..errors.error_occurrence import ErrorOccurrence
 
 from opentrons.hardware_control import HardwareControlAPI
@@ -20,6 +29,7 @@ from ..types import WellLocation, WellOrigin, CurrentWell, DeckPoint
 
 if TYPE_CHECKING:
     from ..execution import MovementHandler, PipettingHandler
+    from ..resources import ModelUtils
     from ..state import StateView
     from ..notes import CommandNoteAdder
 
@@ -41,9 +51,13 @@ class AspirateResult(BaseLiquidHandlingResult, DestinationPositionResult):
     pass
 
 
-class AspirateImplementation(
-    AbstractCommandImpl[AspirateParams, SuccessData[AspirateResult, None]]
-):
+_ExecuteReturn = Union[
+    SuccessData[AspirateResult, None],
+    DefinedErrorData[OverpressureError, OverpressureErrorInternalData],
+]
+
+
+class AspirateImplementation(AbstractCommandImpl[AspirateParams, _ExecuteReturn]):
     """Aspirate command implementation."""
 
     def __init__(
@@ -53,6 +67,7 @@ class AspirateImplementation(
         hardware_api: HardwareControlAPI,
         movement: MovementHandler,
         command_note_adder: CommandNoteAdder,
+        model_utils: ModelUtils,
         **kwargs: object,
     ) -> None:
         self._pipetting = pipetting
@@ -60,10 +75,9 @@ class AspirateImplementation(
         self._hardware_api = hardware_api
         self._movement = movement
         self._command_note_adder = command_note_adder
+        self._model_utils = model_utils
 
-    async def execute(
-        self, params: AspirateParams
-    ) -> SuccessData[AspirateResult, None]:
+    async def execute(self, params: AspirateParams) -> _ExecuteReturn:
         """Move to and aspirate from the requested well.
 
         Raises:
@@ -105,20 +119,42 @@ class AspirateImplementation(
             current_well=current_well,
         )
 
-        volume = await self._pipetting.aspirate_in_place(
-            pipette_id=pipette_id,
-            volume=params.volume,
-            flow_rate=params.flowRate,
-            command_note_adder=self._command_note_adder,
-        )
-
-        return SuccessData(
-            public=AspirateResult(
-                volume=volume,
-                position=DeckPoint(x=position.x, y=position.y, z=position.z),
-            ),
-            private=None,
-        )
+        try:
+            volume_aspirated = await self._pipetting.aspirate_in_place(
+                pipette_id=pipette_id,
+                volume=params.volume,
+                flow_rate=params.flowRate,
+                command_note_adder=self._command_note_adder,
+            )
+        except PipetteOverpressureError as e:
+            return DefinedErrorData(
+                public=OverpressureError(
+                    id=self._model_utils.generate_id(),
+                    createdAt=self._model_utils.get_timestamp(),
+                    wrappedErrors=[
+                        ErrorOccurrence.from_failed(
+                            id=self._model_utils.generate_id(),
+                            createdAt=self._model_utils.get_timestamp(),
+                            error=e,
+                        )
+                    ],
+                ),
+                private=OverpressureErrorInternalData(
+                    position=DeckPoint.construct(
+                        x=position.x, y=position.y, z=position.z
+                    )
+                ),
+            )
+        else:
+            return SuccessData(
+                public=AspirateResult(
+                    volume=volume_aspirated,
+                    position=DeckPoint.construct(
+                        x=position.x, y=position.y, z=position.z
+                    ),
+                ),
+                private=None,
+            )
 
 
 class Aspirate(BaseCommand[AspirateParams, AspirateResult, ErrorOccurrence]):

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -92,7 +92,11 @@ class HardwarePipettingHandler(PipettingHandler):
         flow_rate: float,
         command_note_adder: CommandNoteAdder,
     ) -> float:
-        """Set flow-rate and aspirate."""
+        """Set flow-rate and aspirate.
+
+        Raises:
+            PipetteOverpressureError, propagated as-is from the hardware controller.
+        """
         # get mount and config data from state and hardware controller
         adjusted_volume = _validate_aspirate_volume(
             state_view=self._state_view,

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -490,7 +490,7 @@ def test_aspirate_from_well(
                 origin=WellOrigin.TOP, offset=WellOffset(x=3, y=2, z=1)
             ),
         ),
-        mock_engine_client.aspirate(
+        mock_engine_client.aspirate_wait_for_recovery(
             pipette_id="abc123",
             labware_id="123abc",
             well_name="my cool well",

--- a/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_aspirate.py
@@ -1,7 +1,14 @@
 """Test aspirate commands."""
-import pytest
-from decoy import Decoy
+from datetime import datetime
 
+from opentrons_shared_data.errors.exceptions import PipetteOverpressureError
+from decoy import matchers, Decoy
+import pytest
+
+from opentrons.protocol_engine.commands.pipetting_common import (
+    OverpressureError,
+    OverpressureErrorInternalData,
+)
 from opentrons.types import MountType, Point
 from opentrons.protocol_engine import WellLocation, WellOrigin, WellOffset, DeckPoint
 
@@ -10,7 +17,7 @@ from opentrons.protocol_engine.commands.aspirate import (
     AspirateResult,
     AspirateImplementation,
 )
-from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.command import DefinedErrorData, SuccessData
 
 from opentrons.protocol_engine.state import StateView
 
@@ -18,6 +25,7 @@ from opentrons.protocol_engine.execution import (
     MovementHandler,
     PipettingHandler,
 )
+from opentrons.protocol_engine.resources.model_utils import ModelUtils
 from opentrons.protocol_engine.types import CurrentWell, LoadedPipette
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.notes import CommandNoteAdder
@@ -30,6 +38,7 @@ def subject(
     movement: MovementHandler,
     pipetting: PipettingHandler,
     mock_command_note_adder: CommandNoteAdder,
+    model_utils: ModelUtils,
 ) -> AspirateImplementation:
     """Get the implementation subject."""
     return AspirateImplementation(
@@ -38,6 +47,7 @@ def subject(
         movement=movement,
         hardware_api=hardware_api,
         command_note_adder=mock_command_note_adder,
+        model_utils=model_utils,
     )
 
 
@@ -191,3 +201,71 @@ async def test_aspirate_raises_volume_error(
 
     with pytest.raises(AssertionError):
         await subject.execute(data)
+
+
+async def test_overpressure_error(
+    decoy: Decoy,
+    movement: MovementHandler,
+    pipetting: PipettingHandler,
+    subject: AspirateImplementation,
+    model_utils: ModelUtils,
+    mock_command_note_adder: CommandNoteAdder,
+) -> None:
+    """It should return an overpressure error if the hardware API indicates that."""
+    pipette_id = "pipette-id"
+    labware_id = "labware-id"
+    well_name = "well-name"
+    well_location = WellLocation(
+        origin=WellOrigin.BOTTOM, offset=WellOffset(x=0, y=0, z=1)
+    )
+
+    position = Point(x=1, y=2, z=3)
+
+    error_id = "error-id"
+    error_timestamp = datetime(year=2020, month=1, day=2)
+
+    data = AspirateParams(
+        pipetteId=pipette_id,
+        labwareId=labware_id,
+        wellName=well_name,
+        wellLocation=well_location,
+        volume=50,
+        flowRate=1.23,
+    )
+
+    decoy.when(pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)).then_return(
+        True
+    )
+
+    decoy.when(
+        await movement.move_to_well(
+            pipette_id=pipette_id,
+            labware_id=labware_id,
+            well_name=well_name,
+            well_location=well_location,
+            current_well=None,
+        ),
+    ).then_return(position)
+
+    decoy.when(
+        await pipetting.aspirate_in_place(
+            pipette_id=pipette_id,
+            volume=50,
+            flow_rate=1.23,
+            command_note_adder=mock_command_note_adder,
+        ),
+    ).then_raise(PipetteOverpressureError())
+
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+    decoy.when(model_utils.get_timestamp()).then_return(error_timestamp)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=OverpressureError.construct(
+            id=error_id, createdAt=error_timestamp, wrappedErrors=[matchers.Anything()]
+        ),
+        private=OverpressureErrorInternalData(
+            position=DeckPoint(x=position.x, y=position.y, z=position.z)
+        ),
+    )


### PR DESCRIPTION
# Overview

Closes EXEC-376.

# Test plan

Run a protocol that `aspirate()`s. Hold the well plate against the nozzles to induce an overpressure error.

```python
from opentrons import protocol_api

requirements = {
    "apiLevel": "2.18",
    "robotType": "Flex",
}


def run(protocol: protocol_api.ProtocolContext) -> None:
    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D2")
    well_plate = protocol.load_labware("nest_96_wellplate_100ul_pcr_full_skirt", "C3")

    protocol.load_trash_bin("A3")

    pipette = protocol.load_instrument("flex_96channel_1000")

    pipette.configure_nozzle_layout(protocol_api.COLUMN, start="A1")
    pipette.pick_up_tip(tip_rack["A12"])
    for _ in range(10):
        pipette.move_to(well_plate["A1"].bottom(-0.5))
        pipette.aspirate(1000)
        pipette.move_to(well_plate["A1"].top())
        pipette.blow_out()
    pipette.drop_tip()
```

With this PR, the run should pause and await recovery.

If you proceed to the next step, and that step is a blowout or home, the protocol *should* do that and then continue as normal. It will currently raise a `MustHomeError` for reasons that we think are related to firmware, and that we're looking into separately.

# Changelog

* Update the Protocol Engine `aspirate` command so that if it encounters an overpressure during the actual aspirate step, it swallows the exception, converts it to a defined `overpressure` error, and returns it.
* Update our error recovery policy to put the run in an `awaiting-recovery` state when this happens.
* Update PAPI's bindings to Protocol Engine to wait for any potential error recovery to complete before returning from the `aspirate()`.

# Review requests

None in particular.

# Risk assessment

Low.