### PR TITLE
refactor(app): update CommandText

### DIFF
--- a/app/src/molecules/Command/CommandText.tsx
+++ b/app/src/molecules/Command/CommandText.tsx
@@ -52,6 +52,7 @@ interface Props extends StyleProps {
   command: RunTimeCommand
   commandTextData: CommandTextData
   robotType: RobotType
+  as?: React.ComponentProps<typeof StyledText>['as']
   isOnDevice?: boolean
   propagateCenter?: boolean
   propagateTextLimit?: boolean
@@ -63,6 +64,7 @@ export function CommandText(props: Props): JSX.Element | null {
     robotType,
     propagateCenter = false,
     propagateTextLimit = false,
+    as = 'p',
     ...styleProps
   } = props
   const { t } = useTranslation('protocol_command_text')
@@ -81,7 +83,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'dropTipInPlace':
     case 'pickUpTip': {
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           <PipettingCommandText {...{ command, commandTextData, robotType }} />
         </StyledText>
       )
@@ -91,7 +93,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'loadModule':
     case 'loadLiquid': {
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           <LoadCommandText {...{ command, commandTextData, robotType }} />
         </StyledText>
       )
@@ -102,7 +104,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'thermocycler/setTargetLidTemperature':
     case 'heaterShaker/setTargetTemperature': {
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           <TemperatureCommandText command={command} />
         </StyledText>
       )
@@ -135,12 +137,12 @@ export function CommandText(props: Props): JSX.Element | null {
             } ;
           `}
         >
-          <StyledText as="p" marginBottom={SPACING.spacing4} {...styleProps}>
+          <StyledText as={as} marginBottom={SPACING.spacing4} {...styleProps}>
             {t('tc_starting_profile', {
               repetitions: Object.keys(steps).length,
             })}
           </StyledText>
-          <StyledText as="p" marginLeft={SPACING.spacing16}>
+          <StyledText as={as} marginLeft={SPACING.spacing16}>
             <ul>
               {shouldPropagateTextLimit ? (
                 <li
@@ -171,7 +173,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'heaterShaker/setAndWaitForShakeSpeed': {
       const { rpm } = command.params
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('set_and_await_hs_shake', { rpm })}
         </StyledText>
       )
@@ -179,7 +181,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'moveToSlot': {
       const { slotName } = command.params
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('move_to_slot', { slot_name: slotName })}
         </StyledText>
       )
@@ -187,7 +189,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'moveRelative': {
       const { axis, distance } = command.params
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('move_relative', { axis, distance })}
         </StyledText>
       )
@@ -195,7 +197,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'moveToCoordinates': {
       const { coordinates } = command.params
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('move_to_coordinates', coordinates)}
         </StyledText>
       )
@@ -220,7 +222,7 @@ export function CommandText(props: Props): JSX.Element | null {
             )
           : ''
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('move_to_well', {
             well_name: wellName,
             labware: getLabwareName(commandTextData, labwareId),
@@ -231,7 +233,7 @@ export function CommandText(props: Props): JSX.Element | null {
     }
     case 'moveLabware': {
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           <MoveLabwareCommandText
             {...{ command, commandTextData, robotType }}
           />
@@ -245,7 +247,7 @@ export function CommandText(props: Props): JSX.Element | null {
       )?.pipetteName
 
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('configure_for_volume', {
             volume,
             pipette:
@@ -264,7 +266,7 @@ export function CommandText(props: Props): JSX.Element | null {
 
       // TODO (sb, 11/9/23): Add support for other configurations when needed
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('configure_nozzle_layout', {
             amount: configurationParams.style === 'COLUMN' ? '8' : 'all',
             pipette:
@@ -282,7 +284,7 @@ export function CommandText(props: Props): JSX.Element | null {
       )?.pipetteName
 
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('prepare_to_aspirate', {
             pipette:
               pipetteName != null
@@ -300,7 +302,7 @@ export function CommandText(props: Props): JSX.Element | null {
       )
 
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('move_to_addressable_area', {
             addressable_area: addressableAreaDisplayName,
           })}
@@ -314,7 +316,7 @@ export function CommandText(props: Props): JSX.Element | null {
         t
       )
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('move_to_addressable_area_drop_tip', {
             addressable_area: addressableAreaDisplayName,
           })}
@@ -342,7 +344,7 @@ export function CommandText(props: Props): JSX.Element | null {
       const simpleTKey =
         SIMPLE_TRANSLATION_KEY_BY_COMMAND_TYPE[command.commandType]
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {simpleTKey != null ? t(simpleTKey) : null}
         </StyledText>
       )
@@ -350,7 +352,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'waitForDuration': {
       const { seconds, message } = command.params
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {t('wait_for_duration', { seconds, message })}
         </StyledText>
       )
@@ -358,7 +360,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'pause': // legacy pause command
     case 'waitForResume': {
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {command.params?.message && command.params.message !== ''
             ? command.params.message
             : t('wait_for_resume')}
@@ -370,7 +372,7 @@ export function CommandText(props: Props): JSX.Element | null {
       const { message = '' } = command.params
       if ('waitForResume' in command.params) {
         return (
-          <StyledText as="p" {...styleProps}>
+          <StyledText as={as} {...styleProps}>
             {command.params?.message && command.params.message !== ''
               ? command.params.message
               : t('wait_for_resume')}
@@ -378,7 +380,7 @@ export function CommandText(props: Props): JSX.Element | null {
         )
       } else {
         return (
-          <StyledText as="p" {...styleProps}>
+          <StyledText as={as} {...styleProps}>
             {t('wait_for_duration', {
               seconds: command.params.seconds,
               message,
@@ -390,7 +392,7 @@ export function CommandText(props: Props): JSX.Element | null {
     case 'comment': {
       const { message } = command.params
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {message}
         </StyledText>
       )
@@ -402,7 +404,7 @@ export function CommandText(props: Props): JSX.Element | null {
           ? JSON.stringify(legacyCommandText)
           : String(legacyCommandText)
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {legacyCommandText != null
             ? sanitizedCommandText
             : `${command.commandType}: ${JSON.stringify(command.params)}`}
@@ -415,7 +417,7 @@ export function CommandText(props: Props): JSX.Element | null {
         command
       )
       return (
-        <StyledText as="p" {...styleProps}>
+        <StyledText as={as} {...styleProps}>
           {JSON.stringify(command)}
         </StyledText>
       )

--- a/app/src/organisms/ErrorRecoveryFlows/shared/StepInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/StepInfo.tsx
@@ -47,6 +47,7 @@ export function StepInfo({
           commandTextData={protocolAnalysis}
           robotType={robotType}
           display={DISPLAY_INLINE}
+          as={as}
         />
       ) : null}
     </Flex>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

`CommandText` should take a typography override. Let's use `as` with a default of `p`, since it's a consistent method for utilizing design-approved typography without generating our own one-off CSS styles. This adds the style override to the only place it's used, `StepInfo`.

<img width="896" alt="Screenshot 2024-06-18 at 10 58 58 AM" src="https://github.com/Opentrons/opentrons/assets/64858653/93bf54c4-65e7-4de1-b198-1270e1565c45">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
