### PR TITLE
feat(app, shared-data): check for new 'file-required' analysis result on protocol card and details

### DIFF
--- a/app-shell/src/protocol-analysis/__tests__/writeFailedAnalysis.test.ts
+++ b/app-shell/src/protocol-analysis/__tests__/writeFailedAnalysis.test.ts
@@ -42,6 +42,7 @@ describe('write failed analysis', () => {
           pipettes: [],
           liquids: [],
           runTimeParameters: [],
+          result: 'not-ok',
         })
       })
   })

--- a/app-shell/src/protocol-analysis/writeFailedAnalysis.ts
+++ b/app-shell/src/protocol-analysis/writeFailedAnalysis.ts
@@ -32,6 +32,7 @@ export function createFailedAnalysis(
     // analysis that was unable to complete, but is required by
     // ProtocolAnalysisOutput
     config: {} as any,
+    result: 'not-ok',
   }
 }
 

--- a/app-shell/src/protocol-storage/__tests__/protocol-storage.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/protocol-storage.test.ts
@@ -120,6 +120,7 @@ describe('protocol storage directory utilities', () => {
         modules: [],
         labware: [],
         runTimeParameters: [],
+        result: 'not-ok',
       })
     })
   })

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -29,6 +29,7 @@
   "confirm": "Confirm",
   "continue_editing": "Continue editing",
   "controls": "Controls",
+  "csv_required_for_analysis": "CSV required for analysis. Add it during run setup.",
   "current_speed": "Current: {{speed}} rpm",
   "current_temp": "Current: {{temp}} °C",
   "current_version": "Current Version",

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -659,13 +659,15 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
         )
         const missingAnalysisData =
           analysisStatus === 'error' || analysisStatus === 'stale'
