### PR TITLE
feat(labware-library): add alert to stacking offsets section

### DIFF
--- a/labware-library/src/labware-creator/__tests__/StackingOffsets.test.tsx
+++ b/labware-library/src/labware-creator/__tests__/StackingOffsets.test.tsx
@@ -103,4 +103,34 @@ describe('StackingOffsets', () => {
       magneticBlockV1: 0,
     })
   })
+  it('renders the stacking offset alert', () => {
+    vi.mocked(useFormikContext).mockReturnValue({
+      values: {
+        labwareType: 'wellPlate',
+        wellBottomShape: 'v',
+        wellShape: 'circular',
+        labwareXDimension: '10',
+        gridColumns: '12',
+        gridRows: '8',
+        compatibleAdapters: { adapter: 10 },
+        compatibleModules: {},
+      },
+      touched: {
+        labwareType: true,
+        wellBottomShape: true,
+        wellShape: true,
+        labwareXDimension: true,
+        gridColumns: true,
+        gridRows: true,
+        compatibleAdapters: {},
+        compatibleModules: {},
+      },
+      errors: {},
+      setFieldValue: vi.fn(),
+    } as any)
+    render(<StackingOffsets />)
+    screen.getByText(
+      'The stacking offset fields require App version 7.0.0 or higher'
+    )
+  })
 })

--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -16,6 +16,8 @@ import {
   SPACING,
   TYPOGRAPHY,
   StyledText,
+  AlertItem,
+  Box,
 } from '@opentrons/components'
 import { isEveryFieldHidden } from '../../utils'
 import { makeMaskToDecimal } from '../../fieldMasks'
@@ -143,6 +145,22 @@ export function StackingOffsets(): JSX.Element | null {
     <div className={styles.new_definition_section}>
       <SectionBody label={label} id="StackingOffsets">
         <>
+          {Object.values(values.compatibleAdapters).length > 0 ||
+          Object.values(values.compatibleModules).length > 0 ? (
+            <Box
+              marginBottom={
+                errors.compatibleAdapters != null ||
+                errors.compatibleModules != null
+                  ? '0rem'
+                  : '-1rem'
+              }
+            >
+              <AlertItem
+                type="warning"
+                title="The stacking offset fields require App version 7.0.0 or higher"
+              />
+            </Box>
+          ) : null}
           <FormAlerts
             values={values}
             touched={touched}
@@ -221,8 +239,6 @@ export function StackingOffsets(): JSX.Element | null {
                       </Flex>
                       {key === 'opentrons_flex_96_tiprack_adapter' &&
                       isChecked ? (
-                        //  NOTE(jr, 6/7/24): keeping the yucky classname + inline style to match other
-                        //  LC designs
                         <div
                           style={{
                             marginTop: '-1.4rem',


### PR DESCRIPTION
closes AUTH-511

# Overview

This PR adds an alert banner to the stacking offsets section if one of the checkboxes is selected to let users know that App version 7.0.0 or higher is required.

<img width="826" alt="Screenshot 2024-06-13 at 12 58 16" src="https://github.com/Opentrons/opentrons/assets/66035149/c3698f8f-39da-4cba-82fb-336b30a0ab72">

# Test Plan

Go to Labware creator and create a well plate. select 8 rows evenly spaced and 12 columns evenly spaced. Change the well shape to V-bottom. Then you should be able to see the stacking offset section. If you click any checkbox, the alert banner should appear saying app version 7.0.0 or higher is required.

# Changelog

- add alert to `StackingOffsets`
- add test coverage

# Review requests

see test plan 

# Risk assessment

low