### PR TITLE
feat(app, api-client, react-api-client): send CSV RTP file to robot before creating protocol and run

### DIFF
--- a/api-client/src/dataFiles/uploadCsvFile.ts
+++ b/api-client/src/dataFiles/uploadCsvFile.ts
@@ -27,9 +27,11 @@ export function uploadCsvFile(
   const fileId = uuidv4()
   const stub = {
     data: {
-      id: fileId,
-      createdAt: '2024-06-07T19:19:56.268029+00:00',
-      name: 'rtp_mock_file.csv',
+      data: {
+        id: fileId,
+        createdAt: '2024-06-07T19:19:56.268029+00:00',
+        name: 'rtp_mock_file.csv',
+      },
     },
   }
   return Promise.resolve(stub)

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -132,7 +132,7 @@ export interface LabwareOffsetCreateData {
   vector: VectorOffset
 }
 
-type RunTimeParameterValueType = string | number | boolean | { file_id: string }
+type RunTimeParameterValueType = string | number | boolean | { fileId: string }
 export type RunTimeParameterCreateData = Record<
   string,
   RunTimeParameterValueType

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -132,13 +132,10 @@ export interface LabwareOffsetCreateData {
   vector: VectorOffset
 }
 
-type FileRunTimeParameterCreateData = Record<string, string | number | boolean>
-
-type ValueRunTimeParameterCreateData = Record<string, { id: string }>
-
-export type RunTimeParameterCreateData =
-  | FileRunTimeParameterCreateData
-  | ValueRunTimeParameterCreateData
+export type RunTimeParameterCreateData = Record<
+  string,
+  string | number | boolean | { file_id: string }
+>
 
 export interface CommandData {
   data: RunTimeCommand

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -132,9 +132,10 @@ export interface LabwareOffsetCreateData {
   vector: VectorOffset
 }
 
+type RunTimeParameterValueType = string | number | boolean | { file_id: string }
 export type RunTimeParameterCreateData = Record<
   string,
-  string | number | boolean | { file_id: string }
+  RunTimeParameterValueType
 >
 
 export interface CommandData {

--- a/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/__tests__/ChooseProtocolSlideout.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { vi, it, describe, expect, beforeEach } from 'vitest'
 import { StaticRouter } from 'react-router-dom'
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 
 import { simpleAnalysisFileFixture } from '@opentrons/api-client'
 import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
@@ -106,7 +106,7 @@ describe('ChooseProtocolSlideout', () => {
     ).toBeInTheDocument()
   })
 
-  it('calls createRunFromProtocolSource if CTA clicked', () => {
+  it('calls createRunFromProtocolSource if CTA clicked', async () => {
     const protocolDataWithoutRunTimeParameter = {
       ...storedProtocolDataWithoutRunTimeParameters,
     }
@@ -122,10 +122,13 @@ describe('ChooseProtocolSlideout', () => {
       name: 'Proceed to setup',
     })
     fireEvent.click(proceedButton)
-    expect(mockCreateRunFromProtocol).toHaveBeenCalledWith({
-      files: [expect.any(File)],
-      protocolKey: storedProtocolDataFixture.protocolKey,
-    })
+    await waitFor(() =>
+      expect(mockCreateRunFromProtocol).toHaveBeenCalledWith({
+        files: [expect.any(File)],
+        protocolKey: storedProtocolDataFixture.protocolKey,
+        runTimeParameterValues: expect.any(Object),
+      })
+    )
     expect(mockTrackCreateProtocolRunEvent).toHaveBeenCalled()
   })
 

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -724,8 +724,7 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
         const missingAnalysisData =
           analysisStatus === 'error' || analysisStatus === 'stale'
         const requiresCsvRunTimeParameter =
-          storedProtocol.mostRecentAnalysis?.result ===
-          'parameter-value-required'
+          analysisStatus === 'parameterRequired'
         return (
           <React.Fragment key={storedProtocol.protocolKey}>
             <Flex flexDirection={DIRECTION_COLUMN}>
@@ -829,7 +828,7 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                 color={COLORS.yellow60}
                 overflowWrap="anywhere"
                 display={DISPLAY_BLOCK}
-                marginTop={`-${SPACING.spacing8}`}
+                marginTop={`-${SPACING.spacing4}`}
                 marginBottom={SPACING.spacing8}
               >
                 {t('csv_required_for_analysis')}
@@ -841,7 +840,7 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
                 color={COLORS.yellow60}
                 overflowWrap="anywhere"
                 display={DISPLAY_BLOCK}
-                marginTop={`-${SPACING.spacing8}`}
+                marginTop={`-${SPACING.spacing4}`}
                 marginBottom={SPACING.spacing8}
               >
                 {analysisStatus === 'stale'

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -233,7 +233,7 @@ export function ChooseProtocolSlideoutComponent(
             const [response, varName] = responseTuple
             return {
               ...acc,
-              [varName]: { file_id: response.data.id },
+              [varName]: { fileId: response.data.id },
             }
           },
           runTimeParameterValues

--- a/app/src/organisms/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseProtocolSlideout/index.tsx
@@ -29,7 +29,10 @@ import {
   useTooltip,
   useHoverTooltip,
 } from '@opentrons/components'
-import { ApiHostProvider } from '@opentrons/react-api-client'
+import {
+  ApiHostProvider,
+  useUploadCsvFileMutation,
+} from '@opentrons/react-api-client'
 import { sortRuntimeParameters } from '@opentrons/shared-data'
 
 import { useLogger } from '../../logger'
@@ -147,6 +150,17 @@ export function ChooseProtocolSlideoutComponent(
     robot.ip
   )
 
+  const { uploadCsvFile } = useUploadCsvFileMutation(
+    {},
+    robot != null
+      ? {
+          hostname: robot.ip,
+          requestor:
+            robot?.ip === OPENTRONS_USB ? appShellRequestor : undefined,
+        }
+      : null
+  )
+
   const srcFileObjects =
     selectedProtocol != null
       ? selectedProtocol.srcFiles.map((srcFileBuffer, index) => {
@@ -189,15 +203,46 @@ export function ChooseProtocolSlideoutComponent(
           location,
           definitionUri,
         }))
-      : [],
-    getRunTimeParameterValuesForRun(runTimeParametersOverrides)
+      : []
   )
   const handleProceed: React.MouseEventHandler<HTMLButtonElement> = () => {
     if (selectedProtocol != null) {
       trackCreateProtocolRunEvent({ name: 'createProtocolRecordRequest' })
-      createRunFromProtocolSource({
-        files: srcFileObjects,
-        protocolKey: selectedProtocol.protocolKey,
+      const dataFilesForProtocolMap = runTimeParametersOverrides.reduce<
+        Record<string, File>
+      >(
+        (acc, parameter) =>
+          parameter.type === 'csv_file' && parameter.file?.file != null
+            ? { ...acc, [parameter.variableName]: parameter.file.file }
+            : acc,
+        {}
+      )
+      Promise.all(
+        Object.entries(dataFilesForProtocolMap).map(([key, file]) => {
+          const fileResponse = uploadCsvFile(file)
+          const varName = Promise.resolve(key)
+          return Promise.all([fileResponse, varName])
+        })
+      ).then(responseTuples => {
+        const runTimeParameterValues = getRunTimeParameterValuesForRun(
+          runTimeParametersOverrides
+        )
+
+        const runTimeParameterValuesWithFiles = responseTuples.reduce(
+          (acc, responseTuple) => {
+            const [response, varName] = responseTuple
+            return {
+              ...acc,
+              [varName]: { file_id: response.data.id },
+            }
+          },
+          runTimeParameterValues
+        )
+        createRunFromProtocolSource({
+          files: srcFileObjects,
+          protocolKey: selectedProtocol.protocolKey,
+          runTimeParameterValues: runTimeParameterValuesWithFiles,
+        })
       })
     } else {
       logger.warn('failed to create protocol, no protocol selected')

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -306,7 +306,7 @@ export function ChooseRobotSlideout(
                   color={COLORS.red60}
                   overflowWrap={OVERFLOW_WRAP_ANYWHERE}
                   display={DISPLAY_INLINE_BLOCK}
-                  marginTop={`-${SPACING.spacing8}`}
+                  marginTop={`-${SPACING.spacing4}`}
                   marginBottom={SPACING.spacing8}
                 >
                   {runCreationErrorCode === 409 ? (

--- a/app/src/organisms/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotSlideout/index.tsx
@@ -405,9 +405,7 @@ export function ChooseRobotSlideout(
               runtimeParam.type === 'float'
             ) {
               const value = runtimeParam.value as number
-              const id = `InputField_${
-                runtimeParam.variableName
-              }_${index.toString()}`
+              const id = `InputField_${runtimeParam.variableName}_${index}`
               const error =
                 (Number.isNaN(value) && !isInputFocused) ||
                 value < runtimeParam.min ||

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -164,7 +164,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
             const [response, varName] = responseTuple
             return {
               ...acc,
-              [varName]: { file_id: response.data.id },
+              [varName]: { fileId: response.data.id },
             }
           },
           runTimeParameterValues

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -168,7 +168,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       createRunFromProtocolSource({
         files: srcFileObjects,
         protocolKey,
-        runTimeParameterValues: runTimeParameterValuesWithFiles,
+        runTimeParameterValues, // : runTimeParameterValuesWithFiles,
       })
     })
   }

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -168,7 +168,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       createRunFromProtocolSource({
         files: srcFileObjects,
         protocolKey,
-        runTimeParameterValues, // : runTimeParameterValuesWithFiles,
+        runTimeParameterValues: runTimeParameterValuesWithFiles,
       })
     })
   }

--- a/app/src/organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -14,7 +14,6 @@ import type {
   HostConfig,
   LabwareOffsetCreateData,
   Protocol,
-  RunTimeParameterCreateData,
 } from '@opentrons/api-client'
 import type { UseCreateRunMutationOptions } from '@opentrons/react-api-client/src/runs/useCreateRunMutation'
 import type { CreateProtocolVariables } from '@opentrons/react-api-client/src/protocols/useCreateProtocolMutation'
@@ -36,8 +35,7 @@ export interface UseCreateRun {
 export function useCreateRunFromProtocol(
   options: UseCreateRunMutationOptions,
   hostOverride?: HostConfig | null,
-  labwareOffsets?: LabwareOffsetCreateData[],
-  runTimeParameterValues?: RunTimeParameterCreateData
+  labwareOffsets?: LabwareOffsetCreateData[]
 ): UseCreateRun {
   const contextHost = useHost()
   const host =
@@ -73,7 +71,7 @@ export function useCreateRunFromProtocol(
     reset: resetProtocolMutation,
   } = useCreateProtocolMutation(
     {
-      onSuccess: data => {
+      onSuccess: (data, { runTimeParameterValues }) => {
         createRun({
           protocolId: data.data.id,
           labwareOffsets,
@@ -81,8 +79,7 @@ export function useCreateRunFromProtocol(
         })
       },
     },
-    host,
-    runTimeParameterValues
+    host
   )
 
   let error =
@@ -101,7 +98,7 @@ export function useCreateRunFromProtocol(
 
   return {
     createRunFromProtocolSource: (
-      { files: srcFiles, protocolKey },
+      { files: srcFiles, protocolKey, runTimeParameterValues },
       ...args
     ) => {
       resetRunMutation()

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -433,9 +433,7 @@ export function ProtocolDetails(
               mostRecentAnalysis?.result === 'parameter-value-required' ? (
                 <ProtocolStatusBanner />
               ) : null}
-              {analysisStatus !== 'loading' &&
-              mostRecentAnalysis != null &&
-              analysisStatus === 'error' ? (
+              {mostRecentAnalysis != null && analysisStatus === 'error' ? (
                 <ProtocolAnalysisFailure
                   protocolKey={protocolKey}
                   errors={mostRecentAnalysis.errors.map(e => e.detail)}

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -352,6 +352,7 @@ export function ProtocolDetails(
     missing: <Box size="14rem" backgroundColor={COLORS.grey30} />,
     loading: <Box size="14rem" backgroundColor={COLORS.grey30} />,
     error: <Box size="14rem" backgroundColor={COLORS.grey30} />,
+    parameterRequired: <Box size="14rem" backgroundColor={COLORS.grey30} />,
     complete: (
       <Box size="14rem" height="auto">
         {deckMap}
@@ -434,7 +435,7 @@ export function ProtocolDetails(
               ) : null}
               {analysisStatus !== 'loading' &&
               mostRecentAnalysis != null &&
-              mostRecentAnalysis.errors.length > 0 ? (
+              analysisStatus === 'error' ? (
                 <ProtocolAnalysisFailure
                   protocolKey={protocolKey}
                   errors={mostRecentAnalysis.errors.map(e => e.detail)}

--- a/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/ProtocolsLanding/ProtocolCard.tsx
@@ -194,6 +194,13 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
                 borderRadius={SPACING.spacing8}
               />
             ),
+            parameterRequired: (
+              <Box
+                size="6rem"
+                backgroundColor={COLORS.grey30}
+                borderRadius={SPACING.spacing8}
+              />
+            ),
             stale: (
               <Box
                 size="6rem"
@@ -217,7 +224,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
       >
         {/* error and protocol name section */}
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
-          {mostRecentAnalysis?.result === 'parameter-value-required' ? (
+          {analysisStatus === 'parameterRequired' ? (
             <ProtocolStatusBanner />
           ) : null}
           {analysisStatus === 'error' ? (
@@ -279,6 +286,9 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
                       <LegacyStyledText as="p">{t('no_data')}</LegacyStyledText>
                     ),
                     error: (
+                      <LegacyStyledText as="p">{t('no_data')}</LegacyStyledText>
+                    ),
+                    parameterRequired: (
                       <LegacyStyledText as="p">{t('no_data')}</LegacyStyledText>
                     ),
                     stale: (

--- a/app/src/organisms/ProtocolsLanding/utils.ts
+++ b/app/src/organisms/ProtocolsLanding/utils.ts
@@ -16,22 +16,20 @@ export function getAnalysisStatus(
 ): AnalysisStatus {
   if (isAnalyzing) {
     return 'loading'
-  } else if (
-    analysis != null &&
-    (analysis.liquids == null || analysis.runTimeParameters == null)
-  ) {
-    return 'stale'
-  } else if (analysis != null) {
-    if (analysis.result === 'parameter-value-required') {
-      return 'parameterRequired'
-    } else if (analysis.errors.length > 0) {
-      return 'error'
-    } else {
-      return 'complete'
-    }
-  } else {
+  }
+  if (analysis == null || analysis === undefined) {
     return 'missing'
   }
+  if (analysis.liquids == null || analysis.runTimeParameters == null) {
+    return 'stale'
+  }
+  if (analysis.result === 'parameter-value-required') {
+    return 'parameterRequired'
+  }
+  if (analysis.errors.length > 0) {
+    return 'error'
+  }
+  return 'complete'
 }
 
 export function getProtocolDisplayName(

--- a/app/src/organisms/ProtocolsLanding/utils.ts
+++ b/app/src/organisms/ProtocolsLanding/utils.ts
@@ -2,7 +2,13 @@ import first from 'lodash/first'
 import { FLEX_STANDARD_MODEL } from '@opentrons/shared-data'
 import type { ProtocolAnalysisOutput, RobotType } from '@opentrons/shared-data'
 
-type AnalysisStatus = 'missing' | 'loading' | 'error' | 'complete' | 'stale'
+type AnalysisStatus =
+  | 'missing'
+  | 'loading'
+  | 'error'
+  | 'complete'
+  | 'stale'
+  | 'parameterRequired'
 
 export function getAnalysisStatus(
   isAnalyzing: boolean,
@@ -16,7 +22,13 @@ export function getAnalysisStatus(
   ) {
     return 'stale'
   } else if (analysis != null) {
-    return analysis.errors.length > 0 ? 'error' : 'complete'
+    if (analysis.result === 'parameter-value-required') {
+      return 'parameterRequired'
+    } else if (analysis.errors.length > 0) {
+      return 'error'
+    } else {
+      return 'complete'
+    }
   } else {
     return 'missing'
   }

--- a/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
+++ b/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { uploadCsvFile } from '@opentrons/api-client'
 import { useHost } from '../../api'
 import { useUploadCsvFileMutation } from '../useUploadCsvFileMutation'
@@ -69,7 +69,7 @@ describe('useUploadCsvFileMutation', () => {
     } as Response<UploadedCsvFileResponse>)
 
     const { result } = renderHook(() => useUploadCsvFileMutation(), { wrapper })
-    await act(async () => result.current.uploadCsvFile(mockFilePath))
+    await waitFor(() => result.current.uploadCsvFile(mockFilePath))
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockUploadResponse)

--- a/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
+++ b/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
@@ -56,20 +56,20 @@ describe('useUploadCsvFileMutation', () => {
       wrapper,
     })
     expect(result.current.data).toBeUndefined()
-    result.current.uploadCsvFile(mockFilePath)
+    result.current.uploadCsvFile(mockFilePath).catch(_ => {})
     await waitFor(() => {
-      expect(result.current.data).toBeUndefined()
+      expect(result.current.error).toBe('oh no')
     })
   })
 
-  it.skip('should return data when calling uploadCsvFile successfully', async () => {
+  it('should return data when calling uploadCsvFile successfully', async () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(uploadCsvFile).mockResolvedValue({
       data: mockUploadResponse,
     } as Response<UploadedCsvFileResponse>)
 
     const { result } = renderHook(() => useUploadCsvFileMutation(), { wrapper })
-    act(() => result.current.uploadCsvFile(mockFilePath))
+    await act(async () => result.current.uploadCsvFile(mockFilePath))
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockUploadResponse)

--- a/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
+++ b/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
@@ -17,6 +17,7 @@ vi.mock('../../api/useHost')
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
 const mockFilePath = 'media/mock-usb-drive/mock.csv'
+const mockFile = { name: 'my_file.csv' } as File
 const mockUploadResponse = {
   data: {
     id: '1',
@@ -58,11 +59,14 @@ describe('useUploadCsvFileMutation', () => {
     expect(result.current.data).toBeUndefined()
     result.current.uploadCsvFile(mockFilePath).catch(_ => {})
     await waitFor(() => {
+      expect(result.current.data).toBeUndefined()
+    })
+    await waitFor(() => {
       expect(result.current.error).toBe('oh no')
     })
   })
 
-  it('should return data when calling uploadCsvFile successfully', async () => {
+  it('should return data when calling uploadCsvFile with filePath successfully', async () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(uploadCsvFile).mockResolvedValue({
       data: mockUploadResponse,
@@ -70,6 +74,20 @@ describe('useUploadCsvFileMutation', () => {
 
     const { result } = renderHook(() => useUploadCsvFileMutation(), { wrapper })
     await waitFor(() => result.current.uploadCsvFile(mockFilePath))
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockUploadResponse)
+    })
+  })
+
+  it('should return data when calling uploadCsvFile with file successfully', async () => {
+    vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
+    vi.mocked(uploadCsvFile).mockResolvedValue({
+      data: mockUploadResponse,
+    } as Response<UploadedCsvFileResponse>)
+
+    const { result } = renderHook(() => useUploadCsvFileMutation(), { wrapper })
+    await waitFor(() => result.current.uploadCsvFile(mockFile))
 
     await waitFor(() => {
       expect(result.current.data).toEqual(mockUploadResponse)

--- a/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
+++ b/react-api-client/src/dataFiles/__tests__/useUploadCsvFileMutation.test.tsx
@@ -42,12 +42,9 @@ describe('useUploadCsvFileMutation', () => {
   it('should return no data if no host', () => {
     vi.mocked(useHost).mockReturnValue(null)
 
-    const { result } = renderHook(
-      () => useUploadCsvFileMutation(mockFilePath),
-      {
-        wrapper,
-      }
-    )
+    const { result } = renderHook(() => useUploadCsvFileMutation(), {
+      wrapper,
+    })
     expect(result.current.data).toBeUndefined()
   })
 
@@ -55,12 +52,9 @@ describe('useUploadCsvFileMutation', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(uploadCsvFile).mockRejectedValue('oh no')
 
-    const { result } = renderHook(
-      () => useUploadCsvFileMutation(mockFilePath),
-      {
-        wrapper,
-      }
-    )
+    const { result } = renderHook(() => useUploadCsvFileMutation(), {
+      wrapper,
+    })
     expect(result.current.data).toBeUndefined()
     result.current.uploadCsvFile(mockFilePath)
     await waitFor(() => {
@@ -68,16 +62,13 @@ describe('useUploadCsvFileMutation', () => {
     })
   })
 
-  it('should return data when calling uploadCsvFile successfully', async () => {
+  it.skip('should return data when calling uploadCsvFile successfully', async () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(uploadCsvFile).mockResolvedValue({
       data: mockUploadResponse,
     } as Response<UploadedCsvFileResponse>)
 
-    const { result } = renderHook(
-      () => useUploadCsvFileMutation(mockFilePath),
-      { wrapper }
-    )
+    const { result } = renderHook(() => useUploadCsvFileMutation(), { wrapper })
     act(() => result.current.uploadCsvFile(mockFilePath))
 
     await waitFor(() => {

--- a/react-api-client/src/dataFiles/useUploadCsvFileMutation.ts
+++ b/react-api-client/src/dataFiles/useUploadCsvFileMutation.ts
@@ -5,7 +5,7 @@ import type { AxiosError } from 'axios'
 import type {
   UseMutationResult,
   UseMutationOptions,
-  UseMutateFunction,
+  UseMutateAsyncFunction,
 } from 'react-query'
 import type {
   ErrorResponse,
@@ -19,7 +19,7 @@ export type UseUploadCsvFileMutationResult = UseMutationResult<
   AxiosError<ErrorResponse>,
   FileData
 > & {
-  uploadCsvFile: UseMutateFunction<
+  uploadCsvFile: UseMutateAsyncFunction<
     UploadedCsvFileResponse,
     AxiosError<ErrorResponse>,
     FileData
@@ -33,11 +33,12 @@ export type UseUploadCsvFileMutationOption = UseMutationOptions<
 >
 
 export function useUploadCsvFileMutation(
-  fileData: FileData,
   options: UseUploadCsvFileMutationOption = {},
   hostOverride?: HostConfig | null
 ): UseUploadCsvFileMutationResult {
-  const host = useHost()
+  const contextHost = useHost()
+  const host =
+    hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
 
   const mutation = useMutation<
@@ -61,6 +62,6 @@ export function useUploadCsvFileMutation(
   )
   return {
     ...mutation,
-    uploadCsvFile: mutation.mutate,
+    uploadCsvFile: mutation.mutateAsync,
   }
 }

--- a/react-api-client/src/index.ts
+++ b/react-api-client/src/index.ts
@@ -2,6 +2,7 @@
 export * from './api'
 export * from './calibration'
 export * from './deck_configuration'
+export * from './dataFiles'
 export * from './health'
 export * from './instruments'
 export * from './maintenance_runs'

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -39,8 +39,7 @@ export type UseCreateProtocolMutationOptions = UseMutationOptions<
 
 export function useCreateProtocolMutation(
   options: UseCreateProtocolMutationOptions = {},
-  hostOverride?: HostConfig | null,
-  runTimeParameterValues?: RunTimeParameterCreateData
+  hostOverride?: HostConfig | null
 ): UseCreateProtocolMutationResult {
   const contextHost = useHost()
   const host =
@@ -53,7 +52,7 @@ export function useCreateProtocolMutation(
     CreateProtocolVariables
   >(
     [host, 'protocols'],
-    ({ files: protocolFiles, protocolKey }) =>
+    ({ files: protocolFiles, protocolKey, runTimeParameterValues }) =>
       createProtocol(
         host as HostConfig,
         protocolFiles,


### PR DESCRIPTION
# Overview

The new RTP paradigm for utilizing CSV files as runtime parameters requires sending the ID of the file to be used as the value in the `runTimeParameterValues` object sent with `createProtocol` and `createRun`. Here, we send any selected RTP files to the new `/dataFiles` endpoint and await the response containing an ID for each file. We then associate the returned ID with its respective runtime parameter variable name, and send that key:value pair along with the other value runtime parameters.

# Test Plan

This is a little tricky to test right now because the `/dataFiles` endpoint is not yet wired up, and the `/protocols` and `/runs` endpoint only accepts `<variableName>: <value>` pairs for `runTimeParameterValues`, not the new format of `<variableName>: {file_id: <id>}` for CSV parameters.

#### Protocol card and detail
- upload protocol that requires CSV file parameter like this:
[rtp_tests.py.zip](https://github.com/user-attachments/files/16018648/rtp_tests.py.zip)

- verify that `CSV file required` banner renders on protocol card
- select protocol card
- verify that `CSV file required` banner renders on protocol details

# Changelog

- post CSV files from RTPs when confirming values on both `ChooseProtocolSlideout` and `ChooseRobotToRunProtocolSlideout`, and use returned IDs in `runTimeParametersValues` sent with `createRunFromProtocolSource`
- fix MiniCard warning text margins on above slideouts
- update `getAnalysisStatus` util to return new `parameterRequired` status when analysis result is `parameter-value-required` 
- refactor `useCreateProtocolMutation` to accept `runTimeParameterValues` argument in its returned mutation's callback rather than in the hook's invocation itself
- update tests

# Review requests

Go through flow of uploading a CSV parameter protocol according to test plan above. Expected behavior is for a `runCreationError` to be raised when confirming value because the robot server does not yet know what to do with CSV parameter runTimeParameterValues overrides.

# Risk assessment

medium