### PR TITLE
refactor(app): Fill in error type placeholders

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -43,6 +43,7 @@ class LiquidProbeResult(DestinationPositionResult):
     z_position: float = Field(
         ..., description="The Z coordinate, in mm, of the found liquid in deck space."
     )
+    # New fields should use camelCase. z_position is snake_case for historical reasons.
 
 
 _ExecuteReturn = Union[

--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -155,7 +155,7 @@ class LiquidNotFoundError(ErrorOccurrence):
 
     isDefined: bool = True
 
-    errorType: Literal["LiquidNotFound"] = "LiquidNotFound"
+    errorType: Literal["liquidNotFound"] = "liquidNotFound"
 
     errorCode: str = ErrorCodes.PIPETTE_LIQUID_NOT_FOUND.value.code
     detail: str = ErrorCodes.PIPETTE_LIQUID_NOT_FOUND.value.detail

--- a/app/src/organisms/ErrorRecoveryFlows/ErrorRecoveryWizard.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/ErrorRecoveryWizard.tsx
@@ -71,7 +71,7 @@ export function ErrorRecoveryWizard(
     recoveryCommands,
     routeUpdateActions,
   } = props
-  const errorKind = getErrorKind(failedCommand?.error?.errorType)
+  const errorKind = getErrorKind(failedCommand)
 
   useInitialPipetteHome({
     hasLaunchedRecovery,

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -46,7 +46,7 @@ export function RunPausedSplash(
 ): JSX.Element | null {
   const { toggleERWiz, routeUpdateActions, failedCommand } = props
   const { t } = useTranslation('error_recovery')
-  const errorKind = getErrorKind(failedCommand?.error?.errorType)
+  const errorKind = getErrorKind(failedCommand)
   const title = useErrorName(errorKind)
 
   const { proceedToRouteAndStep } = routeUpdateActions

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
@@ -84,7 +84,8 @@ describe('RunPausedSplash', () => {
       ...props,
       failedCommand: {
         ...props.failedCommand,
-        error: { errorType: 'overpressure' },
+        commandType: 'aspirate',
+        error: { isDefined: true, errorType: 'overpressure' },
       } as any,
     }
     render(props)

--- a/app/src/organisms/ErrorRecoveryFlows/constants.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/constants.ts
@@ -4,15 +4,14 @@ import { SPACING, TYPOGRAPHY } from '@opentrons/components'
 
 import type { StepOrder } from './types'
 
-// TODO(jh, 06-18-24): Add the correct errorTypes for these errors when they are available.
-// Error types of "defined" errors, those handled explicitly by Error Recovery.
+// Server-defined error types.
+// (Values for the .error.errorType property of a run command.)
 export const DEFINED_ERROR_TYPES = {
-  NO_LIQUID_DETECTED: 'NO_FLUIDS_OH_NO',
-  PIPETTE_COLLISION: 'AAAAAHHHHHHHHH',
-  OVERPRESSURE_ASPIRATION: 'overpressure',
-  OVERPRESSURE_DISPENSING: 'OVERPRESSURE_DISPENSING',
+  OVERPRESSURE: 'overpressure',
+  LIQUID_NOT_FOUND: 'liquidNotFound',
 }
 
+// Client-defined error-handling flows.
 export const ERROR_KINDS = {
   GENERAL_ERROR: 'GENERAL_ERROR',
   NO_LIQUID_DETECTED: 'NO_LIQUID_DETECTED',

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -18,6 +18,7 @@ import type {
   PickUpTipRunTimeCommand,
   AspirateRunTimeCommand,
   DispenseRunTimeCommand,
+  LiquidProbeRunTimeCommand,
 } from '@opentrons/shared-data'
 import type { ErrorRecoveryFlowsProps } from '..'
 
@@ -88,8 +89,9 @@ export function useFailedLabwareUtils({
 
 type FailedCommandRelevantLabware =
   | Omit<AspirateRunTimeCommand, 'result'>
-  | Omit<PickUpTipRunTimeCommand, 'result'>
   | Omit<DispenseRunTimeCommand, 'result'>
+  | Omit<LiquidProbeRunTimeCommand, 'result'>
+  | Omit<PickUpTipRunTimeCommand, 'result'>
   | null
 
 interface RelevantFailedLabwareCmd {
@@ -102,11 +104,11 @@ export function getRelevantFailedLabwareCmdFrom({
   failedCommand,
   runCommands,
 }: RelevantFailedLabwareCmd): FailedCommandRelevantLabware {
-  const errorKind = getErrorKind(failedCommand?.error?.errorType)
+  const errorKind = getErrorKind(failedCommand)
 
   switch (errorKind) {
     case ERROR_KINDS.NO_LIQUID_DETECTED:
-      return failedCommand as Omit<AspirateRunTimeCommand, 'result'>
+      return failedCommand as LiquidProbeRunTimeCommand
     case ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE:
     case ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING:
     case ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING:

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
@@ -58,7 +58,7 @@ export function ErrorDetailsModalODD(
   props: ErrorDetailsModalProps
 ): JSX.Element {
   const { failedCommand, toggleModal, isOnDevice } = props
-  const errorKind = getErrorKind(failedCommand?.error?.errorType)
+  const errorKind = getErrorKind(failedCommand)
   const errorName = useErrorName(errorKind)
 
   const getIsOverpressureErrorKind = (): boolean => {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
@@ -106,7 +106,8 @@ describe('ErrorDetailsModalODD', () => {
   it('renders the OverpressureBanner when the error kind is an overpressure error', () => {
     props.failedCommand = {
       ...props.failedCommand,
-      error: { errorType: 'overpressure' },
+      commandType: 'aspirate',
+      error: { isDefined: true, errorType: 'overpressure' },
     } as any
     render(props)
 

--- a/app/src/organisms/ErrorRecoveryFlows/utils/__tests__/getErrorKind.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/utils/__tests__/getErrorKind.test.ts
@@ -3,30 +3,63 @@ import { describe, expect, it } from 'vitest'
 import { ERROR_KINDS, DEFINED_ERROR_TYPES } from '../../constants'
 import { getErrorKind } from '../getErrorKind'
 
+import type { RunCommandError, RunTimeCommand } from '@opentrons/shared-data'
+
 describe('getErrorKind', () => {
-  it(`returns ${ERROR_KINDS.NO_LIQUID_DETECTED} for ${DEFINED_ERROR_TYPES.NO_LIQUID_DETECTED} errorType`, () => {
-    const result = getErrorKind(DEFINED_ERROR_TYPES.NO_LIQUID_DETECTED)
+  it(`returns ${ERROR_KINDS.NO_LIQUID_DETECTED} for ${DEFINED_ERROR_TYPES.LIQUID_NOT_FOUND} errorType`, () => {
+    const result = getErrorKind({
+      commandType: 'liquidProbe',
+      error: {
+        isDefined: true,
+        errorType: DEFINED_ERROR_TYPES.LIQUID_NOT_FOUND,
+      } as RunCommandError,
+    } as RunTimeCommand)
     expect(result).toEqual(ERROR_KINDS.NO_LIQUID_DETECTED)
   })
 
-  it(`returns ${ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE} for ${DEFINED_ERROR_TYPES.PIPETTE_COLLISION} errorType`, () => {
-    const result = getErrorKind(DEFINED_ERROR_TYPES.PIPETTE_COLLISION)
-    expect(result).toEqual(ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE)
-  })
-
-  it(`returns ${ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING} for ${DEFINED_ERROR_TYPES.OVERPRESSURE_ASPIRATION} errorType`, () => {
-    const result = getErrorKind(DEFINED_ERROR_TYPES.OVERPRESSURE_ASPIRATION)
+  it(`returns ${ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING} for ${DEFINED_ERROR_TYPES.OVERPRESSURE} errorType`, () => {
+    const result = getErrorKind({
+      commandType: 'aspirate',
+      error: {
+        isDefined: true,
+        errorType: DEFINED_ERROR_TYPES.OVERPRESSURE,
+      } as RunCommandError,
+    } as RunTimeCommand)
     expect(result).toEqual(ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING)
   })
 
-  it(`returns ${ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING} for ${DEFINED_ERROR_TYPES.OVERPRESSURE_DISPENSING} errorType`, () => {
-    const result = getErrorKind(DEFINED_ERROR_TYPES.OVERPRESSURE_DISPENSING)
+  it(`returns ${ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING} for ${DEFINED_ERROR_TYPES.OVERPRESSURE} errorType`, () => {
+    const result = getErrorKind({
+      commandType: 'dispense',
+      error: {
+        isDefined: true,
+        errorType: DEFINED_ERROR_TYPES.OVERPRESSURE,
+      } as RunCommandError,
+    } as RunTimeCommand)
     expect(result).toEqual(ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING)
   })
 
-  it(`returns ${ERROR_KINDS.GENERAL_ERROR} if the errorType isn't handled explicitly`, () => {
-    const mockErrorType = 'NON_HANDLED_ERROR'
-    const result = getErrorKind(mockErrorType)
+  it(`returns ${ERROR_KINDS.GENERAL_ERROR} for undefined errors`, () => {
+    const result = getErrorKind({
+      commandType: 'aspirate',
+      error: {
+        isDefined: false,
+        // It should treat this error as undefined because isDefined===false,
+        // even though the errorType happens to match a defined error.
+        errorType: DEFINED_ERROR_TYPES.OVERPRESSURE,
+      } as RunCommandError,
+    } as RunTimeCommand)
+    expect(result).toEqual(ERROR_KINDS.GENERAL_ERROR)
+  })
+
+  it(`returns ${ERROR_KINDS.GENERAL_ERROR} for defined errors not handled explicitly`, () => {
+    const result = getErrorKind({
+      commandType: 'aspirate',
+      error: {
+        isDefined: true,
+        errorType: 'someHithertoUnknownDefinedErrorType',
+      } as RunCommandError,
+    } as RunTimeCommand)
     expect(result).toEqual(ERROR_KINDS.GENERAL_ERROR)
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/utils/getErrorKind.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/utils/getErrorKind.ts
@@ -28,6 +28,8 @@ export function getErrorKind(failedCommand: RunTimeCommand | null): ErrorKind {
       errorType === DEFINED_ERROR_TYPES.LIQUID_NOT_FOUND
     )
       return ERROR_KINDS.NO_LIQUID_DETECTED
+    // todo(mm, 2024-07-02): Also handle aspirateInPlace and dispenseInPlace.
+    // https://opentrons.atlassian.net/browse/EXEC-593
   }
 
   return ERROR_KINDS.GENERAL_ERROR

--- a/app/src/organisms/ErrorRecoveryFlows/utils/getErrorKind.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/utils/getErrorKind.ts
@@ -1,19 +1,34 @@
 import { ERROR_KINDS, DEFINED_ERROR_TYPES } from '../constants'
 
+import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { ErrorKind } from '../types'
 
-// TODO(jh, 06-18-24): Add the correct errorTypes for these errors when they are available.
-export function getErrorKind(errorType?: string): ErrorKind {
-  switch (errorType) {
-    case DEFINED_ERROR_TYPES.NO_LIQUID_DETECTED:
-      return ERROR_KINDS.NO_LIQUID_DETECTED
-    case DEFINED_ERROR_TYPES.PIPETTE_COLLISION:
-      return ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE
-    case DEFINED_ERROR_TYPES.OVERPRESSURE_ASPIRATION:
+/**
+ * Given server-side information about a failed command,
+ * decide which UI flow to present to recover from it.
+ */
+export function getErrorKind(failedCommand: RunTimeCommand | null): ErrorKind {
+  const commandType = failedCommand?.commandType
+  const errorIsDefined = failedCommand?.error?.isDefined ?? false
+  const errorType = failedCommand?.error?.errorType
+
+  if (errorIsDefined) {
+    if (
+      commandType === 'aspirate' &&
+      errorType === DEFINED_ERROR_TYPES.OVERPRESSURE
+    )
       return ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING
-    case DEFINED_ERROR_TYPES.OVERPRESSURE_DISPENSING:
+    else if (
+      commandType === 'dispense' &&
+      errorType === DEFINED_ERROR_TYPES.OVERPRESSURE
+    )
       return ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING
-    default:
-      return ERROR_KINDS.GENERAL_ERROR
+    else if (
+      commandType === 'liquidProbe' &&
+      errorType === DEFINED_ERROR_TYPES.LIQUID_NOT_FOUND
+    )
+      return ERROR_KINDS.NO_LIQUID_DETECTED
   }
+
+  return ERROR_KINDS.GENERAL_ERROR
 }

--- a/shared-data/command/types/pipetting.ts
+++ b/shared-data/command/types/pipetting.ts
@@ -17,6 +17,7 @@ export type PipettingRunTimeCommand =
   | PrepareToAspirateRunTimeCommand
   | TouchTipRunTimeCommand
   | VerifyTipPresenceRunTimeCommand
+  | LiquidProbeRunTimeCommand
 
 export type PipettingCreateCommand =
   | AspirateCreateCommand
@@ -34,6 +35,7 @@ export type PipettingCreateCommand =
   | PrepareToAspirateCreateCommand
   | TouchTipCreateCommand
   | VerifyTipPresenceCreateCommand
+  | LiquidProbeCreateCommand
 
 export interface ConfigureForVolumeCreateCommand
   extends CommonCommandCreateInfo {
@@ -100,6 +102,7 @@ export interface BlowoutRunTimeCommand
     BlowoutCreateCommand {
   result?: BasicLiquidHandlingResult
 }
+
 export interface BlowoutInPlaceCreateCommand extends CommonCommandCreateInfo {
   commandType: 'blowOutInPlace'
   params: BlowoutInPlaceParams
@@ -119,6 +122,7 @@ export interface TouchTipRunTimeCommand
     TouchTipCreateCommand {
   result?: BasicLiquidHandlingResult
 }
+
 export interface PickUpTipCreateCommand extends CommonCommandCreateInfo {
   commandType: 'pickUpTip'
   params: PickUpTipParams
@@ -128,6 +132,7 @@ export interface PickUpTipRunTimeCommand
     PickUpTipCreateCommand {
   result?: any
 }
+
 export interface DropTipCreateCommand extends CommonCommandCreateInfo {
   commandType: 'dropTip'
   params: DropTipParams
@@ -137,6 +142,7 @@ export interface DropTipRunTimeCommand
     DropTipCreateCommand {
   result?: any
 }
+
 export interface DropTipInPlaceCreateCommand extends CommonCommandCreateInfo {
   commandType: 'dropTipInPlace'
   params: DropTipInPlaceParams
@@ -163,7 +169,6 @@ export interface PrepareToAspirateCreateCommand
   commandType: 'prepareToAspirate'
   params: PipetteIdentityParams
 }
-
 export interface PrepareToAspirateRunTimeCommand
   extends CommonCommandRunTimeInfo,
     PrepareToAspirateCreateCommand {
@@ -174,7 +179,6 @@ export interface GetTipPresenceCreateCommand extends CommonCommandCreateInfo {
   commandType: 'getTipPresence'
   params: PipetteIdentityParams
 }
-
 export interface GetTipPresenceRunTimeCommand
   extends CommonCommandRunTimeInfo,
     GetTipPresenceCreateCommand {
@@ -186,11 +190,20 @@ export interface VerifyTipPresenceCreateCommand
   commandType: 'verifyTipPresence'
   params: VerifyTipPresenceParams
 }
-
 export interface VerifyTipPresenceRunTimeCommand
   extends CommonCommandRunTimeInfo,
     VerifyTipPresenceCreateCommand {
   result?: any
+}
+
+export interface LiquidProbeCreateCommand extends CommonCommandCreateInfo {
+  commandType: 'liquidProbe'
+  params: WellLocationParam & PipetteAccessParams
+}
+export interface LiquidProbeRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    LiquidProbeCreateCommand {
+  result?: Record<string, unknown>
 }
 
 export type AspDispAirgapParams = FlowRateParams &


### PR DESCRIPTION
# Overview

The frontend has some code to decide, based on the failed command and its error, which error recovery flow to run. This updates that code to follow the interface that the server will use in the upcoming release.

Closes EXEC-594.

# Test plan

* [x] Induce a run error and make sure it still starts the correct recovery flow.

# Changelog

* Unify `OVERPRESSURE_WHILE_ASPIRATING` and `OVERPRESSURE_WHILE_DISPENSING`. My plan is for the server to use `errorType: 'overpressure'` for both, and the client will use `commandType` to disambiguate. This PR makes the client do that. The client currently just handles `aspirate` and `dispense`—see EXEC-593 for `aspirateInPlace` and `dispenseInPlace`.
* Fill in the `NO_LIQUID_DETECTED` placeholder.
* Remove, without filling in, the `PIPETTE_COLLISION` placeholder. [The server will not emit this error type in the upcoming release](https://opentrons.slack.com/archives/C06M9F26YGH/p1719863593167419?thread_ts=1719429843.314929&cid=C06M9F26YGH), and there is not an HTTP API for it yet.
* Some other minor adjustments—see inline notes.

# Review requests

See inline notes.

# Risk assessment

Low.
