### PR TITLE
refactor(app): update current step behavior

### DIFF
--- a/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
+++ b/app/src/organisms/RunProgressMeter/__tests__/RunProgressMeter.test.tsx
@@ -100,7 +100,7 @@ describe('RunProgressMeter', () => {
   it('should show only the total count of commands in run and not show the meter when protocol is non-deterministic', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
     render(props)
-    expect(screen.getByText('Current Step 42/?')).toBeTruthy()
+    expect(screen.getByText('Current Step ?/?')).toBeTruthy()
     expect(screen.queryByText('MOCK PROGRESS BAR')).toBeFalsy()
   })
   it('should give the correct info when run status is idle', () => {
@@ -142,6 +142,6 @@ describe('RunProgressMeter', () => {
     vi.mocked(useCommandQuery).mockReturnValue({ data: null } as any)
     vi.mocked(useRunStatus).mockReturnValue(RUN_STATUS_SUCCEEDED)
     render(props)
-    screen.getByText('Final Step 42/?')
+    screen.getByText('Final Step ?/?')
   })
 })

--- a/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
+++ b/app/src/resources/protocols/hooks/__tests__/useRunningStepCount.test.ts
@@ -20,7 +20,7 @@ const mockCommandsData = {
 } as any
 
 describe('useRunningStepCounts', () => {
-  it('returns current step number and total step count for a deterministic run', () => {
+  it('returns current step number and total step count for a non-diverged run', () => {
     const mockAnalysis = {
       commands: [{ key: 'key1' }, { key: 'key2' }, { key: 'key3' }],
     } as any
@@ -38,16 +38,20 @@ describe('useRunningStepCounts', () => {
     })
   })
 
-  it('returns current step number and null total step count for a non-deterministic run', () => {
-    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
-    vi.mocked(useLastRunProtocolCommand).mockReturnValue(null)
+  it('returns null current step number and null total step count for a diverged run', () => {
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue({
+      commands: [{ key: 'key1' }, { key: 'key2' }, { key: 'key3' }],
+    } as any)
+    vi.mocked(useLastRunProtocolCommand).mockReturnValue({
+      key: 'different_key',
+    } as any)
 
     const { result } = renderHook(() =>
       useRunningStepCounts(mockRunId, mockCommandsData)
     )
 
     expect(result.current).toEqual({
-      currentStepNumber: 2,
+      currentStepNumber: null,
       totalStepCount: null,
       hasRunDiverged: true,
     })

--- a/app/src/resources/protocols/hooks/useRunningStepCounts.ts
+++ b/app/src/resources/protocols/hooks/useRunningStepCounts.ts
@@ -18,7 +18,7 @@ export interface StepCounts {
  * that has the same commandKey as the most recent
  * command from the run record.
  * In the case of a non-deterministic protocol,
- * source from the run rather than the analysis.
+ * return null for the current and total steps.
  * NOTE: The most recent
  * command may not always be "current", for instance if
  * the run has completed/failed.
@@ -41,19 +41,14 @@ export function useRunningStepCounts(
 
   const currentStepNumberByAnalysis =
     lastRunAnalysisCommandIndex === -1 ? null : lastRunAnalysisCommandIndex + 1
-  const currentStepNumberByRun = commandsData?.meta.totalLength ?? null
 
   const hasRunDiverged =
     lastRunCommandNoFixit?.key == null || currentStepNumberByAnalysis == null
 
-  const currentStepNumber = !hasRunDiverged
-    ? currentStepNumberByAnalysis
-    : currentStepNumberByRun
-
   const totalStepCount = !hasRunDiverged ? analysisCommands.length : null
 
   return {
-    currentStepNumber,
+    currentStepNumber: currentStepNumberByAnalysis,
     totalStepCount,
     hasRunDiverged,
   }


### PR DESCRIPTION
[EXEC-572](https://opentrons.atlassian.net/browse/EXEC-572)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Harmonizes the return value logic of `currentStepNumber` with `totalStepCount`. 

Prior to 8.0, we’d fallback to deriving the current step count from the active run endpoint if we couldn’t get it from analysis (the run had diverged). Now, because we have fixit commands, we can’t do this, since that fallback step count will include fixit commands. This isn’t a functional change, just an "enforcing consistency change". We were already not using the run commands endpoint for “total steps” as a fallback. Realistically, we can always find the current step number from protocol analysis, since we filter out “not protocol” commands, so if `currentStepNumber` is ever `null`, there's an issue with a fetch, the protocol analysis itself, or most likely, the current command has diverged from analysis.


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- If you want to test, throw `edge` robot-server and cherry-pick this commit on top of #15466 before pushing the ODD. Open the error details modal in the upper right during error recovery, look at the step count, then issue some fixit commands. Re-open the error details modal and confirm the step counts haven't changed.
-  Smoked test app to confirm no regression. Verified adding fixit commands does not cause the step count to change. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-572]: https://opentrons.atlassian.net/browse/EXEC-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