### PR TITLE
fix(app): link to `api` release notes from robot settings, not `app-shell`

### DIFF
--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/RobotServerVersion.tsx
@@ -27,7 +27,7 @@ interface RobotServerVersionProps {
 }
 
 const GITHUB_LINK =
-  'https://github.com/Opentrons/opentrons/blob/edge/app-shell/build/release-notes.md'
+  'https://github.com/Opentrons/opentrons/blob/edge/api/release-notes.md'
 
 export function RobotServerVersion({
   robotName,

--- a/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
+++ b/app/src/organisms/Devices/RobotSettings/AdvancedTab/__tests__/RobotServerVersion.test.tsx
@@ -86,7 +86,7 @@ describe('RobotSettings RobotServerVersion', () => {
   it('the link should have the correct href', () => {
     render()
     const GITHUB_LINK =
-      'https://github.com/Opentrons/opentrons/blob/edge/app-shell/build/release-notes.md'
+      'https://github.com/Opentrons/opentrons/blob/edge/api/release-notes.md'
     const githubLink = screen.getByText('GitHub')
     expect(githubLink.getAttribute('href')).toBe(GITHUB_LINK)
   })


### PR DESCRIPTION
# Overview

Updates the link target in robot settings. Previously there was no way to get to the API release notes from within the app — you'd have to go directly to GitHub.

# Test Plan

- `make test-js`
- run dev app and dev robot, go to robot settings, click link

# Changelog

update URL constant in component and test.

# Risk assessment

v low