### PR TITLE
refactor(api): Sort allowed values in error message

### DIFF
--- a/api/src/opentrons/protocols/parameters/parameter_definition.py
+++ b/api/src/opentrons/protocols/parameters/parameter_definition.py
@@ -115,7 +115,7 @@ class ParameterDefinition(AbstractParameterDefinition[PrimitiveAllowedTypes]):
         validation.validate_type(new_value, self._type)
         if self._allowed_values is not None and new_value not in self._allowed_values:
             raise ParameterValueError(
-                f"Parameter must be set to one of the allowed values of {self._allowed_values}."
+                f"Parameter must be set to one of the allowed values of {sorted(self._allowed_values)}."
             )
         elif (
             isinstance(self._minimum, (int, float))

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60c1d39463][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_int_default_no_matching_choices].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60c1d39463][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_int_default_no_matching_choices].json
@@ -9,17 +9,17 @@
   },
   "errors": [
     {
-      "detail": "ParameterValueError [line 24]: Parameter must be set to one of the allowed values of {9, 20, 15}.",
+      "detail": "ParameterValueError [line 24]: Parameter must be set to one of the allowed values of [9, 15, 20].",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
       "isDefined": false,
       "wrappedErrors": [
         {
-          "detail": "opentrons.protocols.parameters.types.ParameterValueError: Parameter must be set to one of the allowed values of {9, 20, 15}.",
+          "detail": "opentrons.protocols.parameters.types.ParameterValueError: Parameter must be set to one of the allowed values of [9, 15, 20].",
           "errorCode": "4000",
           "errorInfo": {
-            "args": "('Parameter must be set to one of the allowed values of {9, 20, 15}.',)",
+            "args": "('Parameter must be set to one of the allowed values of [9, 15, 20].',)",
             "class": "ParameterValueError",
             "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/execution/execute_python.py\", line 80, in _parse_and_set_parameters\n    exec(\"add_parameters(__param_context)\", new_globs)\n\n  File \"<string>\", line 1, in <module>\n\n  File \"Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_int_default_no_matching_choices.py\", line 24, in add_parameters\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_api/_parameter_context.py\", line 61, in add_int\n    parameter = parameter_definition.create_int_parameter(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 200, in create_int_parameter\n    return ParameterDefinition(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 106, in __init__\n    self.value: PrimitiveAllowedTypes = default\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 117, in value\n    raise ParameterValueError(\n"
           },

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e744cbb48][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_str_default_no_matching_choices].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e744cbb48][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_str_default_no_matching_choices].json
@@ -9,17 +9,17 @@
   },
   "errors": [
     {
-      "detail": "ParameterValueError [line 48]: Parameter must be set to one of the allowed values of {'flex_1channel_50', 'flex_8channel_50'}.",
+      "detail": "ParameterValueError [line 48]: Parameter must be set to one of the allowed values of ['flex_1channel_50', 'flex_8channel_50'].",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
       "isDefined": false,
       "wrappedErrors": [
         {
-          "detail": "opentrons.protocols.parameters.types.ParameterValueError: Parameter must be set to one of the allowed values of {'flex_1channel_50', 'flex_8channel_50'}.",
+          "detail": "opentrons.protocols.parameters.types.ParameterValueError: Parameter must be set to one of the allowed values of ['flex_1channel_50', 'flex_8channel_50'].",
           "errorCode": "4000",
           "errorInfo": {
-            "args": "(\"Parameter must be set to one of the allowed values of {'flex_1channel_50', 'flex_8channel_50'}.\",)",
+            "args": "(\"Parameter must be set to one of the allowed values of ['flex_1channel_50', 'flex_8channel_50'].\",)",
             "class": "ParameterValueError",
             "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/execution/execute_python.py\", line 80, in _parse_and_set_parameters\n    exec(\"add_parameters(__param_context)\", new_globs)\n\n  File \"<string>\", line 1, in <module>\n\n  File \"Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_str_default_no_matching_choices.py\", line 48, in add_parameters\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_api/_parameter_context.py\", line 157, in add_str\n    parameter = parameter_definition.create_str_parameter(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 263, in create_str_parameter\n    return ParameterDefinition(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 106, in __init__\n    self.value: PrimitiveAllowedTypes = default\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 117, in value\n    raise ParameterValueError(\n"
           },

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7f2ef0eaff][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_float_default_no_matching_choices].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7f2ef0eaff][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_float_default_no_matching_choices].json
@@ -9,17 +9,17 @@
   },
   "errors": [
     {
-      "detail": "ParameterValueError [line 36]: Parameter must be set to one of the allowed values of {160.0, 100.0, 200.0}.",
+      "detail": "ParameterValueError [line 36]: Parameter must be set to one of the allowed values of [100.0, 160.0, 200.0].",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
       "isDefined": false,
       "wrappedErrors": [
         {
-          "detail": "opentrons.protocols.parameters.types.ParameterValueError: Parameter must be set to one of the allowed values of {160.0, 100.0, 200.0}.",
+          "detail": "opentrons.protocols.parameters.types.ParameterValueError: Parameter must be set to one of the allowed values of [100.0, 160.0, 200.0].",
           "errorCode": "4000",
           "errorInfo": {
-            "args": "('Parameter must be set to one of the allowed values of {160.0, 100.0, 200.0}.',)",
+            "args": "('Parameter must be set to one of the allowed values of [100.0, 160.0, 200.0].',)",
             "class": "ParameterValueError",
             "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/execution/execute_python.py\", line 80, in _parse_and_set_parameters\n    exec(\"add_parameters(__param_context)\", new_globs)\n\n  File \"<string>\", line 1, in <module>\n\n  File \"Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_float_default_no_matching_choices.py\", line 36, in add_parameters\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_api/_parameter_context.py\", line 98, in add_float\n    parameter = parameter_definition.create_float_parameter(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 224, in create_float_parameter\n    return ParameterDefinition(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 106, in __init__\n    self.value: PrimitiveAllowedTypes = default\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/parameters/parameter_definition.py\", line 117, in value\n    raise ParameterValueError(\n"
           },


### PR DESCRIPTION
# Overview

This error message prints out a Python `set` of values, which has a nondeterministic order in Python. This causes sporadic snapshot test failures, e.g. as seen in https://github.com/Opentrons/opentrons/pull/15430. This sorts the values to guarantee a stable order.

# Test plan

None.

# Review requests

None.

# Risk assessment

Low.