### PR TITLE
refactor(robot-server): Rename EngineStore to RunOrchestratorStore

### DIFF
--- a/robot-server/robot_server/commands/get_default_orchestrator.py
+++ b/robot-server/robot_server/commands/get_default_orchestrator.py
@@ -10,8 +10,11 @@ from opentrons_shared_data.errors import ErrorCodes
 
 from robot_server.errors.error_responses import ErrorDetails
 from robot_server.hardware import get_hardware
-from robot_server.runs.dependencies import get_engine_store
-from robot_server.runs.engine_store import EngineStore, EngineConflictError
+from robot_server.runs.dependencies import get_run_orchestrator_store
+from robot_server.runs.run_orchestrator_store import (
+    RunOrchestratorStore,
+    RunConflictError,
+)
 from robot_server.modules.module_identifier import ModuleIdentifier
 
 
@@ -31,14 +34,14 @@ class RunActive(ErrorDetails):
 
 
 async def get_default_orchestrator(
-    engine_store: EngineStore = Depends(get_engine_store),
+    run_orchestrator_store: RunOrchestratorStore = Depends(get_run_orchestrator_store),
     hardware_api: HardwareControlAPI = Depends(get_hardware),
     module_identifier: ModuleIdentifier = Depends(ModuleIdentifier),
 ) -> RunOrchestrator:
     """Get the default run orchestrator with attached modules loaded."""
     try:
-        orchestrator = await engine_store.get_default_orchestrator()
-    except EngineConflictError as e:
+        orchestrator = await run_orchestrator_store.get_default_orchestrator()
+    except RunConflictError as e:
         raise RunActive.from_exc(e).as_error(status.HTTP_409_CONFLICT) from e
 
     attached_modules = hardware_api.attached_modules

--- a/robot-server/robot_server/maintenance_runs/dependencies.py
+++ b/robot-server/robot_server/maintenance_runs/dependencies.py
@@ -13,43 +13,46 @@ from server_utils.fastapi_utils.app_state import (
 )
 from robot_server.hardware import get_hardware, get_deck_type, get_robot_type
 
-from .maintenance_engine_store import MaintenanceEngineStore
+from .maintenance_run_orchestrator_store import MaintenanceRunOrchestratorStore
 from .maintenance_run_data_manager import MaintenanceRunDataManager
 from robot_server.service.notifications import (
     MaintenanceRunsPublisher,
     get_maintenance_runs_publisher,
 )
 
