### PR TITLE
chore(release): 7.3.1 release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,16 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons Robot Software Changes in 7.3.1
+
+Welcome to the v7.3.1 release of the Opentrons robot software!
+
+### Improved Features
+
+- Updated values for how much a tip overlaps with the pipette nozzle when the pipette picks up tips, in order to make protocols more reliable. These new values only apply to JSON protocols and Python protocols specifying API version 2.19.
+
+---
+
 ## Opentrons Robot Software Changes in 7.3.0
 
 Welcome to the v7.3.0 release of the Opentrons robot software!

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,18 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 ---
 
+## Opentrons App Changes in 7.3.1
+
+Welcome to the v7.3.1 release of the Opentrons App!
+
+There are no changes to the Opentrons App in v7.3.1, but it is required for updating the robot software to improve some features.
+
+### Known Issue
+
+- Robots that have completed a run won't appear as available until you clear the "Run complete" banner on the protocol run screen.
+
+---
+
 ## Opentrons App Changes in 7.3.0
 
 Welcome to the v7.3.0 release of the Opentrons App! This release adds support for Python protocols with runtime parameters, letting you change the behavior of a protocol each time you run it.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -14,7 +14,7 @@ There are no changes to the Opentrons App in v7.3.1, but it is required for upda
 
 ### Known Issue
 
-- Robots that have completed a run won't appear as available until you clear the "Run complete" banner on the protocol run screen.
+- Robots that have completed a run won't appear as available until you clear the run completion notification. This appears as a banner on the protocol run screen in the app, or as a splash screen on the Flex touchscreen.
 
 ---
 


### PR DESCRIPTION

# Overview

Notes for tip overlap in 7.3.1. Also called out the known issue with robots not becoming immediately available after a run.

# Risk assessment

zero