### PR TITLE
feat(app): migrate to Public sans in the desktop app

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -29,7 +29,7 @@ export const parameters = {
 export const decorators = [
   Story => (
     <I18nextProvider i18n={i18n}>
-      <GlobalStyle isOnDevice={true} />
+      <GlobalStyle />
       <Story />
     </I18nextProvider>
   ),

--- a/app/src/App/index.tsx
+++ b/app/src/App/index.tsx
@@ -20,7 +20,7 @@ export const App = (): JSX.Element | null => {
   // render null until getIsOnDevice returns the isOnDevice value from config
   return hasConfigLoaded ? (
     <>
-      <GlobalStyle isOnDevice={isOnDevice} />
+      <GlobalStyle />
       <Flex
         position={POSITION_FIXED}
         flexDirection={DIRECTION_ROW}

--- a/app/src/atoms/GlobalStyle/index.ts
+++ b/app/src/atoms/GlobalStyle/index.ts
@@ -15,7 +15,7 @@ export const GlobalStyle = createGlobalStyle<{}>`
     box-sizing: border-box;
     margin: 0;
     padding: 0;
-    font-family: 'Public Sans, DejaVu Sans', sans-serif;
+    font-family: 'Public Sans', 'DejaVu Sans', sans-serif;
   }
 
   html,

--- a/app/src/atoms/GlobalStyle/index.ts
+++ b/app/src/atoms/GlobalStyle/index.ts
@@ -10,15 +10,12 @@ import '@fontsource/public-sans/700.css'
 // needed to display chemical formulae on the liquids page. I've added DejaVu Sans, which
 // does have the glyphs, as a fallback so subscripts will get displayed. Mel and the design
 // team will want to revisit the fonts we use at some point in the future.
-export const GlobalStyle = createGlobalStyle<{ isOnDevice?: boolean }>`
+export const GlobalStyle = createGlobalStyle<{}>`
   * {
     box-sizing: border-box;
     margin: 0;
     padding: 0;
-    font-family: ${props =>
-      props.isOnDevice ?? false
-        ? 'Public Sans, DejaVu Sans'
-        : 'Open Sans'}, sans-serif;
+    font-family: 'Public Sans, DejaVu Sans', sans-serif;
   }
 
   html,


### PR DESCRIPTION
closes RSQ-87 https://opentrons.atlassian.net/browse/RSQ-87

# Overview

Change desktop app font to public sans.

# Test Plan

We should probably smoke test this a bit in the app to makes sure things look ok. I've smoke tested the app and robot settings and the labware tab. 
 
# Changelog

change global styles

# Review requests

see test plan

# Risk assessment

low