### PR TITLE
ci(app-shell): update macos github runner version

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -96,7 +96,7 @@ jobs:
   backend-unit-test:
     strategy:
       matrix:
-        os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
+        os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
     name: 'opentrons app backend unit tests on ${{matrix.os}}'
     runs-on: ${{ matrix.os }}
     steps:
@@ -207,13 +207,13 @@ jobs:
     if: needs.determine-build-type.outputs.variants != '[]'
     strategy:
       matrix:
-        os: ['windows-2022', 'ubuntu-22.04', 'macos-11']
+        os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
         variant: ${{fromJSON(needs.determine-build-type.outputs.variants)}}
         target: ['desktop', 'odd']
         exclude:
           - os: 'windows-2022'
             target: 'odd'
-          - os: 'macos-11'
+          - os: 'macos-latest'
             target: 'odd'
 
     runs-on: ${{ matrix.os }}

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -145,8 +145,8 @@ dist-ot3: package-deps
 .PHONY: dist-macos-latest
 dist-macos-latest: dist-osx
 
-.PHONY: dist-macos-11
-dist-macos-11: dist-osx
+.PHONY: dist-macos-12
+dist-macos-12: dist-osx
 
 .PHONY: dist-ubuntu-latest
 dist-ubuntu-latest: dist-linux

--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -145,9 +145,6 @@ dist-ot3: package-deps
 .PHONY: dist-macos-latest
 dist-macos-latest: dist-osx
 
-.PHONY: dist-macos-12
-dist-macos-12: dist-osx
-
 .PHONY: dist-ubuntu-latest
 dist-ubuntu-latest: dist-linux
 


### PR DESCRIPTION
# Overview

Github actions using macos-11 (which we use for app backend tests) are stalled because github depcrted macos-11 at the end of June: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

This PR updates the app workflow to use the latest macos version