### PR TITLE
refactor(labware-library): increase margin between checkbox and descr…

### DIFF
--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -241,8 +241,8 @@ export function StackingOffsets(): JSX.Element | null {
                       isChecked ? (
                         <div
                           style={{
-                            marginTop: '-1.4rem',
-                            height: '2.2rem',
+                            marginTop: '-1.2rem',
+                            height: '2.0rem',
                             fontSize: '0.75rem',
                           }}
                         >
@@ -261,6 +261,7 @@ export function StackingOffsets(): JSX.Element | null {
               <Flex
                 flexDirection={DIRECTION_COLUMN}
                 marginTop={SPACING.spacing4}
+                gridGap={SPACING.spacing4}
               >
                 <StyledText as="h3" fontWeight={TYPOGRAPHY.fontWeightSemiBold}>
                   Modules
@@ -322,8 +323,8 @@ export function StackingOffsets(): JSX.Element | null {
                       {isChecked ? (
                         <div
                           style={{
-                            marginTop: '-1.4rem',
-                            height: '2.2rem',
+                            marginTop: '-1.2rem',
+                            height: '2.0rem',
                             fontSize: '0.75rem',
                           }}
                         >


### PR DESCRIPTION
…iption

closes AUTH-515


# Overview

Look at the ticket and see that the margin between checkbox and description was really small. This PR increases it a bit and adds a gridGap to the module stacking offset so it matches the adapter stacking offset

<img width="786" alt="Screenshot 2024-06-17 at 13 25 59" src="https://github.com/Opentrons/opentrons/assets/66035149/27cc49ab-167a-4124-89f6-b9e0e566c9d3">

# Test Plan

Open the labware library dev env and navigate to labware creator on the top left navigation. Create a new definition for a well plate. Add 16 for the height, 12 evenly spaced columns and 8 evenly spaced rows, change the well bottom shape to v-bottom. Then you should see 2 adapters and 2 module selections under the Stacking Offsets. Click on a module checkbox and see that the description text has enough top margin

# Changelog

- adjust top margin and add grid gap

# Review requests

see test plan

# Risk assessment

low