### PR TITLE
Robot server maximum quick transfer protocols

### DIFF
--- a/robot-server/robot_server/protocols/dependencies.py
+++ b/robot-server/robot_server/protocols/dependencies.py
@@ -138,3 +138,8 @@ async def get_protocol_auto_deleter(
             maximum_unused_protocols=get_settings().maximum_unused_protocols
         ),
     )
+
+
+def get_maximum_quick_transfer_protocols() -> int:
+    """Get the maximum quick transfer protocol setting."""
+    return get_settings().maximum_quick_transfer_protocols

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -64,6 +64,7 @@ from .dependencies import (
     get_protocol_directory,
     get_file_reader_writer,
     get_file_hasher,
+    get_maximum_quick_transfer_protocols,
 )
 
 
@@ -226,6 +227,9 @@ async def create_protocol(  # noqa: C901
     protocol_id: str = Depends(get_unique_id, use_cache=False),
     analysis_id: str = Depends(get_unique_id, use_cache=False),
     created_at: datetime = Depends(get_current_time),
+    maximum_quick_transfer_protocols: int = Depends(
+        get_maximum_quick_transfer_protocols
+    ),
 ) -> PydanticResponse[SimpleBody[Protocol]]:
     """Create a new protocol by uploading its files.
 
@@ -248,6 +252,7 @@ async def create_protocol(  # noqa: C901
         protocol_id: Unique identifier to attach to the protocol resource.
         analysis_id: Unique identifier to attach to the analysis resource.
         created_at: Timestamp to attach to the new resource.
+        maximum_quick_transfer_protocols: Robot setting value limiting stored quick transfers protocols.
     """
     kind = ProtocolKind.from_string(protocol_kind)
     if isinstance(protocol_kind, str) and kind is None:
@@ -255,6 +260,17 @@ async def create_protocol(  # noqa: C901
             status_code=400, detail=f"Invalid protocol_kind: {protocol_kind}"
         )
     kind = kind or ProtocolKind.STANDARD
+
+    quick_transfer_protocols = [
+        protocol
+        for protocol in protocol_store.get_all()
+        if protocol.protocol_kind == "quick_transfer"
+    ]
+    quick_transfer_protocol_count = len(quick_transfer_protocols)
+    if quick_transfer_protocol_count >= maximum_quick_transfer_protocols:
+        raise HTTPException(
+            status_code=409, detail="Maximum quick transfer protocols exceeded"
+        )
 
     for file in files:
         # TODO(mm, 2024-02-07): Investigate whether the filename can actually be None.

--- a/robot-server/robot_server/settings.py
+++ b/robot-server/robot_server/settings.py
@@ -94,5 +94,14 @@ class RobotServerSettings(BaseSettings):
         ),
     )
 
+    maximum_quick_transfer_protocols: int = Field(
+        default=20,
+        gt=0,
+        description=(
+            'The maximum number of "quick transfer protocols" to allow before auto-deleting'
+            " old ones."
+        ),
+    )
+
     class Config:
         env_prefix = "OT_ROBOT_SERVER_"

--- a/robot-server/settings_schema.json
+++ b/robot-server/settings_schema.json
@@ -6,32 +6,24 @@
     "simulator_configuration_file_path": {
       "title": "Simulator Configuration File Path",
       "description": "Path to a json file that describes the hardware simulator.",
-      "env_names": [
-        "ot_robot_server_simulator_configuration_file_path"
-      ],
+      "env_names": ["ot_robot_server_simulator_configuration_file_path"],
       "type": "string"
     },
     "notification_server_subscriber_address": {
       "title": "Notification Server Subscriber Address",
       "description": "The endpoint to subscribe to notification server topics.",
       "default": "tcp://localhost:5555",
-      "env_names": [
-        "ot_robot_server_notification_server_subscriber_address"
-      ],
+      "env_names": ["ot_robot_server_notification_server_subscriber_address"],
       "type": "string"
     },
     "persistence_directory": {
       "title": "Persistence Directory",
       "description": "A directory for the server to store things persistently across boots. If this directory doesn't already exist, the server will create it. If this is the string `automatically_make_temporary`, the server will use a fresh temporary directory (effectively not persisting anything).\n\nNote that the `opentrons` library is also responsible for persisting certain things, and it has its own configuration.",
       "default": "automatically_make_temporary",
-      "env_names": [
-        "ot_robot_server_persistence_directory"
-      ],
+      "env_names": ["ot_robot_server_persistence_directory"],
       "anyOf": [
         {
-          "enum": [
-            "automatically_make_temporary"
-          ],
+          "enum": ["automatically_make_temporary"],
           "type": "string"
         },
         {
@@ -45,9 +37,7 @@
       "description": "The maximum number of runs to allow HTTP clients to create before auto-deleting old ones.",
       "default": 20,
       "exclusiveMinimum": 0,
-      "env_names": [
-        "ot_robot_server_maximum_runs"
-      ],
+      "env_names": ["ot_robot_server_maximum_runs"],
       "type": "integer"
     },
     "maximum_unused_protocols": {
@@ -55,9 +45,15 @@
       "description": "The maximum number of \"unused protocols\" to allow before auto-deleting old ones. A protocol is \"unused\" if it isn't used by any run that currently exists.",
       "default": 5,
       "exclusiveMinimum": 0,
-      "env_names": [
-        "ot_robot_server_maximum_unused_protocols"
-      ],
+      "env_names": ["ot_robot_server_maximum_unused_protocols"],
+      "type": "integer"
+    },
+    "maximum_quick_transfer_protocols": {
+      "title": "Maximum Quick Transfer Protocols",
+      "description": "The maximum number of \"quick transfer protocols\" to allow before auto-deleting old ones.",
+      "default": 20,
+      "exclusiveMinimum": 0,
+      "env_names": ["ot_robot_server_maximum_quick_transfer_protocols"],
       "type": "integer"
     }
   },

--- a/robot-server/tests/integration/dev_server.py
+++ b/robot-server/tests/integration/dev_server.py
@@ -17,6 +17,7 @@ class DevServer:
         persistence_directory: Optional[Path] = None,
         maximum_runs: Optional[int] = None,
         maximum_unused_protocols: Optional[int] = None,
+        maximum_quick_transfer_protocols: Optional[int] = None,
     ) -> None:
         """Initialize a dev server."""
         self.port: str = port
