### PR TITLE
refactor(app): use one-col content in attach pipette

### DIFF
--- a/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentOneColSimpleButtons.tsx
@@ -20,12 +20,15 @@ export interface ModalContentOneColSimpleButtonsProps {
   secondButton: ButtonProps
   furtherButtons?: ButtonProps[]
   onSelect?: React.ChangeEventHandler<HTMLInputElement>
+  initialSelected?: string
 }
 
 export function ModalContentOneColSimpleButtons(
   props: ModalContentOneColSimpleButtonsProps
 ): JSX.Element {
-  const [selected, setSelected] = React.useState<string | null>(null)
+  const [selected, setSelected] = React.useState<string | null>(
+    props.initialSelected ?? null
+  )
   const furtherButtons = props.furtherButtons ?? []
   const buttons = [props.firstButton, props.secondButton, ...furtherButtons]
   return (

--- a/app/src/molecules/InterventionModal/__tests__/ModalContentOneColSimpleButtons.test.tsx
+++ b/app/src/molecules/InterventionModal/__tests__/ModalContentOneColSimpleButtons.test.tsx
@@ -65,6 +65,21 @@ describe('InterventionModal', () => {
     expect(inputElForButtonFromButtonText('third button').checked).toBeTruthy()
   })
 
+  it('can start with a button selected', () => {
+    render(
+      <ModalContentOneColSimpleButtons
+        topText={'top text'}
+        firstButton={{ label: 'first button', value: 'first' }}
+        secondButton={{ label: 'second button', value: 'second' }}
+        furtherButtons={[{ label: 'third button', value: 'third' }]}
+        initialSelected={'second'}
+      />
+    )
+    expect(inputElForButtonFromButtonText('first button').checked).toBeFalsy()
+    expect(inputElForButtonFromButtonText('second button').checked).toBeTruthy()
+    expect(inputElForButtonFromButtonText('third button').checked).toBeFalsy()
+  })
+
   it('propagates individual button onChange', () => {
     const onChange = vi.fn()
     render(

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -154,6 +154,7 @@ export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
         <Flex
           flexDirection={DIRECTION_COLUMN}
           width="100%"
+          height="472px"
           position={POSITION_ABSOLUTE}
           backgroundColor={COLORS.white}
         >
@@ -167,28 +168,35 @@ export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
               isOnDevice={isOnDevice}
             />
           ) : (
-            <ModalContentOneColSimpleButtons
-              topText={t('choose_pipette')}
-              firstButton={{
-                label: singleMount,
-                value: SINGLE_MOUNT_PIPETTES,
-              }}
-              secondButton={{
-                label: bothMounts,
-                value: NINETY_SIX_CHANNEL,
-              }}
-              onSelect={event => {
-                setSelectedPipette(event.target.value as any)
-              }}
-            />
+            <Flex
+              margin={SPACING.spacing32}
+              flexDirection={DIRECTION_COLUMN}
+              height="100%"
+              justifyContent={JUSTIFY_SPACE_BETWEEN}
+            >
+              <ModalContentOneColSimpleButtons
+                topText={t('choose_pipette')}
+                firstButton={{
+                  label: singleMount,
+                  value: SINGLE_MOUNT_PIPETTES,
+                }}
+                secondButton={{
+                  label: bothMounts,
+                  value: NINETY_SIX_CHANNEL,
+                }}
+                onSelect={event => {
+                  setSelectedPipette(event.target.value as any)
+                }}
+              />
+              <Flex justifyContent={JUSTIFY_FLEX_END}>
+                <SmallButton
+                  onClick={proceed}
+                  textTransform={TYPOGRAPHY.textTransformCapitalize}
+                  buttonText={i18n.format(t('shared:continue'), 'capitalize')}
+                />
+              </Flex>
+            </Flex>
           )}
-          <Flex justifyContent={JUSTIFY_FLEX_END}>
-            <SmallButton
-              onClick={proceed}
-              textTransform={TYPOGRAPHY.textTransformCapitalize}
-              buttonText={i18n.format(t('shared:continue'), 'capitalize')}
-            />
-          </Flex>
         </Flex>
       </LegacyModalShell>
     ) : (

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -37,6 +37,7 @@ import { getTopPortalEl } from '../../App/portal'
 import { SmallButton } from '../../atoms/buttons'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { WizardHeader } from '../../molecules/WizardHeader'
+import { ModalContentOneColSimpleButtons } from '../../molecules/InterventionModal'
 import singleChannelAndEightChannel from '../../assets/images/change-pip/1_and_8_channel.png'
 import ninetySixChannel from '../../assets/images/change-pip/ninety-six-channel.png'
 import { useAttachedPipettesFromInstrumentsQuery } from '../Devices/hooks'
@@ -166,56 +167,28 @@ export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
               isOnDevice={isOnDevice}
             />
           ) : (
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              padding={SPACING.spacing32}
-              justifyContent={JUSTIFY_SPACE_BETWEEN}
-              height="29.5rem"
-            >
-              <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-                <StyledText
-                  as="h4"
-                  fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  marginBottom={SPACING.spacing4}
-                >
-                  {t('choose_pipette')}
-                </StyledText>
-                <PipetteMountOption
-                  isSelected={selectedPipette === SINGLE_MOUNT_PIPETTES}
-                  onClick={() => {
-                    setSelectedPipette(SINGLE_MOUNT_PIPETTES)
-                  }}
-                >
-                  <StyledText
-                    as="h4"
-                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  >
-                    {singleMount}
-                  </StyledText>
-                </PipetteMountOption>
-                <PipetteMountOption
-                  isSelected={selectedPipette === NINETY_SIX_CHANNEL}
-                  onClick={() => {
-                    setSelectedPipette(NINETY_SIX_CHANNEL)
-                  }}
-                >
-                  <StyledText
-                    as="h4"
-                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                  >
-                    {bothMounts}
-                  </StyledText>
-                </PipetteMountOption>
-              </Flex>
-              <Flex justifyContent={JUSTIFY_FLEX_END}>
-                <SmallButton
-                  onClick={proceed}
-                  textTransform={TYPOGRAPHY.textTransformCapitalize}
-                  buttonText={i18n.format(t('shared:continue'), 'capitalize')}
-                />
-              </Flex>
-            </Flex>
+            <ModalContentOneColSimpleButtons
+              topText={t('choose_pipette')}
+              firstButton={{
+                label: singleMount,
+                value: SINGLE_MOUNT_PIPETTES,
+              }}
+              secondButton={{
+                label: bothMounts,
+                value: NINETY_SIX_CHANNEL,
+              }}
+              onSelect={event => {
+                setSelectedPipette(event.target.value as any)
+              }}
+            />
           )}
+          <Flex justifyContent={JUSTIFY_FLEX_END}>
+            <SmallButton
+              onClick={proceed}
+              textTransform={TYPOGRAPHY.textTransformCapitalize}
+              buttonText={i18n.format(t('shared:continue'), 'capitalize')}
+            />
+          </Flex>
         </Flex>
       </LegacyModalShell>
     ) : (

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -187,6 +187,7 @@ export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
                 onSelect={event => {
                   setSelectedPipette(event.target.value as any)
                 }}
+                initialSelected={SINGLE_MOUNT_PIPETTES}
               />
               <Flex justifyContent={JUSTIFY_FLEX_END}>
                 <SmallButton


### PR DESCRIPTION
Now that we have a one-col-simple-buttons component, let's use it. A place that uses this layout open-coded is the ODD attach pipette screen. Beautifully enough, we can drop the component in place instead of the open-coded version and the tests all still pass.
## Testing
Also I don't trust at all that the tests pass because there's some weird nested stuff for the back button so let's actually try it on a machine.