### PR TITLE
refactor(app,shared-data): add useRunningStepCounts hook

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis.ts
@@ -8,6 +8,7 @@ import { useNotifyRunQuery } from '../../resources/runs'
 
 import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
 
+// TODO(jh, 06-17-24): This is used elsewhere in the app and should probably live in something like resources.
 export function useMostRecentCompletedAnalysis(
   runId: string | null
 ): CompletedProtocolAnalysis | null {

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -45,7 +45,7 @@ import {
   useNotifyAllCommandsQuery,
 } from '../../resources/runs'
 import { getCommandTextData } from '../../molecules/Command/utils/getCommandTextData'
-import { useRunningStepCounts } from '../../resources/protocols/hooks/useRunningStepCounts'
+import { useRunningStepCounts } from '../../resources/protocols/hooks'
 
 import type { RunStatus } from '@opentrons/api-client'
 

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
+
 import {
   ALIGN_CENTER,
   BORDERS,
@@ -18,6 +19,7 @@ import {
   TYPOGRAPHY,
   useHoverTooltip,
 } from '@opentrons/components'
+import { useCommandQuery } from '@opentrons/react-api-client'
 import {
   RUN_STATUS_IDLE,
   RUN_STATUS_STOPPED,
@@ -27,7 +29,6 @@ import {
   RUN_STATUS_RUNNING,
   RUN_STATUS_BLOCKED_BY_OPEN_DOOR,
 } from '@opentrons/api-client'
-import { useCommandQuery } from '@opentrons/react-api-client'
 
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { getTopPortalEl } from '../../App/portal'
@@ -44,6 +45,7 @@ import {
   useNotifyAllCommandsQuery,
 } from '../../resources/runs'
 import { getCommandTextData } from '../../molecules/Command/utils/getCommandTextData'
+import { useRunningStepCounts } from '../../resources/protocols/hooks/useRunningStepCounts'
 
 import type { RunStatus } from '@opentrons/api-client'
 
@@ -74,14 +76,26 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   })
   const { data: runRecord } = useNotifyRunQuery(runId)
   const runData = runRecord?.data ?? null
-  const analysis = useMostRecentCompletedAnalysis(runId)
-  const { data: allCommandsQueryData } = useNotifyAllCommandsQuery(runId, {
+
+  const { data: mostRecentCommandData } = useNotifyAllCommandsQuery(runId, {
     cursor: null,
     pageLength: 1,
   })
+  // This lastRunCommand also includes "fixit" commands.
+  const lastRunCommand = mostRecentCommandData?.data[0] ?? null
+  const { data: runCommandDetails } = useCommandQuery(
+    runId,
+    lastRunCommand?.id ?? null
+  )
+
+  const analysis = useMostRecentCompletedAnalysis(runId)
   const analysisCommands = analysis?.commands ?? []
-  const lastRunCommand = allCommandsQueryData?.data[0] ?? null
-  const runCommandsLength = allCommandsQueryData?.meta.totalLength
+
+  const {
+    currentStepNumber,
+    totalStepCount,
+    isDeterministicRun,
+  } = useRunningStepCounts(runId, mostRecentCommandData)
 
   const downloadIsDisabled =
     runStatus === RUN_STATUS_RUNNING ||
@@ -90,41 +104,10 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
 
   const { downloadRunLog } = useDownloadRunLog(robotName, runId)
 
-  /**
-   * find the index of the analysis command within the analysis
-   * that has the same commandKey as the most recent
-   * command from the run record.
-   * Or in the case of a non-deterministic protocol
-   * source from the run rather than the analysis
-   * NOTE: the most recent
-   * command may not always be "current", for instance if
-   * the run has completed/failed */
-  const lastRunAnalysisCommandIndex =
-    analysisCommands.findIndex(c => c.key === lastRunCommand?.key) ?? 0
-  const { data: runCommandDetails } = useCommandQuery(
-    runId,
-    lastRunCommand?.id ?? null
-  )
-  let countOfTotalText = ''
-  if (
-    lastRunAnalysisCommandIndex >= 0 &&
-    lastRunAnalysisCommandIndex <= analysisCommands.length - 1
-  ) {
-    countOfTotalText = ` ${lastRunAnalysisCommandIndex + 1}/${
-      analysisCommands.length
-    }`
-  } else if (
-    lastRunAnalysisCommandIndex === -1 &&
-    lastRunCommand?.key != null &&
-    runCommandsLength != null
-  ) {
-    countOfTotalText = `${runCommandsLength}/?`
-  } else if (analysis == null) {
-    countOfTotalText = ''
-  }
+  const stepCountStr = `${currentStepNumber ?? '?'}/${totalStepCount ?? '?'}`
 
   const runHasNotBeenStarted =
-    (lastRunAnalysisCommandIndex === 0 &&
+    (currentStepNumber === 0 &&
       runStatus === RUN_STATUS_BLOCKED_BY_OPEN_DOOR) ||
     runStatus === RUN_STATUS_IDLE
 
@@ -133,20 +116,17 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     currentStepContents = (
       <StyledText as="h2">{t('not_started_yet')}</StyledText>
     )
-  } else if (
-    analysis != null &&
-    analysisCommands[lastRunAnalysisCommandIndex] != null
-  ) {
+  } else if (analysis != null && isDeterministicRun) {
     currentStepContents = (
       <CommandText
         commandTextData={getCommandTextData(analysis)}
-        command={analysisCommands[lastRunAnalysisCommandIndex]}
+        command={analysisCommands[(currentStepNumber as number) - 1]}
         robotType={robotType}
       />
     )
   } else if (
     analysis != null &&
-    lastRunAnalysisCommandIndex === -1 &&
+    !isDeterministicRun &&
     runCommandDetails != null
   ) {
     currentStepContents = (
@@ -212,9 +192,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
             }${
               runStatus === RUN_STATUS_IDLE
                 ? ':'
-                : ` ${countOfTotalText}${
-                    currentStepContents != null ? ': ' : ''
-                  }`
+                : ` ${stepCountStr}${currentStepContents != null ? ': ' : ''}`
             }`}</StyledText>
 
             {currentStepContents}
@@ -247,13 +225,12 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
             </Tooltip>
           ) : null}
         </Flex>
-        {analysis != null && lastRunAnalysisCommandIndex >= 0 ? (
+        {isDeterministicRun ? (
           <ProgressBar
             percentComplete={
               runHasNotBeenStarted
                 ? 0
-                : ((lastRunAnalysisCommandIndex + 1) /
-                    analysisCommands.length) *
+                : ((currentStepNumber as number) / analysisCommands.length) *
                   100
             }
             outerStyles={css`

--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -94,7 +94,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
   const {
     currentStepNumber,
     totalStepCount,
-    isDeterministicRun,
+    hasRunDiverged,
   } = useRunningStepCounts(runId, mostRecentCommandData)
 
   const downloadIsDisabled =
@@ -116,7 +116,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
     currentStepContents = (
       <StyledText as="h2">{t('not_started_yet')}</StyledText>
     )
-  } else if (analysis != null && isDeterministicRun) {
+  } else if (analysis != null && !hasRunDiverged) {
     currentStepContents = (
       <CommandText
         commandTextData={getCommandTextData(analysis)}
@@ -124,11 +124,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
         robotType={robotType}
       />
     )
-  } else if (
-    analysis != null &&
-    !isDeterministicRun &&
-    runCommandDetails != null
-  ) {
+  } else if (analysis != null && hasRunDiverged && runCommandDetails != null) {
     currentStepContents = (
       <CommandText
         commandTextData={getCommandTextData(analysis)}
@@ -225,7 +221,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
             </Tooltip>
           ) : null}
         </Flex>
-        {isDeterministicRun ? (
+        {!hasRunDiverged ? (
           <ProgressBar
             percentComplete={
               runHasNotBeenStarted

--- a/app/src/resources/protocols/hooks/__tests__/useLastRunCommandNoFixit.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useLastRunCommandNoFixit.test.ts
@@ -1,0 +1,58 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useCommandQuery } from '@opentrons/react-api-client'
+
+import { useLastRunCommandNoFixit } from '../useLastRunCommandNoFixit'
+
+vi.mock('@opentrons/react-api-client')
+
+const mockRunId = 'mock-run-id'
+const mockCommandsData = {
+  data: [
+    { id: 'cmd1', key: 'key1' },
+    { id: 'cmd2', key: 'key2' },
+  ],
+  meta: { totalLength: 2 },
+} as any
+
+describe('useLastRunCommandNoFixit', () => {
+  it('returns the last run command when it is not a fixit command', () => {
+    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+
+    const { result } = renderHook(() =>
+      useLastRunCommandNoFixit(mockRunId, mockCommandsData)
+    )
+
+    expect(result.current).toEqual({ id: 'cmd2', key: 'key2' })
+  })
+
+  it('returns the failed command when the last run command is a fixit command', () => {
+    const mockFixitCommand = {
+      id: 'fixit-cmd',
+      intent: 'fixit',
+      failedCommandId: 'failed-cmd-id',
+    }
+    const mockFailedCommand = { id: 'failed-cmd-id', key: 'failed-key' }
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: mockFailedCommand },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useLastRunCommandNoFixit(mockRunId, {
+        data: [mockFixitCommand],
+        meta: { totalLength: 1 },
+      } as any)
+    )
+
+    expect(result.current).toEqual(mockFailedCommand)
+  })
+
+  it('returns null when there are no run commands', () => {
+    const { result } = renderHook(() =>
+      useLastRunCommandNoFixit(mockRunId, null)
+    )
+
+    expect(result.current).toBeNull()
+  })
+})

--- a/app/src/resources/protocols/hooks/__tests__/useLastRunProtocolCommand.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useLastRunProtocolCommand.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { useCommandQuery } from '@opentrons/react-api-client'
 
-import { useLastRunCommandNoFixit } from '../useLastRunCommandNoFixit'
+import { useLastRunProtocolCommand } from '../useLastRunProtocolCommand'
 
 vi.mock('@opentrons/react-api-client')
 
 const mockRunId = 'mock-run-id'
 const mockCommandsData = {
   data: [
-    { id: 'cmd1', key: 'key1' },
-    { id: 'cmd2', key: 'key2' },
+    { id: 'cmd1', key: 'key1', intent: 'protocol' },
+    { id: 'cmd2', key: 'key2', intent: 'protocol' },
   ],
   meta: { totalLength: 2 },
 } as any
@@ -21,10 +21,14 @@ describe('useLastRunCommandNoFixit', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
 
     const { result } = renderHook(() =>
-      useLastRunCommandNoFixit(mockRunId, mockCommandsData)
+      useLastRunProtocolCommand(mockRunId, mockCommandsData)
     )
 
-    expect(result.current).toEqual({ id: 'cmd2', key: 'key2' })
+    expect(result.current).toEqual({
+      id: 'cmd2',
+      key: 'key2',
+      intent: 'protocol',
+    })
   })
 
   it('returns the failed command when the last run command is a fixit command', () => {
@@ -39,7 +43,7 @@ describe('useLastRunCommandNoFixit', () => {
     } as any)
 
     const { result } = renderHook(() =>
-      useLastRunCommandNoFixit(mockRunId, {
+      useLastRunProtocolCommand(mockRunId, {
         data: [mockFixitCommand],
         meta: { totalLength: 1 },
       } as any)
@@ -50,7 +54,7 @@ describe('useLastRunCommandNoFixit', () => {
 
   it('returns null when there are no run commands', () => {
     const { result } = renderHook(() =>
-      useLastRunCommandNoFixit(mockRunId, null)
+      useLastRunProtocolCommand(mockRunId, null)
     )
 
     expect(result.current).toBeNull()

--- a/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+import { useCommandQuery } from '@opentrons/react-api-client'
+import { useMostRecentCompletedAnalysis } from '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
+import { useRunningStepCounts } from '../useRunningStepCounts'
+
+vi.mock('@opentrons/react-api-client', async () => {
+  const actual = await vi.importActual('@opentrons/react-api-client')
+  return {
+    ...actual,
+    useCommandQuery: vi.fn(),
+  }
+})
+vi.mock(
+  '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
+)
+
+const mockRunId = 'mock-run-id'
+const mockCommandsData = {
+  data: [
+    { id: 'cmd1', key: 'key1' },
+    { id: 'cmd2', key: 'key2' },
+  ],
+  meta: { totalLength: 2 },
+}
+
+describe('useRunningStepCounts', () => {
+  it('returns current step number and total step count for a deterministic run', () => {
+    const mockAnalysis = {
+      commands: [{ key: 'key1' }, { key: 'key2' }, { key: 'key3' }],
+    }
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(
+      mockAnalysis as any
+    )
+    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+
+    const { result } = renderHook(() =>
+      useRunningStepCounts(mockRunId, mockCommandsData as any)
+    )
+
+    expect(result.current).toEqual({
+      currentStepNumber: 2,
+      totalStepCount: 3,
+      isDeterministicRun: true,
+      lastRunCommandNoFixit: { id: 'cmd2', key: 'key2' },
+    })
+  })
+
+  it('returns current step number and null total step count for a non-deterministic run', () => {
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
+    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+
+    const { result } = renderHook(() =>
+      useRunningStepCounts(mockRunId, mockCommandsData as any)
+    )
+
+    expect(result.current).toEqual({
+      currentStepNumber: 2,
+      totalStepCount: null,
+      isDeterministicRun: false,
+      lastRunCommandNoFixit: { id: 'cmd2', key: 'key2' },
+    })
+  })
+
+  it('returns null current step number and total step count when analysis and run command data are not available', () => {
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
+    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+
+    const { result } = renderHook(() =>
+      useRunningStepCounts(mockRunId, undefined)
+    )
+
+    expect(result.current).toEqual({
+      currentStepNumber: null,
+      totalStepCount: null,
+      isDeterministicRun: false,
+      lastRunCommandNoFixit: null,
+    })
+  })
+
+  it('returns the failed command as lastRunCommandNoFixit when the last run command is a fixit command', () => {
+    const mockFixitCommand = {
+      id: 'fixit-cmd',
+      intent: 'fixit',
+      failedCommandId: 'failed-cmd-id',
+    }
+    const mockFailedCommand = { id: 'failed-cmd-id', key: 'failed-key' }
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
+    vi.mocked(useCommandQuery).mockReturnValue({
+      data: { data: mockFailedCommand },
+    } as any)
+
+    const { result } = renderHook(() =>
+      useRunningStepCounts(mockRunId, {
+        data: [mockFixitCommand],
+        meta: { totalLength: 1 },
+      } as any)
+    )
+
+    expect(result.current).toEqual({
+      currentStepNumber: 1,
+      totalStepCount: null,
+      isDeterministicRun: false,
+      lastRunCommandNoFixit: mockFailedCommand,
+    })
+  })
+})

--- a/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
@@ -34,7 +34,7 @@ describe('useRunningStepCounts', () => {
     expect(result.current).toEqual({
       currentStepNumber: 2,
       totalStepCount: 3,
-      isDeterministicRun: true,
+      hasRunDiverged: false,
     })
   })
 
@@ -49,7 +49,7 @@ describe('useRunningStepCounts', () => {
     expect(result.current).toEqual({
       currentStepNumber: 2,
       totalStepCount: null,
-      isDeterministicRun: false,
+      hasRunDiverged: true,
     })
   })
 
@@ -64,7 +64,7 @@ describe('useRunningStepCounts', () => {
     expect(result.current).toEqual({
       currentStepNumber: null,
       totalStepCount: null,
-      isDeterministicRun: false,
+      hasRunDiverged: true,
     })
   })
 })

--- a/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
@@ -3,9 +3,9 @@ import { renderHook } from '@testing-library/react'
 
 import { useMostRecentCompletedAnalysis } from '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useRunningStepCounts } from '../useRunningStepCounts'
-import { useLastRunCommandNoFixit } from '../useLastRunCommandNoFixit'
+import { useLastRunProtocolCommand } from '../useLastRunProtocolCommand'
 
-vi.mock('../useLastRunCommandNoFixit')
+vi.mock('../useLastRunProtocolCommand')
 vi.mock(
   '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 )
@@ -25,7 +25,7 @@ describe('useRunningStepCounts', () => {
       commands: [{ key: 'key1' }, { key: 'key2' }, { key: 'key3' }],
     } as any
     vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(mockAnalysis)
-    vi.mocked(useLastRunCommandNoFixit).mockReturnValue({ key: 'key2' } as any)
+    vi.mocked(useLastRunProtocolCommand).mockReturnValue({ key: 'key2' } as any)
 
     const { result } = renderHook(() =>
       useRunningStepCounts(mockRunId, mockCommandsData)
@@ -40,7 +40,7 @@ describe('useRunningStepCounts', () => {
 
   it('returns current step number and null total step count for a non-deterministic run', () => {
     vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
-    vi.mocked(useLastRunCommandNoFixit).mockReturnValue(null)
+    vi.mocked(useLastRunProtocolCommand).mockReturnValue(null)
 
     const { result } = renderHook(() =>
       useRunningStepCounts(mockRunId, mockCommandsData)
@@ -55,7 +55,7 @@ describe('useRunningStepCounts', () => {
 
   it('returns null current step number and total step count when analysis and run command data are not available', () => {
     vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
-    vi.mocked(useLastRunCommandNoFixit).mockReturnValue(null)
+    vi.mocked(useLastRunProtocolCommand).mockReturnValue(null)
 
     const { result } = renderHook(() =>
       useRunningStepCounts(mockRunId, undefined)

--- a/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 
-import { useCommandQuery } from '@opentrons/react-api-client'
 import { useMostRecentCompletedAnalysis } from '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 import { useRunningStepCounts } from '../useRunningStepCounts'
+import { useLastRunCommandNoFixit } from '../useLastRunCommandNoFixit'
 
-vi.mock('@opentrons/react-api-client', async () => {
-  const actual = await vi.importActual('@opentrons/react-api-client')
-  return {
-    ...actual,
-    useCommandQuery: vi.fn(),
-  }
-})
+vi.mock('../useLastRunCommandNoFixit')
 vi.mock(
   '../../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 )
@@ -23,49 +17,45 @@ const mockCommandsData = {
     { id: 'cmd2', key: 'key2' },
   ],
   meta: { totalLength: 2 },
-}
+} as any
 
 describe('useRunningStepCounts', () => {
   it('returns current step number and total step count for a deterministic run', () => {
     const mockAnalysis = {
       commands: [{ key: 'key1' }, { key: 'key2' }, { key: 'key3' }],
-    }
-    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(
-      mockAnalysis as any
-    )
-    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+    } as any
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(mockAnalysis)
+    vi.mocked(useLastRunCommandNoFixit).mockReturnValue({ key: 'key2' } as any)
 
     const { result } = renderHook(() =>
-      useRunningStepCounts(mockRunId, mockCommandsData as any)
+      useRunningStepCounts(mockRunId, mockCommandsData)
     )
 
     expect(result.current).toEqual({
       currentStepNumber: 2,
       totalStepCount: 3,
       isDeterministicRun: true,
-      lastRunCommandNoFixit: { id: 'cmd2', key: 'key2' },
     })
   })
 
   it('returns current step number and null total step count for a non-deterministic run', () => {
     vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
-    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+    vi.mocked(useLastRunCommandNoFixit).mockReturnValue(null)
 
     const { result } = renderHook(() =>
-      useRunningStepCounts(mockRunId, mockCommandsData as any)
+      useRunningStepCounts(mockRunId, mockCommandsData)
     )
 
     expect(result.current).toEqual({
       currentStepNumber: 2,
       totalStepCount: null,
       isDeterministicRun: false,
-      lastRunCommandNoFixit: { id: 'cmd2', key: 'key2' },
     })
   })
 
   it('returns null current step number and total step count when analysis and run command data are not available', () => {
     vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
-    vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
+    vi.mocked(useLastRunCommandNoFixit).mockReturnValue(null)
 
     const { result } = renderHook(() =>
       useRunningStepCounts(mockRunId, undefined)
@@ -75,34 +65,6 @@ describe('useRunningStepCounts', () => {
       currentStepNumber: null,
       totalStepCount: null,
       isDeterministicRun: false,
-      lastRunCommandNoFixit: null,
-    })
-  })
-
-  it('returns the failed command as lastRunCommandNoFixit when the last run command is a fixit command', () => {
-    const mockFixitCommand = {
-      id: 'fixit-cmd',
-      intent: 'fixit',
-      failedCommandId: 'failed-cmd-id',
-    }
-    const mockFailedCommand = { id: 'failed-cmd-id', key: 'failed-key' }
-    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
-    vi.mocked(useCommandQuery).mockReturnValue({
-      data: { data: mockFailedCommand },
-    } as any)
-
-    const { result } = renderHook(() =>
-      useRunningStepCounts(mockRunId, {
-        data: [mockFixitCommand],
-        meta: { totalLength: 1 },
-      } as any)
-    )
-
-    expect(result.current).toEqual({
-      currentStepNumber: 1,
-      totalStepCount: null,
-      isDeterministicRun: false,
-      lastRunCommandNoFixit: mockFailedCommand,
     })
   })
 })

--- a/app/src/resources/protocols/hooks/index.ts
+++ b/app/src/resources/protocols/hooks/index.ts
@@ -1,0 +1,4 @@
+export { useLastRunCommandNoFixit } from './useLastRunCommandNoFixit'
+export { useRunningStepCounts } from './useRunningStepCounts'
+
+export type { StepCounts } from './useRunningStepCounts'

--- a/app/src/resources/protocols/hooks/index.ts
+++ b/app/src/resources/protocols/hooks/index.ts
@@ -1,4 +1,4 @@
-export { useLastRunCommandNoFixit } from './useLastRunCommandNoFixit'
+export { useLastRunProtocolCommand } from './useLastRunProtocolCommand'
 export { useRunningStepCounts } from './useRunningStepCounts'
 
 export type { StepCounts } from './useRunningStepCounts'

--- a/app/src/resources/protocols/hooks/useLastRunCommandNoFixit.ts
+++ b/app/src/resources/protocols/hooks/useLastRunCommandNoFixit.ts
@@ -1,0 +1,30 @@
+import last from 'lodash/last'
+
+import { useCommandQuery } from '@opentrons/react-api-client'
+
+import type { CommandsData, RunCommandSummary } from '@opentrons/api-client'
+
+// Return the last run command is not a "fixit" command. If it is a "fixit" command,
+// return the command that failed (ie, the last run command without a fixit intent).
+export function useLastRunCommandNoFixit(
+  runId: string,
+  commandsData: CommandsData | null
+): RunCommandSummary | null {
+  const lastRunCommand = last(commandsData?.data) ?? null
+
+  const isFixitIntent =
+    lastRunCommand != null && lastRunCommand.intent === 'fixit'
+
+  // Get the failed command from the fixit command.
+  const lastRunCommandActual = useCommandQuery(
+    runId,
+    lastRunCommand?.failedCommandId ?? null,
+    {
+      enabled: isFixitIntent,
+    }
+  )
+
+  return isFixitIntent
+    ? lastRunCommandActual.data?.data ?? null
+    : lastRunCommand ?? null
+}

--- a/app/src/resources/protocols/hooks/useLastRunProtocolCommand.ts
+++ b/app/src/resources/protocols/hooks/useLastRunProtocolCommand.ts
@@ -4,27 +4,26 @@ import { useCommandQuery } from '@opentrons/react-api-client'
 
 import type { CommandsData, RunCommandSummary } from '@opentrons/api-client'
 
-// Return the last run command is not a "fixit" command. If it is a "fixit" command,
-// return the command that failed (ie, the last run command without a fixit intent).
-export function useLastRunCommandNoFixit(
+// Return the last command with a "protocol" intent. If the command does not have "protocol" intent,
+// return the last command with "protocol" intent.
+export function useLastRunProtocolCommand(
   runId: string,
   commandsData: CommandsData | null
 ): RunCommandSummary | null {
   const lastRunCommand = last(commandsData?.data) ?? null
 
-  const isFixitIntent =
-    lastRunCommand != null && lastRunCommand.intent === 'fixit'
+  const isProtocolIntent = lastRunCommand?.intent === 'protocol'
 
   // Get the failed command from the fixit command.
   const lastRunCommandActual = useCommandQuery(
     runId,
     lastRunCommand?.failedCommandId ?? null,
     {
-      enabled: isFixitIntent,
+      enabled: !isProtocolIntent && lastRunCommand != null,
     }
   )
 
-  return isFixitIntent
+  return !isProtocolIntent && lastRunCommand != null
     ? lastRunCommandActual.data?.data ?? null
     : lastRunCommand ?? null
 }

--- a/app/src/resources/protocols/hooks/useRunningStepCounts.ts
+++ b/app/src/resources/protocols/hooks/useRunningStepCounts.ts
@@ -1,13 +1,13 @@
 import { useMostRecentCompletedAnalysis } from '../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 
-import { useLastRunCommandNoFixit } from './useLastRunCommandNoFixit'
+import { useLastRunProtocolCommand } from './useLastRunProtocolCommand'
 
 import type { CommandsData } from '@opentrons/api-client'
 
 export interface StepCounts {
-  /* Excludes "fixit" commands. Returns -1 if the step is not found. */
+  /* Excludes "fixit" commands. Returns null if the step is not found. */
   currentStepNumber: number | null
-  /* Returns null if the run is non-deterministic or the total command count is not found. */
+  /* Returns null if the run has diverged or the total command count is not found. */
   totalStepCount: number | null
   /* Returns whether the run has diverged from analysis. */
   hasRunDiverged: boolean
@@ -30,7 +30,7 @@ export function useRunningStepCounts(
 ): StepCounts {
   const analysis = useMostRecentCompletedAnalysis(runId)
   const analysisCommands = analysis?.commands ?? []
-  const lastRunCommandNoFixit = useLastRunCommandNoFixit(
+  const lastRunCommandNoFixit = useLastRunProtocolCommand(
     runId,
     commandsData ?? null
   )

--- a/app/src/resources/protocols/hooks/useRunningStepCounts.ts
+++ b/app/src/resources/protocols/hooks/useRunningStepCounts.ts
@@ -1,0 +1,92 @@
+import last from 'lodash/last'
+
+import { useCommandQuery } from '@opentrons/react-api-client'
+
+import { useMostRecentCompletedAnalysis } from '../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
+
+import type { CommandsData, RunCommandSummary } from '@opentrons/api-client'
+
+// TOME: Handle fixit commands.
+
+export interface StepCounts {
+  /* Excludes "fixit" commands. Returns -1 if the step is not found. */
+  currentStepNumber: number | null
+  /* Returns null if the run is non-deterministic or the total command count is not found. */
+  totalStepCount: number | null
+  /* Returns whether the run is deterministic. */
+  isDeterministicRun: boolean
+  /* The last run command, excluding "fixit" commands. */
+  lastRunCommandNoFixit: RunCommandSummary | null
+}
+
+/**
+ * Find the index of the analysis command within the analysis
+ * that has the same commandKey as the most recent
+ * command from the run record.
+ * In the case of a non-deterministic protocol,
+ * source from the run rather than the analysis.
+ * NOTE: The most recent
+ * command may not always be "current", for instance if
+ * the run has completed/failed.
+ * NOTE #2: "Fixit" commands are excluded from the step count.
+ * */
+export function useRunningStepCounts(
+  runId: string,
+  commandsData: CommandsData | undefined
+): StepCounts {
+  const analysis = useMostRecentCompletedAnalysis(runId)
+  const analysisCommands = analysis?.commands ?? []
+  const lastRunCommandNoFixit = useLastRunCommandNoFixit(
+    runId,
+    commandsData ?? null
+  )
+
+  const lastRunAnalysisCommandIndex = analysisCommands.findIndex(
+    c => c.key === lastRunCommandNoFixit?.key
+  )
+
+  const currentStepNumberByAnalysis =
+    lastRunAnalysisCommandIndex === -1 ? null : lastRunAnalysisCommandIndex + 1
+  const currentStepNumberByRun = commandsData?.meta.totalLength ?? null
+
+  const isDeterministicRun =
+    lastRunCommandNoFixit?.key != null && currentStepNumberByAnalysis != null
+
+  const currentStepNumber = isDeterministicRun
+    ? currentStepNumberByAnalysis
+    : currentStepNumberByRun
+
+  const totalStepCount = isDeterministicRun ? analysisCommands.length : null
+
+  return {
+    currentStepNumber,
+    totalStepCount,
+    isDeterministicRun,
+    lastRunCommandNoFixit,
+  }
+}
+
+// Return the last run command is not a "fixit" command. If it is a "fixit" command,
+// return the command that failed (ie, the last run command without a fixit intent).
+export function useLastRunCommandNoFixit(
+  runId: string,
+  commandsData: CommandsData | null
+): RunCommandSummary | null {
+  const lastRunCommand = last(commandsData?.data) ?? null
+
+  const isFixitIntent =
+    lastRunCommand != null && lastRunCommand.intent === 'fixit'
+
+  // Get the failed command from the fixit command.
+  const lastRunCommandActual = useCommandQuery(
+    runId,
+    lastRunCommand?.failedCommandId ?? null,
+    {
+      enabled: isFixitIntent,
+    }
+  )
+
+  return isFixitIntent
+    ? lastRunCommandActual.data?.data ?? null
+    : lastRunCommand ?? null
+}

--- a/app/src/resources/protocols/hooks/useRunningStepCounts.ts
+++ b/app/src/resources/protocols/hooks/useRunningStepCounts.ts
@@ -1,12 +1,8 @@
-import last from 'lodash/last'
-
-import { useCommandQuery } from '@opentrons/react-api-client'
-
 import { useMostRecentCompletedAnalysis } from '../../../organisms/LabwarePositionCheck/useMostRecentCompletedAnalysis'
 
-import type { CommandsData, RunCommandSummary } from '@opentrons/api-client'
+import { useLastRunCommandNoFixit } from './useLastRunCommandNoFixit'
 
-// TOME: Handle fixit commands.
+import type { CommandsData } from '@opentrons/api-client'
 
 export interface StepCounts {
   /* Excludes "fixit" commands. Returns -1 if the step is not found. */
@@ -15,8 +11,6 @@ export interface StepCounts {
   totalStepCount: number | null
   /* Returns whether the run is deterministic. */
   isDeterministicRun: boolean
-  /* The last run command, excluding "fixit" commands. */
-  lastRunCommandNoFixit: RunCommandSummary | null
 }
 
 /**
@@ -62,31 +56,5 @@ export function useRunningStepCounts(
     currentStepNumber,
     totalStepCount,
     isDeterministicRun,
-    lastRunCommandNoFixit,
   }
-}
-
-// Return the last run command is not a "fixit" command. If it is a "fixit" command,
-// return the command that failed (ie, the last run command without a fixit intent).
-export function useLastRunCommandNoFixit(
-  runId: string,
-  commandsData: CommandsData | null
-): RunCommandSummary | null {
-  const lastRunCommand = last(commandsData?.data) ?? null
-
-  const isFixitIntent =
-    lastRunCommand != null && lastRunCommand.intent === 'fixit'
-
-  // Get the failed command from the fixit command.
-  const lastRunCommandActual = useCommandQuery(
-    runId,
-    lastRunCommand?.failedCommandId ?? null,
-    {
-      enabled: isFixitIntent,
-    }
-  )
-
-  return isFixitIntent
-    ? lastRunCommandActual.data?.data ?? null
-    : lastRunCommand ?? null
 }

--- a/app/src/resources/protocols/hooks/useRunningStepCounts.ts
+++ b/app/src/resources/protocols/hooks/useRunningStepCounts.ts
@@ -9,8 +9,8 @@ export interface StepCounts {
   currentStepNumber: number | null
   /* Returns null if the run is non-deterministic or the total command count is not found. */
   totalStepCount: number | null
-  /* Returns whether the run is deterministic. */
-  isDeterministicRun: boolean
+  /* Returns whether the run has diverged from analysis. */
+  hasRunDiverged: boolean
 }
 
 /**
@@ -43,18 +43,18 @@ export function useRunningStepCounts(
     lastRunAnalysisCommandIndex === -1 ? null : lastRunAnalysisCommandIndex + 1
   const currentStepNumberByRun = commandsData?.meta.totalLength ?? null
 
-  const isDeterministicRun =
-    lastRunCommandNoFixit?.key != null && currentStepNumberByAnalysis != null
+  const hasRunDiverged =
+    lastRunCommandNoFixit?.key == null || currentStepNumberByAnalysis == null
 
-  const currentStepNumber = isDeterministicRun
+  const currentStepNumber = !hasRunDiverged
     ? currentStepNumberByAnalysis
     : currentStepNumberByRun
 
-  const totalStepCount = isDeterministicRun ? analysisCommands.length : null
+  const totalStepCount = !hasRunDiverged ? analysisCommands.length : null
 
   return {
     currentStepNumber,
     totalStepCount,
-    isDeterministicRun,
+    hasRunDiverged,
   }
 }

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -49,6 +49,7 @@ export interface CommonCommandRunTimeInfo {
   completedAt: string | null
   intent?: CommandIntent
   notes?: CommandNote[] | null
+  failedCommandId?: string // only present if intent === 'fixit'
 }
 export interface CommonCommandCreateInfo {
   intent?: CommandIntent


### PR DESCRIPTION
Works towards [EXEC-550](https://opentrons.atlassian.net/browse/EXEC-550) and closes [EXEC-510](https://opentrons.atlassian.net/browse/EXEC-510)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Since we'll be showing step counts in a few more places, during ER and also on the RunningProtocol page, let's go ahead and create a hook for getting the step count and whether or not a run is deterministic (since this helps clarify certain rendering behavior). 

This hook is added to the one place it's used, `RunProgressMeter`.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Pretty well covered by added tests here, but I also went through the office and all the protocol step counts look correct.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-550]: https://opentrons.atlassian.net/browse/EXEC-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EXEC-510]: https://opentrons.atlassian.net/browse/EXEC-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