### PR TITLE
feat(app-shell): add temp user license agreement to app installer

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -97,6 +97,7 @@ clean:
 .PHONY: lib
 lib: export NODE_ENV := production
 lib:
+	echo "Building app shell JS bundle (electron layer)"
 	vite build
 
 .PHONY: deps

--- a/app-shell/build/license_en.txt
+++ b/app-shell/build/license_en.txt
@@ -1,0 +1,1 @@
+we're open source yo

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -82,6 +82,8 @@ module.exports = async () => ({
     executableName: 'opentrons',
     category: 'Science',
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
+  },
+  appImage: {
     license: 'build/license_en.txt',
   },
   publish: publishConfig,

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -75,12 +75,14 @@ module.exports = async () => ({
   },
   nsis: {
     oneClick: false,
+    license: 'build/license_en.txt',
   },
   linux: {
     target: ['AppImage'],
     executableName: 'opentrons',
     category: 'Science',
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
+    license: 'build/license_en.txt',
   },
   publish: publishConfig,
   generateUpdatesFilesForAllChannels: true,

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -202,8 +202,8 @@ describe('config migration', () => {
     expect(result).toEqual(MOCK_CONFIG_V22)
   })
   it('should keep version 22', () => {
-    const v21Config = MOCK_CONFIG_V22
-    const result = migrate(v21Config)
+    const v22Config = MOCK_CONFIG_V22
+    const result = migrate(v22Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
     expect(result).toEqual(MOCK_CONFIG_V22)

--- a/app/Makefile
+++ b/app/Makefile
@@ -46,6 +46,7 @@ clean:
 .PHONY: dist
 dist: export NODE_ENV := production
 dist:
+	echo "Building app JS bundle (browser layer)"
 	vite build
 
 # development


### PR DESCRIPTION
# Overview
This PR adds a temporary user license agreement confirmation to each of the desktop app installers (mac, linux, windows)

closes AUTH-534

# Test Plan

- tested on mac, had @ryanthecoder open the apps on windows and linux (thanks, ryan!)



# Changelog

- Add fake EULA agreement confirmation to app


# Review requests

- Download a build on whatever OS you run and make sure you see the fake license agreement before the app opens. Build available here: https://opentrons.slack.com/archives/C81CR4VCZ/p1719856516599449

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
