### PR TITLE
refactor(app): add flex-wrap for two-column

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -21,6 +21,27 @@ export const customViewports = {
       height: '600px',
     },
   },
+  desktopMinWidth: {
+    // retains a 4:3 aspect ratio... minHeight is not set so the user
+    // could drag the app up to a thin strip, but that's not terribly
+    // useful for viewing designs
+    name: 'Desktop Minimum Width',
+    type: 'desktop',
+    styles: {
+      width: '600px',
+      height: '450px'
+    }
+  },
+  desktopSmall: {
+    // A size typically used in figma app backgrounds, useful for viewing
+    // larger components in context
+    name: 'Desktop Typical Small',
+    type: 'desktop',
+    styles: {
+      width: '1024px',
+      height: '700px'
+    }
+  }
 }
 
 export const parameters = {

--- a/app/src/molecules/InterventionModal/TwoColumn.stories.tsx
+++ b/app/src/molecules/InterventionModal/TwoColumn.stories.tsx
@@ -28,8 +28,6 @@ interface StorybookArgs {
   rightNotificationType: 'alert' | 'error' | 'neutral'
   leftText?: string
   rightText?: string
-  containerWidth: number
-  containerHeight: number
 }
 
 function StandInContent(): JSX.Element {
@@ -118,11 +116,7 @@ const meta: Meta<React.ComponentProps<TwoColumnComponent> & StorybookArgs> = {
   title: 'App/Molecules/InterventionModal/TwoColumn',
   component: TwoColumnComponent,
   render: args => (
-    <Box
-      width={`${args.containerWidth}px`}
-      height={`${args.containerHeight}px`}
-      borderWidth={'8px'}
-    >
+    <Box width="100%" height="100%" borderWidth="8px">
       <TwoColumnComponent>
         <SectionBodyOrStandIn
           standIn={args.leftStandIn}
@@ -155,18 +149,6 @@ const meta: Meta<React.ComponentProps<TwoColumnComponent> & StorybookArgs> = {
         type: 'boolean',
       },
       defaultValue: true,
-    },
-    containerHeight: {
-      control: {
-        type: 'number',
-      },
-      defaultValue: 104,
-    },
-    containerWidth: {
-      control: {
-        type: 'number',
-      },
-      defaultValue: 454,
     },
     leftText: {
       control: {
@@ -262,8 +244,6 @@ export const TwoColumnWithStandins: Story = {
     rightNotificationHeading: undefined,
     rightNotificationMessage: undefined,
     rightNotificationType: 'alert',
-    containerWidth: 452,
-    containerHeight: 104,
   },
 }
 
@@ -281,7 +261,5 @@ export const ExampleTwoColumn: Story = {
     rightNotificationHeading: undefined,
     rightNotificationMessage: undefined,
     rightNotificationType: 'neutral',
-    containerWidth: 452,
-    containerHeight: 104,
   },
 }

--- a/app/src/molecules/InterventionModal/TwoColumn.tsx
+++ b/app/src/molecules/InterventionModal/TwoColumn.tsx
@@ -11,7 +11,7 @@ export function TwoColumn({
 }: TwoColumnProps): JSX.Element {
   return (
     <Flex flexDirection={DIRECTION_ROW} gap={SPACING.spacing40} flexWrap={WRAP}>
-      <Box flex="1" minWidth="275px">
+      <Box flex="1" minWidth="17.1875rem">
         {leftElement}
       </Box>
       <Box flex="1" minWidth="275px">

--- a/app/src/molecules/InterventionModal/TwoColumn.tsx
+++ b/app/src/molecules/InterventionModal/TwoColumn.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import { Flex, Box, DIRECTION_ROW, SPACING } from '@opentrons/components'
+import { Flex, Box, DIRECTION_ROW, SPACING, WRAP } from '@opentrons/components'
 
 export interface TwoColumnProps {
   children: [React.ReactNode, React.ReactNode]
@@ -10,9 +10,13 @@ export function TwoColumn({
   children: [leftElement, rightElement],
 }: TwoColumnProps): JSX.Element {
   return (
-    <Flex flexDirection={DIRECTION_ROW} gap={SPACING.spacing40}>
-      <Box flex={1}>{leftElement}</Box>
-      <Box flex={1}>{rightElement}</Box>
+    <Flex flexDirection={DIRECTION_ROW} gap={SPACING.spacing40} flexWrap={WRAP}>
+      <Box flex="1" minWidth="275px">
+        {leftElement}
+      </Box>
+      <Box flex="1" minWidth="275px">
+        {rightElement}
+      </Box>
     </Flex>
   )
 }


### PR DESCRIPTION
Lets the component reflow when necessary. Specs from figma.

Also, add some smaller desktop app viewport sizes to storybook so you can test it a bit easier.

Closes EXEC-570
