### PR TITLE
fix(step-generation): error when pipetting off-deck labware

### DIFF
--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -4,6 +4,7 @@ import {
   COLUMN,
   getWellDepth,
   LOW_VOLUME_PIPETTES,
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -116,8 +117,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
 
   if (
     hasWasteChute &&
-    (initialDestLabwareSlot === 'gripperWasteChute' ||
-      initialSourceLabwareSlot === 'gripperWasteChute')
+    (initialDestLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA ||
+      initialSourceLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA)
   ) {
     return { errors: [errorCreators.labwareDiscarded()] }
   }

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -20,6 +20,7 @@ import {
   moveHelper,
   getIsSafePipetteMovement,
   getWasteChuteAddressableAreaNamePip,
+  getHasWasteChute,
 } from '../../utils'
 import {
   aspirate,
@@ -78,6 +79,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     aspirateYOffset,
     dispenseXOffset,
     dispenseYOffset,
+    destLabware,
+    sourceLabware,
   } = args
 
   const actionName = 'consolidate'
@@ -103,6 +106,20 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       !invariantContext.additionalEquipmentEntities[args.destLabware])
   ) {
     return { errors: [errorCreators.equipmentDoesNotExist()] }
+  }
+
+  const initialDestLabwareSlot = prevRobotState.labware[destLabware]?.slot
+  const initialSourceLabwareSlot = prevRobotState.labware[sourceLabware]?.slot
+  const hasWasteChute = getHasWasteChute(
+    invariantContext.additionalEquipmentEntities
+  )
+
+  if (
+    hasWasteChute &&
+    (initialDestLabwareSlot === 'gripperWasteChute' ||
+      initialSourceLabwareSlot === 'gripperWasteChute')
+  ) {
+    return { errors: [errorCreators.labwareDiscarded()] }
   }
 
   if (

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -18,6 +18,7 @@ import {
   getDispenseAirGapLocation,
   getIsSafePipetteMovement,
   getWasteChuteAddressableAreaNamePip,
+  getHasWasteChute,
 } from '../../utils'
 import {
   aspirate,
@@ -98,6 +99,21 @@ export const distribute: CommandCreator<DistributeArgs> = (
         labware: args.sourceLabware,
       })
     )
+  }
+
+  const initialDestLabwareSlot = prevRobotState.labware[args.destLabware]?.slot
+  const initialSourceLabwareSlot =
+    prevRobotState.labware[args.sourceLabware]?.slot
+  const hasWasteChute = getHasWasteChute(
+    invariantContext.additionalEquipmentEntities
+  )
+
+  if (
+    hasWasteChute &&
+    (initialDestLabwareSlot === 'gripperWasteChute' ||
+      initialSourceLabwareSlot === 'gripperWasteChute')
+  ) {
+    errors.push(errorCreators.labwareDiscarded())
   }
 
   if (

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -5,6 +5,7 @@ import {
   COLUMN,
   getWellDepth,
   LOW_VOLUME_PIPETTES,
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -110,8 +111,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
 
   if (
     hasWasteChute &&
-    (initialDestLabwareSlot === 'gripperWasteChute' ||
-      initialSourceLabwareSlot === 'gripperWasteChute')
+    (initialDestLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA ||
+      initialSourceLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA)
   ) {
     errors.push(errorCreators.labwareDiscarded())
   }

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -6,6 +6,7 @@ import {
   curryCommandCreator,
   reduceCommandCreators,
   getIsSafePipetteMovement,
+  getHasWasteChute,
 } from '../../utils'
 import * as errorCreators from '../../errorCreators'
 import {
@@ -168,6 +169,15 @@ export const mix: CommandCreator<MixArgs> = (
         }),
       ],
     }
+  }
+
+  const initialLabwareSlot = prevRobotState.labware[labware]?.slot
+  const hasWasteChute = getHasWasteChute(
+    invariantContext.additionalEquipmentEntities
+  )
+
+  if (hasWasteChute && initialLabwareSlot === 'gripperWasteChute') {
+    return { errors: [errorCreators.labwareDiscarded()] }
   }
 
   if (

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -1,5 +1,9 @@
 import flatMap from 'lodash/flatMap'
-import { LOW_VOLUME_PIPETTES, COLUMN } from '@opentrons/shared-data'
+import {
+  LOW_VOLUME_PIPETTES,
+  COLUMN,
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+} from '@opentrons/shared-data'
 import {
   repeatArray,
   blowoutUtil,
@@ -176,7 +180,10 @@ export const mix: CommandCreator<MixArgs> = (
     invariantContext.additionalEquipmentEntities
   )
 
-  if (hasWasteChute && initialLabwareSlot === 'gripperWasteChute') {
+  if (
+    hasWasteChute &&
+    initialLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA
+  ) {
     return { errors: [errorCreators.labwareDiscarded()] }
   }
 

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -4,6 +4,7 @@ import {
   getWellDepth,
   COLUMN,
   LOW_VOLUME_PIPETTES,
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 import { AIR_GAP_OFFSET_FROM_TOP } from '../../constants'
 import * as errorCreators from '../../errorCreators'
@@ -143,8 +144,8 @@ export const transfer: CommandCreator<TransferArgs> = (
 
   if (
     hasWasteChute &&
-    (initialDestLabwareSlot === 'gripperWasteChute' ||
-      initialSourceLabwareSlot === 'gripperWasteChute')
+    (initialDestLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA ||
+      initialSourceLabwareSlot === GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA)
   ) {
     errors.push(errorCreators.labwareDiscarded())
   }

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -20,6 +20,7 @@ import {
   moveHelper,
   getIsSafePipetteMovement,
   getWasteChuteAddressableAreaNamePip,
+  getHasWasteChute,
 } from '../../utils'
 import {
   aspirate,
@@ -79,6 +80,8 @@ export const transfer: CommandCreator<TransferArgs> = (
     tipRack,
     aspirateXOffset,
     aspirateYOffset,
+    destLabware,
+    sourceLabware,
     dispenseXOffset,
     dispenseYOffset,
   } = args
@@ -130,6 +133,20 @@ export const transfer: CommandCreator<TransferArgs> = (
         labware: args.sourceLabware,
       })
     )
+  }
+
+  const initialDestLabwareSlot = prevRobotState.labware[destLabware]?.slot
+  const initialSourceLabwareSlot = prevRobotState.labware[sourceLabware]?.slot
+  const hasWasteChute = getHasWasteChute(
+    invariantContext.additionalEquipmentEntities
+  )
+
+  if (
+    hasWasteChute &&
+    (initialDestLabwareSlot === 'gripperWasteChute' ||
+      initialSourceLabwareSlot === 'gripperWasteChute')
+  ) {
+    errors.push(errorCreators.labwareDiscarded())
   }
 
   if (


### PR DESCRIPTION
closes RESC-284

# Overview

We need to raise a timeline error if a user tries to pipette into a labware that was previously moved off-deck.

# Test Plan

Upload the attached protocol in PD in production and see that it does not raise a timeline error. Upload it to PD off of this branch and see that there is a timeline error indicating that the labware was discarded into the waste chute.

[IRepertoire TCR-b Non-FFPE Pilot 3 Columns OG.json](https://github.com/user-attachments/files/16071982/IRepertoire.TCR-b.Non-FFPE.Pilot.3.Columns.OG.json)


# Changelog

- add error for raising the `labwareDiscarded()` error creator and add it to the pipetting compound commands. Then add some test coverage.

# Review requests

see test plan

# Risk assessment

low