### PR TITLE
fix(protocol-designer): getPipetteCapacity correctly updates tip capa…

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/DisposalVolumeField.tsx
@@ -69,7 +69,6 @@ export const DisposalVolumeField = (
 
   const disposalOptions = useSelector(uiLabwareSelectors.getDisposalOptions)
   const pipetteEntities = useSelector(stepFormSelectors.getPipetteEntities)
-  const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
   const blowoutLocationOptions = getBlowoutLocationOptionsForForm({
     path,
     stepType,
@@ -83,8 +82,7 @@ export const DisposalVolumeField = (
       volume,
       tipRack,
     },
-    pipetteEntities,
-    labwareEntities
+    pipetteEntities
   )
   const disposalDestinationOptions = [
     ...disposalOptions,

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/PathField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/PathField.tsx
@@ -124,7 +124,6 @@ export const PathField = (props: PathFieldProps): JSX.Element => {
   } = props
   const { t } = useTranslation('form')
   const pipetteEntities = useSelector(stepFormSelectors.getPipetteEntities)
-  const labwareEntities = useSelector(stepFormSelectors.getLabwareEntities)
   const disabledPathMap = getDisabledPathMap(
     {
       aspirate_airGap_checkbox,
@@ -137,7 +136,6 @@ export const PathField = (props: PathFieldProps): JSX.Element => {
       tipRack,
     },
     pipetteEntities,
-    labwareEntities,
     t
   )
   return (

--- a/protocol-designer/src/components/StepEditForm/fields/PathField/getDisabledPathMap.ts
+++ b/protocol-designer/src/components/StepEditForm/fields/PathField/getDisabledPathMap.ts
@@ -6,7 +6,6 @@ import {
 } from '../../../../steplist/formLevel/handleFormChange/utils'
 import type {
   ChangeTipOptions,
-  LabwareEntities,
   PipetteEntities,
 } from '@opentrons/step-generation'
 import type { PathOption } from '../../../../form-types'
@@ -24,7 +23,6 @@ export interface ValuesForPath {
 export function getDisabledPathMap(
   values: ValuesForPath,
   pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities,
   t: any
 ): DisabledPathMap {
   const {
@@ -59,7 +57,7 @@ export function getDisabledPathMap(
   // transfer volume overwrites change tip disable reasoning
   const pipetteEntity = pipetteEntities[pipette]
   const pipetteCapacity =
-    pipetteEntity && getPipetteCapacity(pipetteEntity, labwareEntities, tipRack)
+    pipetteEntity && getPipetteCapacity(pipetteEntity, tipRack)
   const volume = Number(values.volume)
   const airGapChecked = aspirate_airGap_checkbox
   let airGapVolume = airGapChecked ? Number(values.aspirate_airGap_volume) : 0

--- a/protocol-designer/src/pipettes/pipetteData.ts
+++ b/protocol-designer/src/pipettes/pipetteData.ts
@@ -46,10 +46,10 @@ export const getPipetteCapacity = (
       break
     }
   }
-  const tiprackTipVol = getTiprackVolume(chosenTipRack ?? tipRackDefs[0])
+  const tipRackTipVol = getTiprackVolume(chosenTipRack ?? tipRackDefs[0])
 
-  if (maxVolume != null && tiprackTipVol != null) {
-    return Math.min(maxVolume, tiprackTipVol)
+  if (maxVolume != null && tipRackTipVol != null) {
+    return Math.min(maxVolume, tipRackTipVol)
   }
   console.assert(
     false,

--- a/protocol-designer/src/pipettes/pipetteData.ts
+++ b/protocol-designer/src/pipettes/pipetteData.ts
@@ -5,7 +5,7 @@ import {
 } from '@opentrons/shared-data'
 import type { PipetteName } from '@opentrons/shared-data'
 import type { Options } from '@opentrons/components'
-import type { LabwareEntities, PipetteEntity } from '@opentrons/step-generation'
+import type { PipetteEntity } from '@opentrons/step-generation'
 import type { DropdownOption } from '../../../components/lib/forms/DropdownField.d'
 const supportedPipetteNames: PipetteName[] = [
   'p10_single',
@@ -35,36 +35,27 @@ export const pipetteOptions: Options = supportedPipetteNames
 // NOTE: this is similar to getPipetteWithTipMaxVol, the fns
 export const getPipetteCapacity = (
   pipetteEntity: PipetteEntity,
-  labwareEntities: LabwareEntities,
-  tipRack?: string | null
+  tipRackDefUri?: string | null
 ): number => {
-  const spec = pipetteEntity.spec
-  const tiprackDefs = pipetteEntity.tiprackLabwareDef
-  const tipRackDefUri =
-    tipRack != null && labwareEntities[tipRack] != null
-      ? labwareEntities[tipRack]?.labwareDefURI
-      : ''
+  const maxVolume = pipetteEntity.spec.liquids.default.maxVolume
+  const tipRackDefs = pipetteEntity.tiprackLabwareDef
   let chosenTipRack = null
-
-  for (const def of tiprackDefs) {
+  for (const def of tipRackDefs) {
     if (getLabwareDefURI(def) === tipRackDefUri) {
       chosenTipRack = def
       break
     }
   }
-  if (spec && tiprackDefs) {
-    return Math.min(
-      spec.liquids.default.maxVolume,
-      //  not sure if this is a good way to handle this. chosenTipRack is null until you select it
-      getTiprackVolume(chosenTipRack ?? tiprackDefs[0])
-    )
-  }
+  const tiprackTipVol = getTiprackVolume(chosenTipRack ?? tipRackDefs[0])
 
+  if (maxVolume != null && tiprackTipVol != null) {
+    return Math.min(maxVolume, tiprackTipVol)
+  }
   console.assert(
     false,
     `Expected spec and tiprack def for pipette ${
       pipetteEntity ? pipetteEntity.id : '???'
-    } and ${tipRack ?? '???'}`
+    } and ${tipRackDefUri ?? '???'}`
   )
   return NaN
 }

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -238,18 +238,11 @@ export const wellRatioMoveLiquid = (
     ? null
     : wellRatioFormError
 }
-export const volumeTooHigh = (
-  fields: HydratedFormData,
-  labwareEntities?: LabwareEntities
-): FormError | null => {
+export const volumeTooHigh = (fields: HydratedFormData): FormError | null => {
   const { pipette, tipRack } = fields
   const volume = Number(fields.volume)
 
-  const pipetteCapacity = getPipetteCapacity(
-    pipette,
-    labwareEntities ?? {},
-    tipRack
-  )
+  const pipetteCapacity = getPipetteCapacity(pipette, tipRack)
   if (
     !Number.isNaN(volume) &&
     !Number.isNaN(pipetteCapacity) &&

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -132,8 +132,7 @@ const wellRatioUpdater = makeConditionalPatchUpdater(wellRatioUpdatesMap)
 export function updatePatchPathField(
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
 ): FormPatch {
   const { id, stepType, ...stepData } = rawForm
   const appliedPatch = { ...(stepData as FormPatch), ...patch }
@@ -154,8 +153,7 @@ export function updatePatchPathField(
     pipetteCapacityExceeded = !volumeInCapacityForMulti(
       // @ts-expect-error(sa, 2021-6-14): appliedPatch is not of type FormData, address in #3161
       appliedPatch,
-      pipetteEntities,
-      labwareEntities
+      pipetteEntities
     )
   }
 
@@ -266,8 +264,7 @@ const getClearedDisposalVolumeFields = (): FormPatch =>
 const clampAspirateAirGapVolume = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
 ): FormPatch => {
   const patchedAspirateAirgapVolume =
     patch.aspirate_airGap_volume ?? rawForm?.aspirate_airGap_volume
@@ -284,8 +281,7 @@ const clampAspirateAirGapVolume = (
     const minAirGapVolume = 0 // NOTE: a form level warning will occur if the air gap volume is below the pipette min volume
 
     const maxAirGapVolume =
-      getPipetteCapacity(pipetteEntity, labwareEntities, tipRack) -
-      minPipetteVolume
+      getPipetteCapacity(pipetteEntity, tipRack) - minPipetteVolume
     const clampedAirGapVolume = clamp(
       Number(patchedAspirateAirgapVolume),
       minAirGapVolume,
@@ -302,8 +298,7 @@ const clampAspirateAirGapVolume = (
 const clampDispenseAirGapVolume = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
 ): FormPatch => {
   const { id, stepType, ...stepData } = rawForm
   const appliedPatch = { ...(stepData as FormPatch), ...patch, id, stepType }
@@ -327,7 +322,7 @@ const clampDispenseAirGapVolume = (
     pipetteId in pipetteEntities
   ) {
     const pipetteEntity = pipetteEntities[pipetteId]
-    const capacity = getPipetteCapacity(pipetteEntity, labwareEntities, tipRack)
+    const capacity = getPipetteCapacity(pipetteEntity, tipRack)
     const minAirGapVolume = 0 // NOTE: a form level warning will occur if the air gap volume is below the pipette min volume
 
     const maxAirGapVolume =
@@ -407,8 +402,7 @@ const updatePatchDisposalVolumeFields = (
 const clampDisposalVolume = (
   patch: FormPatch,
   rawForm: FormData,
-  pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
 ): FormPatch => {
   const { id, stepType, ...stepData } = rawForm
   const appliedPatch = { ...(stepData as FormPatch), ...patch, id, stepType }
@@ -419,8 +413,7 @@ const clampDisposalVolume = (
   const maxDisposalVolume = getMaxDisposalVolumeForMultidispense(
     // @ts-expect-error(sa, 2021-6-14): appliedPatch isn't well-typed, address in #3161
     appliedPatch,
-    pipetteEntities,
-    labwareEntities
+    pipetteEntities
   )
 
   if (maxDisposalVolume == null) {
@@ -644,37 +637,15 @@ export function dependentFieldsUpdateMoveLiquid(
     chainPatch =>
       updatePatchOnPipetteChange(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchOnWellRatioChange(chainPatch, rawForm),
-    chainPatch =>
-      updatePatchPathField(
-        chainPatch,
-        rawForm,
-        pipetteEntities,
-        labwareEntities
-      ),
+    chainPatch => updatePatchPathField(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
       updatePatchDisposalVolumeFields(chainPatch, rawForm, pipetteEntities),
     chainPatch =>
-      clampAspirateAirGapVolume(
-        chainPatch,
-        rawForm,
-        pipetteEntities,
-        labwareEntities
-      ),
-    chainPatch =>
-      clampDisposalVolume(
-        chainPatch,
-        rawForm,
-        pipetteEntities,
-        labwareEntities
-      ),
+      clampAspirateAirGapVolume(chainPatch, rawForm, pipetteEntities),
+    chainPatch => clampDisposalVolume(chainPatch, rawForm, pipetteEntities),
     chainPatch => updatePatchMixFields(chainPatch, rawForm),
     chainPatch => updatePatchBlowoutFields(chainPatch, rawForm),
     chainPatch =>
-      clampDispenseAirGapVolume(
-        chainPatch,
-        rawForm,
-        pipetteEntities,
-        labwareEntities
-      ),
+      clampDispenseAirGapVolume(chainPatch, rawForm, pipetteEntities),
   ])
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/utils.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/utils.test.ts
@@ -7,10 +7,7 @@ import {
 } from '../utils'
 import { fixture_tiprack_300_ul } from '@opentrons/shared-data/labware/fixtures/2'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
-import type {
-  PipetteEntities,
-  LabwareEntities,
-} from '@opentrons/step-generation'
+import type { PipetteEntities } from '@opentrons/step-generation'
 import type { FormData } from '../../../../form-types'
 
 const fixtureTiprack300ul = fixture_tiprack_300_ul as LabwareDefinition2
@@ -19,7 +16,6 @@ describe('utils', () => {
   describe('volumeInCapacityForMulti', () => {
     let sharedForm: FormData
     let pipetteEntities: PipetteEntities
-    let labwareEntities: LabwareEntities
     beforeEach(() => {
       sharedForm = {
         pipette: 'p300_single',
@@ -30,7 +26,6 @@ describe('utils', () => {
           tiprackLabwareDef: [fixtureTiprack300ul],
         },
       } as any
-      labwareEntities = {}
     })
     describe('multi dispense path', () => {
       const testCases = [
@@ -92,8 +87,7 @@ describe('utils', () => {
             expect(
               volumeInCapacityForMulti(
                 { ...sharedForm, ...form },
-                pipetteEntities,
-                labwareEntities
+                pipetteEntities
               )
             ).toBe(expected)
           })
@@ -150,8 +144,7 @@ describe('utils', () => {
             expect(
               volumeInCapacityForMulti(
                 { ...sharedForm, ...form },
-                pipetteEntities,
-                labwareEntities
+                pipetteEntities
               )
             ).toBe(expected)
           })

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -65,8 +65,7 @@ export function getMaxDisposalVolumeForMultidispense(
     volume: string | null
     tipRack?: string | null
   },
-  pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
 ): number | null | undefined {
   // calculate max disposal volume for given volume & pipette. Might be negative!
   const pipetteId = values?.pipette
@@ -76,11 +75,7 @@ export function getMaxDisposalVolumeForMultidispense(
     `getMaxDisposalVolumeForMultidispense expected multiDispense, got path ${values.path}`
   )
   const pipetteEntity = pipetteEntities[pipetteId]
-  const pipetteCapacity = getPipetteCapacity(
-    pipetteEntity,
-    labwareEntities,
-    values.tipRack
-  )
+  const pipetteCapacity = getPipetteCapacity(pipetteEntity, values.tipRack)
   const volume = Number(values.volume)
   const airGapChecked = values.aspirate_airGap_checkbox
   let airGapVolume = airGapChecked ? Number(values.aspirate_airGap_volume) : 0
@@ -92,8 +87,7 @@ export function getMaxDisposalVolumeForMultidispense(
 // is responsibility of dependentFieldsUpdateMoveLiquid's clamp fn
 export function volumeInCapacityForMulti(
   rawForm: FormData,
-  pipetteEntities: PipetteEntities,
-  labwareEntities: LabwareEntities
+  pipetteEntities: PipetteEntities
 ): boolean {
   console.assert(
     rawForm.pipette in pipetteEntities,
@@ -101,8 +95,7 @@ export function volumeInCapacityForMulti(
   )
   const pipetteEntity = pipetteEntities[rawForm.pipette]
   const pipetteCapacity =
-    pipetteEntity &&
-    getPipetteCapacity(pipetteEntity, labwareEntities, rawForm.tipRack)
+    pipetteEntity && getPipetteCapacity(pipetteEntity, rawForm.tipRack)
   const volume = Number(rawForm.volume)
   const airGapChecked = rawForm.aspirate_airGap_checkbox
   let airGapVolume = airGapChecked ? Number(rawForm.aspirate_airGap_volume) : 0
@@ -137,6 +130,8 @@ export function volumeInCapacityForMultiDispense(args: {
   airGapVolume: number
 }): boolean {
   const { volume, pipetteCapacity, airGapVolume } = args
+  console.log('pipetteCapacity', pipetteCapacity, volume)
+
   return (
     volume > 0 &&
     pipetteCapacity > 0 &&

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -130,7 +130,6 @@ export function volumeInCapacityForMultiDispense(args: {
   airGapVolume: number
 }): boolean {
   const { volume, pipetteCapacity, airGapVolume } = args
-  console.log('pipetteCapacity', pipetteCapacity, volume)
 
   return (
     volume > 0 &&


### PR DESCRIPTION
 closes AUTH-553

# Overview

This is a bug from https://github.com/Opentrons/opentrons/pull/15096, in that PR, i changed it so for multi tiprack support, the tiprack key that is required for the transfer and mix forms changed from the tiprack id to the tiprack def uri. But i forgot to migrate it to this util!! This resulted in the user being unable to get accurate tip volume capacity.

# Test Plan

Upload the attached protocol to PD in this branch and navigate to transfer step number 44. Open it and see that the multi-dispense path option is not available. Change the tiprack to the 1000uL tiprack and see that the multi-dispense path option is available.

[sirt activity assay_buffer test_test of volumes_short breaks_shaker.json](https://github.com/user-attachments/files/16132054/sirt.activity.assay_buffer.test_test.of.volumes_short.breaks_shaker.json)


# Changelog

- clean up the getPipetteCapacity util and affected components

# Review requests

see test plan

# Risk assessment

low
