### PR TITLE
fix(protocol-designer): append definitionId to the labwareId in migration

### DIFF
--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Author name",
     "description": "Description here",
     "created": 1560957631666,
-    "lastModified": 1714570455185,
+    "lastModified": 1718200660693,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.1.0",
     "data": {
-      "_internalAppBuildDate": "Wed, 01 May 2024 13:32:34 GMT",
+      "_internalAppBuildDate": "Wed, 12 Jun 2024 13:56:36 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -60,9 +60,9 @@
       "savedStepForms": {
         "__INITIAL_DECK_SETUP_STEP__": {
           "labwareLocationUpdate": {
-            "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul": "1",
-            "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul": "2",
-            "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well": "10"
+            "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1": "1",
+            "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul:opentrons/tipone_96_tiprack_200ul/1": "2",
+            "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1": "10"
           },
           "pipetteLocationUpdate": {
             "c6f45030-92a5-11e9-ac62-1b173f839d9e": "left",
@@ -80,7 +80,7 @@
           "path": "single",
           "aspirate_wells_grouped": false,
           "aspirate_flowRate": 0.6,
-          "aspirate_labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+          "aspirate_labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
           "aspirate_wells": ["A1"],
           "aspirate_wellOrder_first": "t2b",
           "aspirate_wellOrder_second": "l2r",
@@ -91,7 +91,7 @@
           "aspirate_touchTip_checkbox": true,
           "aspirate_touchTip_mmFromBottom": 28.5,
           "dispense_flowRate": null,
-          "dispense_labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+          "dispense_labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
           "dispense_wells": [
             "C6",
             "D6",
@@ -114,7 +114,7 @@
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "1",
           "blowout_checkbox": true,
-          "blowout_location": "9b1c0d01-9d4f-4016-afe6-9e08b46acf5e:trashBin",
+          "blowout_location": "756ef516-7632-4441-901c-31e55bd2816a:trashBin",
           "preWetTip": false,
           "aspirate_airGap_checkbox": false,
           "aspirate_airGap_volume": null,
@@ -126,7 +126,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_delay_mmFromBottom": "0.5",
-          "dropTip_location": "9b1c0d01-9d4f-4016-afe6-9e08b46acf5e:trashBin",
+          "dropTip_location": "756ef516-7632-4441-901c-31e55bd2816a:trashBin",
           "nozzles": null,
           "dispense_x_position": 0,
           "dispense_y_position": 0,
@@ -142,7 +142,7 @@
         "18113c80-92a6-11e9-ac62-1b173f839d9e": {
           "times": 3,
           "changeTip": "always",
-          "labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+          "labware": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
           "mix_wellOrder_first": "t2b",
           "mix_wellOrder_second": "l2r",
           "blowout_checkbox": true,
@@ -159,7 +159,7 @@
           "dispense_delay_seconds": "1",
           "mix_touchTip_checkbox": true,
           "mix_touchTip_mmFromBottom": 30.5,
-          "dropTip_location": "9b1c0d01-9d4f-4016-afe6-9e08b46acf5e:trashBin",
+          "dropTip_location": "756ef516-7632-4441-901c-31e55bd2816a:trashBin",
           "nozzles": null,
           "tipRack": "opentrons/opentrons_96_tiprack_10ul/1",
           "mix_x_position": 0,
@@ -3346,7 +3346,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "f6753216-417b-49fa-88cc-e359adae26f6",
+      "key": "e88d9578-5b27-4b30-8ccc-4e9d20c7fb74",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p10_single",
@@ -3355,7 +3355,7 @@
       }
     },
     {
-      "key": "aeec3001-087f-4074-b098-9dfdb465e008",
+      "key": "78be1f0b-0b34-42d1-9cc1-717827621ef3",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single",
@@ -3364,11 +3364,11 @@
       }
     },
     {
-      "key": "c540d35e-88e1-49da-aa90-5f9cbcd9068f",
+      "key": "17dbaf45-4053-41b4-8383-f1a343f28135",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 10ul (1)",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "loadName": "opentrons_96_tiprack_10ul",
         "namespace": "opentrons",
         "version": 1,
@@ -3376,11 +3376,11 @@
       }
     },
     {
-      "key": "827e73cf-2870-43d6-aa0b-5ac87d8996c4",
+      "key": "145d4b57-d2fa-4e35-9979-30f612b13d87",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 200ul (1)",
-        "labwareId": "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul",
+        "labwareId": "c6f51380-92a5-11e9-ac62-1b173f839d9e:tiprack-200ul:opentrons/tipone_96_tiprack_200ul/1",
         "loadName": "tipone_96_tiprack_200ul",
         "namespace": "opentrons",
         "version": 1,
@@ -3388,11 +3388,11 @@
       }
     },
     {
-      "key": "c519abb5-64ae-4068-bcb7-198e29e865e0",
+      "key": "de11d0ac-5ce7-4501-b8c4-2d252c268870",
       "commandType": "loadLabware",
       "params": {
         "displayName": "96 deep well (1)",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "loadName": "usascientific_96_wellplate_2.4ml_deep",
         "namespace": "opentrons",
         "version": 1,
@@ -3401,7 +3401,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "ae991255-3f64-47be-a541-cbe63e0ef907",
+      "key": "02619748-f892-4748-9596-f821ddff6e15",
       "params": {
         "liquidId": "1",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
@@ -3410,7 +3410,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "1b2418da-a26d-4cb3-9578-17782cf79f1b",
+      "key": "ba462279-0d89-43de-b4e8-f15332750465",
       "params": {
         "liquidId": "0",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
@@ -3425,20 +3425,20 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "3e69c4c9-2255-4043-b548-1b9c410360aa",
+      "key": "a7ecd51d-6e21-4d77-9580-fe882abf925b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "A1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "9ce167a0-b022-45cf-bc14-d3ec56381d9d",
+      "key": "e6cf36cc-4ff7-4238-aa43-a40ccb7220ea",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3449,11 +3449,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "85330ac5-e850-47d3-8089-b38866d4a2d0",
+      "key": "bf5b7fa2-57b4-4460-ac12-789fcbdc3e61",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3464,11 +3464,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1db1dfc0-62db-4d89-9de5-3d2fa230ff07",
+      "key": "8172a3b2-0199-4656-8879-46152f7f4aa7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3479,11 +3479,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "1a39e7f0-8a76-4936-ac5d-114f8c10ae91",
+      "key": "820e89f0-4214-4f76-be18-3cbf6c26a1e0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3494,11 +3494,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "496b2ad5-b4da-4259-be84-8b441d0a4b60",
+      "key": "25de5082-1ab1-48b7-bc4b-58d9f838c6dc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3509,11 +3509,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "93ab5d06-a448-45b3-a276-272edfd91873",
+      "key": "244c8dd7-f5a2-47a7-9fa6-69f719ef30b0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3524,11 +3524,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3d0984ed-5b02-4d38-912e-10c031b55ee0",
+      "key": "7588e50b-ff7e-4c9d-9204-a03641aa16a6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3539,21 +3539,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "4d66aa3a-446e-400f-a24a-ac34accfbc3b",
+      "key": "eb15b3fb-5fc2-4659-a168-0c722e111a7a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "d6f1e7d9-d050-46e0-9403-d7ab6ac26ffb",
+      "key": "24d3bed4-bacf-4bce-9b4c-6b28f7b6fbc5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E8",
         "wellLocation": {
           "origin": "bottom",
@@ -3564,11 +3564,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "10b51ab7-5889-447a-a992-b74734023f81",
+      "key": "9453c37a-a7c3-467b-b28a-b0abff7c9185",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E8",
         "wellLocation": {
           "origin": "bottom",
@@ -3579,11 +3579,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "caa702df-9c41-421a-8c98-76d9d7f95889",
+      "key": "5270cb61-3341-4d1e-abf4-d8f89bb7eb93",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E8",
         "wellLocation": {
           "origin": "bottom",
@@ -3594,11 +3594,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cb96c8d0-5f14-484b-80fc-60753c2c6b14",
+      "key": "452fe139-4c12-4895-970d-87e14d9c0cdf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E8",
         "wellLocation": {
           "origin": "bottom",
@@ -3609,11 +3609,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "a7ddff78-c39b-4fb0-9db6-cdadea58a4e2",
+      "key": "865eba3b-02b6-4ffd-a7c3-b9d464f6536c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E8",
         "wellLocation": {
           "origin": "bottom",
@@ -3624,7 +3624,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "80b7c947-e20f-4331-9b87-2c7bebebfa07",
+      "key": "26fbf52a-36dd-4da6-baf4-53dfaa33b7f1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3633,7 +3633,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "e26b883d-9bb2-49e2-9a26-62626eb04e04",
+      "key": "ebb9f1b0-154a-49ee-bf0c-35e16ac49ac6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3641,17 +3641,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "87a0b1e4-f375-4dee-9597-87f8f15b8c25",
+      "key": "0cead70f-9586-4527-b006-97d02409b795",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E8",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "268d8310-7f0a-4545-a8ed-ef2fb22a3085",
+      "key": "2c6b2309-acda-4207-a921-4da3d5eb6aab",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3661,25 +3661,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "abbc727f-81d6-4b5d-8a52-cd8f966e8fbf",
+      "key": "f32165fb-84ad-4f95-baa6-7fa6798e7d7a",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "292c5f17-65f9-4af7-88fd-33c012df2059",
+      "key": "a9a4a3f9-6324-4277-be01-b94c3d92ea46",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "B1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "1bb202e6-007b-4631-8aa0-5f5211c263fc",
+      "key": "b7c58798-3235-4491-a2b4-cca61d4b08a9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3690,11 +3690,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "cdf0ab85-fdd3-41ab-89f7-5c7b696c48dd",
+      "key": "4bac02bb-146b-493e-b526-347a00a22260",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3705,11 +3705,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b8d9161d-0835-44b3-8223-73fa752a5a5a",
+      "key": "661e7c97-481c-45ff-8af0-29b548ffb130",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3720,11 +3720,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "33c2f20d-6d68-4b63-a812-7f40735bbaaa",
+      "key": "56f5748e-037a-4825-a83f-2eed20c08e26",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3735,11 +3735,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "95d4ac3a-8094-46fc-9c30-275f37701e3f",
+      "key": "915bc54a-619f-4424-8276-5852481b8bb9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3750,11 +3750,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "cef01434-9fa2-48dd-8139-755a0d5f5568",
+      "key": "580214c5-5695-470c-9775-eef55a78b672",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3765,11 +3765,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "67786140-5e0b-4290-a448-925cec83c85c",
+      "key": "8adfcd4d-7560-4f8e-b91d-4dc1460f26de",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3780,21 +3780,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "4f6e1cc6-67be-49ab-814d-d7534a0da726",
+      "key": "cb27cb03-b7fc-4bc8-8595-f2fd3821c1df",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "7b33de85-68cb-4888-8023-8be805f5a77a",
+      "key": "f48d4bdd-27e7-4b93-8adb-36c718bfd5e2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D8",
         "wellLocation": {
           "origin": "bottom",
@@ -3805,11 +3805,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "13c080bb-8e30-41c9-a237-e2591f09ee3c",
+      "key": "335a4684-328e-464a-9ca8-713b45951caa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D8",
         "wellLocation": {
           "origin": "bottom",
@@ -3820,11 +3820,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "61c081de-e44b-4583-b963-89be8985723f",
+      "key": "35daf263-f2eb-4edc-828e-3e6b06a7931d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D8",
         "wellLocation": {
           "origin": "bottom",
@@ -3835,11 +3835,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "63421ac3-10f1-4472-b813-2cce280b2ddc",
+      "key": "6f3c7e87-e0d3-41c8-a681-cd86cd08618b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D8",
         "wellLocation": {
           "origin": "bottom",
@@ -3850,11 +3850,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "56253d18-7874-44ab-83a5-bb39c3c306e8",
+      "key": "a9552e8b-c3cd-44a0-ab47-d9b025d51122",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D8",
         "wellLocation": {
           "origin": "bottom",
@@ -3865,7 +3865,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "f7030e97-02d3-46c0-9275-d53932064855",
+      "key": "42652626-e9b8-4b94-8843-26956bbf38f8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3874,7 +3874,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "1a5179e1-6ec6-4028-9b13-32bae277e68e",
+      "key": "cdded12c-93af-4124-b5be-c1f0c724d08e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3882,17 +3882,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "aa2fa938-b38e-4d92-a4c5-0123131b29a7",
+      "key": "b152f069-2729-4b41-bc62-38c671d85288",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D8",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "c90e2918-1615-4d2a-b7a0-daaa013e2a42",
+      "key": "325c0a62-bf85-4361-ac54-7430538ba83c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3902,25 +3902,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "220b1148-9a8f-4826-b515-6a2e87419f4c",
+      "key": "f01ebf9b-1581-4db9-bd45-e9d08bb860b2",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "001b95fd-fd21-425a-8846-432768900785",
+      "key": "92267aca-3cdb-4f0b-8425-fcdb6a8966a2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "C1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "a1e24a66-7c37-40d8-8415-9ae9ce1107b5",
+      "key": "f4daf3bb-248d-462d-9a8e-35317229c0c8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3931,11 +3931,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "42b2126b-b283-469f-b3f9-dfa2b78c5958",
+      "key": "83a515b5-4656-42c7-be01-418600e15c10",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3946,11 +3946,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b73d2141-34cd-4cd0-828a-6640f6f75ded",
+      "key": "8a3dd70c-130c-4a29-b372-5d2835ca074b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3961,11 +3961,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "ad64a163-5293-4b98-89df-28766993bf09",
+      "key": "8c4040b4-5bf6-4fee-b32f-4af80dd6f0b0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3976,11 +3976,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b514ff83-cd73-41ee-8d08-9862e6989924",
+      "key": "89315eb6-53d2-4e2c-bb62-db2d5e81c3e4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -3991,11 +3991,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "0d5bba7e-ac6a-48a6-82f0-cb46cdc0d5cd",
+      "key": "fe0b9024-c1cc-44b1-a69e-fb093583823e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4006,11 +4006,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c20937ce-e7d3-4f45-9e71-80d6c8439a08",
+      "key": "1b3249e8-db43-429c-94ce-aa62187c75dc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4021,21 +4021,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "ee7d026d-e7fa-4027-8ba8-8ac575ea7ead",
+      "key": "7c38cd21-16bc-4380-8b96-a47c9c8fd865",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "fe445e71-616e-42a1-ac92-3b2dd37ac7f1",
+      "key": "3d1e4994-3152-4f42-987b-cc1d33d8d3bd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C8",
         "wellLocation": {
           "origin": "bottom",
@@ -4046,11 +4046,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4ebe6cc3-442a-4a2c-80ba-9dee24865d15",
+      "key": "06fb34b5-5752-4825-a95b-51458dde1c95",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C8",
         "wellLocation": {
           "origin": "bottom",
@@ -4061,11 +4061,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "092fcbe7-cd36-4077-8ab4-7e7b3ee5e2d2",
+      "key": "9d5e32c3-4128-4d40-b7bb-00be4ee033cb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C8",
         "wellLocation": {
           "origin": "bottom",
@@ -4076,11 +4076,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "27d6abf5-7f62-441c-aab3-fb0d0d68bf3a",
+      "key": "f0e82b14-2d6d-4523-ad25-aeaa7d067d38",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C8",
         "wellLocation": {
           "origin": "bottom",
@@ -4091,11 +4091,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "3acb966b-898d-43bb-a212-f23a9351fb00",
+      "key": "da15debb-d7e8-4970-961a-07c0250d165c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C8",
         "wellLocation": {
           "origin": "bottom",
@@ -4106,7 +4106,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "10f4ee73-f68b-45c9-a2cb-e4826433e952",
+      "key": "8124634c-d4eb-445a-a1e7-f502a2e0cfaa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4115,7 +4115,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "5d40f966-01f9-441e-b16f-05782f0a6921",
+      "key": "b3eecc43-e38f-4239-9302-e26876fd6317",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4123,17 +4123,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "e79182b7-eb3d-4421-b6a5-73e3f7e9df54",
+      "key": "83510de2-2360-4622-b844-b59b148c62bd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C8",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "11dd25c1-64f6-47b3-ba17-1f8d4c85b30f",
+      "key": "f928fd80-0e33-4c3b-ab16-7ae0c679da98",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4143,25 +4143,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c2d99c79-fa4b-448b-ab79-c5ea22d3b5db",
+      "key": "24e85219-6194-4d5e-b07f-5fc73ce20af0",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "70a9d1cf-db05-4510-9219-d0e18e0ceab6",
+      "key": "296c90a4-37ac-48d8-b650-9f7380cb4f98",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "D1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "88a00826-d936-495b-81a0-08b2db4b0cbd",
+      "key": "e3f510c6-25cd-4c75-b62d-42e34488d0c2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4172,11 +4172,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "e62b965a-6150-4857-81a4-83808731bb63",
+      "key": "fbe1fdbd-9daf-4e46-b967-c336dd28e428",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4187,11 +4187,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "dfd3261d-d508-45db-bc07-4b66aab7f4ee",
+      "key": "a390e437-c143-4d01-9cdc-2791a1d7899c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4202,11 +4202,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "fd6702e4-1dc4-42b3-a479-ccd252df34b7",
+      "key": "53ac166f-dabe-4837-a4e9-6dbd4d0840ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4217,11 +4217,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "4a5703bb-d4fd-431f-9c3c-928fd654d667",
+      "key": "792ef436-63de-49d0-9e7e-4deb26bb1e34",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4232,11 +4232,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "cd9e2d71-2f8d-4a3e-beb5-664df5b40ed4",
+      "key": "0d7f5ac2-ad6d-467d-ab48-af6fe3d648c3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4247,11 +4247,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f43a5ddf-41e8-4763-a897-5463be83a450",
+      "key": "1b868534-a0e1-41ea-8968-6ede87d3e652",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4262,21 +4262,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "9a38f25f-8e70-4e48-906f-5ad8549f97a9",
+      "key": "d37b309f-fbbb-45b9-a927-fd375a457c0c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "356a5ed5-4055-434b-925e-dc9d74b86916",
+      "key": "306c1a4d-3968-4a7e-8a55-97b4140abf5e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E7",
         "wellLocation": {
           "origin": "bottom",
@@ -4287,11 +4287,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "83147cc6-40bd-4d31-8d7c-cebc82587da2",
+      "key": "1f500ac1-f752-4011-be0f-bb459b48baba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E7",
         "wellLocation": {
           "origin": "bottom",
@@ -4302,11 +4302,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "e48e7e86-5bcf-411f-85aa-fd880047317d",
+      "key": "6a95b228-c1ce-4fe7-8d51-b458bce32691",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E7",
         "wellLocation": {
           "origin": "bottom",
@@ -4317,11 +4317,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3ed7361d-167a-4624-90e7-be018382c29d",
+      "key": "9a2acde6-7226-4ecb-b2af-7e436252b5a3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E7",
         "wellLocation": {
           "origin": "bottom",
@@ -4332,11 +4332,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "edcad86c-128a-4b11-b3f6-c00af215f751",
+      "key": "cfdd9fa2-ef26-43fa-a6dc-77c0080eae8f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E7",
         "wellLocation": {
           "origin": "bottom",
@@ -4347,7 +4347,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "f524c6b9-a2c8-4e20-8088-ebc799e37701",
+      "key": "27af1b49-c875-44c1-8f38-26936f156a73",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4356,7 +4356,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "017496c5-bfda-45b4-a70d-cae13a05406f",
+      "key": "4e2ebeec-e947-45d8-bfca-51e3229a46ce",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4364,17 +4364,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "88956734-eece-42e3-a7d8-8d759f9de247",
+      "key": "1d2322d1-dc77-4a70-9281-74da343eeddb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E7",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "c5550d27-fdd6-43c9-a876-aa3e50489707",
+      "key": "cd0303a8-2e97-43e4-afb9-f9fbde71b076",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4384,25 +4384,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "9eaf32a8-bdec-434e-a644-22f6bba08a6b",
+      "key": "8cafac21-165c-4a42-b0a1-b843fc3ee535",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ecb5d2d9-7e63-43b0-b8b9-5464c9478ed0",
+      "key": "a2dddae1-bafe-4ca1-9a6a-08c661454e59",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "E1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "09671823-b2bf-4803-8b7f-d21f37e064bb",
+      "key": "54186d69-4388-4f73-b575-6fde65d98b09",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4413,11 +4413,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "05adf9ce-7912-44ec-8639-248408431a8d",
+      "key": "cae9d37e-f4a2-4b4e-a7d3-317ce4bb37d9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4428,11 +4428,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "91630cc1-d209-4c82-ba0d-cc0a16a8b24f",
+      "key": "f9fb7499-a596-46eb-b73e-fbffb48c74a7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4443,11 +4443,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "94f28a06-4afd-4bde-809f-33a6ef4c4479",
+      "key": "4ac882f9-60b7-49a9-8de9-88eb7fb6573e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4458,11 +4458,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cf37f60a-7f87-483d-ae7d-b637273a9f65",
+      "key": "3e4cd5eb-c934-4e6c-9066-36fb6abb4b47",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4473,11 +4473,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "dae3c16b-f335-4f48-8fa0-f7304d986601",
+      "key": "0cf40718-fcbc-4321-8fc0-d50bdbf7435b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4488,11 +4488,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "91698561-8c9a-43a6-be0e-48fc7169be0c",
+      "key": "75a8e440-21e6-467b-8fec-f36eb80b6906",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4503,21 +4503,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "0a0d2b0f-de56-41dd-b69b-901ff5899ac9",
+      "key": "355d5292-3a51-4ea6-aee2-2ec11e60f323",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "8f9ab04c-96e7-4e9d-9a19-5075e18519a6",
+      "key": "bc716cad-839b-4fb3-8dbd-2e53a37db51b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D7",
         "wellLocation": {
           "origin": "bottom",
@@ -4528,11 +4528,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "03610238-537c-4b82-8c6d-fa101cae4631",
+      "key": "f9b4273e-142a-4d67-b990-c18116ab3d39",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D7",
         "wellLocation": {
           "origin": "bottom",
@@ -4543,11 +4543,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "071af969-3818-4807-9fd7-26cd00945ab0",
+      "key": "6f81ba2d-7686-4c1a-9012-166de0fbac8d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D7",
         "wellLocation": {
           "origin": "bottom",
@@ -4558,11 +4558,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "ff423f6d-35ef-4ecd-bf8f-435776a5a3b2",
+      "key": "d0515f57-fa3b-43eb-a577-5fe94d5c95fb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D7",
         "wellLocation": {
           "origin": "bottom",
@@ -4573,11 +4573,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "44d4dacd-8cac-4961-892e-cda32094f127",
+      "key": "49a958e5-b352-4a18-b5dd-b923bd0145da",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D7",
         "wellLocation": {
           "origin": "bottom",
@@ -4588,7 +4588,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "53b1ccc5-7b58-4d48-b8fd-0c6ac738b4d1",
+      "key": "40bd47e2-3bcd-4aa3-93f0-016216c30d0e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4597,7 +4597,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "c812e493-c61f-4719-a31f-ac74b2019c54",
+      "key": "60658693-516f-421f-bede-3e0e18e7eb3b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4605,17 +4605,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "ac2ff63c-9b28-4835-89aa-22d3c1edfca8",
+      "key": "e7bc3896-a92f-4cf0-b48b-a568137bbdf0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D7",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "8f6ec1bb-1f7f-49e7-8830-0881bd980638",
+      "key": "d703ba99-9183-4bd4-96bf-cf58d09c4f95",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4625,25 +4625,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "749b4670-f63f-4377-bae9-57e1115f6756",
+      "key": "7f869579-75ad-4ad4-a2f2-d0ec5114ceea",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "38da00e9-f4aa-4e74-b377-b19d635f62a8",
+      "key": "f9c03886-f7db-4ab2-813f-a7880f1874ee",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "F1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "c8dad345-cf97-45ef-95a5-13ab38df4734",
+      "key": "e4c64a21-4c42-49ac-a74d-2cf4714c46c5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4654,11 +4654,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "b6f8c5d0-1348-4eff-a0e5-e90cd5a0b34b",
+      "key": "b85e9483-9e66-4ca1-ad41-752a5451c59c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4669,11 +4669,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "662d7128-430c-46aa-ab97-348de5ae1b59",
+      "key": "a59e0c7f-b2f9-4b6d-8fb1-6578c1b7f97b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4684,11 +4684,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "08d301f7-b6b8-46f8-983f-3e33e5727c25",
+      "key": "25740cb0-4ee8-4e7d-a6d2-9fe6c22d5113",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4699,11 +4699,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "24bbc121-f08f-42e4-8a4d-37a88bca03c7",
+      "key": "40c841a0-019a-418b-b61d-f02075a913fa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4714,11 +4714,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "9d07468c-42c4-41c9-a67e-3fdeac16fa0b",
+      "key": "3ae40c78-b0da-453b-b97f-7cac04202d92",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4729,11 +4729,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "44cc4edd-ff47-487c-ac33-9815b9af3ae9",
+      "key": "fc69a736-0705-45bc-8edb-8b0987e07f61",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4744,21 +4744,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "5f0a3727-1976-4927-852b-8fee2e8cff77",
+      "key": "58ed0f7a-0aae-439f-9e9d-c8d9c1d401d4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "a69b2c7d-115d-4ffe-ac02-6b65b306411e",
+      "key": "a5bae401-a728-451e-b026-ace6da5ce82e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C7",
         "wellLocation": {
           "origin": "bottom",
@@ -4769,11 +4769,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d8fc74ae-bbef-43b5-afcb-c04c86f98b71",
+      "key": "537c7de1-f8c7-40d8-a3e0-aa82404d0a1f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C7",
         "wellLocation": {
           "origin": "bottom",
@@ -4784,11 +4784,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "4d83b666-8df0-47cb-8cca-5bb9532e21b0",
+      "key": "15f38e4a-205d-4427-b7db-407ffc8c9f9c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C7",
         "wellLocation": {
           "origin": "bottom",
@@ -4799,11 +4799,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "984cc219-9237-49b9-a775-93589e5a66ae",
+      "key": "15761a52-dea8-4e97-b235-aacd16371fe9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C7",
         "wellLocation": {
           "origin": "bottom",
@@ -4814,11 +4814,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "a45e7f3f-64d4-4dc9-aab3-10a6d2c38660",
+      "key": "771329bb-bda2-4b8e-8196-ea429a27bc6f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C7",
         "wellLocation": {
           "origin": "bottom",
@@ -4829,7 +4829,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "e440bc8d-adbd-47c9-b0b9-2432a13f8664",
+      "key": "e1e9a42f-9961-4fae-95a3-11e7b6047931",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4838,7 +4838,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "f78482cb-1663-43ca-ad28-2aa0f9c1e926",
+      "key": "d88d149d-a530-483d-ab44-be0664631d16",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4846,17 +4846,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "f7ef1b94-cceb-4ae8-9a22-65b1a7339438",
+      "key": "fb85c3c9-2aab-4500-ae69-c937f024ab76",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C7",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "50ca2b65-11fe-4b52-bfc6-60efba9a6445",
+      "key": "b61ba036-600f-452f-81d3-4ecea6d31cde",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4866,25 +4866,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "1dc894fa-effa-4b0a-b1a4-50766e1a9454",
+      "key": "c123789f-dded-4855-9776-e4416800daf7",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "2c14e46f-4257-485a-abd9-a6fa88233d08",
+      "key": "9987a819-e186-411a-8418-6fe5ecdd7f31",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "G1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "a75ee83e-f86a-4ba7-8982-1e67573eebc5",
+      "key": "894cd396-9398-41dc-8a7e-974ec4b4426d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4895,11 +4895,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "93d11701-ab94-4693-bd67-2c9a5b8ca905",
+      "key": "54707bad-df03-4e91-84b7-21cc85563db9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4910,11 +4910,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "618e28e9-06d3-40ed-af8c-beebf2b230ed",
+      "key": "43ed7f68-446d-4ee4-a47a-78333639c264",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4925,11 +4925,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "8096ab04-2d76-4c5c-ba8c-c3eb0791ac16",
+      "key": "c3514f4d-36a9-4807-a886-2e50fa5885db",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4940,11 +4940,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d7f16642-48b2-44e8-990c-d152f2e3effd",
+      "key": "a084925d-acff-4919-8fcd-f472dc43037b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4955,11 +4955,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "20c1fb9e-82ff-4329-8e06-bbf3b69312f5",
+      "key": "4e4cfa5d-1a7f-4871-afba-139e29e2f37a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4970,11 +4970,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a7904076-7aa5-4af0-9b33-0b782e4c574b",
+      "key": "8b271083-1396-4b91-af10-2e10ced03f01",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -4985,21 +4985,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "f8314e7a-2934-4f37-87ff-df93adee027c",
+      "key": "af5f0c47-6fe6-47da-adca-c7681e9ec78e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "5261a98e-b9ef-4654-be05-63bd6d625b95",
+      "key": "313d6bb4-11ac-4fc2-a4a0-c390b3568547",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E6",
         "wellLocation": {
           "origin": "bottom",
@@ -5010,11 +5010,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2d7e6164-5ff0-474f-8793-bed55e9268f6",
+      "key": "fd6d7f9d-2482-402a-8a5d-8754dcf9a320",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E6",
         "wellLocation": {
           "origin": "bottom",
@@ -5025,11 +5025,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "b1d778c2-7c4b-4989-9819-4f70959bf690",
+      "key": "59b1015c-e34a-43b3-97d4-cc2d867d0c9b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E6",
         "wellLocation": {
           "origin": "bottom",
@@ -5040,11 +5040,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2da23b46-c32e-45a9-93b4-e6ba54209279",
+      "key": "a3d1acc3-7cf8-4d93-90ec-b9f760ba10ca",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E6",
         "wellLocation": {
           "origin": "bottom",
@@ -5055,11 +5055,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "c0f8e9a6-704d-409e-86c6-cdfece6d75cf",
+      "key": "34e837da-fd19-488b-a0d1-2bec86887a3c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E6",
         "wellLocation": {
           "origin": "bottom",
@@ -5070,7 +5070,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "f9669e2a-89c9-4e89-b11a-792ca9372110",
+      "key": "65563f3e-a480-4d08-a010-72982df7e2bc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5079,7 +5079,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "76f1f9d1-5ed9-4fe9-ac86-e44b8669bcef",
+      "key": "c8c2b730-35c3-4142-9e0c-f7410c1b976d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5087,17 +5087,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "44c1606d-102c-4b0e-9af4-27719c14bf25",
+      "key": "ccba4dc4-b96b-412f-a5b0-1d7bbd37b5bc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "E6",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e8d9bb09-8188-46d1-bb5b-2fe490c85243",
+      "key": "40c2cc9d-515d-4ae3-b934-3228ffe1ba47",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5107,25 +5107,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4e5f18e9-9192-46eb-932f-0dcf604c4649",
+      "key": "0bc5ae55-64af-45f5-b754-41b2a8bc1be4",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "52647b11-c226-4918-80ea-9bac8a02a373",
+      "key": "ef50fbaa-e49a-428f-9f68-5cf2f1f98db6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "H1"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "e3239197-dbe6-4c71-917a-4fd41af8d75d",
+      "key": "1cac337a-22d0-42ed-aa8b-6cc247a30778",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5136,11 +5136,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "01f40e1b-bdd0-4973-b2b8-ee4785ea9c6f",
+      "key": "e996f70f-6e06-45a4-b279-015d3c25a10f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5151,11 +5151,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5be5ae28-4e96-40dc-833c-60ac08044f96",
+      "key": "aaec7655-9dea-4110-803a-692498472521",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5166,11 +5166,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "001da4d7-697d-49b0-9654-8d0bdde1ac93",
+      "key": "91526182-e07c-45c5-ab62-c073886ecc63",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5181,11 +5181,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b4c0188b-ee1f-4859-9856-a7426109c2e3",
+      "key": "46715cd8-6077-45bb-984c-51af91b3957e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5196,11 +5196,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "00de49e0-d834-4458-9e4b-1a01ce5ed2c3",
+      "key": "0226e399-c03c-4b0c-b986-9f1df0209add",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5211,11 +5211,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5522605f-01b7-46a6-8f6a-2b51f0edc8ca",
+      "key": "cd393fc9-085f-422f-bfae-8b0edc80da23",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5226,21 +5226,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "9040c7b6-7714-48b9-94ad-b2d992287dad",
+      "key": "9942ea4e-9184-4690-931a-44afef679d9f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "8d65f1cf-058a-4666-8da5-403be4b98fed",
+      "key": "45f5072a-145c-4a3e-8e5c-eef1fbb26f25",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D6",
         "wellLocation": {
           "origin": "bottom",
@@ -5251,11 +5251,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b710f746-3424-40cb-80a0-c77bcaf03816",
+      "key": "c779b1d9-f37c-4efc-841a-4b6d46bec2ca",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D6",
         "wellLocation": {
           "origin": "bottom",
@@ -5266,11 +5266,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "a91072f7-47c9-4c85-8b43-491dc6d0b0be",
+      "key": "f2a43512-287d-4293-968a-bcd6d257d80a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D6",
         "wellLocation": {
           "origin": "bottom",
@@ -5281,11 +5281,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "6dc84887-b4b4-432c-87d8-92ab8431c127",
+      "key": "c5b2be11-639f-49bf-8d27-8c5b00cb1beb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D6",
         "wellLocation": {
           "origin": "bottom",
@@ -5296,11 +5296,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "b463a520-0c4c-4dbe-b5b9-330a35fcef55",
+      "key": "8d8bbc97-fdb7-4879-9cf3-906861ad3680",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D6",
         "wellLocation": {
           "origin": "bottom",
@@ -5311,7 +5311,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "9ba7bef1-dca0-43fe-b6e1-382a1e2dd958",
+      "key": "181934e7-9559-43c8-a234-b9b69f53ee54",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5320,7 +5320,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "9f279224-1420-4f8f-a2ff-ac959fb45c42",
+      "key": "8621c4b1-c574-4bf0-9ad9-dfde498ec4f9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5328,17 +5328,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "270a207d-7ad2-43bb-8392-11d68bde94ce",
+      "key": "7810ea77-112e-4ebf-8113-3b09df2ffce7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "D6",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ad560eb4-0e24-4801-9a9f-aeaf7f21cb75",
+      "key": "ea1ae0ab-5b10-4ff9-9b73-825896835fdd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5348,25 +5348,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "ebdaf15a-14d8-4527-9dc8-0b1027009ee9",
+      "key": "ab102ce0-c0e8-457e-95a9-7a278f370bb3",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "7ffd9d57-22c6-40ca-85fb-8e0ab86c881a",
+      "key": "ffd53981-4b91-4c75-8e86-403578c8a366",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "A2"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "7115280b-eea5-462f-aa18-815a876a9213",
+      "key": "55b20d0d-7fa3-47b7-ac33-769a31667785",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5377,11 +5377,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "5c04e6ab-5619-47e3-8421-49667b56ebc3",
+      "key": "4fde7d1a-6e00-49b9-b8b6-102652fb8068",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5392,11 +5392,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b065331a-9ce4-45a6-860a-9d8ae5eda44a",
+      "key": "9e77c484-bf33-4a58-82c2-d1684b1da606",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5407,11 +5407,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "2eaa51b7-ade3-43aa-8f84-d6e908d256fa",
+      "key": "cf8941bd-b164-4f86-89de-0a82685a618f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5422,11 +5422,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7af395d3-372b-44c8-89e2-cc7961567036",
+      "key": "d17bf303-1712-4ea1-931c-c00db1088fbe",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5437,11 +5437,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "25d443bc-3925-492d-9341-102d29aa125d",
+      "key": "8a02a18a-ed6e-4e4f-a392-17894b9bae3f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5452,11 +5452,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "30a6ae71-1028-4137-b11f-7bd905b6bd74",
+      "key": "b1d9d0bd-2c1f-42c7-b6f3-a1f6f6314e51",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": {
           "origin": "bottom",
@@ -5467,21 +5467,21 @@
     },
     {
       "commandType": "touchTip",
-      "key": "5d318386-78b3-4b6e-998a-bfd61ce94e29",
+      "key": "cc2eddcd-e96a-4d19-a3fc-d6b9e27f2402",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "A1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
       }
     },
     {
       "commandType": "dispense",
-      "key": "e2019112-8a64-4b03-9812-a0a840a7d035",
+      "key": "97fc8bf9-7e12-4f80-ac62-da65666764a3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C6",
         "wellLocation": {
           "origin": "bottom",
@@ -5492,11 +5492,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "09b49957-6e19-43a1-b402-9c1eed0857d4",
+      "key": "19bbf6b5-23da-411a-88cf-71c545989192",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C6",
         "wellLocation": {
           "origin": "bottom",
@@ -5507,11 +5507,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "5f04a962-0466-4791-a019-4af5217a06f2",
+      "key": "c2286eb2-fc00-4f3a-88cd-c55745f1b5a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C6",
         "wellLocation": {
           "origin": "bottom",
@@ -5522,11 +5522,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b8c78bae-cc23-4415-9f63-fab416b2d674",
+      "key": "a2a3306e-149d-4b70-aadf-97aef4dfecb8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C6",
         "wellLocation": {
           "origin": "bottom",
@@ -5537,11 +5537,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "41c297e4-fa47-487d-9219-f4959d2b3f6a",
+      "key": "a26b75dc-fbc2-45c7-87a3-33a7fe0b8dec",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C6",
         "wellLocation": {
           "origin": "bottom",
@@ -5552,7 +5552,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "23137a5d-6b82-4ecc-9180-f1ebd051f54a",
+      "key": "68d84f24-b345-4d82-92de-df51e81392e6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5561,7 +5561,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "3ec2c77d-bd1e-4aa6-b36f-37757218adee",
+      "key": "fd2ead1b-7aa7-484e-949e-9316b44dbf0c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5569,17 +5569,17 @@
     },
     {
       "commandType": "touchTip",
-      "key": "10638801-4c1c-45d5-a61e-1160a9c4ddca",
+      "key": "d2000644-51ea-4259-b73e-50f4d69b5735",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "C6",
         "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "fcbf438c-40c0-4446-acae-d8f6ccce95e7",
+      "key": "9cdcbf02-6bb4-4e87-908f-b6b61de85343",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5589,25 +5589,25 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "cd3743de-0470-48bb-98f1-4c1cc9f05491",
+      "key": "f13c7e33-55e9-4228-a613-f1e66b5b49af",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "3fce8a1e-1857-4146-8a5d-296a06fa5101",
+      "key": "005a3cf6-8756-4c57-a805-534caa9cd5ed",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
         "wellName": "B2"
       }
     },
     {
       "commandType": "aspirate",
-      "key": "555deb27-6ccf-4f69-a22a-e88693869e01",
+      "key": "5052b45c-ea8b-437f-80db-429f8d276359",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
@@ -5618,11 +5618,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "c720bf94-d982-4989-8d05-5be11f5c56ac",
+      "key": "e22cacfa-1d07-4d3c-93c0-a32f7500d81f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
@@ -5633,11 +5633,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "56079904-e3a0-4c8d-b302-8351c2f23cf9",
+      "key": "e78794bb-a16a-441b-babb-8e31cb2a3685",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
@@ -5648,11 +5648,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "591975c1-bc72-456d-b186-2c5900e8990c",
+      "key": "a4722827-a605-4b8d-8875-e2c368c0d807",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
@@ -5663,11 +5663,11 @@
     },
     {
       "commandType": "aspirate",
-      "key": "44c87d5e-e8c7-414f-abcc-4f7dbab5448b",
+      "key": "218ce3cf-c6a5-441a-998d-d90c679a6737",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
@@ -5678,11 +5678,11 @@
     },
     {
       "commandType": "dispense",
-      "key": "a10a0fa5-b411-4227-b5c0-03bd0f00f1da",
+      "key": "2b873cb7-ae25-4ac3-b435-f603d318831c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": {
           "origin": "bottom",
@@ -5692,29 +5692,35 @@
       }
     },
     {
-      "commandType": "blowout",
-      "key": "d23eab2f-7882-4bed-907e-baf8755ab557",
+      "commandType": "moveToAddressableArea",
+      "key": "4a2e696e-b591-458c-85ef-1e07cd83f289",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
-        "wellName": "A1",
-        "flowRate": 1000,
-        "wellLocation": { "origin": "top", "offset": { "z": 0 } }
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "884876d1-8a0f-48e2-ba59-bd0b6de5aace",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
       }
     },
     {
       "commandType": "touchTip",
-      "key": "916eabaf-7965-4280-b583-043637f47e1c",
+      "key": "72e18358-9e53-49b6-b0db-936546ea0ae7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "wellName": "F1",
         "wellLocation": { "origin": "bottom", "offset": { "z": 30.5 } }
       }
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "f03d51ec-9bd4-4a21-b8da-a0ebbffaaac2",
+      "key": "78d8d81c-4d60-49c5-9fec-6bce14925e57",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5724,12 +5730,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "64a539fe-7de8-4176-9a56-cd0a4201fae9",
+      "key": "18b4cb99-dcbf-4d07-8653-312a0e2a831c",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "waitForDuration",
-      "key": "55faff89-fd16-49ed-ad0b-760f5f359f5e",
+      "key": "31de1fda-2aca-46b2-b1d8-8e1974b4c175",
       "params": { "seconds": 3723, "message": "Delay plz" }
     }
   ],

--- a/protocol-designer/src/load-file/migration/7_0_0.ts
+++ b/protocol-designer/src/load-file/migration/7_0_0.ts
@@ -248,7 +248,7 @@ export const migrateFile = (
     if (!getIsAdapter(labwareId)) {
       const definitionId = labware[labwareId].definitionId
       const labId =
-        labwareId === 'fixedTrash' || labwareId.includes(definitionId)
+        labwareId.includes(definitionId) || labwareId === 'fixedTrash'
           ? labwareId
           : `${labwareId}:${definitionId}`
       acc[labId] = labwareLocationUpdate[labwareId]

--- a/protocol-designer/src/load-file/migration/8_1_0.ts
+++ b/protocol-designer/src/load-file/migration/8_1_0.ts
@@ -148,7 +148,6 @@ export const migrateFile = (
         )
       : []
 
-      console.log(commands)
   return {
     ...appData,
     designerApplication: {

--- a/protocol-designer/src/load-file/migration/8_1_0.ts
+++ b/protocol-designer/src/load-file/migration/8_1_0.ts
@@ -81,6 +81,8 @@ export const migrateFile = (
       const tiprackLoadCommands = loadLabwareCommands.filter(
         command => command.params.loadName === tiprackLoadName
       )
+      const tipRackDefURI = pipetteTiprackAssignments[item.pipette]
+
       const xyKeys =
         item.stepType === 'mix'
           ? { mix_x_position: 0, mix_y_position: 0 }
@@ -90,12 +92,12 @@ export const migrateFile = (
               dispense_x_position: 0,
               dispense_y_position: 0,
             }
-      const matchingTiprackCommand = tiprackLoadCommands.find(
-        command => command.params.labwareId === item.tipRack
+      const matchingTiprackCommand = tiprackLoadCommands.find(command =>
+        command.params.labwareId?.includes(tipRackDefURI)
       )
       if (matchingTiprackCommand == null) {
         console.error(
-          `expected to find a tiprack loadname from tiprack ${item.tipRack} but could not `
+          `expected to find a tiprack loadname from tiprack ${tipRackDefURI} but could not `
         )
       }
       const matchingTiprackURI =
@@ -120,8 +122,6 @@ export const migrateFile = (
       if (item.blowout_checkbox === false) {
         blowoutFlowRate = null
       }
-
-      const tipRackDefURI = pipetteTiprackAssignments[item.pipette]
 
       acc[item.id] = {
         ...item,
@@ -148,6 +148,7 @@ export const migrateFile = (
         )
       : []
 
+      console.log(commands)
   return {
     ...appData,
     designerApplication: {


### PR DESCRIPTION
closes RESC-271

# Overview

This PR addresses 2 bugs in 1. 

The first bug has to do with the 7.0.0 migration file. Lots of the logic relies on the labware id having the `definitionId` appended to the end of the uuid string. This is NOT GREAT but that's how i architectured it so the migration should handle appending it. It does in most cases but somehow missed some cases which are fixed in this PR. So basically the bug is the migration couldn't find certain labwareIds and labware definitions because it was searching via a string that didn't include the `definitionId`. 

The 2nd bug is in the 8.1.0 migration file where to populate the tiprack command, it is incorrectly searching for a tipRack key in the step form which doesn't exist yet? idk how we didn't notice this bug sooner. I guess it doesn't whitescreen but it does require the user to add their tiprack location manually instead of auto-populating upon migrating.

# Test Plan

Upload the attached protocol and see that it migrated correctly. Go to the deck map and see that there are no errors in the steps (NOTE they will have the tuberack warnings but that is fine). Export the protocol. Then, reimport the migrated protocol and see that there are no errors.

[16S Bakterien qPCR 3 Primer 5mL JoLo tubes_V6.json](https://github.com/user-attachments/files/15805665/16S.Bakterien.qPCR.3.Primer.5mL.JoLo.tubes_V6.json)

# Changelog

- make sure each labwareId instance has the definitionid appended to the end of it unless it is the fixed trash
- fix the tiprack bug in the 8.1.0 migration

# Review requests

see test plan

# Risk assessment

low