### PR TITLE
fix(app): update empty file component to align with the latest design

### DIFF
--- a/app/src/organisms/ProtocolSetupParameters/EmptyFile.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/EmptyFile.tsx
@@ -4,7 +4,9 @@ import {
   ALIGN_CENTER,
   BORDERS,
   COLORS,
+  DIRECTION_COLUMN,
   Flex,
+  Icon,
   JUSTIFY_CENTER,
   SPACING,
   StyledText,
@@ -16,19 +18,21 @@ export function EmptyFile(): JSX.Element {
 
   return (
     <Flex
-      padding={SPACING.spacing24}
+      padding={`${SPACING.spacing40} ${SPACING.spacing80}`}
       borderRadius={BORDERS.borderRadius16}
       backgroundColor={COLORS.grey35}
-      width="27.75rem"
-      height="23rem"
+      width="28rem"
+      height="24rem"
       alignItems={ALIGN_CENTER}
       justifyContent={JUSTIFY_CENTER}
       data-testid="EmptyFile"
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing32}
     >
+      <Icon name="ot-alert" size="3rem" data-testid="EmptyFile_icon" />
       <StyledText
         fontSize={TYPOGRAPHY.fontSize28}
         lineHeight={TYPOGRAPHY.lineHeight36}
-        color={COLORS.grey50}
         fontWeight={TYPOGRAPHY.fontWeightSemiBold}
       >
         {t('no_files_found')}

--- a/app/src/organisms/ProtocolSetupParameters/__tests__/EmptyFile.test.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/__tests__/EmptyFile.test.tsx
@@ -23,8 +23,9 @@ const render = () => {
 }
 
 describe('EmptyFile', () => {
-  it('should render text', () => {
+  it('should render icon and text', () => {
     render()
+    screen.getByTestId('EmptyFile_icon')
     screen.getByText('No files found')
   })
 
@@ -32,13 +33,14 @@ describe('EmptyFile', () => {
     render()
     const element = screen.getByTestId('EmptyFile')
     expect(element).toHaveStyle(`background-color: ${COLORS.grey35}`)
-    expect(element).toHaveStyle(`padding: ${SPACING.spacing24}`)
+    expect(element).toHaveStyle(
+      `padding: ${SPACING.spacing40} ${SPACING.spacing80}`
+    )
     expect(element).toHaveStyle(`justify-content: ${JUSTIFY_CENTER}`)
     expect(element).toHaveStyle(`align-items: ${ALIGN_CENTER}`)
     expect(element).toHaveStyle(`border-radius: ${BORDERS.borderRadius16}`)
 
     const text = screen.getByText('No files found')
-    expect(text).toHaveStyle(`color: ${COLORS.grey50}`)
     expect(text).toHaveStyle(`font-size: ${TYPOGRAPHY.fontSize28}`)
     expect(text).toHaveStyle(`line-height: ${TYPOGRAPHY.lineHeight36}`)
     expect(text).toHaveStyle(`font-weight: ${TYPOGRAPHY.fontWeightSemiBold}`)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update empty file component to align with the latest design

design
https://www.figma.com/design/MlZjOO8aZXsw3HfTBoyw9U/Release%3A-CSV?node-id=21-11976&m=dev

<img width="519" alt="Screenshot 2024-06-07 at 10 24 44 AM" src="https://github.com/Opentrons/opentrons/assets/474225/81b52375-9f4c-4c8e-bb91-fdd5c92ee6b7">

FYI
We will need to create a new component InfoScreen but at this moment we implemented that in each modal component and we don't know how many components we will need to update.
I guess we can work on this later.
https://www.figma.com/design/OIdG64Q5cgvEw82ish5Eee/Design-System%3A-Flex?node-id=583-21826&m=dev

https://opentrons.slack.com/archives/C06M6R72UDS/p1717699723116489?thread_ts=1717689227.845839&cid=C06M6R72UDS

close AUTH-480
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- run make -C components dev
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- update style and add an icon
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
