### PR TITLE
chore: reenable storybook pushes for all branches

### DIFF
--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -119,7 +119,7 @@ jobs:
             echo "No builds for pull requests"
             echo 'type=none' >> $GITHUB_OUTPUT
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/')) }}" = "true" ] ; then
-            echo "storybook s3 builds for edge"
+            echo "storybook s3 builds for branch ${{ github.ref_name }}"
             echo 'type=storybook' >> $GITHUB_OUTPUT
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/tags/components')) }}" = "true" ] ; then
             echo "publish builds for components tags"

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -118,7 +118,7 @@ jobs:
           if [ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ] ;
             echo "No builds for pull requests"
             echo 'type=none' >> $GITHUB_OUTPUT
-          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/') }}" = "true" ] ; then
+          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/')) }}" = "true" ] ; then
             echo "storybook s3 builds for edge"
             echo 'type=storybook' >> $GITHUB_OUTPUT
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/tags/components')) }}" = "true" ] ; then

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -114,15 +114,18 @@ jobs:
     steps:
       - id: determine-build-type
         run: |
-          echo "Determining build type for event ${{github.event_type}} and ref ${{github.ref}}"
-          if [ "${{ format('{0}', github.ref == 'refs/heads/edge') }}" = "true" ] ; then
+          echo "Determining build type for event ${{github.event_name}} and ref ${{github.ref}}"
+          if [ "${{ format('{0}', github.event_name == 'pull_request' }}" = "true" ] ;
+            echo "No builds for pull requests"
+            echo 'type=none' >> $GITHUB_OUTPUT
+          elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/') }}" = "true" ] ; then
             echo "storybook s3 builds for edge"
             echo 'type=storybook' >> $GITHUB_OUTPUT
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/tags/components')) }}" = "true" ] ; then
             echo "publish builds for components tags"
             echo 'type=publish' >> $GITHUB_OUTPUT
           else
-            echo "No build for ref ${{github.ref}} and event ${{github.event_type}}"
+            echo "No build for ref ${{github.ref}} and event ${{github.event_name}}"
             echo 'type=none' >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -115,7 +115,7 @@ jobs:
       - id: determine-build-type
         run: |
           echo "Determining build type for event ${{github.event_name}} and ref ${{github.ref}}"
-          if [ "${{ format('{0}', github.event_name == 'pull_request' }}" = "true" ] ;
+          if [ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ] ;
             echo "No builds for pull requests"
             echo 'type=none' >> $GITHUB_OUTPUT
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/') }}" = "true" ] ; then

--- a/.github/workflows/components-test-build-deploy.yaml
+++ b/.github/workflows/components-test-build-deploy.yaml
@@ -115,7 +115,7 @@ jobs:
       - id: determine-build-type
         run: |
           echo "Determining build type for event ${{github.event_name}} and ref ${{github.ref}}"
-          if [ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ] ;
+          if [ "${{ format('{0}', github.event_name == 'pull_request') }}" = "true" ] ; then
             echo "No builds for pull requests"
             echo 'type=none' >> $GITHUB_OUTPUT
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/heads/')) }}" = "true" ] ; then


### PR DESCRIPTION
This was removed in 3c4008d38 and shouldn't have been.
