### PR TITLE
refactor(components): Add web style to location icon

### DIFF
--- a/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
@@ -14,10 +14,11 @@ import {
   Icon,
   InfoScreen,
   JUSTIFY_FLEX_START,
+  LegacyStyledText,
   Link,
+  LocationIcon,
   OVERFLOW_HIDDEN,
   SPACING,
-  LegacyStyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
@@ -271,19 +272,7 @@ export function HistoricalProtocolRunDrawer(
                   gridGap={SPACING.spacing4}
                   alignItems={ALIGN_CENTER}
                 >
-                  {/* TODO (nd: 06/20/2024) finalize small version of LocationIcon w/ Design and implement below */}
-                  <LegacyStyledText
-                    as="label"
-                    fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-                    borderRadius="6px"
-                    padding="3px"
-                    minWidth="max-content"
-                    css={css`
-                      border: 1px solid;
-                    `}
-                  >
-                    {offset.location.slotName}
-                  </LegacyStyledText>
+                  <LocationIcon slotName={offset.location.slotName} />
                   <LegacyStyledText as="p">
                     {offset.location.moduleModel != null
                       ? getModuleDisplayName(offset.location.moduleModel)

--- a/components/src/molecules/LocationIcon/LocationIcon.stories.tsx
+++ b/components/src/molecules/LocationIcon/LocationIcon.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<typeof LocationIcon> = {
   decorators: [
     Story => (
       <Flex padding={SPACING.spacing16} width="15rem" height="5rem">
-        <GlobalStyle isOnDevice />
+        <GlobalStyle />
         <Story />
       </Flex>
     ),

--- a/components/src/molecules/LocationIcon/__tests__/LocationIcon.test.tsx
+++ b/components/src/molecules/LocationIcon/__tests__/LocationIcon.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, beforeEach, expect } from 'vitest'
 import { renderWithProviders } from '../../../testing/utils'
 import { screen } from '@testing-library/react'
 import { SPACING } from '../../../ui-style-constants'
-import { BORDERS, COLORS } from '../../../helix-design-system'
+import { COLORS } from '../../../helix-design-system'
 
 import { LocationIcon } from '..'
 

--- a/components/src/molecules/LocationIcon/__tests__/LocationIcon.test.tsx
+++ b/components/src/molecules/LocationIcon/__tests__/LocationIcon.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, beforeEach, expect } from 'vitest'
 import { renderWithProviders } from '../../../testing/utils'
 import { screen } from '@testing-library/react'
 import { SPACING } from '../../../ui-style-constants'
-import { COLORS } from '../../../helix-design-system'
+import { BORDERS, COLORS } from '../../../helix-design-system'
 
 import { LocationIcon } from '..'
 
@@ -29,7 +29,7 @@ describe('LocationIcon', () => {
     expect(locationIcon).toHaveStyle('height: max-content')
     expect(locationIcon).toHaveStyle('width: max-content')
     expect(locationIcon).toHaveStyle(`border: 1px solid ${COLORS.black90}`)
-    expect(locationIcon).toHaveStyle(`border-radius: 6px`)
+    expect(locationIcon).toHaveStyle(`border-radius: ${BORDERS.borderRadius4}`)
   })
 
   it.todo('should render the proper styles - odd style')

--- a/components/src/molecules/LocationIcon/__tests__/LocationIcon.test.tsx
+++ b/components/src/molecules/LocationIcon/__tests__/LocationIcon.test.tsx
@@ -20,15 +20,19 @@ describe('LocationIcon', () => {
     }
   })
 
-  it('should render the proper styles', () => {
+  it('should render the proper styles - web style', () => {
     render(props)
     const locationIcon = screen.getByTestId('LocationIcon_A1')
-    expect(locationIcon).toHaveStyle(`padding: ${SPACING.spacing4} 0.375rem`)
-    expect(locationIcon).toHaveStyle('height: 2rem')
+    expect(locationIcon).toHaveStyle(
+      `padding: ${SPACING.spacing2} ${SPACING.spacing4}`
+    )
+    expect(locationIcon).toHaveStyle('height: max-content')
     expect(locationIcon).toHaveStyle('width: max-content')
-    expect(locationIcon).toHaveStyle(`border: 2px solid ${COLORS.black90}`)
-    expect(locationIcon).toHaveStyle(`border-radius: ${BORDERS.borderRadius12}`)
+    expect(locationIcon).toHaveStyle(`border: 1px solid ${COLORS.black90}`)
+    expect(locationIcon).toHaveStyle(`border-radius: 6px`)
   })
+
+  it.todo('should render the proper styles - odd style')
 
   it('should render slot name', () => {
     render(props)

--- a/components/src/molecules/LocationIcon/index.tsx
+++ b/components/src/molecules/LocationIcon/index.tsx
@@ -4,7 +4,7 @@ import { css } from 'styled-components'
 import { Icon } from '../../icons'
 import { Flex, Text } from '../../primitives'
 import { ALIGN_CENTER } from '../../styles'
-import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
+import { RESPONSIVENESS, SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 import { BORDERS, COLORS } from '../../helix-design-system'
 
 import type { IconName } from '../../icons'
@@ -32,16 +32,29 @@ const LOCATION_ICON_STYLE = css<{
   width?: string
 }>`
   align-items: ${ALIGN_CENTER};
-  border: 2px solid ${props => props.color ?? COLORS.black90};
-  border-radius: ${BORDERS.borderRadius12};
-  height: ${props => props.height ?? SPACING.spacing32};
+  border: 1px solid ${props => props.color ?? COLORS.black90};
   width: ${props => props.width ?? 'max-content'};
-  padding: ${SPACING.spacing4}
-    ${props => (props.slotName != null ? SPACING.spacing8 : SPACING.spacing6)};
+  padding: ${SPACING.spacing2} ${SPACING.spacing4};
+  border-radius: 6px;
+  height: max-content;
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    border: 2px solid ${props => props.color ?? COLORS.black90};
+    border-radius: ${BORDERS.borderRadius12};
+    height: ${props => props.height ?? SPACING.spacing32};
+    padding: ${SPACING.spacing4}
+      ${props => (props.slotName != null ? SPACING.spacing8 : SPACING.spacing6)};
+  }
 `
 
 const SLOT_NAME_TEXT_STYLE = css`
-  ${TYPOGRAPHY.smallBodyTextBold}
+  font-size: ${TYPOGRAPHY.fontSizeCaption};
+  line-height: ${TYPOGRAPHY.lineHeightNormal};
+  font-weight: ${TYPOGRAPHY.fontWeightBold};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    ${TYPOGRAPHY.smallBodyTextBold}
+  }
 `
 
 export function LocationIcon({

--- a/components/src/molecules/LocationIcon/index.tsx
+++ b/components/src/molecules/LocationIcon/index.tsx
@@ -35,7 +35,7 @@ const LOCATION_ICON_STYLE = css<{
   border: 1px solid ${props => props.color ?? COLORS.black90};
   width: ${props => props.width ?? 'max-content'};
   padding: ${SPACING.spacing2} ${SPACING.spacing4};
-  border-radius: 6px;
+  border-radius: ${BORDERS.borderRadius4};
   height: max-content;
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/components/src/ui-style-constants/typography.ts
+++ b/components/src/ui-style-constants/typography.ts
@@ -35,6 +35,7 @@ export const lineHeight20 = '1.25rem' // 20px
 export const lineHeight18 = '1.125rem' // 18px
 export const lineHeight16 = '1rem' // 16px
 export const lineHeight12 = '0.75rem' // 12px
+export const lineHeightNormal = 'normal' // normal
 
 // font styles
 export const fontStyleNormal = 'normal'


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add web style to location icon

[design]
https://www.figma.com/design/MlZjOO8aZXsw3HfTBoyw9U/Release%3A-CSV?node-id=584-12470&m=dev

asking about `border-radius`  https://www.figma.com/design/MlZjOO8aZXsw3HfTBoyw9U?node-id=4-2967&m=dev#852356285



close AUTH-538
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
1. [existing Location Icon ](https://s3-us-west-2.amazonaws.com/opentrons-components/edge/index.html?path=/story/library-molecules-locationicon--display-slot) is the same as [the odd sytle location icon](https://s3-us-west-2.amazonaws.com/opentrons-components/add_web-style-to-location-icon/index.html?path=/story/library-molecules-locationicon--display-slot)

2. [web location icon](https://s3-us-west-2.amazonaws.com/opentrons-components/add_web-style-to-location-icon/index.html?path=/story/library-molecules-locationicon--display-slot) is the same as [the design](https://www.figma.com/design/MlZjOO8aZXsw3HfTBoyw9U/Release%3A-CSV?node-id=584-12470&m=dev)
**need to switch the screen size**

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
