### PR TITLE
fix(protocol-designer): refine logic for change tip options being dis…

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/ChangeTipField/getDisabledChangeTipOptions.ts
+++ b/protocol-designer/src/components/StepEditForm/fields/ChangeTipField/getDisabledChangeTipOptions.ts
@@ -16,8 +16,8 @@ export const getDisabledChangeTipOptions = (
     case 'moveLiquid': {
       const wellRatio = getWellRatio(aspirateWells, dispenseWells)
 
-      // form with no wells selected treated as 'single'
-      if (!wellRatio || !path || path === 'single') {
+      //  ensure wells are selected
+      if (wellRatio != null && path === 'single') {
         if (wellRatio === '1:many') {
           return new Set(['perSource'])
         }


### PR DESCRIPTION
…abled

closes RESC-289


# Overview

This bug is interesting. Basically the logic for the different change tip options needed to be refined because there were states when the selection was not disabled but you couldn't successfully set it. Looking at the logic, we needed to account for the well ratio being set. Since the introduction of the trash bin/waste chute, those entities are not labware and are addressable areas. So they don't have wells to select, therefore the certain option such as `perDest` and `perSource` should be disabled

# Test Plan

Create a flex or ot-2 protocol with a single channel and an 8 channel. Add a 1 well reservoir and a 12 well reservoir.

Create a transfer step where you aspirate from the 1 well reservoir and dispense into the trash bin. See that the change tip dropdown's `per source` and `per dest` are disabled. Now change the dispense location to 1 well/column in the 12 well reservoir. See that the `per source` is enabled and selectable and the `per dest` is still disabled. Then change the dispense location to 2 wells/columns in the 12 well reservoir. See that the `per dest` is enabled but the `per source` is disabled.

Repeat those steps with the other pipette.

Note: only the move liquid form needed to be updated since the mix form does not allow you to mix into a trash bin or waste chute.

# Changelog

- refine logic for when the change tip options are disabled

# Review requests

see test plan

# Risk assessment

low