### PR TITLE
feat(hardware-testing): Added mount movements to gripper move script

### DIFF
--- a/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
@@ -25,7 +25,7 @@ async def _main() -> None:
     if mount is not OT3Mount.GRIPPER:
         await wait_for_instrument_presence(hw_api, mount, presence=True)
     timeout_start = time.time()
-    timeout = 60 * 60
+    timeout = args.time_min * 60
     count = 0
     x_offset = 80
     y_offset = 44

--- a/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
@@ -16,14 +16,12 @@ from hardware_testing.opentrons_api.helpers_ot3 import (
 )
 
 
-async def _main() -> None:
+async def _main(mount: OT3Mount, args, z_axis: Axis, distance: int) -> None:
     hw_api = await build_async_ot3_hardware_api(
         is_simulating=args.simulate, use_defaults=True
     )
     await asyncio.sleep(1)
     await hw_api.cache_instruments()
-    if mount is not OT3Mount.GRIPPER:
-        await wait_for_instrument_presence(hw_api, mount, presence=True)
     timeout_start = time.time()
     timeout = args.time_min * 60
     count = 0
@@ -57,33 +55,20 @@ async def _main() -> None:
         await hw_api.clean_up()
 
 
-if __name__ == "__main__":
-    slot_locs = [
-        "A1",
-        "A2",
-        "A3",
-        "B1",
-        "B2",
-        "B3:",
-        "C1",
-        "C2",
-        "C3",
-        "D1",
-        "D2",
-        "D3",
-    ]
+def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
-    parser.add_argument("--time_min", default=60)
+    parser.add_argument("--time_min", type = int, default=60)
     parser.add_argument(
-        "--mount", type=str, choices=["left", "right", "gripper"], default="gripper"
+        "--mount", type=str, choices=["left", "right", "gripper"], default="left"
     )
     args = parser.parse_args()
+    print(args.mount)
     if args.mount == "left":
         mount = OT3Mount.LEFT
         z_axis = Axis.Z_L
         distance = 115
-    if args.mount == "gripper":
+    elif args.mount == "gripper":
         mount = OT3Mount.GRIPPER
         z_axis = Axis.Z_G
         distance = 190
@@ -91,4 +76,9 @@ if __name__ == "__main__":
         mount = OT3Mount.RIGHT
         z_axis = Axis.Z_R
         distance = 115
-    asyncio.run(_main())
+    print(f"Mount Testing: {mount}")
+    asyncio.run(_main(mount, args, z_axis, distance))
+    
+if __name__ == "__main__":
+    main()
+

--- a/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
@@ -12,18 +12,19 @@ from hardware_testing.opentrons_api.types import (
 )
 from hardware_testing.opentrons_api.helpers_ot3 import (
     build_async_ot3_hardware_api,
-    wait_for_instrument_presence,
 )
 
 
-async def _main(mount: OT3Mount, args, z_axis: Axis, distance: int) -> None:
+async def _main(
+    mount: OT3Mount, simulate: bool, time_min: int, z_axis: Axis, distance: int
+) -> None:
     hw_api = await build_async_ot3_hardware_api(
-        is_simulating=args.simulate, use_defaults=True
+        is_simulating=simulate, use_defaults=True
     )
     await asyncio.sleep(1)
     await hw_api.cache_instruments()
     timeout_start = time.time()
-    timeout = args.time_min * 60
+    timeout = time_min * 60
     count = 0
     x_offset = 80
     y_offset = 44
@@ -55,7 +56,8 @@ async def _main(mount: OT3Mount, args, z_axis: Axis, distance: int) -> None:
         await hw_api.clean_up()
 
 
-def main():
+def main() -> None:
+    """Run gripper and zmount move commands using arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
     parser.add_argument("--time_min", type=int, default=60)
@@ -77,7 +79,7 @@ def main():
         z_axis = Axis.Z_R
         distance = 115
     print(f"Mount Testing: {mount}")
-    asyncio.run(_main(mount, args, z_axis, distance))
+    asyncio.run(_main(mount, args.simulate, args.time_min, z_axis, distance))
 
 
 if __name__ == "__main__":

--- a/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
+++ b/hardware-testing/hardware_testing/scripts/gripper_and_zmount_move.py
@@ -58,7 +58,7 @@ async def _main(mount: OT3Mount, args, z_axis: Axis, distance: int) -> None:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--simulate", action="store_true")
-    parser.add_argument("--time_min", type = int, default=60)
+    parser.add_argument("--time_min", type=int, default=60)
     parser.add_argument(
         "--mount", type=str, choices=["left", "right", "gripper"], default="left"
     )
@@ -78,7 +78,7 @@ def main():
         distance = 115
     print(f"Mount Testing: {mount}")
     asyncio.run(_main(mount, args, z_axis, distance))
-    
+
+
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Use gripper_and_zmount_move to test Z movements.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- changed z axis to be based off of mount argument
- added check for instruments if pipette is being tested
- made distance it moves down based off of instrument
- changed time function to be an argument
- removed unused arguments (tiprack and trough)
- disengages left and right z mounts if error or end of test.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
