### PR TITLE
feat(app): handle empty rtp file

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -1,5 +1,6 @@
 {
   "author": "author",
+  "add_required_csv_file": "Add the required CSV file to continue.",
   "both_mounts": "Both Mounts",
   "choices": "{{count}} choices",
   "choose_robot_to_run": "Choose Robot to Run\n{{protocol_name}}",

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -27,6 +27,7 @@ import {
   StyledText,
   TYPOGRAPHY,
   useTooltip,
+  useHoverTooltip,
 } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 import { sortRuntimeParameters } from '@opentrons/shared-data'
@@ -85,6 +86,7 @@ export function ChooseProtocolSlideoutComponent(
   const history = useHistory()
   const logger = useLogger(new URL('', import.meta.url).pathname)
   const [targetProps, tooltipProps] = useTooltip()
+  const [targetPropsHover, tooltipPropsHover] = useHoverTooltip()
   const [
     showRestoreValuesTooltip,
     setShowRestoreValuesTooltip,
@@ -103,6 +105,11 @@ export function ChooseProtocolSlideoutComponent(
   ] = React.useState<RunTimeParameter[]>([])
   const [currentPage, setCurrentPage] = React.useState<number>(1)
   const [hasParamError, setHasParamError] = React.useState<boolean>(false)
+  const [hasMissingFileParam, setHasMissingFileParam] = React.useState<boolean>(
+    runTimeParametersOverrides?.some(
+      parameter => parameter.type === 'csv_file'
+    ) ?? false
+  )
   const [isInputFocused, setIsInputFocused] = React.useState<boolean>(false)
   const enableCsvFile = useFeatureFlag('enableCsvFile')
 
@@ -113,6 +120,12 @@ export function ChooseProtocolSlideoutComponent(
   }, [selectedProtocol])
   React.useEffect(() => {
     setHasParamError(errors.length > 0)
+    setHasMissingFileParam(
+      runTimeParametersOverrides.some(
+        parameter =>
+          parameter.type === 'csv_file' && parameter.file?.file == null
+      )
+    )
   }, [runTimeParametersOverrides])
 
   const runTimeParametersFromAnalysis =
@@ -194,7 +207,7 @@ export function ChooseProtocolSlideoutComponent(
   const isRestoreDefaultsLinkEnabled =
     runTimeParametersOverrides?.some(parameter =>
       parameter.type === 'csv_file'
-        ? true
+        ? parameter.file != null
         : parameter.value !== parameter.default
     ) ?? false
 
@@ -369,7 +382,7 @@ export function ChooseProtocolSlideoutComponent(
               const error =
                 runtimeParam.file?.file?.type === 'text/csv'
                   ? null
-                  : t('protocol_details:file_must_be_csv')
+                  : t('protocol_details:csv_file_type_required')
               if (error != null) {
                 errors.push(error)
               }
@@ -541,6 +554,7 @@ export function ChooseProtocolSlideoutComponent(
           width="49%"
           onClick={handleProceed}
           disabled={hasParamError}
+          {...targetPropsHover}
         >
           {isCreatingRun ? (
             <Icon name="ot-spinner" spin size="1rem" />
@@ -548,6 +562,11 @@ export function ChooseProtocolSlideoutComponent(
             t('shared:confirm_values')
           )}
         </PrimaryButton>
+        {hasMissingFileParam ? (
+          <Tooltip tooltipProps={tooltipPropsHover}>
+            {t('protocol_details:add_required_csv_file')}
+          </Tooltip>
+        ) : null}
       </Flex>
     )
 

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -123,6 +123,7 @@ interface ChooseRobotSlideoutProps
   multiSlideout?: { currentPage: number } | null
   setHasParamError?: (isError: boolean) => void
   resetRunTimeParameters?: () => void
+  setHasMissingFileParam?: (isMissing: boolean) => void
 }
 
 export function ChooseRobotSlideout(
@@ -150,6 +151,7 @@ export function ChooseRobotSlideout(
     setRunTimeParametersOverrides,
     setHasParamError,
     resetRunTimeParameters,
+    setHasMissingFileParam,
   } = props
   const enableCsvFile = useFeatureFlag('enableCsvFile')
 
@@ -520,6 +522,9 @@ export function ChooseRobotSlideout(
                 </Flex>
               )
             } else if (runtimeParam.type === 'csv_file') {
+              if (runtimeParam.file?.file != null) {
+                setHasMissingFileParam?.(false)
+              }
               const error =
                 runtimeParam.file?.file?.type === 'text/csv'
                   ? null

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { vi, it, describe, expect, beforeEach, afterEach } from 'vitest'
 import { StaticRouter } from 'react-router-dom'
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { when } from 'vitest-when'
 
 import { renderWithProviders } from '../../../__testing-utils__'
@@ -427,7 +427,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     )
   })
 
-  it('Disables confirm values button if file parameter missing', () => {
+  it('Disables confirm values button if file parameter missing', async () => {
     vi.mocked(useOffsetCandidatesForAnalysis).mockReturnValue([])
     render({
       storedProtocolData: storedProtocolDataWithCsvRunTimeParameter,
@@ -439,10 +439,9 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     })
     fireEvent.click(proceedButton)
     const confirm = screen.getByRole('button', { name: 'Confirm values' })
-    fireEvent.mouseOver(confirm)
-    setTimeout(
-      () => screen.getByText('Add the required CSV file to continue.'),
-      200 // for tooltip to show up
+    fireEvent.pointerEnter(confirm)
+    await waitFor(() =>
+      screen.getByText('Add the required CSV file to continue.')
     )
   })
 })

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -441,7 +441,7 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     const confirm = screen.getByRole('button', { name: 'Confirm values' })
     fireEvent.pointerEnter(confirm)
     await waitFor(() =>
-      screen.getByText('Add the required CSV file to continue.')
+      screen.findByText('Add the required CSV file to continue.')
     )
   })
 })

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/__tests__/ChooseRobotToRunProtocolSlideout.test.tsx
@@ -27,7 +27,10 @@ import {
   mockUnreachableRobot,
 } from '../../../redux/discovery/__fixtures__'
 import { getNetworkInterfaces } from '../../../redux/networking'
