### PR TITLE
feat(labware-library): remove beta from LC title

### DIFF
--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -417,7 +417,7 @@ export const LabwareCreator = (): JSX.Element => {
 
           return (
             <div className={styles.labware_creator}>
-              <h2>Custom Labware Creator BETA</h2>
+              <h2>Custom Labware Creator</h2>
               <IntroCopy />
               <div className={styles.flex_row}>
                 <CreateNewDefinition


### PR DESCRIPTION
closes AUTH-524

# Overview

Remove BETA from labware creator title -- spoke with some people yesterday that this isn't really a beta?? so why not make the change. plus the next release is the big 3️⃣ 0️⃣ 0️⃣ 

# Test Plan

just verify that the dev env doesn't have Beta in the title 

before
<img width="800" alt="Screenshot 2024-06-21 at 12 13 31" src="https://github.com/Opentrons/opentrons/assets/66035149/ea4f233c-7000-424b-a4f6-35e79e8e14a9">

after (note: idk why the button changes??? but is unrelated to this)
<img width="835" alt="Screenshot 2024-06-21 at 12 13 45" src="https://github.com/Opentrons/opentrons/assets/66035149/abee3d3e-156c-4ef6-9c5a-29ab28a74319">


# Changelog

cut the string ✂️ 

# Review requests

see test plan

# Risk assessment

low