### PR TITLE
fix(protocol-designer): fix logic in safePipetteMovements collision detection

### DIFF
--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -244,12 +244,21 @@ const getSlotHasPotentialCollidingObject = (
       ) &&
       pipetteBounds[0].z != null
     ) {
-      const highestZInSlot = getHighestZInSlot(
-        robotState,
-        invariantContext,
-        labwareId
-      )
-      return highestZInSlot >= pipetteBounds[0]?.z
+      const lwIdInSurroundingSlot =
+        Object.keys(robotState.labware).find(
+          lwId => robotState.labware[lwId].slot === slot.addressableArea?.id
+        ) ?? null
+      const highestZInSlot =
+        lwIdInSurroundingSlot == null
+          ? slotBounds.zDimension ?? 0
+          : getHighestZInSlot(
+              robotState,
+              invariantContext,
+              lwIdInSurroundingSlot
+            )
+      if (highestZInSlot >= pipetteBounds[0]?.z) {
+        return true
+      }
     }
   }
   return false
@@ -346,7 +355,7 @@ export const getIsSafePipetteMovement = (
     const pipetteBoundsAtWellLocation = getPipetteBoundsAtSpecifiedMoveToPosition(
       pipetteEntity,
       tipLength,
-      wellLocationOffset
+      wellLocationPoint
     )
     const surroundingSlots = getFlexSurroundingSlots(
       labwareSlot,

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -76,6 +76,7 @@ const getPipetteBoundsAtSpecifiedMoveToPosition = (
   tipLength: number,
   destinationPosition: Point
 ): Point[] => {
+  console.log(pipetteEntity.spec.nozzleMap)
   const primaryNozzleOffset =
     pipetteEntity.spec.nozzleMap != null
       ? pipetteEntity.spec.nozzleMap.A1
@@ -89,6 +90,7 @@ const getPipetteBoundsAtSpecifiedMoveToPosition = (
   const backLeftBound = {
     x:
       primaryNozzlePosition.x -
+      99 -
       primaryNozzleOffset[0] +
       pipetteBoundsOffsets.backLeftCorner[0],
     y:
@@ -103,6 +105,7 @@ const getPipetteBoundsAtSpecifiedMoveToPosition = (
   const frontRightBound = {
     x:
       primaryNozzlePosition.x -
+      99 -
       primaryNozzleOffset[0] +
       pipetteBoundsOffsets.frontRightCorner[0],
     y:
@@ -134,6 +137,10 @@ const getHasOverlappingRectangles = (
   rectangle1: Point[],
   rectangle2: Point[]
 ): boolean => {
+  console.log({
+    pipetteBounds: rectangle1,
+    rectangle2,
+  })
   const xCoords = [
     rectangle1[0].x,
     rectangle1[1].x,
@@ -157,7 +164,13 @@ const getHasOverlappingRectangles = (
     Math.abs(Math.max(...yCoordinates) - Math.min(...yCoordinates)) <
     yLengthRect1 + yLengthRect2
 
-  return overlappingInX && overlappingInY
+  const oneLeftOfTwo = rectangle1[1].x < rectangle2[0].x
+  const oneRightOfTwo = rectangle1[0].x > rectangle2[1].x
+  const oneUnderTwo = rectangle1[0].y < rectangle2[1].y
+  const oneOverTwo = rectangle1[1].y > rectangle2[0].y
+
+  console.log({ oneLeftOfTwo, oneRightOfTwo, oneUnderTwo, oneOverTwo })
+  return !(oneLeftOfTwo || oneRightOfTwo || oneUnderTwo || oneOverTwo)
 }
 
 //  check the highest Z-point of all items stacked given a deck slot (including modules,
@@ -231,11 +244,24 @@ const getSlotHasPotentialCollidingObject = (
       y: slotBounds.yDimension + slotPosition[1],
       z: slotPosition[2],
     }
+    console.group('FRAME ', slot.addressableArea?.id)
+    const xFrontRight = slotBounds.xDimension + slotPosition[0]
+    const xDim = slotBounds.xDimension
+    console.log('🚀 ~ xFrontRight:', xFrontRight)
+    console.log('🚀 ~ xDim:', xDim)
     const frontRightCoords = {
-      x: slotPosition[0] + slotBounds.xDimension,
+      x: xFrontRight,
       y: slotPosition[1],
       z: slotPosition[2],
     }
+    console.log({
+      backLeftCoords,
+      frontRightCoords,
+      xDim: slotBounds.xDimension,
+      slot: slot.addressableArea?.id,
+    })
+    console.groupEnd()
+
     // Check for overlapping rectangles and pipette z-coordinate if slot overlaps with pipette bounds
     if (
       getHasOverlappingRectangles(
@@ -257,6 +283,7 @@ const getSlotHasPotentialCollidingObject = (
               lwIdInSurroundingSlot
             )
       if (highestZInSlot >= pipetteBounds[0]?.z) {
+        console.log('BAD SLOT', slot.addressableArea?.id)
         return true
       }
     }


### PR DESCRIPTION
Closes RAUT-1046

# Overview

Several errors in `safePipetteMovements` collision logic were causing errors to be raised in `transfer` command creator calls using a 96-channel pipette with COLUMN configuration. This PR addresses these errors by
1. passing `wellLocationPoint` to `getPipetteBoundsAtSpecifiedMoveToPosition` to get correct pipette bounds
2. passing the _surrounding_ labware ID rather than the target labware ID to `getHighestZInSlot`, and
3. not early-returning if the highest Z in the surrounding slot does not exceed to the pipette bounds at that slot.

# Test Plan

- launch dev PD off this branch
- upload the following PD protocol that was incorrectly raising a collision error previously and verify that no warning is raised
- using the same protocol, modify the starting deck state to include a high labware like a 15ml tuberack to the slot left-adjacent to the destination wellplate (slot D1)
- verify that a collision error is properly raised

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
