### PR TITLE
feat(app): Render `comment` commands

### DIFF
--- a/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
+++ b/app/src/organisms/CommandText/__tests__/CommandText.test.tsx
@@ -1179,6 +1179,29 @@ describe('CommandText', () => {
     )
     screen.getByText('Pausing protocol')
   })
+  it('renders correct text for comment', () => {
+    renderWithProviders(
+      <CommandText
+        command={{
+          commandType: 'comment',
+          params: { message: 'THIS IS A MESSAGE' },
+          id: 'def456',
+          result: {},
+          status: 'queued',
+          error: null,
+          createdAt: 'fake_timestamp',
+          startedAt: null,
+          completedAt: null,
+        }}
+        commandTextData={mockCommandTextData}
+        robotType={FLEX_ROBOT_TYPE}
+      />,
+      {
+        i18nInstance: i18n,
+      }
+    )
+    screen.getByText('THIS IS A MESSAGE')
+  })
   it('renders correct text for custom command type with legacy command text', () => {
     renderWithProviders(
       <CommandText

--- a/app/src/organisms/CommandText/index.tsx
+++ b/app/src/organisms/CommandText/index.tsx
@@ -353,6 +353,14 @@ export function CommandText(props: Props): JSX.Element | null {
         )
       }
     }
+    case 'comment': {
+      const { message } = command.params
+      return (
+        <StyledText as="p" {...styleProps}>
+          {message}
+        </StyledText>
+      )
+    }
     case 'custom': {
       const { legacyCommandText } = command.params ?? {}
       const sanitizedCommandText =

--- a/app/src/organisms/RunPreview/CommandIcon.tsx
+++ b/app/src/organisms/RunPreview/CommandIcon.tsx
@@ -3,7 +3,10 @@ import { Icon } from '@opentrons/components'
 import type { IconName, StyleProps } from '@opentrons/components'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
-const ICON_BY_COMMAND_TYPE: { [commandType: string]: IconName } = {
+type CommandType = RunTimeCommand['commandType']
+
+const ICON_BY_COMMAND_TYPE: Partial<Record<CommandType, IconName>> = {
+  comment: 'comment',
   delay: 'pause-circle',
   pause: 'pause-circle',
   waitForDuration: 'pause-circle',


### PR DESCRIPTION
# Overview

For historical reasons, Python Protocol API `ProtocolContext.comment("...")`s have always been reported as "legacy" `custom` commands in the analysis engine and HTTP API. #15408 changes some of them to proper Protocol Engine `comment` commands. This updates the frontend to ensure the new proper `comment` commands are rendered properly, because it's never had to do that before.

# Test Plan

Test atop #15408:

* [ ] PAPIv≤2.13 protocols' comments still render properly
* [x] PAPIv≥2.14 protocols' comments still render properly

# Changelog

* Update command text mapping
* Update command icon mapping

# Review requests

None in particular.

# Risk assessment

Low.