-import { storedProtocolData as storedProtocolDataFixture } from '../../../redux/protocol-storage/__fixtures__'
+import {
+  storedProtocolData as storedProtocolDataFixture,
+  storedProtocolDataWithCsvRunTimeParameter,
+} from '../../../redux/protocol-storage/__fixtures__'
 import { useCreateRunFromProtocol } from '../useCreateRunFromProtocol'
 import { useOffsetCandidatesForAnalysis } from '../../ApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { ChooseRobotToRunProtocolSlideout } from '../'
@@ -122,6 +125,12 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     when(vi.mocked(useOffsetCandidatesForAnalysis))
       .calledWith(
         storedProtocolDataFixture.mostRecentAnalysis,
+        expect.any(String)
+      )
+      .thenReturn([])
+    when(vi.mocked(useOffsetCandidatesForAnalysis))
+      .calledWith(
+        storedProtocolDataWithCsvRunTimeParameter.mostRecentAnalysis,
         expect.any(String)
       )
       .thenReturn([])
@@ -415,6 +424,25 @@ describe('ChooseRobotToRunProtocolSlideout', () => {
     fireEvent.click(learnMoreLink)
     screen.getByText(
       'Labware offset data references previous protocol run labware locations to save you time. If all the labware in this protocol have been checked in previous runs, that data will be applied to this run.'
+    )
+  })
+
+  it('Disables confirm values button if file parameter missing', () => {
+    vi.mocked(useOffsetCandidatesForAnalysis).mockReturnValue([])
+    render({
+      storedProtocolData: storedProtocolDataWithCsvRunTimeParameter,
+      onCloseClick: vi.fn(),
+      showSlideout: true,
+    })
+    const proceedButton = screen.getByRole('button', {
+      name: 'Continue to parameters',
+    })
+    fireEvent.click(proceedButton)
+    const confirm = screen.getByRole('button', { name: 'Confirm values' })
+    fireEvent.mouseOver(confirm)
+    setTimeout(
+      () => screen.getByText('Add the required CSV file to continue.'),
+      200 // for tooltip to show up
     )
   })
 })

--- a/app/src/redux/protocol-storage/__fixtures__/index.ts
+++ b/app/src/redux/protocol-storage/__fixtures__/index.ts
@@ -11,6 +11,26 @@ export const storedProtocolData: StoredProtocolData = {
   modified: 123456789,
 }
 
+export const storedProtocolDataWithCsvRunTimeParameter: StoredProtocolData = {
+  protocolKey: 'protocolKeyStub',
+  mostRecentAnalysis: ({
+    ...simpleAnalysisFileFixture,
+    runTimeParameters: [
+      ...simpleAnalysisFileFixture.runTimeParameters,
+      {
+        displayName: 'mock csv rtp',
+        variable_name: 'my_csv_param',
+        description: '',
+        type: 'csv_file',
+        file: null,
+      },
+    ],
+  } as any) as ProtocolAnalysisOutput,
+  srcFileNames: ['fakeSrcFileName'],
+  srcFiles: ['fakeSrcFile' as any],
+  modified: 123456789,
+}
+
 export const storedProtocolDataWithoutRunTimeParameters: StoredProtocolData = {
   protocolKey: 'protocolKeyStub',
   mostRecentAnalysis: ({


### PR DESCRIPTION
# Overview

update protocol run slideouts to disable value confirmation if no file uploaded

# Test Plan
<img width="329" alt="Screenshot 2024-06-17 at 2 19 24 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/0ddbac48-1321-453d-b5d0-1579194b2ed9">

### setup from protocol
- select a CSV RTP protocol and begin setup on desktop
- select a robot and "proceed to parameters"
- verify that when the CSV file parameter is empty (upload input renders), "confirm values" is disabled and hovering produces "Add the required CSV file to continue." tooltip

### setup from device
- select a robot and "run a protocol" from device overflow menu
- select a CSV RTP protocol and "proceed to parameters"
- verify that when the CSV file parameter is empty (upload input renders), "confirm values" is disabled and hovering produces "Add the required CSV file to continue." tooltip

# Changelog

- add tooltip to ChooseProtocolSlideout and ChooseRobotToRunProtocolSlideout footers' "Confirm values" button when disabled due to a missing CSV file parameter value
- add translation keys
- update tests

# Review requests

auth js

# Risk assessment

low