### PR TITLE
fix(protocol-designer): add missing prop to getPipetteCapacity usage

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -263,7 +263,8 @@ const getClearedDisposalVolumeFields = (): FormPatch =>
 const clampAspirateAirGapVolume = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities
 ): FormPatch => {
   const patchedAspirateAirgapVolume =
     patch.aspirate_airGap_volume ?? rawForm?.aspirate_airGap_volume
@@ -280,7 +281,8 @@ const clampAspirateAirGapVolume = (
     const minAirGapVolume = 0 // NOTE: a form level warning will occur if the air gap volume is below the pipette min volume
 
     const maxAirGapVolume =
-      getPipetteCapacity(pipetteEntity, tipRack) - minPipetteVolume
+      getPipetteCapacity(pipetteEntity, labwareEntities, tipRack) -
+      minPipetteVolume
     const clampedAirGapVolume = clamp(
       Number(patchedAspirateAirgapVolume),
       minAirGapVolume,
@@ -649,7 +651,12 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch =>
       updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
-      clampAspirateAirGapVolume(chainPatch, rawForm, pipetteEntities),
+      clampAspirateAirGapVolume(
+        chainPatch,
+        rawForm,
+        pipetteEntities,
+        labwareEntities
+      ),
     chainPatch =>
       clampDisposalVolume(
         chainPatch,


### PR DESCRIPTION
closes AUTH-489

# Overview

Somehow this didn't error before even though a usage of `getPipetteCapacity` was missing the `labwareEntities`? I guess because the `tiprack` prop is optional. But anyway glad it has been caught and fixed.

# Test Plan



# Changelog

add missing labware entites prop to util

# Review requests



# Risk assessment

low