### PR TITLE
chore(hardware-testing): Gravimetric test supports ethanol, glycerol, and hexane

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -582,7 +582,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--liquid",
         type=str,
-        choices=["water", "water", "glycerol", "hexane"],
+        choices=["water", "ethanol", "glycerol", "hexane"],
         default="water",
     )
     args = parser.parse_args()

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -38,7 +38,7 @@ from .config import (
     get_tip_volumes_for_qc,
 )
 from .measurement.record import GravimetricRecorder
-from .measurement import DELAY_FOR_MEASUREMENT
+from .measurement import DELAY_FOR_MEASUREMENT, SupportedLiquid
 from .measurement.scale import Scale
 from .trial import TestResources, _change_pipettes
 from .tips import get_tips
@@ -582,7 +582,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--liquid",
         type=str,
-        choices=["water", "ethanol", "glycerol", "hexane"],
+        choices=[liq.value.lower() for liq in SupportedLiquid],
         default="water",
     )
     args = parser.parse_args()

--- a/hardware-testing/hardware_testing/gravimetric/__main__.py
+++ b/hardware-testing/hardware_testing/gravimetric/__main__.py
@@ -148,6 +148,7 @@ class RunArgs:
     ctx: ProtocolContext
     protocol_cfg: Any
     test_report: report.CSVReport
+    liquid: str
 
     @classmethod
     def _get_protocol_context(cls, args: argparse.Namespace) -> ProtocolContext:
@@ -366,6 +367,7 @@ class RunArgs:
             ctx=_ctx,
             protocol_cfg=protocol_cfg,
             test_report=report,
+            liquid=args.liquid,
         )
 
 
@@ -414,6 +416,7 @@ def build_gravimetric_cfg(
         same_tip=same_tip,
         ignore_fail=ignore_fail,
         mode=mode,
+        liquid=run_args.liquid,
     )
 
 
@@ -575,6 +578,12 @@ if __name__ == "__main__":
     parser.add_argument("--dye-well-col-offset", nargs="+", type=int, default=[1])
     parser.add_argument(
         "--mode", type=str, choices=["", "default", "lowVolumeDefault"], default=""
+    )
+    parser.add_argument(
+        "--liquid",
+        type=str,
+        choices=["water", "water", "glycerol", "hexane"],
+        default="water",
     )
     args = parser.parse_args()
     run_args = RunArgs.build_run_args(args)

--- a/hardware-testing/hardware_testing/gravimetric/config.py
+++ b/hardware-testing/hardware_testing/gravimetric/config.py
@@ -49,6 +49,7 @@ class GravimetricConfig(VolumetricConfig):
     scale_delay: int
     isolate_channels: List[int]
     isolate_volumes: List[float]
+    liquid: str
 
 
 @dataclass

