### PR TITLE
fix(protocol-designer): reset the touchTip checkbox when labware changes

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -30,7 +30,11 @@ const updatePatchOnLabwareChange = (
   const pipetteId = appliedPatch.pipette
   return {
     ...patch,
-    ...getDefaultFields('mix_mmFromBottom', 'mix_touchTip_mmFromBottom'),
+    ...getDefaultFields(
+      'mix_mmFromBottom',
+      'mix_touchTip_mmFromBottom',
+      'mix_touchTip_checkboxƒ'
+    ),
     wells: getDefaultWells({
       labwareId: appliedPatch.labware,
       pipetteId,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -33,7 +33,7 @@ const updatePatchOnLabwareChange = (
     ...getDefaultFields(
       'mix_mmFromBottom',
       'mix_touchTip_mmFromBottom',
-      'mix_touchTip_checkboxƒ'
+      'mix_touchTip_checkbox'
     ),
     wells: getDefaultWells({
       labwareId: appliedPatch.labware,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -1,4 +1,5 @@
 import pick from 'lodash/pick'
+import { getDefaultsForStepType } from '../getDefaultsForStepType'
 import {
   chainPatchUpdaters,
   fieldHasChanged,
@@ -6,7 +7,6 @@ import {
   getDefaultWells,
   getAllWellsFromPrimaryWells,
 } from './utils'
-import { getDefaultsForStepType } from '../getDefaultsForStepType'
 import type {
   LabwareEntities,
   PipetteEntities,

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -192,7 +192,8 @@ const updatePatchOnLabwareChange = (
     ? {
         ...getDefaultFields(
           'aspirate_mmFromBottom',
-          'aspirate_touchTip_mmFromBottom'
+          'aspirate_touchTip_mmFromBottom',
+          'aspirate_touchTip_checkbox'
         ),
         aspirate_wells: getDefaultWells({
           // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette is type ?unknown. Address in #3161
@@ -207,7 +208,8 @@ const updatePatchOnLabwareChange = (
     ? {
         ...getDefaultFields(
           'dispense_mmFromBottom',
-          'dispense_touchTip_mmFromBottom'
+          'dispense_touchTip_mmFromBottom',
+          'dispense_touchTip_checkbox'
         ),
         dispense_wells: getDefaultWells({
           // @ts-expect-error(sa, 2021-6-14): appliedPatch.pipette is type ?unknown. Address in #3161
@@ -218,6 +220,8 @@ const updatePatchOnLabwareChange = (
         }),
       }
     : {}
+
+  console.log('destLabwarePatch', destLabwarePatch)
   return { ...sourceLabwarePatch, ...destLabwarePatch }
 }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -221,7 +221,6 @@ const updatePatchOnLabwareChange = (
       }
     : {}
 
-  console.log('destLabwarePatch', destLabwarePatch)
   return { ...sourceLabwarePatch, ...destLabwarePatch }
 }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/mix.test.ts
@@ -128,6 +128,7 @@ describe('well selection should update', () => {
       wells: ['A1'],
       mix_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_DISPENSE,
       mix_touchTip_mmFromBottom: null,
+      mix_touchTip_checkbox: false,
     })
   })
   it('select labware with multiple wells', () => {
@@ -140,6 +141,7 @@ describe('well selection should update', () => {
       wells: [],
       mix_mmFromBottom: DEFAULT_MM_FROM_BOTTOM_DISPENSE,
       mix_touchTip_mmFromBottom: null,
+      mix_touchTip_checkbox: false,
     })
   })
 })


### PR DESCRIPTION
closes RESC-273

# Overview

This is an interested bug. Basically, a user selected a labware where touch tip is allowed and checked the touch tip box. Then the user changed the labware to one where touch tip is not allowed. The touch tip check box was disabled but not actually de-selected. This resulted in an unwanted erroneous `touchTip` command to be generated in step-generation. 

The fix is not super straightforward though. What I changed here is when the aspirate, dispense, or mix labware changes, the touch tip checkbox field is reset. This fix is fine however if a protocol is already experiencing this error, it will not be automatically fixed upon importing their protocol.

The more involved fix (simply code-wise but has big implications) would be ensuring that a touch tip command is only generated if the touch tip checkbox is selected AND there is a height is selected. But that would mean changing the current behavior of PD which I do not think is a good idea.

# Test Plan

Upload the attached file to protocol designer in production. Navigate to the 15th step in the timeline (which is a transfer step) and open the advanced settings. change the dispense labware to `Amplicon PCR` see that the touch tip field is selected.

Now, upload the same file to protocol designer on this branch, navigate to the timeline, open the 15th step again. Open up the advanced settings and change the dispense labware to `Amplicon PCR` . See that the touch tip field is NOT selected. (this is because the setting has been properly reset).

[16S Metagenomik Amplicon PCR Clean-Up (manuelle beads zugabe) Optimiert_10-06-2024.json](https://github.com/user-attachments/files/15825137/16S.Metagenomik.Amplicon.PCR.Clean-Up.manuelle.beads.zugabe.Optimiert_10-06-2024.json)

# Changelog

- reset both the `moveLiquid` and `mix` forms touch tip checkbox fields if labware changes

# Review requests

see test plan

# Risk assessment

low
