### PR TITLE
docs(api): fix stringified runtime parameter value

### DIFF
--- a/api/docs/v2/parameters/using_values.rst
+++ b/api/docs/v2/parameters/using_values.rst
@@ -88,7 +88,7 @@ An example of such an action is applying labware offset data. Say you have a par
 
     # within run()
     plate = protocol.load_labware(
-        load_name="protocol.params.plate_type", location="D2"
+        load_name=protocol.params.plate_type, location="D2"
     )
 
 When performing run setup, you're prompted to apply offsets before selecting parameter values. This is your only opportunity to apply offsets, so they're applied for the default parameter values — in this case, the Corning plate. If you then change the "Well plate type" parameter to the NEST plate, the NEST plate will have default offset values (0.0 on all axes). You can fix this by running Labware Position Check, since it takes place after reanalysis, or by using :py:meth:`.Labware.set_offset` in your protocol.


### PR DESCRIPTION
# Overview

RTP value was inside quotes. That won't work.

This is a docs hotfix. Once approved and tests pass, the commit from this branch will be tagged, docs deployed, and then this branch will be regular-merged to `edge`.

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-hotfix-stringified-rtp/v2/parameters/using_values.html#limitations) – make sure no references to 2.20 here

