### PR TITLE
refactor(api): wire protocol engine pick_up_tip to new hardware control function

### DIFF
--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1152,7 +1152,7 @@ class API(
                 mount, back_left_nozzle, front_right_nozzle, starting_nozzle
             )
 
-    async def tip_pickup_moves(
+    async def _tip_pickup_moves(
         self,
         mount: top_types.Mount,
         spec: PickUpTipSpec,
@@ -1200,7 +1200,7 @@ class API(
             home_flagged_axes=False,
         )
 
-        await self.tip_pickup_moves(mount, spec)
+        await self._tip_pickup_moves(mount, spec)
         _add_tip_to_instrs()
 
         if prep_after:

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -65,7 +65,7 @@ from .robot_calibration import (
     RobotCalibration,
 )
 from .protocols import HardwareControlInterface
-from .instruments.ot2.pipette_handler import PipetteHandlerProvider, PickUpTipSpec
+from .instruments.ot2.pipette_handler import PipetteHandlerProvider
 from .instruments.ot2.instrument_calibration import load_pipette_offset
 from .motion_utilities import (
     target_position_from_absolute,
@@ -1152,11 +1152,24 @@ class API(
                 mount, back_left_nozzle, front_right_nozzle, starting_nozzle
             )
 
-    async def _tip_pickup_moves(
+    async def tip_pickup_moves(
         self,
         mount: top_types.Mount,
-        spec: PickUpTipSpec,
+        presses: Optional[int] = None,
+        increment: Optional[float] = None,
     ) -> None:
+        spec, _ = self.plan_check_pick_up_tip(
+            mount=mount, presses=presses, increment=increment
+        )
+        self._backend.set_active_current(spec.plunger_currents)
+        target_absolute = target_position_from_plunger(
+            mount, spec.plunger_prep_pos, self._current_position
+        )
+        await self._move(
+            target_absolute,
+            home_flagged_axes=False,
+        )
+
         for press in spec.presses:
             with self._backend.save_current():
                 self._backend.set_active_current(press.current)
@@ -1176,6 +1189,11 @@ class API(
 
         await self.retract(mount, spec.retract_target)
 
+    def cache_tip(self, mount: top_types.Mount, tip_length: float) -> None:
+        instrument = self.get_pipette(mount)
+        instrument.add_tip(tip_length=tip_length)
+        instrument.set_current_volume(0)
+
     async def pick_up_tip(
         self,
         mount: top_types.Mount,
@@ -1189,7 +1207,7 @@ class API(
         """
 
         spec, _add_tip_to_instrs = self.plan_check_pick_up_tip(
-            mount, tip_length, presses, increment
+            mount=mount, presses=presses, increment=increment, tip_length=tip_length
         )
         self._backend.set_active_current(spec.plunger_currents)
         target_absolute = target_position_from_plunger(
@@ -1200,7 +1218,24 @@ class API(
             home_flagged_axes=False,
         )
 
-        await self._tip_pickup_moves(mount, spec)
+        for press in spec.presses:
+            with self._backend.save_current():
+                self._backend.set_active_current(press.current)
+                target_down = target_position_from_relative(
+                    mount, press.relative_down, self._current_position
+                )
+                await self._move(target_down, speed=press.speed)
+            target_up = target_position_from_relative(
+                mount, press.relative_up, self._current_position
+            )
+            await self._move(target_up)
+        # neighboring tips tend to get stuck in the space between
+        # the volume chamber and the drop-tip sleeve on p1000.
+        # This extra shake ensures those tips are removed
+        for rel_point, speed in spec.shake_off_list:
+            await self.move_rel(mount, rel_point, speed=speed)
+
+        await self.retract(mount, spec.retract_target)
         _add_tip_to_instrs()
 
         if prep_after:

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -744,9 +744,9 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plan_check_pick_up_tip(
         self,
         mount: top_types.Mount,
-        tip_length: float,
         presses: Optional[int],
         increment: Optional[float],
+        tip_length: float = 0,
     ) -> Tuple[PickUpTipSpec, Callable[[], None]]:
         ...
 
@@ -754,18 +754,18 @@ class PipetteHandlerProvider(Generic[MountType]):
     def plan_check_pick_up_tip(
         self,
         mount: OT3Mount,
-        tip_length: float,
         presses: Optional[int],
         increment: Optional[float],
+        tip_length: float = 0,
     ) -> Tuple[PickUpTipSpec, Callable[[], None]]:
         ...
 
     def plan_check_pick_up_tip(  # type: ignore[no-untyped-def]
         self,
         mount,
-        tip_length,
         presses,
         increment,
+        tip_length=0,
     ):
         # Prechecks: ready for pickup tip and press/increment are valid
         instrument = self.get_pipette(mount)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2191,6 +2191,15 @@ class OT3API(
             )
             await self.home_gear_motors()
 
+    def cache_tip(
+        self, mount: Union[top_types.Mount, OT3Mount], tip_length: float
+    ) -> None:
+        realmount = OT3Mount.from_mount(mount)
+        instrument = self._pipette_handler.get_pipette(realmount)
+
+        instrument.add_tip(tip_length=tip_length)
+        instrument.set_current_volume(0)
+
     async def pick_up_tip(
         self,
         mount: Union[top_types.Mount, OT3Mount],

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1799,7 +1799,7 @@ class OT3API(
 
     async def tip_pickup_moves(
         self,
-        mount: OT3Mount,
+        mount: Union[top_types.Mount, OT3Mount],
         presses: Optional[int] = None,
         increment: Optional[float] = None,
     ) -> None:
@@ -2209,7 +2209,7 @@ class OT3API(
 
         await self._move_to_plunger_bottom(realmount, rate=1.0)
 
-        await self.tip_pickup_moves(realmount, presses, increment)
+        await self.tip_pickup_moves(mount, presses, increment)
 
         add_tip_to_instr()
 

--- a/api/src/opentrons/hardware_control/protocols/__init__.py
+++ b/api/src/opentrons/hardware_control/protocols/__init__.py
@@ -59,6 +59,9 @@ class HardwareControlInterface(
     def get_robot_type(self) -> Type[OT2RobotType]:
         return OT2RobotType
 
+    def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
+        ...
+
 
 class FlexHardwareControlInterface(
     ModuleProvider,
@@ -88,6 +91,9 @@ class FlexHardwareControlInterface(
         ...
 
     def encoder_status_ok(self, axis: Axis) -> bool:
+        ...
+
+    def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
         ...
 
 

--- a/api/src/opentrons/hardware_control/protocols/liquid_handler.py
+++ b/api/src/opentrons/hardware_control/protocols/liquid_handler.py
@@ -130,6 +130,14 @@ class LiquidHandler(
         """
         ...
 
+    async def tip_pickup_moves(
+        self,
+        mount: MountArgType,
+        presses: Optional[int] = None,
+        increment: Optional[float] = None,
+    ) -> None:
+        ...
+
     async def pick_up_tip(
         self,
         mount: MountArgType,

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -128,7 +128,7 @@ class TipNotAttachedError(ProtocolEngineError):
         details: Optional[Dict[str, Any]] = None,
         wrapping: Optional[Sequence[EnumeratedError]] = None,
     ) -> None:
-        """Build a PIpetteNotAttachedError."""
+        """Build a PipetteNotAttachedError."""
         super().__init__(ErrorCodes.UNEXPECTED_TIP_REMOVAL, message, details, wrapping)
 
 

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -180,7 +180,7 @@ class HardwareTipHandler(TipHandler):
             )
             try:
                 await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
-            except PythonException:
+            except TipNotAttachedError:
                 raise
             else:
                 self._hardware_api.cache_tip(hw_mount, actual_tip_length)

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -172,12 +172,20 @@ class HardwareTipHandler(TipHandler):
             nominal_fallback=nominal_tip_geometry.length,
         )
 
-        await self._hardware_api.pick_up_tip(
-            mount=hw_mount,
-            tip_length=actual_tip_length,
-            presses=None,
-            increment=None,
-        )
+        if self._state_view.config.robot_type == "OT-3 Standard":
+            await self._hardware_api.tip_pickup_moves(
+                mount=hw_mount,
+                presses=None,
+                increment=None,
+            )
+        else:
+            await self._hardware_api.pick_up_tip(
+                mount=hw_mount,
+                tip_length=actual_tip_length,
+                presses=None,
+                increment=None,
+            )
+
         await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
 
         self._hardware_api.set_current_tiprack_diameter(

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -172,29 +172,13 @@ class HardwareTipHandler(TipHandler):
             nominal_fallback=nominal_tip_geometry.length,
         )
 
-        if self._state_view.config.robot_type == "OT-3 Standard":
-            await self._hardware_api.tip_pickup_moves(
-                mount=hw_mount,
-                presses=None,
-                increment=None,
-            )
-            try:
-                await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
-            except TipNotAttachedError:
-                raise
-            else:
-                self._hardware_api.cache_tip(hw_mount, actual_tip_length)
+        await self._hardware_api.tip_pickup_moves(
+            mount=hw_mount, presses=None, increment=None
+        )
+        await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
 
-            await self._hardware_api.prepare_for_aspirate(hw_mount)
-        else:
-            await self._hardware_api.pick_up_tip(
-                mount=hw_mount,
-                tip_length=actual_tip_length,
-                presses=None,
-                increment=None,
-            )
-
-            await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
+        self._hardware_api.cache_tip(hw_mount, actual_tip_length)
+        await self._hardware_api.prepare_for_aspirate(hw_mount)
 
         self._hardware_api.set_current_tiprack_diameter(
             mount=hw_mount,

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -183,7 +183,6 @@ class HardwareTipHandler(TipHandler):
             except TipNotAttachedError:
                 raise
             else:
-                # breakpoint()
                 self._hardware_api.cache_tip(hw_mount, actual_tip_length)
 
             await self._hardware_api.prepare_for_aspirate(hw_mount)

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -183,6 +183,7 @@ class HardwareTipHandler(TipHandler):
             except TipNotAttachedError:
                 raise
             else:
+                # breakpoint()
                 self._hardware_api.cache_tip(hw_mount, actual_tip_length)
 
             await self._hardware_api.prepare_for_aspirate(hw_mount)

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -178,6 +178,14 @@ class HardwareTipHandler(TipHandler):
                 presses=None,
                 increment=None,
             )
+            try:
+                await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
+            except PythonException:
+                raise
+            else:
+                self._hardware_api.cache_tip(hw_mount, actual_tip_length)
+
+            await self._hardware_api.prepare_for_aspirate(hw_mount)
         else:
             await self._hardware_api.pick_up_tip(
                 mount=hw_mount,
@@ -186,7 +194,7 @@ class HardwareTipHandler(TipHandler):
                 increment=None,
             )
 
-        await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
+            await self.verify_tip_presence(pipette_id, TipPresenceStatus.PRESENT)
 
         self._hardware_api.set_current_tiprack_diameter(
             mount=hw_mount,

--- a/api/tests/opentrons/hardware_control/test_instruments.py
+++ b/api/tests/opentrons/hardware_control/test_instruments.py
@@ -556,7 +556,7 @@ async def test_tip_pickup_moves(sim_and_instr):
         spec, _ = hw_api.plan_check_pick_up_tip(
             mount=mount, tip_length=40.0, presses=None, increment=None
         )
-        await hw_api.tip_pickup_moves(mount, spec)
+        await hw_api.tip_pickup_moves(mount=mount)
     else:
         await hw_api.tip_pickup_moves(mount)
 

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -296,7 +296,6 @@ async def test_tip_pickup_routine(hardware_api, monkeypatch):
     # moves for each press
     tip_motor_routine_num_moves = 2 * presses + 1
 
-    # the tip motor routine should only make the immediate 'press' moves happen
     assert len(_move.call_args_list) == tip_motor_routine_num_moves
     _move.reset_mock()
 

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -292,7 +292,7 @@ async def test_tip_pickup_routine(hardware_api, monkeypatch):
     spec, _ = hardware_api.plan_check_pick_up_tip(
         mount=mount, tip_length=40.0, presses=None, increment=None
     )
-    await hardware_api.tip_pickup_moves(mount, spec)
+    await hardware_api._tip_pickup_moves(mount, spec)
 
     tip_motor_routine_num_moves = 2 * len(spec.presses)
 

--- a/api/tests/opentrons/hardware_control/test_moves.py
+++ b/api/tests/opentrons/hardware_control/test_moves.py
@@ -289,12 +289,12 @@ async def test_tip_pickup_routine(hardware_api, monkeypatch):
     await hardware_api.cache_instruments()
     mount = types.Mount.RIGHT
 
-    spec, _ = hardware_api.plan_check_pick_up_tip(
-        mount=mount, tip_length=40.0, presses=None, increment=None
-    )
-    await hardware_api._tip_pickup_moves(mount, spec)
+    presses = 1
+    await hardware_api.tip_pickup_moves(mount, presses=presses)
 
-    tip_motor_routine_num_moves = 2 * len(spec.presses)
+    # tip pickup moves has an initial move to above the tip, then 2
+    # moves for each press
+    tip_motor_routine_num_moves = 2 * presses + 1
 
     # the tip motor routine should only make the immediate 'press' moves happen
     assert len(_move.call_args_list) == tip_motor_routine_num_moves
@@ -302,9 +302,10 @@ async def test_tip_pickup_routine(hardware_api, monkeypatch):
 
     # pick_up_tip should have the press moves + a plunger move both before and after
     await hardware_api.pick_up_tip(
-        mount=mount, tip_length=40.0, presses=None, increment=None, prep_after=True
+        mount=mount, tip_length=40.0, presses=1, increment=None, prep_after=True
     )
-    assert len(_move.call_args_list) == tip_motor_routine_num_moves + 2
+    # pick_up_tip contains an additional retract
+    assert len(_move.call_args_list) == tip_motor_routine_num_moves + 1
 
 
 async def test_new_critical_point_applied(hardware_api):

--- a/api/tests/opentrons/hardware_control/test_pipette_handler.py
+++ b/api/tests/opentrons/hardware_control/test_pipette_handler.py
@@ -137,7 +137,7 @@ def test_plan_check_pick_up_tip_with_presses_argument(
     )
 
     spec, _add_tip_to_instrs = subject.plan_check_pick_up_tip(
-        mount, tip_length, presses, increment
+        mount=mount, tip_length=tip_length, presses=presses, increment=increment
     )
 
     assert len(spec.presses) == expected_array_length

--- a/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_tip_handler.py
@@ -78,6 +78,7 @@ async def test_create_tip_handler(
     )
 
 
+@pytest.mark.ot3_only
 @pytest.mark.parametrize("tip_state", [TipStateType.PRESENT, TipStateType.ABSENT])
 async def test_flex_pick_up_tip_state(
     decoy: Decoy,
@@ -87,65 +88,61 @@ async def test_flex_pick_up_tip_state(
     tip_state: TipStateType,
 ) -> None:
     """Test the protocol engine's pick_up_tip logic."""
-    try:
-        from opentrons.hardware_control.ot3api import OT3API
+    from opentrons.hardware_control.ot3api import OT3API
 
-        ot3_hardware_api = decoy.mock(cls=OT3API)
-        decoy.when(ot3_hardware_api.get_robot_type()).then_return(FlexRobotType)
+    ot3_hardware_api = decoy.mock(cls=OT3API)
+    decoy.when(ot3_hardware_api.get_robot_type()).then_return(FlexRobotType)
 
-        subject = HardwareTipHandler(
-            state_view=mock_state_view,
-            hardware_api=ot3_hardware_api,
-            labware_data_provider=mock_labware_data_provider,
+    subject = HardwareTipHandler(
+        state_view=mock_state_view,
+        hardware_api=ot3_hardware_api,
+        labware_data_provider=mock_labware_data_provider,
+    )
+    decoy.when(subject._state_view.config.robot_type).then_return("OT-3 Standard")
+    decoy.when(mock_state_view.pipettes.get_mount("pipette-id")).then_return(
+        MountType.LEFT
+    )
+    decoy.when(
+        mock_state_view.geometry.get_nominal_tip_geometry(
+            pipette_id="pipette-id",
+            labware_id="labware-id",
+            well_name="B2",
         )
-        decoy.when(subject._state_view.config.robot_type).then_return("OT-3 Standard")
-        decoy.when(mock_state_view.pipettes.get_mount("pipette-id")).then_return(
-            MountType.LEFT
+    ).then_return(TipGeometry(length=50, diameter=5, volume=300))
+
+    decoy.when(
+        await mock_labware_data_provider.get_calibrated_tip_length(
+            pipette_serial="pipette-serial",
+            labware_definition=tip_rack_definition,
+            nominal_fallback=50,
         )
-        decoy.when(
-            mock_state_view.geometry.get_nominal_tip_geometry(
+    ).then_return(42)
+
+    with patch.object(
+        ot3_hardware_api, "cache_tip", AsyncMock(spec=ot3_hardware_api.cache_tip)
+    ) as mock_add_tip:
+
+        if tip_state == TipStateType.PRESENT:
+            await subject.pick_up_tip(
                 pipette_id="pipette-id",
                 labware_id="labware-id",
                 well_name="B2",
             )
-        ).then_return(TipGeometry(length=50, diameter=5, volume=300))
-
-        decoy.when(
-            await mock_labware_data_provider.get_calibrated_tip_length(
-                pipette_serial="pipette-serial",
-                labware_definition=tip_rack_definition,
-                nominal_fallback=50,
-            )
-        ).then_return(42)
-
-        with patch.object(
-            ot3_hardware_api, "cache_tip", AsyncMock(spec=ot3_hardware_api.cache_tip)
-        ) as mock_add_tip:
-
-            if tip_state == TipStateType.PRESENT:
+            mock_add_tip.assert_called_once()
+        else:
+            decoy.when(
+                await subject.verify_tip_presence(
+                    pipette_id="pipette-id", expected=TipPresenceStatus.PRESENT
+                )
+            ).then_raise(TipNotAttachedError())
+            # if a TipNotAttchedError is caught, we should not add any tip information
+            with pytest.raises(TipNotAttachedError):
                 await subject.pick_up_tip(
                     pipette_id="pipette-id",
                     labware_id="labware-id",
                     well_name="B2",
                 )
-                mock_add_tip.assert_called_once()
-            else:
-                decoy.when(
-                    await subject.verify_tip_presence(
-                        pipette_id="pipette-id", expected=TipPresenceStatus.PRESENT
-                    )
-                ).then_raise(TipNotAttachedError())
-                # if a TipNotAttchedError is caught, we should not add any tip information
-                with pytest.raises(TipNotAttachedError):
-                    await subject.pick_up_tip(
-                        pipette_id="pipette-id",
-                        labware_id="labware-id",
-                        well_name="B2",
-                    )
-                mock_add_tip.assert_not_called()
-
-    except ImportError:
-        pass
+            mock_add_tip.assert_not_called()
 
 
 async def test_pick_up_tip(
@@ -199,9 +196,8 @@ async def test_pick_up_tip(
     assert result == TipGeometry(length=42, diameter=5, volume=300)
 
     decoy.verify(
-        await mock_hardware_api.pick_up_tip(
+        await mock_hardware_api.tip_pickup_moves(
             mount=Mount.LEFT,
-            tip_length=42,
             presses=None,
             increment=None,
         ),


### PR DESCRIPTION
## Overview
Hardware control now has a `tip_pickup_moves` function, which is just the most immediate movement required to pick up a tip, and unlike `pick_up_tip`, does not cache a tip in the pipette handler or prepare the pipette for aspiration. 

This code changes the protocol engine's `pick_up_tip` command to use this new function if a flex is executing the command, and does not change the behavior for an ot2.

## Test Plan

- [x] Test tip pickup on an ot2 and make sure behavior hasn't changed
- [x] Verify that a flex can now retry tip pickup multiple times in error recovery, and then proceed with a protocol once tips are present 