### PR TITLE
chore(api): Ignore AbsorbanceReaderContext errors when building PAPI docs

### DIFF
--- a/api/docs/v2/conf.py
+++ b/api/docs/v2/conf.py
@@ -445,5 +445,6 @@ nitpick_ignore_regex = [
     ("py:class", r".*protocol_api\.config.*"),
     ("py:class", r".*opentrons_shared_data.*"),
     ("py:class", r".*protocol_api._parameters.Parameters.*"),
+    ("py:class", r".*AbsorbanceReaderContext"),  # shh it's a secret (for now)
     ("py:class", r'.*AbstractLabware|APIVersion|LabwareLike|LoadedCoreMap|ModuleTypes|NoneType|OffDeckType|ProtocolCore|WellCore'),  # laundry list of not fully qualified things
 ]


### PR DESCRIPTION
# Overview

This silences this Sphinx warning, which is currently causing the docs build to fail:

> .../api/src/opentrons/protocol_api/protocol_context.py:docstring of opentrons.protocol_api.ProtocolContext.loaded_modules:: WARNING: py:class reference target not found: opentrons.protocol_api.module_contexts.AbsorbanceReaderContext

Sphinx wants to link to `AbsorbanceReaderContext` from the `loaded_modules` return type docs, but it can't because `AbsorbanceReaderContext` is, intentionally for now, excluded from the docs.

# Review requests

Do we need to make a ticket somewhere to undo this later?

# Risk assessment

Low.