### PR TITLE
refactor(app): style update for ODD large button

### DIFF
--- a/app/src/atoms/buttons/LargeButton.stories.tsx
+++ b/app/src/atoms/buttons/LargeButton.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
-import { ICON_DATA_BY_NAME, VIEWPORT } from '@opentrons/components'
+import { Box, COLORS, SPACING, ICON_DATA_BY_NAME } from '@opentrons/components'
 import { LargeButton } from './'
-import { Box, COLORS, SPACING } from '@opentrons/components'
 
 import type { Meta, StoryObj } from '@storybook/react'
 

--- a/app/src/atoms/buttons/LargeButton.stories.tsx
+++ b/app/src/atoms/buttons/LargeButton.stories.tsx
@@ -19,20 +19,27 @@ const meta: Meta<typeof LargeButton> = {
   },
   parameters: {
     viewport: {
-      defaultViewport: 'Touchscreen'
+      defaultViewport: 'Touchscreen',
     },
     pseudo: {
-      rootSelector: '#content'
+      rootSelector: '#content',
     },
   },
   decorators: [
     (Story, context) => (
-      <Box width={'fit-content'} padding={SPACING.spacing32} backgroundColor={['alertStroke', 'alertAlt'].includes(context.args.buttonType) ? COLORS.black90 : COLORS.white }>
+      <Box
+        width={'fit-content'}
+        padding={SPACING.spacing32}
+        backgroundColor={
+          ['alertStroke', 'alertAlt'].includes(context.args.buttonType)
+            ? COLORS.black90
+            : COLORS.white
+        }
+      >
         <Story id={'content'} />
       </Box>
-    )
+    ),
   ],
-
 }
 
 export default meta
@@ -68,7 +75,7 @@ export const AlertStroke: Story = {
     buttonType: 'alertStroke',
     buttonText: 'Button text',
     disabled: false,
-    iconName: 'ot-alert'
+    iconName: 'ot-alert',
   },
 }
 
@@ -77,6 +84,6 @@ export const AlertAlt: Story = {
     buttonType: 'alertAlt',
     buttonText: 'Button text',
     disabled: false,
-    iconName: 'ot-check'
+    iconName: 'ot-check',
   },
 }

--- a/app/src/atoms/buttons/LargeButton.stories.tsx
+++ b/app/src/atoms/buttons/LargeButton.stories.tsx
@@ -1,5 +1,7 @@
+import * as React from 'react'
 import { ICON_DATA_BY_NAME, VIEWPORT } from '@opentrons/components'
 import { LargeButton } from './'
+import { Box, COLORS, SPACING } from '@opentrons/components'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -15,7 +17,22 @@ const meta: Meta<typeof LargeButton> = {
       options: Object.keys(ICON_DATA_BY_NAME),
     },
   },
-  parameters: VIEWPORT.touchScreenViewport,
+  parameters: {
+    viewport: {
+      defaultViewport: 'Touchscreen'
+    },
+    pseudo: {
+      rootSelector: '#content'
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <Box width={'fit-content'} padding={SPACING.spacing32} backgroundColor={['alertStroke', 'alertAlt'].includes(context.args.buttonType) ? COLORS.black90 : COLORS.white }>
+        <Story id={'content'} />
+      </Box>
+    )
+  ],
+
 }
 
 export default meta
@@ -45,26 +62,13 @@ export const Alert: Story = {
     iconName: 'reset',
   },
 }
-export const PrimaryNoIcon: Story = {
-  args: {
-    buttonText: 'Button text',
-    disabled: false,
-  },
-}
-export const PrimaryWithSubtext: Story = {
-  args: {
-    buttonText: 'Button text',
-    disabled: false,
-    subtext: 'Button subtext',
-  },
-}
 
