### PR TITLE
feat(robot-server): Add failedCommandId to command summary model

### DIFF
--- a/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_models.py
@@ -4,10 +4,6 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 
 from opentrons.protocol_engine import (
-    CommandStatus,
-    CommandIntent,
-    CommandType,
-    CommandParams,
     EngineStatus as RunStatus,
     ErrorOccurrence,
     LoadedPipette,
@@ -18,42 +14,6 @@ from opentrons.protocol_engine import (
     Liquid,
 )
 from robot_server.service.json_api import ResourceModel
-
-
-# TODO(mc, 2022-02-01): since the `/maintenance_runs/:run_id/commands` response is now paginated,
-# this summary model is a lot less useful. Remove and replace with full `Command`
-# models once problematically large objects like full labware and module definitions
-# are no longer part of the public command.result API
-class MaintenanceRunCommandSummary(ResourceModel):
-    """A stripped down model of a full Command for usage in a Maintenance run response."""
-
-    id: str = Field(..., description="Unique command identifier.")
-    key: str = Field(
-        ...,
-        description="An identifier representing this command as a step in a protocol.",
-    )
-    commandType: CommandType = Field(..., description="Specific type of command.")
-    createdAt: datetime = Field(..., description="Command creation timestamp")
-    startedAt: Optional[datetime] = Field(
-        None,
-        description="Command execution start timestamp, if started",
-    )
-    completedAt: Optional[datetime] = Field(
-        None,
-        description="Command execution completed timestamp, if completed",
-    )
-    status: CommandStatus = Field(..., description="Execution status of the command.")
-    error: Optional[ErrorOccurrence] = Field(
-        None,
-        description="Error occurrence, if status is 'failed'",
-    )
-    # TODO(mc, 2022-02-01): this does not allow the command summary object to
-    # be narrowed based on `commandType`. Will be resolved by TODO above
-    params: CommandParams = Field(..., description="Command execution parameters.")
-    intent: Optional[CommandIntent] = Field(
-        None,
-        description="Why this command was added to the run.",
-    )
 
 
 class MaintenanceRun(ResourceModel):

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -25,11 +25,9 @@ from robot_server.runs.command_models import (
     CommandLink,
     CommandLinkMeta,
 )
+from robot_server.runs.run_models import RunCommandSummary
 
-from ..maintenance_run_models import (
-    MaintenanceRunCommandSummary,
-    MaintenanceRunNotFoundError,
-)
+from ..maintenance_run_models import MaintenanceRunNotFoundError
 from ..maintenance_run_data_manager import MaintenanceRunDataManager
 from ..maintenance_engine_store import MaintenanceEngineStore
 from ..dependencies import (
@@ -177,7 +175,7 @@ async def create_run_command(
     ),
     responses={
         status.HTTP_200_OK: {
-            "model": MultiBody[MaintenanceRunCommandSummary, CommandCollectionLinks]
+            "model": MultiBody[RunCommandSummary, CommandCollectionLinks]
         },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
@@ -199,7 +197,7 @@ async def get_run_commands(
     run_data_manager: MaintenanceRunDataManager = Depends(
         get_maintenance_run_data_manager
     ),
-) -> PydanticResponse[MultiBody[MaintenanceRunCommandSummary, CommandCollectionLinks]]:
+) -> PydanticResponse[MultiBody[RunCommandSummary, CommandCollectionLinks]]:
     """Get a summary of a set of commands in a run.
 
     Arguments:
@@ -221,7 +219,7 @@ async def get_run_commands(
     recovery_target_command = run_data_manager.get_recovery_target_command(run_id=runId)
 
     data = [
-        MaintenanceRunCommandSummary.construct(
+        RunCommandSummary.construct(
             id=c.id,
             key=c.key,
             commandType=c.commandType,
@@ -232,6 +230,7 @@ async def get_run_commands(
             completedAt=c.completedAt,
             params=c.params,
             error=c.error,
+            failedCommandId=c.failedCommandId,
         )
         for c in command_slice.commands
     ]

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -299,6 +299,7 @@ async def get_run_commands(
             params=c.params,
             error=c.error,
             notes=c.notes,
+            failedCommandId=c.failedCommandId,
         )
         for c in command_slice.commands
     ]

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -73,6 +73,12 @@ class RunCommandSummary(ResourceModel):
         None,
         description="Notes pertaining to this command.",
     )
+    failedCommandId: Optional[str] = Field(
+        None,
+        description=(
+            "FIXIT command use only. Reference of the failed command id we are trying to fix."
+        ),
+    )
 
 
 class Run(ResourceModel):

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -22,7 +22,6 @@ from robot_server.maintenance_runs.maintenance_run_data_manager import (
     MaintenanceRunDataManager,
 )
 from robot_server.maintenance_runs.maintenance_run_models import (
-    MaintenanceRunCommandSummary,
     MaintenanceRunNotFoundError,
 )
 from robot_server.maintenance_runs.router.commands_router import (
@@ -37,6 +36,7 @@ from robot_server.runs.command_models import (
     CommandLink,
     CommandLinkMeta,
 )
+from robot_server.runs.run_models import RunCommandSummary
 
 
 async def test_get_current_run_from_url(
@@ -175,6 +175,7 @@ async def test_get_run_commands(
             createdAt=datetime(year=2024, month=4, day=4),
             detail="Things are not looking good.",
         ),
+        failedCommandId="failed-command-id",
     )
 
     decoy.when(
@@ -214,7 +215,7 @@ async def test_get_run_commands(
     )
 
     assert result.content.data == [
-        MaintenanceRunCommandSummary(
+        RunCommandSummary(
             id="command-id",
             key="command-key",
             commandType="waitForResume",
@@ -230,6 +231,7 @@ async def test_get_run_commands(
                 createdAt=datetime(year=2024, month=4, day=4),
                 detail="Things are not looking good.",
             ),
+            failedCommandId="failed-command-id",
         )
     ]
     assert result.content.meta == MultiBodyMeta(cursor=1, totalLength=3)

--- a/robot-server/tests/runs/router/test_commands_router.py
+++ b/robot-server/tests/runs/router/test_commands_router.py
@@ -309,6 +309,7 @@ async def test_get_run_commands(
             detail="Things are not looking good.",
         ),
         notes=[long_note, unenumed_note],
+        failedCommandId="failed-command-id",
     )
 
     decoy.when(mock_run_data_manager.get_current_command("run-id")).then_return(
@@ -360,6 +361,7 @@ async def test_get_run_commands(
                 detail="Things are not looking good.",
             ),
             notes=[long_note, unenumed_note],
+            failedCommandId="failed-command-id",
         )
     ]
     assert result.content.meta == MultiBodyMeta(cursor=1, totalLength=3)


### PR DESCRIPTION
# Overview

Closes EXEC-571.

# Test plan

None needed.

# Changelog

* Add `failedCommandId` to command summaries (`GET /runs/{id}/commands`).
* Deduplicate the `MaintenanceRunCommandSummary` model with `RunCommandSummary`.

# Review requests

None.

# Risk assessment

Low.
