### PR TITLE
feat(app): Add a running step counter to the ODD

### DIFF
--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -131,6 +131,7 @@
   "status_stopped": "Canceled",
   "status_succeeded": "Completed",
   "status": "Status",
+  "step": "Step",
   "step_failed": "Step failed",
   "step_number": "Step {{step_number}}:",
   "steps_total": "{{count}} steps total",

--- a/app/src/assets/localization/en/run_details.json
+++ b/app/src/assets/localization/en/run_details.json
@@ -119,6 +119,7 @@
   "start_step_time": "Start",
   "start_time": "Start Time",
   "start": "Start",
+  "status_awaiting-recovery": "Awaiting recovery",
   "status_blocked-by-open-door": "Paused - door open",
   "status_failed": "Failed",
   "status_finishing": "Finishing",

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/CurrentRunningProtocolCommand.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import {
   ALIGN_CENTER,
+  ALIGN_FLEX_END,
   ALIGN_FLEX_START,
   BORDERS,
   COLORS,
@@ -25,6 +26,8 @@ import { getCommandTextData } from '../../../molecules/Command/utils/getCommandT
 import { PlayPauseButton } from './PlayPauseButton'
 import { StopButton } from './StopButton'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '../../../redux/analytics'
+import { useRunningStepCounts } from '../../../resources/protocols/hooks'
+import { useNotifyAllCommandsQuery } from '../../../resources/runs'
 
 import type {
   CompletedProtocolAnalysis,
@@ -108,6 +111,7 @@ interface RunTimerInfo {
 }
 
 interface CurrentRunningProtocolCommandProps {
+  runId: string
   runStatus: RunStatus | null
   robotSideAnalysis: CompletedProtocolAnalysis | null
   robotType: RobotType
@@ -125,6 +129,7 @@ interface CurrentRunningProtocolCommandProps {
 }
 
 export function CurrentRunningProtocolCommand({
+  runId,
   runStatus,
   robotSideAnalysis,
   runTimerInfo,
@@ -141,6 +146,11 @@ export function CurrentRunningProtocolCommand({
   updateLastAnimatedCommand,
 }: CurrentRunningProtocolCommandProps): JSX.Element | null {
   const { t } = useTranslation('run_details')
+  const { data: mostRecentCommandData } = useNotifyAllCommandsQuery(runId, {
+    cursor: null,
+    pageLength: 1,
+  })
+
   const currentCommand =
     robotSideAnalysis?.commands.find(
       (c: RunTimeCommand, index: number) => index === currentRunCommandIndex
@@ -159,6 +169,14 @@ export function CurrentRunningProtocolCommand({
     }
   }
   const currentRunStatus = t(`status_${runStatus}`)
+
+  const { currentStepNumber, totalStepCount } = useRunningStepCounts(
+    runId,
+    mostRecentCommandData
+  )
+  const stepCounterCopy = `${t('step')} ${currentStepNumber ?? '?'}/${
+    totalStepCount ?? '?'
+  }`
 
   const onStop = (): void => {
     if (runStatus === RUN_STATUS_RUNNING) pauseRun()
@@ -207,8 +225,13 @@ export function CurrentRunningProtocolCommand({
           </StyledText>
           <StyledText css={TITLE_TEXT_STYLE}>{protocolName}</StyledText>
         </Flex>
-        <Flex height="100%" alignItems={ALIGN_CENTER}>
+        <Flex
+          height="100%"
+          alignItems={ALIGN_FLEX_END}
+          flexDirection={DIRECTION_COLUMN}
+        >
           <RunTimer {...runTimerInfo} style={RUN_TIMER_STYLE} />
+          <StyledText as="h4SemiBold">{stepCounterCopy}</StyledText>
         </Flex>
       </Flex>
 

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/CurrentRunningProtocolCommand.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/CurrentRunningProtocolCommand.test.tsx
@@ -8,7 +8,12 @@ import { renderWithProviders } from '../../../../__testing-utils__'
 import { i18n } from '../../../../i18n'
 import { mockRobotSideAnalysis } from '../../../../molecules/Command/__fixtures__'
 import { CurrentRunningProtocolCommand } from '../CurrentRunningProtocolCommand'
+import { useRunningStepCounts } from '../../../../resources/protocols/hooks'
+import { useNotifyAllCommandsQuery } from '../../../../resources/runs'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
+vi.mock('../../../../resources/runs')
+vi.mock('../../../../resources/protocols/hooks')
 
 const mockPlayRun = vi.fn()
 const mockPauseRun = vi.fn()
@@ -49,7 +54,15 @@ describe('CurrentRunningProtocolCommand', () => {
       lastRunCommand: null,
       updateLastAnimatedCommand: mockUpdateLastAnimatedCommand,
       robotType: FLEX_ROBOT_TYPE,
+      runId: 'MOCK_RUN_ID',
     }
+
+    vi.mocked(useNotifyAllCommandsQuery).mockReturnValue({} as any)
+    vi.mocked(useRunningStepCounts).mockReturnValue({
+      totalStepCount: 10,
+      currentStepNumber: 5,
+      hasRunDiverged: false,
+    })
   })
 
   afterEach(() => {
@@ -95,6 +108,23 @@ describe('CurrentRunningProtocolCommand', () => {
     rerender(<CurrentRunningProtocolCommand {...newProps} />)
     expect(mockUpdateLastAnimatedCommand).toHaveBeenLastCalledWith('-113949561')
     expect(mockUpdateLastAnimatedCommand).toHaveBeenCalledTimes(2)
+  })
+
+  it('renders the step count in appropriate format if values are present', () => {
+    render(props)
+
+    screen.getByText('Step 5/10')
+  })
+
+  it('renders the step count in appropriate format if values are not present', () => {
+    vi.mocked(useRunningStepCounts).mockReturnValue({
+      totalStepCount: null,
+      currentStepNumber: null,
+      hasRunDiverged: true,
+    })
+    render(props)
+
+    screen.getByText('Step ?/?')
   })
 
   // ToDo (kj:04/10/2023) once we fix the track event stuff, we can implement tests

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -214,6 +214,7 @@ export function RunningProtocol(): JSX.Element {
           {robotSideAnalysis != null ? (
             currentOption === 'CurrentRunningProtocolCommand' ? (
               <CurrentRunningProtocolCommand
+                runId={runId}
                 playRun={playRun}
                 pauseRun={pauseRun}
                 setShowConfirmCancelRunModal={setShowConfirmCancelRunModal}

--- a/app/src/resources/protocols/hooks/__tests__/useLastRunProtocolCommand.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useLastRunProtocolCommand.test.ts
@@ -10,8 +10,8 @@ vi.mock('@opentrons/react-api-client')
 const mockRunId = 'mock-run-id'
 const mockCommandsData = {
   data: [
-    { id: 'cmd1', key: 'key1', intent: 'protocol' },
-    { id: 'cmd2', key: 'key2', intent: 'protocol' },
+    { id: 'cmd1', key: 'key1' },
+    { id: 'cmd2', key: 'key2' },
   ],
   meta: { totalLength: 2 },
 } as any
@@ -27,7 +27,6 @@ describe('useLastRunCommandNoFixit', () => {
     expect(result.current).toEqual({
       id: 'cmd2',
       key: 'key2',
-      intent: 'protocol',
     })
   })
 

--- a/app/src/resources/protocols/hooks/useLastRunProtocolCommand.ts
+++ b/app/src/resources/protocols/hooks/useLastRunProtocolCommand.ts
@@ -12,9 +12,15 @@ export function useLastRunProtocolCommand(
 ): RunCommandSummary | null {
   const lastRunCommand = last(commandsData?.data) ?? null
 
-  const isProtocolIntent = lastRunCommand?.intent === 'protocol'
+  // Not all protocol commands specify a protocol intent.
+  // If intent is undefined during a run, we can assume the intent is protocol.
+  const isProtocolIntent =
+    lastRunCommand != null &&
+    (lastRunCommand.intent != null
+      ? lastRunCommand.intent === 'protocol'
+      : true)
 
-  // Get the failed command from the fixit command.
+  // Get the failed command from the non-protocol command.
   const lastRunCommandActual = useCommandQuery(
     runId,
     lastRunCommand?.failedCommandId ?? null,


### PR DESCRIPTION
Closes [EXEC-550](https://opentrons.atlassian.net/browse/EXEC-550)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds a nifty step counter [per design. ](https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery?node-id=3432-54647&t=lxqQyuYubQoFXL4F-4)


<img width="890" alt="Screenshot 2024-06-17 at 7 27 48 PM" src="https://github.com/Opentrons/opentrons/assets/64858653/1ea468e7-f329-4837-8871-b6a546c51ea6">
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run any protocol your heart desires. Verify there is a step counter.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added a protocol step counter to the ODD.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low!
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-550]: https://opentrons.atlassian.net/browse/EXEC-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