### PR TITLE
fix(step-generation): update liquid state 96-channel and reservoir

### DIFF
--- a/step-generation/src/__tests__/forAspirate.test.ts
+++ b/step-generation/src/__tests__/forAspirate.test.ts
@@ -399,4 +399,6 @@ describe('8-channel trough', () => {
   )
 
   it.todo('aspirate from 384 plate starting from B row') // TODO
+
+  it.todo('aspirating from a full 96-channel and a reservoir labware')
 })

--- a/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forAspirate.ts
@@ -23,6 +23,7 @@ export function forAspirate(
   const nozzles = robotState.pipettes[pipetteId].nozzles
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
+  const isReservoir = labwareDef.metadata.displayCategory === 'reservoir'
   const channels = nozzles === COLUMN ? 8 : pipetteSpec.channels
 
   const { allWellsShared, wellsForTips } = getWellsForTips(
@@ -78,6 +79,56 @@ export function forAspirate(
       volume * channels,
       liquidState.labware[labwareId][commonWell]
     ).source
+    return
+  }
+
+  //  all wells in the reservoir are being used in this case but 8 channels per well
+  if (channels === 96 && isReservoir) {
+    //  for each well the 96 channels are aspirating into
+    wellsForTips.forEach(well => {
+      const sourceLiquidState = liquidState.labware[labwareId][well]
+      const isOveraspirate =
+        volume * 8 > getLocationTotalVolume(sourceLiquidState)
+
+      if (isEmpty(sourceLiquidState)) {
+        warnings.push(warningCreators.aspirateFromPristineWell())
+      } else if (isOveraspirate) {
+        warnings.push(warningCreators.aspirateMoreThanWellContents())
+      }
+
+      const volumePerTip = isOveraspirate
+        ? getLocationTotalVolume(sourceLiquidState) / 8
+        : volume
+
+      // all tips get the same amount of the same liquid added to them, from the source well
+      const newLiquidFromWell = splitLiquid(volumePerTip, sourceLiquidState)
+        .dest
+
+      range(channels).forEach(tipIndex => {
+        const pipette = liquidState.pipettes[pipetteId]
+        const indexToString = tipIndex.toString()
+        const tipLiquidState = pipette[indexToString]
+
+        // since volumePerTip is being calculated to avoid splitting unevenly across tips,
+        // AIR needs to be added in here if it's an over-aspiration
+        const nextTipLiquidState = isOveraspirate
+          ? mergeLiquid(tipLiquidState, {
+              ...newLiquidFromWell,
+              [AIR]: {
+                volume: volume - volumePerTip,
+              },
+            })
+          : mergeLiquid(tipLiquidState, newLiquidFromWell)
+
+        pipette[indexToString] = nextTipLiquidState
+      })
+      // Remove liquid from source well
+      liquidState.labware[labwareId][well] = splitLiquid(
+        volumePerTip * 8,
+        liquidState.labware[labwareId][well]
+      ).source
+    })
+
     return
   }
 


### PR DESCRIPTION
closes RESC-278

# Overview

This fixes a gnarly edge case step-generation liquid state bug. basically when the aspirating command was updating the robot state, it didn't account for if you have a pipette aspirating multiple tips from the same well and multiple wells. For example a 96-channel aspirating from a 12 well reservoir (8 channels per reservoir). So the liquid state was not updating properly, showing incorrect liquids on the deck map and incorrect volumes. This PR fixes that

# Test Plan

Upload the attached protocol to PD in production. Click on the final deck state in the timeline and see that the 384 well plate only has some of the wells colored with a liquid (this is incorrect since the transfer was with a 96 channel).

Then upload the attached protocol to PD on this branch. Click on the final dekc state in the timeline and see that the 384 well plate has the correct 96 wells colors with a liquid.

[Nest 15mL reproduce.json](https://github.com/user-attachments/files/15842578/Nest.15mL.reproduce.json)



# Changelog

- add logic for 96 channel + reservoir, it is similar to the logic if you have an 8 channel aspirating from 1 well

# Review requests

see test plan

# Risk assessment

low
