### PR TITLE
feat(scripts): update README to include confirming AWS profile

### DIFF
--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -15,6 +15,8 @@ Before running any of these scripts, the release in question must be tagged and 
 
 **IMPORTANT**: All scripts will do a dryrun by default. **Always** do a dryrun before deploying for real. After you have inspected your dryrun, run the actual deploy by passing the optional `--deploy` flag.
 
+Additionally, the Promote Sandbox to Staging and Staging to Production scripts will prompt you to confirm that you are using the correct AWS profile. Press either `y` to confirm and proceed or `n` to cancel.
+
 ### Cut a new version to sandbox
 
 This process is still manual. Check out the commit you would like to release, and:

--- a/scripts/deploy/README.md
+++ b/scripts/deploy/README.md
@@ -15,7 +15,7 @@ Before running any of these scripts, the release in question must be tagged and 
 
 **IMPORTANT**: All scripts will do a dryrun by default. **Always** do a dryrun before deploying for real. After you have inspected your dryrun, run the actual deploy by passing the optional `--deploy` flag.
 
-Additionally, the Promote Sandbox to Staging and Staging to Production scripts will prompt you to confirm that you are using the correct AWS profile. Press either `y` to confirm and proceed or `n` to cancel.
+Additionally, the `promote-to-staging` and `promote-to-production` scripts will confirm that you are using the correct AWS profile. At the prompt, enter either `y` to confirm and proceed or `n` to cancel.
 
 ### Cut a new version to sandbox
 


### PR DESCRIPTION
closes AUTH-505

# Overview

Figured we should keep the README up to date to include info about how the promote to staging and promote to production scripts now prompt you to confirm if you are using the correct AWS profile.

# Test Plan

proofread my copy. does it make sense?

# Changelog

just add a blurb in the readme

# Review requests

see test plan

# Risk assessment

low