### PR TITLE
fix(app): ERSplash doesn't care about device

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -40,7 +40,7 @@ import type { ERUtilsResults } from './hooks'
 import { useHost } from '@opentrons/react-api-client'
 
 export function useRunPausedSplash(showERWizard: boolean): boolean {
-  // Don't show the splash when desktop ER wizard is active.
+  // Don't show the splash when the ER wizard is active.
   return !showERWizard
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -39,12 +39,9 @@ import type { ErrorRecoveryFlowsProps } from '.'
 import type { ERUtilsResults } from './hooks'
 import { useHost } from '@opentrons/react-api-client'
 
-export function useRunPausedSplash(
-  isOnDevice: boolean,
-  showERWizard: boolean
-): boolean {
+export function useRunPausedSplash(showERWizard: boolean): boolean {
   // Don't show the splash when desktop ER wizard is active.
-  return isOnDevice && !showERWizard
+  return !showERWizard
 }
 
 type RunPausedSplashProps = ERUtilsResults & {

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RunPausedSplash.test.tsx
@@ -36,17 +36,11 @@ describe('useRunPausedSplash', () => {
 
   const IS_WIZARD_SHOWN = [false, true]
   IS_WIZARD_SHOWN.forEach(val => {
-    it(`returns ${!val} if on the ODD and showERWizard is ${val}`, () => {
-      const { result } = renderHook(() => useRunPausedSplash(true, val), {
+    it(`returns ${!val} if showERWizard is ${val}`, () => {
+      const { result } = renderHook(() => useRunPausedSplash(val), {
         wrapper,
       })
       expect(result.current).toEqual(!val)
-    })
-    it(`always returns false if on desktop and showERWizard is ${val}`, () => {
-      const { result } = renderHook(() => useRunPausedSplash(false, val), {
-        wrapper,
-      })
-      expect(result.current).toEqual(false)
     })
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -123,8 +123,7 @@ export function ErrorRecoveryFlows(
   const { protocolAnalysis } = props
   const robotType = protocolAnalysis?.robotType ?? OT2_ROBOT_TYPE
   const isOnDevice = useSelector(getIsOnDevice)
-  const showSplash = useRunPausedSplash(isOnDevice, showERWizard)
-
+  const showSplash = useRunPausedSplash(showERWizard)
   return (
     <>
       {showERWizard ? (


### PR DESCRIPTION
I don't know where in my brain this idea came from but both the ODD and the desktop want to show this screen.

## testing
- [x] enter ER on the desktop app and it shows a splash screen and a wizard when you click the "enter error recovery button"