### PR TITLE
fix(app-testing): only specify labware that is used when running from tests

### DIFF
--- a/app-testing/automation/data/protocols.py
+++ b/app-testing/automation/data/protocols.py
@@ -211,6 +211,7 @@ class Protocols:
         robot="OT2",
         app_error=False,
         robot_error=False,
+        custom_labware=["cpx_4_tuberack_100ul"],
     )
 
     OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release: Protocol = Protocol(

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[004ebb2b82][OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[004ebb2b82][OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift].json
@@ -14229,26 +14229,6 @@
     {
       "name": "OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[011481812b][OT2_S_v2_7_P20S_None_Walkthrough].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[011481812b][OT2_S_v2_7_P20S_None_Walkthrough].json
@@ -4272,26 +4272,6 @@
     {
       "name": "OT2_S_v2_7_P20S_None_Walkthrough.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0190369ce5][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1NoFixtures].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0190369ce5][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1NoFixtures].json
@@ -10496,26 +10496,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1NoFixtures.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0256665840][OT2_S_v2_16_P300M_P20S_aspirateDispenseMix0Volume].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0256665840][OT2_S_v2_16_P300M_P20S_aspirateDispenseMix0Volume].json
@@ -2791,26 +2791,6 @@
     {
       "name": "OT2_S_v2_16_P300M_P20S_aspirateDispenseMix0Volume.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[041ad55e7b][OT2_S_v2_15_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[041ad55e7b][OT2_S_v2_15_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -2991,26 +2991,6 @@
     {
       "name": "OT2_S_v2_15_P300M_P20S_HS_TC_TM_dispense_changes.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[09ba51132a][OT2_S_v2_14_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[09ba51132a][OT2_S_v2_14_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -129,26 +129,6 @@
     {
       "name": "OT2_S_v2_14_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0c4ae179bb][OT2_S_v2_15_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0c4ae179bb][OT2_S_v2_15_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -15395,22 +15395,6 @@
     {
       "name": "cpx_4_tuberack_100ul.json",
       "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10d250f82a][Flex_S_v2_15_P1000_96_GRIP_HS_TM_QuickZymoMagbeadRNAExtraction].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10d250f82a][Flex_S_v2_15_P1000_96_GRIP_HS_TM_QuickZymoMagbeadRNAExtraction].json
@@ -13359,23 +13359,7 @@
       "role": "main"
     },
     {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
       "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
       "role": "labware"
     }
   ],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12a2a22254][Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAEnrichment].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12a2a22254][Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAEnrichment].json
@@ -18356,26 +18356,6 @@
     {
       "name": "Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAEnrichment.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
@@ -7301,26 +7301,6 @@
     {
       "name": "OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1960aa7a4c][Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAEnrichmentv4].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1960aa7a4c][Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAEnrichmentv4].json
@@ -85718,26 +85718,6 @@
     {
       "name": "Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAEnrichmentv4.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19c783e363][Flex_X_v8_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19c783e363][Flex_X_v8_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
@@ -12273,26 +12273,6 @@
     {
       "name": "Flex_X_v8_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19ffa9c839][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin2].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19ffa9c839][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin2].json
@@ -492,26 +492,6 @@
     {
       "name": "OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin2.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c19a2055c][OT2_S_v2_4_P300M_None_MM_TM_Zymo].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c19a2055c][OT2_S_v2_4_P300M_None_MM_TM_Zymo].json
@@ -65158,26 +65158,6 @@
     {
       "name": "OT2_S_v2_4_P300M_None_MM_TM_Zymo.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[24a6b167a7][OT2_X_v2_18_None_None_NoRTPdisplay_name].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[24a6b167a7][OT2_X_v2_18_None_None_NoRTPdisplay_name].json
@@ -34,26 +34,6 @@
     {
       "name": "OT2_X_v2_18_None_None_NoRTPdisplay_name.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b7fcb5b23][Flex_S_v2_18_P1000_96_TipTrackingBug].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b7fcb5b23][Flex_S_v2_18_P1000_96_TipTrackingBug].json
@@ -3702,26 +3702,6 @@
     {
       "name": "Flex_S_v2_18_P1000_96_TipTrackingBug.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
@@ -14561,26 +14561,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3251c6e175][OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3251c6e175][OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase].json
@@ -1521,26 +1521,6 @@
     {
       "name": "OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[33db294a9b][Flex_X_v2_18_NO_PIPETTES_DescriptionTooLongRTP].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[33db294a9b][Flex_X_v2_18_NO_PIPETTES_DescriptionTooLongRTP].json
@@ -29,26 +29,6 @@
     {
       "name": "Flex_X_v2_18_NO_PIPETTES_DescriptionTooLongRTP.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4389e3ab18][OT2_X_v6_P20S_None_SimpleTransfer].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4389e3ab18][OT2_X_v6_P20S_None_SimpleTransfer].json
@@ -1744,26 +1744,6 @@
     {
       "name": "OT2_X_v6_P20S_None_SimpleTransfer.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4458220422][OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4458220422][OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2].json
@@ -191,26 +191,6 @@
     {
       "name": "OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4a82419f1f][OT2_S_v2_16_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4a82419f1f][OT2_S_v2_16_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -15649,22 +15649,6 @@
     {
       "name": "cpx_4_tuberack_100ul.json",
       "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b17883f74][OT2_S_v2_17_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b17883f74][OT2_S_v2_17_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -3018,26 +3018,6 @@
     {
       "name": "OT2_S_v2_17_P300M_P20S_HS_TC_TM_dispense_changes.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4cb705bdbf][Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4cb705bdbf][Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol].json
@@ -74,26 +74,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[51fc977577][OT2_S_v6_P300M_P20S_MixTransferManyLiquids].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[51fc977577][OT2_S_v6_P300M_P20S_MixTransferManyLiquids].json
@@ -5252,26 +5252,6 @@
     {
       "name": "OT2_S_v6_P300M_P20S_MixTransferManyLiquids.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[54f717cfd1][OT2_S_v2_16_P300S_None_verifyNoFloatingPointErrorInPipetting].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[54f717cfd1][OT2_S_v2_16_P300S_None_verifyNoFloatingPointErrorInPipetting].json
@@ -1785,26 +1785,6 @@
     {
       "name": "OT2_S_v2_16_P300S_None_verifyNoFloatingPointErrorInPipetting.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58750bf5fb][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol4].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58750bf5fb][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol4].json
@@ -42,26 +42,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol4.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e958b7c98][Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e958b7c98][Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol].json
@@ -1211,26 +1211,6 @@
     {
       "name": "Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60015c6e65][OT2_X_v2_18_None_None_duplicateRTPVariableName].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60015c6e65][OT2_X_v2_18_None_None_duplicateRTPVariableName].json
@@ -34,26 +34,6 @@
     {
       "name": "OT2_X_v2_18_None_None_duplicateRTPVariableName.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[604023f7f1][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[604023f7f1][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3].json
@@ -167,26 +167,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6126498df7][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol4].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6126498df7][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol4].json
@@ -42,26 +42,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol4.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[61619d5498][Flex_S_v2_18_NO_PIPETTES_GoldenRTP].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[61619d5498][Flex_S_v2_18_NO_PIPETTES_GoldenRTP].json
@@ -191,26 +191,6 @@
     {
       "name": "Flex_S_v2_18_NO_PIPETTES_GoldenRTP.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6cee20a957][OT2_S_v2_12_NO_PIPETTES_Python310SyntaxRobotAnalysisOnlyError].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6cee20a957][OT2_S_v2_12_NO_PIPETTES_Python310SyntaxRobotAnalysisOnlyError].json
@@ -56,26 +56,6 @@
     {
       "name": "OT2_S_v2_12_NO_PIPETTES_Python310SyntaxRobotAnalysisOnlyError.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e34343cfc][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_MagMaxRNAExtraction].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e34343cfc][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_MagMaxRNAExtraction].json
@@ -13278,23 +13278,7 @@
       "role": "main"
     },
     {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
       "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
       "role": "labware"
     }
   ],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e5128f107][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin1].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e5128f107][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin1].json
@@ -492,26 +492,6 @@
     {
       "name": "OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin1.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f3e297a11][OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f3e297a11][OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix].json
@@ -3301,26 +3301,6 @@
     {
       "name": "OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f84e60cb0][OT2_S_v2_16_P300M_P20S_HS_TC_TM_aspirateDispenseMix0Volume].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f84e60cb0][OT2_S_v2_16_P300M_P20S_HS_TC_TM_aspirateDispenseMix0Volume].json
@@ -2739,26 +2739,6 @@
     {
       "name": "OT2_S_v2_16_P300M_P20S_HS_TC_TM_aspirateDispenseMix0Volume.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[82e9853b34][Flex_X_v2_16_NO_PIPETTES_TrashBinInCol2].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[82e9853b34][Flex_X_v2_16_NO_PIPETTES_TrashBinInCol2].json
@@ -42,26 +42,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TrashBinInCol2.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8455adcea9][OT2_S_v2_12_P300M_P20S_FailOnRun].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8455adcea9][OT2_S_v2_12_P300M_P20S_FailOnRun].json
@@ -2598,26 +2598,6 @@
     {
       "name": "OT2_S_v2_12_P300M_P20S_FailOnRun.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8860ee702c][OT2_S_v2_14_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8860ee702c][OT2_S_v2_14_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -12800,22 +12800,6 @@
     {
       "name": "cpx_4_tuberack_100ul.json",
       "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88a20da279][Flex_S_v2_15_P50M_P1000M_KAPALibraryQuantLongv2].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88a20da279][Flex_S_v2_15_P50M_P1000M_KAPALibraryQuantLongv2].json
@@ -146139,26 +146139,6 @@
     {
       "name": "Flex_S_v2_15_P50M_P1000M_KAPALibraryQuantLongv2.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a255db0b][OT2_X_v2_18_None_None_StrRTPwith_unit].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a255db0b][OT2_X_v2_18_None_None_StrRTPwith_unit].json
@@ -34,26 +34,6 @@
     {
       "name": "OT2_X_v2_18_None_None_StrRTPwith_unit.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a8226c4e][Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a8226c4e][Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict].json
@@ -4924,26 +4924,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8fcfd2ced0][Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8fcfd2ced0][Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn].json
@@ -3652,26 +3652,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94913d2988][OT2_S_v3_P300SGen1_None_Gen1PipetteSimple].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94913d2988][OT2_S_v3_P300SGen1_None_Gen1PipetteSimple].json
@@ -5774,26 +5774,6 @@
     {
       "name": "OT2_S_v3_P300SGen1_None_Gen1PipetteSimple.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9618a6623c][OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9618a6623c][OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError].json
@@ -2722,26 +2722,6 @@
     {
       "name": "OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[973fa979e6][Flex_S_v2_16_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[973fa979e6][Flex_S_v2_16_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
@@ -151,26 +151,6 @@
     {
       "name": "Flex_S_v2_16_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e56ee92f6][Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e56ee92f6][Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin].json
@@ -1359,26 +1359,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a01a35c14a][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a01a35c14a][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol3].json
@@ -139,26 +139,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol3.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a08c261369][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModulesNoFixtures].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a08c261369][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModulesNoFixtures].json
@@ -8672,26 +8672,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModulesNoFixtures.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a66d700ed6][OT2_S_v2_13_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a66d700ed6][OT2_S_v2_13_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -12598,22 +12598,6 @@
     {
       "name": "cpx_4_tuberack_100ul.json",
       "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a9557d762c][Flex_X_v2_16_NO_PIPETTES_AccessToFixedTrashProp].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a9557d762c][Flex_X_v2_16_NO_PIPETTES_AccessToFixedTrashProp].json
@@ -42,26 +42,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_AccessToFixedTrashProp.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ac886d7768][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IDTXgen96Part1to3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ac886d7768][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IDTXgen96Part1to3].json
@@ -11150,23 +11150,11 @@
       "role": "main"
     },
     {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
       "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
       "role": "labware"
     },
     {
       "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
       "role": "labware"
     }
   ],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad627dcedf][OT2_S_v6_P300M_P20S_HS_Smoke620release].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad627dcedf][OT2_S_v6_P300M_P20S_HS_Smoke620release].json
@@ -8471,26 +8471,6 @@
     {
       "name": "OT2_S_v6_P300M_P20S_HS_Smoke620release.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad9184067d][Flex_X_v2_18_NO_PIPETTES_ReservedWord].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad9184067d][Flex_X_v2_18_NO_PIPETTES_ReservedWord].json
@@ -34,26 +34,6 @@
     {
       "name": "Flex_X_v2_18_NO_PIPETTES_ReservedWord.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[adc0621263][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[adc0621263][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid].json
@@ -6151,26 +6151,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
@@ -3640,26 +3640,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[baf79d9b4a][Flex_S_v2_15_P1000S_None_SimpleNormalizeLongRight].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[baf79d9b4a][Flex_S_v2_15_P1000S_None_SimpleNormalizeLongRight].json
@@ -99166,23 +99166,7 @@
       "role": "main"
     },
     {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
       "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
       "role": "labware"
     }
   ],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c064d0de2c][OT2_S_v6_P1000S_None_SimpleTransfer].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c064d0de2c][OT2_S_v6_P1000S_None_SimpleTransfer].json
@@ -1827,26 +1827,6 @@
     {
       "name": "OT2_S_v6_P1000S_None_SimpleTransfer.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c195291f84][OT2_S_v2_17_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c195291f84][OT2_S_v2_17_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -129,26 +129,6 @@
     {
       "name": "OT2_S_v2_17_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c1c04baffd][Flex_S_v2_17_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c1c04baffd][Flex_S_v2_17_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
@@ -151,26 +151,6 @@
     {
       "name": "Flex_S_v2_17_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3098303ad][OT2_S_v2_15_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3098303ad][OT2_S_v2_15_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -129,26 +129,6 @@
     {
       "name": "OT2_S_v2_15_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c745e5824a][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModules].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c745e5824a][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModules].json
@@ -11264,26 +11264,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModules.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c821e64fad][OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c821e64fad][OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release].json
@@ -9910,22 +9910,6 @@
     {
       "name": "cpx_4_tuberack_100ul.json",
       "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c9e6e3d59d][OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c9e6e3d59d][OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests].json
@@ -6981,26 +6981,6 @@
     {
       "name": "OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cb5adc3d23][OT2_S_v6_P20S_P300M_TransferReTransferLiquid].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cb5adc3d23][OT2_S_v6_P20S_P300M_TransferReTransferLiquid].json
@@ -10676,26 +10676,6 @@
     {
       "name": "OT2_S_v6_P20S_P300M_TransferReTransferLiquid.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d48bc4f0c9][OT2_S_v2_17_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d48bc4f0c9][OT2_S_v2_17_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -15649,22 +15649,6 @@
     {
       "name": "cpx_4_tuberack_100ul.json",
       "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d6026e11c5][OT2_X_v2_7_P300S_TwinningError].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d6026e11c5][OT2_X_v2_7_P300S_TwinningError].json
@@ -2756,26 +2756,6 @@
     {
       "name": "OT2_X_v2_7_P300S_TwinningError.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d7e862d601][OT2_S_v2_18_None_None_duplicateChoiceValue].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d7e862d601][OT2_S_v2_18_None_None_duplicateChoiceValue].json
@@ -29,26 +29,6 @@
     {
       "name": "OT2_S_v2_18_None_None_duplicateChoiceValue.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d8cb88b3b2][Flex_S_v2_16_P1000_96_TC_PartialTipPickupSingle].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d8cb88b3b2][Flex_S_v2_16_P1000_96_TC_PartialTipPickupSingle].json
@@ -3554,26 +3554,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_TC_PartialTipPickupSingle.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dbba7a71a8][OT2_S_v2_16_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dbba7a71a8][OT2_S_v2_16_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -129,26 +129,6 @@
     {
       "name": "OT2_S_v2_16_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[de4249ddfb][Flex_X_v2_16_NO_PIPETTES_TC_TrashBinAndThermocyclerConflict].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[de4249ddfb][Flex_X_v2_16_NO_PIPETTES_TC_TrashBinAndThermocyclerConflict].json
@@ -151,26 +151,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TC_TrashBinAndThermocyclerConflict.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[de842b7217][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_OmegaHDQDNAExtraction].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[de842b7217][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_OmegaHDQDNAExtraction].json
@@ -13490,23 +13490,7 @@
       "role": "main"
     },
     {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
       "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
       "role": "labware"
     }
   ],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e42e36e3ca][OT2_X_v2_13_None_None_PythonSyntaxError].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e42e36e3ca][OT2_X_v2_13_None_None_PythonSyntaxError].json
@@ -37,26 +37,6 @@
     {
       "name": "OT2_X_v2_13_None_None_PythonSyntaxError.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4660ca6df][OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4660ca6df][OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps].json
@@ -2471,26 +2471,6 @@
     {
       "name": "OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e907467039][Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAPrep24x].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e907467039][Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAPrep24x].json
@@ -32107,26 +32107,6 @@
     {
       "name": "Flex_S_v2_15_P1000M_P50M_GRIP_HS_MB_TC_TM_IlluminaDNAPrep24x.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed1e64c539][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed1e64c539][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2].json
@@ -74,26 +74,6 @@
     {
       "name": "Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f0efddcd7d][Flex_X_v2_16_P1000_96_DropTipsWithNoTrash].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f0efddcd7d][Flex_X_v2_16_P1000_96_DropTipsWithNoTrash].json
@@ -1402,26 +1402,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_DropTipsWithNoTrash.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f24bb0b4d9][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IlluminaDNAPrep96PART3].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f24bb0b4d9][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IlluminaDNAPrep96PART3].json
@@ -5828,23 +5828,11 @@
       "role": "main"
     },
     {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
       "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
       "role": "labware"
     },
     {
       "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
       "role": "labware"
     }
   ],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f301704f56][OT2_S_v6_P300M_P300S_HS_HS_NormalUseWithTransfer].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f301704f56][OT2_S_v6_P300M_P300S_HS_HS_NormalUseWithTransfer].json
@@ -6384,26 +6384,6 @@
     {
       "name": "OT2_S_v6_P300M_P300S_HS_HS_NormalUseWithTransfer.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f345e8e33a][OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f345e8e33a][OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40].json
@@ -9608,26 +9608,6 @@
     {
       "name": "OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40.json",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f37bb0ec36][OT2_S_v2_16_NO_PIPETTES_verifyDoesNotDeadlock].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f37bb0ec36][OT2_S_v2_16_NO_PIPETTES_verifyDoesNotDeadlock].json
@@ -20,26 +20,6 @@
     {
       "name": "OT2_S_v2_16_NO_PIPETTES_verifyDoesNotDeadlock.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [],

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -12972,26 +12972,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5f3b9c5bb][Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5f3b9c5bb][Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict].json
@@ -1293,26 +1293,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f639acc89d][Flex_S_v2_15_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f639acc89d][Flex_S_v2_15_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
@@ -151,26 +151,6 @@
     {
       "name": "Flex_S_v2_15_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7085d7134][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLidClips].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7085d7134][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLidClips].json
@@ -1328,26 +1328,6 @@
     {
       "name": "Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLidClips.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f834b97da1][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f834b97da1][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1].json
@@ -13088,26 +13088,6 @@
     {
       "name": "Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [

--- a/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fc60ef9cbd][OT2_S_v2_16_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/app-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fc60ef9cbd][OT2_S_v2_16_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -2991,26 +2991,6 @@
     {
       "name": "OT2_S_v2_16_P300M_P20S_HS_TC_TM_dispense_changes.py",
       "role": "main"
-    },
-    {
-      "name": "cpx_4_tuberack_100ul.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_1000ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_200ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "opentrons_ot3_96_tiprack_50ul_rss.json",
-      "role": "labware"
-    },
-    {
-      "name": "sample_labware.json",
-      "role": "labware"
     }
   ],
   "labware": [


### PR DESCRIPTION
# Overview

Fixes https://opentrons.atlassian.net/browse/EXEC-582

I ran into an issue when adding PL protocols to snapshot testing. 
We were passing all custom labware in the `labware` folder to `python -m opentrons.cli.analyze`. Subsequently, when you add another custom labware, every protocol has the custom labware added to its command, meaning it ends up in the analysis. This causes every snapshot to need to be updated when you add a new custom labware. 

This PR slightly modifies how we build the `analyze` command when we use `generate_analyses_from_test`. Instead of passing all of the custom labware, we only pass the custom labware that the `Protocol` object specifies. Doing this ensures that adding a new custom labware does not every protocol to change. 

**NOTE:** The functionality of `analyze_against_image` is maintained as passing all the custom labware. 

# Test Plan

- [x] Verify bug
    - [x] Run snapshots and make sure they all pass
    - [x] Without any changes to the logic in `generate_analyses.py`, add new custom labware to the `labware` folder. The added custom labware should not be specified in any of the ran protocols
    - [x] Run snapshot tests and verify that they all fail because new labware was added to analysis output
- [x] Remove previously added custom labware
- [x] Verify fix
    - [x] Add changes to `generate_analyses.py`
    - [x] Run snapshot tests. 
    - [x] Verify all tests fail ONLY because any extraneous labware has been removed. 
    - [x] Verify that any protocols that use custom labware still have them in their analyses
    - [x] Update snapshots on branch
    - [x] Add the same labware that you used to verify the bug
    - [x] Rerun the snapshot tests against the new snapshots and confirm that all tests pass (are not changed by adding that labware)

# Review requests

None

# Risk assessment

Low