### PR TITLE
fix(protocol-designer): append definitionid to end of liquid location…

### DIFF
--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -6,7 +6,7 @@
     "author": "Author name",
     "description": "Description here",
     "created": 1560957631666,
-    "lastModified": 1719517327666,
+    "lastModified": 1719517734390,
     "category": null,
     "subcategory": null,
     "tags": []
@@ -15,7 +15,7 @@
     "name": "opentrons/protocol-designer",
     "version": "8.1.1",
     "data": {
-      "_internalAppBuildDate": "Thu, 27 Jun 2024 19:41:42 GMT",
+      "_internalAppBuildDate": "Thu, 27 Jun 2024 19:48:37 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -46,11 +46,7 @@
         }
       },
       "ingredLocations": {
-<<<<<<< HEAD
-        "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well": {
-=======
         "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1": {
->>>>>>> 7ea5215b3b (update migration)
           "A1": { "0": { "volume": 121 } },
           "B1": { "0": { "volume": 121 } },
           "C1": { "0": { "volume": 121 } },
@@ -118,7 +114,7 @@
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "1",
           "blowout_checkbox": true,
-          "blowout_location": "b3a2f7d4-1ce4-44af-81a9-499528cd2121:trashBin",
+          "blowout_location": "2033bcb6-bbf4-4f46-bd86-1f70cfd3f5fb:trashBin",
           "preWetTip": false,
           "aspirate_airGap_checkbox": false,
           "aspirate_airGap_volume": null,
@@ -130,7 +126,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_delay_mmFromBottom": "0.5",
-          "dropTip_location": "b3a2f7d4-1ce4-44af-81a9-499528cd2121:trashBin",
+          "dropTip_location": "2033bcb6-bbf4-4f46-bd86-1f70cfd3f5fb:trashBin",
           "nozzles": null,
           "dispense_x_position": 0,
           "dispense_y_position": 0,
@@ -163,7 +159,7 @@
           "dispense_delay_seconds": "1",
           "mix_touchTip_checkbox": true,
           "mix_touchTip_mmFromBottom": 30.5,
-          "dropTip_location": "b3a2f7d4-1ce4-44af-81a9-499528cd2121:trashBin",
+          "dropTip_location": "2033bcb6-bbf4-4f46-bd86-1f70cfd3f5fb:trashBin",
           "nozzles": null,
           "tipRack": "opentrons/opentrons_96_tiprack_10ul/1",
           "mix_x_position": 0,
@@ -3350,7 +3346,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "ff2ed9ad-0b92-4026-a35d-6d6770d2492c",
+      "key": "f9c15c4d-9358-4974-9332-4dde77dc5a6c",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p10_single",
@@ -3359,7 +3355,7 @@
       }
     },
     {
-      "key": "24c297e7-71d1-46e5-8434-d249611ca957",
+      "key": "b829a567-f2ec-496c-a73c-21f33bd7e218",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single",
@@ -3368,7 +3364,7 @@
       }
     },
     {
-      "key": "760066c5-cb5d-4068-8a8e-76b459175b8b",
+      "key": "c7ff5ad9-8089-4a6d-aaa6-236b11db7788",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 10ul (1)",
@@ -3380,7 +3376,7 @@
       }
     },
     {
-      "key": "5cc772e3-0ca9-493b-80fb-ade2926fbae4",
+      "key": "08e7b67c-8a25-4066-8d82-f83e6f386da1",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 200ul (1)",
@@ -3392,7 +3388,7 @@
       }
     },
     {
-      "key": "d77e78ef-834f-4180-9570-9c406e728e91",
+      "key": "4021654d-3d26-4ead-8c81-c286b47a7c14",
       "commandType": "loadLabware",
       "params": {
         "displayName": "96 deep well (1)",
@@ -3405,7 +3401,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "6875164d-0525-4561-b0ff-85b7ad185190",
+      "key": "4dc06592-c8c4-490a-be09-f4e1bc2be895",
       "params": {
         "liquidId": "1",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3414,7 +3410,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "4213b84c-b1e0-4ef6-b1b0-376454a497dc",
+      "key": "f7912995-c74a-4515-8a8a-3578ff360118",
       "params": {
         "liquidId": "0",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3429,7 +3425,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "ae4aa970-b7a1-4440-b5eb-1187c0b399e3",
+      "key": "be645bf8-f5a3-406a-a04e-567a57c0ad91",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3438,7 +3434,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "68f08911-7976-4c2f-9dde-3c6fd62d4a40",
+      "key": "9739545e-598a-4e1a-9b48-7df43e07a398",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3453,7 +3449,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0d0f5567-6b4f-4398-b7ab-b6a8c1075d76",
+      "key": "dcfda9b7-9446-496f-a527-f7e996d97480",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3468,7 +3464,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "32ef408a-1701-41b7-920e-ffb2667422ba",
+      "key": "07504535-63a8-4f41-82f7-1c0c0421aa81",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3483,7 +3479,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "54f7f6f5-6512-4198-bfb3-6673ab4279cd",
+      "key": "fd8e8d9b-6db6-444f-9e60-71f9fddd0072",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3498,7 +3494,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9a8dbb61-bdc1-4ac8-b21f-48d0ff4eca22",
+      "key": "73eb2edf-9bae-46a7-8234-c7ad8fb2e614",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3513,7 +3509,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "36a268ab-1aec-40b5-88bd-9426bae523f6",
+      "key": "80d1c030-12da-4052-a359-72f0afeeeaba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3528,7 +3524,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "6d246cf4-b0fd-4112-a2b3-6ff573c60e12",
+      "key": "6bd50521-2373-4d8a-b0e5-75fa267981de",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3543,7 +3539,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "49d72970-e8d3-4da6-a41b-4d26e78185d9",
+      "key": "3ca1d9bf-fd8d-4543-a6cc-106a06be7443",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3553,7 +3549,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6b34ac93-0fb3-41d7-82a2-0982d36c1874",
+      "key": "ce71b365-f74d-4104-8d1a-66ac463c58e4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3568,7 +3564,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "2c7029ae-b651-4e84-8bec-000d69f9c7d4",
+      "key": "24c88c28-363a-4d44-936e-54d01a53fb50",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3583,7 +3579,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "bd6dbf8d-41a5-4e9a-b493-cd07e29a9623",
+      "key": "086ecabb-687d-4b87-b11c-395639918178",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3598,7 +3594,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "85662fb7-e526-4042-94b2-7f8cf965ac87",
+      "key": "38e11f50-8ce9-4377-b2f4-1c54969f9120",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3613,7 +3609,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0f734c11-5069-4d4c-8310-377b65a9c9ef",
+      "key": "00b0eb11-b65a-4829-913e-224720373a36",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3628,7 +3624,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "26fbf52a-36dd-4da6-baf4-53dfaa33b7f1",
+      "key": "049f0d9f-90c7-49a7-899e-f7de9ea7c55e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3637,7 +3633,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "ebb9f1b0-154a-49ee-bf0c-35e16ac49ac6",
+      "key": "fb57f8f5-1d80-4278-a49d-15c8003ba9b8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3645,7 +3641,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "0cead70f-9586-4527-b006-97d02409b795",
+      "key": "5962f4ec-e33d-4b3e-862d-097941da7660",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3655,7 +3651,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "2c6b2309-acda-4207-a921-4da3d5eb6aab",
+      "key": "41ab913e-704a-49ba-a78f-2ebfbd15e041",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3665,12 +3661,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "f32165fb-84ad-4f95-baa6-7fa6798e7d7a",
+      "key": "8d63c073-442d-4910-a9a9-349dca3685e2",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "a9a4a3f9-6324-4277-be01-b94c3d92ea46",
+      "key": "eec9420c-8924-4de6-842d-3dfa943188e7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3679,7 +3675,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b7c58798-3235-4491-a2b4-cca61d4b08a9",
+      "key": "7db6057d-d257-4e74-8241-118b0a54cac0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3694,7 +3690,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4bac02bb-146b-493e-b526-347a00a22260",
+      "key": "73d34a9f-26ad-4cde-ba83-a55b84975d1a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3709,7 +3705,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "661e7c97-481c-45ff-8af0-29b548ffb130",
+      "key": "047208be-c0bf-4081-90b2-ee4d2989372d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3724,7 +3720,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "56f5748e-037a-4825-a83f-2eed20c08e26",
+      "key": "a2a16808-f69d-452e-b952-c1a6054027cf",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3739,7 +3735,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "915bc54a-619f-4424-8276-5852481b8bb9",
+      "key": "7ad8dd32-56a7-4428-ae75-fe77fb72a728",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3754,7 +3750,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "580214c5-5695-470c-9775-eef55a78b672",
+      "key": "7786cb13-45b9-48db-ab12-db300f184bca",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3769,7 +3765,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8adfcd4d-7560-4f8e-b91d-4dc1460f26de",
+      "key": "916bb7d2-94cb-4805-ace8-6f2c75c5b7fd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3784,7 +3780,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "cb27cb03-b7fc-4bc8-8595-f2fd3821c1df",
+      "key": "773ecff3-dff3-4748-aa5e-b45ca83c8ff0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3794,7 +3790,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f48d4bdd-27e7-4b93-8adb-36c718bfd5e2",
+      "key": "43c1d84b-22bc-4bd4-bcef-98060feadf5d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3809,7 +3805,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "335a4684-328e-464a-9ca8-713b45951caa",
+      "key": "cc778be6-0bd5-48ab-8558-3c66a57ae7da",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3824,7 +3820,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "35daf263-f2eb-4edc-828e-3e6b06a7931d",
+      "key": "ec119b76-9048-4eab-8716-ebaa8bd8c04f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3839,7 +3835,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "6f3c7e87-e0d3-41c8-a681-cd86cd08618b",
+      "key": "24cdc24e-b375-45e2-9d0d-ca41cce42d85",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3854,7 +3850,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a9552e8b-c3cd-44a0-ab47-d9b025d51122",
+      "key": "78c8e5b9-0fae-461a-94a5-0cf3fa6e78e3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3869,7 +3865,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "42652626-e9b8-4b94-8843-26956bbf38f8",
+      "key": "d76adfc0-a123-4d28-905b-3efce851987d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3878,7 +3874,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "cdded12c-93af-4124-b5be-c1f0c724d08e",
+      "key": "1d563ffd-27ed-4590-aa16-23f7595621ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -3886,7 +3882,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "b152f069-2729-4b41-bc62-38c671d85288",
+      "key": "ff8e4623-2a48-4964-b0d4-9cdaee696540",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3896,7 +3892,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "325c0a62-bf85-4361-ac54-7430538ba83c",
+      "key": "0a651de5-4bbb-4dea-a9d7-882aa84a17d5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -3906,12 +3902,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "f01ebf9b-1581-4db9-bd45-e9d08bb860b2",
+      "key": "15d9594d-8cf5-46c7-b0f2-6349f540d5b2",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "92267aca-3cdb-4f0b-8425-fcdb6a8966a2",
+      "key": "a0962e3b-ca47-4b7e-9e83-2b28d7bc2f4c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3920,7 +3916,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f4daf3bb-248d-462d-9a8e-35317229c0c8",
+      "key": "5ee732b3-7af4-4ee2-b25a-4a1035407cd0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3935,7 +3931,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "83a515b5-4656-42c7-be01-418600e15c10",
+      "key": "99f50456-a81c-4cec-95dc-3e3a8ee70aef",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3950,7 +3946,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8a3dd70c-130c-4a29-b372-5d2835ca074b",
+      "key": "6dc73236-0371-456c-9dbe-79eda04ca8f3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3965,7 +3961,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8c4040b4-5bf6-4fee-b32f-4af80dd6f0b0",
+      "key": "de540100-3b69-4510-ae75-7c014e90a911",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3980,7 +3976,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "89315eb6-53d2-4e2c-bb62-db2d5e81c3e4",
+      "key": "0fe03ae5-2918-4057-ba49-4419a22be826",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3995,7 +3991,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "fe0b9024-c1cc-44b1-a69e-fb093583823e",
+      "key": "3261215a-aca6-43b9-b7bb-2233881c93d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4010,7 +4006,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1b3249e8-db43-429c-94ce-aa62187c75dc",
+      "key": "b33530e6-aaaa-4078-a7c9-3f659d697d77",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4025,7 +4021,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "7c38cd21-16bc-4380-8b96-a47c9c8fd865",
+      "key": "f19b632d-969f-4bb3-b4ff-d214e5626c7e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4035,7 +4031,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "3d1e4994-3152-4f42-987b-cc1d33d8d3bd",
+      "key": "df75bea9-52ea-4c67-8faf-293164c4a029",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4050,7 +4046,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "06fb34b5-5752-4825-a95b-51458dde1c95",
+      "key": "39564069-dd16-4e13-8641-a176cf24e49a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4065,7 +4061,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "9d5e32c3-4128-4d40-b7bb-00be4ee033cb",
+      "key": "14c0562f-d262-4d49-bd27-aa8676d56947",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4080,7 +4076,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f0e82b14-2d6d-4523-ad25-aeaa7d067d38",
+      "key": "b9669495-3b59-4dcb-ae0b-cf920d5d8a6f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4095,7 +4091,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "da15debb-d7e8-4970-961a-07c0250d165c",
+      "key": "9b8bef53-a2bf-46d2-bfa8-817c22517ab1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4110,7 +4106,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "8124634c-d4eb-445a-a1e7-f502a2e0cfaa",
+      "key": "6b9f40e7-be7b-495d-b3a8-2ff7aaa721f5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4119,7 +4115,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "b3eecc43-e38f-4239-9302-e26876fd6317",
+      "key": "9a620972-8dca-47ad-bfc9-b10a2945e79f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4127,7 +4123,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "83510de2-2360-4622-b844-b59b148c62bd",
+      "key": "05656fb2-4fb4-4e18-94a6-83182f2d791c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4137,7 +4133,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "f928fd80-0e33-4c3b-ab16-7ae0c679da98",
+      "key": "159c80d7-1b87-4b77-a46b-f12156ac56f3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4147,12 +4143,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "24e85219-6194-4d5e-b07f-5fc73ce20af0",
+      "key": "b1e0dcc6-21d0-4c4c-8780-03dc1bf2a1ae",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "296c90a4-37ac-48d8-b650-9f7380cb4f98",
+      "key": "49a11faf-69c1-4637-a0e8-23a01cfb8384",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4161,7 +4157,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e3f510c6-25cd-4c75-b62d-42e34488d0c2",
+      "key": "e98b2a25-db8f-4eb9-91b1-5eb407e8e913",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4176,7 +4172,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "fbe1fdbd-9daf-4e46-b967-c336dd28e428",
+      "key": "f97d9659-b78c-4ee3-888d-2bfc85bd716e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4191,7 +4187,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a390e437-c143-4d01-9cdc-2791a1d7899c",
+      "key": "35994440-9eb0-4062-92d8-86f27f656d5f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4206,7 +4202,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "53ac166f-dabe-4837-a4e9-6dbd4d0840ba",
+      "key": "239f0bd2-4cff-480e-9b39-d10dcde0817a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4221,7 +4217,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "792ef436-63de-49d0-9e7e-4deb26bb1e34",
+      "key": "85564c76-cf38-4f57-8159-4dff86338404",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4236,7 +4232,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0d7f5ac2-ad6d-467d-ab48-af6fe3d648c3",
+      "key": "fb8a7aee-6873-4e0d-aca4-2cf08d2a7248",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4251,7 +4247,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1b868534-a0e1-41ea-8968-6ede87d3e652",
+      "key": "f2847e68-44c9-4c38-bb89-e1efefd981a6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4266,7 +4262,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "d37b309f-fbbb-45b9-a927-fd375a457c0c",
+      "key": "f75b53db-89a9-4477-92c0-23f4d94896e6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4276,7 +4272,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "306c1a4d-3968-4a7e-8a55-97b4140abf5e",
+      "key": "8313f0f7-c4a7-465f-a1fd-2cbe401416b1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4291,7 +4287,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1f500ac1-f752-4011-be0f-bb459b48baba",
+      "key": "f870f8e0-63e4-41ec-a06d-5f237dd5e988",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4306,7 +4302,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6a95b228-c1ce-4fe7-8d51-b458bce32691",
+      "key": "c6a0f324-387e-4885-9cfd-5d2a739d1d2a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4321,7 +4317,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9a2acde6-7226-4ecb-b2af-7e436252b5a3",
+      "key": "87c4940d-85fe-4bf4-816c-cb8594e6cbb3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4336,7 +4332,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "cfdd9fa2-ef26-43fa-a6dc-77c0080eae8f",
+      "key": "d10e281b-681e-4f52-a86c-908d4fcc4255",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4351,7 +4347,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "27af1b49-c875-44c1-8f38-26936f156a73",
+      "key": "9416c7b2-1c13-480c-99cf-753cf7343f0a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4360,7 +4356,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "4e2ebeec-e947-45d8-bfca-51e3229a46ce",
+      "key": "b7db3095-fc86-4090-8169-9e62e91c4360",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4368,7 +4364,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "1d2322d1-dc77-4a70-9281-74da343eeddb",
+      "key": "475b6224-88b4-43ec-b9eb-f2f913697855",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4378,7 +4374,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "cd0303a8-2e97-43e4-afb9-f9fbde71b076",
+      "key": "afc67b1f-5041-47c1-b702-d729261ef8c5",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4388,12 +4384,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "8cafac21-165c-4a42-b0a1-b843fc3ee535",
+      "key": "bbc059f3-dab2-4b77-9acf-629f361fced9",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "a2dddae1-bafe-4ca1-9a6a-08c661454e59",
+      "key": "e3c58273-460c-4b82-a5ce-0156753c70d6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4402,7 +4398,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "54186d69-4388-4f73-b575-6fde65d98b09",
+      "key": "b9dfd0ca-23b5-445a-9022-646a2ea1c0e2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4417,7 +4413,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "cae9d37e-f4a2-4b4e-a7d3-317ce4bb37d9",
+      "key": "722cd73c-ff6f-4688-a5bc-38c9a792d7f9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4432,7 +4428,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f9fb7499-a596-46eb-b73e-fbffb48c74a7",
+      "key": "f73d77f3-24d7-4e38-8d52-f186dd3ab317",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4447,7 +4443,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4ac882f9-60b7-49a9-8de9-88eb7fb6573e",
+      "key": "43f23054-4825-4e2e-9e23-dc5244ed7a7c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4462,7 +4458,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "3e4cd5eb-c934-4e6c-9066-36fb6abb4b47",
+      "key": "03b71bf8-2e63-4bc9-bd49-039dafe5c561",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4477,7 +4473,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0cf40718-fcbc-4321-8fc0-d50bdbf7435b",
+      "key": "1c9240ca-960e-4f6c-ae81-7bea4651a70e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4492,7 +4488,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "75a8e440-21e6-467b-8fec-f36eb80b6906",
+      "key": "4766b2ab-0742-4027-9b5e-90e7f81af552",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4507,7 +4503,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "355d5292-3a51-4ea6-aee2-2ec11e60f323",
+      "key": "c3bb4842-15d9-4047-8f8e-ab53e33e3dda",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4517,7 +4513,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "bc716cad-839b-4fb3-8dbd-2e53a37db51b",
+      "key": "b6a716c6-b7b8-4666-a500-4a4664d900de",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4532,7 +4528,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "f9b4273e-142a-4d67-b990-c18116ab3d39",
+      "key": "51b60d36-9201-4fed-9d87-9ad11a351809",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4547,7 +4543,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "6f81ba2d-7686-4c1a-9012-166de0fbac8d",
+      "key": "d5fc53ca-0a6b-4f6d-a9db-c8e69c982448",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4562,7 +4558,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d0515f57-fa3b-43eb-a577-5fe94d5c95fb",
+      "key": "e82affd6-02e3-4e39-9fdf-e4635bd01ccb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4577,7 +4573,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "49a958e5-b352-4a18-b5dd-b923bd0145da",
+      "key": "dd00eb8f-ff5f-49c6-9296-e68ec3c0fbe6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4592,7 +4588,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "40bd47e2-3bcd-4aa3-93f0-016216c30d0e",
+      "key": "506644cc-e507-4254-89aa-c1c97d8f4af6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4601,7 +4597,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "60658693-516f-421f-bede-3e0e18e7eb3b",
+      "key": "df24712c-3581-462e-bf79-931d3420cca4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4609,7 +4605,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "e7bc3896-a92f-4cf0-b48b-a568137bbdf0",
+      "key": "23ed0954-8e34-43de-a4d0-872acdeee528",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4619,7 +4615,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d703ba99-9183-4bd4-96bf-cf58d09c4f95",
+      "key": "6472505e-536d-4348-9397-a95b9742fa21",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4629,12 +4625,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "7f869579-75ad-4ad4-a2f2-d0ec5114ceea",
+      "key": "47de3513-27fc-4645-a980-b2b45119e98c",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "f9c03886-f7db-4ab2-813f-a7880f1874ee",
+      "key": "783660b4-6634-402f-a2f9-a01d5231c765",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4643,7 +4639,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e4c64a21-4c42-49ac-a74d-2cf4714c46c5",
+      "key": "8dd05a0f-aef6-4c17-8855-14445c93d3c4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4658,7 +4654,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "b85e9483-9e66-4ca1-ad41-752a5451c59c",
+      "key": "c8ada9e8-9d84-4fe6-afd5-f9a4ddefad67",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4673,7 +4669,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a59e0c7f-b2f9-4b6d-8fb1-6578c1b7f97b",
+      "key": "0e40f107-d594-4588-9295-fdf3ca1891a4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4688,7 +4684,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "25740cb0-4ee8-4e7d-a6d2-9fe6c22d5113",
+      "key": "e4a4e9b6-2f54-4022-8c09-0f2c1198b6a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4703,7 +4699,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "40c841a0-019a-418b-b61d-f02075a913fa",
+      "key": "0e8311f8-942c-49a0-97fb-6a7bd439057e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4718,7 +4714,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "3ae40c78-b0da-453b-b97f-7cac04202d92",
+      "key": "24fc957c-1f86-40df-b7ec-dd55a5940d9a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4733,7 +4729,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "fc69a736-0705-45bc-8edb-8b0987e07f61",
+      "key": "5b0987fa-8ea0-48dc-8ede-e9a5918f7677",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4748,7 +4744,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "58ed0f7a-0aae-439f-9e9d-c8d9c1d401d4",
+      "key": "e0e280b0-3666-44f7-8f45-a4a8588ccdcc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4758,7 +4754,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a5bae401-a728-451e-b026-ace6da5ce82e",
+      "key": "3e60ad0d-7828-4b9b-8638-298456770450",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4773,7 +4769,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "537c7de1-f8c7-40d8-a3e0-aa82404d0a1f",
+      "key": "1fae14c1-62ca-4e72-9bff-4c51c0cafb8f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4788,7 +4784,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "15f38e4a-205d-4427-b7db-407ffc8c9f9c",
+      "key": "7e8c934f-68b4-43b3-87a0-3831103ac3a0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4803,7 +4799,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "15761a52-dea8-4e97-b235-aacd16371fe9",
+      "key": "e2f2aef5-f5e2-4d11-8a74-2d4727a64d2b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4818,7 +4814,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "771329bb-bda2-4b8e-8196-ea429a27bc6f",
+      "key": "29b46765-e2ce-4af5-b3c6-a0051b2f779e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -4833,7 +4829,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "e1e9a42f-9961-4fae-95a3-11e7b6047931",
+      "key": "7861ba4f-9d4d-4289-bc3c-fede5e02443a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4842,7 +4838,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "d88d149d-a530-483d-ab44-be0664631d16",
+      "key": "4da4ea88-a559-48c0-9056-4fc48dd1e4b1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -4850,7 +4846,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "fb85c3c9-2aab-4500-ae69-c937f024ab76",
+      "key": "6a58982d-47fc-4c1e-8cf5-9ead11cd1b79",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4860,7 +4856,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "b61ba036-600f-452f-81d3-4ecea6d31cde",
+      "key": "f967c1fa-4c24-4936-a237-94e74d318ee2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -4870,12 +4866,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "c123789f-dded-4855-9776-e4416800daf7",
+      "key": "157e596d-cdb5-43a5-8092-2c4ec65c04f3",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "9987a819-e186-411a-8418-6fe5ecdd7f31",
+      "key": "ea6b2387-515b-4f5b-931d-17cc9a9144cc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -4884,7 +4880,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "894cd396-9398-41dc-8a7e-974ec4b4426d",
+      "key": "f0a32b44-8912-468f-96bb-31def2b7e7a1",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4899,7 +4895,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "54707bad-df03-4e91-84b7-21cc85563db9",
+      "key": "c22fcea4-27c6-49fe-ad78-6d597e1c0514",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4914,7 +4910,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "43ed7f68-446d-4ee4-a47a-78333639c264",
+      "key": "5d4659f5-ff84-47a4-b25e-e5b32d9e0ddc",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4929,7 +4925,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "c3514f4d-36a9-4807-a886-2e50fa5885db",
+      "key": "d9fce39e-4280-4b61-8947-4d3d606f39b0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4944,7 +4940,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a084925d-acff-4919-8fcd-f472dc43037b",
+      "key": "f4292691-65b5-4f5f-aae3-07df9bb15964",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4959,7 +4955,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4e4cfa5d-1a7f-4871-afba-139e29e2f37a",
+      "key": "11d889fd-4d18-4d01-88df-0612e601c85c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -4974,7 +4970,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8b271083-1396-4b91-af10-2e10ced03f01",
+      "key": "2525d978-2111-484c-8044-0b943ed68949",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -4989,7 +4985,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "af5f0c47-6fe6-47da-adca-c7681e9ec78e",
+      "key": "ac1c1847-0d18-4d5d-9918-ec71cf0af423",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -4999,7 +4995,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "313d6bb4-11ac-4fc2-a4a0-c390b3568547",
+      "key": "cf6c60f6-93b2-4b78-80ad-5f26a0d91441",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5014,7 +5010,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "fd6d7f9d-2482-402a-8a5d-8754dcf9a320",
+      "key": "0a208694-e7dc-4577-8f39-bbb916e8da8c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5029,7 +5025,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "59b1015c-e34a-43b3-97d4-cc2d867d0c9b",
+      "key": "3ff67fdf-e220-4fcc-a03b-d46b673cca49",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5044,7 +5040,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a3d1acc3-7cf8-4d93-90ec-b9f760ba10ca",
+      "key": "7b7c81fe-3269-4117-a063-3e96a7bac479",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5059,7 +5055,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "34e837da-fd19-488b-a0d1-2bec86887a3c",
+      "key": "7380c1d7-f7af-409e-a8a4-83b1a2b32265",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5074,7 +5070,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "65563f3e-a480-4d08-a010-72982df7e2bc",
+      "key": "497abb35-1b15-42c9-9010-1e337966460b",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5083,7 +5079,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "c8c2b730-35c3-4142-9e0c-f7410c1b976d",
+      "key": "edd1b17b-5b36-4b25-8c38-b70b06ba58a3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5091,7 +5087,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "ccba4dc4-b96b-412f-a5b0-1d7bbd37b5bc",
+      "key": "5e0bc14b-926e-4269-b295-71f13551aac7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5101,7 +5097,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "40c2cc9d-515d-4ae3-b934-3228ffe1ba47",
+      "key": "61f5c9ec-b5fb-4d11-a778-62232854242c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5111,12 +5107,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "0bc5ae55-64af-45f5-b754-41b2a8bc1be4",
+      "key": "cf07527a-c921-463e-9aa1-33d7c0cc79c6",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ef50fbaa-e49a-428f-9f68-5cf2f1f98db6",
+      "key": "3d75fb59-bd99-4e76-8a30-29e926a47d84",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5125,7 +5121,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "1cac337a-22d0-42ed-aa8b-6cc247a30778",
+      "key": "079e3852-427d-499c-b4e7-c9c80ff89c9c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5140,7 +5136,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e996f70f-6e06-45a4-b279-015d3c25a10f",
+      "key": "3da46c92-574f-41b5-9cba-6b4ab41317f6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5155,7 +5151,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "aaec7655-9dea-4110-803a-692498472521",
+      "key": "4696f7f6-b12b-4dc3-867e-c547d9d3f48d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5170,7 +5166,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "91526182-e07c-45c5-ab62-c073886ecc63",
+      "key": "fa2adacd-bcaa-4030-ab39-e1bb18f09ceb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5185,7 +5181,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "46715cd8-6077-45bb-984c-51af91b3957e",
+      "key": "cf888475-ad09-47d8-a747-0db2c9dd996d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5200,7 +5196,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "0226e399-c03c-4b0c-b986-9f1df0209add",
+      "key": "81af9e33-f9ab-4be3-8ed5-7cde8a5f9d04",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5215,7 +5211,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "cd393fc9-085f-422f-bfae-8b0edc80da23",
+      "key": "03423fda-a235-4814-89d8-bc92122744f2",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5230,7 +5226,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "9942ea4e-9184-4690-931a-44afef679d9f",
+      "key": "ab1c9c23-198b-4f41-850f-bc7b1eaa774e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5240,7 +5236,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "45f5072a-145c-4a3e-8e5c-eef1fbb26f25",
+      "key": "35bc3d2b-8721-45c6-bbd7-48f75860bc1c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5255,7 +5251,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c779b1d9-f37c-4efc-841a-4b6d46bec2ca",
+      "key": "e616575c-4a16-470d-8989-d63390a9ec16",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5270,7 +5266,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "f2a43512-287d-4293-968a-bcd6d257d80a",
+      "key": "667e4126-28b1-4089-b844-1cb7a94182ca",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5285,7 +5281,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "c5b2be11-639f-49bf-8d27-8c5b00cb1beb",
+      "key": "b81f5ad8-26f5-48f8-82dc-88012590d657",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5300,7 +5296,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8d8bbc97-fdb7-4879-9cf3-906861ad3680",
+      "key": "787d7303-5ac7-4b02-b0aa-d109e9d72f87",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5315,7 +5311,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "181934e7-9559-43c8-a234-b9b69f53ee54",
+      "key": "1b07169b-a409-4b73-8e38-e513d9fe9ade",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5324,7 +5320,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "8621c4b1-c574-4bf0-9ad9-dfde498ec4f9",
+      "key": "5cd4176f-1df9-4d60-84ae-a558b2b4771a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5332,7 +5328,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "7810ea77-112e-4ebf-8113-3b09df2ffce7",
+      "key": "a013a83a-8c58-452c-9bae-7e0fe17332c9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5342,7 +5338,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "ea1ae0ab-5b10-4ff9-9b73-825896835fdd",
+      "key": "c4a52a0a-a4b9-400f-a000-fcc7b18e4f78",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5352,12 +5348,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "ab102ce0-c0e8-457e-95a9-7a278f370bb3",
+      "key": "b588ec8a-7fbe-4eef-a220-b1871074494e",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "ffd53981-4b91-4c75-8e86-403578c8a366",
+      "key": "da609a74-129b-4286-8503-604b750fb51f",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5366,7 +5362,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "55b20d0d-7fa3-47b7-ac33-769a31667785",
+      "key": "5059facd-107d-4088-8ee3-60fbc4e439ac",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5381,7 +5377,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "4fde7d1a-6e00-49b9-b8b6-102652fb8068",
+      "key": "3813fa57-feb3-46de-94f0-a63c35c84679",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5396,7 +5392,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9e77c484-bf33-4a58-82c2-d1684b1da606",
+      "key": "1158f890-7d5b-4c65-80d9-1f404a2f4a83",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5411,7 +5407,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "cf8941bd-b164-4f86-89de-0a82685a618f",
+      "key": "7f54a97c-a9cc-4435-b2ee-f5cf24dfadfe",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5426,7 +5422,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "d17bf303-1712-4ea1-931c-c00db1088fbe",
+      "key": "f9ac272d-be4e-49e9-823c-f79d2c9f34aa",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5441,7 +5437,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "8a02a18a-ed6e-4e4f-a392-17894b9bae3f",
+      "key": "be4ab31e-33c1-4920-bed6-79b1ee8f3bf6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -5456,7 +5452,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "b1d9d0bd-2c1f-42c7-b6f3-a1f6f6314e51",
+      "key": "b2cdeaf8-4f13-4c9a-a0e2-df7e25bf20d7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5471,7 +5467,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "cc2eddcd-e96a-4d19-a3fc-d6b9e27f2402",
+      "key": "06142b5e-85ac-4386-accb-aebe3bce4639",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5481,7 +5477,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "97fc8bf9-7e12-4f80-ac62-da65666764a3",
+      "key": "6c87acb9-ad0a-48e9-9892-83971736233d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -5496,7 +5492,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "19bbf6b5-23da-411a-88cf-71c545989192",
+      "key": "b8b79126-048d-4fdf-8ccd-502607f8011d",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5511,7 +5507,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "c2286eb2-fc00-4f3a-88cd-c55745f1b5a0",
+      "key": "febdfbfb-57a9-4a14-b38e-b8373c1ad159",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5526,7 +5522,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "a2a3306e-149d-4b70-aadf-97aef4dfecb8",
+      "key": "037e0671-35d5-4b6e-9e27-5e60fd3491d8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5541,7 +5537,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a26b75dc-fbc2-45c7-87a3-33a7fe0b8dec",
+      "key": "6b27927f-230c-4394-9bd3-91d09ca4e0a8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5556,7 +5552,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "68d84f24-b345-4d82-92de-df51e81392e6",
+      "key": "c290a3ab-8bf6-4e3f-ba92-354052a10bc6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5565,7 +5561,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "fd2ead1b-7aa7-484e-949e-9316b44dbf0c",
+      "key": "9bd96509-8f95-4f62-a3a1-181a7cbe9f4e",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5573,7 +5569,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "d2000644-51ea-4259-b73e-50f4d69b5735",
+      "key": "77d12fa7-10e4-4792-aa8e-9ebba1e4c500",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5583,7 +5579,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9cdcbf02-6bb4-4e87-908f-b6b61de85343",
+      "key": "9b7d4653-2565-4fd9-b669-80e37b9db950",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5593,12 +5589,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "f13c7e33-55e9-4228-a613-f1e66b5b49af",
+      "key": "fb4b1d63-eae5-4f72-9ec5-ebf1bdb16b4b",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "pickUpTip",
-      "key": "005a3cf6-8756-4c57-a805-534caa9cd5ed",
+      "key": "5fc07fd1-e073-4ef3-ace8-02201c882f03",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -5607,7 +5603,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "5052b45c-ea8b-437f-80db-429f8d276359",
+      "key": "78f97e95-f2cc-4e67-bed2-ad297d8c2ef8",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -5622,7 +5618,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "e22cacfa-1d07-4d3c-93c0-a32f7500d81f",
+      "key": "28850cb6-c152-45f7-b481-a727ec859b49",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -5637,7 +5633,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e78794bb-a16a-441b-babb-8e31cb2a3685",
+      "key": "494dd60c-8375-4f62-b69e-44abc5d62919",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -5652,7 +5648,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "a4722827-a605-4b8d-8875-e2c368c0d807",
+      "key": "e61b818f-80f5-419b-b600-730c455b65b7",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -5667,7 +5663,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "218ce3cf-c6a5-441a-998d-d90c679a6737",
+      "key": "2c86b6b8-b305-4f3a-b9b0-ca9e54d56e2a",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -5682,7 +5678,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "2b873cb7-ae25-4ac3-b435-f603d318831c",
+      "key": "75cd8999-8ca6-4e8e-8da2-8ae9cc01dae0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 5.5,
@@ -5697,7 +5693,7 @@
     },
     {
       "commandType": "moveToAddressableArea",
-      "key": "4a2e696e-b591-458c-85ef-1e07cd83f289",
+      "key": "ade1584c-ba18-48b8-9ded-6d228ff2efcb",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5706,7 +5702,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "5da8dc6c-bfab-44db-93d7-7b49e5505244",
+      "key": "ae39e8f5-9508-4a5a-9211-740baceda73c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5714,7 +5710,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "29258e2f-aa85-4a52-8e9c-a9f7cd5a8659",
+      "key": "072f5a6f-795f-4981-8397-d5a0ff4c4cb0",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5724,7 +5720,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "85ef05c7-d22b-41aa-bebc-e18f9396387c",
+      "key": "bdcd6a64-7e99-4e2e-8415-2f637573c8c9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5734,2081 +5730,12 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "4f4073fb-fffa-4b47-84b3-e91f685e5075",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "7453824b-c7da-49ee-ba31-5c9f73374c55",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "B1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "1756ab98-c85f-4977-90ad-f8e5f49cb459",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "bf3bbabc-5ebf-4720-8180-12d5de8e297b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "76d1300e-81a4-4385-99ca-63330d9cea4c",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "655fd074-aad9-4499-a2ff-7e32b4acea02",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "e04d2711-909b-4fb7-9071-b43bb8f54e66",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "eb0d09ac-5407-4e3a-a0c2-3cb3f94937a5",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "458316d5-4120-4132-81d7-766c2e80fbae",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "5fc16d8b-bf1e-45a6-ad35-22e486648c4c",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "362dd336-7b16-4a91-b27b-879ed53741ce",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "4460aab4-1806-435b-a56e-af46704b361d",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "40929bc6-3a78-40fb-b8a2-04173e4162e6",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "29bfe1e3-e80e-45ae-b58f-3766ba65b6a0",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "a0b81e23-c311-4a93-91e7-17b2d16443de",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "bc95424e-2481-4641-bc61-3ee5e103549a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "bd798868-28dc-40c8-8a1a-ab8b63ed5fa5",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "81423581-9275-4d6f-8024-94a40cd9c544",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D8",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "d1071044-1946-43fb-8607-5783a51d108a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "08211033-39cc-4987-8de8-d0254e0b8017",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "47c0bb47-6b35-4329-8ab3-8ef74a27d2db",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "C1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "9c2d9dd8-c021-4afd-bc01-d2d54692e2ce",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "675289ae-0458-4848-a2eb-dfd566dc0827",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "7bf7b710-6651-4e9f-978c-7799ad374d7d",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "071161be-43f9-470c-8416-54b16db7dfbb",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "4e805d98-ac81-4e23-859e-4d3e519fb72c",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "b5bd2eff-9ea6-44d3-afe3-9b72803709fc",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "74fde4e8-78a2-4d99-9b06-66f0f1608461",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "3f36c6a7-1821-4b34-a19f-3994f1ae5d47",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "01a68cec-a821-4adf-a5ae-8fd16b95953b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "fb2b4b2c-064f-4be6-8df3-152f08618ab1",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "dd1ebf4b-a619-45fd-b0c3-fec676796c07",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "42e59ad7-c888-4430-b1b7-7d6017b35161",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "4ccf5137-cafe-4782-bf3b-a3d303742ad2",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C8",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "9ac2dd26-77be-4398-80f4-570520cbcbda",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "48f358e3-8c1c-4760-8d53-af69bcd2830a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "3b8f412c-cb94-48a1-a684-17c62845d934",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C8",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "06a297a3-0336-4518-a51b-dc7fbbd7636e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "73a16c1f-4ba2-4a6b-85dd-93ac98c067bd",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "db8c6d49-bc56-490f-bc8c-0177943f2b48",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "D1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "59c14642-ac5d-4b86-af19-ca5edb7f10e7",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "b334280f-d9ab-483c-b8f8-4596b5f38a07",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "9686c29c-e88e-4cb8-8599-27589b1dab14",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "66bf662a-aa21-4583-a82e-1369414708d6",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "55061ef4-f0b3-4a05-b9e2-dcf6a60d8bef",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "ea8022f9-f106-4dff-a06a-46beed5831f8",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "4eb28d3f-5be4-48ba-986e-0e1ef2e51c86",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "c8262acd-7dd0-436c-9868-ef24263a76d2",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "3475f885-4371-4332-88df-fe5d704f6eee",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "f4fdfdb9-1951-46a2-9871-1c6054c11c96",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "a46c25c6-1790-4e5f-8a0f-9cd0c29c6456",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "7ed069c4-eee1-4bad-9d6c-3739a2a7b3cb",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "fef59af7-68da-424a-a41b-ce6f5a3fe61a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "fd5a5c1d-cfc9-4b59-ad2f-ec635b8db470",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "bcb3ddb2-2e2a-4d84-b9ee-5dc64547c57b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "8e14adca-6b8d-404b-9653-953212e87f50",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E7",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "9305bf9c-4cad-4e31-b2c5-69e75badc76f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "37297941-eb69-4e6e-8092-26ec1d5f243e",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "fc2444ec-cb9d-4946-9aca-74b5a1c354e2",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "E1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "1d7ce575-a2b9-4a85-8ea6-2a4c3fecd904",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "d47b6b2a-daf5-4363-b2db-e118891461a5",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "5864438d-6ee0-4b46-a075-aab17a7a42fa",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "8ecbe69a-a849-4555-909b-ba2892be0ea0",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "b9f35364-823f-4c07-bce9-b4b8e6bec052",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "c1fac007-b43d-479b-a6ba-ec3e826dd8eb",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "a6faf831-b19e-482b-af1a-0e903365281a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "45e3c9b2-b2cd-41dc-9a1b-8d13664963ab",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "3bcd810f-603d-4e11-93e6-56368e173171",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "8d217688-e3a6-41e7-ba7c-6566b1aa4e6d",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "ce8fe4a1-8602-42bd-88dc-4c14e9451ad6",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "d2d33b3a-0295-426b-bdcd-9a0190a42b16",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "12a0b120-8337-4c19-b5bf-d6696317a743",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "4a8fa892-5c98-424c-a3a2-04722313db8b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "b8c8910a-fc9e-41e5-b1dd-919bb13a1d39",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "4b984649-28d8-46b9-a89f-78cf6e1c6be0",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D7",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "cc97d9d3-1721-49be-825c-d738cf157383",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "890ac01b-c76e-4a31-bf77-8c0b40bb41c3",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "f9cc205a-4cf2-4a48-8587-2a84a173864a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "F1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "2a881c65-4913-45a0-ad89-25aca6adcf46",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "5c02e2c7-38af-433a-8ada-9343c885a89f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "91ec9312-8551-42a9-aaad-7d615aedcd89",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "00c9be42-13bb-4357-b935-08453219d719",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "d1462510-bcb5-4365-a374-860fefa84b37",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "69c4c63f-3baf-4764-b9ec-fc0024163026",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "e11300b2-a24c-466e-8320-19b94316e809",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "713e31ff-358d-4049-b71a-0b1f2dbb0070",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "66b87eb7-1eff-44a6-b468-463bab704246",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "76435e75-8a55-4da5-bd90-31ba320454f6",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "526236d4-3da2-49d1-bc52-7eb373202458",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "1a14b614-4086-4239-9633-c7500d28f363",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "03943156-d762-4320-8f12-b617034e7a0e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C7",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "8e30dfa4-d91e-4df5-940a-724331bec261",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "18664b61-5329-4117-890d-21c1c7a55080",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "6a1257f2-5ee4-4e73-bd68-836dfaa3cb40",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C7",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "31728cef-de6f-45bd-be45-96d8fce7ca6e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "f0d9269a-28b1-45d6-8896-3297462bc3bb",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "924a8341-650e-4346-a4ef-0328b973e9d1",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "G1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "67b5a005-fefd-42a5-ad81-8aec82d84cf2",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "34cd73c5-646f-4e64-80f3-659114842e2b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "fc51f93c-f357-4120-b041-a405bb287776",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "a3ea424f-2e99-41b7-a1b9-f6dc170fb0e4",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "2c02fd22-7198-4e7f-a507-10d75e0afa6e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "04c25c25-ffad-4d3e-bea4-8a9455275f90",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "060393f4-6a88-4b0e-ae52-087cb1d055b2",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "53225768-1d9a-4d2a-b596-f7d69a11c4ad",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "a1ecc346-a713-4d48-95ae-64a7f4aa9c65",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "c0c041ea-c2de-462c-b03e-3f1f353dab72",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "dfa01432-0877-445e-a52f-50492d88fc33",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "a6f70d92-eac6-4882-9ee8-6eaf0dffbb1b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "3c08835f-df1b-445b-b196-12a0b07f51af",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "291ca3cc-6d5f-4d58-967d-2efb0959a904",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "13c343bf-11e4-4fd6-9a8c-16c521566460",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "43e97c33-4df1-4f96-97b2-68da358e6a8b",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "E6",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "a2dfabd7-05fb-469e-a144-6b25a893cae7",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "639f3bac-752b-4ad8-96c4-8bd9a53c9f73",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "07c0e5f0-7bcc-475a-b8ae-147db16befa5",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "H1"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "9429d649-d0cc-40b3-a38e-c24f5b30611f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "9c2ef389-beee-4e3f-b8cb-b24304cd3211",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "5e7849e6-5cca-4568-84ae-efca3ad8f937",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "310da5bc-21c7-41be-bf0b-52e50eb32ab4",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "4c096a48-a57d-4f22-9f48-07ae27983a68",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "e30b05b0-9b44-4674-bf67-964f4198c97e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "01611324-b7c7-4427-89bd-9dea3eef456a",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "f8254e1a-3f1d-4572-9bf7-2885a1d252e7",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "6e148a06-5209-43c5-ba29-f2da98dd3b5f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "77078db8-bd9b-4241-a5aa-89953d8c9057",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "1af4e9c6-8bc7-4485-a648-85e49cfae279",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "4ccb9a86-e370-4334-b202-880c4b94bc0e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "a12ef2eb-f950-4eb3-84cb-48ad4b642ebe",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "f7e2e8f8-05ea-471a-b1f9-95b4cc6d16e3",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "a7b36540-9b23-493f-8b3f-1c7528f8c9f9",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "f053239f-6a44-472a-9aae-ece71ac8f0e7",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "D6",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "58dcbaee-0a6c-48c4-b5ae-687b955908b0",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "4e77ecf6-9263-4859-97eb-5ebc7e9c0a79",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "44d756cc-83f9-4f9d-bc64-478b5673112f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "A2"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "41cbb543-e24b-4837-9595-673a9f9b9b92",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "c4fd3414-f9e7-4898-9ba3-dbe2c8e47c12",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "2bed22cd-6432-4822-a8fa-3dcaa5efb9fc",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "bad42699-2dff-40a1-9fd3-34c199f0638f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "616329f4-ee70-46da-beeb-c91aa3ba6a28",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "1bd072a0-de58-4066-b47d-a87cdf472661",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 2,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "d37750b3-bfe0-4b41-988a-fd2d11ead9e2",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 1, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "c429c316-9739-4aca-b960-86cfb57aa3d6",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "A1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "f1a11cab-c55c-41c8-9c62-283012fb3482",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 6,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "e459dfc8-224d-4d9a-b1d3-486b722bdd99",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "0fc8c065-8711-4678-9eb4-9c8c5c4e6b62",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "1d8e2a78-7d3f-4e59-a9a8-c14090ed6a8f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 0.6
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "3d6a1a96-cb55-4c23-a088-f9e6c4c81076",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 3,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C6",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 2.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 10
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "9ed4f0b3-dc3f-4a2a-820c-aa07951c1ccf",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "ed21695b-5009-4ae5-9e67-148afa0e102e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "d48f3e5e-c67d-4af6-9dac-12c563002d8f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "C6",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "e9b4442e-bb61-4dbe-a584-5dc979d97aa0",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "0a507498-39ee-4ca2-b300-6e99859078b1",
-      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
-    },
-    {
-      "commandType": "pickUpTip",
-      "key": "0571f7be-9f9c-4a95-b1ec-96647fae8d47",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
-        "wellName": "B2"
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "d795e64e-e1af-413c-b05d-c0be646075c8",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 8
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "a799a4e4-6455-4d63-aca3-627cf28e1392",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 7
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "27377ab8-3e1b-49db-87e9-5abc8e53f84c",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 8
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "420b3ec7-e80f-4cb0-a117-d7e64929b25c",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 7
-      }
-    },
-    {
-      "commandType": "aspirate",
-      "key": "40bd2634-d3ba-4a01-9179-9a52e5faf287",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 8
-      }
-    },
-    {
-      "commandType": "dispense",
-      "key": "40def224-275f-479e-b483-7e8cc58b4337",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "volume": 5.5,
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": {
-          "origin": "bottom",
-          "offset": { "z": 0.5, "x": 0, "y": 0 }
-        },
-        "flowRate": 7
-      }
-    },
-    {
-      "commandType": "moveToAddressableArea",
-      "key": "37f6a510-62d4-4892-b933-24bcaeb156b7",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 }
-      }
-    },
-    {
-      "commandType": "blowOutInPlace",
-      "key": "555a47cc-3e76-40af-ad5c-10350834015f",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "flowRate": 1000
-      }
-    },
-    {
-      "commandType": "touchTip",
-      "key": "7d91b002-cd94-484f-87fb-b1077a0a0a4d",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
-        "wellName": "F1",
-        "wellLocation": { "origin": "bottom", "offset": { "z": 30.5 } }
-      }
-    },
-    {
-      "commandType": "moveToAddressableAreaForDropTip",
-      "key": "73fc82d3-6516-4ee5-acdf-437072f0387e",
-      "params": {
-        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
-        "addressableAreaName": "fixedTrash",
-        "offset": { "x": 0, "y": 0, "z": 0 },
-        "alternateDropLocation": true
-      }
-    },
-    {
-      "commandType": "dropTipInPlace",
-      "key": "cc891b0a-9b44-4fce-9b2c-2379034ce18c",
+      "key": "c7224b3f-da9a-4765-818f-64a46b6e3548",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "waitForDuration",
-      "key": "8b8706c2-b80a-4ea9-bc82-c79495959cf5",
+      "key": "a49aa815-5a3a-4f0d-ba36-8a3dce351785",
       "params": { "seconds": 3723, "message": "Delay plz" }
     }
   ],

