### PR TITLE
refactor(app): add modal mixed media content

### DIFF
--- a/app/src/molecules/InterventionModal/ModalContentMixed.stories.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentMixed.stories.tsx
@@ -1,0 +1,107 @@
+import successIcon from '../../assets/images/icon_success.png'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import { customViewports } from '../../../../.storybook/preview'
+
+import {
+  ModalContentMixed as ModalContentMixedComponent,
+  MODAL_CONTENT_MIXED_ICONS,
+} from './ModalContentMixed'
+
+const meta: Meta<typeof ModalContentMixedComponent> = {
+  title: 'App/Molecules/InterventionModal/ModalContentMixed',
+  component: ModalContentMixedComponent,
+  argTypes: {
+    iconType: {
+      control: {
+        type: 'select',
+      },
+      options: Object.keys(MODAL_CONTENT_MIXED_ICONS),
+      defaultValue: undefined,
+      if: { arg: 'type', eq: 'icon' },
+    },
+    imageUrl: {
+      control: {
+        type: 'file',
+        accept: '.png',
+      },
+      if: { arg: 'type', eq: 'image' },
+    },
+    imageAltText: {
+      control: {
+        type: 'text',
+      },
+      defaultValue: undefined,
+      if: { arg: 'type', eq: 'image' },
+    },
+    imageAriaLabel: {
+      control: {
+        type: 'text',
+      },
+      defaultValue: undefined,
+      if: { arg: 'type', eq: 'image' },
+    },
+    type: {
+      control: {
+        type: 'select',
+      },
+      options: ['icon', 'image', 'spinner', 'no-media'],
+      defaultValue: undefined,
+    },
+  },
+  parameters: {
+    viewport: {
+      viewports: customViewports,
+      defaultViewport: 'onDeviceDisplay',
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ModalContentMixedComponent>
+
+export const ModalContentMixed: Story = {
+  args: {
+    headline: 'Selectable mixed content',
+    subText: 'Mixed content subtext',
+    iconType: 'error',
+  },
+}
+
+export const IconModalContentMixed: Story = {
+  args: {
+    headline: 'Mixed content with an icon',
+    iconType: 'caution',
+    subText: 'Intervention is necessary',
+    type: 'icon',
+  },
+}
+
+export const SpinnerModalContentMixed: Story = {
+  args: {
+    headline: 'Mixed content with a spinner',
+    subText: 'Check me out!',
+    type: 'spinner',
+  },
+}
+
+export const ImageModalContentMixed: Story = {
+  args: {
+    headline: 'Mixed content with an image',
+    imgName: 'something',
+    subText: 'Isnt this cool?',
+    type: 'image',
+    imageUrl: successIcon,
+    imageAriaLabel: 'Success has occurred',
+    imageAltText: 'A successful image',
+  },
+}
+
+export const NoMediaModalContentMixed: Story = {
+  args: {
+    headline: 'Mixed content with no media',
+    subText: 'This counts too!',
+    type: 'no-media',
+  },
+}

--- a/app/src/molecules/InterventionModal/ModalContentMixed.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentMixed.tsx
@@ -1,0 +1,178 @@
+import * as React from 'react'
+import {
+  Icon,
+  Flex,
+  Box,
+  StyledText,
+  DIRECTION_COLUMN,
+  SPACING,
+  COLORS,
+  ALIGN_CENTER,
+  RESPONSIVENESS,
+} from '@opentrons/components'
+
+export type ModalContentMixedType =
+  | 'icon'
+  | 'image'
+  | 'spinner'
+  | 'no-media'
+  | undefined
+
+export type ModalContentMixedIcons = 'error' | 'caution' | 'neutral'
+
+export const MODAL_CONTENT_MIXED_ICONS: Record<
+  ModalContentMixedIcons,
+  string
+> = {
+  neutral: COLORS.grey50,
+  caution: COLORS.yellow50,
+  error: COLORS.red50,
+}
+
+interface ModalContentMixedIconProps {
+  type: 'icon'
+  iconType: ModalContentMixedIcons
+}
+
+interface ModalContentMixedImageProps {
+  type: 'image'
+  imageUrl: string
+  imageAltText: string
+  imageAriaLabel: string
+}
+
+interface ModalContentMixedSpinnerProps {
+  type: 'spinner'
+}
+
+interface ModalContentMixedNoMediaProps {
+  type: 'no-media' | undefined
+}
+
+type ModalContentMixedMandatoryHeadlineProps =
+  | ModalContentMixedIconProps
+  | ModalContentMixedImageProps
+
+type ModalContentMixedNoMandatoryHeadlineProps =
+  | ModalContentMixedSpinnerProps
+  | ModalContentMixedNoMediaProps
+
+interface ModalContentMixedTextProps {
+  headline: string
+  subText?: string
+}
+
+export type ModalContentMixedProps =
+  | (ModalContentMixedMandatoryHeadlineProps & ModalContentMixedTextProps)
+  | (ModalContentMixedNoMandatoryHeadlineProps &
+      Partial<ModalContentMixedTextProps>)
+export function ModalContentMixed(props: ModalContentMixedProps): JSX.Element {
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      alignItems={ALIGN_CENTER}
+      padding={SPACING.spacing40}
+    >
+      <ModalContentMixedMedia {...props} />
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        alignItems={ALIGN_CENTER}
+        css={`
+          gap: ${SPACING.spacing8};
+
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            gap: ${SPACING.spacing4};
+          }
+        `}
+      >
+        {props.headline != null ? (
+          <StyledText as="h3Bold">{props.headline}</StyledText>
+        ) : null}
+        {props.subText != null ? (
+          <StyledText as="h4" color={COLORS.grey60}>
+            {props.subText}
+          </StyledText>
+        ) : null}
+      </Flex>
+    </Flex>
+  )
+}
+
+function ModalContentMixedMedia(
+  props:
+    | ModalContentMixedMandatoryHeadlineProps
+    | ModalContentMixedNoMandatoryHeadlineProps
+): JSX.Element {
+  switch (props?.type) {
+    case 'icon':
+      return <ModalContentMixedIcon {...props} />
+    case 'spinner':
+      return <ModalContentMixedSpinner {...props} />
+    case 'image':
+      return <ModalContentMixedImage {...props} />
+    case 'no-media':
+    case undefined:
+      return <></>
+  }
+}
+
+function ModalContentMixedIcon(props: ModalContentMixedIconProps): JSX.Element {
+  return (
+    <Box
+      marginBottom={SPACING.spacing24}
+      css={`
+        width: ${SPACING.spacing40};
+        margin-bottom: ${SPACING.spacing16};
+        @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          width: ${SPACING.spacing60};
+          margin-bottom: ${SPACING.spacing24};
+        }
+      `}
+    >
+      <Icon
+        name="ot-alert"
+        color={MODAL_CONTENT_MIXED_ICONS[props.iconType]}
+        size="100%"
+      />
+    </Box>
+  )
+}
+
+function ModalContentMixedSpinner(
+  props: ModalContentMixedSpinnerProps
+): JSX.Element {
+  return (
+    <Box
+      marginBottom={SPACING.spacing16}
+      width={'80px'}
+      css={`
+        @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          width: 100px;
+          margin-bottom: ${SPACING.spacing24};
+        }
+      `}
+    >
+      <Icon name="ot-spinner" color={COLORS.grey60} width="100%" spin />
+    </Box>
+  )
+}
+
+function ModalContentMixedImage(
+  props: ModalContentMixedImageProps
+): JSX.Element {
+  return (
+    <img
+      src={props.imageUrl}
+      aria-label={props.imageAriaLabel}
+      alt={props.imageAltText}
+      css={`
+        height: 150px;
+        margin-bottom: ${SPACING.spacing16};
+        @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          height: 180px;
+          margin-bottom: ${SPACING.spacing24};
+        }
+      `}
+    />
+  )
+}

--- a/app/src/molecules/InterventionModal/ModalContentMixed.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentMixed.tsx
@@ -86,10 +86,19 @@ export function ModalContentMixed(props: ModalContentMixedProps): JSX.Element {
         `}
       >
         {props.headline != null ? (
-          <StyledText as="h3Bold">{props.headline}</StyledText>
+          <StyledText
+            oddStyle="level3HeaderBold"
+            desktopStyle="headingSmallBold"
+          >
+            {props.headline}
+          </StyledText>
         ) : null}
         {props.subText != null ? (
-          <StyledText as="h4" color={COLORS.grey60}>
+          <StyledText
+            oddStyle="level4HeaderRegular"
+            desktopStyle="bodyDefaultRegular"
+            color={COLORS.grey60}
+          >
             {props.subText}
           </StyledText>
         ) : null}

--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -23,7 +23,8 @@ import type { IconName } from '@opentrons/components'
 import { ModalContentOneColSimpleButtons } from './ModalContentOneColSimpleButtons'
 import { TwoColumn } from './TwoColumn'
 import { OneColumn } from './OneColumn'
-export { ModalContentOneColSimpleButtons, TwoColumn, OneColumn }
+import { ModalContentMixed } from './ModalContentMixed'
+export { ModalContentOneColSimpleButtons, TwoColumn, OneColumn, ModalContentMixed }
 
 export type ModalType = 'intervention-required' | 'error'
 

--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -24,7 +24,12 @@ import { ModalContentOneColSimpleButtons } from './ModalContentOneColSimpleButto
 import { TwoColumn } from './TwoColumn'
 import { OneColumn } from './OneColumn'
 import { ModalContentMixed } from './ModalContentMixed'
-export { ModalContentOneColSimpleButtons, TwoColumn, OneColumn, ModalContentMixed }
+export {
+  ModalContentOneColSimpleButtons,
+  TwoColumn,
+  OneColumn,
+  ModalContentMixed,
+}
 
 export type ModalType = 'intervention-required' | 'error'
 


### PR DESCRIPTION
This is a component for InterventionModal (and eventually the rest of the kinds of modal) that presents some kind of selectable visual element
- spinner, icon, image 
- and some text.

Implements https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery?node-id=1935-44819&t=pKbR40CZeBMrPLxM-4

Storybook: https://s3-us-west-2.amazonaws.com/opentrons-components/exec-489-add-mixed-content/index.html?path=/docs/app-molecules-interventionmodal-modalcontentmixed--docs

Closes EXEC-489