@@ -35,6 +36,7 @@ class DevServer:
 
         self.maximum_runs = maximum_runs
         self.maximum_unused_protocols = maximum_unused_protocols
+        self.maximum_quick_transfer_protocols = maximum_quick_transfer_protocols
 
     def __enter__(self) -> DevServer:
         return self
@@ -63,6 +65,10 @@ class DevServer:
         if self.maximum_unused_protocols is not None:
             env["OT_ROBOT_SERVER_maximum_unused_protocols"] = str(
                 self.maximum_unused_protocols
+            )
+        if self.maximum_quick_transfer_protocols is not None:
+            env["OT_ROBOT_SERVER_maximum_quick_transfer_protocols"] = str(
+                self.maximum_quick_transfer_protocols
             )
 
         # In order to collect coverage we run using `coverage`.

--- a/robot-server/tests/integration/http_api/protocols/test_upload_protocol_kind.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_upload_protocol_kind.tavern.yaml
@@ -73,4 +73,4 @@ stages:
     response:
       strict:
         - json:off
-      status_code: 400
+      status_code: 422

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -1710,41 +1710,6 @@ async def test_create_protocol_kind_quick_transfer(
     assert result.status_code == 201
 
 
-async def test_create_protocol_kind_invalid(
-    protocol_store: ProtocolStore,
-    analysis_store: AnalysisStore,
-    protocol_reader: ProtocolReader,
-    file_reader_writer: FileReaderWriter,
-    file_hasher: FileHasher,
-    protocol_auto_deleter: ProtocolAutoDeleter,
-) -> None:
-    """It should throw a 400 error if the protocol kind is invalid."""
-    protocol_directory = Path("/dev/null")
-    content = bytes("some_content", encoding="utf-8")
-    uploaded_file = io.BytesIO(content)
-    protocol_file = UploadFile(filename="foo.json", file=uploaded_file)
-
-    with pytest.raises(HTTPException) as exc_info:
-        await create_protocol(
-            files=[protocol_file],
-            key="dummy-key-111",
-            protocol_directory=protocol_directory,
-            protocol_store=protocol_store,
-            analysis_store=analysis_store,
-            file_reader_writer=file_reader_writer,
-            protocol_reader=protocol_reader,
-            file_hasher=file_hasher,
-            protocol_auto_deleter=protocol_auto_deleter,
-            robot_type="OT-3 Standard",
-            protocol_id="protocol-id",
-            analysis_id="analysis-id",
-            protocol_kind="invalid",
-            created_at=datetime(year=2021, month=1, day=1),
-        )
-
-        assert exc_info.value.status_code == 400
-
-
 async def test_create_protocol_maximum_quick_transfer_protocols_exceeded(
     decoy: Decoy,
     protocol_store: ProtocolStore,
@@ -1799,7 +1764,7 @@ async def test_create_protocol_maximum_quick_transfer_protocols_exceeded(
             robot_type="OT-3 Standard",
             protocol_id="protocol-id",
             analysis_id="analysis-id",
-            protocol_kind="quick_transfer",
+            protocol_kind=ProtocolKind.QUICK_TRANSFER,
             created_at=datetime(year=2021, month=1, day=1),
             maximum_quick_transfer_protocols=1,
         )

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -1684,7 +1684,7 @@ async def test_create_protocol_kind_quick_transfer(
         analyses_manager=analyses_manager,
         protocol_auto_deleter=protocol_auto_deleter,
         robot_type="OT-3 Standard",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
         protocol_id="protocol-id",
         analysis_id="analysis-id",
         created_at=datetime(year=2021, month=1, day=1),


### PR DESCRIPTION
# Overview

Quick Transfer protocols are meant to be easy to set up and use protocols from the ODD, so
1. We don't want to crowd the screen real estate with unlimited protocols
2. We want to encourage users to delete and create new quick transfer protocols as they see fit
3. We want to limit the number of protocols stored on the robot so performance is not impacted.

Let's introduce a robot server setting `maximum_quick_transfer_protocols` to set the maximum number of quick transfer protocols. Then let's use this setting to return a 400 error if we have reached the limit,

Closes: [PLAT-314](https://opentrons.atlassian.net/browse/PLAT-314) [PLAT-317](https://opentrons.atlassian.net/browse/PLAT-317)

# Test Plan

- [x] Make sure we store quick transfer protocols until we hit the limit
- [x] Once the protocol limit is hit, make sure we don't store the new protocol and respond with a 400 error

# Changelog

- Add `maximum_quick_transfer_protocols` robot server config
- Limit the number of quick transfer protocols based on the above config and return a 400 error once the limit is reached

# Review requests

- Makes sense?

# Risk assessment
Low, unreleased

[PLAT-314]: https://opentrons.atlassian.net/browse/PLAT-314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-317]: https://opentrons.atlassian.net/browse/PLAT-317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