-export const OnColor: Story = {
+export const AlertStroke: Story = {
   args: {
-    buttonType: 'onColor',
+    buttonType: 'alertStroke',
     buttonText: 'Button text',
     disabled: false,
-    subtext: 'Button subtext',
+    iconName: 'ot-alert'
   },
 }
 
@@ -73,6 +77,6 @@ export const AlertAlt: Story = {
     buttonType: 'alertAlt',
     buttonText: 'Button text',
     disabled: false,
-    subtext: 'Button subtext',
+    iconName: 'ot-check'
   },
 }

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -131,8 +131,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
   const LARGE_BUTTON_STYLE = css`
     text-align: ${TYPOGRAPHY.textAlignLeft};
     color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
-    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-      .defaultBackgroundColor};
+    background-color: ${
+      LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+    };
     cursor: default;
     border-radius: ${BORDERS.borderRadius16};
     box-shadow: none;
@@ -140,21 +141,26 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     line-height: ${TYPOGRAPHY.lineHeight20};
     grid-gap: ${SPACING.spacing60}
     border: ${BORDERS.borderRadius4} solid
-      ${!!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
-        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
-        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor};
+      ${
+        !!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
+          ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
+          : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+      };
 
     ${TYPOGRAPHY.pSemiBold}
 
     #btn-icon: {
-      color: ${disabled
-        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
-        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor};
+      color: ${
+        disabled
+          ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
+          : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
+      };
     }
 
     &:active {
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+      };
       ${activeColorFor(buttonType)};
       border: ${BORDERS.borderRadius4} solid
         ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
@@ -164,8 +170,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     }
 
     &:focus-visible {
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .focusVisibleBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleBackgroundColor
+      };
       ${activeColorFor(buttonType)};
       padding: calc(${SPACING.spacing24} + ${SPACING.spacing2});
       border: ${SPACING.spacing2} solid ${COLORS.transparent};
@@ -177,8 +184,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
     &:disabled {
       color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+      };
     }
   `
   return (

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -20,14 +20,13 @@ type LargeButtonTypes =
   | 'primary'
   | 'secondary'
   | 'alert'
-  | 'onColor'
+  | 'alertStroke'
   | 'alertAlt'
 interface LargeButtonProps extends StyleProps {
   onClick: () => void
   buttonType?: LargeButtonTypes
   buttonText: React.ReactNode
   iconName?: IconName
-  subtext?: string
   disabled?: boolean
 }
 
@@ -36,7 +35,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     buttonType = 'primary',
     buttonText,
     iconName,
-    subtext,
     disabled = false,
     ...buttonProps
   } = props
@@ -53,6 +51,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledIconColor: string
       border?: string
       disabledBorder?: string