+        const requiresCsvRunTimeParameter =
+          storedProtocol.mostRecentAnalysis?.result === 'file-required'
         return (
           <React.Fragment key={storedProtocol.protocolKey}>
             <Flex flexDirection={DIRECTION_COLUMN}>
               <MiniCard
                 isSelected={isSelected}
                 isError={runCreationError != null}
-                isWarning={missingAnalysisData}
+                isWarning={missingAnalysisData || requiresCsvRunTimeParameter}
                 onClick={() => {
                   handleSelectProtocol(storedProtocol)
                 }}
@@ -675,7 +677,7 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                   gridTemplateColumns="1fr 3fr"
                   marginRight={SPACING.spacing16}
                 >
-                  {!missingAnalysisData ? (
+                  {!missingAnalysisData && !requiresCsvRunTimeParameter ? (
                     <Box
                       marginY={SPACING.spacingAuto}
                       backgroundColor={isSelected ? COLORS.white : 'inherit'}
@@ -707,7 +709,9 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                       storedProtocol.protocolKey}
                   </StyledText>
                 </Box>
-                {(runCreationError != null || missingAnalysisData) &&
+                {(runCreationError != null ||
+                  missingAnalysisData ||
+                  requiresCsvRunTimeParameter) &&
                 isSelected ? (
                   <>
                     <Box flex="1 1 auto" />
@@ -752,6 +756,18 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                 ) : (
                   runCreationError
                 )}
+              </StyledText>
+            ) : null}
+            {requiresCsvRunTimeParameter && isSelected ? (
+              <StyledText
+                as="label"
+                color={COLORS.yellow60}
+                overflowWrap="anywhere"
+                display={DISPLAY_BLOCK}
+                marginTop={`-${SPACING.spacing8}`}
+                marginBottom={SPACING.spacing8}
+              >
+                {t('csv_required_for_analysis')}
               </StyledText>
             ) : null}
             {missingAnalysisData && isSelected ? (

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -64,6 +64,7 @@ import { useFeatureFlag } from '../../redux/config'
 import { ChooseRobotToRunProtocolSlideout } from '../ChooseRobotToRunProtocolSlideout'
 import { SendProtocolToFlexSlideout } from '../SendProtocolToFlexSlideout'
 import { ProtocolAnalysisFailure } from '../ProtocolAnalysisFailure'
+import { ProtocolStatusBanner } from '../ProtocolStatusBanner'
 import {
   getAnalysisStatus,
   getProtocolDisplayName,
@@ -427,6 +428,10 @@ export function ProtocolDetails(
               padding={`${SPACING.spacing16} 0 ${SPACING.spacing16} ${SPACING.spacing16}`}
               width="100%"
             >
+              {analysisStatus !== 'loading' &&
+              mostRecentAnalysis?.result === 'file-required' ? (
+                <ProtocolStatusBanner />
+              ) : null}
               {analysisStatus !== 'loading' &&
               mostRecentAnalysis != null &&
               mostRecentAnalysis.errors.length > 0 ? (

--- a/app/src/organisms/ProtocolStatusBanner/index.tsx
+++ b/app/src/organisms/ProtocolStatusBanner/index.tsx
@@ -13,8 +13,8 @@ export function ProtocolStatusBanner(): JSX.Element {
     <Banner
       type="warning"
       icon={alertIcon}
-      width="100%"
       iconMarginLeft={SPACING.spacing4}
+      marginRight={SPACING.spacing24}
     >
       <StyledText>{t('csv_file_required')}</StyledText>
     </Banner>

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -41,6 +41,7 @@ import { getIsProtocolAnalysisInProgress } from '../../redux/protocol-storage'
 import { InstrumentContainer } from '../../atoms/InstrumentContainer'
 import { ProtocolOverflowMenu } from './ProtocolOverflowMenu'
 import { ProtocolAnalysisFailure } from '../ProtocolAnalysisFailure'
+import { ProtocolStatusBanner } from '../ProtocolStatusBanner'
 import { getProtocolUsesGripper } from '../ProtocolSetupInstruments/utils'
 import { ProtocolAnalysisStale } from '../ProtocolAnalysisFailure/ProtocolAnalysisStale'
 import {
@@ -216,6 +217,9 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
       >
         {/* error and protocol name section */}
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
+          {mostRecentAnalysis?.result === 'file-required' ? (
+            <ProtocolStatusBanner />
+          ) : null}
           {analysisStatus === 'error' ? (
             <ProtocolAnalysisFailure
               protocolKey={protocolKey}

--- a/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ProtocolsLanding/__tests__/hooks.test.tsx
@@ -99,6 +99,7 @@ const mockStoredProtocolData = [
       ],
       runTimeParameters: [],
       errors: [],
+      result: 'ok',
     } as ProtocolAnalysisOutput,
   },
   {
@@ -186,6 +187,7 @@ const mockStoredProtocolData = [
       ],
       runTimeParameters: [],
       errors: [],
+      result: 'ok',
     } as ProtocolAnalysisOutput,
   },
   {
@@ -277,6 +279,7 @@ const mockStoredProtocolData = [
       ],
       runTimeParameters: [],
       errors: [],
+      result: 'ok',
     } as ProtocolAnalysisOutput,
   },
 ] as StoredProtocolData[]

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -671,7 +671,7 @@ export type RunTimeParameter =
 export interface CompletedProtocolAnalysis {
   id: string
   status?: 'completed'
-  result: 'ok' | 'not-ok' | 'error'
+  result: 'ok' | 'not-ok' | 'error' | 'file-required'
   pipettes: LoadedPipette[]
   labware: LoadedLabware[]
   modules: LoadedModule[]

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -139,6 +139,7 @@ export interface ProtocolAnalysisOutput {
   errors: AnalysisError[]
   runTimeParameters: RunTimeParameter[]
   robotType?: RobotType
+  result: 'ok' | 'not-ok' | 'error' | 'file-required'
 }
 
 interface AnalysisSourceFile {


### PR DESCRIPTION
Closes AUTH-448

# Overview

To accommodate file requirements in analysis failure, robot server will now introduce a `result` field on CLI analysis and update the existing `result` field on robot analysis to provide a value of file-required`. This will be returned in the special case of analysis failure due to analysis occurring before a CSV runtimeparameter value is input.

Here, I update the these analyses' respective interfaces accordingly. I also check for this status to render a csv-required banner on `ProtocolCard` and `ProtocolDetails`, and to prompt a warning message under protocol `MiniCard`s on `ChooseProtocolSlideout`.

To do:
- [ ] add test coverage

# Test Plan

- import a CSV RTP protocol like this
- from the protocol's overflow menu, select "Show in folder" and navigate to the parent folder to find the most recent analysis
- add this line to the JSON analysis (robot server work still in progress):
```
"result": "file-required",
```
- navigate to protocols landing and verify that the protocol card displays csv-required banner
<img width="901" alt="Screenshot 2024-06-17 at 4 52 46 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/e7c1db06-4edf-4e60-b950-30083acd9980">

- click the protocol card and verify that the protocol details page displays csv-required banner
<img width="899" alt="Screenshot 2024-06-17 at 4 52 52 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/ba6b6c3b-1d68-41ed-8d53-f2fe11bb1256">

- navigate to an available robot and select "Start a run" from the overflow menu
- select the protocol that was just uploaded and updated and verify that it is in warning state and displays an error message prompting the user that csv upload is required and deck map is grayed out
<img width="331" alt="Screenshot 2024-06-17 at 4 53 09 PM" src="https://github.com/Opentrons/opentrons/assets/47604184/7a051cf8-f25d-4fb1-b00b-3a3941a31644">


# Changelog

- update types for protocol analyses to include `result` field / expand union type of `result` field to include `file-required`
- add csv banner to `ProtocolCard` and `ProtocolDetails` components for protocols whose most recent analyses contain `result: 'file-required'`
- add message and translation keys for CSV protocol `MiniCard` warning on `ChooseProtocolSlideout`
- add right margin to `ProtocolStatusBanner` to mirror other banners
- update tests

# Review requests

auth js

# Risk assessment

low