### PR TITLE
feat(app): add ODD toasts for successful error recovery

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -22,6 +22,8 @@
   "if_tips_are_attached": "If tips are attached, you can choose to blow out any aspirated liquid and drop tips before the run is terminated.",
   "ignore_all_errors_of_this_type": "Ignore all errors of this type",
   "ignore_error_and_skip": "Ignore error and skip to next step",
+  "skipping_to_step_succeeded": "Skipping to step {{step}} succeeded",
+  "retrying_step_succeeded": "Retrying step {{step}} succeeded",
   "ignore_only_this_error": "Ignore only this error",
   "ignore_similar_errors_later_in_run": "Ignore similar errors later in the run?",
   "launch_recovery_mode": "Launch Recovery Mode",

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -33,13 +33,16 @@ const mockRouteUpdateActions = {
 } as any
 
 describe('useRecoveryCommands', () => {
-  const mockResumeRunFromRecovery = vi.fn()
+  const mockMakeSuccessToast = vi.fn()
+  const mockResumeRunFromRecovery = vi.fn(() =>
+    Promise.resolve(mockMakeSuccessToast())
+  )
   const mockStopRun = vi.fn()
   const mockChainRunCommands = vi.fn().mockResolvedValue([])
 
   beforeEach(() => {
     vi.mocked(useResumeRunFromRecoveryMutation).mockReturnValue({
-      resumeRunFromRecovery: mockResumeRunFromRecovery,
+      mutateAsync: mockResumeRunFromRecovery,
     } as any)
     vi.mocked(useStopRunMutation).mockReturnValue({
       stopRun: mockStopRun,
@@ -56,6 +59,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -81,6 +85,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -107,6 +112,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -120,19 +126,23 @@ describe('useRecoveryCommands', () => {
     )
   })
 
-  it('should call resumeRun with runId', () => {
+  it('should call resumeRun with runId and show success toast on success', async () => {
     const { result } = renderHook(() =>
       useRecoveryCommands({
         runId: mockRunId,
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: { makeSuccessToast: mockMakeSuccessToast } as any,
       })
     )
 
-    result.current.resumeRun()
+    await act(async () => {
+      await result.current.resumeRun()
+    })
 
     expect(mockResumeRunFromRecovery).toHaveBeenCalledWith(mockRunId)
+    expect(mockMakeSuccessToast).toHaveBeenCalled()
   })
 
   it('should call cancelRun with runId', () => {
@@ -142,6 +152,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -157,6 +168,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -195,6 +207,7 @@ describe('useRecoveryCommands', () => {
           failedLabware: mockFailedLabware,
         },
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -215,6 +228,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 
@@ -235,6 +249,7 @@ describe('useRecoveryCommands', () => {
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
+        recoveryToastUtils: {} as any,
       })
     )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryToasts.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryToasts.test.tsx
@@ -1,0 +1,125 @@
+import * as React from 'react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { I18nextProvider } from 'react-i18next'
+import { i18n } from '../../../../i18n'
+import { renderHook, render, screen } from '@testing-library/react'
+import {
+  useRecoveryToasts,
+  useToastText,
+  getStepNumber,
+} from '../useRecoveryToasts'
+import { RECOVERY_MAP } from '../../constants'
+import { useToaster } from '../../../ToasterOven'
+
+import type { Mock } from 'vitest'
+
+vi.mock('../../../ToasterOven')
+
+let mockMakeToast: Mock
+
+describe('useRecoveryToasts', () => {
+  beforeEach(() => {
+    mockMakeToast = vi.fn()
+    vi.mocked(useToaster).mockReturnValue({ makeToast: mockMakeToast } as any)
+  })
+
+  it('should return makeSuccessToast function', () => {
+    const { result } = renderHook(() =>
+      useRecoveryToasts({
+        isOnDevice: false,
+        currentStepCount: 1,
+        selectedRecoveryOption: RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE,
+      })
+    )
+
+    expect(result.current.makeSuccessToast).toBeInstanceOf(Function)
+  })
+
+  it(`should not make toast for ${RECOVERY_MAP.CANCEL_RUN.ROUTE} option`, () => {
+    const { result } = renderHook(() =>
+      useRecoveryToasts({
+        isOnDevice: false,
+        currentStepCount: 1,
+        selectedRecoveryOption: RECOVERY_MAP.CANCEL_RUN.ROUTE,
+      })
+    )
+
+    const mockMakeToast = vi.fn()
+    vi.mocked(useToaster).mockReturnValue({ makeToast: mockMakeToast } as any)
+
+    result.current.makeSuccessToast()
+    expect(mockMakeToast).not.toHaveBeenCalled()
+  })
+})
+
+describe('useToastText', () => {
+  it(`should return correct text for ${RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE} option`, () => {
+    const { result } = renderHook(() =>
+      useToastText({
+        currentStepCount: 2,
+        selectedRecoveryOption: RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE,
+      })
+    )
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <div>{result.current}</div>
+      </I18nextProvider>
+    )
+    screen.getByText('Retrying step 2 succeeded')
+  })
+
+  it(`should return correct text for ${RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE} option`, () => {
+    const { result } = renderHook(() =>
+      useToastText({
+        currentStepCount: 2,
+        selectedRecoveryOption: RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE,
+      })
+    )
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <div>{result.current}</div>
+      </I18nextProvider>
+    )
+    screen.getByText('Skipping to step 3 succeeded')
+  })
+
+  it('should handle a falsy currentStepCount', () => {
+    const { result } = renderHook(() =>
+      useToastText({
+        currentStepCount: null,
+        selectedRecoveryOption: RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE,
+      })
+    )
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <div>{result.current}</div>
+      </I18nextProvider>
+    )
+    screen.getByText('Retrying step ? succeeded')
+  })
+})
+
+describe('getStepNumber', () => {
+  it(`should return current step for ${RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE} option`, () => {
+    expect(getStepNumber(RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE, 3)).toBe(3)
+  })
+
+  it(`should return next step for ${RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE} option`, () => {
+    expect(getStepNumber(RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE, 3)).toBe(
+      4
+    )
+  })
+
+  it('should handle a falsy currentStepCount', () => {
+    expect(getStepNumber(RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE, null)).toBe('?')
+  })
+
+  it('should handle unknown recovery option', () => {
+    expect(getStepNumber('UNKNOWN_OPTION' as any, 3)).toBe(
+      'HANDLE RECOVERY TOAST OPTION EXPLICITLY.'
+    )
+  })
+})

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../resources/runs'
 import { useRecoveryOptionCopy } from './useRecoveryOptionCopy'
 import { useRunningStepCounts } from '../../../resources/protocols/hooks'
+import { useRecoveryToasts } from './useRecoveryToasts'
 
 import type { PipetteData } from '@opentrons/api-client'
 import type { IRecoveryMap } from '../types'
@@ -28,6 +29,7 @@ import type { StepCounts } from '../../../resources/protocols/hooks'
 type ERUtilsProps = ErrorRecoveryFlowsProps & {
   toggleERWizard: (launchER: boolean) => Promise<void>
   hasLaunchedRecovery: boolean
+  isOnDevice: boolean
 }
 
 export interface ERUtilsResults {
@@ -54,6 +56,7 @@ export function useERUtils({
   toggleERWizard,
   hasLaunchedRecovery,
   protocolAnalysis,
+  isOnDevice,
 }: ERUtilsProps): ERUtilsResults {
   const { data: attachedInstruments } = useInstrumentsQuery()
   const { data: runRecord } = useNotifyRunQuery(runId)
@@ -67,12 +70,21 @@ export function useERUtils({
     pageLength: 999,
   })
 
+  const stepCounts = useRunningStepCounts(runId, runCommands)
+  const commandAfterFailedCommand = getNextStep(failedCommand, protocolAnalysis)
+
   const {
     recoveryMap,
     setRM,
     trackExternalMap,
     currentRecoveryOptionUtils,
   } = useRecoveryRouting()
+
+  const recoveryToastUtils = useRecoveryToasts({
+    currentStepCount: stepCounts.currentStepNumber,
+    selectedRecoveryOption: currentRecoveryOptionUtils.selectedRecoveryOption,
+    isOnDevice,
+  })
 
   const tipStatusUtils = useRecoveryTipStatus({
     runId,
@@ -107,6 +119,7 @@ export function useERUtils({
     failedCommand,
     failedLabwareUtils,
     routeUpdateActions,
+    recoveryToastUtils,
   })
 
   const recoveryMapUtils = useRecoveryMapUtils({
@@ -115,9 +128,6 @@ export function useERUtils({
     protocolAnalysis,
     failedLabwareUtils,
   })
-
-  const stepCounts = useRunningStepCounts(runId, runCommands)
-  const commandAfterFailedCommand = getNextStep(failedCommand, protocolAnalysis)
 
   // TODO(jh, 06-14-24): Ensure other string build utilities that are internal to ErrorRecoveryFlows are exported under
   // one utility object in useERUtils.

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -15,17 +15,20 @@ import type { WellGroup } from '@opentrons/components'
 import type { FailedCommand } from '../types'
 import type { UseFailedLabwareUtilsResult } from './useFailedLabwareUtils'
 import type { UseRouteUpdateActionsResult } from './useRouteUpdateActions'
+import type { RecoveryToasts } from './useRecoveryToasts'
 
 interface UseRecoveryCommandsParams {
   runId: string
   failedCommand: FailedCommand | null
   failedLabwareUtils: UseFailedLabwareUtilsResult
   routeUpdateActions: UseRouteUpdateActionsResult
+  recoveryToastUtils: RecoveryToasts
 }
 export interface UseRecoveryCommandsResult {
   /* A terminal recovery command that causes ER to exit as the run status becomes "running" */
   resumeRun: () => void
-  /* A terminal recovery command that causes ER to exit as the run status becomes "stop-requested" */
+  /* A terminal recovery command that causes ER to exit when the run status becomes "cancelled". ER still renders while
+   * in a "stop-requested" state */
   cancelRun: () => void
   /* A non-terminal recovery command, but should generally be chained with a resumeRun. */
   skipFailedCommand: () => Promise<void>
@@ -44,11 +47,15 @@ export function useRecoveryCommands({
   failedCommand,
   failedLabwareUtils,
   routeUpdateActions,
+  recoveryToastUtils,
 }: UseRecoveryCommandsParams): UseRecoveryCommandsResult {
   const { proceedToRouteAndStep } = routeUpdateActions
   const { chainRunCommands } = useChainRunCommands(runId, failedCommand?.id)
-  const { resumeRunFromRecovery } = useResumeRunFromRecoveryMutation()
+  const {
+    mutateAsync: resumeRunFromRecovery,
+  } = useResumeRunFromRecoveryMutation()
   const { stopRun } = useStopRunMutation()
+  const { makeSuccessToast } = recoveryToastUtils
 
   const chainRunRecoveryCommands = React.useCallback(
     (
@@ -96,8 +103,10 @@ export function useRecoveryCommands({
   }, [chainRunRecoveryCommands, failedCommand, failedLabwareUtils])
 
   const resumeRun = React.useCallback((): void => {
-    resumeRunFromRecovery(runId)
-  }, [runId, resumeRunFromRecovery])
+    void resumeRunFromRecovery(runId).then(() => {
+      makeSuccessToast()
+    })
+  }, [runId, resumeRunFromRecovery, makeSuccessToast])
 
   const cancelRun = React.useCallback((): void => {
     stopRun(runId)

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
@@ -1,0 +1,103 @@
+import { useToaster } from '../../ToasterOven'
+import { RECOVERY_MAP } from '../constants'
+import type { CurrentRecoveryOptionUtils } from './useRecoveryRouting'
+import { useTranslation } from 'react-i18next'
+import type { StepCounts } from '../../../resources/protocols/hooks'
+
+interface BuildToast {
+  isOnDevice: boolean
+  currentStepCount: StepCounts['currentStepNumber']
+  selectedRecoveryOption: CurrentRecoveryOptionUtils['selectedRecoveryOption']
+}
+
+export interface RecoveryToasts {
+  /* Renders a recovery success toast. */
+  makeSuccessToast: () => void
+}
+
+// Provides methods for rendering success/failure toasts after performing a terminal recovery command.
+export function useRecoveryToasts({
+  currentStepCount,
+  isOnDevice,
+  selectedRecoveryOption,
+}: BuildToast): RecoveryToasts {
+  const { makeToast } = useToaster()
+
+  const toastText = useToastText({ currentStepCount, selectedRecoveryOption })
+
+  const makeSuccessToast = (): void => {
+    if (selectedRecoveryOption !== RECOVERY_MAP.CANCEL_RUN.ROUTE) {
+      makeToast(toastText, 'success', {
+        closeButton: true,
+        disableTimeout: true,
+        displayType: isOnDevice ? 'odd' : 'desktop',
+      })
+    }
+  }
+
+  return { makeSuccessToast }
+}
+
+// Return i18n toast text for the corresponding user selected recovery option.
+export function useToastText({
+  currentStepCount,
+  selectedRecoveryOption,
+}: Omit<BuildToast, 'isOnDevice'>): string {
+  const { t } = useTranslation('error_recovery')
+
+  const stepNumber = getStepNumber(selectedRecoveryOption, currentStepCount)
+
+  const currentStepReturnVal = t('retrying_step_succeeded', {
+    step: stepNumber,
+  }) as string
+  const nextStepReturnVal = t('skipping_to_step_succeeded', {
+    step: stepNumber,
+  }) as string
+
+  const toastText = handleRecoveryOptionAction(
+    selectedRecoveryOption,
+    currentStepReturnVal,
+    nextStepReturnVal
+  )
+
+  return toastText
+}
+
+export function getStepNumber(
+  selectedRecoveryOption: BuildToast['selectedRecoveryOption'],
+  currentStepCount: BuildToast['currentStepCount']
+): number | string {
+  const currentStepReturnVal = currentStepCount ?? '?'
+  // There is always a next protocol step after a command that can error, therefore, we don't need to handle that.
+  const nextStepReturnVal =
+    typeof currentStepCount === 'number' ? currentStepCount + 1 : '?'
+
+  return handleRecoveryOptionAction(
+    selectedRecoveryOption,
+    currentStepReturnVal,
+    nextStepReturnVal
+  )
+}
+
+// Recovery options can be categorized into broad categories of behavior, currently performing the same step again
+// or skipping to the next step.
+function handleRecoveryOptionAction<T>(
+  selectedRecoveryOption: CurrentRecoveryOptionUtils['selectedRecoveryOption'],
+  currentStepReturnVal: T,
+  nextStepReturnVal: T
+): T | string {
+  switch (selectedRecoveryOption) {
+    case RECOVERY_MAP.FILL_MANUALLY_AND_SKIP.ROUTE:
+    case RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE:
+    case RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE:
+    case RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE:
+      return nextStepReturnVal
+    case RECOVERY_MAP.CANCEL_RUN.ROUTE:
+    case RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE:
+    case RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE:
+    case RECOVERY_MAP.RETRY_FAILED_COMMAND.ROUTE:
+      return currentStepReturnVal
+    default:
+      return 'HANDLE RECOVERY TOAST OPTION EXPLICITLY.'
+  }
+}

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -100,16 +100,17 @@ export function ErrorRecoveryFlows(
   const enableRunNotes = useFeatureFlag('enableRunNotes')
   const { hasLaunchedRecovery, toggleERWizard, showERWizard } = useERWizard()
   const showSplash = useRunPausedSplash()
+  const isOnDevice = useSelector(getIsOnDevice)
 
   const recoveryUtils = useERUtils({
     ...props,
     hasLaunchedRecovery,
     toggleERWizard,
+    isOnDevice,
   })
 
   const { protocolAnalysis } = props
   const robotType = protocolAnalysis?.robotType ?? OT2_ROBOT_TYPE
-  const isOnDevice = useSelector(getIsOnDevice)
 
   if (!enableRunNotes) {
     return null


### PR DESCRIPTION
Closes [EXEC-573](https://opentrons.atlassian.net/browse/EXEC-573)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Add success toasts for the ODD after resumeRun commands, except in the instance in which the selected recovery option is "cancel run".

https://github.com/Opentrons/opentrons/assets/64858653/e6e1fd93-2651-4c40-8b69-ac5294b5391f

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Verified success toasts work after different recovery actions.
- Verified the toast does not display if the recovery action is cancel run.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added "success" toasts after a successful error recovery to the ODD.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-573]: https://opentrons.atlassian.net/browse/EXEC-573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