+      activeColor?: string
+      activeBorder?: string
+      activeIconColor?: string
     }
   > = {
     secondary: {
@@ -82,33 +83,42 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       iconColor: COLORS.white,
       disabledIconColor: COLORS.grey50,
     },
-    onColor: {
+    alertStroke: {
       defaultColor: COLORS.white,
       disabledColor: COLORS.grey40,
+      activeColor: COLORS.red60,
       defaultBackgroundColor: COLORS.transparent,
-      activeBackgroundColor: COLORS.transparent,
+      activeBackgroundColor: COLORS.red35,
       disabledBackgroundColor: COLORS.transparent,
       iconColor: COLORS.white,
       disabledIconColor: COLORS.grey40,
       border: `${BORDERS.borderRadius4} solid ${COLORS.white}`,
       disabledBorder: `${BORDERS.borderRadius4} solid ${COLORS.grey35}`,
+      activeBorder: 'none',
+      activeIconColor: COLORS.red60,
     },
     alertAlt: {
       defaultColor: COLORS.red50,
       disabledColor: COLORS.grey50,
       defaultBackgroundColor: COLORS.white,
-      activeBackgroundColor: COLORS.white,
+      activeBackgroundColor: COLORS.red35,
       disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.red50,
       disabledIconColor: COLORS.grey50,
+      activeIconColor: COLORS.red60,
+      activeColor: COLORS.red60,
     },
   }
+  const activeColorFor = (style: keyof typeof LARGE_BUTTON_PROPS_BY_TYPE): string =>
+    LARGE_BUTTON_PROPS_BY_TYPE[style].activeColor ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeColor}` : ''
+  const activeIconStyle = (style: keyof typeof LARGE_BUTTON_PROPS_BY_TYPE): string =>
+    LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor}` : ''
 
   const LARGE_BUTTON_STYLE = css`
     text-align: ${TYPOGRAPHY.textAlignLeft};
     color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
     background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-      .defaultBackgroundColor};
+    .defaultBackgroundColor};
     cursor: default;
     border-radius: ${BORDERS.borderRadius16};
     box-shadow: none;
@@ -117,38 +127,34 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].border};
     ${TYPOGRAPHY.pSemiBold}
 
-    &:focus {
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
-      box-shadow: none;
+    #btn-icon: {
+       color: ${disabled ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor};
     }
-    &:hover {
-      border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].border};
-      box-shadow: none;
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .defaultBackgroundColor};
-      color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
-    }
+
     &:focus-visible {
-      box-shadow: ${ODD_FOCUS_VISIBLE};
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .defaultBackgroundColor};
+    box-shadow: ${ODD_FOCUS_VISIBLE};
+    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+    .defaultBackgroundColor};
     }
     &:active {
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
+    ${activeColorFor(buttonType)};
+    border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBorder ?? 0}
+    }
+    &:active #btn-icon: {
+    ${activeIconStyle(buttonType)};
     }
 
     &:disabled {
-      color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+    color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
+    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+    .disabledBackgroundColor};
     }
   `
   return (
     <Btn
-      display={DISPLAY_FLEX}
-      css={LARGE_BUTTON_STYLE}
+    display={DISPLAY_FLEX}
+    css={LARGE_BUTTON_STYLE}
       flexDirection={DIRECTION_COLUMN}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       disabled={disabled}
@@ -158,22 +164,13 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
         <LegacyStyledText css={TYPOGRAPHY.level3HeaderSemiBold}>
           {buttonText}
         </LegacyStyledText>
-        {subtext ? (
-          <LegacyStyledText css={TYPOGRAPHY.level3HeaderRegular}>
-            {subtext}
-          </LegacyStyledText>
-        ) : null}
       </Flex>
       {iconName ? (
         <Icon
           name={iconName}
           aria-label={`${iconName} icon`}
-          color={
-            disabled
-              ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
-              : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
-          }
           size="5rem"
+          id={`btn-icon`}
         />
       ) : null}
     </Btn>

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -49,9 +49,10 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       iconColor: string
       disabledIconColor: string
       focusVisibleOutlineColor: string
+      focusVisibleBackgroundColor: string
+      activeIconColor?: string
       isInverse?: boolean
       activeColor?: string
-      activeIconColor?: string
     }
   > = {
     secondary: {
@@ -63,6 +64,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       iconColor: COLORS.blue50,
       disabledIconColor: COLORS.grey50,
       focusVisibleOutlineColor: COLORS.blue50,
+      focusVisibleBackgroundColor: COLORS.blue40,
     },
     alert: {
       defaultColor: COLORS.red60,
@@ -73,6 +75,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       iconColor: COLORS.red60,
       disabledIconColor: COLORS.grey50,
       focusVisibleOutlineColor: COLORS.blue50,
+      focusVisibleBackgroundColor: COLORS.red40,
     },
     primary: {
       defaultColor: COLORS.white,
@@ -83,6 +86,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       iconColor: COLORS.white,
       disabledIconColor: COLORS.grey50,
       focusVisibleOutlineColor: COLORS.blue55,
+      focusVisibleBackgroundColor: COLORS.blue55,
     },
     alertStroke: {
       defaultColor: COLORS.white,
@@ -96,6 +100,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       isInverse: true,
       activeIconColor: COLORS.red60,
       focusVisibleOutlineColor: COLORS.blue50,
+      focusVisibleBackgroundColor: COLORS.red40,
     },
     alertAlt: {
       defaultColor: COLORS.red50,
@@ -108,6 +113,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       activeIconColor: COLORS.red60,
       activeColor: COLORS.red60,
       focusVisibleOutlineColor: COLORS.blue50,
+      focusVisibleBackgroundColor: COLORS.red40,
     },
   }
   const activeColorFor = (
@@ -158,7 +164,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
     &:focus-visible {
       background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+        .focusVisibleBackgroundColor};
       ${activeColorFor(buttonType)};
       padding: calc(${SPACING.spacing24} + ${SPACING.spacing2});
       border: ${SPACING.spacing2} solid ${COLORS.transparent};

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -13,7 +13,6 @@ import {
   LegacyStyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { ODD_FOCUS_VISIBLE } from './constants'
 import type { IconName, StyleProps } from '@opentrons/components'
 
 type LargeButtonTypes =
@@ -49,10 +48,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledColor: string
       iconColor: string
       disabledIconColor: string
-      border?: string
-      disabledBorder?: string
+      focusVisibleOutlineColor: string
+      isInverse?: boolean
       activeColor?: string
-      activeBorder?: string
       activeIconColor?: string
     }
   > = {
@@ -64,6 +62,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.blue50,
       disabledIconColor: COLORS.grey50,
+      focusVisibleOutlineColor: COLORS.blue50,
     },
     alert: {
       defaultColor: COLORS.red60,
@@ -73,6 +72,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.red60,
       disabledIconColor: COLORS.grey50,
+      focusVisibleOutlineColor: COLORS.blue50,
     },
     primary: {
       defaultColor: COLORS.white,
@@ -82,6 +82,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.white,
       disabledIconColor: COLORS.grey50,
+      focusVisibleOutlineColor: COLORS.blue55,
     },
     alertStroke: {
       defaultColor: COLORS.white,
@@ -92,10 +93,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledBackgroundColor: COLORS.transparent,
       iconColor: COLORS.white,
       disabledIconColor: COLORS.grey40,
-      border: `${BORDERS.borderRadius4} solid ${COLORS.white}`,
-      disabledBorder: `${BORDERS.borderRadius4} solid ${COLORS.grey35}`,
-      activeBorder: 'none',
+      isInverse: true,
       activeIconColor: COLORS.red60,
+      focusVisibleOutlineColor: COLORS.blue50,
     },
     alertAlt: {
       defaultColor: COLORS.red50,
@@ -107,54 +107,77 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledIconColor: COLORS.grey50,
       activeIconColor: COLORS.red60,
       activeColor: COLORS.red60,
+      focusVisibleOutlineColor: COLORS.blue50,
     },
   }
