### PR TITLE
refactor(protocol-designer): check if adapter through allowedRoles

### DIFF
--- a/protocol-designer/src/components/DeckSetup/index.tsx
+++ b/protocol-designer/src/components/DeckSetup/index.tsx
@@ -237,8 +237,9 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
           moduleOnDeck.slot
         )
 
-        const isAdapter =
-          labwareLoadedOnModule?.def.metadata.displayCategory === 'adapter'
+        const isAdapter = labwareLoadedOnModule?.def.allowedRoles?.includes(
+          'adapter'
+        )
         return (
           <Module
             key={moduleOnDeck.slot}
@@ -383,8 +384,7 @@ export const DeckSetupContents = (props: ContentsProps): JSX.Element => {
           console.warn(`no slot ${labware.slot} for labware ${labware.id}!`)
           return null
         }
-        const labwareIsAdapter =
-          labware.def.metadata.displayCategory === 'adapter'
+        const labwareIsAdapter = labware.def.allowedRoles?.includes('adapter')
         return (
           <React.Fragment key={labware.id}>
             <LabwareOnDeck


### PR DESCRIPTION
closes AUTH-506

# Overview

This is not really a bug (yet) but will be a bug once https://github.com/Opentrons/opentrons/pull/15385 merges in. Basically, we updated the categorizations of some labware by changing the `displayCategory`. This is fine, we just can't rely on the `displayCategory` for cataloging the adapters in PD, instead we need to rely on the `allowedRole`s. This PR fixes that.

# Test Plan

Not much to test here, just check that my logic makes sense!

# Changelog

- update the `deckSetup` component to base the adapter info off of `includedRoles` instead of `displayCategory`

# Review requests

see test plan

# Risk assessment

low
