### PR TITLE
feat(shared-data): add labware repository JSON interface

### DIFF
--- a/shared-data/labware/repository/fixtures/1/exampleLabwareRepository.json
+++ b/shared-data/labware/repository/fixtures/1/exampleLabwareRepository.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+    "name": "Example Labware Repository",
+    "owner": "Opentrons Example App",
+    "lastModifiedDate": "2024-06-11T15:00:00Z"
+  },
+  "123e4567-e89b-12d3-a456-426614174000": {
+    "labwareUri": "http://example.com/labware/123e4567-e89b-12d3-a456-426614174000",
+    "definitionPath": "definitions/labware1.json",
+    "additionalContent": [
+      {
+        "contentMimeType": "image/png",
+        "semanticType": "topViewImage",
+        "contentPath": "images/labware1_top.png"
+      },
+      {
+        "contentMimeType": "image/png",
+        "semanticType": "orthographicViewImage",
+        "contentPath": "images/labware1_ortho.png"
+      }
+    ],
+    "lastEditTimestamp": "2024-06-10T12:00:00Z",
+    "valid": true
+  },
+  "223e4567-e89b-12d3-a456-426614174001": {
+    "labwareUri": "http://example.com/labware/223e4567-e89b-12d3-a456-426614174001",
+    "definitionPath": "definitions/labware2.json",
+    "additionalContent": [
+      {
+        "contentMimeType": "image/jpeg",
+        "semanticType": "longSideViewImage",
+        "contentPath": "images/labware2_long.jpg"
+      },
+      {
+        "contentMimeType": "image/jpeg",
+        "semanticType": "shortSideViewImage",
+        "contentPath": "images/labware2_short.jpg"
+      }
+    ],
+    "lastEditTimestamp": "2024-06-10T13:00:00Z",
+    "valid": false
+  }
+}

--- a/shared-data/labware/repository/schemas/1.json
+++ b/shared-data/labware/repository/schemas/1.json
@@ -2,7 +2,27 @@
   "$id": "opentronsLabwareRepositorySchemaV1",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "format": "This schema defines the labware repository interface. It must be keyed by labware def uri, with values representing each labware's data",
+  "format": "This schema defines the labware repository interface. Labware entries must be keyed by labware def uri, with values representing each labware's data",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of the labware repository"
+        },
+        "owner": {
+          "type": "string",
+          "description": "owner of the labware repository"
+        },
+        "lastModifiedDate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "required": ["name", "owner", "lastModifiedDate"]
+    }
+  },
   "patternProperties": {
     "^[0-9a-fA-F-]{36}$": {
       "type": "object",

--- a/shared-data/labware/repository/schemas/1.json
+++ b/shared-data/labware/repository/schemas/1.json
@@ -1,0 +1,61 @@
+{
+  "$id": "opentronsLabwareRepositorySchemaV1",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "format": "This schema defines an the labware repository interface. It must be keyed by labware def uri, with values representing each labware's data",
+  "patternProperties": {
+    "^[0-9a-fA-F-]{36}$": {
+      "type": "object",
+      "properties": {
+        "labwareDefUri": {
+          "type": "string",
+          "format": "labware definition uri"
+        },
+        "definitionPath": {
+          "type": "string",
+          "description": "a path to the labware definition relative to the index file’s containing directory"
+        },
+        "additionalContent": {
+          "type": "array",
+          "description": "additional metadata for file contents for this labware",
+          "items": {
+            "type": "object",
+            "properties": {
+              "contentMimeType": {
+                "type": "string"
+              },
+              "semanticType": {
+                "type": "string",
+                "enum": [
+                  "orthographicViewImage",
+                  "topViewImage",
+                  "longSideViewImage",
+                  "shortSideViewImage"
+                ]
+              },
+              "contentPath": {
+                "type": "string"
+              }
+            },
+            "required": ["contentMimeType", "semanticType", "contentPath"]
+          }
+        },
+        "lastEditTimestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "valid": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "labwareDefUri",
+        "definitionPath",
+        "additionalContent",
+        "lastEditTimestamp",
+        "valid"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/shared-data/labware/repository/schemas/1.json
+++ b/shared-data/labware/repository/schemas/1.json
@@ -2,7 +2,7 @@
   "$id": "opentronsLabwareRepositorySchemaV1",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "format": "This schema defines an the labware repository interface. It must be keyed by labware def uri, with values representing each labware's data",
+  "format": "This schema defines the labware repository interface. It must be keyed by labware def uri, with values representing each labware's data",
   "patternProperties": {
     "^[0-9a-fA-F-]{36}$": {
       "type": "object",


### PR DESCRIPTION
# Overview

This PR creates a JSON schema for the labware repository interface outlined here: https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/4081647645/Decoupling+Labware+from+Robots#Labware-Repositories

This idea is that this interface will be recognized by the software system as a first class citizen (much like protocols and labware definitions). The next steps:

- The app should recognize and store a protocol's labware repository along side its in app protocol storage
- The robot server should accept a protocol's labware repository and store it along side robot protocol storage


# Changelog

- Add labware repository JSON interface


# Risk assessment

Low