### PR TITLE
refactor(app, components): fix styling of ProtocolDetails

### DIFF
--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -29,6 +29,7 @@
   "labware": "labware",
   "last_analyzed": "last analyzed",
   "last_updated": "last updated",
+  "left_and_right_mounts": "left + right mounts",
   "left_mount": "left mount",
   "left_right": "Left, Right",
   "liquid_name": "liquid name",

--- a/app/src/assets/localization/en/protocol_details.json
+++ b/app/src/assets/localization/en/protocol_details.json
@@ -38,7 +38,7 @@
   "listed_values_are_view_only": "Listed values are view-only",
   "location": "location",
   "modules": "modules",
-  "n_a": "—",
+  "n_a": "–",
   "name": "Name",
   "no_available_robots_found": "No available robots found",
   "no_custom_values": "No custom values specified",

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -17,7 +17,6 @@ import {
   Icon,
   JUSTIFY_CENTER,
   JUSTIFY_FLEX_START,
-  SIZE_1,
   SIZE_AUTO,
   SPACING,
   LegacyStyledText,
@@ -303,14 +302,14 @@ export const LiquidsListItemDetails = (
     description,
   } = props
   return (
-    <Flex flexDirection={DIRECTION_ROW}>
+    <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
       <Flex
         css={LIQUID_BORDER_STYLE}
-        padding={SPACING.spacing12}
+        padding="0.55rem"
         height="max-content"
         backgroundColor={COLORS.white}
       >
-        <Icon name="circle" color={displayColor} size={SIZE_1} />
+        <Icon name="circle" color={displayColor} size="0.55rem" />
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_CENTER}>
         <LegacyStyledText

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -305,11 +305,11 @@ export const LiquidsListItemDetails = (
     <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
       <Flex
         css={LIQUID_BORDER_STYLE}
-        padding="0.55rem"
+        padding="0.5rem"
         height="max-content"
         backgroundColor={COLORS.white}
       >
-        <Icon name="circle" color={displayColor} size="0.55rem" />
+        <Icon name="circle" color={displayColor} size="0.5rem" />
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_CENTER}>
         <LegacyStyledText

--- a/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/SetupLiquids/SetupLiquidsList.tsx
@@ -21,6 +21,7 @@ import {
   SPACING,
   LegacyStyledText,
   TYPOGRAPHY,
+  StyledText,
 } from '@opentrons/components'
 import { getModuleDisplayName, MICRO_LITERS } from '@opentrons/shared-data'
 import {
@@ -312,35 +313,32 @@ export const LiquidsListItemDetails = (
         <Icon name="circle" color={displayColor} size="0.5rem" />
       </Flex>
       <Flex flexDirection={DIRECTION_COLUMN} justifyContent={JUSTIFY_CENTER}>
-        <LegacyStyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+        <StyledText
+          desktopStyle="bodyDefaultSemiBold"
           marginX={SPACING.spacing16}
         >
           {displayName}
-        </LegacyStyledText>
-        <LegacyStyledText
-          as="p"
-          fontWeight={TYPOGRAPHY.fontWeightRegular}
+        </StyledText>
+        <StyledText
+          desktopStyle="bodyDefaultRegular"
           color={COLORS.grey60}
           marginX={SPACING.spacing16}
         >
           {description != null ? description : null}
-        </LegacyStyledText>
+        </StyledText>
       </Flex>
       <Flex
-        backgroundColor={COLORS.black90 + '1A'}
-        borderRadius={BORDERS.borderRadius8}
+        backgroundColor={`${COLORS.black90}${COLORS.opacity20HexCode}`}
+        borderRadius={BORDERS.borderRadius4}
         height="max-content"
-        paddingY={SPACING.spacing4}
-        paddingX={SPACING.spacing8}
+        padding={`${SPACING.spacing2} ${SPACING.spacing8}`}
         alignSelf={ALIGN_CENTER}
         marginLeft={SIZE_AUTO}
       >
-        <LegacyStyledText as="p" fontWeight={TYPOGRAPHY.fontWeightRegular}>
+        <StyledText desktopStyle="bodyDefaultRegular">
           {getTotalVolumePerLiquidId(liquidId, labwareByLiquidId).toFixed(1)}{' '}
           {MICRO_LITERS}
-        </LegacyStyledText>
+        </StyledText>
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolLabwareDetails.tsx
@@ -12,8 +12,7 @@ import {
   POSITION_ABSOLUTE,
   POSITION_RELATIVE,
   SPACING,
-  LegacyStyledText,
-  TYPOGRAPHY,
+  StyledText,
 } from '@opentrons/components'
 import { getLabwareDefURI } from '@opentrons/shared-data'
 import { Divider } from '../../atoms/structure'
@@ -60,22 +59,22 @@ export const ProtocolLabwareDetails = (
       {labwareDetails.length > 0 ? (
         <Flex flexDirection={DIRECTION_COLUMN} width="100%">
           <Flex flexDirection={DIRECTION_ROW}>
-            <LegacyStyledText
-              as="label"
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              color={COLORS.grey60}
               marginBottom={SPACING.spacing8}
               data-testid="ProtocolLabwareDetails_labware_name"
               width="66%"
             >
               {t('labware_name')}
-            </LegacyStyledText>
-            <LegacyStyledText
-              as="label"
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            </StyledText>
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              color={COLORS.grey60}
               data-testid="ProtocolLabwareDetails_quantity"
             >
               {t('quantity')}
-            </LegacyStyledText>
+            </StyledText>
           </Flex>
           {labwareDetails?.map((labware, index) => (
             <ProtocolLabwareDetailItem
@@ -124,19 +123,22 @@ export const ProtocolLabwareDetailItem = (
             <Icon
               color={COLORS.blue50}
               name="check-decagram"
-              height="0.75rem"
-              minHeight="0.75rem"
-              minWidth="0.75rem"
-              marginRight={SPACING.spacing8}
+              height="1rem"
+              minHeight="1rem"
+              minWidth="1rem"
+              marginRight={SPACING.spacing4}
             />
           ) : (
             <Flex marginLeft={SPACING.spacing20} />
           )}
-          <LegacyStyledText as="p" paddingRight={SPACING.spacing32}>
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
+            paddingRight={SPACING.spacing32}
+          >
             {displayName}
-          </LegacyStyledText>
+          </StyledText>
         </Flex>
-        <LegacyStyledText as="p">{quantity}</LegacyStyledText>
+        <StyledText desktopStyle="bodyDefaultRegular">{quantity}</StyledText>
         <LabwareDetailOverflowMenu labware={labware} />
       </Flex>
     </>

--- a/app/src/organisms/ProtocolDetails/ProtocolParameters/index.tsx
+++ b/app/src/organisms/ProtocolDetails/ProtocolParameters/index.tsx
@@ -7,8 +7,7 @@ import {
   InfoScreen,
   ParametersTable,
   SPACING,
-  LegacyStyledText,
-  TYPOGRAPHY,
+  StyledText,
 } from '@opentrons/components'
 import { Banner } from '../../../atoms/Banner'
 
@@ -37,15 +36,12 @@ export function ProtocolParameters({
             iconMarginLeft={SPACING.spacing4}
           >
             <Flex flexDirection={DIRECTION_COLUMN}>
-              <LegacyStyledText
-                as="p"
-                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-              >
+              <StyledText desktopStyle="bodyDefaultSemiBold">
                 {t('listed_values_are_view_only')}
-              </LegacyStyledText>
-              <LegacyStyledText as="p">
+              </StyledText>
+              <StyledText desktopStyle="bodyDefaultRegular">
                 {t('start_setup_customize_values')}
-              </LegacyStyledText>
+              </StyledText>
             </Flex>
           </Banner>
           <ParametersTable runTimeParameters={runTimeParameters} t={t} />

--- a/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
+++ b/app/src/organisms/ProtocolDetails/RobotConfigurationDetails.tsx
@@ -10,7 +10,7 @@ import {
   ModuleIcon,
   SIZE_1,
   SPACING,
-  LegacyStyledText,
+  StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
@@ -64,12 +64,17 @@ export const RobotConfigurationDetails = (
   const { t } = useTranslation(['protocol_details', 'shared'])
 
   const loadingText = (
-    <LegacyStyledText as="p">{t('shared:loading')}</LegacyStyledText>
+    <StyledText desktopStyle="bodyDefaultRegular">
+      {t('shared:loading')}
+    </StyledText>
   )
   const emptyText = (
-    <LegacyStyledText as="p" textTransform={TYPOGRAPHY.textTransformCapitalize}>
+    <StyledText
+      desktopStyle="bodyDefaultRegular"
+      textTransform={TYPOGRAPHY.textTransformCapitalize}
+    >
       {t('shared:empty')}
-    </LegacyStyledText>
+    </StyledText>
   )
 
   const is96PipetteUsed = leftMountPipetteName === 'p1000_96'
@@ -117,15 +122,15 @@ export const RobotConfigurationDetails = (
           isLoading ? (
             loadingText
           ) : (
-            <LegacyStyledText as="p">
+            <StyledText desktopStyle="bodyDefaultRegular">
               {getRobotTypeDisplayName(robotType)}
-            </LegacyStyledText>
+            </StyledText>
           )
         }
       />
       <Divider marginY={SPACING.spacing12} width="100%" />
       <RobotConfigurationDetailsItem
-        label={is96PipetteUsed ? t('both_mounts') : t('left_mount')}
+        label={is96PipetteUsed ? t('left_and_right_mounts') : t('left_mount')}
         item={isLoading ? loadingText : leftMountItem}
       />
       {!is96PipetteUsed && (
@@ -151,11 +156,11 @@ export const RobotConfigurationDetails = (
           <React.Fragment key={`module_${index}`}>
             <Divider marginY={SPACING.spacing12} width="100%" />
             <RobotConfigurationDetailsItem
-              label={
+              label={`${t('slot')} ${
                 getModuleType(module.params.model) === THERMOCYCLER_MODULE_TYPE
                   ? getSlotsForThermocycler(robotType)
                   : module.params.location.slotName
-              }
+              }`}
               item={
                 <>
                   <ModuleIcon
@@ -168,9 +173,9 @@ export const RobotConfigurationDetails = (
                     minWidth={SIZE_1}
                     minHeight={SIZE_1}
                   />
-                  <LegacyStyledText as="p">
+                  <StyledText desktopStyle="bodyDefaultRegular">
                     {getModuleDisplayName(module.params.model)}
-                  </LegacyStyledText>
+                  </StyledText>
                 </>
               }
             />
@@ -182,7 +187,7 @@ export const RobotConfigurationDetails = (
           <React.Fragment key={`fixture_${index}`}>
             <Divider marginY={SPACING.spacing12} width="100%" />
             <RobotConfigurationDetailsItem
-              label={getCutoutDisplayName(fixture.cutoutId)}
+              label={`${t('slot')} ${getCutoutDisplayName(fixture.cutoutId)}`}
               item={
                 <>
                   {MAGNETIC_BLOCK_FIXTURES.includes(fixture.cutoutFixtureId) ? (
@@ -197,9 +202,9 @@ export const RobotConfigurationDetails = (
                       minHeight={SIZE_1}
                     />
                   ) : null}
-                  <LegacyStyledText as="p">
+                  <StyledText desktopStyle="bodyDefaultRegular">
                     {getFixtureDisplayName(fixture.cutoutFixtureId)}
-                  </LegacyStyledText>
+                  </StyledText>
                 </>
               }
             />
@@ -225,17 +230,16 @@ export const RobotConfigurationDetailsItem = (
       flexDirection={DIRECTION_ROW}
       alignItems={ALIGN_CENTER}
     >
-      <LegacyStyledText
-        as="label"
+      <StyledText
+        desktopStyle="bodyDefaultRegular"
         flex="0 0 auto"
-        fontWeight={TYPOGRAPHY.fontWeightSemiBold}
         marginRight={SPACING.spacing16}
         color={COLORS.grey60}
         textTransform={TYPOGRAPHY.textTransformCapitalize}
-        width="4.625rem"
+        width="9.375rem"
       >
         {label}
-      </LegacyStyledText>
+      </StyledText>
       <Flex data-testid={`RobotConfigurationDetails_${label}`}>{item}</Flex>
     </Flex>
   )

--- a/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -176,7 +176,7 @@ describe('RobotConfigurationDetails', () => {
     }
 
     render(props)
-    screen.getByText('1')
+    screen.getByText('Slot 1')
     screen.getByText('Magnetic Module GEN2')
   })
 

--- a/app/src/organisms/ProtocolDetails/index.tsx
+++ b/app/src/organisms/ProtocolDetails/index.tsx
@@ -685,12 +685,7 @@ export function ProtocolDetails(
               </Flex>
               <Box
                 backgroundColor={COLORS.white}
-                // remove left upper corner border radius when first tab is active
-                borderRadius={`${
-                  currentTab === 'robot_config' ? '0' : BORDERS.borderRadius4
-                } ${BORDERS.borderRadius4} ${BORDERS.borderRadius4} ${
-                  BORDERS.borderRadius4
-                }`}
+                borderRadius={BORDERS.borderRadius8}
                 padding={SPACING.spacing16}
               >
                 {contentsByTabName[currentTab]}

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -7,8 +7,9 @@ import {
 } from '@opentrons/shared-data'
 import { BORDERS, COLORS } from '../../helix-design-system'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants/index'
+import { TYPOGRAPHY as HELIX_TYPOGRAPHY } from '../../helix-design-system/product'
 import { Chip } from '../../atoms/Chip'
-import { LegacyStyledText } from '../../atoms/StyledText'
+import { StyledText } from '../../atoms/StyledText'
 import { Tooltip, useHoverTooltip } from '../../tooltips'
 import { Icon } from '../../icons'
 import { Flex } from '../../primitives'
@@ -89,17 +90,17 @@ export function ParametersTable({
                       width={FLEX_MAX_CONTENT}
                     />
                   ) : (
-                    <LegacyStyledText as="p">
+                    <StyledText desktopStyle="bodyDefaultRegular">
                       {formatRunTimeParameterDefaultValue(parameter, t)}
-                    </LegacyStyledText>
+                    </StyledText>
                   )}
                 </StyledTableCell>
                 <StyledTableCell isLast={isLast} paddingRight="0">
-                  <LegacyStyledText as="p">
+                  <StyledText desktopStyle="bodyDefaultRegular">
                     {parameter.type === 'csv_file'
                       ? t('n_a')
                       : formatRange(parameter)}
-                  </LegacyStyledText>
+                  </StyledText>
                 </StyledTableCell>
               </StyledTableRow>
             )
@@ -122,23 +123,24 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
 
   return (
     <StyledTableCell display="span" isLast={isLast}>
-      <LegacyStyledText
-        as="p"
+      <StyledText
+        desktopStyle="bodyDefaultRegular"
         css={css`
           display: ${DISPLAY_INLINE};
           padding-right: ${SPACING.spacing8};
         `}
       >
         {displayName}
-      </LegacyStyledText>
+      </StyledText>
       {description != null ? (
         <>
           <Flex display={DISPLAY_INLINE} {...targetProps}>
             <Icon
               name="information"
-              size={SPACING.spacing12}
+              size={SPACING.spacing16}
               color={COLORS.grey60}
               data-testid={`Icon_${index}`}
+              paddingTop={SPACING.spacing4}
             />
           </Flex>
           <Tooltip
@@ -162,7 +164,8 @@ const StyledTable = styled.table`
 `
 
 const StyledTableHeader = styled.th`
-  ${TYPOGRAPHY.labelSemiBold}
+  font: ${HELIX_TYPOGRAPHY.fontStyleBodyDefaultRegular};
+  color: ${COLORS.grey60};
   grid-gap: ${SPACING.spacing16};
   padding-bottom: ${SPACING.spacing8};
   border-bottom: ${BORDERS.lineBorder};

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -16,7 +16,7 @@ import { StyledText } from '../../atoms/StyledText'
 import { Tooltip, useHoverTooltip } from '../../tooltips'
 import { Icon } from '../../icons'
 import { Flex } from '../../primitives'
-import { DISPLAY_INLINE, FLEX_MAX_CONTENT, SIZE_1 } from '../../styles'
+import { DISPLAY_INLINE, FLEX_MAX_CONTENT } from '../../styles'
 
 import type { RunTimeParameter } from '@opentrons/shared-data'
 
@@ -140,7 +140,7 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
           <Flex display={DISPLAY_INLINE} {...targetProps}>
             <Icon
               name="information"
-              size={SIZE_1}
+              size="1rem"
               color={COLORS.grey60}
               data-testid={`Icon_${index}`}
               paddingTop={SPACING.spacing4}

--- a/components/src/molecules/ParametersTable/index.tsx
+++ b/components/src/molecules/ParametersTable/index.tsx
@@ -6,14 +6,17 @@ import {
   orderRuntimeParameterRangeOptions,
 } from '@opentrons/shared-data'
 import { BORDERS, COLORS } from '../../helix-design-system'
-import { SPACING, TYPOGRAPHY } from '../../ui-style-constants/index'
-import { TYPOGRAPHY as HELIX_TYPOGRAPHY } from '../../helix-design-system/product'
+import {
+  SPACING,
+  TYPOGRAPHY as LEGACY_TYPOGERAPHY,
+} from '../../ui-style-constants/index'
+import { TYPOGRAPHY } from '../../helix-design-system/product'
 import { Chip } from '../../atoms/Chip'
 import { StyledText } from '../../atoms/StyledText'
 import { Tooltip, useHoverTooltip } from '../../tooltips'
 import { Icon } from '../../icons'
 import { Flex } from '../../primitives'
-import { DISPLAY_INLINE, FLEX_MAX_CONTENT } from '../../styles'
+import { DISPLAY_INLINE, FLEX_MAX_CONTENT, SIZE_1 } from '../../styles'
 
 import type { RunTimeParameter } from '@opentrons/shared-data'
 
@@ -137,7 +140,7 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
           <Flex display={DISPLAY_INLINE} {...targetProps}>
             <Icon
               name="information"
-              size={SPACING.spacing16}
+              size={SIZE_1}
               color={COLORS.grey60}
               data-testid={`Icon_${index}`}
               paddingTop={SPACING.spacing4}
@@ -146,7 +149,7 @@ const ParameterName = (props: ParameterNameProps): JSX.Element => {
           <Tooltip
             {...tooltipProps}
             backgroundColor={COLORS.black90}
-            css={TYPOGRAPHY.labelRegular}
+            css={LEGACY_TYPOGERAPHY.labelRegular}
             width="8.75rem"
           >
             {description}
@@ -164,7 +167,7 @@ const StyledTable = styled.table`
 `
 
 const StyledTableHeader = styled.th`
-  font: ${HELIX_TYPOGRAPHY.fontStyleBodyDefaultRegular};
+  font: ${TYPOGRAPHY.fontStyleBodyDefaultRegular};
   color: ${COLORS.grey60};
   grid-gap: ${SPACING.spacing16};
   padding-bottom: ${SPACING.spacing8};


### PR DESCRIPTION
Closes AUTH-495

# Overview

Apply styling changes including new Helix typography constants to  `ProtocolDetails` table content ([Figma reference](https://www.figma.com/file/MlZjOO8aZXsw3HfTBoyw9U?type=design%27&node-id=447:7837))

# Test Plan

- upload protocol with parameters, hardware config, and liquids ([example](https://github.com/user-attachments/files/16059046/flex_demo.py.zip))
- click through each `ProtooclDetails` tab and verify that styling specified on ticket is reflected

# Changelog
- update styling across all content of `ProtocolDetails` tabbed table
- add translation key
- fix test

# Review requests
see test plan

# Risk assessment
low