### PR TITLE
chore: make "make push" actually restart flex

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -189,7 +189,7 @@ push-no-restart-ot3: sdist
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),$(host),$(ssh_opts),"opentrons-robot-server")
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: simulate
 simulate:

--- a/hardware-testing/Makefile
+++ b/hardware-testing/Makefile
@@ -213,7 +213,7 @@ push: push-no-restart restart
 
 .PHONY: restart-ot3
 restart-ot3:
-	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: sdist Pipfile.lock

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -137,7 +137,7 @@ push-no-restart-ot3: sdist Pipfile.lock
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 
 # Launch the emulator application.

--- a/shared-data/python/Makefile
+++ b/shared-data/python/Makefile
@@ -117,7 +117,7 @@ push-no-restart-ot3: sdist
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3
-	$(call restart-server,$(host),$(ssh_key),$(ssh_opts),opentrons-robot-server)
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),"opentrons-robot-server")
 
 .PHONY: deploy
 deploy: wheel sdist


### PR DESCRIPTION
`make push` wasn't restarting the flex. Now it does