### PR TITLE
fix(protocol-designer): add missing prop to getPipetteCapacity usage

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -266,7 +266,8 @@ const getClearedDisposalVolumeFields = (): FormPatch =>
 const clampAspirateAirGapVolume = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities
+  pipetteEntities: PipetteEntities,
+  labwareEntities: LabwareEntities
 ): FormPatch => {
   const patchedAspirateAirgapVolume =
     patch.aspirate_airGap_volume ?? rawForm?.aspirate_airGap_volume
@@ -283,7 +284,8 @@ const clampAspirateAirGapVolume = (
     const minAirGapVolume = 0 // NOTE: a form level warning will occur if the air gap volume is below the pipette min volume
 
     const maxAirGapVolume =
-      getPipetteCapacity(pipetteEntity, tipRack) - minPipetteVolume
+      getPipetteCapacity(pipetteEntity, labwareEntities, tipRack) -
+      minPipetteVolume
     const clampedAirGapVolume = clamp(
       Number(patchedAspirateAirgapVolume),
       minAirGapVolume,
@@ -652,7 +654,12 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch =>
       updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
-      clampAspirateAirGapVolume(chainPatch, rawForm, pipetteEntities),
+      clampAspirateAirGapVolume(
+        chainPatch,
+        rawForm,
+        pipetteEntities,
+        labwareEntities
+      ),
     chainPatch =>
       clampDisposalVolume(
         chainPatch,


### PR DESCRIPTION
closes AUTH-489 and RESC-272

# Overview

this is a copy of this PR https://github.com/Opentrons/opentrons/pull/15360, i'm pretty sure it is causing this escalations error https://opentrons.atlassian.net/browse/RESC-272. The error is when 2 tipracks are selected and the tipracks are on the deck, the pipetting step thinks there is no tiprack on the deck with the default tiprack. there is a work around by changing the tipracks a few times but its an annoying workaround.

# Test Plan

create a flex or ot-2 protocol and add 2 tipracks. Go to the deck map and add a transfer or mix step with the default tip selected. Save the step and see that there is no timeline error.

# Changelog

- add missing prop to util

# Review requests

see test plan

# Risk assessment

low
