### PR TITLE
fix(protocol-designer): display column count in WellSelectionField fo…

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/WellSelectionField/WellSelectionField.tsx
@@ -41,6 +41,7 @@ export const WellSelectionField = (props: Props): JSX.Element => {
   const stepId = useSelector(getSelectedStepId)
   const pipetteEntities = useSelector(stepFormSelectors.getPipetteEntities)
   const wellSelectionLabwareKey = useSelector(getWellSelectionLabwareKey)
+  const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
   const primaryWellCount =
     Array.isArray(selectedWells) && selectedWells.length > 0
       ? selectedWells.length.toString()
@@ -84,15 +85,26 @@ export const WellSelectionField = (props: Props): JSX.Element => {
 
   const modalKey = getModalKey()
   const label =
-    nozzleType === '8-channel' || nozzleType === COLUMN
+    nozzleType === '8-channel' || nozzleType === COLUMN || nozzleType === ALL
       ? t('step_edit_form.wellSelectionLabel.columns')
       : t('step_edit_form.wellSelectionLabel.wells')
+
+  const labwareDef = labwareId != null ? labwareEntities[labwareId] : null
+  const numColumns = labwareDef != null ? labwareDef.def.ordering.length : null
+  const wellCountDisplay =
+    primaryWellCount != null &&
+    labwareDef != null &&
+    nozzleType === ALL &&
+    numColumns != null &&
+    Array.isArray(selectedWells)
+      ? (selectedWells.length * Math.min(12, numColumns)).toString()
+      : primaryWellCount
   return (
     <FormGroup label={label} disabled={disabled} className={styles.small_field}>
       <InputField
         readOnly
         name={name}
-        value={primaryWellCount ?? null}
+        value={wellCountDisplay}
         onClick={handleOpen}
         error={errorToShow}
       />


### PR DESCRIPTION
…r 96-channel transfers

We should display the number of columns accessed by the 96-channel pipette depending on the labeware format in the WellSelectionField component.

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
