### PR TITLE
fix(api): change error checks in liquid_probe

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -85,12 +85,12 @@ class LiquidProbeImplementation(AbstractCommandImpl[LiquidProbeParams, _ExecuteR
 
         # throw error if pipette has no tip
         # _validate_tip_attached in pipetting.py is a private method so we're using
-        # get_is_ready_to_aspirate as an indirect way to throw the NoTipAttachedError
+        # get_is_ready_to_aspirate as an indirect way to throw the TipNotAttachedError
         self._pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)
 
-        # throw error if pipette has a working volume volume
+        # throw error if pipette has a working volume == max volume
 
-        # throw error if plunger not homed
+        # throw error if plunger isn't in valid position
         if await self._movement.check_for_valid_position(mount=MountType.LEFT) is False:
             raise PositionUnknownError(
                 message="Current position of pipette is invalid. Please home."

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -85,18 +85,15 @@ class LiquidProbeImplementation(AbstractCommandImpl[LiquidProbeParams, _ExecuteR
         labware_id = params.labwareId
         well_name = params.wellName
 
-        # throw error if pipette has no tip
         # _validate_tip_attached in pipetting.py is a private method so we're using
-        # get_is_ready_to_aspirate as an indirect way to throw the TipNotAttachedError
+        # get_is_ready_to_aspirate as an indirect way to throw a TipNotAttachedError if appropriate
         self._pipetting.get_is_ready_to_aspirate(pipette_id=pipette_id)
 
-        # throw error if pipette has a working volume != 0
         if self._pipetting.get_is_empty(pipette_id=pipette_id) is False:
             raise TipNotEmptyError(
                 message="This operation requires a tip with no liquid in it."
             )
 
-        # throw error if plunger isn't in valid position
         if await self._movement.check_for_valid_position(mount=MountType.LEFT) is False:
             raise MustHomeError(
                 message="Current position of pipette is invalid. Please home."

--- a/api/src/opentrons/protocol_engine/commands/liquid_probe.py
+++ b/api/src/opentrons/protocol_engine/commands/liquid_probe.py
@@ -78,7 +78,7 @@ class LiquidProbeImplementation(AbstractCommandImpl[LiquidProbeParams, _ExecuteR
 
         Raises:
             TipNotAttachedError: if there is not tip attached to the pipette
-            PositionUnknownError: if the plunger is not in a valid position
+            MustHomeError: if the plunger is not in a valid position
             LiquidNotFoundError: if liquid is not found during the probe process.
         """
         pipette_id = params.pipetteId

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -1017,3 +1017,16 @@ class NotSupportedOnRobotType(ProtocolEngineError):
         super().__init__(
             ErrorCodes.NOT_SUPPORTED_ON_ROBOT_TYPE, message, details, wrapping
         )
+
+
+class TipNotEmptyError(ProtocolEngineError):
+    """Raised when an operation requires an empty tip but is provided a tip with liquid."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a TipNotEmptyError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -29,6 +29,9 @@ _VOLUME_ROUNDING_ERROR_TOLERANCE = 1e-9
 class PipettingHandler(TypingProtocol):
     """Liquid handling commands."""
 
+    def get_is_empty(self, pipette_id: str) -> bool:
+        """Get whether a pipette has a working volume equal to max volume."""
+
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""
 
@@ -76,6 +79,10 @@ class HardwarePipettingHandler(PipettingHandler):
         """Initialize a PipettingHandler instance."""
         self._state_view = state_view
         self._hardware_api = hardware_api
+
+    def get_is_empty(self, pipette_id: str) -> bool:
+        """Get whether a pipette has a working volume equal to max volume."""
+        return self._state_view.pipettes.get_working_volume(pipette_id) == 0
 
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""
@@ -225,6 +232,10 @@ class VirtualPipettingHandler(PipettingHandler):
     ) -> None:
         """Initialize a PipettingHandler instance."""
         self._state_view = state_view
+
+    def get_is_empty(self, pipette_id: str) -> bool:
+        """Get whether a pipette has a working volume equal to max volume."""
+        return self._state_view.pipettes.get_working_volume(pipette_id) == 0
 
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -30,7 +30,7 @@ class PipettingHandler(TypingProtocol):
     """Liquid handling commands."""
 
     def get_is_empty(self, pipette_id: str) -> bool:
-        """Get whether a pipette has a working volume equal to max volume."""
+        """Get whether a pipette has a working volume equal to 0."""
 
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
         """Get whether a pipette is ready to aspirate."""
@@ -81,7 +81,7 @@ class HardwarePipettingHandler(PipettingHandler):
         self._hardware_api = hardware_api
 
     def get_is_empty(self, pipette_id: str) -> bool:
-        """Get whether a pipette has a working volume equal to max volume."""
+        """Get whether a pipette has a working volume equal to 0."""
         return self._state_view.pipettes.get_working_volume(pipette_id) == 0
 
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:
@@ -234,7 +234,7 @@ class VirtualPipettingHandler(PipettingHandler):
         self._state_view = state_view
 
     def get_is_empty(self, pipette_id: str) -> bool:
-        """Get whether a pipette has a working volume equal to max volume."""
+        """Get whether a pipette has a working volume equal to 0."""
         return self._state_view.pipettes.get_working_volume(pipette_id) == 0
 
     def get_is_ready_to_aspirate(self, pipette_id: str) -> bool:

--- a/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_liquid_probe.py
@@ -255,6 +255,8 @@ async def test_liquid_probe_tip_checking(
         assert False
     except TipNotAttachedError:
         assert True
+    except Exception:
+        assert False
 
 
 async def test_liquid_probe_volume_checking(
@@ -286,6 +288,8 @@ async def test_liquid_probe_volume_checking(
         assert False
     except TipNotEmptyError:
         assert True
+    except Exception:
+        assert False
 
 
 async def test_liquid_probe_location_checking(
@@ -319,3 +323,5 @@ async def test_liquid_probe_location_checking(
         assert False
     except MustHomeError:
         assert True
+    except Exception:
+        assert False


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Delete the current, incorrect, checks in execution of liquid_probe and replace them with individual, specific checks for tip presence, working volume, and pipette position

fix EXEC-591

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->


Added 3 unit tests to test_liquid_probe.py to make sure the proper errors are being raised.
1 for tip attachment error, 1 for tip empty error, and 1 for position error.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Error checks in execute in liquid_probe.py
New unit tests in test_liquid_probe.py
New exception type called "TipNotEmptyError" in `protocol_engine/errors/exceptions.py`. It is marked as a "GENERAL_ERROR".
New get_is_empty function in `protocol_engine/execution/pipetting.py`. 


# Review requests

<!--
Describe any requests for your reviewers here.
-->

I'm not sure if adding the get_is_empty function is the proper thing to do but I didn't know how to check the working volume another way without breaking some layer of abstraction.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->

Low.