-  const activeColorFor = (style: keyof typeof LARGE_BUTTON_PROPS_BY_TYPE): string =>
-    LARGE_BUTTON_PROPS_BY_TYPE[style].activeColor ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeColor}` : ''
-  const activeIconStyle = (style: keyof typeof LARGE_BUTTON_PROPS_BY_TYPE): string =>
-    LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor}` : ''
-
+  const activeColorFor = (
+    style: keyof typeof LARGE_BUTTON_PROPS_BY_TYPE
+  ): string =>
+    LARGE_BUTTON_PROPS_BY_TYPE[style].activeColor
+      ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeColor}`
+      : ''
+  const activeIconStyle = (
+    style: keyof typeof LARGE_BUTTON_PROPS_BY_TYPE
+  ): string =>
+    LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor
+      ? `color: ${LARGE_BUTTON_PROPS_BY_TYPE[style].activeIconColor}`
+      : ''
   const LARGE_BUTTON_STYLE = css`
     text-align: ${TYPOGRAPHY.textAlignLeft};
     color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
     background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-    .defaultBackgroundColor};
+      .defaultBackgroundColor};
     cursor: default;
     border-radius: ${BORDERS.borderRadius16};
     box-shadow: none;
     padding: ${SPACING.spacing24};
     line-height: ${TYPOGRAPHY.lineHeight20};
-    border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].border};
+    border: ${BORDERS.borderRadius4} solid
+      ${!!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
+        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].color
+        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor};
+
     ${TYPOGRAPHY.pSemiBold}
 
     #btn-icon: {
-       color: ${disabled ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor};
+      color: ${disabled
+        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
+        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor};
+    }
+
+    &:active {
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .activeBackgroundColor};
+      ${activeColorFor(buttonType)};
+      border: ${BORDERS.borderRadius4} solid
+        ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
+    }
+    &:active #btn-icon {
+      ${activeIconStyle(buttonType)};
     }
 
     &:focus-visible {
-    box-shadow: ${ODD_FOCUS_VISIBLE};
-    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-    .defaultBackgroundColor};
-    }
-    &:active {
-    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
-    ${activeColorFor(buttonType)};
-    border: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBorder ?? 0}
-    }
-    &:active #btn-icon: {
-    ${activeIconStyle(buttonType)};
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .activeBackgroundColor};
+      ${activeColorFor(buttonType)};
+      padding: calc(${SPACING.spacing24} + ${SPACING.spacing2});
+      border: ${SPACING.spacing2} solid ${COLORS.transparent};
+      outline: 3px solid
+        ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleOutlineColor};
+      background-clip: padding-box;
+      box-shadow: none;
     }
 
     &:disabled {
-    color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-    .disabledBackgroundColor};
+      color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .disabledBackgroundColor};
     }
   `
   return (
     <Btn
-    display={DISPLAY_FLEX}
-    css={LARGE_BUTTON_STYLE}
+      display={DISPLAY_FLEX}
+      css={LARGE_BUTTON_STYLE}
       flexDirection={DIRECTION_COLUMN}
       justifyContent={JUSTIFY_SPACE_BETWEEN}
       disabled={disabled}

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -131,36 +131,30 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
   const LARGE_BUTTON_STYLE = css`
     text-align: ${TYPOGRAPHY.textAlignLeft};
     color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
