### PR TITLE
fix(step-generation): add nozzle props to consolidate and distribute

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -292,6 +292,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             pipette: args.pipette,
             dropTipLocation,
             tipRack: args.tipRack,
+            nozzles: args.nozzles ?? undefined,
           }),
         ]
       }

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -459,7 +459,6 @@ export const distribute: CommandCreator<DistributeArgs> = (
             }),
           ]
         : []
-      console.log('tipcommands', ...tipCommands)
 
       return [
         ...tipCommands,

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -308,6 +308,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             pipette: args.pipette,
             dropTipLocation: args.dropTipLocation,
             tipRack: args.tipRack,
+            nozzles: args.nozzles ?? undefined,
           }),
         ]
       }
@@ -458,6 +459,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
             }),
           ]
         : []
+      console.log('tipcommands', ...tipCommands)
 
       return [
         ...tipCommands,


### PR DESCRIPTION
closes RESC-283

# Overview

Oof, this is not a great bug. Basically, distribute and consolidate are currently broken in production when using a 96-channel because the not required `nozzles` prop was not extended for those components 🫠 I need to work with the QA team to add testing consolidate and distribute for single, 8 and 96 channels to the test plan. I'm pretty sure we only ever tested single and 8 channel 😬 

Anyway, this PR adds those props in and solves the issue the user was having.

# Test Plan

Upload the attached protocol to PD in production and see that it errors on step 9. Upload it to PD on this branch and see that it does not error

[Flex LDH 96 well kit (2) (1).json](https://github.com/user-attachments/files/15888095/Flex.LDH.96.well.kit.2.1.json)


# Changelog

- add nozzles prop to the replace tip in consolidate and distribute

# Review requests

see test plan

# Risk assessment

low