### PR TITLE
test(protocol-engine): Port some tests

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -231,7 +231,6 @@ class CommandStore(HasState[CommandState], HandlesActions):
             # TODO(mc, 2021-06-22): mypy has trouble with this automatic
             # request > command mapping, figure out how to type precisely
             # (or wait for a future mypy version that can figure it out).
-            # For now, unit tests cover mapping every request type
             queued_command = action.request._CommandCls.construct(
                 id=action.command_id,
                 key=(

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -679,10 +679,6 @@ class CommandView(HasState[CommandState]):
         """Get whether the robot door is open when 'pause on door open' ff is True."""
         return self._state.is_door_blocking
 
-    def get_is_implicitly_active(self) -> bool:
-        """Get whether the queue is implicitly active, i.e., never 'played'."""
-        return self._state.queue_status == QueueStatus.SETUP
-
     def get_is_running(self) -> bool:
         """Get whether the protocol is running & queued commands should be executed."""
         return self._state.queue_status == QueueStatus.RUNNING

--- a/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
@@ -55,40 +55,6 @@ def _make_config(block_on_door_open: bool = False) -> Config:
     )
 
 
-@pytest.mark.parametrize(
-    ("is_door_open", "config", "expected_is_door_blocking"),
-    [
-        (False, _make_config(), False),
-        (True, _make_config(), False),
-        (False, _make_config(block_on_door_open=True), False),
-        (True, _make_config(block_on_door_open=True), True),
-    ],
-)
-def test_initial_state(
-    is_door_open: bool,
-    config: Config,
-    expected_is_door_blocking: bool,
-) -> None:
-    """It should set the initial state."""
-    subject = CommandStore(is_door_open=is_door_open, config=config)
-
-    assert subject.state == CommandState(
-        command_history=CommandHistory(),
-        queue_status=QueueStatus.SETUP,
-        run_completed_at=None,
-        run_started_at=None,
-        is_door_blocking=expected_is_door_blocking,
-        run_result=None,
-        run_error=None,
-        finish_error=None,
-        failed_command=None,
-        command_error_recovery_types={},
-        recovery_target_command_id=None,
-        latest_protocol_command_hash=None,
-        stopped_by_estop=False,
-    )
-
-
 class QueueCommandSpec(NamedTuple):
     """Test data for the QueueCommandAction."""
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
@@ -52,37 +52,6 @@ def _make_config(block_on_door_open: bool = False) -> Config:
     )
 
 
-def test_command_queue_with_hash() -> None:
-    """It should queue a command with a command hash and no explicit key."""
-    create = commands.WaitForResumeCreate(
-        params=commands.WaitForResumeParams(message="hello world"),
-    )
-
-    subject = CommandStore(is_door_open=False, config=_make_config())
-    subject.handle_action(
-        QueueCommandAction(
-            request=create,
-            request_hash="abc123",
-            created_at=datetime(year=2021, month=1, day=1),
-            command_id="command-id-1",
-        )
-    )
-
-    assert subject.state.command_history.get("command-id-1").command.key == "abc123"
-    assert subject.state.latest_protocol_command_hash == "abc123"
-
-    subject.handle_action(
-        QueueCommandAction(
-            request=create,
-            request_hash="def456",
-            created_at=datetime(year=2021, month=1, day=1),
-            command_id="command-id-2",
-        )
-    )
-
-    assert subject.state.latest_protocol_command_hash == "def456"
-
-
 def test_command_queue_and_unqueue() -> None:
     """It should queue on QueueCommandAction and dequeue on RunCommandAction."""
     queue_1 = QueueCommandAction(

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -216,7 +216,9 @@ def test_get_next_to_execute_returns_no_commands_if_paused() -> None:
     assert result is None
 
 
-def test_get_next_to_execute_returns_no_commands_if_awaiting_recovery_no_fixit() -> None:
+def test_get_next_to_execute_returns_no_commands_if_awaiting_recovery_no_fixit() -> (
+    None
+):
     """It should not return any type of command if the engine is awaiting-recovery."""
     subject = get_command_view(
         queue_status=QueueStatus.AWAITING_RECOVERY,
@@ -1020,9 +1022,3 @@ def test_get_slice_default_cursor_queued() -> None:
         cursor=2,
         total_length=5,
     )
-
-
-def test_get_latest_command_hash() -> None:
-    """It should get the latest command hash from state, if set."""
-    subject = get_command_view(latest_command_hash="abc123")
-    assert subject.get_latest_protocol_command_hash() == "abc123"


### PR DESCRIPTION
# Overview

Minor refactors in the neighborhood of EXEC-383.

# Test plan

None needed.

# Changelog

* Delete `CommandView.get_implicitly_active()`, which was unused.
* Port some old `CommandStore` and `CommandView` tests to the new higher-level style, as opposed to testing low-level `CommandState` values. (See [this note](https://github.com/Opentrons/opentrons/blob/36b9b5ffa53f9403679ab1549e8b9941df5ac0dc/api/tests/opentrons/protocol_engine/state/test_command_store_old.py#L3-L4).)

# Risk assessment

Low.