### PR TITLE
fix(protocol-designer): hide pause message for waitForTemperature com…

### DIFF
--- a/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
+++ b/protocol-designer/src/components/StepEditForm/forms/PauseForm.tsx
@@ -164,21 +164,25 @@ export const PauseForm = (props: StepFormProps): JSX.Element => {
           </div>
         </div>
         <div className={styles.section_column}>
-          <div className={styles.form_row}>
-            {/* TODO: Ian 2019-03-25 consider making this a component eg `TextAreaField.js` if used anywhere else */}
-            <FormGroup
-              className={styles.full_width_field}
-              label={t('form:step_edit_form.field.pauseMessage.label')}
-            >
-              <textarea
-                className={styles.textarea_field}
-                value={propsForFields.pauseMessage.value as string}
-                onChange={(e: React.ChangeEvent<any>) => {
-                  propsForFields.pauseMessage.updateValue(e.currentTarget.value)
-                }}
-              />
-            </FormGroup>
-          </div>
+          {pauseAction === PAUSE_UNTIL_TEMP ? null : (
+            <div className={styles.form_row}>
+              {/* TODO: Ian 2019-03-25 consider making this a component eg `TextAreaField.js` if used anywhere else */}
+              <FormGroup
+                className={styles.full_width_field}
+                label={t('form:step_edit_form.field.pauseMessage.label')}
+              >
+                <textarea
+                  className={styles.textarea_field}
+                  value={propsForFields.pauseMessage.value as string}
+                  onChange={(e: React.ChangeEvent<any>) => {
+                    propsForFields.pauseMessage.updateValue(
+                      e.currentTarget.value
+                    )
+                  }}
+                />
+              </FormGroup>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
…mands

closes RAUT-1049

# Overview

NOTE: not adding this to the hot fix since it is a low-level fix

@jbleon95 noted that a customer had a pause step with a message and it wasn't showing up in the run log. Looking into the code, the message was only wired up for a pause `delay` command but not for the pause `waitForTemperature` command. Digging into it more, the `heaterShaker/waitForTemperature` and `temperatureModule/waitForTemperature` do not even have `message` as a command param! Sooo the fix is to hide the message section in PD for the pause form.

# Test Plan

Create an ot-2 or flex protocol and add a heater-shaker and a temperature module.Add a pause step and see that the "message to display" is not visible. Next, add a heater-skaker command to change the temperature and select "build pause now". See that a pause command is added and open the form to see that the "message to display" is not visible. Repeat for the temperature module and see that the pause command does not display the "message to display".

# Changelog

- filter out message text area if it is a waitForTemp command

# Review requests

see test plan

# Risk assessment

low