--- a/hardware-testing/hardware_testing/gravimetric/execute.py
+++ b/hardware-testing/hardware_testing/gravimetric/execute.py
@@ -40,6 +40,7 @@ from .measurement import (
     record_measurement_data,
     calculate_change_in_volume,
     create_measurement_tag,
+    SupportedLiquid,
 )
 from .measurement.environment import get_min_reading, get_max_reading
 from .measurement.record import (
@@ -335,8 +336,9 @@ def _run_trial(
     ui.print_info(f"\tinitial grams: {m_data_init.grams_average} g")
     # update the vials volumes, using the last-known weight
     if _PREV_TRIAL_GRAMS is not None:
+        liq = SupportedLiquid.from_string(trial.cfg.liquid)
         _evaporation_loss_ul = abs(
-            calculate_change_in_volume(_PREV_TRIAL_GRAMS, m_data_init)
+            calculate_change_in_volume(_PREV_TRIAL_GRAMS, m_data_init, liq)
         )
         ui.print_info(f"{_evaporation_loss_ul} ul evaporated since last trial")
         trial.liquid_tracker.update_affected_wells(
@@ -386,8 +388,9 @@ def _run_trial(
     m_data_dispense = _record_measurement_and_store(MeasurementType.DISPENSE)
     ui.print_info(f"\tgrams after dispense: {m_data_dispense.grams_average} g")
     # calculate volumes
-    volume_aspirate = calculate_change_in_volume(m_data_init, m_data_aspirate)
-    volume_dispense = calculate_change_in_volume(m_data_aspirate, m_data_dispense)
+    liq = SupportedLiquid.from_string(trial.cfg.liquid)
+    volume_aspirate = calculate_change_in_volume(m_data_init, m_data_aspirate, liq)
+    volume_dispense = calculate_change_in_volume(m_data_aspirate, m_data_dispense, liq)
     return volume_aspirate, m_data_aspirate, volume_dispense, m_data_dispense
 
 

--- a/hardware-testing/hardware_testing/gravimetric/measurement/__init__.py
+++ b/hardware-testing/hardware_testing/gravimetric/measurement/__init__.py
@@ -20,14 +20,10 @@ class SupportedLiquid(Enum):
 
     @classmethod
     def from_string(cls, s: str) -> "SupportedLiquid":
-        if s.lower() == "water":
-            return SupportedLiquid.WATER
-        if s.lower() == "ethanol":
-            return SupportedLiquid.ETHANOL
-        if s.lower() == "glycerol":
-            return SupportedLiquid.GLYCEROL
-        if s.lower() == "hexane":
-            return SupportedLiquid.HEXANE
+        for liq in cls:
+            if s.lower() == liq.value.lower():
+                return liq
+        raise ValueError(f"no supported liquid matching {s}")
 
 
 RELATIVE_DENSITY: Dict[SupportedLiquid, float] = {

--- a/hardware-testing/hardware_testing/gravimetric/measurement/__init__.py
+++ b/hardware-testing/hardware_testing/gravimetric/measurement/__init__.py
@@ -13,6 +13,8 @@ from hardware_testing.drivers import asair_sensor
 
 
 class SupportedLiquid(Enum):
+    """Liquids supported by gravimetric calculations."""
+
     WATER = "water"
     ETHANOL = "ethanol"
     GLYCEROL = "glycerol"
@@ -20,6 +22,7 @@ class SupportedLiquid(Enum):
 
     @classmethod
     def from_string(cls, s: str) -> "SupportedLiquid":
+        """Get SupportedLiquid enum from string."""
         for liq in cls:
             if s.lower() == liq.value.lower():
                 return liq

--- a/hardware-testing/hardware_testing/gravimetric/measurement/__init__.py
+++ b/hardware-testing/hardware_testing/gravimetric/measurement/__init__.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from time import sleep
-from typing import Optional
+from typing import Optional, Dict
 from typing_extensions import Final
 
 from opentrons.protocol_api import ProtocolContext
@@ -11,7 +11,31 @@ from .record import GravimetricRecorder, GravimetricRecording
 from .environment import read_environment_data, EnvironmentData, get_average_reading
 from hardware_testing.drivers import asair_sensor
 
-RELATIVE_DENSITY_WATER: Final = 1.0
+
+class SupportedLiquid(Enum):
+    WATER = "water"
+    ETHANOL = "ethanol"
+    GLYCEROL = "glycerol"
+    HEXANE = "hexane"
+
+    @classmethod
+    def from_string(cls, s: str) -> "SupportedLiquid":
+        if s.lower() == "water":
+            return SupportedLiquid.WATER
+        if s.lower() == "ethanol":
+            return SupportedLiquid.ETHANOL
+        if s.lower() == "glycerol":
+            return SupportedLiquid.GLYCEROL
+        if s.lower() == "hexane":
+            return SupportedLiquid.HEXANE
+
+
+RELATIVE_DENSITY: Dict[SupportedLiquid, float] = {
+    SupportedLiquid.WATER: 1.0,
+    SupportedLiquid.ETHANOL: 0.78905,  # wikipedia
+    SupportedLiquid.GLYCEROL: 1.261,  # wikipedia
+    SupportedLiquid.HEXANE: 0.6606,  # wikipedia
+}
 
 CONSTANT_SCALE_CALIBRATED_DENSITY_KG_M3: Final = 7950  # from certificate
 CONSTANT_TEMPERATURE_TA0: Final = 273.15
@@ -161,7 +185,9 @@ def record_measurement_data(
 
 
 def calculate_change_in_volume(
-    before: MeasurementData, after: MeasurementData
+    before: MeasurementData,
+    after: MeasurementData,
+    liquid: SupportedLiquid = SupportedLiquid.WATER,
 ) -> float:
     """Calculate volume of water."""
     # TODO: actually calculate volume
@@ -176,7 +202,7 @@ def calculate_change_in_volume(
         ]
     )
     liquid_density_kg_m3 = (
-        RELATIVE_DENSITY_WATER * water_density_at_this_temperature_kg_m3
+        RELATIVE_DENSITY[liquid] * water_density_at_this_temperature_kg_m3
     )
     # equations in ISO use hPa, so sticking with that
     air_pressure_hpa = avg_env.pascals_air / 100


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds a few different liquids to the gravimetric test, specifically defining the relative humidity of each liquid type so that we can measure how many uL were aspirated/dispensed. This liquid type is set through an argument, and the choices are:

- water (default)
- ethanol
- glycerol
- hexane

All are considered to be 100% (not diluted). We could probably add something later to specify the percentage of water in each, and then linear scale the relative density based on that concentration.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
