### PR TITLE
refactor(app): remove implicit width constraints from WellSelection

### DIFF
--- a/app/src/organisms/QuickTransferFlow/SelectDestWells.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectDestWells.tsx
@@ -140,29 +140,36 @@ export function SelectDestWells(props: SelectDestWellsProps): JSX.Element {
         width="100%"
       >
         {state.destination != null && state.source != null ? (
-          <WellSelection
-            definition={
-              state.destination === 'source' ? state.source : state.destination
-            }
-            deselectWells={(wells: string[]) => {
-              setSelectedWells(prevWells =>
-                without(Object.keys(prevWells), ...wells).reduce(
-                  (acc, well) => {
-                    return { ...acc, [well]: null }
-                  },
-                  {}
-                )
-              )
-            }}
-            selectedPrimaryWells={selectedWells}
-            selectWells={wellGroup => {
-              if (Object.keys(wellGroup).length > 0) {
-                setIsNumberWellsSelectedError(false)
-                setSelectedWells(prevWells => ({ ...prevWells, ...wellGroup }))
+          <Flex width="75%">
+            <WellSelection
+              definition={
+                state.destination === 'source'
+                  ? state.source
+                  : state.destination
               }
-            }}
-            channels={channels}
-          />
+              deselectWells={(wells: string[]) => {
+                setSelectedWells(prevWells =>
+                  without(Object.keys(prevWells), ...wells).reduce(
+                    (acc, well) => {
+                      return { ...acc, [well]: null }
+                    },
+                    {}
+                  )
+                )
+              }}
+              selectedPrimaryWells={selectedWells}
+              selectWells={wellGroup => {
+                if (Object.keys(wellGroup).length > 0) {
+                  setIsNumberWellsSelectedError(false)
+                  setSelectedWells(prevWells => ({
+                    ...prevWells,
+                    ...wellGroup,
+                  }))
+                }
+              }}
+              channels={channels}
+            />
+          </Flex>
         ) : null}
       </Flex>
     </>

--- a/app/src/organisms/QuickTransferFlow/SelectSourceWells.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectSourceWells.tsx
@@ -72,24 +72,26 @@ export function SelectSourceWells(props: SelectSourceWellsProps): JSX.Element {
         width="100%"
       >
         {state.source != null ? (
-          <WellSelection
-            definition={state.source}
-            deselectWells={(wells: string[]) => {
-              setSelectedWells(prevWells =>
-                without(Object.keys(prevWells), ...wells).reduce(
-                  (acc, well) => {
-                    return { ...acc, [well]: null }
-                  },
-                  {}
+          <Flex width="75%">
+            <WellSelection
+              definition={state.source}
+              deselectWells={(wells: string[]) => {
+                setSelectedWells(prevWells =>
+                  without(Object.keys(prevWells), ...wells).reduce(
+                    (acc, well) => {
+                      return { ...acc, [well]: null }
+                    },
+                    {}
+                  )
                 )
-              )
-            }}
-            selectedPrimaryWells={selectedWells}
-            selectWells={wellGroup => {
-              setSelectedWells(prevWells => ({ ...prevWells, ...wellGroup }))
-            }}
-            channels={state.pipette?.channels ?? 1}
-          />
+              }}
+              selectedPrimaryWells={selectedWells}
+              selectWells={wellGroup => {
+                setSelectedWells(prevWells => ({ ...prevWells, ...wellGroup }))
+              }}
+              channels={state.pipette?.channels ?? 1}
+            />
+          </Flex>
         ) : null}
       </Flex>
     </>

--- a/app/src/organisms/WellSelection/SelectionRect.tsx
+++ b/app/src/organisms/WellSelection/SelectionRect.tsx
@@ -113,7 +113,7 @@ export function SelectionRect(props: SelectionRectProps): JSX.Element {
       justifyContent={JUSTIFY_CENTER}
       width="100%"
     >
-      <Flex width="75%">{children}</Flex>
+      {children}
     </Flex>
   )
 }


### PR DESCRIPTION
Closes [EXEC-535](https://opentrons.atlassian.net/browse/EXEC-535)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

`SelectionRect` within `WellSelection` contains a `Flex` with a `width=75%`, which results in the entire `WellSelection` SVG to render at 75% width. This CSS constraint should probably be placed outside of the component itself, as it makes manipulating CSS difficult.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

- Verified Quick Transfer `WellSelection` CSS is consistent after changes.

<img width="896" alt="Screenshot 2024-06-14 at 3 02 44 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/ec83d155-673e-4a08-aa14-4f3dec22f4c9">

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-535]: https://opentrons.atlassian.net/browse/EXEC-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