-    background-color: ${
-      LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
-    };
+    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+      .defaultBackgroundColor};
     cursor: default;
     border-radius: ${BORDERS.borderRadius16};
     box-shadow: none;
     padding: ${SPACING.spacing24};
     line-height: ${TYPOGRAPHY.lineHeight20};
-    grid-gap: ${SPACING.spacing60}
+    gap: ${SPACING.spacing60};
     border: ${BORDERS.borderRadius4} solid
-      ${
-        !!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
-          ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
-          : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
-      };
+      ${!!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
+        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
+        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor};
 
     ${TYPOGRAPHY.pSemiBold}
 
     #btn-icon: {
-      color: ${
-        disabled
-          ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
-          : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor
-      };
+      color: ${disabled
+        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledIconColor
+        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].iconColor};
     }
 
     &:active {
-      background-color: ${
-        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
-      };
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .activeBackgroundColor};
       ${activeColorFor(buttonType)};
       border: ${BORDERS.borderRadius4} solid
         ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
@@ -170,9 +164,8 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     }
 
     &:focus-visible {
-      background-color: ${
-        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleBackgroundColor
-      };
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .focusVisibleBackgroundColor};
       ${activeColorFor(buttonType)};
       padding: calc(${SPACING.spacing24} + ${SPACING.spacing2});
       border: ${SPACING.spacing2} solid ${COLORS.transparent};
