### PR TITLE
feat(api): add liquid state property

### DIFF
--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -111,6 +111,7 @@ class InstrumentContext(publisher.CommandPublisher):
             labware.Labware, TrashBin, WasteChute, None
         ] = trash
         self.requested_as = requested_as
+        self._liquid_presence_state: Optional[types.LiquidPresenceState] = None
 
     @property
     @requires_version(2, 0)
@@ -1641,6 +1642,16 @@ class InstrumentContext(publisher.CommandPublisher):
 
         """
         return self._core.get_flow_rate()
+
+    @property
+    @requires_version(2, 0)
+    def liquid_presence_state(self) -> Optional[types.LiquidPresenceState]:
+        return self._liquid_presence_state
+
+    @liquid_presence_state.setter
+    @requires_version(2, 0)
+    def liquid_presence_state(self, state: types.LiquidPresenceState) -> None:
+        self._liquid_presence_state = state
 
     @property
     @requires_version(2, 0)

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1644,7 +1644,7 @@ class InstrumentContext(publisher.CommandPublisher):
         return self._core.get_flow_rate()
 
     @property
-    @requires_version(2, 0)
+    @requires_version(2, 20)
     def liquid_presence_state(self) -> Optional[types.LiquidPresenceState]:
         return self._liquid_presence_state
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -199,6 +199,12 @@ class Mount(enum.Enum):
             return cls.EXTENSION
 
 
+class LiquidPresenceState(str, enum.Enum):
+    PRESENT = "present"
+    ABSENT = "absent"
+    UNKNOWN = "unknown"
+
+
 class MountType(str, enum.Enum):
     LEFT = "left"
     RIGHT = "right"


### PR DESCRIPTION
## Overview
This adds a `liquid_presence_state` property to the protocol api's instrument context, along with an enum for the possible states.

The value here is `Optional` and defaulted to `None`, which I think makes sense for the ot2 case.

## Changelog

- add getter and setter for `liquid_presence_state`
- add `LiquidPresenceState` enum in `opentrons.types` 

## Review Requests
Is there any further error handling/prevention I should do for ot2 instruments?