### PR TITLE
refactor(protocol-engine): Minor CommandStore/CommandView refactors

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -96,12 +96,12 @@ class QueueStatus(enum.Enum):
     """
 
 
-class RunResult(str, enum.Enum):
+class RunResult(enum.Enum):
     """Result of the run."""
 
-    SUCCEEDED = "succeeded"
-    FAILED = "failed"
-    STOPPED = "stopped"
+    SUCCEEDED = enum.auto()
+    FAILED = enum.auto()
+    STOPPED = enum.auto()
 
 
 @dataclass(frozen=True)

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -382,20 +382,12 @@ class CommandStore(HasState[CommandState], HandlesActions):
             if not self._state.run_result:
                 self._state.recovery_target_command_id = None
 
+                self._state.queue_status = QueueStatus.PAUSED
                 if action.from_estop:
                     self._state.stopped_by_estop = True
                     self._state.run_result = RunResult.FAILED
-                elif self._state.queue_status in (
-                    QueueStatus.AWAITING_RECOVERY,
-                    QueueStatus.AWAITING_RECOVERY_PAUSED,
-                ):
-                    # If someone aborts error recovery (by stopping the run), treat it
-                    # as a run failure, not a normal run stop.
-                    self._state.run_result = RunResult.FAILED
                 else:
                     self._state.run_result = RunResult.STOPPED
-
-                self._state.queue_status = QueueStatus.PAUSED
 
         elif isinstance(action, FinishAction):
             if not self._state.run_result:

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -835,4 +835,5 @@ def test_final_state_after_error_recovery_stop() -> None:
         )
     )
     assert subject_view.get_status() == EngineStatus.FAILED
+    assert subject_view.get_recovery_target() is None
     assert subject_view.get_error() is None

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -208,14 +208,7 @@ def test_command_failure_clears_queues() -> None:
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
         error=errors.ProtocolEngineError(message="oh no"),
-        notes=[
-            CommandNote(
-                noteKind="noteKind",
-                shortMessage="shortMessage",
-                longMessage="longMessage",
-                source="source",
-            )
-        ],
+        notes=[],
         type=ErrorRecoveryType.FAIL_RUN,
     )
     subject.handle_action(fail_1)
@@ -281,14 +274,7 @@ def test_setup_command_failure_only_clears_setup_command_queue() -> None:
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
         error=errors.ProtocolEngineError(message="oh no"),
-        notes=[
-            CommandNote(
-                noteKind="noteKind",
-                shortMessage="shortMessage",
-                longMessage="longMessage",
-                source="source",
-            )
-        ],
+        notes=[],
         type=ErrorRecoveryType.FAIL_RUN,
     )
     subject.handle_action(fail_2_setup)
@@ -347,14 +333,7 @@ def test_nonfatal_command_failure() -> None:
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
         error=errors.ProtocolEngineError(message="oh no"),
-        notes=[
-            CommandNote(
-                noteKind="noteKind",
-                shortMessage="shortMessage",
-                longMessage="longMessage",
-                source="source",
-            )
-        ],
+        notes=[],
         type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
     )
     subject.handle_action(fail_1)
@@ -482,14 +461,7 @@ def test_door_during_error_recovery() -> None:
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
         error=errors.ProtocolEngineError(message="oh no"),
-        notes=[
-            CommandNote(
-                noteKind="noteKind",
-                shortMessage="shortMessage",
-                longMessage="longMessage",
-                source="source",
-            )
-        ],
+        notes=[],
         type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
     )
     subject.handle_action(fail_1)
@@ -801,14 +773,7 @@ def test_final_state_after_error_recovery_stop() -> None:
         error_id="error-id",
         failed_at=datetime(year=2023, month=3, day=3),
         error=errors.ProtocolEngineError(message="oh no"),
-        notes=[
-            CommandNote(
-                noteKind="noteKind",
-                shortMessage="shortMessage",
-                longMessage="longMessage",
-                source="source",
-            )
-        ],
+        notes=[],
         type=ErrorRecoveryType.WAIT_FOR_RECOVERY,
     )
     subject.handle_action(fail_1)

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -747,7 +747,7 @@ def test_final_state_after_stop() -> None:
 def test_final_state_after_error_recovery_stop() -> None:
     """Test the final state of the run after it's stopped during error recovery.
 
-    Unlike a stop outside of error recovery, we count this as a run failure.
+    We still want to count this as "stopped," not "failed."
     """
     subject = CommandStore(config=_make_config(), is_door_open=False)
     subject_view = CommandView(subject.state)
@@ -799,6 +799,6 @@ def test_final_state_after_error_recovery_stop() -> None:
             finish_error_details=None,
         )
     )
-    assert subject_view.get_status() == EngineStatus.FAILED
+    assert subject_view.get_status() == EngineStatus.STOPPED
     assert subject_view.get_recovery_target() is None
     assert subject_view.get_error() is None


### PR DESCRIPTION
# Overview

This was originally going to fix EXEC-581, but it turns out that that behavior is intentional. So now this just adds a test for the intended behavior and makes a couple of other very minor refactors.

# Test plan

None needed.

# Review requests

See comments below.

# Risk assessment

Low.
