### PR TITLE
docs(api): Corrected slicing and well names in Multiple Air Gaps example

### DIFF
--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -397,7 +397,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
                 p300.return_tip()
 
-Notice here how Python's :py:class:`slice` functionality (in the code sample as ``[:5]``) lets us select the first five wells of the well plate only. Also, in Python, a range of numbers is *exclusive* of the end value and counting starts at 0, not 1. For the Corning 96-well plate used here, this means well A1=0, B1=1, C1=2, and so on to the last well used, which is E1=4. See also, the :ref:`tutorial-commands` section of the Tutorial.
+Notice here how Python's :py:class:`slice` functionality (in the code sample as ``[:5]``) lets us select the first five wells of the well plate only. Also, in Python, a range of numbers is *exclusive* of the end value and counting starts at 0, not 1. For the USA Scientific 12-well reservoir used here, this means well A1=0, A2=1, A3=2, and so on to the last well used, which is A5=4. See also, the :ref:`tutorial-commands` section of the Tutorial.
 
 Dilution
 ========

--- a/api/docs/v2/new_examples.rst
+++ b/api/docs/v2/new_examples.rst
@@ -397,7 +397,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
 
                 p300.return_tip()
 
-Notice here how Python's :py:class:`slice` functionality (in the code sample as ``[:4]``) lets us select the first five wells of the well plate only. Also, in Python, a range of numbers is *exclusive* of the end value and counting starts at 0, not 1. For the Corning 96-well plate used here, this means well A1=0, B1=1, C1=2, and so on to the last well used, which is E1=4. See also, the :ref:`tutorial-commands` section of the Tutorial.
+Notice here how Python's :py:class:`slice` functionality (in the code sample as ``[:5]``) lets us select the first five wells of the well plate only. Also, in Python, a range of numbers is *exclusive* of the end value and counting starts at 0, not 1. For the Corning 96-well plate used here, this means well A1=0, B1=1, C1=2, and so on to the last well used, which is E1=4. See also, the :ref:`tutorial-commands` section of the Tutorial.
 
 Dilution
 ========


### PR DESCRIPTION
# Overview

Fixed a mistake in the documentation.

In the Example for [Multiple Air Gaps](https://docs.opentrons.com/v2/new_examples.html#multiple-air-gaps) there is the code:
``` python
# aspirate from the first 5 wells
    for well in reservoir.wells()[:5]
```

In the text below the code it says:

> [...] (in the code sample as **[:4]**) lets us select the first five wells of the well plate only. [...]

For the first five wells the slicing of the code **[:5]** is correct and should be corrected in the text.

- The slice `[:5]` means "from the start up to but not including index 5".
- So, we get the elements at indices 0, 1, 2, 3, and 4.

# Test Plan
Think about it and accept it.

# Changelog

- Minor error correction in the documentation

# Review requests


# Risk assessment
