### PR TITLE
refactor(robot-server): redirect maintenance engine/runner calls via run orchestrator

### DIFF
--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -19,6 +19,7 @@ from ..protocol_engine import (
     StateSummary,
     CommandPointer,
     CommandSlice,
+    DeckType
 )
 from ..protocol_engine.types import (
     PostRunHardwareState,
@@ -329,3 +330,7 @@ class RunOrchestrator:
     def get_robot_type(self) -> RobotType:
         """Get engine robot type."""
         return self._protocol_engine.state_view.config.robot_type
+
+    def get_deck_type(self) -> DeckType:
+        """Get engine deck type."""
+        return self._protocol_engine.state_view.config.deck_type

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -19,7 +19,7 @@ from ..protocol_engine import (
     StateSummary,
     CommandPointer,
     CommandSlice,
-    DeckType
+    DeckType,
 )
 from ..protocol_engine.types import (
     PostRunHardwareState,

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -28,6 +28,7 @@ from opentrons.protocol_engine import (
     CommandSlice,
     CommandPointer,
     Command,
+    CommandCreate,
 )
 
 from opentrons.protocol_engine.types import DeckConfigurationType
@@ -234,3 +235,14 @@ class MaintenanceEngineStore:
     def get_state_summary(self) -> StateSummary:
         """Get protocol run data."""
         return self.run_orchestrator.get_state_summary()
+
+    async def add_command_and_wait_for_interval(
+        self,
+        request: CommandCreate,
+        wait_until_complete: bool = False,
+        timeout: Optional[int] = None,
+    ) -> Command:
+        """Add a new command to execute and wait for it to complete if needed."""
+        return await self.run_orchestrator.add_command_and_wait_for_interval(
+            command=request, wait_until_complete=wait_until_complete, timeout=timeout
+        )

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -25,6 +25,9 @@ from opentrons.protocol_engine import (
     ProtocolEngine,
     StateSummary,
     create_protocol_engine,
+    CommandSlice,
+    CommandPointer,
+    Command,
 )
 
 from opentrons.protocol_engine.types import DeckConfigurationType
@@ -202,3 +205,32 @@ class MaintenanceEngineStore:
         self._run_orchestrator = None
 
         return RunResult(state_summary=run_data, commands=commands, parameters=[])
+
+    def get_command_slice(
+        self,
+        cursor: Optional[int],
+        length: int,
+    ) -> CommandSlice:
+        """Get a slice of run commands.
+
+        Args:
+            cursor: Requested index of first command in the returned slice.
+            length: Length of slice to return.
+        """
+        return self.run_orchestrator.get_command_slice(cursor=cursor, length=length)
+
+    def get_current_command(self) -> Optional[CommandPointer]:
+        """Get the current running command."""
+        return self.run_orchestrator.get_current_command()
+
+    def get_command_recovery_target(self) -> Optional[CommandPointer]:
+        """Get the current error recovery target."""
+        return self.run_orchestrator.get_command_recovery_target()
+
+    def get_command(self, command_id: str) -> Command:
+        """Get a run's command by ID."""
+        return self.run_orchestrator.get_command(command_id=command_id)
+
+    def get_state_summary(self) -> StateSummary:
+        """Get protocol run data."""
+        return self.run_orchestrator.get_state_summary()

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -5,11 +5,23 @@ from datetime import datetime
 from typing import List, Optional, Callable
 
 from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
-from opentrons.protocol_engine.types import PostRunHardwareState
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons.protocol_engine.types import PostRunHardwareState, DeckConfigurationType
+from opentrons.protocol_engine import (
+    Config as ProtocolEngineConfig,
+    DeckType,
+    LabwareOffsetCreate,
+    StateSummary,
+    create_protocol_engine,
+    CommandSlice,
+    CommandPointer,
+    Command,
+    CommandCreate,
+    LabwareOffset,
+)
+from opentrons.protocol_runner import RunResult, RunOrchestrator
 
 from opentrons.config import feature_flags
+
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import (
     EstopState,
@@ -17,22 +29,10 @@ from opentrons.hardware_control.types import (
     EstopStateNotification,
     HardwareEventHandler,
 )
-from opentrons.protocol_runner import LiveRunner, RunResult, RunOrchestrator
-from opentrons.protocol_engine import (
-    Config as ProtocolEngineConfig,
-    DeckType,
-    LabwareOffsetCreate,
-    ProtocolEngine,
-    StateSummary,
-    create_protocol_engine,
-    CommandSlice,
-    CommandPointer,
-    Command,
-    CommandCreate,
-)
 
-from opentrons.protocol_engine.types import DeckConfigurationType
-
+from opentrons_shared_data.robot.dev_types import RobotType, RobotTypeEnum
+from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 _log = logging.getLogger(__name__)
 
@@ -246,3 +246,11 @@ class MaintenanceEngineStore:
         return await self.run_orchestrator.add_command_and_wait_for_interval(
             command=request, wait_until_complete=wait_until_complete, timeout=timeout
         )
+
+    def add_labware_offset(self, request: LabwareOffsetCreate) -> LabwareOffset:
+        """Add a new labware offset to state."""
+        return self.run_orchestrator.add_labware_offset(request)
+
+    def add_labware_definition(self, definition: LabwareDefinition) -> LabwareUri:
+        """Add a new labware definition to state."""
+        return self.run_orchestrator.add_labware_definition(definition)

--- a/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_engine_store.py
@@ -100,6 +100,7 @@ class MaintenanceEngineStore:
     """Factory and in-memory storage for ProtocolEngine."""
 
     _run_orchestrator: Optional[RunOrchestrator] = None
+    _created_at: Optional[datetime] = None
 
     def __init__(
         self,
@@ -137,7 +138,8 @@ class MaintenanceEngineStore:
     @property
     def current_run_created_at(self) -> datetime:
         """Get the run creation datetime."""
-        raise NotImplementedError("run created at not implemented.")
+        assert self._created_at is not None, "Run not yet created."
+        return self._created_at
 
     async def create(
         self,
@@ -183,6 +185,8 @@ class MaintenanceEngineStore:
             run_id=run_id, protocol_engine=engine, hardware_api=self._hardware_api
         )
 
+        self._created_at = created_at
+
         return self._run_orchestrator.get_state_summary()
 
     async def clear(self) -> RunResult:
@@ -204,6 +208,7 @@ class MaintenanceEngineStore:
         run_data = self.run_orchestrator.get_state_summary()
         commands = self.run_orchestrator.get_all_commands()
         self._run_orchestrator = None
+        self._created_at = None
 
         return RunResult(state_summary=run_data, commands=commands, parameters=[])
 

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -178,9 +178,7 @@ class MaintenanceRunDataManager:
         """
         if run_id != self._engine_store.current_run_id:
             raise MaintenanceRunNotFoundError(run_id=run_id)
-        the_slice = self._engine_store.engine.state_view.commands.get_slice(
-            cursor=cursor, length=length
-        )
+        the_slice = self._engine_store.get_command_slice(cursor=cursor, length=length)
         return the_slice
 
     def get_current_command(self, run_id: str) -> Optional[CommandPointer]:
@@ -193,7 +191,7 @@ class MaintenanceRunDataManager:
             run_id: ID of the run.
         """
         if self._engine_store.current_run_id == run_id:
-            return self._engine_store.engine.state_view.commands.get_current()
+            return self._engine_store.get_current_command()
         else:
             # todo(mm, 2024-05-20):
             # For historical runs to behave consistently with the current run,
@@ -209,7 +207,7 @@ class MaintenanceRunDataManager:
             run_id: ID of the run.
         """
         if self._engine_store.current_run_id == run_id:
-            return self._engine_store.engine.state_view.commands.get_recovery_target()
+            return self._engine_store.get_command_recovery_target()
         else:
             # Historical runs can't have any ongoing error recovery.
             return None
@@ -227,7 +225,7 @@ class MaintenanceRunDataManager:
         """
         if run_id != self._engine_store.current_run_id:
             raise MaintenanceRunNotFoundError(run_id=run_id)
-        return self._engine_store.engine.state_view.commands.get(command_id=command_id)
+        return self._engine_store.get_command(command_id=command_id)
 
     def _get_state_summary(self, run_id: str) -> Optional[StateSummary]:
-        return self._engine_store.engine.state_view.get_summary()
+        return self._engine_store.get_state_summary()

--- a/robot-server/robot_server/maintenance_runs/router/labware_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/labware_router.py
@@ -47,7 +47,7 @@ async def add_labware_offset(
         engine_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
-    added_offset = engine_store.engine.add_labware_offset(request_body.data)
+    added_offset = engine_store.add_labware_offset(request_body.data)
     log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
 
     return await PydanticResponse.create(
@@ -84,7 +84,7 @@ async def add_labware_definition(
         engine_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
-    uri = engine_store.engine.add_labware_definition(request_body.data)
+    uri = engine_store.add_labware_definition(request_body.data)
     log.info(f'Added labware definition "{uri}"' f' to run "{run.id}".')
 
     return PydanticResponse(

--- a/robot-server/robot_server/runs/engine_store.py
+++ b/robot-server/robot_server/runs/engine_store.py
@@ -138,7 +138,7 @@ class EngineStore:
 
     @property
     def current_run_id(self) -> Optional[str]:
-        """Get the run identifier associated with the current engine/runner pair."""
+        """Get the run identifier associated with the current engine."""
         return (
             self.run_orchestrator.run_id if self._run_orchestrator is not None else None
         )

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -30,7 +30,7 @@ from robot_server.maintenance_runs.router.commands_router import (
     create_run_command,
     get_run_command,
     get_run_commands,
-    get_current_run_engine_from_url,
+    get_current_run_from_url,
 )
 from robot_server.runs.command_models import (
     RequestModelWithCommandCreate,
@@ -40,22 +40,22 @@ from robot_server.runs.command_models import (
 )
 
 
-async def test_get_current_run_engine_from_url(
+async def test_get_current_run_from_url(
     decoy: Decoy,
     mock_maintenance_engine_store: MaintenanceEngineStore,
 ) -> None:
     """Should get an instance of a maintenance run protocol engine."""
     decoy.when(mock_maintenance_engine_store.current_run_id).then_return("run-id")
 
-    result = await get_current_run_engine_from_url(
+    result = await get_current_run_from_url(
         runId="run-id",
         engine_store=mock_maintenance_engine_store,
     )
 
-    assert result is mock_maintenance_engine_store.engine
+    assert result == "run-id"
 
 
-async def test_get_current_run_engine_from_url_not_current(
+async def test_get_current_run_from_url_not_current(
     decoy: Decoy,
     mock_maintenance_engine_store: MaintenanceEngineStore,
 ) -> None:
@@ -65,7 +65,7 @@ async def test_get_current_run_engine_from_url_not_current(
     )
 
     with pytest.raises(ApiError) as exc_info:
-        await get_current_run_engine_from_url(
+        await get_current_run_from_url(
             runId="run-id",
             engine_store=mock_maintenance_engine_store,
         )
@@ -76,7 +76,7 @@ async def test_get_current_run_engine_from_url_not_current(
 
 async def test_create_run_command(
     decoy: Decoy,
-    mock_protocol_engine: ProtocolEngine,
+    mock_maintenance_engine_store: MaintenanceEngineStore,
 ) -> None:
     """It should add the requested command to the ProtocolEngine and return it."""
     command_request = pe_commands.WaitForResumeCreate(
@@ -91,48 +91,40 @@ async def test_create_run_command(
         params=pe_commands.WaitForResumeParams(message="Hello"),
     )
 
-    def _stub_queued_command_state(*_a: object, **_k: object) -> pe_commands.Command:
-        decoy.when(
-            mock_protocol_engine.state_view.commands.get("command-id")
-        ).then_return(command_once_added)
-        return command_once_added
-
     decoy.when(
-        mock_protocol_engine.add_command(
-            pe_commands.WaitForResumeCreate(
+        await mock_maintenance_engine_store.add_command_and_wait_for_interval(
+            request=pe_commands.WaitForResumeCreate(
                 params=pe_commands.WaitForResumeParams(message="Hello"),
                 intent=pe_commands.CommandIntent.SETUP,
-            )
+            ),
+            wait_until_complete=False,
+            timeout=None,
         )
-    ).then_do(_stub_queued_command_state)
+    ).then_return(command_once_added)
+
+    decoy.when(mock_maintenance_engine_store.get_command("command-id")).then_return(
+        command_once_added
+    )
 
     result = await create_run_command(
         request_body=RequestModelWithCommandCreate(data=command_request),
         waitUntilComplete=False,
-        protocol_engine=mock_protocol_engine,
+        engine_store=mock_maintenance_engine_store,
+        timeout=None,
     )
 
     assert result.content.data == command_once_added
     assert result.status_code == 201
-    decoy.verify(await mock_protocol_engine.wait_for_command("command-id"), times=0)
 
 
 async def test_create_run_command_blocking_completion(
     decoy: Decoy,
-    mock_protocol_engine: ProtocolEngine,
+    mock_maintenance_engine_store: MaintenanceEngineStore,
 ) -> None:
     """It should be able to create a command and wait for it to execute."""
     command_request = pe_commands.WaitForResumeCreate(
         params=pe_commands.WaitForResumeParams(message="Hello"),
         intent=pe_commands.CommandIntent.SETUP,
-    )
-
-    command_once_added = pe_commands.WaitForResume(
-        id="command-id",
-        key="command-key",
-        createdAt=datetime(year=2021, month=1, day=1),
-        status=pe_commands.CommandStatus.QUEUED,
-        params=pe_commands.WaitForResumeParams(message="Hello"),
     )
 
     command_once_completed = pe_commands.WaitForResume(
@@ -144,31 +136,21 @@ async def test_create_run_command_blocking_completion(
         result=pe_commands.WaitForResumeResult(),
     )
 
-    def _stub_queued_command_state(*_a: object, **_k: object) -> pe_commands.Command:
-        decoy.when(
-            mock_protocol_engine.state_view.commands.get("command-id")
-        ).then_return(command_once_added)
+    decoy.when(
+        await mock_maintenance_engine_store.add_command_and_wait_for_interval(
+            request=command_request, wait_until_complete=True, timeout=999
+        )
+    ).then_return(command_once_completed)
 
-        return command_once_added
-
-    def _stub_completed_command_state(*_a: object, **_k: object) -> None:
-        decoy.when(
-            mock_protocol_engine.state_view.commands.get("command-id")
-        ).then_return(command_once_completed)
-
-    decoy.when(mock_protocol_engine.add_command(command_request)).then_do(
-        _stub_queued_command_state
-    )
-
-    decoy.when(await mock_protocol_engine.wait_for_command("command-id")).then_do(
-        _stub_completed_command_state
+    decoy.when(mock_maintenance_engine_store.get_command("command-id")).then_return(
+        command_once_completed
     )
 
     result = await create_run_command(
         request_body=RequestModelWithCommandCreate(data=command_request),
         waitUntilComplete=True,
         timeout=999,
-        protocol_engine=mock_protocol_engine,
+        engine_store=mock_maintenance_engine_store,
     )
 
     assert result.content.data == command_once_completed

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -7,7 +7,6 @@ from decoy import Decoy, matchers
 from opentrons.protocol_engine import (
     CommandSlice,
     CommandPointer,
-    ProtocolEngine,
     commands as pe_commands,
     errors as pe_errors,
 )

--- a/robot-server/tests/maintenance_runs/router/test_labware_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_labware_router.py
@@ -68,7 +68,7 @@ async def test_add_labware_offset(
     )
 
     decoy.when(
-        mock_maintenance_engine_store.engine.add_labware_offset(labware_offset_request)
+        mock_maintenance_engine_store.add_labware_offset(labware_offset_request)
     ).then_return(labware_offset)
 
     result = await add_labware_offset(
@@ -91,7 +91,7 @@ async def test_add_labware_definition(
     uri = pe_types.LabwareUri("some/definition/uri")
 
     decoy.when(
-        mock_maintenance_engine_store.engine.add_labware_definition(labware_definition)
+        mock_maintenance_engine_store.add_labware_definition(labware_definition)
     ).then_return(uri)
 
     result = await add_labware_definition(

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -11,16 +11,14 @@ from opentrons.types import DeckSlotName
 from opentrons.hardware_control import API
 from opentrons.hardware_control.types import EstopStateNotification, EstopState
 from opentrons.protocol_engine import (
-    ProtocolEngine,
     StateSummary,
     types as pe_types,
 )
-from opentrons.protocol_runner import LiveRunner, RunResult
+from opentrons.protocol_runner import RunResult
 
 from robot_server.maintenance_runs.maintenance_engine_store import (
     MaintenanceEngineStore,
     EngineConflictError,
-    NoRunnerEnginePairError,
     handle_estop_event,
     NoRunOrchestrator,
 )

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -22,6 +22,7 @@ from robot_server.maintenance_runs.maintenance_engine_store import (
     EngineConflictError,
     NoRunnerEnginePairError,
     handle_estop_event,
+    NoRunOrchestrator,
 )
 
 
@@ -56,8 +57,7 @@ async def test_create_engine(subject: MaintenanceEngineStore) -> None:
 
     assert subject.current_run_id == "run-id"
     assert isinstance(result, StateSummary)
-    assert isinstance(subject.runner, LiveRunner)
-    assert isinstance(subject.engine, ProtocolEngine)
+    assert subject.run_orchestrator.get_protocol_runner() is None
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
@@ -82,8 +82,8 @@ async def test_create_engine_uses_robot_and_deck_type(
         notify_publishers=mock_notify_publishers,
     )
 
-    assert subject.engine.state_view.config.robot_type == robot_type
-    assert subject.engine.state_view.config.deck_type == deck_type
+    assert subject.run_orchestrator.get_robot_type() == robot_type
+    assert subject.run_orchestrator.get_deck_type() == deck_type
 
 
 async def test_create_engine_with_labware_offsets(
@@ -122,17 +122,14 @@ async def test_clear_engine(subject: MaintenanceEngineStore) -> None:
         created_at=datetime(2023, 5, 1),
         notify_publishers=mock_notify_publishers,
     )
-    await subject.runner.run(deck_configuration=[])
+    await subject.run_orchestrator.run(deck_configuration=[])
     result = await subject.clear()
 
     assert subject.current_run_id is None
     assert isinstance(result, RunResult)
 
-    with pytest.raises(NoRunnerEnginePairError):
-        subject.engine
-
-    with pytest.raises(NoRunnerEnginePairError):
-        subject.runner
+    with pytest.raises(NoRunOrchestrator):
+        subject.run_orchestrator
 
 
 async def test_clear_engine_not_stopped_or_idle(
@@ -145,7 +142,7 @@ async def test_clear_engine_not_stopped_or_idle(
         created_at=datetime(2023, 6, 1),
         notify_publishers=mock_notify_publishers,
     )
-    subject.runner.play()
+    subject.run_orchestrator.play()
 
     with pytest.raises(EngineConflictError):
         await subject.clear()
@@ -159,16 +156,13 @@ async def test_clear_idle_engine(subject: MaintenanceEngineStore) -> None:
         created_at=datetime(2023, 7, 1),
         notify_publishers=mock_notify_publishers,
     )
-    assert subject.engine is not None
-    assert subject.runner is not None
+    assert subject._run_orchestrator is not None
 
     await subject.clear()
 
     # TODO: test engine finish is called
-    with pytest.raises(NoRunnerEnginePairError):
-        subject.engine
-    with pytest.raises(NoRunnerEnginePairError):
-        subject.runner
+    with pytest.raises(NoRunOrchestrator):
+        subject.run_orchestrator
 
 
 async def test_estop_callback(
@@ -187,12 +181,12 @@ async def test_estop_callback(
     decoy.when(engine_store.current_run_id).then_return(None)
     await handle_estop_event(engine_store, disengage_event)
     decoy.verify(
-        engine_store.engine.estop(),
+        engine_store.run_orchestrator.estop(),
         ignore_extra_args=True,
         times=0,
     )
     decoy.verify(
-        await engine_store.engine.finish(),
+        await engine_store.run_orchestrator.finish(),
         ignore_extra_args=True,
         times=0,
     )
@@ -200,7 +194,9 @@ async def test_estop_callback(
     decoy.when(engine_store.current_run_id).then_return("fake-run-id")
     await handle_estop_event(engine_store, engage_event)
     decoy.verify(
-        engine_store.engine.estop(),
-        await engine_store.engine.finish(error=matchers.IsA(EStopActivatedError)),
+        engine_store.run_orchestrator.estop(),
+        await engine_store.run_orchestrator.finish(
+            error=matchers.IsA(EStopActivatedError)
+        ),
         times=1,
     )

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -54,8 +54,15 @@ async def test_create_engine(subject: MaintenanceEngineStore) -> None:
     )
 
     assert subject.current_run_id == "run-id"
+    assert subject.current_run_created_at is not None
     assert isinstance(result, StateSummary)
     assert subject.run_orchestrator.get_protocol_runner() is None
+
+
+def test_run_created_at_raises(subject: MaintenanceEngineStore) -> None:
+    """Should raise that the run has not yet created."""
+    with pytest.raises(AssertionError):
+        subject.current_run_created_at
 
 
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
@@ -124,6 +131,7 @@ async def test_clear_engine(subject: MaintenanceEngineStore) -> None:
     result = await subject.clear()
 
     assert subject.current_run_id is None
+    assert subject._created_at is None
     assert isinstance(result, RunResult)
 
     with pytest.raises(NoRunOrchestrator):

--- a/robot-server/tests/maintenance_runs/test_run_data_manager.py
+++ b/robot-server/tests/maintenance_runs/test_run_data_manager.py
@@ -232,9 +232,9 @@ async def test_get_current_run(
     run_id = "hello world"
 
     decoy.when(mock_maintenance_engine_store.current_run_id).then_return(run_id)
-    decoy.when(
-        mock_maintenance_engine_store.engine.state_view.get_summary()
-    ).then_return(engine_state_summary)
+    decoy.when(mock_maintenance_engine_store.get_state_summary()).then_return(
+        engine_state_summary
+    )
     decoy.when(mock_maintenance_engine_store.current_run_created_at).then_return(
         datetime(2023, 1, 1)
     )
@@ -311,9 +311,9 @@ def test_get_commands_slice_current_run(
         commands=expected_commands_result, cursor=1, total_length=3
     )
     decoy.when(mock_maintenance_engine_store.current_run_id).then_return("run-id")
-    decoy.when(
-        mock_maintenance_engine_store.engine.state_view.commands.get_slice(1, 2)
-    ).then_return(expected_command_slice)
+    decoy.when(mock_maintenance_engine_store.get_command_slice(1, 2)).then_return(
+        expected_command_slice
+    )
 
     result = subject.get_commands_slice("run-id", 1, 2)
 


### PR DESCRIPTION
# Overview

phase 3-> maintenance router `engine_store` and `run_data_manager`.

# Test Plan

- All tavern tests are passing.
- tested with dev server and POSTing commands. 


# Changelog

- Use `RunOrchestrator` instead of using engine/runners in `MaintenanceEngineStore` and `RunDataManager`.

# Risk assessment

low. use `RunOrchestrator` instead of using engine/runners.
