### PR TITLE
fix(app): fix choose csv file button label

### DIFF
--- a/app/src/organisms/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
@@ -154,6 +154,8 @@ describe('ProtocolSetupParameters', () => {
     })
     screen.getByText('CSV File')
     screen.getByText('Required')
+    const button = screen.getByRole('button', { name: 'Confirm values' })
+    expect(button).toBeDisabled()
   })
 
   it.todo(

--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -186,7 +186,11 @@ export function ProtocolSetupParameters({
                   status={
                     parameter.type === 'csv_file' ? 'not ready' : 'inform'
                   }
-                  title={parameter.displayName}
+                  title={
+                    parameter.type === 'csv_file'
+                      ? t('csv_file')
+                      : parameter.displayName
+                  }
                   onClickSetupStep={() => {
                     handleSetParameter(parameter)
                   }}

--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -24,8 +24,10 @@ import { ChildNavigation } from '../ChildNavigation'
 import { ResetValuesModal } from './ResetValuesModal'
 import { ChooseEnum } from './ChooseEnum'
 import { ChooseNumber } from './ChooseNumber'
+import { useFeatureFlag } from '../../redux/config'
 
 import type {
+  CompletedProtocolAnalysis,
   ChoiceParameter,
   NumberParameter,
   RunTimeParameter,
@@ -37,14 +39,17 @@ interface ProtocolSetupParametersProps {
   protocolId: string
   runTimeParameters: RunTimeParameter[]
   labwareOffsets?: LabwareOffsetCreateData[]
+  mostRecentAnalysis?: CompletedProtocolAnalysis | null
 }
 
 export function ProtocolSetupParameters({
   protocolId,
   labwareOffsets,
   runTimeParameters,
+  mostRecentAnalysis,
 }: ProtocolSetupParametersProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
+  const enableCsvFile = useFeatureFlag('enableCsvFile')
   const history = useHistory()
   const host = useHost()
   const queryClient = useQueryClient()
@@ -184,7 +189,9 @@ export function ProtocolSetupParameters({
                   hasRightIcon={!(parameter.type === 'bool')}
                   hasLeftIcon={false}
                   status={
-                    parameter.type === 'csv_file' ? 'not ready' : 'inform'
+                    enableCsvFile && parameter.type === 'csv_file'
+                      ? 'not ready'
+                      : 'inform'
                   }
                   title={
                     parameter.type === 'csv_file'
@@ -195,7 +202,9 @@ export function ProtocolSetupParameters({
                     handleSetParameter(parameter)
                   }}
                   detail={
-                    parameter.type === 'csv_file'
+                    enableCsvFile && // ToDo this line will be removed
+                    parameter.type === 'csv_file' &&
+                    mostRecentAnalysis?.result === 'parameter-value-required'
                       ? t('required')
                       : formatRunTimeParameterValue(parameter, t)
                   }

--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -153,14 +153,6 @@ export function ProtocolSetupParameters({
     }
   }
 
-  console.log('isLoading', isLoading)
-  console.log('startSetup', startSetup)
-  console.log('enableCsvFile', enableCsvFile)
-  console.log(
-    'result',
-    mostRecentAnalysis?.result === 'parameter-value-required'
-  )
-
   let children = (
     <>
       <ChildNavigation

--- a/app/src/organisms/ProtocolSetupParameters/index.tsx
+++ b/app/src/organisms/ProtocolSetupParameters/index.tsx
@@ -153,6 +153,14 @@ export function ProtocolSetupParameters({
     }
   }
 
+  console.log('isLoading', isLoading)
+  console.log('startSetup', startSetup)
+  console.log('enableCsvFile', enableCsvFile)
+  console.log(
+    'result',
+    mostRecentAnalysis?.result === 'parameter-value-required'
+  )
+
   let children = (
     <>
       <ChildNavigation
@@ -162,6 +170,10 @@ export function ProtocolSetupParameters({
         }}
         onClickButton={handleConfirmValues}
         buttonText={t('confirm_values')}
+        buttonIsDisabled={
+          enableCsvFile &&
+          mostRecentAnalysis?.result === 'parameter-value-required'
+        }
         iconName={isLoading || startSetup ? 'ot-spinner' : undefined}
         iconPlacement="startIcon"
         secondaryButtonProps={{
@@ -183,16 +195,33 @@ export function ProtocolSetupParameters({
       >
         {sortRuntimeParameters(runTimeParametersOverrides).map(
           (parameter, index) => {
+            const detailLabelForCsv =
+              mostRecentAnalysis?.result === 'parameter-value-required'
+                ? t('required')
+                : parameter.displayName
+
+            let setupStatus: 'ready' | 'not ready' | 'general' | 'inform' =
+              'inform'
+            if (
+              enableCsvFile &&
+              parameter.type === 'csv_file' &&
+              mostRecentAnalysis?.result === 'parameter-value-required'
+            ) {
+              setupStatus = 'not ready'
+            }
+            if (
+              enableCsvFile &&
+              parameter.type === 'csv_file' &&
+              mostRecentAnalysis?.result === 'ok'
+            ) {
+              setupStatus = 'ready'
+            }
             return (
               <React.Fragment key={`${parameter.displayName}_${index}`}>
                 <ProtocolSetupStep
                   hasRightIcon={!(parameter.type === 'bool')}
                   hasLeftIcon={false}
-                  status={
-                    enableCsvFile && parameter.type === 'csv_file'
-                      ? 'not ready'
-                      : 'inform'
-                  }
+                  status={setupStatus}
                   title={
                     parameter.type === 'csv_file'
                       ? t('csv_file')
@@ -202,10 +231,8 @@ export function ProtocolSetupParameters({
                     handleSetParameter(parameter)
                   }}
                   detail={
-                    enableCsvFile && // ToDo this line will be removed
-                    parameter.type === 'csv_file' &&
-                    mostRecentAnalysis?.result === 'parameter-value-required'
-                      ? t('required')
+                    enableCsvFile && parameter.type === 'csv_file'
+                      ? detailLabelForCsv
                       : formatRunTimeParameterValue(parameter, t)
                   }
                   description={

--- a/app/src/pages/ProtocolDetails/index.tsx
+++ b/app/src/pages/ProtocolDetails/index.tsx
@@ -459,6 +459,7 @@ export function ProtocolDetails(): JSX.Element | null {
       protocolId={protocolId}
       labwareOffsets={labwareOffsets}
       runTimeParameters={runTimeParameters}
+      mostRecentAnalysis={mostRecentAnalysis}
     />
   ) : (
     <>


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update the label for choose csv button, confirm values disabled condition and add `useFeatureFlag`
For `ChooseCSV` button, we need check two things. One is type and the other is analysis's reuslt.
if type is csv_file and result is ok => green background('ready') and display `file name`
if type is csv_file and result is parameter-value-required => background ('not ready') and display `required`

close AUTH-539


### before
![Screenshot 2024-06-26 at 2 11 02 PM](https://github.com/Opentrons/opentrons/assets/474225/e3cc4db1-f8f1-403f-8227-5eb680eb0838)


### after
![Screenshot 2024-06-26 at 4 44 01 PM](https://github.com/Opentrons/opentrons/assets/474225/baca1691-a68d-4f87-a08a-7ef2bb649f72)


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
set up a protocol run with the following protocol
[rtp_phase2_test.py.zip](https://github.com/user-attachments/files/15993624/rtp_phase2_test.py.zip)

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
