### PR TITLE
refactor(app): InterventionModal Description component

### DIFF
--- a/app/src/atoms/InlineNotification/InlineNotification.stories.tsx
+++ b/app/src/atoms/InlineNotification/InlineNotification.stories.tsx
@@ -4,7 +4,7 @@ import { InlineNotification } from '.'
 import type { Story, Meta } from '@storybook/react'
 
 export default {
-  title: 'ODD/Atoms/InlineNotification',
+  title: 'App/Atoms/InlineNotification',
   argTypes: {
     hug: {
       control: {

--- a/app/src/atoms/InlineNotification/InlineNotification.stories.tsx
+++ b/app/src/atoms/InlineNotification/InlineNotification.stories.tsx
@@ -25,17 +25,50 @@ export default {
       },
       defaultValue: true,
     },
+    hasMessage: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: true,
+    },
+    message: {
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'hasMessage' },
+    },
   },
   parameters: VIEWPORT.touchScreenViewport,
 } as Meta
 
-const Template: Story<
-  React.ComponentProps<typeof InlineNotification>
-> = args => <InlineNotification {...args} />
+export interface WrapperProps extends React.ComponentProps<InlineNotification> {
+  hasMessage: boolean
+}
+
+function Wrapper(props: WrapperProps): JSX.Element {
+  return (
+    <InlineNotification
+      {...props}
+      onCloseClick={
+        props.onCloseClick
+          ? () => {
+              console.log('Close clicked')
+            }
+          : undefined
+      }
+      message={props.hasMessage ? props.message : undefined}
+    />
+  )
+}
+
+const Template: Story<React.ComponentProps<typeof Wrapper>> = args => (
+  <Wrapper {...args} />
+)
 
 export const InlineNotificationComponent = Template.bind({})
 InlineNotificationComponent.args = {
   heading: 'awesome',
   message: 'you did it',
   type: 'success',
+  hasMessage: true,
 }

--- a/app/src/atoms/InlineNotification/InlineNotification.stories.tsx
+++ b/app/src/atoms/InlineNotification/InlineNotification.stories.tsx
@@ -37,12 +37,25 @@ export default {
       },
       if: { arg: 'hasMessage' },
     },
+    hasLink: {
+      control: {
+        type: 'boolean',
+      },
+      defaultValue: false,
+    },
+    linkText: {
+      control: {
+        type: 'text',
+      },
+      if: { arg: 'hasLink' },
+    },
   },
   parameters: VIEWPORT.touchScreenViewport,
 } as Meta
 
 export interface WrapperProps extends React.ComponentProps<InlineNotification> {
   hasMessage: boolean
+  hasLink: boolean
 }
 
 function Wrapper(props: WrapperProps): JSX.Element {
@@ -57,6 +70,14 @@ function Wrapper(props: WrapperProps): JSX.Element {
           : undefined
       }
       message={props.hasMessage ? props.message : undefined}
+      linkText={props.hasLink ? props.linkText : undefined}
+      onLinkClick={
+        props.hasLink
+          ? () => {
+              console.log('Link clicked')
+            }
+          : undefined
+      }
     />
   )
 }
