### PR TITLE
fix(api): add runner load error handling to analyze cli

### DIFF
--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -58,7 +58,6 @@ from opentrons_shared_data.errors.exceptions import (
 )
 
 from opentrons.protocols.parse import PythonParseMode
-from opentrons.util.performance_helpers import track_analysis
 
 OutputKind = Literal["json", "human-json"]
 
@@ -238,7 +237,6 @@ class UnexpectedAnalysisError(EnumeratedError):
         )
 
 
-@track_analysis
 async def _do_analyze(protocol_source: ProtocolSource) -> RunResult:
 
     runner = await create_simulating_runner(

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -1,8 +1,5 @@
 """Opentrons analyze CLI."""
-from types import TracebackType
-
 import click
-import traceback
 
 from anyio import run
 from contextlib import contextmanager
@@ -57,7 +54,6 @@ from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.errors.exceptions import (
     EnumeratedError,
     PythonException,
-    GeneralError,
 )
 
 from opentrons.protocols.parse import PythonParseMode
@@ -239,64 +235,6 @@ class RunnerLoadError(EnumeratedError):
             message=message,
             wrapping=[e for e in _convert_exc()],
         )
-
-
-# class ExceptionDuringProtocolLoad(GeneralError):
-#     """This exception wraps an exception that was raised from a protocol
-#     for proper error message formatting by the rpc, since it's only here that
-#     we can properly figure out formatting
-#     """
-#
-#     def __init__(
-#         self,
-#         original_exc: Exception,
-#         original_tb: Optional[TracebackType],
-#         message: str,
-#         line: Optional[int],
-#     ) -> None:
-#         self.original_exc = original_exc
-#         self.original_tb = original_tb
-#         self.line = line
-#         super().__init__(
-#             wrapping=[original_exc],
-#             message=_build_message(
-#                 exception_class_name=self.original_exc.__class__.__name__,
-#                 line_number=self.line,
-#                 message=message,
-#             ),
-#         )
-#
-#     def __str__(self) -> str:
-#         return self.message
-#
-# def _build_message(
-#     exception_class_name: str, line_number: Optional[int], message: str
-# ) -> str:
-#     line_number_part = f" [line {line_number}]" if line_number is not None else ""
-#     return f"{exception_class_name}{line_number_part}: {message}"
-
-
-# def _find_protocol_error(tb, proto_name):
-#     """Return the FrameInfo for the lowest frame in the traceback from the
-#     protocol.
-#     """
-#     tb_info = traceback.extract_tb(tb)
-#     for frame in reversed(tb_info):
-#         if frame.filename == proto_name:
-#             return frame
-#     else:
-#         raise KeyError
-#
-# def _raise_pretty_protocol_error(exception: Exception, filename: str) -> None:
-#     exc_type, exc_value, tb = sys.exc_info()
-#     try:
-#         frame = _find_protocol_error(tb, filename)
-#     except KeyError:
-#         # No pretty names, just raise it
-#         raise exception
-#     raise ExceptionDuringProtocolLoad(
-#         exception, tb, str(exception), frame.lineno
-#     ) from exception
 
 
 @track_analysis

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -379,3 +379,25 @@ def test_unexpected_runner_load_error(
     assert error["detail"] == "name 'call_a_non_existent_func' is not defined"
     assert error["errorCode"] == "4000"
     assert error["errorType"] == "UnexpectedAnalysisError"
+
+
+@pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
+def test_analyze_json_protocol(
+    tmp_path: Path,
+    output: str,
+) -> None:
+    """Test that a json protocol analyzes correctly."""
+    json_file = (
+        Path(__file__).parents[4]
+        / "shared-data"
+        / "protocol"
+        / "fixtures"
+        / "8"
+        / "simpleV8.json"
+    )
+    result = _get_analysis_result([json_file], output)
+
+    assert result.exit_code == 0
+    op = result.json_output
+    assert op is not None
+    assert len(op["commands"]) == 27

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -260,3 +260,53 @@ def test_python_error_line_numbers(
     assert result.json_output is not None
     [error] = result.json_output["errors"]
     assert error["detail"] == expected_detail
+
+
+@pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
+@pytest.mark.parametrize(
+    ("python_protocol_source", "expected_error"),
+    [
+        (
+            textwrap.dedent(
+                # Raises an exception during runner load.
+                """\
+                requirements = {"robotType": "OT-2", "apiLevel": "2.18"}  # line 1
+                                                                          # line 2
+                def add_parameters(parameters):                           # line 3
+                    # No default value specified                          # line 4
+                    parameters.add_bool(                                  # line 5
+                        display_name="Dry Run",
+                        variable_name="dry_run",
+                    )
+                def run(protocol):          
+                    pass
+                """
+            ),
+            "TypeError [line 5]: ParameterContext.add_bool() missing 1 required positional argument: 'default'",
+        ),
+    ],
+)
+def test_run_time_parameter_error(
+    tmp_path: Path,
+    python_protocol_source: str,
+    expected_error: str,
+    output: str,
+) -> None:
+    """Test that the error message due to RTP error is correct.
+
+    Also verify that analysis result contains all static data.
+    """
+    protocol_source_file = tmp_path / "protocol.py"
+    protocol_source_file.write_text(python_protocol_source, encoding="utf-8")
+    result = _get_analysis_result([protocol_source_file], output)
+
+    assert result.exit_code == 0
+
+    assert result.json_output is not None
+    assert "robotType" in result.json_output
+    assert "pipettes" in result.json_output
+    assert "commands" in result.json_output
+    assert "labware" in result.json_output
+    assert "liquids" in result.json_output
+    assert "modules" in result.json_output
+    assert expected_error in result.json_output.get("errors")[0].get("detail")


### PR DESCRIPTION
Closes AUTH-486

# Overview

Fixes the issues caught in #15211 

Previously, RTP validation occurred as part of a simulating runner's run process. This run process executes the protocol inside a separate task, and any errors raised while running the task are wrapped and presented in the 'Rune result" as an analysis error. 

Now that RTP validation is happening as part of the runner load process, we have to handle the error raised in the load process in a similar way as well. This PR adds this missing error handling in `analyze` cli function.

# Test Plan

- [ ] Upload a protocol with incorrect RTP definition and verify that the in-app analysis fails with the correct error and no traceback in the error pop-up window.
- [ ] Verify that the static data of the above protocol- metadata, requirements and files are populated in the failed analysis
- [ ] Verify that any other, non-RTP-related errors raised during the runner load process are handled just like they would have in the previous stable software.

# Review requests

- does this approach make sense? Does it miss any edge cases?

# Risk assessment

Medium. Updates a critical part of in-app analysis, but is a fix and is isolated to error handling of `runner.load` only.
