### PR TITLE
fix(app): fix Error Recovery launching when manually cancelling a run

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/ErrorRecoveryFlows.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/ErrorRecoveryFlows.test.tsx
@@ -39,19 +39,19 @@ describe('useErrorRecoveryFlows', () => {
   })
 
   it('should toggle the value of isEREnabled properly when the run status is valid', () => {
-    const { result } = renderHook(() =>
-      useErrorRecoveryFlows('MOCK_ID', RUN_STATUS_AWAITING_RECOVERY)
+    const { result, rerender } = renderHook(
+      runStatus => useErrorRecoveryFlows('MOCK_ID', runStatus),
+      {
+        initialProps: RUN_STATUS_AWAITING_RECOVERY,
+      }
     )
 
     expect(result.current.isERActive).toBe(true)
 
-    const { result: resultStopRequested } = renderHook(() =>
-      useErrorRecoveryFlows('MOCK_ID', RUN_STATUS_STOP_REQUESTED)
-    )
+    rerender(RUN_STATUS_STOP_REQUESTED as any)
 
-    expect(resultStopRequested.current.isERActive).toBe(true)
+    expect(result.current.isERActive).toBe(true)
   })
-
   it('should disable error recovery when runStatus is not a valid ER run status', () => {
     const { result } = renderHook(
       (runStatus: RunStatus) => useErrorRecoveryFlows('MOCK_ID', runStatus),
@@ -69,6 +69,14 @@ describe('useErrorRecoveryFlows', () => {
     )
 
     expect(result.current.failedCommand).toEqual('mockCommand')
+  })
+
+  it(`should return isERActive false if the run status is ${RUN_STATUS_STOP_REQUESTED} before seeing ${RUN_STATUS_AWAITING_RECOVERY}`, () => {
+    const { result } = renderHook(() =>
+      useErrorRecoveryFlows('MOCK_ID', RUN_STATUS_RUNNING)
+    )
+
+    expect(result.current.isERActive).toEqual(false)
   })
 })
 

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -33,10 +33,20 @@ export function useErrorRecoveryFlows(
   runStatus: RunStatus | null
 ): UseErrorRecoveryResult {
   const [isERActive, setIsERActive] = React.useState(false)
+  // If client accesses a valid ER runs status besides AWAITING_RECOVERY but accesses it outside of Error Recovery flows, don't show ER.
+  const [hasSeenAwaitingRecovery, setHasSeenAwaitingRecovery] = React.useState(
+    false
+  )
   const failedCommand = useCurrentlyRecoveringFrom(runId, runStatus)
 
+  if (!hasSeenAwaitingRecovery && runStatus === RUN_STATUS_AWAITING_RECOVERY) {
+    setHasSeenAwaitingRecovery(true)
+  }
+
   const isValidRunStatus =
-    runStatus != null && VALID_ER_RUN_STATUSES.includes(runStatus)
+    runStatus != null &&
+    VALID_ER_RUN_STATUSES.includes(runStatus) &&
+    hasSeenAwaitingRecovery
 
   if (!isERActive && isValidRunStatus) {
     setIsERActive(true)


### PR DESCRIPTION
Closes [EXEC-521](https://opentrons.atlassian.net/browse/EXEC-521)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

When manually cancelling a run, Error Recovery would launch because it recognizes `STOP_REQUESTED` as a valid state to show ER flows (correct behavior). However, we don't want to show error recovery if the FIRST run status seen is `STOP_REQUESTED`. Error Recovery should always see `AWAITING_RECOVERY` before `STOP_REQUESTED`. 

`STOP_REQUESTED` is a valid state to render ER, and we use this when cancelling a run after recovery actions to show special run cancelling components.

I think adding state to the ER hook is the best way to solve this, otherwise we'd have to pass some sort of state for each manual cancel action elsewhere. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run a run with ER FFs enabled, and manually cancel it. The ER splash will no longer appear.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Error Recovery no longer renders when manually cancelling a run.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-521]: https://opentrons.atlassian.net/browse/EXEC-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