### PR TITLE
fix(protocol-designer): dropTip location auto-generates upon import

### DIFF
--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1585,7 +1585,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
               ),
         },
       }
-      console.log('trashBin', trashBin)
+
       if (isFlex) {
         if (trashBin != null) {
           return {

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -1439,49 +1439,43 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
               command.params.addressableAreaName === 'fixedTrash')) ||
           command.commandType === 'moveToAddressableAreaForDropTip'
       )
+
       const trashAddressableAreaName =
         trashBinCommand?.params.addressableAreaName
       const savedStepForms = file.designerApplication?.data?.savedStepForms
-      const moveLiquidStepTrashBin =
-        savedStepForms != null
-          ? Object.values(savedStepForms).find(
-              stepForm =>
-                stepForm.stepType === 'moveLiquid' &&
-                (stepForm.aspirate_labware.includes('trashBin') ||
-                  stepForm.dispense_labware.includes('trashBin') ||
-                  stepForm.dropTip_location.includes('trashBin') ||
-                  stepForm.blowout_location?.includes('trashBin'))
-            )
-          : null
-      const mixStepTrashBin =
-        savedStepForms != null
-          ? Object.values(savedStepForms).find(
-              stepForm =>
-                stepForm.stepType === 'mix' &&
-                stepForm.dropTip_location.includes('trashBin')
-            )
-          : null
 
-      let trashBinId: string | null = null
-      if (moveLiquidStepTrashBin != null) {
-        if (moveLiquidStepTrashBin.aspirate_labware.includes('trashBin')) {
-          trashBinId = moveLiquidStepTrashBin.aspirate_labware
-        } else if (
-          moveLiquidStepTrashBin.dispense_labware.includes('trashBin')
-        ) {
-          trashBinId = moveLiquidStepTrashBin.dispense_labware
-        } else if (
-          moveLiquidStepTrashBin.dropTip_location.includes('trashBin')
-        ) {
-          trashBinId = moveLiquidStepTrashBin.dropTip_location
-        } else if (
-          moveLiquidStepTrashBin.blowOut_location?.includes('trashBin')
-        ) {
-          trashBinId = moveLiquidStepTrashBin.blowOut_location
+      const findTrashBinId = (): string | null => {
+        if (!savedStepForms) {
+          return null
         }
-      } else if (mixStepTrashBin != null) {
-        trashBinId = mixStepTrashBin.dropTip_location
+
+        for (const stepForm of Object.values(savedStepForms)) {
+          if (stepForm.stepType === 'moveLiquid') {
+            if (stepForm.dispense_labware.toLowerCase().includes('trash')) {
+              return stepForm.dispense_labware
+            }
+            if (stepForm.dropTip_location.toLowerCase().includes('trash')) {
+              return stepForm.dropTip_location
+            }
+            if (stepForm.blowout_location?.toLowerCase().includes('trash')) {
+              return stepForm.blowout_location
+            }
+          }
+          if (stepForm.stepType === 'mix') {
+            if (stepForm.dropTip_location.toLowerCase().includes('trash')) {
+              return stepForm.dropTip_location
+            } else if (
+              stepForm.blowout_location?.toLowerCase().includes('trash')
+            ) {
+              return stepForm.blowout_location
+            }
+          }
+        }
+
+        return null
       }
+
+      const trashBinId = findTrashBinId()
       const trashCutoutId =
         trashAddressableAreaName != null
           ? getCutoutIdByAddressableArea(
@@ -1490,6 +1484,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
               isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
             )
           : null
+
       const trashBin =
         trashAddressableAreaName != null && trashBinId != null
           ? {
@@ -1590,6 +1585,7 @@ export const additionalEquipmentInvariantProperties = handleActions<NormalizedAd
               ),
         },
       }
+      console.log('trashBin', trashBin)
       if (isFlex) {
         if (trashBin != null) {
           return {


### PR DESCRIPTION
closes RESC-290

# Overview

This has existed in production for at least since 8.1.0. Basically, the drop tip location is being auto-generated incorrectly for an OT-2 protocol because the reducer was not finding a trash bin step. So it was auto-generating a trash bin entity with a `trashId` that did not match the current `trashId`. So the drop tip location from the imported protocol wouldn't populate correctly in the pipetting form because there was a new drop tip location generated.

# Test Plan

Upload the attached protocol and see that there is no timeline error. Upload the same protocol in PD in production and see that there is a timeline error.

[MakeBeads_v1.0_2X_SingleCycleTest10_MockReagents.json](https://github.com/user-attachments/files/15971111/MakeBeads_v1.0_2X_SingleCycleTest10_MockReagents.json)

# Changelog

- clean up the trash bin logic for if a trash bin is being used via dispense, blowout and dropTip for mix and move liquid. NOTE: i removed the aspirate because you can't aspirate into a trash bin anymore

# Review requests

see test plan

# Risk assessment

low