### PR TITLE
fix(app-shell-odd): quit the app when the render process is killed.

### DIFF
--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -61,8 +61,8 @@ let rendererLogger: Logger
 app.prependOnceListener('ready', startUp)
 if (config.devtools) app.once('ready', installDevtools)
 
-app.once('window-all-closed', () => {
-  log.debug('all windows closed, quitting the app')
+function quitApplication(): void {
+  app.quit()
   closeBrokerConnection()
     .then(() => {
       app.quit()
@@ -71,6 +71,16 @@ app.once('window-all-closed', () => {
       log.warn('Failed to properly close MQTT connections:', error)
       app.quit()
     })
+}
+
+app.once('window-all-closed', () => {
+    log.debug('all windows closed, quitting the app')
+    quitApplication()
+})
+
+app.once('render-process-gone', () => {
+    log.debug('Renderer process has died, quitting the app')
+    quitApplication()
 })
 
 function startUp(): void {

--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -74,13 +74,13 @@ function quitApplication(): void {
 }
 
 app.once('window-all-closed', () => {
-    log.debug('all windows closed, quitting the app')
-    quitApplication()
+  log.debug('all windows closed, quitting the app')
+  quitApplication()
 })
 
 app.once('render-process-gone', () => {
-    log.debug('Renderer process has died, quitting the app')
-    quitApplication()
+  log.debug('Renderer process has died, quitting the app')
+  quitApplication()
 })
 
 function startUp(): void {

--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -79,7 +79,7 @@ app.once('window-all-closed', () => {
 })
 
 app.once('render-process-gone', () => {
-  log.debug('Renderer process has died, quitting the app')
+  log.error('Renderer process has died, quitting the app')
   quitApplication()
 })
 

--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -78,8 +78,8 @@ app.once('window-all-closed', () => {
   quitApplication()
 })
 
-app.once('render-process-gone', () => {
-  log.error('Renderer process has died, quitting the app')
+app.once('render-process-gone', (_, __, details) => {
+  log.error('Renderer process has died, quitting the app', details)
   quitApplication()
 })
 


### PR DESCRIPTION
# Overview

While investigating an issue with the ODD, we noticed that the ODD electron app (opentrons-robot-app.service) continues to run even when the render process is killed for whatever reason. If we ever get into this state, we should quit the application so that the service exits and systemd can restart the service. This pull request goes in conjunction with this oe-core pr [Opentrons/oe-core#152](https://github.com/Opentrons/oe-core/pull/152).

# Test Plan

- [x] Make sure that the application exits when the render process is killed
- [x] Make sure that the `opentrons-robot-app.service` exits and restarts when the renderer is killed

# Changelog

- Quit the electron app when we get a `render-process-gone` event

# Review requests

- Makes sense?
- Any other times the renderer can be killed that we don't want this to happen, ie we have another window that gets closed or something?

# Risk assessment

Low, this should only happen when the renderer is killed.