@@ -184,9 +177,8 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
     &:disabled {
       color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-      background-color: ${
-        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
-      };
+      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
+        .disabledBackgroundColor};
     }
   `
   return (

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -138,6 +138,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     box-shadow: none;
     padding: ${SPACING.spacing24};
     line-height: ${TYPOGRAPHY.lineHeight20};
+    grid-gap: ${SPACING.spacing60}
     border: ${BORDERS.borderRadius4} solid
       ${!!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
         ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -134,7 +134,7 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     line-height: ${TYPOGRAPHY.lineHeight20};
     border: ${BORDERS.borderRadius4} solid
       ${!!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
-        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].color
+        ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
         : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor};
 
     ${TYPOGRAPHY.pSemiBold}

--- a/app/src/atoms/buttons/__tests__/LargeButton.test.tsx
+++ b/app/src/atoms/buttons/__tests__/LargeButton.test.tsx
@@ -46,10 +46,10 @@ describe('LargeButton', () => {
     )
   })
 
-  it('renders the onColor button', () => {
+  it('renders the alertStroke button', () => {
     props = {
       ...props,
-      buttonType: 'onColor',
+      buttonType: 'alertStroke',
     }
     render(props)
     expect(screen.getByRole('button')).toHaveStyle(

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -116,7 +116,7 @@ export function RunPausedSplash(
             buttonText={t('launch_recovery_mode')}
             css={SHARED_BUTTON_STYLE}
             iconName={'recovery'}
-            buttonType="onColor"
+            buttonType="alertStroke"
           />
         </Flex>
       </Flex>

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
@@ -4,8 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, screen, waitFor, renderHook } from '@testing-library/react'
 import { createStore } from 'redux'
 
-import { COLORS } from '@opentrons/components'
-
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
 import { mockRecoveryContentProps } from '../__fixtures__'

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
@@ -105,16 +105,6 @@ describe('RunPausedSplash', () => {
     expect(primaryBtn).toBeInTheDocument()
     expect(secondaryBtn).toBeInTheDocument()
 
-    expect(primaryBtn).toHaveStyle({ 'background-color': 'transparent' })
-    expect(secondaryBtn).toHaveStyle({ 'background-color': COLORS.white })
-
-    expect(screen.getByLabelText('remove icon')).toHaveStyle({
-      color: COLORS.red50,
-    })
-    expect(screen.getByLabelText('recovery icon')).toHaveStyle({
-      color: COLORS.white,
-    })
-
     fireEvent.click(secondaryBtn)
 
     await waitFor(() => {

--- a/app/src/organisms/QuickTransferFlow/SelectDestLabware.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectDestLabware.tsx
@@ -10,7 +10,7 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 
-import { LargeButton, TabbedButton } from '../../atoms/buttons'
+import { RadioButton, TabbedButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 import { getCompatibleLabwareByCategory } from './utils'
 
@@ -114,32 +114,30 @@ export function SelectDestLabware(
           marginTop="175px"
         >
           {selectedCategory === 'all' && state?.source != null ? (
-            <LargeButton
-              buttonType={
-                selectedLabware === 'source' ? 'primary' : 'secondary'
-              }
-              onClick={() => {
+            <RadioButton
+              isSelected={selectedLabware === 'source'}
+              onChange={() => {
                 setSelectedLabware('source')
               }}
-              buttonText={t('source_labware_d2')}
-              subtext={state.source.metadata.displayName}
+              buttonLabel={t('source_labware_d2')}
+              buttonValue="source-labware-d2"
+              subButtonLabel={state.source.metadata.displayName}
             />
           ) : null}
           {compatibleLabwareDefinitions?.map(definition => {
             return definition.metadata.displayName != null ? (
-              <LargeButton
+              <RadioButton
                 key={`${selectedCategory}-${definition.metadata.displayName}`}
-                buttonType={
+                isSelected={
                   selectedLabware !== 'source' &&
                   selectedLabware?.metadata.displayName ===
                     definition.metadata.displayName
-                    ? 'primary'
-                    : 'secondary'
                 }
-                onClick={() => {
+                onChange={() => {
                   setSelectedLabware(definition)
                 }}
-                buttonText={definition.metadata.displayName}
+                buttonValue={definition.metadata.displayName}
+                buttonLabel={definition.metadata.displayName}
               />
             ) : null
           })}

--- a/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
@@ -9,7 +9,7 @@ import {
 } from '@opentrons/components'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 import { getPipetteSpecsV2, RIGHT, LEFT } from '@opentrons/shared-data'
-import { LargeButton } from '../../atoms/buttons'
+import { RadioButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 
 import type { PipetteData, Mount } from '@opentrons/api-client'
@@ -89,27 +89,29 @@ export function SelectPipette(props: SelectPipetteProps): JSX.Element {
           {t('pipette_currently_attached')}
         </LegacyStyledText>
         {leftPipetteSpecs != null ? (
-          <LargeButton
-            buttonType={selectedPipette === LEFT ? 'primary' : 'secondary'}
-            onClick={() => {
+          <RadioButton
+            isSelected={selectedPipette === LEFT}
+            onChange={() => {
               setSelectedPipette(LEFT)
             }}
-            buttonText={
+            buttonValue={LEFT}
+            buttonLabel={
               leftPipetteSpecs.channels === 96
                 ? t('both_mounts')
                 : t('left_mount')
             }
-            subtext={leftPipetteSpecs.displayName}
+            subButtonLabel={leftPipetteSpecs.displayName}
           />
         ) : null}
         {rightPipetteSpecs != null ? (
-          <LargeButton
-            buttonType={selectedPipette === RIGHT ? 'primary' : 'secondary'}
-            onClick={() => {
+          <RadioButton
+            isSelected={selectedPipette === RIGHT}
+            onChange={() => {
               setSelectedPipette(RIGHT)
             }}
-            buttonText={t('right_mount')}
-            subtext={rightPipetteSpecs.displayName}
+            buttonValue={RIGHT}
+            buttonLabel={t('right_mount')}
+            subButtonLabel={rightPipetteSpecs.displayName}
           />
         ) : null}
       </Flex>

--- a/app/src/organisms/QuickTransferFlow/SelectSourceLabware.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectSourceLabware.tsx
@@ -10,7 +10,7 @@ import {
   ALIGN_CENTER,
 } from '@opentrons/components'
 
-import { LargeButton, TabbedButton } from '../../atoms/buttons'
+import { RadioButton, TabbedButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 import { getCompatibleLabwareByCategory } from './utils'
 
@@ -116,18 +116,17 @@ export function SelectSourceLabware(
         >
           {compatibleLabwareDefinitions?.map(definition => {
             return definition.metadata.displayName != null ? (
-              <LargeButton
+              <RadioButton
                 key={`${selectedCategory}-${definition.metadata.displayName}`}
-                buttonType={
+                isSelected={
                   selectedLabware?.metadata.displayName ===
                   definition.metadata.displayName
-                    ? 'primary'
-                    : 'secondary'
                 }
-                onClick={() => {
+                onChange={() => {
                   setSelectedLabware(definition)
                 }}
-                buttonText={definition.metadata.displayName}
+                buttonValue={definition.metadata.displayName}
+                buttonLabel={definition.metadata.displayName}
               />
             ) : null
           })}

--- a/app/src/organisms/QuickTransferFlow/SelectTipRack.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectTipRack.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { Flex, SPACING, DIRECTION_COLUMN } from '@opentrons/components'
 import { getAllDefinitions } from '@opentrons/shared-data'
-import { LargeButton } from '../../atoms/buttons'
+import { RadioButton } from '../../atoms/buttons'
 import { ChildNavigation } from '../ChildNavigation'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -64,15 +64,14 @@ export function SelectTipRack(props: SelectTipRackProps): JSX.Element {
           const tipRackDef = allLabwareDefinitionsByUri[tipRack]
 
           return tipRackDef != null ? (
-            <LargeButton
+            <RadioButton
               key={tipRack}
-              buttonType={
-                selectedTipRack === tipRackDef ? 'primary' : 'secondary'
-              }
-              onClick={() => {
+              isSelected={selectedTipRack === tipRackDef}
+              buttonValue={tipRack}
+              buttonLabel={tipRackDef.metadata.displayName}
+              onChange={() => {
                 setSelectedTipRack(tipRackDef)
               }}
-              buttonText={tipRackDef.metadata.displayName}
             />
           ) : null
         })}

--- a/app/src/organisms/QuickTransferFlow/TipManagement/ChangeTip.tsx
+++ b/app/src/organisms/QuickTransferFlow/TipManagement/ChangeTip.tsx
@@ -9,7 +9,7 @@ import {
   COLORS,
 } from '@opentrons/components'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { ChildNavigation } from '../../ChildNavigation'
 
 import type {
@@ -69,15 +69,14 @@ export function ChangeTip(props: ChangeTipProps): JSX.Element {
         width="100%"
       >
         {allowedChangeTipOptions.map(option => (
-          <LargeButton
+          <RadioButton
             key={option}
-            buttonType={
-              selectedChangeTipOption === option ? 'primary' : 'secondary'
-            }
-            onClick={() => {
+            isSelected={selectedChangeTipOption === option}
+            onChange={() => {
               setSelectedChangeTipOption(option)
             }}
-            buttonText={t(`${option}`)}
+            buttonValue={option}
+            buttonLabel={t(`${option}`)}
           />
         ))}
       </Flex>

--- a/app/src/organisms/QuickTransferFlow/TipManagement/TipDropLocation.tsx
+++ b/app/src/organisms/QuickTransferFlow/TipManagement/TipDropLocation.tsx
@@ -14,7 +14,7 @@ import {
   TRASH_BIN_ADAPTER_FIXTURE,
 } from '@opentrons/shared-data'
 import { getTopPortalEl } from '../../../App/portal'
-import { LargeButton } from '../../../atoms/buttons'
+import { RadioButton } from '../../../atoms/buttons'
 import { useNotifyDeckConfigurationQuery } from '../../../resources/deck_configuration'
 import { ChildNavigation } from '../../ChildNavigation'
 
@@ -80,17 +80,14 @@ export function TipDropLocation(props: TipDropLocationProps): JSX.Element {
         width="100%"
       >
         {tipDropLocationOptions.map(option => (
-          <LargeButton
+          <RadioButton
             key={option.cutoutId}
-            buttonType={
-              selectedTipDropLocation.cutoutId === option.cutoutId
-                ? 'primary'
-                : 'secondary'
-            }
-            onClick={() => {
+            isSelected={selectedTipDropLocation.cutoutId === option.cutoutId}
+            onChange={() => {
               setSelectedTipDropLocation(option)
             }}
-            buttonText={t(
+            buttonValue={option.cutoutId}
+            buttonLabel={t(
               `${
                 option.cutoutFixtureId === TRASH_BIN_ADAPTER_FIXTURE
                   ? 'trashBin'


### PR DESCRIPTION
Style updates for `LargeButton`, including
- No subtext
- renames to some alternate styles for using the buttons on backgrounds of other colors
- updates to the `focus-visible` style
- updates to various active styles

See https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery?node-id=953-17455&t=4vdRKwF6TpZna0tb-4

Notes for looking at this:
- Check it out on storybook
- make sure that various interaction states don't make the button change sizes slightly

Closes EXEC-495