@@ -71,4 +92,15 @@ InlineNotificationComponent.args = {
   message: 'you did it',
   type: 'success',
   hasMessage: true,
+  hasLink: false,
+}
+
+export const InlineNotificationWithLink = Template.bind({})
+InlineNotificationWithLink.args = {
+  heading: 'Something has happened',
+  message: 'Here is an alert about it',
+  type: 'neutral',
+  hasMessage: true,
+  hasLink: true,
+  linkText: 'Link',
 }

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
+import { css } from 'styled-components'
 import {
   ALIGN_CENTER,
   BORDERS,
+  Box,
   Btn,
   COLORS,
   DIRECTION_ROW,
@@ -9,8 +11,9 @@ import {
   Icon,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
-  LegacyStyledText,
+  StyledText,
   TYPOGRAPHY,
+  RESPONSIVENESS,
 } from '@opentrons/components'
 
 import type { IconProps, StyleProps } from '@opentrons/components'
@@ -64,8 +67,8 @@ export function InlineNotification(
   const inlineNotificationProps = INLINE_NOTIFICATION_PROPS_BY_TYPE[type]
   const iconProps = {
     ...inlineNotificationProps.icon,
-    size: '1.75rem',
     color: INLINE_NOTIFICATION_PROPS_BY_TYPE[type].color,
+    size: '100%',
   }
   return (
     <Flex
@@ -79,12 +82,22 @@ export function InlineNotification(
       padding={`${SPACING.spacing12} ${SPACING.spacing16}`}
       width={hug ? 'max-content' : '100%'}
     >
-      <Icon {...iconProps} aria-label={`icon_${type}`} />
+      <Box
+        css={css`
+          width: ${SPACING.spacing16};
+          height: ${SPACING.spacing16};
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            width: 1.75rem;
+            height: 1.75rem;
+          }
+        `}
+      >
+        <Icon {...iconProps} aria-label={`icon_${type}`} />
+      </Box>
       <Flex flex="1" alignItems={ALIGN_CENTER}>
-        <LegacyStyledText
-          fontSize={TYPOGRAPHY.fontSize22}
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
-          lineHeight={TYPOGRAPHY.lineHeight28}
+        <StyledText
+          oddStyle="bodyTextRegular"
+          desktopStyle="bodyDefaultRegular"
         >
           <span
             css={`
@@ -93,8 +106,17 @@ export function InlineNotification(
           >
             {fullHeading}
           </span>
+          {/* this break is because the desktop wants this on two lines, but also wants/
+            inline text layout on ODD. Soooo here you go*/}
+          <br
+            css={`
+              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                display: none;
+              }
+            `}
+          />
           {message != null && fullmessage}
-        </LegacyStyledText>
+        </StyledText>
       </Flex>
       {onCloseClick && (
         <Btn

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -107,7 +107,7 @@ export function InlineNotification(
             {fullHeading}
           </span>
           {/* this break is because the desktop wants this on two lines, but also wants/
-            inline text layout on ODD. Soooo here you go*/}
+            inline text layout on ODD. Soooo here you go */}
           <br
             css={`
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -89,13 +89,14 @@ export function InlineNotification(
       backgroundColor={INLINE_NOTIFICATION_PROPS_BY_TYPE[type].backgroundColor}
       data-testid={`InlineNotification_${type}`}
       flexDirection={DIRECTION_ROW}
-      gridGap={SPACING.spacing12}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       width={hug ? 'max-content' : '100%'}
       css={css`
+        gap: ${SPACING.spacing8};
         border-radius: ${BORDERS.borderRadius4};
-        padding: ${SPACING.spacing4} ${SPACING.spacing12};
+        padding: ${SPACING.spacing8} ${SPACING.spacing12};
         @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          gap: ${SPACING.spacing12};
           border-radius: ${BORDERS.borderRadius8};
           padding: ${SPACING.spacing12} ${SPACING.spacing16};
         }
@@ -104,8 +105,13 @@ export function InlineNotification(
       <Flex
         justifyContent={JUSTIFY_FLEX_START}
         alignItems={ALIGN_CENTER}
-        gap={SPACING.spacing12}
         flexDirection={DIRECTION_ROW}
+        css={css`
+          gap: ${SPACING.spacing8};
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            gap: ${SPACING.spacing12};
+          }
+        `}
       >
         <Box
           css={css`
@@ -164,6 +170,16 @@ export function InlineNotification(
           <Btn
             data-testid="InlineNotification_close-button"
             onClick={onCloseClick}
+            css={css`
+              width: 28px;
+              height: 28px;
+              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                width: ${SPACING.spacing48};
+                height: ${SPACING.spacing48};
+              }
+            `}
+            width=""
+            height="fit-content"
           >
             <Icon
               aria-label="close_icon"

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -23,7 +23,7 @@ import type { IconProps, StyleProps } from '@opentrons/components'
 
 type InlineNotificationType = 'alert' | 'error' | 'neutral' | 'success'
 
-interface InlineNotificationProps extends StyleProps {
+export interface InlineNotificationProps extends StyleProps {
   /** name constant of the icon to display */
   type: InlineNotificationType
   /** InlineNotification contents */

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -129,7 +129,18 @@ export function InlineNotification(
           data-testid="InlineNotification_close-button"
           onClick={onCloseClick}
         >
-          <Icon aria-label="close_icon" name="close" size="3rem" />
+          <Icon
+            aria-label="close_icon"
+            name="close"
+            css={css`
+              width: 28px;
+              height: 28px;
+              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                width: ${SPACING.spacing48};
+                height: ${SPACING.spacing48};
+              }
+            `}
+          />
         </Btn>
       )}
     </Flex>

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -74,15 +74,16 @@ export function InlineNotification(
     <Flex
       alignItems={ALIGN_CENTER}
       backgroundColor={INLINE_NOTIFICATION_PROPS_BY_TYPE[type].backgroundColor}
-      borderRadius={BORDERS.borderRadius12}
       data-testid={`InlineNotification_${type}`}
       flexDirection={DIRECTION_ROW}
       gridGap={SPACING.spacing12}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       width={hug ? 'max-content' : '100%'}
       css={css`
+        border-radius: ${BORDERS.borderRadius4};
         padding: ${SPACING.spacing4} ${SPACING.spacing12};
         @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          border-radius: ${BORDERS.borderRadius8};
           padding: ${SPACING.spacing12} ${SPACING.spacing16};
         }
       `}

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -79,8 +79,13 @@ export function InlineNotification(
       flexDirection={DIRECTION_ROW}
       gridGap={SPACING.spacing12}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
-      padding={`${SPACING.spacing12} ${SPACING.spacing16}`}
       width={hug ? 'max-content' : '100%'}
+      css={css`
+        padding: ${SPACING.spacing4} ${SPACING.spacing12};
+        @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          padding: ${SPACING.spacing12} ${SPACING.spacing16};
+        }
+      `}
     >
       <Box
         css={css`
@@ -107,7 +112,7 @@ export function InlineNotification(
             {fullHeading}
           </span>
           {/* this break is because the desktop wants this on two lines, but also wants/
-            inline text layout on ODD. Soooo here you go */}
+              inline text layout on ODD. Soooo here you go */}
           <br
             css={`
               @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/app/src/atoms/InlineNotification/index.tsx
+++ b/app/src/atoms/InlineNotification/index.tsx
@@ -10,17 +10,20 @@ import {
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
+  JUSTIFY_FLEX_START,
+  JUSTIFY_FLEX_END,
   SPACING,
   StyledText,
   TYPOGRAPHY,
   RESPONSIVENESS,
+  Link,
 } from '@opentrons/components'
 
 import type { IconProps, StyleProps } from '@opentrons/components'
 
 type InlineNotificationType = 'alert' | 'error' | 'neutral' | 'success'
 
-export interface InlineNotificationProps extends StyleProps {
+interface InlineNotificationProps extends StyleProps {
   /** name constant of the icon to display */
   type: InlineNotificationType
   /** InlineNotification contents */
@@ -30,6 +33,8 @@ export interface InlineNotificationProps extends StyleProps {
   hug?: boolean
   /** optional handler to show close button/clear alert  */
   onCloseClick?: (() => void) | React.MouseEventHandler<HTMLButtonElement>
+  linkText?: string
+  onLinkClick?: (() => void) | React.MouseEventHandler<HTMLButtonElement>
 }
 
 const INLINE_NOTIFICATION_PROPS_BY_TYPE: Record<
@@ -61,7 +66,15 @@ const INLINE_NOTIFICATION_PROPS_BY_TYPE: Record<
 export function InlineNotification(
   props: InlineNotificationProps
 ): JSX.Element {
-  const { heading, hug = false, onCloseClick, message, type } = props
+  const {
+    heading,
+    hug = false,
+    onCloseClick,
+    message,
+    type,
+    linkText,
+    onLinkClick,
+  } = props
   const fullHeading = `${heading}${message ? '. ' : ''}`
   const fullmessage = `${message}.`
   const inlineNotificationProps = INLINE_NOTIFICATION_PROPS_BY_TYPE[type]
@@ -88,61 +101,85 @@ export function InlineNotification(
         }
       `}
     >
-      <Box
-        css={css`
-          width: ${SPACING.spacing16};
-          height: ${SPACING.spacing16};
-          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-            width: 1.75rem;
-            height: 1.75rem;
-          }
-        `}
+      <Flex
+        justifyContent={JUSTIFY_FLEX_START}
+        alignItems={ALIGN_CENTER}
+        gap={SPACING.spacing12}
+        flexDirection={DIRECTION_ROW}
       >
-        <Icon {...iconProps} aria-label={`icon_${type}`} />
-      </Box>
-      <Flex flex="1" alignItems={ALIGN_CENTER}>
-        <StyledText
-          oddStyle="bodyTextRegular"
-          desktopStyle="bodyDefaultRegular"
+        <Box
+          css={css`
+            width: ${SPACING.spacing16};
+            height: ${SPACING.spacing16};
+            @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+              width: 1.75rem;
+              height: 1.75rem;
+            }
+          `}
         >
-          <span
-            css={`
-              font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
-            `}
+          <Icon {...iconProps} aria-label={`icon_${type}`} />
+        </Box>
+        <Flex flex="1" alignItems={ALIGN_CENTER}>
+          <StyledText
+            oddStyle="bodyTextRegular"
+            desktopStyle="bodyDefaultRegular"
           >
-            {fullHeading}
-          </span>
-          {/* this break is because the desktop wants this on two lines, but also wants/
+            <span
+              css={`
+                font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
+              `}
+            >
+              {fullHeading}
+            </span>
+            {/* this break is because the desktop wants this on two lines, but also wants/
               inline text layout on ODD. Soooo here you go */}
-          <br
-            css={`
-              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                display: none;
-              }
-            `}
-          />
-          {message != null && fullmessage}
-        </StyledText>
+            <br
+              css={`
+                @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                  display: none;
+                }
+              `}
+            />
+            {message != null && fullmessage}
+          </StyledText>
+        </Flex>
       </Flex>
-      {onCloseClick && (
-        <Btn
-          data-testid="InlineNotification_close-button"
-          onClick={onCloseClick}
-        >
-          <Icon
-            aria-label="close_icon"
-            name="close"
-            css={css`
-              width: 28px;
-              height: 28px;
-              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-                width: ${SPACING.spacing48};
-                height: ${SPACING.spacing48};
-              }
-            `}
-          />
-        </Btn>
-      )}
+      <Flex
+        alignItems={ALIGN_CENTER}
+        justifyContent={JUSTIFY_FLEX_END}
+        gap={SPACING.spacing16}
+      >
+        {linkText && (
+          <Link onClick={onLinkClick}>
+            <StyledText
+              oddStyle="bodyTextRegular"
+              desktopStyle="bodyDefaultRegular"
+              textDecoration="underline"
+            >
+              {linkText}{' '}
+            </StyledText>
+          </Link>
+        )}
+        {onCloseClick && (
+          <Btn
+            data-testid="InlineNotification_close-button"
+            onClick={onCloseClick}
+          >
+            <Icon
+              aria-label="close_icon"
+              name="close"
+              css={css`
+                width: 28px;
+                height: 28px;
+                @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                  width: ${SPACING.spacing48};
+                  height: ${SPACING.spacing48};
+                }
+              `}
+            />
+          </Btn>
+        )}
+      </Flex>
     </Flex>
   )
 }

--- a/app/src/molecules/InterventionModal/DescriptionContent.stories.tsx
+++ b/app/src/molecules/InterventionModal/DescriptionContent.stories.tsx
@@ -1,0 +1,22 @@
+import { DescriptionContent as DescriptionContentComponent } from './'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<DescriptionContentComponent> = {
+  title: 'App/Molecules/InterventionModal/DescriptionContent',
+  component: DescriptionContentComponent,
+}
+
+export default meta
+
+export type Story = StoryObj<DescriptionContentComponent>
+
+export const ExampleDescriptionContent: Story = {
+  args: {
+    headline: 'Headline',
+    message:
+      'At odio faucibus ac eget lorem habitasse. Non pretium pellentesque mattis arcu pellentesque in a odio sapien. Ut dignissim amet odio adipiscing ipsum condimentum sit ac lacus. Amet elit felis aenean laoreet sem erat arcu felis. Nulla magna facilisis velit tortor dictumst mauris quam faucibus.',
+    notificationHeader: 'Header goes here',
+    notificationMessage:
+      'Keep subtext short, no more than two lines and use regular weight',
+  },
+}

--- a/app/src/molecules/InterventionModal/DescriptionContent.tsx
+++ b/app/src/molecules/InterventionModal/DescriptionContent.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react'
+import {
+  Flex,
+  SPACING,
+  DIRECTION_COLUMN,
+  StyledText,
+  RESPONSIVENESS,
+} from '@opentrons/components'
+import { InlineNotification } from '../../atoms/InlineNotification'
+
+interface NotificationProps {
+  notificationHeader?: string
+  notificationMessage?: string
+}
+
+export interface DescriptionContentProps extends NotificationProps {
+  headline: string
+  message: string
+}
+
+export function DescriptionContent(
+  props: DescriptionContentProps
+): JSX.Element {
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gap={SPACING.spacing24}
+      css={`
+        gap: ${SPACING.spacing16} @media:
+          ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          gap: ${SPACING.spacing24};
+        }
+      `}
+    >
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        css={`
+          gap: ${SPACING.spacing16};
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            gap: ${SPACING.spacing8};
+          }
+        `}
+      >
+        <StyledText
+          oddStyle="level4HeaderSemiBold"
+          desktopStyle="headingSmallBold"
+        >
+          {props.headline}
+        </StyledText>
+        <StyledText
+          oddStyle="bodyTextRegular"
+          desktopStyle="bodyDefaultRegular"
+        >
+          {props.message}
+        </StyledText>
+      </Flex>
+      <NotificationIfSpecified {...props} />
+    </Flex>
+  )
+}
+
+function NotificationIfSpecified({
+  notificationHeader,
+  notificationMessage,
+}: NotificationProps): JSX.Element | null {
+  return (notificationHeader == null || notificationHeader.length === 0) &&
+    (notificationMessage == null || notificationMessage.length === 0) ? null : (
+    <InlineNotification
+      type="alert"
+      heading={notificationHeader as string}
+      message={notificationMessage}
+    />
+  )
+}

--- a/app/src/molecules/InterventionModal/DescriptionContent.tsx
+++ b/app/src/molecules/InterventionModal/DescriptionContent.tsx
@@ -25,6 +25,8 @@ export function DescriptionContent(
     <Flex
       flexDirection={DIRECTION_COLUMN}
       gap={SPACING.spacing24}
+      paddingX={SPACING.spacing12}
+      paddingY={SPACING.spacing4}
       css={`
         gap: ${SPACING.spacing16} @media:
           ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/app/src/molecules/InterventionModal/DescriptionContent.tsx
+++ b/app/src/molecules/InterventionModal/DescriptionContent.tsx
@@ -25,8 +25,6 @@ export function DescriptionContent(
     <Flex
       flexDirection={DIRECTION_COLUMN}
       gap={SPACING.spacing24}
-      paddingX={SPACING.spacing12}
-      paddingY={SPACING.spacing4}
       css={`
         gap: ${SPACING.spacing16} @media:
           ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -24,11 +24,13 @@ import { ModalContentOneColSimpleButtons } from './ModalContentOneColSimpleButto
 import { TwoColumn } from './TwoColumn'
 import { OneColumn } from './OneColumn'
 import { ModalContentMixed } from './ModalContentMixed'
+import { DescriptionContent } from './DescriptionContent'
 export {
   ModalContentOneColSimpleButtons,
   TwoColumn,
   OneColumn,
   ModalContentMixed,
+  DescriptionContent,
 }
 
 export type ModalType = 'intervention-required' | 'error'

--- a/components/src/atoms/StyledText/StyledText.tsx
+++ b/components/src/atoms/StyledText/StyledText.tsx
@@ -181,6 +181,14 @@ const ODDStyleMap = {
       }
     `,
   },
+  level4HeaderSemiBold: {
+    as: 'h4',
+    style: css`
+      @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+        ${TYPOGRAPHY.level4HeaderSemiBold}
+      }
+    `,
+  },
   level4HeaderBold: {
     as: 'h4',
     style: css`


### PR DESCRIPTION
Implements the Description modal content component for ODD and Desktop.

Also updates `InlineNotification` to have corresponding desktop styles using the new `StyledText`, which means it doesn't have to be ODD only anymore so pop its stories over to `App`.

Note - can't be merged until #15373 is merged because it needs the StyledText fixes from there.