-_engine_store_accessor = AppStateAccessor[MaintenanceEngineStore](
-    "maintenance_engine_store"
+_run_orchestrator_store_accessor = AppStateAccessor[MaintenanceRunOrchestratorStore](
+    "maintenance_run_orchestrator_store"
 )
 
 
-async def get_maintenance_engine_store(
+async def get_maintenance_run_orchestrator_store(
     app_state: AppState = Depends(get_app_state),
     hardware_api: HardwareControlAPI = Depends(get_hardware),
     deck_type: DeckType = Depends(get_deck_type),
     robot_type: RobotType = Depends(get_robot_type),
-) -> MaintenanceEngineStore:
-    """Get a singleton MaintenanceEngineStore to keep track of created engines / runners."""
-    engine_store = _engine_store_accessor.get_from(app_state)
+) -> MaintenanceRunOrchestratorStore:
+    """Get a singleton MaintenanceRunOrchestratorStore to keep track of created engines / runners."""
+    run_orchestrator_store = _run_orchestrator_store_accessor.get_from(app_state)
 
-    if engine_store is None:
-        engine_store = MaintenanceEngineStore(
+    if run_orchestrator_store is None:
+        run_orchestrator_store = MaintenanceRunOrchestratorStore(
             hardware_api=hardware_api, robot_type=robot_type, deck_type=deck_type
         )
-        _engine_store_accessor.set_on(app_state, engine_store)
+        _run_orchestrator_store_accessor.set_on(app_state, run_orchestrator_store)
 
-    return engine_store
+    return run_orchestrator_store
 
 
 async def get_maintenance_run_data_manager(
-    engine_store: MaintenanceEngineStore = Depends(get_maintenance_engine_store),
+    run_orchestrator_store: MaintenanceRunOrchestratorStore = Depends(
+        get_maintenance_run_orchestrator_store
+    ),
     maintenance_runs_publisher: MaintenanceRunsPublisher = Depends(
         get_maintenance_runs_publisher
     ),
 ) -> MaintenanceRunDataManager:
     """Get a maintenance run data manager to keep track of current run data."""
     return MaintenanceRunDataManager(
-        engine_store=engine_store, maintenance_runs_publisher=maintenance_runs_publisher
+        run_orchestrator_store=run_orchestrator_store,
+        maintenance_runs_publisher=maintenance_runs_publisher,
     )

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_data_manager.py
@@ -148,7 +148,7 @@ class MaintenanceRunDataManager:
             run_id: The identifier of the run to remove.
 
         Raises:
-            EngineConflictError: If deleting the current run, the current run
+            RunConflictError: If deleting the current run, the current run
                 is not idle and cannot be deleted.
             RunNotFoundError: The given run identifier was not found.
         """

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -108,7 +108,7 @@ class MaintenanceRunOrchestratorStore:
         robot_type: RobotType,
         deck_type: DeckType,
     ) -> None:
-        """Initialize an engine storage interface.
+        """Initialize a run orchestrator storage interface.
 
         Arguments:
             hardware_api: Hardware control API instance used for ProtocolEngine
@@ -130,7 +130,7 @@ class MaintenanceRunOrchestratorStore:
 
     @property
     def current_run_id(self) -> Optional[str]:
-        """Get the run identifier associated with the current engine."""
+        """Get the run identifier associated with the current run orchestrator."""
         return (
             self.run_orchestrator.run_id if self._run_orchestrator is not None else None
         )
@@ -152,16 +152,16 @@ class MaintenanceRunOrchestratorStore:
         """Create and store a ProtocolRunner and ProtocolEngine for a given Run.
 
         Args:
-            run_id: The run resource the engine is assigned to.
+            run_id: The run resource the run orchestrator is assigned to.
             created_at: Run creation datetime
-            labware_offsets: Labware offsets to create the engine with.
+            labware_offsets: Labware offsets to create the run with.
             notify_publishers: Utilized by the engine to notify publishers of state changes.
 
         Returns:
             The initial equipment and status summary of the engine.
         """
-        # Because we will be clearing engine store before creating a new one,
-        # the runner-engine pair should be None at this point.
+        # Because we will be clearing run orchestrator store before creating a new one,
+        # the run orchestrator should be None at this point.
         assert (
             self._run_orchestrator is None
         ), "There is an active maintenance run that was not cleared correctly."
@@ -194,8 +194,8 @@ class MaintenanceRunOrchestratorStore:
         """Remove the ProtocolEngine.
 
         Raises:
-            EngineConflictError: The current runner/engine pair is not idle, so
-            they cannot be cleared.
+            RunConflictError: The current run orchestrator is not idle, so
+            it cannot be cleared.
         """
         if self.run_orchestrator.get_is_okay_to_clear():
             await self.run_orchestrator.finish(

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -31,7 +31,7 @@ from ..maintenance_run_models import (
     MaintenanceRunCreate,
     MaintenanceRunNotFoundError,
 )
-from ..maintenance_engine_store import EngineConflictError
+from ..maintenance_run_orchestrator_store import RunConflictError
 from ..maintenance_run_data_manager import MaintenanceRunDataManager
 from ..dependencies import get_maintenance_run_data_manager
 
@@ -279,7 +279,7 @@ async def remove_run(
     try:
         await run_data_manager.delete(runId)
 
-    except EngineConflictError as e:
+    except RunConflictError as e:
         raise RunNotIdle().as_error(status.HTTP_409_CONFLICT) from e
     except MaintenanceRunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e

--- a/robot-server/robot_server/maintenance_runs/router/labware_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/labware_router.py
@@ -9,8 +9,8 @@ from robot_server.errors.error_responses import ErrorBody
 from robot_server.service.json_api import RequestModel, SimpleBody, PydanticResponse
 
 from ..maintenance_run_models import MaintenanceRun, LabwareDefinitionSummary
-from ..maintenance_engine_store import MaintenanceEngineStore
-from ..dependencies import get_maintenance_engine_store
+from ..maintenance_run_orchestrator_store import MaintenanceRunOrchestratorStore
+from ..dependencies import get_maintenance_run_orchestrator_store
 from .base_router import RunNotFound, RunNotIdle, get_run_data_from_url
 
 log = logging.getLogger(__name__)
@@ -37,17 +37,19 @@ labware_router = APIRouter()
 )
 async def add_labware_offset(
     request_body: RequestModel[LabwareOffsetCreate],
-    engine_store: MaintenanceEngineStore = Depends(get_maintenance_engine_store),
+    run_orchestrator_store: MaintenanceRunOrchestratorStore = Depends(
+        get_maintenance_run_orchestrator_store
+    ),
     run: MaintenanceRun = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[LabwareOffset]]:
     """Add a labware offset to a maintenance run.
 
     Args:
         request_body: New labware offset request data from request body.
-        engine_store: Engine storage interface.
+        run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
-    added_offset = engine_store.add_labware_offset(request_body.data)
+    added_offset = run_orchestrator_store.add_labware_offset(request_body.data)
     log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
 
     return await PydanticResponse.create(
@@ -74,17 +76,19 @@ async def add_labware_offset(
 )
 async def add_labware_definition(
     request_body: RequestModel[LabwareDefinition],
-    engine_store: MaintenanceEngineStore = Depends(get_maintenance_engine_store),
+    run_orchestrator_store: MaintenanceRunOrchestratorStore = Depends(
+        get_maintenance_run_orchestrator_store
+    ),
     run: MaintenanceRun = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[LabwareDefinitionSummary]]:
     """Add a labware offset to a run.
 
     Args:
         request_body: New labware offset request data from request body.
-        engine_store: Engine storage interface.
+        run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
-    uri = engine_store.add_labware_definition(request_body.data)
+    uri = run_orchestrator_store.add_labware_definition(request_body.data)
     log.info(f'Added labware definition "{uri}"' f' to run "{run.id}".')
 
     return PydanticResponse(

--- a/robot-server/robot_server/runs/light_control_task.py
+++ b/robot-server/robot_server/runs/light_control_task.py
@@ -4,7 +4,7 @@ from logging import getLogger
 import asyncio
 from dataclasses import dataclass
 
-from .engine_store import EngineStore
+from .run_orchestrator_store import RunOrchestratorStore
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine.types import EngineStatus
 from opentrons.hardware_control.types import (
@@ -89,20 +89,24 @@ class LightController:
     """LightController sets the Flex's status bar to match the protocol status."""
 
     def __init__(
-        self, api: HardwareControlAPI, engine_store: Optional[EngineStore]
+        self,
+        api: HardwareControlAPI,
+        run_orchestrator_store: Optional[RunOrchestratorStore],
     ) -> None:
         """Create a new LightController."""
         self._api = api
-        self._engine_store = engine_store
+        self._run_orchestrator_store = run_orchestrator_store
         self._initialization_done = False
 
     def mark_initialization_done(self) -> None:
         """Called once the robot server hardware initialization finishes."""
         self._initialization_done = True
 
-    def update_engine_store(self, engine_store: EngineStore) -> None:
+    def update_run_orchestrator_store(
+        self, run_orchestrator_store: RunOrchestratorStore
+    ) -> None:
         """Provide a handle to an EngineStore for the light control task."""
-        self._engine_store = engine_store
+        self._run_orchestrator_store = run_orchestrator_store
 
     async def update(self, prev_status: Optional[Status], new_status: Status) -> None:
         """Update the status bar if the current run status has changed."""
@@ -137,11 +141,11 @@ class LightController:
 
     def _get_current_engine_status(self) -> Optional[EngineStatus]:
         """Get the `status` value from the engine's active run engine."""
-        if self._engine_store is None:
+        if self._run_orchestrator_store is None:
             return None
-        current_id = self._engine_store.current_run_id
+        current_id = self._run_orchestrator_store.current_run_id
         if current_id is not None:
-            return self._engine_store.get_status()
+            return self._run_orchestrator_store.get_status()
 
         return None
 

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -17,17 +17,19 @@ from robot_server.deck_configuration.fastapi_dependencies import (
 from robot_server.deck_configuration.store import DeckConfigurationStore
 from opentrons.protocol_engine.types import DeckConfigurationType
 
-from ..engine_store import EngineStore
+from ..run_orchestrator_store import RunOrchestratorStore
 from ..run_store import RunStore
 from ..run_models import RunNotFoundError
 from ..run_controller import RunController, RunActionNotAllowedError
 from ..action_models import RunAction, RunActionCreate, RunActionType
-from ..dependencies import get_engine_store, get_run_store
+from ..dependencies import get_run_orchestrator_store, get_run_store
 from .base_router import RunNotFound, RunStopped
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
 )
-from robot_server.maintenance_runs.dependencies import get_maintenance_engine_store
+from robot_server.maintenance_runs.dependencies import (
+    get_maintenance_run_orchestrator_store,
+)
 from robot_server.service.notifications import get_runs_publisher, RunsPublisher
 
 log = logging.getLogger(__name__)
@@ -44,7 +46,7 @@ class RunActionNotAllowed(ErrorDetails):
 async def get_run_controller(
     runId: str,
     task_runner: TaskRunner = Depends(get_task_runner),
-    engine_store: EngineStore = Depends(get_engine_store),
+    run_orchestrator_store: RunOrchestratorStore = Depends(get_run_orchestrator_store),
     run_store: RunStore = Depends(get_run_store),
     runs_publisher: RunsPublisher = Depends(get_runs_publisher),
 ) -> RunController:
@@ -59,7 +61,7 @@ async def get_run_controller(
             status.HTTP_404_NOT_FOUND
         )
 
-    if runId != engine_store.current_run_id:
+    if runId != run_orchestrator_store.current_run_id:
         raise RunStopped(detail=f"Run {runId} is not the current run").as_error(
             status.HTTP_409_CONFLICT
         )
@@ -67,7 +69,7 @@ async def get_run_controller(
     return RunController(
         run_id=runId,
         task_runner=task_runner,
-        engine_store=engine_store,
+        run_orchestrator_store=run_orchestrator_store,
         run_store=run_store,
         runs_publisher=runs_publisher,
     )
@@ -93,8 +95,8 @@ async def create_run_action(
     run_controller: RunController = Depends(get_run_controller),
     action_id: str = Depends(get_unique_id),
     created_at: datetime = Depends(get_current_time),
-    maintenance_engine_store: MaintenanceEngineStore = Depends(
-        get_maintenance_engine_store
+    maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore = Depends(
+        get_maintenance_run_orchestrator_store
     ),
     deck_configuration_store: DeckConfigurationStore = Depends(
         get_deck_configuration_store
@@ -110,11 +112,11 @@ async def create_run_action(
     Arguments:
         runId: Run ID pulled from the URL.
         request_body: Input payload from the request body.
-        engine_store: Dependency to fetch the engine store.
+        run_orchestrator_store: Dependency to fetch the engine store.
         run_controller: Run controller bound to the given run ID.
         action_id: Generated ID to assign to the control action.
         created_at: Timestamp to attach to the control action.
-        maintenance_engine_store: The maintenance run's EngineStore
+        maintenance_run_orchestrator_store: The maintenance run's EngineStore
         deck_configuration_store: The deck configuration store
         check_estop: Dependency to verify the estop is in a valid state.
         deck_configuration_store: Dependency to fetch the deck configuration.
@@ -122,9 +124,9 @@ async def create_run_action(
     action_type = request_body.data.actionType
     if (
         action_type == RunActionType.PLAY
-        and maintenance_engine_store.current_run_id is not None
+        and maintenance_run_orchestrator_store.current_run_id is not None
     ):
-        await maintenance_engine_store.clear()
+        await maintenance_run_orchestrator_store.clear()
     try:
         deck_configuration: DeckConfigurationType = []
         if action_type == RunActionType.PLAY:

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -37,7 +37,7 @@ from robot_server.protocols.router import ProtocolNotFound
 from ..run_models import RunNotFoundError
 from ..run_auto_deleter import RunAutoDeleter
 from ..run_models import Run, BadRun, RunCreate, RunUpdate
-from ..engine_store import EngineConflictError
+from ..run_orchestrator_store import RunConflictError
 from ..run_data_manager import RunDataManager, RunNotCurrentError
 from ..dependencies import get_run_data_manager, get_run_auto_deleter
 
@@ -192,7 +192,7 @@ async def create_run(
             protocol=protocol_resource,
             notify_publishers=notify_publishers,
         )
-    except EngineConflictError as e:
+    except RunConflictError as e:
         raise RunAlreadyActive(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
     except ProtocolNotFoundError as e:
         raise ProtocolNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
@@ -296,7 +296,7 @@ async def remove_run(
     try:
         await run_data_manager.delete(runId)
 
-    except EngineConflictError as e:
+    except RunConflictError as e:
         raise RunNotIdle().as_error(status.HTTP_409_CONFLICT) from e
 
     except RunNotFoundError as e:
@@ -335,7 +335,7 @@ async def update_run(
         run_data = await run_data_manager.update(
             runId, current=request_body.data.current
         )
-    except EngineConflictError as e:
+    except RunConflictError as e:
         raise RunNotIdle(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
     except RunNotCurrentError as e:
         raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e

--- a/robot-server/robot_server/runs/router/labware_router.py
+++ b/robot-server/robot_server/runs/router/labware_router.py
@@ -21,8 +21,8 @@ from robot_server.service.json_api import (
 
 from ..run_models import Run, LabwareDefinitionSummary
 from ..run_data_manager import RunDataManager, RunNotCurrentError
-from ..engine_store import EngineStore
-from ..dependencies import get_engine_store, get_run_data_manager
+from ..run_orchestrator_store import RunOrchestratorStore
+from ..dependencies import get_run_orchestrator_store, get_run_data_manager
 from .base_router import RunNotFound, RunStopped, RunNotIdle, get_run_data_from_url
 
 log = logging.getLogger(__name__)
@@ -49,14 +49,14 @@ labware_router = APIRouter()
 )
 async def add_labware_offset(
     request_body: RequestModel[LabwareOffsetCreate],
-    engine_store: EngineStore = Depends(get_engine_store),
+    run_orchestrator_store: RunOrchestratorStore = Depends(get_run_orchestrator_store),
     run: Run = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[LabwareOffset]]:
     """Add a labware offset to a run.
 
     Args:
         request_body: New labware offset request data from request body.
-        engine_store: Engine storage interface.
+        run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
     if run.current is False:
@@ -64,7 +64,7 @@ async def add_labware_offset(
             status.HTTP_409_CONFLICT
         )
 
-    added_offset = engine_store.add_labware_offset(request_body.data)
+    added_offset = run_orchestrator_store.add_labware_offset(request_body.data)
     log.info(f'Added labware offset "{added_offset.id}"' f' to run "{run.id}".')
 
     return await PydanticResponse.create(
@@ -91,14 +91,14 @@ async def add_labware_offset(
 )
 async def add_labware_definition(
     request_body: RequestModel[LabwareDefinition],
-    engine_store: EngineStore = Depends(get_engine_store),
+    run_orchestrator_store: RunOrchestratorStore = Depends(get_run_orchestrator_store),
     run: Run = Depends(get_run_data_from_url),
 ) -> PydanticResponse[SimpleBody[LabwareDefinitionSummary]]:
     """Add a labware offset to a run.
 
     Args:
         request_body: New labware offset request data from request body.
-        engine_store: Engine storage interface.
+        run_orchestrator_store: Engine storage interface.
         run: Run response data by ID from URL; ensures 404 if run not found.
     """
     if run.current is False:
@@ -106,7 +106,7 @@ async def add_labware_definition(
             status.HTTP_409_CONFLICT
         )
 
-    uri = engine_store.add_labware_definition(request_body.data)
+    uri = run_orchestrator_store.add_labware_definition(request_body.data)
     log.info(f'Added labware definition "{uri}"' f' to run "{run.id}".')
 
     return PydanticResponse(

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -18,7 +18,7 @@ from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.task_runner import TaskRunner
 from robot_server.service.notifications import RunsPublisher
 
-from .engine_store import EngineStore
+from .run_orchestrator_store import RunOrchestratorStore
 from .run_store import RunResource, RunStore, BadRunResource, BadStateSummary
 from .run_models import Run, BadRun, RunDataError
 
@@ -123,18 +123,18 @@ class RunDataManager:
     (historical runs). Returns `Run` response models to the router.
 
     Args:
-        engine_store: In-memory store of the current run's ProtocolEngine.
+        run_orchestrator_store: In-memory store of the current run's ProtocolEngine.
         run_store: Persistent database of current and historical run data.
     """
 
     def __init__(
         self,
-        engine_store: EngineStore,
+        run_orchestrator_store: RunOrchestratorStore,
         run_store: RunStore,
         task_runner: TaskRunner,
         runs_publisher: RunsPublisher,
     ) -> None:
-        self._engine_store = engine_store
+        self._run_orchestrator_store = run_orchestrator_store
         self._run_store = run_store
         self._task_runner = task_runner
         self._runs_publisher = runs_publisher
@@ -142,7 +142,7 @@ class RunDataManager:
     @property
     def current_run_id(self) -> Optional[str]:
         """The identifier of the current run, if any."""
-        return self._engine_store.current_run_id
+        return self._run_orchestrator_store.current_run_id
 
     async def create(
         self,
@@ -172,16 +172,16 @@ class RunDataManager:
             EngineConflictError: There is a currently active run that cannot
                 be superceded by this new run.
         """
-        prev_run_id = self._engine_store.current_run_id
+        prev_run_id = self._run_orchestrator_store.current_run_id
         if prev_run_id is not None:
-            prev_run_result = await self._engine_store.clear()
+            prev_run_result = await self._run_orchestrator_store.clear()
             self._run_store.update_run_state(
                 run_id=prev_run_id,
                 summary=prev_run_result.state_summary,
                 commands=prev_run_result.commands,
                 run_time_parameters=prev_run_result.parameters,
             )
-        state_summary = await self._engine_store.create(
+        state_summary = await self._run_orchestrator_store.create(
             run_id=run_id,
             labware_offsets=labware_offsets,
             deck_configuration=deck_configuration,
@@ -226,7 +226,7 @@ class RunDataManager:
         run_resource = self._run_store.get(run_id=run_id)
         state_summary = self._get_state_summary(run_id=run_id)
         parameters = self._get_run_time_parameters(run_id=run_id)
-        current = run_id == self._engine_store.current_run_id
+        current = run_id == self._run_orchestrator_store.current_run_id
 
         return _build_run(run_resource, state_summary, current, parameters)
 
@@ -249,12 +249,12 @@ class RunDataManager:
         """
         # The database doesn't store runs' loaded labware definitions in a way that we
         # can query quickly. Avoid it by only supporting this on in-memory runs.
-        if run_id != self._engine_store.current_run_id:
+        if run_id != self._run_orchestrator_store.current_run_id:
             raise RunNotCurrentError(
                 f"Cannot get load labware definitions of {run_id} because it is not the current run."
             )
 
-        return self._engine_store.get_loaded_labware_definitions()
+        return self._run_orchestrator_store.get_loaded_labware_definitions()
 
     def get_all(self, length: Optional[int]) -> List[Union[Run, BadRun]]:
         """Get current and stored run resources.
@@ -268,7 +268,8 @@ class RunDataManager:
             _build_run(
                 run_resource=run_resource,
                 state_summary=self._get_state_summary(run_resource.run_id),
-                current=run_resource.run_id == self._engine_store.current_run_id,
+                current=run_resource.run_id
+                == self._run_orchestrator_store.current_run_id,
                 run_time_parameters=self._get_run_time_parameters(run_resource.run_id),
             )
             for run_resource in self._run_store.get_all(length)
@@ -285,8 +286,8 @@ class RunDataManager:
                 is not idle and cannot be deleted.
             RunNotFoundError: The given run identifier was not found in the database.
         """
-        if run_id == self._engine_store.current_run_id:
-            await self._engine_store.clear()
+        if run_id == self._run_orchestrator_store.current_run_id:
+            await self._run_orchestrator_store.clear()
 
         await self._runs_publisher.clean_up_run(run_id=run_id)
 
@@ -312,7 +313,7 @@ class RunDataManager:
             RunNotCurrentError: The run is not the current run.
             EngineConflictError: The run cannot be updated because it is not idle.
         """
-        if run_id != self._engine_store.current_run_id:
+        if run_id != self._run_orchestrator_store.current_run_id:
             raise RunNotCurrentError(
                 f"Cannot update {run_id} because it is not the current run."
             )
@@ -320,7 +321,11 @@ class RunDataManager:
         next_current = current if current is False else True
 
         if next_current is False:
-            commands, state_summary, parameters = await self._engine_store.clear()
+            (
+                commands,
+                state_summary,
+                parameters,
+            ) = await self._run_orchestrator_store.clear()
             run_resource: Union[
                 RunResource, BadRunResource
             ] = self._run_store.update_run_state(
@@ -333,8 +338,8 @@ class RunDataManager:
                 run_id
             )
         else:
-            state_summary = self._engine_store.get_state_summary()
-            parameters = self._engine_store.get_run_time_parameters()
+            state_summary = self._run_orchestrator_store.get_state_summary()
+            parameters = self._run_orchestrator_store.get_run_time_parameters()
             run_resource = self._run_store.get(run_id=run_id)
 
         return _build_run(
@@ -360,8 +365,10 @@ class RunDataManager:
         Raises:
             RunNotFoundError: The given run identifier was not found in the database.
         """
-        if run_id == self._engine_store.current_run_id:
-            return self._engine_store.get_command_slice(cursor=cursor, length=length)
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_command_slice(
+                cursor=cursor, length=length
+            )
 
         # Let exception propagate
         return self._run_store.get_commands_slice(
@@ -377,8 +384,8 @@ class RunDataManager:
         Args:
             run_id: ID of the run.
         """
-        if self._engine_store.current_run_id == run_id:
-            return self._engine_store.get_current_command()
+        if self._run_orchestrator_store.current_run_id == run_id:
+            return self._run_orchestrator_store.get_current_command()
         else:
             # todo(mm, 2024-05-20):
             # For historical runs to behave consistently with the current run,
@@ -393,8 +400,8 @@ class RunDataManager:
         Args:
             run_id: ID of the run.
         """
-        if self._engine_store.current_run_id == run_id:
-            return self._engine_store.get_command_recovery_target()
+        if self._run_orchestrator_store.current_run_id == run_id:
+            return self._run_orchestrator_store.get_command_recovery_target()
         else:
             # Historical runs can't have any ongoing error recovery.
             return None
@@ -410,16 +417,16 @@ class RunDataManager:
             RunNotFoundError: The given run identifier was not found.
             CommandNotFoundError: The given command identifier was not found.
         """
-        if self._engine_store.current_run_id == run_id:
-            return self._engine_store.get_command(command_id=command_id)
+        if self._run_orchestrator_store.current_run_id == run_id:
+            return self._run_orchestrator_store.get_command(command_id=command_id)
 
         return self._run_store.get_command(run_id=run_id, command_id=command_id)
 
     def get_all_commands_as_preserialized_list(self, run_id: str) -> List[str]:
         """Get all commands of a run in a serialized json list."""
         if (
-            run_id == self._engine_store.current_run_id
-            and not self._engine_store.get_is_run_terminal()
+            run_id == self._run_orchestrator_store.current_run_id
+            and not self._run_orchestrator_store.get_is_run_terminal()
         ):
             raise PreSerializedCommandsNotAvailableError(
                 "Pre-serialized commands are only available after a run has ended."
@@ -427,8 +434,8 @@ class RunDataManager:
         return self._run_store.get_all_commands_as_preserialized_list(run_id)
 
     def _get_state_summary(self, run_id: str) -> Union[StateSummary, BadStateSummary]:
-        if run_id == self._engine_store.current_run_id:
-            return self._engine_store.get_state_summary()
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_state_summary()
         else:
             return self._run_store.get_state_summary(run_id=run_id)
 
@@ -437,7 +444,7 @@ class RunDataManager:
         return summary if isinstance(summary, StateSummary) else None
 
     def _get_run_time_parameters(self, run_id: str) -> List[RunTimeParameter]:
-        if run_id == self._engine_store.current_run_id:
-            return self._engine_store.get_run_time_parameters()
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_run_time_parameters()
         else:
             return self._run_store.get_run_time_parameters(run_id=run_id)

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -169,7 +169,7 @@ class RunDataManager:
             The run resource.
 
         Raise:
-            EngineConflictError: There is a currently active run that cannot
+            RunConflictError: There is a currently active run that cannot
                 be superceded by this new run.
         """
         prev_run_id = self._run_orchestrator_store.current_run_id
@@ -282,7 +282,7 @@ class RunDataManager:
             run_id: The identifier of the run to remove.
 
         Raises:
-            EngineConflictError: If deleting the current run, the current run
+            RunConflictError: If deleting the current run, the current run
                 is not idle and cannot be deleted.
             RunNotFoundError: The given run identifier was not found in the database.
         """
@@ -311,7 +311,7 @@ class RunDataManager:
         Raises:
             RunNotFoundError: The run identifier was not found in the database.
             RunNotCurrentError: The run is not the current run.
-            EngineConflictError: The run cannot be updated because it is not idle.
+            RunConflictError: The run cannot be updated because it is not idle.
         """
         if run_id != self._run_orchestrator_store.current_run_id:
             raise RunNotCurrentError(

--- a/robot-server/tests/maintenance_runs/router/conftest.py
+++ b/robot-server/tests/maintenance_runs/router/conftest.py
@@ -2,8 +2,8 @@
 import pytest
 from decoy import Decoy
 
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
 )
 from robot_server.maintenance_runs.maintenance_run_data_manager import (
     MaintenanceRunDataManager,
@@ -13,14 +13,16 @@ from robot_server.deck_configuration.store import DeckConfigurationStore
 
 
 @pytest.fixture()
-def mock_maintenance_engine_store(decoy: Decoy) -> MaintenanceEngineStore:
-    """Get a mock MaintenanceEngineStore interface."""
-    return decoy.mock(cls=MaintenanceEngineStore)
+def mock_maintenance_run_orchestrator_store(
+    decoy: Decoy,
+) -> MaintenanceRunOrchestratorStore:
+    """Get a mock MaintenanceRunOrchestratorStore interface."""
+    return decoy.mock(cls=MaintenanceRunOrchestratorStore)
 
 
 @pytest.fixture()
 def mock_protocol_engine(decoy: Decoy) -> ProtocolEngine:
-    """Get a mock MaintenanceEngineStore interface."""
+    """Get a mock MaintenanceRunOrchestratorStore interface."""
     return decoy.mock(cls=ProtocolEngine)
 
 

--- a/robot-server/tests/maintenance_runs/router/test_base_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_base_router.py
@@ -19,7 +19,9 @@ from robot_server.maintenance_runs.maintenance_run_models import (
     MaintenanceRunCreate,
     MaintenanceRunNotFoundError,
 )
-from robot_server.maintenance_runs.maintenance_engine_store import EngineConflictError
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    RunConflictError,
+)
 from robot_server.maintenance_runs.maintenance_run_data_manager import (
     MaintenanceRunDataManager,
 )
@@ -288,7 +290,7 @@ async def test_delete_active_run(
 ) -> None:
     """It should 409 if the run is not finished."""
     decoy.when(await mock_maintenance_run_data_manager.delete("run-id")).then_raise(
-        EngineConflictError("oh no")
+        RunConflictError("oh no")
     )
 
     with pytest.raises(ApiError) as exc_info:

--- a/robot-server/tests/maintenance_runs/router/test_labware_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_labware_router.py
@@ -14,8 +14,8 @@ from robot_server.maintenance_runs.maintenance_run_models import (
     MaintenanceRun,
     LabwareDefinitionSummary,
 )
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
 )
 from robot_server.maintenance_runs.router.labware_router import (
     add_labware_offset,
@@ -49,7 +49,7 @@ def labware_definition(minimal_labware_def: LabwareDefDict) -> LabwareDefinition
 
 async def test_add_labware_offset(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     run: MaintenanceRun,
 ) -> None:
     """It should add the labware offset to the engine, assuming the run is current."""
@@ -68,12 +68,14 @@ async def test_add_labware_offset(
     )
 
     decoy.when(
-        mock_maintenance_engine_store.add_labware_offset(labware_offset_request)
+        mock_maintenance_run_orchestrator_store.add_labware_offset(
+            labware_offset_request
+        )
     ).then_return(labware_offset)
 
     result = await add_labware_offset(
         request_body=RequestModel(data=labware_offset_request),
-        engine_store=mock_maintenance_engine_store,
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         run=run,
     )
 
@@ -83,7 +85,7 @@ async def test_add_labware_offset(
 
 async def test_add_labware_definition(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     run: MaintenanceRun,
     labware_definition: LabwareDefinition,
 ) -> None:
@@ -91,11 +93,13 @@ async def test_add_labware_definition(
     uri = pe_types.LabwareUri("some/definition/uri")
 
     decoy.when(
-        mock_maintenance_engine_store.add_labware_definition(labware_definition)
+        mock_maintenance_run_orchestrator_store.add_labware_definition(
+            labware_definition
+        )
     ).then_return(uri)
 
     result = await add_labware_definition(
-        engine_store=mock_maintenance_engine_store,
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         run=run,
         request_body=RequestModel(data=labware_definition),
     )

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -1,4 +1,4 @@
-"""Tests for the MaintenanceEngineStore interface."""
+"""Tests for the MaintenanceRunOrchestratorStore interface."""
 from datetime import datetime
 
 import pytest
@@ -16,9 +16,9 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_runner import RunResult
 
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
-    EngineConflictError,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
+    RunConflictError,
     handle_estop_event,
     NoRunOrchestrator,
 )
@@ -30,21 +30,21 @@ def mock_notify_publishers() -> None:
 
 
 @pytest.fixture
-async def subject(decoy: Decoy) -> MaintenanceEngineStore:
-    """Get a MaintenanceEngineStore test subject."""
+async def subject(decoy: Decoy) -> MaintenanceRunOrchestratorStore:
+    """Get a MaintenanceRunOrchestratorStore test subject."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
-    return MaintenanceEngineStore(
+    return MaintenanceRunOrchestratorStore(
         hardware_api=hardware_api,
         # Arbitrary choice of robot and deck type. Tests where these matter should
-        # construct their own MaintenanceEngineStore.
+        # construct their own MaintenanceRunOrchestratorStore.
         robot_type="OT-2 Standard",
         deck_type=pe_types.DeckType.OT2_SHORT_TRASH,
     )
 
 
-async def test_create_engine(subject: MaintenanceEngineStore) -> None:
+async def test_create_engine(subject: MaintenanceRunOrchestratorStore) -> None:
     """It should create an engine for a run."""
     result = await subject.create(
         run_id="run-id",
@@ -59,7 +59,7 @@ async def test_create_engine(subject: MaintenanceEngineStore) -> None:
     assert subject.run_orchestrator.get_protocol_runner() is None
 
 
-def test_run_created_at_raises(subject: MaintenanceEngineStore) -> None:
+def test_run_created_at_raises(subject: MaintenanceRunOrchestratorStore) -> None:
     """Should raise that the run has not yet created."""
     with pytest.raises(AssertionError):
         subject.current_run_created_at
@@ -74,7 +74,7 @@ async def test_create_engine_uses_robot_and_deck_type(
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
-    subject = MaintenanceEngineStore(
+    subject = MaintenanceRunOrchestratorStore(
         hardware_api=hardware_api,
         robot_type=robot_type,
         deck_type=deck_type,
@@ -92,7 +92,7 @@ async def test_create_engine_uses_robot_and_deck_type(
 
 
 async def test_create_engine_with_labware_offsets(
-    subject: MaintenanceEngineStore,
+    subject: MaintenanceRunOrchestratorStore,
 ) -> None:
     """It should create an engine for a run with labware offsets."""
     labware_offset = pe_types.LabwareOffsetCreate(
@@ -119,7 +119,7 @@ async def test_create_engine_with_labware_offsets(
     ]
 
 
-async def test_clear_engine(subject: MaintenanceEngineStore) -> None:
+async def test_clear_engine(subject: MaintenanceRunOrchestratorStore) -> None:
     """It should clear a stored engine entry."""
     await subject.create(
         run_id="run-id",
@@ -139,7 +139,7 @@ async def test_clear_engine(subject: MaintenanceEngineStore) -> None:
 
 
 async def test_clear_engine_not_stopped_or_idle(
-    subject: MaintenanceEngineStore,
+    subject: MaintenanceRunOrchestratorStore,
 ) -> None:
     """It should raise a conflict if the engine is not stopped."""
     await subject.create(
@@ -150,11 +150,11 @@ async def test_clear_engine_not_stopped_or_idle(
     )
     subject.run_orchestrator.play()
 
-    with pytest.raises(EngineConflictError):
+    with pytest.raises(RunConflictError):
         await subject.clear()
 
 
-async def test_clear_idle_engine(subject: MaintenanceEngineStore) -> None:
+async def test_clear_idle_engine(subject: MaintenanceRunOrchestratorStore) -> None:
     """It should successfully clear engine if idle (not started)."""
     await subject.create(
         run_id="run-id",
@@ -175,7 +175,7 @@ async def test_estop_callback(
     decoy: Decoy,
 ) -> None:
     """The callback should stop an active engine."""
-    engine_store = decoy.mock(cls=MaintenanceEngineStore)
+    run_orchestrator_store = decoy.mock(cls=MaintenanceRunOrchestratorStore)
 
     disengage_event = EstopStateNotification(
         old_state=EstopState.PHYSICALLY_ENGAGED, new_state=EstopState.LOGICALLY_ENGAGED
@@ -184,24 +184,24 @@ async def test_estop_callback(
         old_state=EstopState.LOGICALLY_ENGAGED, new_state=EstopState.PHYSICALLY_ENGAGED
     )
 
-    decoy.when(engine_store.current_run_id).then_return(None)
-    await handle_estop_event(engine_store, disengage_event)
+    decoy.when(run_orchestrator_store.current_run_id).then_return(None)
+    await handle_estop_event(run_orchestrator_store, disengage_event)
     decoy.verify(
-        engine_store.run_orchestrator.estop(),
+        run_orchestrator_store.run_orchestrator.estop(),
         ignore_extra_args=True,
         times=0,
     )
     decoy.verify(
-        await engine_store.run_orchestrator.finish(),
+        await run_orchestrator_store.run_orchestrator.finish(),
         ignore_extra_args=True,
         times=0,
     )
 
-    decoy.when(engine_store.current_run_id).then_return("fake-run-id")
-    await handle_estop_event(engine_store, engage_event)
+    decoy.when(run_orchestrator_store.current_run_id).then_return("fake-run-id")
+    await handle_estop_event(run_orchestrator_store, engage_event)
     decoy.verify(
-        engine_store.run_orchestrator.estop(),
-        await engine_store.run_orchestrator.finish(
+        run_orchestrator_store.run_orchestrator.estop(),
+        await run_orchestrator_store.run_orchestrator.finish(
             error=matchers.IsA(EStopActivatedError)
         ),
         times=1,

--- a/robot-server/tests/maintenance_runs/test_run_data_manager.py
+++ b/robot-server/tests/maintenance_runs/test_run_data_manager.py
@@ -17,9 +17,9 @@ from opentrons.protocol_engine import (
     LabwareOffset,
 )
 
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
-    EngineConflictError,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
+    RunConflictError,
 )
 from robot_server.maintenance_runs.maintenance_run_data_manager import (
     MaintenanceRunDataManager,
@@ -41,9 +41,11 @@ def mock_notify_publishers() -> None:
 
 
 @pytest.fixture
-def mock_maintenance_engine_store(decoy: Decoy) -> MaintenanceEngineStore:
-    """Get a mock MaintenanceEngineStore."""
-    mock = decoy.mock(cls=MaintenanceEngineStore)
+def mock_maintenance_run_orchestrator_store(
+    decoy: Decoy,
+) -> MaintenanceRunOrchestratorStore:
+    """Get a mock MaintenanceRunOrchestratorStore."""
+    mock = decoy.mock(cls=MaintenanceRunOrchestratorStore)
     decoy.when(mock.current_run_id).then_return(None)
     return mock
 
@@ -83,19 +85,19 @@ def run_command() -> commands.Command:
 
 @pytest.fixture
 def subject(
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_maintenance_runs_publisher: MaintenanceRunsPublisher,
 ) -> MaintenanceRunDataManager:
     """Get a MaintenanceRunDataManager test subject."""
     return MaintenanceRunDataManager(
-        engine_store=mock_maintenance_engine_store,
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         maintenance_runs_publisher=mock_maintenance_runs_publisher,
     )
 
 
 async def test_create(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
 ) -> None:
@@ -104,7 +106,7 @@ async def test_create(
     created_at = datetime(year=2021, month=1, day=1)
 
     decoy.when(
-        await mock_maintenance_engine_store.create(
+        await mock_maintenance_run_orchestrator_store.create(
             run_id=run_id,
             labware_offsets=[],
             created_at=created_at,
@@ -112,9 +114,9 @@ async def test_create(
             notify_publishers=mock_notify_publishers,
         )
     ).then_return(engine_state_summary)
-    decoy.when(mock_maintenance_engine_store.current_run_created_at).then_return(
-        created_at
-    )
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.current_run_created_at
+    ).then_return(created_at)
     result = await subject.create(
         run_id=run_id,
         created_at=created_at,
@@ -140,7 +142,7 @@ async def test_create(
 
 async def test_create_with_options(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
 ) -> None:
@@ -155,7 +157,7 @@ async def test_create_with_options(
     )
 
     decoy.when(
-        await mock_maintenance_engine_store.create(
+        await mock_maintenance_run_orchestrator_store.create(
             run_id=run_id,
             labware_offsets=[labware_offset],
             created_at=created_at,
@@ -163,9 +165,9 @@ async def test_create_with_options(
             notify_publishers=mock_notify_publishers,
         )
     ).then_return(engine_state_summary)
-    decoy.when(mock_maintenance_engine_store.current_run_created_at).then_return(
-        created_at
-    )
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.current_run_created_at
+    ).then_return(created_at)
 
     result = await subject.create(
         run_id=run_id,
@@ -192,7 +194,7 @@ async def test_create_with_options(
 
 async def test_create_engine_error(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
 ) -> None:
     """It should not create a resource if engine creation fails."""
@@ -200,19 +202,19 @@ async def test_create_engine_error(
     created_at = datetime(year=2021, month=1, day=1)
 
     decoy.when(
-        await mock_maintenance_engine_store.create(
+        await mock_maintenance_run_orchestrator_store.create(
             run_id,
             labware_offsets=[],
             created_at=created_at,
             deck_configuration=[],
             notify_publishers=mock_notify_publishers,
         )
-    ).then_raise(EngineConflictError("oh no"))
-    decoy.when(mock_maintenance_engine_store.current_run_created_at).then_return(
-        created_at
-    )
+    ).then_raise(RunConflictError("oh no"))
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.current_run_created_at
+    ).then_return(created_at)
 
-    with pytest.raises(EngineConflictError):
+    with pytest.raises(RunConflictError):
         await subject.create(
             run_id=run_id,
             created_at=created_at,
@@ -224,20 +226,22 @@ async def test_create_engine_error(
 
 async def test_get_current_run(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
 ) -> None:
     """It should get the current run from the engine."""
     run_id = "hello world"
 
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return(run_id)
-    decoy.when(mock_maintenance_engine_store.get_state_summary()).then_return(
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
+        run_id
+    )
+    decoy.when(mock_maintenance_run_orchestrator_store.get_state_summary()).then_return(
         engine_state_summary
     )
-    decoy.when(mock_maintenance_engine_store.current_run_created_at).then_return(
-        datetime(2023, 1, 1)
-    )
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.current_run_created_at
+    ).then_return(datetime(2023, 1, 1))
 
     result = subject.get(run_id=run_id)
 
@@ -259,14 +263,14 @@ async def test_get_current_run(
 
 async def test_get_run_not_current(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
 ) -> None:
     """It should raise a MaintenanceRunNotFoundError."""
     run_id = "hello world"
 
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return(
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
         "not-current-id"
     )
     with pytest.raises(MaintenanceRunNotFoundError):
@@ -275,24 +279,26 @@ async def test_get_run_not_current(
 
 async def test_delete_current_run(
     decoy: Decoy,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
 ) -> None:
     """It should delete the current run from the engine."""
     run_id = "hello world"
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return(run_id)
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
+        run_id
+    )
 
     await subject.delete(run_id=run_id)
 
     decoy.verify(
-        await mock_maintenance_engine_store.clear(),
+        await mock_maintenance_run_orchestrator_store.clear(),
     )
 
 
 def test_get_commands_slice_current_run(
     decoy: Decoy,
     subject: MaintenanceRunDataManager,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get a sliced command list from engine store."""
@@ -310,10 +316,12 @@ def test_get_commands_slice_current_run(
     expected_command_slice = CommandSlice(
         commands=expected_commands_result, cursor=1, total_length=3
     )
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return("run-id")
-    decoy.when(mock_maintenance_engine_store.get_command_slice(1, 2)).then_return(
-        expected_command_slice
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
+        "run-id"
     )
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.get_command_slice(1, 2)
+    ).then_return(expected_command_slice)
 
     result = subject.get_commands_slice("run-id", 1, 2)
 

--- a/robot-server/tests/runs/router/conftest.py
+++ b/robot-server/tests/runs/router/conftest.py
@@ -5,10 +5,10 @@ from decoy import Decoy
 from robot_server.protocols.protocol_store import ProtocolStore
 from robot_server.runs.run_auto_deleter import RunAutoDeleter
 from robot_server.runs.run_store import RunStore
-from robot_server.runs.engine_store import EngineStore
+from robot_server.runs.run_orchestrator_store import RunOrchestratorStore
 from robot_server.runs.run_data_manager import RunDataManager
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
 
@@ -28,9 +28,9 @@ def mock_run_store(decoy: Decoy) -> RunStore:
 
 
 @pytest.fixture()
-def mock_engine_store(decoy: Decoy) -> EngineStore:
+def mock_run_orchestrator_store(decoy: Decoy) -> RunOrchestratorStore:
     """Get a mock EngineStore interface."""
-    return decoy.mock(cls=EngineStore)
+    return decoy.mock(cls=RunOrchestratorStore)
 
 
 @pytest.fixture()
@@ -52,9 +52,11 @@ def mock_run_auto_deleter(decoy: Decoy) -> RunAutoDeleter:
 
 
 @pytest.fixture()
-def mock_maintenance_engine_store(decoy: Decoy) -> MaintenanceEngineStore:
-    """Get a mock MaintenanceEngineStore interface."""
-    return decoy.mock(cls=MaintenanceEngineStore)
+def mock_maintenance_run_orchestrator_store(
+    decoy: Decoy,
+) -> MaintenanceRunOrchestratorStore:
+    """Get a mock MaintenanceRunOrchestratorStore interface."""
+    return decoy.mock(cls=MaintenanceRunOrchestratorStore)
 
 
 @pytest.fixture

--- a/robot-server/tests/runs/router/test_actions_router.py
+++ b/robot-server/tests/runs/router/test_actions_router.py
@@ -14,8 +14,8 @@ from robot_server.runs.action_models import (
 )
 from robot_server.runs.router.actions_router import create_run_action
 
-from robot_server.maintenance_runs.maintenance_engine_store import (
-    MaintenanceEngineStore,
+from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
+    MaintenanceRunOrchestratorStore,
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
 
@@ -29,7 +29,7 @@ def mock_run_controller(decoy: Decoy) -> RunController:
 async def test_create_run_action(
     decoy: Decoy,
     mock_run_controller: RunController,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_deck_configuration_store: DeckConfigurationStore,
 ) -> None:
     """It should create a run action."""
@@ -46,7 +46,7 @@ async def test_create_run_action(
     decoy.when(
         await mock_deck_configuration_store.get_deck_configuration()
     ).then_return([])
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return(None)
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(None)
     decoy.when(
         mock_run_controller.create_action(
             action_id=action_id,
@@ -62,7 +62,7 @@ async def test_create_run_action(
         run_controller=mock_run_controller,
         action_id=action_id,
         created_at=created_at,
-        maintenance_engine_store=mock_maintenance_engine_store,
+        maintenance_run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         deck_configuration_store=mock_deck_configuration_store,
     )
 
@@ -73,7 +73,7 @@ async def test_create_run_action(
 async def test_play_action_clears_maintenance_run(
     decoy: Decoy,
     mock_run_controller: RunController,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_deck_configuration_store: DeckConfigurationStore,
 ) -> None:
     """It should clear an existing maintenance run before issuing play action."""
@@ -90,7 +90,9 @@ async def test_play_action_clears_maintenance_run(
     decoy.when(
         await mock_deck_configuration_store.get_deck_configuration()
     ).then_return([])
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return("some-id")
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
+        "some-id"
+    )
     decoy.when(
         mock_run_controller.create_action(
             action_id=action_id,
@@ -106,11 +108,11 @@ async def test_play_action_clears_maintenance_run(
         run_controller=mock_run_controller,
         action_id=action_id,
         created_at=created_at,
-        maintenance_engine_store=mock_maintenance_engine_store,
+        maintenance_run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         deck_configuration_store=mock_deck_configuration_store,
     )
 
-    decoy.verify(await mock_maintenance_engine_store.clear(), times=1)
+    decoy.verify(await mock_maintenance_run_orchestrator_store.clear(), times=1)
     assert result.content.data == expected_result
     assert result.status_code == 201
 
@@ -128,7 +130,7 @@ async def test_create_play_action_not_allowed(
     exception: Exception,
     expected_error_id: str,
     expected_status_code: int,
-    mock_maintenance_engine_store: MaintenanceEngineStore,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_deck_configuration_store: DeckConfigurationStore,
 ) -> None:
     """It should 409 if the runner is not able to handle the action."""
@@ -141,7 +143,7 @@ async def test_create_play_action_not_allowed(
     decoy.when(
         await mock_deck_configuration_store.get_deck_configuration()
     ).then_return([])
-    decoy.when(mock_maintenance_engine_store.current_run_id).then_return(None)
+    decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(None)
     decoy.when(
         mock_run_controller.create_action(
             action_id=action_id,
@@ -158,7 +160,7 @@ async def test_create_play_action_not_allowed(
             run_controller=mock_run_controller,
             action_id=action_id,
             created_at=created_at,
-            maintenance_engine_store=mock_maintenance_engine_store,
+            maintenance_run_orchestrator_store=mock_maintenance_run_orchestrator_store,
             deck_configuration_store=mock_deck_configuration_store,
         )
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -26,7 +26,7 @@ from robot_server.protocols.protocol_store import (
 from robot_server.runs.run_auto_deleter import RunAutoDeleter
 
 from robot_server.runs.run_models import Run, RunCreate, RunUpdate
-from robot_server.runs.engine_store import EngineConflictError
+from robot_server.runs.run_orchestrator_store import RunConflictError
 from robot_server.runs.run_data_manager import RunDataManager, RunNotCurrentError
 from robot_server.runs.run_models import RunNotFoundError
 from robot_server.runs.router.base_router import (
@@ -242,7 +242,7 @@ async def test_create_run_conflict(
             run_time_param_values=None,
             notify_publishers=mock_notify_publishers,
         )
-    ).then_raise(EngineConflictError("oh no"))
+    ).then_raise(RunConflictError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:
         await create_run(
@@ -433,7 +433,7 @@ async def test_delete_active_run(
 ) -> None:
     """It should 409 if the run is not finished."""
     decoy.when(await mock_run_data_manager.delete("run-id")).then_raise(
-        EngineConflictError("oh no")
+        RunConflictError("oh no")
     )
 
     with pytest.raises(ApiError) as exc_info:
@@ -538,7 +538,7 @@ async def test_update_to_current_conflict(
     """It should 409 if attempting to un-current a run that is not idle."""
     decoy.when(
         await mock_run_data_manager.update(run_id="run-id", current=False)
-    ).then_raise(EngineConflictError("oh no"))
+    ).then_raise(RunConflictError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:
         await update_run(

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -13,7 +13,7 @@ from robot_server.errors.error_responses import ApiError
 from robot_server.service.json_api import RequestModel, SimpleBody
 from robot_server.runs.run_models import Run, LabwareDefinitionSummary
 from robot_server.runs.run_data_manager import RunDataManager
-from robot_server.runs.engine_store import EngineStore
+from robot_server.runs.run_orchestrator_store import RunOrchestratorStore
 from robot_server.runs.router.labware_router import (
     add_labware_offset,
     add_labware_definition,
@@ -51,7 +51,7 @@ def labware_definition(minimal_labware_def: LabwareDefDict) -> LabwareDefinition
 
 async def test_add_labware_offset(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run: Run,
 ) -> None:
     """It should add the labware offset to the engine, assuming the run is current."""
@@ -70,12 +70,12 @@ async def test_add_labware_offset(
     )
 
     decoy.when(
-        mock_engine_store.add_labware_offset(labware_offset_request)
+        mock_run_orchestrator_store.add_labware_offset(labware_offset_request)
     ).then_return(labware_offset)
 
     result = await add_labware_offset(
         request_body=RequestModel(data=labware_offset_request),
-        engine_store=mock_engine_store,
+        run_orchestrator_store=mock_run_orchestrator_store,
         run=run,
     )
 
@@ -85,7 +85,7 @@ async def test_add_labware_offset(
 
 async def test_add_labware_offset_not_current(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run: Run,
 ) -> None:
     """It should 409 if the run is not current."""
@@ -100,7 +100,7 @@ async def test_add_labware_offset_not_current(
     with pytest.raises(ApiError) as exc_info:
         await add_labware_offset(
             request_body=RequestModel(data=labware_offset_request),
-            engine_store=mock_engine_store,
+            run_orchestrator_store=mock_run_orchestrator_store,
             run=not_current_run,
         )
 
@@ -110,7 +110,7 @@ async def test_add_labware_offset_not_current(
 
 async def test_add_labware_definition(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run: Run,
     labware_definition: LabwareDefinition,
 ) -> None:
@@ -118,11 +118,11 @@ async def test_add_labware_definition(
     uri = pe_types.LabwareUri("some/definition/uri")
 
     decoy.when(
-        mock_engine_store.add_labware_definition(labware_definition)
+        mock_run_orchestrator_store.add_labware_definition(labware_definition)
     ).then_return(uri)
 
     result = await add_labware_definition(
-        engine_store=mock_engine_store,
+        run_orchestrator_store=mock_run_orchestrator_store,
         run=run,
         request_body=RequestModel(data=labware_definition),
     )
@@ -133,7 +133,7 @@ async def test_add_labware_definition(
 
 async def test_add_labware_definition_not_current(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run: Run,
     labware_definition: LabwareDefinition,
 ) -> None:
@@ -142,7 +142,7 @@ async def test_add_labware_definition_not_current(
 
     with pytest.raises(ApiError) as exc_info:
         await add_labware_definition(
-            engine_store=mock_engine_store,
+            run_orchestrator_store=mock_run_orchestrator_store,
             run=not_current_run,
             request_body=RequestModel(data=labware_definition),
         )

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -17,9 +17,9 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_runner import RunResult, RunOrchestrator
 from opentrons.protocol_reader import ProtocolReader, ProtocolSource
 
-from robot_server.runs.engine_store import (
-    EngineStore,
-    EngineConflictError,
+from robot_server.runs.run_orchestrator_store import (
+    RunOrchestratorStore,
+    RunConflictError,
     NoRunOrchestrator,
     handle_estop_event,
 )
@@ -31,9 +31,11 @@ def mock_notify_publishers() -> None:
 
 
 @pytest.fixture
-async def subject(decoy: Decoy, hardware_api: HardwareControlAPI) -> EngineStore:
+async def subject(
+    decoy: Decoy, hardware_api: HardwareControlAPI
+) -> RunOrchestratorStore:
     """Get a EngineStore test subject."""
-    return EngineStore(
+    return RunOrchestratorStore(
         hardware_api=hardware_api,
         # Arbitrary choice of robot and deck type. Tests where these matter should
         # construct their own EngineStore.
@@ -51,7 +53,7 @@ async def json_protocol_source() -> ProtocolSource:
     return await ProtocolReader().read_saved(files=[simple_protocol], directory=None)
 
 
-async def test_create_engine(decoy: Decoy, subject: EngineStore) -> None:
+async def test_create_engine(decoy: Decoy, subject: RunOrchestratorStore) -> None:
     """It should create an engine for a run."""
     result = await subject.create(
         run_id="run-id",
@@ -76,7 +78,7 @@ async def test_create_engine_uses_robot_type(
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
-    subject = EngineStore(
+    subject = RunOrchestratorStore(
         hardware_api=hardware_api, robot_type=robot_type, deck_type=deck_type
     )
 
@@ -91,7 +93,9 @@ async def test_create_engine_uses_robot_type(
     assert subject._run_orchestrator is not None
 
 
-async def test_create_engine_with_labware_offsets(subject: EngineStore) -> None:
+async def test_create_engine_with_labware_offsets(
+    subject: RunOrchestratorStore,
+) -> None:
     """It should create an engine for a run with labware offsets."""
     labware_offset = pe_types.LabwareOffsetCreate(
         definitionUri="namespace/load_name/version",
@@ -118,7 +122,9 @@ async def test_create_engine_with_labware_offsets(subject: EngineStore) -> None:
     ]
 
 
-async def test_archives_state_if_engine_already_exists(subject: EngineStore) -> None:
+async def test_archives_state_if_engine_already_exists(
+    subject: RunOrchestratorStore,
+) -> None:
     """It should not create more than one engine / runner pair."""
     await subject.create(
         run_id="run-id-1",
@@ -128,7 +134,7 @@ async def test_archives_state_if_engine_already_exists(subject: EngineStore) -> 
         notify_publishers=mock_notify_publishers,
     )
 
-    with pytest.raises(EngineConflictError):
+    with pytest.raises(RunConflictError):
         await subject.create(
             run_id="run-id-2",
             labware_offsets=[],
@@ -140,7 +146,7 @@ async def test_archives_state_if_engine_already_exists(subject: EngineStore) -> 
     assert subject.current_run_id == "run-id-1"
 
 
-async def test_clear_engine(subject: EngineStore) -> None:
+async def test_clear_engine(subject: RunOrchestratorStore) -> None:
     """It should clear a stored engine entry."""
     await subject.create(
         run_id="run-id",
@@ -160,7 +166,7 @@ async def test_clear_engine(subject: EngineStore) -> None:
 
 
 async def test_clear_engine_not_stopped_or_idle(
-    subject: EngineStore, json_protocol_source: ProtocolSource
+    subject: RunOrchestratorStore, json_protocol_source: ProtocolSource
 ) -> None:
     """It should raise a conflict if the engine is not stopped."""
     await subject.create(
@@ -172,11 +178,11 @@ async def test_clear_engine_not_stopped_or_idle(
     )
     assert subject._run_orchestrator is not None
     subject._run_orchestrator.play(deck_configuration=[])
-    with pytest.raises(EngineConflictError):
+    with pytest.raises(RunConflictError):
         await subject.clear()
 
 
-async def test_clear_idle_engine(subject: EngineStore) -> None:
+async def test_clear_idle_engine(subject: RunOrchestratorStore) -> None:
     """It should successfully clear engine if idle (not started)."""
     await subject.create(
         run_id="run-id",
@@ -194,7 +200,9 @@ async def test_clear_idle_engine(subject: EngineStore) -> None:
         subject.run_orchestrator
 
 
-async def test_get_default_orchestrator_idempotent(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_idempotent(
+    subject: RunOrchestratorStore,
+) -> None:
     """It should create and retrieve the same default ProtocolEngine."""
     result = await subject.get_default_orchestrator()
     repeated_result = await subject.get_default_orchestrator()
@@ -212,7 +220,7 @@ async def test_get_default_orchestrator_robot_type(
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
-    subject = EngineStore(
+    subject = RunOrchestratorStore(
         hardware_api=hardware_api,
         robot_type=robot_type,
         deck_type=deck_type,
@@ -223,7 +231,9 @@ async def test_get_default_orchestrator_robot_type(
     assert result.get_robot_type() == robot_type
 
 
-async def test_get_default_orchestrator_current_unstarted(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_current_unstarted(
+    subject: RunOrchestratorStore,
+) -> None:
     """It should allow a default engine if another engine current but unstarted."""
     await subject.create(
         run_id="run-id",
@@ -237,7 +247,7 @@ async def test_get_default_orchestrator_current_unstarted(subject: EngineStore) 
     assert isinstance(result, RunOrchestrator)
 
 
-async def test_get_default_orchestrator_conflict(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_conflict(subject: RunOrchestratorStore) -> None:
     """It should not allow a default engine if another engine is executing commands."""
     await subject.create(
         run_id="run-id",
@@ -248,11 +258,13 @@ async def test_get_default_orchestrator_conflict(subject: EngineStore) -> None:
     )
     subject.play()
 
-    with pytest.raises(EngineConflictError):
+    with pytest.raises(RunConflictError):
         await subject.get_default_orchestrator()
 
 
-async def test_get_default_orchestrator_run_stopped(subject: EngineStore) -> None:
+async def test_get_default_orchestrator_run_stopped(
+    subject: RunOrchestratorStore,
+) -> None:
     """It allow a default engine if another engine is terminal."""
     await subject.create(
         run_id="run-id",
@@ -271,7 +283,7 @@ async def test_estop_callback(
     decoy: Decoy,
 ) -> None:
     """The callback should stop an active engine."""
-    engine_store = decoy.mock(cls=EngineStore)
+    run_orchestrator_store = decoy.mock(cls=RunOrchestratorStore)
 
     disengage_event = EstopStateNotification(
         old_state=EstopState.PHYSICALLY_ENGAGED, new_state=EstopState.LOGICALLY_ENGAGED
@@ -280,26 +292,26 @@ async def test_estop_callback(
         old_state=EstopState.LOGICALLY_ENGAGED, new_state=EstopState.PHYSICALLY_ENGAGED
     )
 
-    decoy.when(engine_store.current_run_id).then_return(None)
-    await handle_estop_event(engine_store, disengage_event)
-    assert engine_store.run_orchestrator is not None
+    decoy.when(run_orchestrator_store.current_run_id).then_return(None)
+    await handle_estop_event(run_orchestrator_store, disengage_event)
+    assert run_orchestrator_store.run_orchestrator is not None
     decoy.verify(
-        engine_store.run_orchestrator.estop(),
+        run_orchestrator_store.run_orchestrator.estop(),
         ignore_extra_args=True,
         times=0,
     )
     decoy.verify(
-        await engine_store.finish(error=None),
+        await run_orchestrator_store.finish(error=None),
         ignore_extra_args=True,
         times=0,
     )
 
-    decoy.when(engine_store.current_run_id).then_return("fake-run-id")
-    await handle_estop_event(engine_store, engage_event)
-    assert engine_store._run_orchestrator is not None
+    decoy.when(run_orchestrator_store.current_run_id).then_return("fake-run-id")
+    await handle_estop_event(run_orchestrator_store, engage_event)
+    assert run_orchestrator_store._run_orchestrator is not None
     decoy.verify(
-        engine_store.run_orchestrator.estop(),
-        await engine_store.run_orchestrator.finish(
+        run_orchestrator_store.run_orchestrator.estop(),
+        await run_orchestrator_store.run_orchestrator.finish(
             error=matchers.IsA(EStopActivatedError)
         ),
         times=1,

--- a/robot-server/tests/runs/test_light_control_task.py
+++ b/robot-server/tests/runs/test_light_control_task.py
@@ -14,23 +14,27 @@ from opentrons.hardware_control.types import (
     UpdateState,
 )
 from opentrons.protocol_engine.types import EngineStatus
-from robot_server.runs.engine_store import EngineStore
+from robot_server.runs.run_orchestrator_store import RunOrchestratorStore
 from robot_server.runs.light_control_task import LightController, Status
 
 
 @pytest.fixture
-def engine_store(decoy: Decoy) -> EngineStore:
+def run_orchestrator_store(decoy: Decoy) -> RunOrchestratorStore:
     """Mock out the EngineStore."""
-    return decoy.mock(cls=EngineStore)
+    return decoy.mock(cls=RunOrchestratorStore)
 
 
 @pytest.fixture
 def subject(
-    hardware_api: HardwareControlAPI, engine_store: EngineStore, decoy: Decoy
+    hardware_api: HardwareControlAPI,
+    run_orchestrator_store: RunOrchestratorStore,
+    decoy: Decoy,
 ) -> LightController:
     """Test subject - LightController."""
     decoy.when(hardware_api.attached_subsystems).then_return({})
-    return LightController(api=hardware_api, engine_store=engine_store)
+    return LightController(
+        api=hardware_api, run_orchestrator_store=run_orchestrator_store
+    )
 
 
 @pytest.mark.parametrize(
@@ -48,7 +52,7 @@ def subject(
 )
 async def test_get_current_status_ot2(
     decoy: Decoy,
-    engine_store: EngineStore,
+    run_orchestrator_store: RunOrchestratorStore,
     subject: LightController,
     active: bool,
     status: EngineStatus,
@@ -56,8 +60,10 @@ async def test_get_current_status_ot2(
     hardware_api: HardwareControlAPI,
 ) -> None:
     """Test LightController.get_current_status."""
-    decoy.when(engine_store.current_run_id).then_return("fake_id" if active else None)
-    decoy.when(engine_store.get_status()).then_return(status)
+    decoy.when(run_orchestrator_store.current_run_id).then_return(
+        "fake_id" if active else None
+    )
+    decoy.when(run_orchestrator_store.get_status()).then_return(status)
     decoy.when(hardware_api.get_estop_state()).then_return(estop)
 
     expected = Status(
@@ -184,12 +190,14 @@ async def test_light_controller_update(
     )
 
 
-async def test_provide_engine_store(
-    decoy: Decoy, hardware_api: HardwareControlAPI, engine_store: EngineStore
+async def test_provide_run_orchestrator_store(
+    decoy: Decoy,
+    hardware_api: HardwareControlAPI,
+    run_orchestrator_store: RunOrchestratorStore,
 ) -> None:
     """Test providing an engine store after initialization."""
     decoy.when(hardware_api.attached_subsystems).then_return({})
-    subject = LightController(api=hardware_api, engine_store=None)
+    subject = LightController(api=hardware_api, run_orchestrator_store=None)
     decoy.when(hardware_api.get_estop_state()).then_return(EstopState.DISENGAGED)
     assert subject.get_current_status() == Status(
         active_updates=[],
@@ -197,10 +205,10 @@ async def test_provide_engine_store(
         engine_status=None,
     )
 
-    decoy.when(engine_store.current_run_id).then_return("fake_id")
-    decoy.when(engine_store.get_status()).then_return(EngineStatus.RUNNING)
+    decoy.when(run_orchestrator_store.current_run_id).then_return("fake_id")
+    decoy.when(run_orchestrator_store.get_status()).then_return(EngineStatus.RUNNING)
 
-    subject.update_engine_store(engine_store=engine_store)
+    subject.update_run_orchestrator_store(run_orchestrator_store=run_orchestrator_store)
     assert subject.get_current_status() == Status(
         active_updates=[],
         estop_status=EstopState.DISENGAGED,

--- a/robot-server/tests/runs/test_run_controller.py
+++ b/robot-server/tests/runs/test_run_controller.py
@@ -17,15 +17,15 @@ from opentrons.protocol_runner import RunResult
 from robot_server.service.notifications import RunsPublisher
 from robot_server.service.task_runner import TaskRunner
 from robot_server.runs.action_models import RunAction, RunActionType
-from robot_server.runs.engine_store import EngineStore
+from robot_server.runs.run_orchestrator_store import RunOrchestratorStore
 from robot_server.runs.run_store import RunStore
 from robot_server.runs.run_controller import RunController, RunActionNotAllowedError
 
 
 @pytest.fixture
-def mock_engine_store(decoy: Decoy, run_id: str) -> EngineStore:
+def mock_run_orchestrator_store(decoy: Decoy, run_id: str) -> RunOrchestratorStore:
     """Get a mock EngineStore."""
-    mock = decoy.mock(cls=EngineStore)
+    mock = decoy.mock(cls=RunOrchestratorStore)
     decoy.when(mock.current_run_id).then_return(run_id)
     return mock
 
@@ -94,7 +94,7 @@ def protocol_commands() -> List[pe_commands.Command]:
 @pytest.fixture
 def subject(
     run_id: str,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
@@ -102,7 +102,7 @@ def subject(
     """Get a RunController test subject."""
     return RunController(
         run_id=run_id,
-        engine_store=mock_engine_store,
+        run_orchestrator_store=mock_run_orchestrator_store,
         run_store=mock_run_store,
         task_runner=mock_task_runner,
         runs_publisher=mock_runs_publisher,
@@ -111,13 +111,13 @@ def subject(
 
 async def test_create_play_action_to_resume(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     run_id: str,
     subject: RunController,
 ) -> None:
     """It should resume a run."""
-    decoy.when(mock_engine_store.run_was_started()).then_return(True)
+    decoy.when(mock_run_orchestrator_store.run_was_started()).then_return(True)
 
     result = subject.create_action(
         action_id="some-action-id",
@@ -133,13 +133,13 @@ async def test_create_play_action_to_resume(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_engine_store.play(), times=1)
-    decoy.verify(await mock_engine_store.run(deck_configuration=[]), times=0)
+    decoy.verify(mock_run_orchestrator_store.play(), times=1)
+    decoy.verify(await mock_run_orchestrator_store.run(deck_configuration=[]), times=0)
 
 
 async def test_create_play_action_to_start(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
@@ -150,7 +150,7 @@ async def test_create_play_action_to_start(
     subject: RunController,
 ) -> None:
     """It should start a run."""
-    decoy.when(mock_engine_store.run_was_started()).then_return(False)
+    decoy.when(mock_run_orchestrator_store.run_was_started()).then_return(False)
 
     result = subject.create_action(
         action_id="some-action-id",
@@ -170,7 +170,9 @@ async def test_create_play_action_to_start(
     background_task_captor = matchers.Captor()
     decoy.verify(mock_task_runner.run(background_task_captor, deck_configuration=[]))
 
-    decoy.when(await mock_engine_store.run(deck_configuration=[])).then_return(
+    decoy.when(
+        await mock_run_orchestrator_store.run(deck_configuration=[])
+    ).then_return(
         RunResult(
             commands=protocol_commands,
             state_summary=engine_state_summary,
@@ -194,7 +196,7 @@ async def test_create_play_action_to_start(
 
 def test_create_pause_action(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     run_id: str,
     subject: RunController,
@@ -214,12 +216,12 @@ def test_create_pause_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_engine_store.pause(), times=1)
+    decoy.verify(mock_run_orchestrator_store.pause(), times=1)
 
 
 def test_create_stop_action(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     run_id: str,
@@ -240,12 +242,12 @@ def test_create_stop_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_task_runner.run(mock_engine_store.stop), times=1)
+    decoy.verify(mock_task_runner.run(mock_run_orchestrator_store.stop), times=1)
 
 
 def test_create_resume_from_recovery_action(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     run_id: str,
@@ -266,7 +268,7 @@ def test_create_resume_from_recovery_action(
     )
 
     decoy.verify(mock_run_store.insert_action(run_id, result), times=1)
-    decoy.verify(mock_engine_store.resume_from_recovery())
+    decoy.verify(mock_run_orchestrator_store.resume_from_recovery())
 
 
 @pytest.mark.parametrize(
@@ -279,7 +281,7 @@ def test_create_resume_from_recovery_action(
 )
 async def test_action_not_allowed(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     run_id: str,
@@ -288,9 +290,9 @@ async def test_action_not_allowed(
     exception: Exception,
 ) -> None:
     """It should raise a RunActionNotAllowedError if a play/pause action is rejected."""
-    decoy.when(mock_engine_store.run_was_started()).then_return(True)
-    decoy.when(mock_engine_store.play()).then_raise(exception)
-    decoy.when(mock_engine_store.pause()).then_raise(exception)
+    decoy.when(mock_run_orchestrator_store.run_was_started()).then_return(True)
+    decoy.when(mock_run_orchestrator_store.play()).then_raise(exception)
+    decoy.when(mock_run_orchestrator_store.pause()).then_raise(exception)
 
     with pytest.raises(RunActionNotAllowedError, match="oh no"):
         subject.create_action(

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -22,7 +22,10 @@ from opentrons.protocol_engine import (
 )
 
 from robot_server.protocols.protocol_store import ProtocolResource
-from robot_server.runs.engine_store import EngineStore, EngineConflictError
+from robot_server.runs.run_orchestrator_store import (
+    RunOrchestratorStore,
+    RunConflictError,
+)
 from robot_server.runs.run_data_manager import (
     RunDataManager,
     RunNotCurrentError,
@@ -50,9 +53,9 @@ def mock_notify_publishers() -> None:
 
 
 @pytest.fixture
-def mock_engine_store(decoy: Decoy) -> EngineStore:
+def mock_run_orchestrator_store(decoy: Decoy) -> RunOrchestratorStore:
     """Get a mock EngineStore."""
-    mock = decoy.mock(cls=EngineStore)
+    mock = decoy.mock(cls=RunOrchestratorStore)
     decoy.when(mock.current_run_id).then_return(None)
     return mock
 
@@ -128,14 +131,14 @@ def run_command() -> commands.Command:
 
 @pytest.fixture
 def subject(
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
 ) -> RunDataManager:
     """Get a RunDataManager test subject."""
     return RunDataManager(
-        engine_store=mock_engine_store,
+        run_orchestrator_store=mock_run_orchestrator_store,
         run_store=mock_run_store,
         task_runner=mock_task_runner,
         runs_publisher=mock_runs_publisher,
@@ -144,7 +147,7 @@ def subject(
 
 async def test_create(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
     engine_state_summary: StateSummary,
@@ -155,7 +158,7 @@ async def test_create(
     created_at = datetime(year=2021, month=1, day=1)
 
     decoy.when(
-        await mock_engine_store.create(
+        await mock_run_orchestrator_store.create(
             run_id=run_id,
             labware_offsets=[],
             protocol=None,
@@ -200,7 +203,7 @@ async def test_create(
 
 async def test_create_with_options(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
     engine_state_summary: StateSummary,
@@ -225,7 +228,7 @@ async def test_create_with_options(
     )
 
     decoy.when(
-        await mock_engine_store.create(
+        await mock_run_orchestrator_store.create(
             run_id=run_id,
             labware_offsets=[labware_offset],
             protocol=protocol,
@@ -271,7 +274,7 @@ async def test_create_with_options(
 
 async def test_create_engine_error(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
@@ -280,7 +283,7 @@ async def test_create_engine_error(
     created_at = datetime(year=2021, month=1, day=1)
 
     decoy.when(
-        await mock_engine_store.create(
+        await mock_run_orchestrator_store.create(
             run_id,
             labware_offsets=[],
             protocol=None,
@@ -288,9 +291,9 @@ async def test_create_engine_error(
             run_time_param_values=None,
             notify_publishers=mock_notify_publishers,
         )
-    ).then_raise(EngineConflictError("oh no"))
+    ).then_raise(RunConflictError("oh no"))
 
-    with pytest.raises(EngineConflictError):
+    with pytest.raises(RunConflictError):
         await subject.create(
             run_id=run_id,
             created_at=created_at,
@@ -313,7 +316,7 @@ async def test_create_engine_error(
 
 async def test_get_current_run(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
     engine_state_summary: StateSummary,
@@ -324,9 +327,11 @@ async def test_get_current_run(
     run_id = "hello world"
 
     decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
-    decoy.when(mock_engine_store.current_run_id).then_return(run_id)
-    decoy.when(mock_engine_store.get_state_summary()).then_return(engine_state_summary)
-    decoy.when(mock_engine_store.get_run_time_parameters()).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
+    decoy.when(mock_run_orchestrator_store.get_state_summary()).then_return(
+        engine_state_summary
+    )
+    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
         run_time_parameters
     )
 
@@ -352,7 +357,7 @@ async def test_get_current_run(
 
 async def test_get_historical_run(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
     engine_state_summary: StateSummary,
@@ -369,7 +374,7 @@ async def test_get_historical_run(
     decoy.when(mock_run_store.get_run_time_parameters(run_id=run_id)).then_return(
         run_time_parameters
     )
-    decoy.when(mock_engine_store.current_run_id).then_return("some other id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
     result = subject.get(run_id=run_id)
 
@@ -392,7 +397,7 @@ async def test_get_historical_run(
 
 async def test_get_historical_run_no_data(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
     run_resource: RunResource,
@@ -410,7 +415,7 @@ async def test_get_historical_run_no_data(
     decoy.when(mock_run_store.get_run_time_parameters(run_id=run_id)).then_return(
         run_time_parameters
     )
-    decoy.when(mock_engine_store.current_run_id).then_return("some other id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
     result = subject.get(run_id=run_id)
 
@@ -434,7 +439,7 @@ async def test_get_historical_run_no_data(
 
 async def test_get_all_runs(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
@@ -491,9 +496,11 @@ async def test_get_all_runs(
         actions=[],
     )
 
-    decoy.when(mock_engine_store.current_run_id).then_return("current-run")
-    decoy.when(mock_engine_store.get_state_summary()).then_return(current_run_data)
-    decoy.when(mock_engine_store.get_run_time_parameters()).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run")
+    decoy.when(mock_run_orchestrator_store.get_state_summary()).then_return(
+        current_run_data
+    )
+    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
         current_run_time_parameters
     )
     decoy.when(mock_run_store.get_state_summary("historical-run")).then_return(
@@ -544,35 +551,35 @@ async def test_get_all_runs(
 
 async def test_delete_current_run(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
     """It should delete the current run from the engine."""
     run_id = "hello world"
-    decoy.when(mock_engine_store.current_run_id).then_return(run_id)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
 
     await subject.delete(run_id=run_id)
 
     decoy.verify(
-        await mock_engine_store.clear(),
+        await mock_run_orchestrator_store.clear(),
         mock_run_store.remove(run_id=run_id),
     )
 
 
 async def test_delete_historical_run(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
     """It should delete a historical run from the store."""
     run_id = "hello world"
-    decoy.when(mock_engine_store.current_run_id).then_return("some other id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
     await subject.delete(run_id=run_id)
 
-    decoy.verify(await mock_engine_store.clear(), times=0)
+    decoy.verify(await mock_run_orchestrator_store.clear(), times=0)
     decoy.verify(mock_run_store.remove(run_id=run_id), times=1)
 
 
@@ -582,15 +589,15 @@ async def test_update_current(
     run_time_parameters: List[pe_types.RunTimeParameter],
     run_resource: RunResource,
     run_command: commands.Command,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_runs_publisher: RunsPublisher,
     subject: RunDataManager,
 ) -> None:
     """It should persist the current run and clear the engine on current=false."""
     run_id = "hello world"
-    decoy.when(mock_engine_store.current_run_id).then_return(run_id)
-    decoy.when(await mock_engine_store.clear()).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
+    decoy.when(await mock_run_orchestrator_store.clear()).then_return(
         RunResult(
             commands=[run_command],
             state_summary=engine_state_summary,
@@ -637,7 +644,7 @@ async def test_update_current_noop(
     run_time_parameters: List[pe_types.RunTimeParameter],
     run_resource: RunResource,
     run_command: commands.Command,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     mock_runs_publisher: RunsPublisher,
     subject: RunDataManager,
@@ -645,16 +652,18 @@ async def test_update_current_noop(
 ) -> None:
     """It should noop on current=None and current=True."""
     run_id = "hello world"
-    decoy.when(mock_engine_store.current_run_id).then_return(run_id)
-    decoy.when(mock_engine_store.get_state_summary()).then_return(engine_state_summary)
-    decoy.when(mock_engine_store.get_run_time_parameters()).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
+    decoy.when(mock_run_orchestrator_store.get_state_summary()).then_return(
+        engine_state_summary
+    )
+    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
         run_time_parameters
     )
     decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
 
     result = await subject.update(run_id=run_id, current=current)
 
-    decoy.verify(await mock_engine_store.clear(), times=0)
+    decoy.verify(await mock_run_orchestrator_store.clear(), times=0)
     decoy.verify(
         mock_run_store.update_run_state(
             run_id=run_id,
@@ -688,13 +697,13 @@ async def test_update_current_not_allowed(
     engine_state_summary: StateSummary,
     run_resource: RunResource,
     run_command: commands.Command,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
     """It should noop on current=None."""
     run_id = "hello world"
-    decoy.when(mock_engine_store.current_run_id).then_return("some other id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
     with pytest.raises(RunNotCurrentError):
         await subject.update(run_id=run_id, current=False)
@@ -706,7 +715,7 @@ async def test_create_archives_existing(
     run_time_parameters: List[pe_types.RunTimeParameter],
     run_resource: RunResource,
     run_command: commands.Command,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
@@ -714,8 +723,8 @@ async def test_create_archives_existing(
     run_id_old = "hello world"
     run_id_new = "hello is it me you're looking for"
 
-    decoy.when(mock_engine_store.current_run_id).then_return(run_id_old)
-    decoy.when(await mock_engine_store.clear()).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id_old)
+    decoy.when(await mock_run_orchestrator_store.clear()).then_return(
         RunResult(
             commands=[run_command],
             state_summary=engine_state_summary,
@@ -724,7 +733,7 @@ async def test_create_archives_existing(
     )
 
     decoy.when(
-        await mock_engine_store.create(
+        await mock_run_orchestrator_store.create(
             run_id=run_id_new,
             labware_offsets=[],
             protocol=None,
@@ -795,7 +804,7 @@ def test_get_commands_slice_from_db(
 def test_get_commands_slice_current_run(
     decoy: Decoy,
     subject: RunDataManager,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get a sliced command list from engine store."""
@@ -813,8 +822,8 @@ def test_get_commands_slice_current_run(
     expected_command_slice = CommandSlice(
         commands=expected_commands_result, cursor=1, total_length=3
     )
-    decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(mock_engine_store.get_command_slice(1, 2)).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
+    decoy.when(mock_run_orchestrator_store.get_command_slice(1, 2)).then_return(
         expected_command_slice
     )
 
@@ -838,7 +847,7 @@ def test_get_current_command(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get current command from engine store."""
@@ -848,8 +857,10 @@ def test_get_current_command(
         created_at=run_command.createdAt,
         index=0,
     )
-    decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(mock_engine_store.get_current_command()).then_return(expected_current)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
+    decoy.when(mock_run_orchestrator_store.get_current_command()).then_return(
+        expected_current
+    )
     result = subject.get_current_command("run-id")
 
     assert result == expected_current
@@ -859,10 +870,10 @@ def test_get_current_command_not_current_run(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
 ) -> None:
     """Should return None because the run is not current."""
-    decoy.when(mock_engine_store.current_run_id).then_return("not-run-id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("not-run-id")
     result = subject.get_current_command("run-id")
 
     assert result is None
@@ -872,12 +883,14 @@ def test_get_command_from_engine(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get command by id from engine store."""
-    decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(mock_engine_store.get_command("command-id")).then_return(run_command)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
+    decoy.when(mock_run_orchestrator_store.get_command("command-id")).then_return(
+        run_command
+    )
     result = subject.get_command("run-id", "command-id")
 
     assert result == run_command
@@ -887,11 +900,11 @@ def test_get_command_from_db(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get command by id from engine store."""
-    decoy.when(mock_engine_store.current_run_id).then_return("not-run-id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("not-run-id")
     decoy.when(
         mock_run_store.get_command(run_id="run-id", command_id="command-id")
     ).then_return(run_command)
@@ -904,11 +917,11 @@ def test_get_command_from_db_run_not_found(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get command by id from engine store."""
-    decoy.when(mock_engine_store.current_run_id).then_return("not-run-id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("not-run-id")
     decoy.when(
         mock_run_store.get_command(run_id="run-id", command_id="command-id")
     ).then_raise(RunNotFoundError("run-id"))
@@ -921,11 +934,11 @@ def test_get_command_from_db_command_not_found(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     run_command: commands.Command,
 ) -> None:
     """Should get command by id from engine store."""
-    decoy.when(mock_engine_store.current_run_id).then_return("not-run-id")
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("not-run-id")
     decoy.when(
         mock_run_store.get_command(run_id="run-id", command_id="command-id")
     ).then_raise(CommandNotFoundError(command_id="command-id"))
@@ -938,10 +951,10 @@ def test_get_all_commands_as_preserialized_list(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
 ) -> None:
     """It should return the pre-serialized commands list."""
-    decoy.when(mock_engine_store.current_run_id).then_return(None)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(None)
     decoy.when(
         mock_run_store.get_all_commands_as_preserialized_list("run-id")
     ).then_return(['{"id": command-1}', '{"id": command-2}'])
@@ -955,25 +968,27 @@ def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
     decoy: Decoy,
     subject: RunDataManager,
     mock_run_store: RunStore,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
 ) -> None:
     """It should raise an error when fetching pre-serialized commands list while run is active."""
-    decoy.when(mock_engine_store.current_run_id).then_return("current-run-id")
-    decoy.when(mock_engine_store.get_is_run_terminal()).then_return(False)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run-id")
+    decoy.when(mock_run_orchestrator_store.get_is_run_terminal()).then_return(False)
     with pytest.raises(PreSerializedCommandsNotAvailableError):
         subject.get_all_commands_as_preserialized_list("current-run-id")
 
 
 async def test_get_current_run_labware_definition(
     decoy: Decoy,
-    mock_engine_store: EngineStore,
+    mock_run_orchestrator_store: RunOrchestratorStore,
     subject: RunDataManager,
     engine_state_summary: StateSummary,
     run_resource: RunResource,
 ) -> None:
     """It should get the current run labware definition from the engine."""
-    decoy.when(mock_engine_store.current_run_id).then_return("run-id")
-    decoy.when(mock_engine_store.get_loaded_labware_definitions()).then_return(
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
+    decoy.when(
+        mock_run_orchestrator_store.get_loaded_labware_definitions()
+    ).then_return(
         [
             LabwareDefinition.construct(namespace="test_1"),  # type: ignore[call-arg]
             LabwareDefinition.construct(namespace="test_2"),  # type: ignore[call-arg]


### PR DESCRIPTION
# Overview

Other PRs in EXEC-418 have made it so robot-server interacts with `opentrons.protocol_engine` only through *run orchestrators.* `EngineStore` and `MaintenanceEngineStore`, which formerly exposed `ProtocolEngine`s, now expose `RunOrchestrator`s.

This PR renames `EngineStore` and `MaintenanceEngineStore` accordingly, to `RunOrchestratorStore` and `MaintenanceRunOrchestratorStore`.

This goes towards EXEC-418.

# Test Plan

Just CI.

# Changelog

* Replaced `EngineStore` with `RunOrchestratorStore` and `MaintenanceEngineStore` with `MaintenanceRunOrchestratorStore`, via IDE. Also `EngineConflictError` -> `RunConflictError`.
* Some name changes (e.g. `engine_store` param -> `run_orchestrator_store` param) mostly through global text find+replace.
* Some docstring changes from manual review.

# Risk assessment

Low.
