### PR TITLE
fix(ci): analyses snapshot test trigger and step if logic improvements

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -16,6 +16,8 @@ on:
   pull_request:
     paths:
       - 'api/**'
+      - '!api/tests/**'
+      - '!api/docs/**'
       - 'shared-data/**/*'
       - '!shared-data/js/**'
 
@@ -65,14 +67,15 @@ jobs:
         path: analyses-snapshot-testing/results/
 
     - name: Handle Test Failure
-      if: failure()
+      id: handle_failure
+      if: steps.run_test.outcome == 'failure'
       working-directory: analyses-snapshot-testing
       run: make snapshot-test-update
 
     - name: Create Snapshot update Request
-      id: create-pull-request
-      if: failure()
-      uses: peter-evans/create-pull-request@v5
+      id: create_pull_request
+      if: steps.handle_failure.outcome == 'success'
+      uses: peter-evans/create-pull-request@v6
       with:
           commit-message: 'fix(analyses-snapshot-testing): snapshot failure capture'
           title: 'fix(analyses-snapshot-testing): ${{ env.ANALYSIS_REF }} snapshot failure capture'
@@ -81,7 +84,7 @@ jobs:
           base: ${{ env.SNAPSHOT_REF}}
 
     - name: Comment on PR
-      if: failure() && github.event_name == 'pull_request'
+      if: steps.create_pull_request.outcome == 'success' && github.event_name == 'pull_request'
       uses: actions/github-script@v7
       with:
         script: |


### PR DESCRIPTION
### Update analyses snapshot workflow so that:

- [x] doc or test changes alone do not trigger the test
- [x] only run the snapshot-update if the tests actually ran and failed
- [x] only run the PR creator if the snapshot update actually ran successfully
- [x] only comment on the PR if the PR creator was successful
- [x] update to v6 of PR creator