### PR TITLE
feat(robot-server): add protocol_kind query arg to GET protocols endpoint.

### DIFF
--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -212,7 +212,7 @@ async def create_protocol(  # noqa: C901
         default=None,
         description=(
             "Whether this is a `standard` protocol or a `quick-transfer` protocol."
-            "if ommited, the protocol will be `standard` by default."
+            "if omitted, the protocol will be `standard` by default."
         ),
         alias="protocolKind",
     ),
@@ -429,12 +429,7 @@ async def _start_new_analysis_if_necessary(
     summary="Get uploaded protocols",
     description="""
     Return all stored protocols by default, in order from first-uploaded to last-uploaded.
-    You can provide the kind of protocol with the `protocol_kind` query arg
-        The protocol kind can be:
-
-        - `quick-transfer` for Quick Transfer protocols
-        - `standard`       for non Quick transfer protocols
-        Note: all protocols will be provided if the `protocol_kind` query arg is ommited.
+    You can provide the kind of protocol with the `protocolKind` query arg
     """,
     responses={status.HTTP_200_OK: {"model": SimpleMultiBody[Protocol]}},
 )
@@ -446,6 +441,7 @@ async def get_protocols(
             " protocol kind can be `quick-transfer` or `standard` "
             " If this is omitted or `null`, all protocols will be returned."
         ),
+        alias="protocolKind",
     ),
     protocol_store: ProtocolStore = Depends(get_protocol_store),
     analysis_store: AnalysisStore = Depends(get_analysis_store),

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -181,7 +181,6 @@ async def test_get_protocols(
         protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
     )
 
-
     analysis_1 = AnalysisSummary(id="analysis-id-abc", status=AnalysisStatus.PENDING)
     analysis_2 = AnalysisSummary(id="analysis-id-123", status=AnalysisStatus.PENDING)
     analysis_3 = AnalysisSummary(id="analysis-id-333", status=AnalysisStatus.PENDING)
@@ -220,7 +219,9 @@ async def test_get_protocols(
         key="dummy-key-333",
     )
 
-    decoy.when(protocol_store.get_all()).then_return([resource_1, resource_2, resource_3])
+    decoy.when(protocol_store.get_all()).then_return(
+        [resource_1, resource_2, resource_3]
+    )
     decoy.when(analysis_store.get_summaries_by_protocol("abc")).then_return(
         [analysis_1]
     )
@@ -238,7 +239,11 @@ async def test_get_protocols(
         analysis_store=analysis_store,
     )
 
-    assert result.content.data == [expected_protocol_1, expected_protocol_2, expected_protocol_3]
+    assert result.content.data == [
+        expected_protocol_1,
+        expected_protocol_2,
+        expected_protocol_3,
+    ]
     assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=3)
     assert result.status_code == 200
 

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -165,9 +165,26 @@ async def test_get_protocols(
         protocol_key="dummy-key-222",
         protocol_kind=ProtocolKind.STANDARD.value,
     )
+    resource_3 = ProtocolResource(
+        protocol_id="333",
+        created_at=created_at_2,
+        source=ProtocolSource(
+            directory=Path("/dev/null"),
+            main_file=Path("/dev/null/333.json"),
+            config=JsonProtocolConfig(schema_version=1234),
+            files=[],
+            metadata={},
+            robot_type="OT-3 Standard",
+            content_hash="3_3_3",
+        ),
+        protocol_key="dummy-key-333",
+        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+    )
+
 
     analysis_1 = AnalysisSummary(id="analysis-id-abc", status=AnalysisStatus.PENDING)
     analysis_2 = AnalysisSummary(id="analysis-id-123", status=AnalysisStatus.PENDING)
+    analysis_3 = AnalysisSummary(id="analysis-id-333", status=AnalysisStatus.PENDING)
 
     expected_protocol_1 = Protocol(
         id="abc",
@@ -191,22 +208,60 @@ async def test_get_protocols(
         files=[],
         key="dummy-key-222",
     )
+    expected_protocol_3 = Protocol(
+        id="333",
+        createdAt=created_at_2,
+        protocolKind=ProtocolKind.QUICK_TRANSFER,
+        protocolType=ProtocolType.JSON,
+        metadata=Metadata(),
+        robotType="OT-3 Standard",
+        analysisSummaries=[analysis_3],
+        files=[],
+        key="dummy-key-333",
+    )
 
-    decoy.when(protocol_store.get_all()).then_return([resource_1, resource_2])
+    decoy.when(protocol_store.get_all()).then_return([resource_1, resource_2, resource_3])
     decoy.when(analysis_store.get_summaries_by_protocol("abc")).then_return(
         [analysis_1]
     )
     decoy.when(analysis_store.get_summaries_by_protocol("123")).then_return(
         [analysis_2]
     )
+    decoy.when(analysis_store.get_summaries_by_protocol("333")).then_return(
+        [analysis_3]
+    )
 
+    # Test GET all protocols
     result = await get_protocols(
+        protocol_kind=None,
+        protocol_store=protocol_store,
+        analysis_store=analysis_store,
+    )
+
+    assert result.content.data == [expected_protocol_1, expected_protocol_2, expected_protocol_3]
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=3)
+    assert result.status_code == 200
+
+    # Test GET standard protocols
+    result = await get_protocols(
+        protocol_kind=ProtocolKind.STANDARD,
         protocol_store=protocol_store,
         analysis_store=analysis_store,
     )
 
     assert result.content.data == [expected_protocol_1, expected_protocol_2]
     assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=2)
+    assert result.status_code == 200
+
+    # Test GET Quick transfer protocols
+    result = await get_protocols(
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
+        protocol_store=protocol_store,
+        analysis_store=analysis_store,
+    )
+
+    assert result.content.data == [expected_protocol_3]
+    assert result.content.meta == MultiBodyMeta(cursor=0, totalLength=1)
     assert result.status_code == 200
 
 


### PR DESCRIPTION
# Overview

The client app needs to filter out protocols based on their kind, this pull request allows that at the server side by adding a `protocolKind` query arg to the `GET /protocols` endpoint.

Closes: [PLAT-330](https://opentrons.atlassian.net/browse/PLAT-330)

# Test Plan

- [x] Make sure that omitting the 'protocolKind' query arg returns ALL protocols
- [x] Make sure that only `standard` protocols are returned when `protocolKind=standard`
- [x] Make sure that only `quick-transfer` protocols are returned when `protocolKind=quick-transfer`
- [x] Make sure that we return a 400 when the `protocolKind` is invalid

# Changelog

- Add `protocolKind` query arg to the `GET /protocols` endpoint

# Review requests

# Risk assessment

Low, unreleased feature

[PLAT-330]: https://opentrons.atlassian.net/browse/PLAT-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