### PR TITLE
feat(shared-data, protocol-designer): fix adapter and aluminum categorization

### DIFF
--- a/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
+++ b/protocol-designer/fixtures/protocol/8/newAdvancedSettingsAndMultiTemp.json
@@ -1510,7 +1510,7 @@
       "brand": { "brand": "Opentrons", "brandId": [] },
       "metadata": {
         "displayName": "Opentrons 96 Well Aluminum Block",
-        "displayCategory": "adapter",
+        "displayCategory": "aluminumBlock",
         "displayVolumeUnits": "µL",
         "tags": []
       },

--- a/shared-data/labware/definitions/2/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep/1.json
@@ -20,7 +20,7 @@
   },
   "metadata": {
     "displayName": "Opentrons 96 Deep Well Heater-Shaker Adapter with NEST Deep Well Plate 2 mL",
-    "displayCategory": "aluminumBlock",
+    "displayCategory": "adapter",
     "displayVolumeUnits": "µL",
     "tags": []
   },

--- a/shared-data/labware/definitions/2/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat/1.json
@@ -20,7 +20,7 @@
   },
   "metadata": {
     "displayName": "Opentrons 96 Flat Bottom Heater-Shaker Adapter with NEST 96 Well Plate 200 µL Flat",
-    "displayCategory": "aluminumBlock",
+    "displayCategory": "adapter",
     "displayVolumeUnits": "µL",
     "tags": []
   },

--- a/shared-data/labware/definitions/2/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt/1.json
@@ -20,7 +20,7 @@
   },
   "metadata": {
     "displayName": "Opentrons 96 PCR Heater-Shaker Adapter with NEST Well Plate 100 µl",
-    "displayCategory": "aluminumBlock",
+    "displayCategory": "adapter",
     "displayVolumeUnits": "µL",
     "tags": []
   },

--- a/shared-data/labware/definitions/2/opentrons_96_well_aluminum_block/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_well_aluminum_block/1.json
@@ -19,7 +19,7 @@
   },
   "metadata": {
     "displayName": "Opentrons 96 Well Aluminum Block",
-    "displayCategory": "adapter",
+    "displayCategory": "aluminum",
     "displayVolumeUnits": "\u00b5L",
     "tags": []
   },

--- a/shared-data/labware/definitions/2/opentrons_96_well_aluminum_block/1.json
+++ b/shared-data/labware/definitions/2/opentrons_96_well_aluminum_block/1.json
@@ -19,7 +19,7 @@
   },
   "metadata": {
     "displayName": "Opentrons 96 Well Aluminum Block",
-    "displayCategory": "aluminum",
+    "displayCategory": "aluminumBlock",
     "displayVolumeUnits": "\u00b5L",
     "tags": []
   },

--- a/shared-data/labware/definitions/2/opentrons_aluminum_flat_bottom_plate/1.json
+++ b/shared-data/labware/definitions/2/opentrons_aluminum_flat_bottom_plate/1.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "displayName": "Opentrons Aluminum Flat Bottom Plate",
-    "displayCategory": "adapter",
+    "displayCategory": "aluminumBlock",
     "displayVolumeUnits": "\u00b5L",
     "tags": []
   },

--- a/shared-data/labware/definitions/2/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json
+++ b/shared-data/labware/definitions/2/opentrons_universal_flat_adapter_corning_384_wellplate_112ul_flat/1.json
@@ -439,7 +439,7 @@
   },
   "metadata": {
     "displayName": "Opentrons Universal Flat Heater-Shaker Adapter with Corning 384 Well Plate 112 µl Flat",
-    "displayCategory": "aluminumBlock",
+    "displayCategory": "adapter",
     "displayVolumeUnits": "µL",
     "tags": []
   },


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->
AUTH-76: Fix categorization of adapters and aluminum blocks in Labware Library

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct
-->
- Verified that the labware definitions are listed correctly under “adapters” in the website LL 
- Verified that the labware definitions are listed correctly under “aluminum” in the website LL 

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->
- Fixed categorization of labware adapter and aluminum blocks
- Updated labware definition category for cypress tests failing issue

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
