### PR TITLE
feat(api): Enable error recovery without the feature flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -211,11 +211,8 @@ settings = [
         title="Enable error recovery experiments",
         description=(
             "Do not enable."
-            " This is an Opentrons internal setting to experiment with"
+            " This is an Opentrons internal setting to enable additional,"
             " in-development error recovery features."
-            " This will interfere with your protocol runs,"
-            " corrupt your robot's storage,"
-            " bring misfortune and pestilence upon you and your livestock, etc."
         ),
         robot_type=[RobotTypeEnum.FLEX],
         internal_only=True,

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -546,7 +546,7 @@ def _create_live_context_pe(
         create_protocol_engine_in_thread(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(),
-            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+            error_recovery_policy=error_recovery_policy.never_recover,
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
@@ -630,7 +630,7 @@ def _run_file_pe(
         protocol_engine = await create_protocol_engine(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(),
-            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+            error_recovery_policy=error_recovery_policy.never_recover,
             load_fixed_trash=should_load_fixed_trash(protocol_source.config),
         )
 

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -58,6 +58,7 @@ from opentrons.protocol_engine import (
     Config,
     DeckType,
     EngineStatus,
+    error_recovery_policy,
 )
 from opentrons.protocol_engine.create_protocol_engine import (
     create_protocol_engine_in_thread,
@@ -545,6 +546,7 @@ def _create_live_context_pe(
         create_protocol_engine_in_thread(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(),
+            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
@@ -628,6 +630,7 @@ def _run_file_pe(
         protocol_engine = await create_protocol_engine(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(),
+            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             load_fixed_trash=should_load_fixed_trash(protocol_source.config),
         )
 

--- a/api/src/opentrons/protocol_engine/create_protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/create_protocol_engine.py
@@ -13,11 +13,11 @@ from .state import Config, StateStore
 from .types import PostRunHardwareState, DeckConfigurationType
 
 
-# TODO(mm, 2023-06-16): Arguably, this not being a context manager makes us prone to forgetting to
-# clean it up properly, especially in tests. See e.g. https://opentrons.atlassian.net/browse/RSS-222
 from .engine_support import create_run_orchestrator
 
 
+# TODO(mm, 2023-06-16): Arguably, this not being a context manager makes us prone to forgetting to
+# clean it up properly, especially in tests. See e.g. https://opentrons.atlassian.net/browse/RSS-222
 async def create_protocol_engine(
     hardware_api: HardwareControlAPI,
     config: Config,

--- a/api/src/opentrons/protocol_engine/create_protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/create_protocol_engine.py
@@ -5,13 +5,13 @@ import typing
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import DoorState
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 from opentrons.util.async_helpers import async_context_manager_in_thread
 
 from .protocol_engine import ProtocolEngine
 from .resources import DeckDataProvider, ModuleDataProvider
 from .state import Config, StateStore
 from .types import PostRunHardwareState, DeckConfigurationType
-
 
 from .engine_support import create_run_orchestrator
 
@@ -21,6 +21,7 @@ from .engine_support import create_run_orchestrator
 async def create_protocol_engine(
     hardware_api: HardwareControlAPI,
     config: Config,
+    error_recovery_policy: ErrorRecoveryPolicy,
     load_fixed_trash: bool = False,
     deck_configuration: typing.Optional[DeckConfigurationType] = None,
     notify_publishers: typing.Optional[typing.Callable[[], None]] = None,
@@ -30,6 +31,8 @@ async def create_protocol_engine(
     Arguments:
         hardware_api: Hardware control API to pass down to dependencies.
         config: ProtocolEngine configuration.
+        error_recovery_policy: The error recovery policy to create the engine with.
+            See documentation on `ErrorRecoveryPolicy`.
         load_fixed_trash: Automatically load fixed trash labware in engine.
         deck_configuration: The initial deck configuration the engine will be instantiated with.
         notify_publishers: Notifies robot server publishers of internal state change.
@@ -56,6 +59,7 @@ async def create_protocol_engine(
     return ProtocolEngine(
         state_store=state_store,
         hardware_api=hardware_api,
+        error_recovery_policy=error_recovery_policy,
     )
 
 
@@ -63,6 +67,7 @@ async def create_protocol_engine(
 def create_protocol_engine_in_thread(
     hardware_api: HardwareControlAPI,
     config: Config,
+    error_recovery_policy: ErrorRecoveryPolicy,
     drop_tips_after_run: bool,
     post_run_hardware_state: PostRunHardwareState,
     load_fixed_trash: bool = False,
@@ -90,6 +95,7 @@ def create_protocol_engine_in_thread(
         _protocol_engine(
             hardware_api,
             config,
+            error_recovery_policy,
             drop_tips_after_run,
             post_run_hardware_state,
             load_fixed_trash,
@@ -105,6 +111,7 @@ def create_protocol_engine_in_thread(
 async def _protocol_engine(
     hardware_api: HardwareControlAPI,
     config: Config,
+    error_recovery_policy: ErrorRecoveryPolicy,
     drop_tips_after_run: bool,
     post_run_hardware_state: PostRunHardwareState,
     load_fixed_trash: bool = False,
@@ -112,6 +119,7 @@ async def _protocol_engine(
     protocol_engine = await create_protocol_engine(
         hardware_api=hardware_api,
         config=config,
+        error_recovery_policy=error_recovery_policy,
         load_fixed_trash=load_fixed_trash,
     )
 

--- a/api/src/opentrons/protocol_engine/error_recovery_policy.py
+++ b/api/src/opentrons/protocol_engine/error_recovery_policy.py
@@ -72,3 +72,16 @@ def error_recovery_by_ff(
         return ErrorRecoveryType.WAIT_FOR_RECOVERY
     else:
         return ErrorRecoveryType.FAIL_RUN
+
+
+def never_recover(
+    failed_command: Command,
+    defined_error_data: Optional[CommandDefinedErrorData],
+) -> ErrorRecoveryType:
+    """An error recovery policy where error recovery is never attempted.
+
+    This makes sense for things like the `opentrons_simulate` and `opentrons_execute`
+    CLIs. Those don't expose any way to bring the run out of recovery mode after it's
+    been entered, so we need to avoid entering recovery mode in the first place.
+    """
+    return ErrorRecoveryType.FAIL_RUN

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -169,6 +169,7 @@ class CommandExecutor:
                     failed_at=self._model_utils.get_timestamp(),
                     notes=note_tracker.get_notes(),
                     type=self._error_recovery_policy(
+                        self._state_store.config,
                         running_command,
                         None,
                     ),
@@ -199,6 +200,10 @@ class CommandExecutor:
                         error_id=result.public.id,
                         failed_at=result.public.createdAt,
                         notes=note_tracker.get_notes(),
-                        type=self._error_recovery_policy(running_command, result),
+                        type=self._error_recovery_policy(
+                            self._state_store.config,
+                            running_command,
+                            result,
+                        ),
                     )
                 )

--- a/api/src/opentrons/protocol_engine/protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/protocol_engine.py
@@ -3,10 +3,7 @@ from contextlib import AsyncExitStack
 from logging import getLogger
 from typing import Dict, Optional, Union, AsyncGenerator, Callable
 from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
-from opentrons.protocol_engine.error_recovery_policy import (
-    ErrorRecoveryPolicy,
-    error_recovery_by_ff,
-)
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.hardware_control import HardwareControlAPI
@@ -86,6 +83,7 @@ class ProtocolEngine:
         self,
         hardware_api: HardwareControlAPI,
         state_store: StateStore,
+        error_recovery_policy: ErrorRecoveryPolicy,
         action_dispatcher: Optional[ActionDispatcher] = None,
         plugin_starter: Optional[PluginStarter] = None,
         queue_worker: Optional[QueueWorker] = None,
@@ -93,7 +91,6 @@ class ProtocolEngine:
         hardware_stopper: Optional[HardwareStopper] = None,
         door_watcher: Optional[DoorWatcher] = None,
         module_data_provider: Optional[ModuleDataProvider] = None,
-        error_recovery_policy: ErrorRecoveryPolicy = error_recovery_by_ff,
     ) -> None:
         """Initialize a ProtocolEngine instance.
 

--- a/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
@@ -61,7 +61,7 @@ async def create_simulating_orchestrator(
             use_simulated_deck_config=True,
             use_virtual_pipettes=True,
         ),
-        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+        error_recovery_policy=error_recovery_policy.never_recover,
         load_fixed_trash=should_load_fixed_trash(protocol_config),
     )
 

--- a/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
@@ -6,6 +6,7 @@ from opentrons.protocols.api_support.deck_type import should_load_fixed_trash
 from opentrons.protocol_engine import (
     Config as ProtocolEngineConfig,
     DeckType,
+    error_recovery_policy,
 )
 from opentrons.protocol_engine.create_protocol_engine import create_protocol_engine
 from opentrons.protocol_reader.protocol_source import ProtocolConfig
@@ -60,6 +61,7 @@ async def create_simulating_orchestrator(
             use_simulated_deck_config=True,
             use_virtual_pipettes=True,
         ),
+        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
         load_fixed_trash=should_load_fixed_trash(protocol_config),
     )
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -807,7 +807,7 @@ def _create_live_context_pe(
             config=_get_protocol_engine_config(
                 robot_type, virtual=use_virtual_hardware
             ),
-            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+            error_recovery_policy=error_recovery_policy.never_recover,
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
@@ -912,7 +912,7 @@ def _run_file_pe(
         protocol_engine = await create_protocol_engine(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(robot_type, virtual=True),
-            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+            error_recovery_policy=error_recovery_policy.never_recover,
             load_fixed_trash=should_load_fixed_trash(protocol_source.config),
         )
 

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -45,6 +45,7 @@ from opentrons.protocol_engine.create_protocol_engine import (
     create_protocol_engine_in_thread,
     create_protocol_engine,
 )
+from opentrons.protocol_engine import error_recovery_policy
 from opentrons.protocol_engine.state.config import Config
 from opentrons.protocol_engine.types import DeckType, EngineStatus, PostRunHardwareState
 from opentrons.protocol_reader.protocol_source import ProtocolSource
@@ -806,6 +807,7 @@ def _create_live_context_pe(
             config=_get_protocol_engine_config(
                 robot_type, virtual=use_virtual_hardware
             ),
+            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             drop_tips_after_run=False,
             post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
             load_fixed_trash=should_load_fixed_trash_labware_for_python_protocol(
@@ -910,6 +912,7 @@ def _run_file_pe(
         protocol_engine = await create_protocol_engine(
             hardware_api=hardware_api_wrapped,
             config=_get_protocol_engine_config(robot_type, virtual=True),
+            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             load_fixed_trash=should_load_fixed_trash(protocol_source.config),
         )
 

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -316,7 +316,7 @@ def _make_ot3_pe_ctx(
             use_simulated_deck_config=True,
             block_on_door_open=False,
         ),
-        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+        error_recovery_policy=error_recovery_policy.never_recover,
         drop_tips_after_run=False,
         post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
         # TODO(jbl 10-30-2023) load_fixed_trash being hardcoded to True will be refactored once we need tests to have

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -64,7 +64,11 @@ from opentrons.protocol_api.core.legacy.deck import (
 from opentrons.protocol_engine.create_protocol_engine import (
     create_protocol_engine_in_thread,
 )
-from opentrons.protocol_engine import Config as ProtocolEngineConfig, DeckType
+from opentrons.protocol_engine import (
+    Config as ProtocolEngineConfig,
+    DeckType,
+    error_recovery_policy,
+)
 from opentrons.protocols.api_support import deck_type
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
@@ -312,6 +316,7 @@ def _make_ot3_pe_ctx(
             use_simulated_deck_config=True,
             block_on_door_open=False,
         ),
+        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
         drop_tips_after_run=False,
         post_run_hardware_state=PostRunHardwareState.STAY_ENGAGED_IN_PLACE,
         # TODO(jbl 10-30-2023) load_fixed_trash being hardcoded to True will be refactored once we need tests to have

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -498,9 +498,9 @@ async def test_execute_undefined_error(
         datetime(year=2023, month=3, day=3),
     )
 
-    decoy.when(error_recovery_policy(matchers.Anything(), None)).then_return(
-        ErrorRecoveryType.WAIT_FOR_RECOVERY
-    )
+    decoy.when(
+        error_recovery_policy(matchers.Anything(), matchers.Anything(), None)
+    ).then_return(ErrorRecoveryType.WAIT_FOR_RECOVERY)
 
     decoy.when(command_note_tracker.get_notes()).then_return(command_notes)
 
@@ -636,6 +636,7 @@ async def test_execute_defined_error(
 
     decoy.when(
         error_recovery_policy(
+            matchers.Anything(),
             matchers.Anything(),
             returned_error,  # type: ignore[arg-type]
         )

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -84,7 +84,7 @@ async def test_create_engine_initializes_state_with_no_fixed_trash(
             robot_type=robot_type,
             deck_type=deck_type,
         ),
-        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+        error_recovery_policy=error_recovery_policy.never_recover,
         load_fixed_trash=False,
     )
     state = engine.state_view
@@ -142,7 +142,7 @@ async def test_create_engine_initializes_state_with_fixed_trash(
             robot_type=robot_type,
             deck_type=deck_type,
         ),
-        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+        error_recovery_policy=error_recovery_policy.never_recover,
         load_fixed_trash=True,
     )
     state = engine.state_view
@@ -177,7 +177,7 @@ async def test_create_engine_initializes_state_with_door_state(
             robot_type="OT-2 Standard",
             deck_type=DeckType.OT2_SHORT_TRASH,
         ),
-        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+        error_recovery_policy=error_recovery_policy.never_recover,
     )
     state = engine.state_view
     assert state.commands.get_is_door_blocking() is True

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -14,6 +14,7 @@ from opentrons.protocol_engine import (
     ProtocolEngine,
     Config as EngineConfig,
     DeckType,
+    error_recovery_policy,
 )
 from opentrons.protocol_engine.create_protocol_engine import create_protocol_engine
 
@@ -83,6 +84,7 @@ async def test_create_engine_initializes_state_with_no_fixed_trash(
             robot_type=robot_type,
             deck_type=deck_type,
         ),
+        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
         load_fixed_trash=False,
     )
     state = engine.state_view
@@ -140,6 +142,7 @@ async def test_create_engine_initializes_state_with_fixed_trash(
             robot_type=robot_type,
             deck_type=deck_type,
         ),
+        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
         load_fixed_trash=True,
     )
     state = engine.state_view
@@ -174,6 +177,7 @@ async def test_create_engine_initializes_state_with_door_state(
             robot_type="OT-2 Standard",
             deck_type=DeckType.OT2_SHORT_TRASH,
         ),
+        error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
     )
     state = engine.state_view
     assert state.commands.get_is_door_blocking() is True

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -8,7 +8,6 @@ import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons.protocol_engine.actions.actions import ResumeFromRecoveryAction
 
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
@@ -33,6 +32,7 @@ from opentrons.protocol_engine.types import (
     PostRunHardwareState,
     AddressableAreaLocation,
 )
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 from opentrons.protocol_engine.execution import (
     QueueWorker,
     HardwareStopper,
@@ -53,6 +53,7 @@ from opentrons.protocol_engine.actions import (
     PlayAction,
     PauseAction,
     PauseSource,
+    ResumeFromRecoveryAction,
     StopAction,
     FinishAction,
     FinishErrorDetails,
@@ -116,6 +117,12 @@ def module_data_provider(decoy: Decoy) -> ModuleDataProvider:
     return decoy.mock(cls=ModuleDataProvider)
 
 
+@pytest.fixture
+def error_recovery_policy(decoy: Decoy) -> ErrorRecoveryPolicy:
+    """Get a mock ErrorRecoveryPolicy."""
+    return decoy.mock(cls=ErrorRecoveryPolicy)
+
+
 @pytest.fixture(autouse=True)
 def _mock_slot_standardization_module(
     decoy: Decoy, monkeypatch: pytest.MonkeyPatch
@@ -139,6 +146,7 @@ def _mock_hash_command_params_module(
 def subject(
     hardware_api: HardwareControlAPI,
     state_store: StateStore,
+    error_recovery_policy: ErrorRecoveryPolicy,
     action_dispatcher: ActionDispatcher,
     plugin_starter: PluginStarter,
     queue_worker: QueueWorker,
@@ -151,6 +159,7 @@ def subject(
     return ProtocolEngine(
         hardware_api=hardware_api,
         state_store=state_store,
+        error_recovery_policy=error_recovery_policy,
         action_dispatcher=action_dispatcher,
         plugin_starter=plugin_starter,
         queue_worker=queue_worker,

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -175,7 +175,7 @@ class MaintenanceRunOrchestratorStore:
                     RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
-            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+            error_recovery_policy=error_recovery_policy.never_recover,
             deck_configuration=deck_configuration,
             notify_publishers=notify_publishers,
         )

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -16,6 +16,7 @@ from opentrons.protocol_engine import (
     CommandCreate,
     LabwareOffset,
     Config as ProtocolEngineConfig,
+    error_recovery_policy,
 )
 from opentrons.protocol_engine.create_protocol_engine import create_protocol_engine
 from opentrons.protocol_runner import RunResult, RunOrchestrator
@@ -174,6 +175,7 @@ class MaintenanceRunOrchestratorStore:
                     RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
+            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             deck_configuration=deck_configuration,
             notify_publishers=notify_publishers,
         )

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -171,7 +171,9 @@ class RunOrchestratorStore:
                     deck_type=self._deck_type,
                     block_on_door_open=False,
                 ),
-                error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+                # todo(mm, 2024-07-05): It's unclear what error recovery policy
+                # makes sense for the default orchestrator.
+                error_recovery_policy=error_recovery_policy.never_recover,
             )
             self._default_run_orchestrator = RunOrchestrator.build_orchestrator(
                 protocol_engine=engine, hardware_api=self._hardware_api

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -223,7 +223,7 @@ class RunOrchestratorStore:
                     RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
-            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
+            error_recovery_policy=error_recovery_policy.standard_run_policy,
             load_fixed_trash=load_fixed_trash,
             deck_configuration=deck_configuration,
             notify_publishers=notify_publishers,

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -34,6 +34,7 @@ from opentrons.protocol_engine import (
     CommandCreate,
     LabwareOffset,
     Config as ProtocolEngineConfig,
+    error_recovery_policy,
 )
 from opentrons.protocol_engine.create_protocol_engine import create_protocol_engine
 
@@ -170,6 +171,7 @@ class RunOrchestratorStore:
                     deck_type=self._deck_type,
                     block_on_door_open=False,
                 ),
+                error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             )
             self._default_run_orchestrator = RunOrchestrator.build_orchestrator(
                 protocol_engine=engine, hardware_api=self._hardware_api
@@ -219,6 +221,7 @@ class RunOrchestratorStore:
                     RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
+            error_recovery_policy=error_recovery_policy.error_recovery_by_ff,
             load_fixed_trash=load_fixed_trash,
             deck_configuration=deck_configuration,
             notify_publishers=notify_publishers,

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -171,8 +171,6 @@ class RunOrchestratorStore:
                     deck_type=self._deck_type,
                     block_on_door_open=False,
                 ),
-                # todo(mm, 2024-07-05): It's unclear what error recovery policy
-                # makes sense for the default orchestrator.
                 error_recovery_policy=error_recovery_policy.never_recover,
             )
             self._default_run_orchestrator = RunOrchestrator.build_orchestrator(


### PR DESCRIPTION
# Overview

Closes EXEC-547.

# Test Plan

* [x] Flex protocols still enter recovery mode when there's a tip pickup or overpressure error, and still fail for other errors.
* [x] `opentrons_simulate`, local in-app analysis, and robot-side analysis still work as expected when the protocol has an error.
* [x] OT-2 protocols still fail, without entering recovery mode, when there's an error.

# Changelog

* Stop gating error recovery behind the `enableErrorRecoveryExperiments` feature flag.

  The feature flag doesn't do anything anymore. I'm leaving it in-place in case we want to use it for the ongoing work in liquid level detection.

* For things other than real robot-server protocol runs (including analysis, `opentrons_execute`, maintenance runs, etc.), explicitly choose a policy of "never recover."

  We don't ever want to enter recovery mode for these things, because nothing could bring it *out* of recovery mode, and it would hang forever.
  
* Explicitly disable error recovery on the OT-2. None of the designs for the upcoming release make sense on an OT-2, because the OT-2 lacks the hardware feedback to detect the errors in the first place.

# Review requests

* I looked around for a frontend feature flag but I couldn't find one. Have we already removed it?
* Anyone have thoughts on what error recovery policy is appropriate for stateless commands (the "default orchestrator", in this code)?

# Risk assessment

Medium.