### PR TITLE
feat(app): Add InterventionInfo: Move component

### DIFF
--- a/app/src/molecules/InterventionModal/InterventionStep/Move.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionStep/Move.stories.tsx
@@ -1,0 +1,89 @@
+import { ICON_DATA_BY_NAME } from '@opentrons/components'
+
+import { Move } from './Move'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof Move> = {
+  title: 'App/Organisms/InterventionModal/InterventionStep/Move',
+  component: Move,
+  argTypes: {
+    type: {
+      control: {
+        type: 'select',
+        options: ['move', 'refill', 'select'],
+      },
+    },
+    labwareName: {
+      control: 'text',
+    },
+    currentLocationProps: {
+      control: {
+        type: 'object',
+      },
+      slotName: {
+        control: 'text',
+      },
+      iconName: {
+        control: {
+          type: 'select',
+          options: Object.keys(ICON_DATA_BY_NAME),
+        },
+      },
+    },
+    newLocationProps: {
+      control: {
+        type: 'object',
+      },
+      slotName: {
+        control: 'text',
+      },
+      iconName: {
+        control: {
+          type: 'select',
+          options: Object.keys(ICON_DATA_BY_NAME),
+        },
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Move>
+
+export const MoveBetweenSlots: Story = {
+  args: {
+    type: 'move',
+    labwareName: 'Plate',
+    currentLocationProps: {
+      slotName: 'A1',
+    },
+    newLocationProps: {
+      slotName: 'B2',
+    },
+  },
+}
+
+export const Refill: Story = {
+  args: {
+    type: 'refill',
+    labwareName: 'Tip Rack',
+    currentLocationProps: {
+      slotName: 'A1',
+    },
+  },
+}
+
+export const Select: Story = {
+  args: {
+    type: 'select',
+    labwareName: 'Well',
+    currentLocationProps: {
+      slotName: 'A1',
+    },
+    newLocationProps: {
+      slotName: 'B1',
+    },
+  },
+}

--- a/app/src/molecules/InterventionModal/InterventionStep/Move.tsx
+++ b/app/src/molecules/InterventionModal/InterventionStep/Move.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+
+import {
+  LocationIcon,
+  Flex,
+  Icon,
+  COLORS,
+  BORDERS,
+  SPACING,
+  DIRECTION_COLUMN,
+  StyledText,
+  ALIGN_CENTER,
+} from '@opentrons/components'
+
+import type { LocationIconProps } from '@opentrons/components'
+
+export interface MoveProps {
+  type: 'move' | 'refill' | 'select'
+  labwareName: string
+  currentLocationProps: LocationIconProps
+  newLocationProps?: LocationIconProps
+}
+
+export function Move(props: MoveProps): JSX.Element {
+  const content = buildContent(props)
+
+  return (
+    <Flex css={CARD_STYLE}>
+      <StyledText as="pBold">{props.labwareName}</StyledText>
+      {content}
+    </Flex>
+  )
+}
+
+const buildContent = (props: MoveProps): JSX.Element => {
+  switch (props.type) {
+    case 'move':
+      return buildMove(props)
+    case 'refill':
+      return buildRefill(props)
+    case 'select':
+      return buildSelect(props)
+  }
+}
+
+const buildMove = (props: MoveProps): JSX.Element => {
+  const { currentLocationProps, newLocationProps } = props
+
+  if (newLocationProps != null) {
+    return (
+      <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
+        <LocationIcon {...currentLocationProps} />
+        <Icon name="arrow-right" css={ICON_STYLE} />
+        <LocationIcon {...newLocationProps} />
+      </Flex>
+    )
+  } else {
+    return buildRefill(props)
+  }
+}
+
+const buildRefill = ({ currentLocationProps }: MoveProps): JSX.Element => {
+  return (
+    <Flex gridGap={SPACING.spacing8}>
+      <LocationIcon {...currentLocationProps} />
+    </Flex>
+  )
+}
+
+const buildSelect = (props: MoveProps): JSX.Element => {
+  const { currentLocationProps, newLocationProps } = props
+
+  if (newLocationProps != null) {
+    return (
+      <Flex gridGap={SPACING.spacing8}>
+        <LocationIcon {...currentLocationProps} />
+        <Icon name="colon" css={ICON_STYLE} />
+        <LocationIcon {...newLocationProps} />
+      </Flex>
+    )
+  } else {
+    return buildRefill(props)
+  }
+}
+
+const ICON_STYLE = css`
+  width: ${SPACING.spacing40};
+  height: ${SPACING.spacing40};
+`
+
+const CARD_STYLE = css`
+  flex-direction: ${DIRECTION_COLUMN};
+  background-color: ${COLORS.grey35};
+  width: 26.75rem;
+  padding: ${SPACING.spacing16};
+  grid-gap: ${SPACING.spacing8};
+  border-radius: ${BORDERS.borderRadius8};
+`

--- a/app/src/molecules/InterventionModal/InterventionStep/index.tsx
+++ b/app/src/molecules/InterventionModal/InterventionStep/index.tsx
@@ -1,0 +1,3 @@
+export { Move } from './Move'
+
+export type { MoveProps } from './Move'

--- a/components/src/molecules/LocationIcon/index.tsx
+++ b/components/src/molecules/LocationIcon/index.tsx
@@ -23,7 +23,7 @@ interface HardwareIconProps extends StyleProps {
 }
 
 // type union requires one of slotName or iconName, but not both
-type LocationIconProps = SlotLocationProps | HardwareIconProps
+export type LocationIconProps = SlotLocationProps | HardwareIconProps
 
 const LOCATION_ICON_STYLE = css<{
   slotName?: string


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds the [Move component](https://www.figma.com/design/OIdG64Q5cgvEw82ish5Eee/Design-System%3A-Flex?node-id=7832-132093&t=f7ZYarjta4m1PmOc-4) to the app. Since this is only used in intervention modals, keeping the InterventionInfo components as a subfolder within InterventionModal makes some sense. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Storybook
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Add the Move component to the app.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