--- a/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
+++ b/protocol-designer/fixtures/protocol/8/example_1_1_0MigratedToV8.json
@@ -6,16 +6,16 @@
     "author": "Author name",
     "description": "Description here",
     "created": 1560957631666,
-    "lastModified": 1718200660693,
+    "lastModified": 1719517327666,
     "category": null,
     "subcategory": null,
     "tags": []
   },
   "designerApplication": {
     "name": "opentrons/protocol-designer",
-    "version": "8.1.0",
+    "version": "8.1.1",
     "data": {
-      "_internalAppBuildDate": "Wed, 12 Jun 2024 13:56:36 GMT",
+      "_internalAppBuildDate": "Thu, 27 Jun 2024 19:41:42 GMT",
       "defaultValues": {
         "aspirate_mmFromBottom": 1,
         "dispense_mmFromBottom": 1,
@@ -46,7 +46,11 @@
         }
       },
       "ingredLocations": {
+<<<<<<< HEAD
         "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well": {
+=======
+        "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1": {
+>>>>>>> 7ea5215b3b (update migration)
           "A1": { "0": { "volume": 121 } },
           "B1": { "0": { "volume": 121 } },
           "C1": { "0": { "volume": 121 } },
@@ -114,7 +118,7 @@
           "disposalVolume_checkbox": true,
           "disposalVolume_volume": "1",
           "blowout_checkbox": true,
-          "blowout_location": "756ef516-7632-4441-901c-31e55bd2816a:trashBin",
+          "blowout_location": "b3a2f7d4-1ce4-44af-81a9-499528cd2121:trashBin",
           "preWetTip": false,
           "aspirate_airGap_checkbox": false,
           "aspirate_airGap_volume": null,
@@ -126,7 +130,7 @@
           "dispense_delay_checkbox": false,
           "dispense_delay_seconds": "1",
           "dispense_delay_mmFromBottom": "0.5",
-          "dropTip_location": "756ef516-7632-4441-901c-31e55bd2816a:trashBin",
+          "dropTip_location": "b3a2f7d4-1ce4-44af-81a9-499528cd2121:trashBin",
           "nozzles": null,
           "dispense_x_position": 0,
           "dispense_y_position": 0,
@@ -159,7 +163,7 @@
           "dispense_delay_seconds": "1",
           "mix_touchTip_checkbox": true,
           "mix_touchTip_mmFromBottom": 30.5,
-          "dropTip_location": "756ef516-7632-4441-901c-31e55bd2816a:trashBin",
+          "dropTip_location": "b3a2f7d4-1ce4-44af-81a9-499528cd2121:trashBin",
           "nozzles": null,
           "tipRack": "opentrons/opentrons_96_tiprack_10ul/1",
           "mix_x_position": 0,
@@ -3346,7 +3350,7 @@
   "commandSchemaId": "opentronsCommandSchemaV8",
   "commands": [
     {
-      "key": "e88d9578-5b27-4b30-8ccc-4e9d20c7fb74",
+      "key": "ff2ed9ad-0b92-4026-a35d-6d6770d2492c",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p10_single",
@@ -3355,7 +3359,7 @@
       }
     },
     {
-      "key": "78be1f0b-0b34-42d1-9cc1-717827621ef3",
+      "key": "24c297e7-71d1-46e5-8434-d249611ca957",
       "commandType": "loadPipette",
       "params": {
         "pipetteName": "p50_single",
@@ -3364,7 +3368,7 @@
       }
     },
     {
-      "key": "17dbaf45-4053-41b4-8383-f1a343f28135",
+      "key": "760066c5-cb5d-4068-8a8e-76b459175b8b",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 10ul (1)",
@@ -3376,7 +3380,7 @@
       }
     },
     {
-      "key": "145d4b57-d2fa-4e35-9979-30f612b13d87",
+      "key": "5cc772e3-0ca9-493b-80fb-ade2926fbae4",
       "commandType": "loadLabware",
       "params": {
         "displayName": "tiprack 200ul (1)",
@@ -3388,7 +3392,7 @@
       }
     },
     {
-      "key": "de11d0ac-5ce7-4501-b8c4-2d252c268870",
+      "key": "d77e78ef-834f-4180-9570-9c406e728e91",
       "commandType": "loadLabware",
       "params": {
         "displayName": "96 deep well (1)",
@@ -3401,19 +3405,19 @@
     },
     {
       "commandType": "loadLiquid",
-      "key": "02619748-f892-4748-9596-f821ddff6e15",
+      "key": "6875164d-0525-4561-b0ff-85b7ad185190",
       "params": {
         "liquidId": "1",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "volumeByWell": { "F1": 44, "G1": 44, "H1": 44 }
       }
     },
     {
       "commandType": "loadLiquid",
-      "key": "ba462279-0d89-43de-b4e8-f15332750465",
+      "key": "4213b84c-b1e0-4ef6-b1b0-376454a497dc",
       "params": {
         "liquidId": "0",
-        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
         "volumeByWell": {
           "A1": 121,
           "B1": 121,
@@ -3425,7 +3429,7 @@
     },
     {
       "commandType": "pickUpTip",
-      "key": "a7ecd51d-6e21-4d77-9580-fe882abf925b",
+      "key": "ae4aa970-b7a1-4440-b5eb-1187c0b399e3",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
@@ -3434,7 +3438,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "e6cf36cc-4ff7-4238-aa43-a40ccb7220ea",
+      "key": "68f08911-7976-4c2f-9dde-3c6fd62d4a40",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3449,7 +3453,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "bf5b7fa2-57b4-4460-ac12-789fcbdc3e61",
+      "key": "0d0f5567-6b4f-4398-b7ab-b6a8c1075d76",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3464,7 +3468,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "8172a3b2-0199-4656-8879-46152f7f4aa7",
+      "key": "32ef408a-1701-41b7-920e-ffb2667422ba",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3479,7 +3483,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "820e89f0-4214-4f76-be18-3cbf6c26a1e0",
+      "key": "54f7f6f5-6512-4198-bfb3-6673ab4279cd",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3494,7 +3498,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "25de5082-1ab1-48b7-bc4b-58d9f838c6dc",
+      "key": "9a8dbb61-bdc1-4ac8-b21f-48d0ff4eca22",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3509,7 +3513,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "244c8dd7-f5a2-47a7-9fa6-69f719ef30b0",
+      "key": "36a268ab-1aec-40b5-88bd-9426bae523f6",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 2,
@@ -3524,7 +3528,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "7588e50b-ff7e-4c9d-9204-a03641aa16a6",
+      "key": "6d246cf4-b0fd-4112-a2b3-6ff573c60e12",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3539,7 +3543,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "eb15b3fb-5fc2-4659-a168-0c722e111a7a",
+      "key": "49d72970-e8d3-4da6-a41b-4d26e78185d9",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -3549,7 +3553,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "24d3bed4-bacf-4bce-9b4c-6b28f7b6fbc5",
+      "key": "6b34ac93-0fb3-41d7-82a2-0982d36c1874",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 6,
@@ -3564,7 +3568,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "9453c37a-a7c3-467b-b28a-b0abff7c9185",
+      "key": "2c7029ae-b651-4e84-8bec-000d69f9c7d4",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3579,7 +3583,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "5270cb61-3341-4d1e-abf4-d8f89bb7eb93",
+      "key": "bd6dbf8d-41a5-4e9a-b493-cd07e29a9623",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3594,7 +3598,7 @@
     },
     {
       "commandType": "aspirate",
-      "key": "452fe139-4c12-4895-970d-87e14d9c0cdf",
+      "key": "85662fb7-e526-4042-94b2-7f8cf965ac87",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -3609,7 +3613,7 @@
     },
     {
       "commandType": "dispense",
-      "key": "865eba3b-02b6-4ffd-a7c3-b9d464f6536c",
+      "key": "0f734c11-5069-4d4c-8310-377b65a9c9ef",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "volume": 3,
@@ -5702,7 +5706,7 @@
     },
     {
       "commandType": "blowOutInPlace",
-      "key": "884876d1-8a0f-48e2-ba59-bd0b6de5aace",
+      "key": "5da8dc6c-bfab-44db-93d7-7b49e5505244",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "flowRate": 1000
@@ -5710,7 +5714,7 @@
     },
     {
       "commandType": "touchTip",
-      "key": "72e18358-9e53-49b6-b0db-936546ea0ae7",
+      "key": "29258e2f-aa85-4a52-8e9c-a9f7cd5a8659",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
@@ -5720,7 +5724,7 @@
     },
     {
       "commandType": "moveToAddressableAreaForDropTip",
-      "key": "78d8d81c-4d60-49c5-9fec-6bce14925e57",
+      "key": "85ef05c7-d22b-41aa-bebc-e18f9396387c",
       "params": {
         "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
         "addressableAreaName": "fixedTrash",
@@ -5730,12 +5734,2081 @@
     },
     {
       "commandType": "dropTipInPlace",
-      "key": "18b4cb99-dcbf-4d07-8653-312a0e2a831c",
+      "key": "4f4073fb-fffa-4b47-84b3-e91f685e5075",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "7453824b-c7da-49ee-ba31-5c9f73374c55",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "1756ab98-c85f-4977-90ad-f8e5f49cb459",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "bf3bbabc-5ebf-4720-8180-12d5de8e297b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "76d1300e-81a4-4385-99ca-63330d9cea4c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "655fd074-aad9-4499-a2ff-7e32b4acea02",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "e04d2711-909b-4fb7-9071-b43bb8f54e66",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "eb0d09ac-5407-4e3a-a0c2-3cb3f94937a5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "458316d5-4120-4132-81d7-766c2e80fbae",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "5fc16d8b-bf1e-45a6-ad35-22e486648c4c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "362dd336-7b16-4a91-b27b-879ed53741ce",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4460aab4-1806-435b-a56e-af46704b361d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "40929bc6-3a78-40fb-b8a2-04173e4162e6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "29bfe1e3-e80e-45ae-b58f-3766ba65b6a0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a0b81e23-c311-4a93-91e7-17b2d16443de",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "bc95424e-2481-4641-bc61-3ee5e103549a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "bd798868-28dc-40c8-8a1a-ab8b63ed5fa5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "81423581-9275-4d6f-8024-94a40cd9c544",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "d1071044-1946-43fb-8607-5783a51d108a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "08211033-39cc-4987-8de8-d0254e0b8017",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "47c0bb47-6b35-4329-8ab3-8ef74a27d2db",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "C1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9c2d9dd8-c021-4afd-bc01-d2d54692e2ce",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "675289ae-0458-4848-a2eb-dfd566dc0827",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "7bf7b710-6651-4e9f-978c-7799ad374d7d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "071161be-43f9-470c-8416-54b16db7dfbb",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4e805d98-ac81-4e23-859e-4d3e519fb72c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "b5bd2eff-9ea6-44d3-afe3-9b72803709fc",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "74fde4e8-78a2-4d99-9b06-66f0f1608461",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "3f36c6a7-1821-4b34-a19f-3994f1ae5d47",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "01a68cec-a821-4adf-a5ae-8fd16b95953b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "fb2b4b2c-064f-4be6-8df3-152f08618ab1",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "dd1ebf4b-a619-45fd-b0c3-fec676796c07",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "42e59ad7-c888-4430-b1b7-7d6017b35161",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "4ccf5137-cafe-4782-bf3b-a3d303742ad2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C8",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "9ac2dd26-77be-4398-80f4-570520cbcbda",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "48f358e3-8c1c-4760-8d53-af69bcd2830a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "3b8f412c-cb94-48a1-a684-17c62845d934",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C8",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "06a297a3-0336-4518-a51b-dc7fbbd7636e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "73a16c1f-4ba2-4a6b-85dd-93ac98c067bd",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "db8c6d49-bc56-490f-bc8c-0177943f2b48",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "D1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "59c14642-ac5d-4b86-af19-ca5edb7f10e7",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "b334280f-d9ab-483c-b8f8-4596b5f38a07",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9686c29c-e88e-4cb8-8599-27589b1dab14",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "66bf662a-aa21-4583-a82e-1369414708d6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "55061ef4-f0b3-4a05-b9e2-dcf6a60d8bef",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "ea8022f9-f106-4dff-a06a-46beed5831f8",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4eb28d3f-5be4-48ba-986e-0e1ef2e51c86",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "c8262acd-7dd0-436c-9868-ef24263a76d2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3475f885-4371-4332-88df-fe5d704f6eee",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "f4fdfdb9-1951-46a2-9871-1c6054c11c96",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a46c25c6-1790-4e5f-8a0f-9cd0c29c6456",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "7ed069c4-eee1-4bad-9d6c-3739a2a7b3cb",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "fef59af7-68da-424a-a41b-ce6f5a3fe61a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "fd5a5c1d-cfc9-4b59-ad2f-ec635b8db470",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "bcb3ddb2-2e2a-4d84-b9ee-5dc64547c57b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "8e14adca-6b8d-404b-9653-953212e87f50",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "9305bf9c-4cad-4e31-b2c5-69e75badc76f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "37297941-eb69-4e6e-8092-26ec1d5f243e",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "fc2444ec-cb9d-4946-9aca-74b5a1c354e2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "E1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "1d7ce575-a2b9-4a85-8ea6-2a4c3fecd904",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "d47b6b2a-daf5-4363-b2db-e118891461a5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "5864438d-6ee0-4b46-a075-aab17a7a42fa",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "8ecbe69a-a849-4555-909b-ba2892be0ea0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "b9f35364-823f-4c07-bce9-b4b8e6bec052",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "c1fac007-b43d-479b-a6ba-ec3e826dd8eb",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "a6faf831-b19e-482b-af1a-0e903365281a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "45e3c9b2-b2cd-41dc-9a1b-8d13664963ab",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3bcd810f-603d-4e11-93e6-56368e173171",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "8d217688-e3a6-41e7-ba7c-6566b1aa4e6d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "ce8fe4a1-8602-42bd-88dc-4c14e9451ad6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "d2d33b3a-0295-426b-bdcd-9a0190a42b16",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "12a0b120-8337-4c19-b5bf-d6696317a743",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "4a8fa892-5c98-424c-a3a2-04722313db8b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "b8c8910a-fc9e-41e5-b1dd-919bb13a1d39",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "4b984649-28d8-46b9-a89f-78cf6e1c6be0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "cc97d9d3-1721-49be-825c-d738cf157383",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "890ac01b-c76e-4a31-bf77-8c0b40bb41c3",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "f9cc205a-4cf2-4a48-8587-2a84a173864a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "F1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2a881c65-4913-45a0-ad89-25aca6adcf46",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "5c02e2c7-38af-433a-8ada-9343c885a89f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "91ec9312-8551-42a9-aaad-7d615aedcd89",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "00c9be42-13bb-4357-b935-08453219d719",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "d1462510-bcb5-4365-a374-860fefa84b37",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "69c4c63f-3baf-4764-b9ec-fc0024163026",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "e11300b2-a24c-466e-8320-19b94316e809",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "713e31ff-358d-4049-b71a-0b1f2dbb0070",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "66b87eb7-1eff-44a6-b468-463bab704246",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "76435e75-8a55-4da5-bd90-31ba320454f6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "526236d4-3da2-49d1-bc52-7eb373202458",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "1a14b614-4086-4239-9633-c7500d28f363",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "03943156-d762-4320-8f12-b617034e7a0e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C7",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "8e30dfa4-d91e-4df5-940a-724331bec261",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "18664b61-5329-4117-890d-21c1c7a55080",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "6a1257f2-5ee4-4e73-bd68-836dfaa3cb40",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C7",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "31728cef-de6f-45bd-be45-96d8fce7ca6e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "f0d9269a-28b1-45d6-8896-3297462bc3bb",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "924a8341-650e-4346-a4ef-0328b973e9d1",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "G1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "67b5a005-fefd-42a5-ad81-8aec82d84cf2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "34cd73c5-646f-4e64-80f3-659114842e2b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "fc51f93c-f357-4120-b041-a405bb287776",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a3ea424f-2e99-41b7-a1b9-f6dc170fb0e4",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2c02fd22-7198-4e7f-a507-10d75e0afa6e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "04c25c25-ffad-4d3e-bea4-8a9455275f90",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "060393f4-6a88-4b0e-ae52-087cb1d055b2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "53225768-1d9a-4d2a-b596-f7d69a11c4ad",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a1ecc346-a713-4d48-95ae-64a7f4aa9c65",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "c0c041ea-c2de-462c-b03e-3f1f353dab72",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "dfa01432-0877-445e-a52f-50492d88fc33",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "a6f70d92-eac6-4882-9ee8-6eaf0dffbb1b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3c08835f-df1b-445b-b196-12a0b07f51af",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "291ca3cc-6d5f-4d58-967d-2efb0959a904",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "13c343bf-11e4-4fd6-9a8c-16c521566460",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "43e97c33-4df1-4f96-97b2-68da358e6a8b",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "E6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "a2dfabd7-05fb-469e-a144-6b25a893cae7",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "639f3bac-752b-4ad8-96c4-8bd9a53c9f73",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "07c0e5f0-7bcc-475a-b8ae-147db16befa5",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "H1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "9429d649-d0cc-40b3-a38e-c24f5b30611f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "9c2ef389-beee-4e3f-b8cb-b24304cd3211",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "5e7849e6-5cca-4568-84ae-efca3ad8f937",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "310da5bc-21c7-41be-bf0b-52e50eb32ab4",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4c096a48-a57d-4f22-9f48-07ae27983a68",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "e30b05b0-9b44-4674-bf67-964f4198c97e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "01611324-b7c7-4427-89bd-9dea3eef456a",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "f8254e1a-3f1d-4572-9bf7-2885a1d252e7",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "6e148a06-5209-43c5-ba29-f2da98dd3b5f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "77078db8-bd9b-4241-a5aa-89953d8c9057",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "1af4e9c6-8bc7-4485-a648-85e49cfae279",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "4ccb9a86-e370-4334-b202-880c4b94bc0e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a12ef2eb-f950-4eb3-84cb-48ad4b642ebe",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "f7e2e8f8-05ea-471a-b1f9-95b4cc6d16e3",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "a7b36540-9b23-493f-8b3f-1c7528f8c9f9",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "f053239f-6a44-472a-9aae-ece71ac8f0e7",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "D6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "58dcbaee-0a6c-48c4-b5ae-687b955908b0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "4e77ecf6-9263-4859-97eb-5ebc7e9c0a79",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "44d756cc-83f9-4f9d-bc64-478b5673112f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "A2"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "41cbb543-e24b-4837-9595-673a9f9b9b92",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "c4fd3414-f9e7-4898-9ba3-dbe2c8e47c12",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "2bed22cd-6432-4822-a8fa-3dcaa5efb9fc",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "bad42699-2dff-40a1-9fd3-34c199f0638f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "616329f4-ee70-46da-beeb-c91aa3ba6a28",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "1bd072a0-de58-4066-b47d-a87cdf472661",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 2,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "d37750b3-bfe0-4b41-988a-fd2d11ead9e2",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 1, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "c429c316-9739-4aca-b960-86cfb57aa3d6",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "A1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 28.5 } }
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "f1a11cab-c55c-41c8-9c62-283012fb3482",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 6,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "e459dfc8-224d-4d9a-b1d3-486b722bdd99",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "0fc8c065-8711-4678-9eb4-9c8c5c4e6b62",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "1d8e2a78-7d3f-4e59-a9a8-c14090ed6a8f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 0.6
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "3d6a1a96-cb55-4c23-a088-f9e6c4c81076",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 3,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C6",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 2.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 10
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "9ed4f0b3-dc3f-4a2a-820c-aa07951c1ccf",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "ed21695b-5009-4ae5-9e67-148afa0e102e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "d48f3e5e-c67d-4af6-9dac-12c563002d8f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "C6",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 40.3 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "e9b4442e-bb61-4dbe-a584-5dc979d97aa0",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "0a507498-39ee-4ca2-b300-6e99859078b1",
+      "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
+    },
+    {
+      "commandType": "pickUpTip",
+      "key": "0571f7be-9f9c-4a95-b1ec-96647fae8d47",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "c6f4ec70-92a5-11e9-ac62-1b173f839d9e:tiprack-10ul:opentrons/opentrons_96_tiprack_10ul/1",
+        "wellName": "B2"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "d795e64e-e1af-413c-b05d-c0be646075c8",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 8
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "a799a4e4-6455-4d63-aca3-627cf28e1392",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 7
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "27377ab8-3e1b-49db-87e9-5abc8e53f84c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 8
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "420b3ec7-e80f-4cb0-a117-d7e64929b25c",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 7
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "key": "40bd2634-d3ba-4a01-9179-9a52e5faf287",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 8
+      }
+    },
+    {
+      "commandType": "dispense",
+      "key": "40def224-275f-479e-b483-7e8cc58b4337",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "volume": 5.5,
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "z": 0.5, "x": 0, "y": 0 }
+        },
+        "flowRate": 7
+      }
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "key": "37f6a510-62d4-4892-b933-24bcaeb156b7",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 }
+      }
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "key": "555a47cc-3e76-40af-ad5c-10350834015f",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "flowRate": 1000
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "key": "7d91b002-cd94-484f-87fb-b1077a0a0a4d",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "labwareId": "dafd4000-92a5-11e9-ac62-1b173f839d9e:96-deep-well:opentrons/usascientific_96_wellplate_2.4ml_deep/1",
+        "wellName": "F1",
+        "wellLocation": { "origin": "bottom", "offset": { "z": 30.5 } }
+      }
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "73fc82d3-6516-4ee5-acdf-437072f0387e",
+      "params": {
+        "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e",
+        "addressableAreaName": "fixedTrash",
+        "offset": { "x": 0, "y": 0, "z": 0 },
+        "alternateDropLocation": true
+      }
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "key": "cc891b0a-9b44-4fce-9b2c-2379034ce18c",
       "params": { "pipetteId": "c6f45030-92a5-11e9-ac62-1b173f839d9e" }
     },
     {
       "commandType": "waitForDuration",
-      "key": "31de1fda-2aca-46b2-b1d8-8e1974b4c175",
+      "key": "8b8706c2-b80a-4ea9-bc82-c79495959cf5",
       "params": { "seconds": 3723, "message": "Delay plz" }
     }
   ],


### PR DESCRIPTION
…s key

closes RESC-294

# Overview

This is part 2 of the duplication bug error fixed in PD 8.1.1, basically the duplicated labware from prior to 7.0.0 migration does not include the `definitionId` at the end of labware id string. 

# Test Plan

Open the attached protocol and see that the 2nd `loadLiquid` command has a labware id that is just a uuid. Upload it to the branch and export and see that the exported file's 2nd `loadLiquid` command has a labware id that includes the definition id (the `labwareDefURI`) at the end
[testingColors.json](https://github.com/user-attachments/files/16020354/testingColors.json)


# Changelog

- make sure definition id is appended to the end of labware id

# Review requests

see test plan

# Risk assessment

low