### PR TITLE
feat(performance-metrics): run system resource tracker as systemd service

### DIFF
--- a/performance-metrics/Makefile
+++ b/performance-metrics/Makefile
@@ -97,6 +97,7 @@ override-robot-version:
 .PHONY: set-performance-metrics-ff
 set-performance-metrics-ff:
 	@curl \
+	--silent \
     -H "opentrons-version: *" \
     -X POST $(host):31950/settings \
     -H "content-type: application/json" \
@@ -105,6 +106,7 @@ set-performance-metrics-ff:
 .PHONY: unset-performance-metrics-ff
 unset-performance-metrics-ff:
 	@curl \
+	--silent \
 	-H "opentrons-version: *" \
 	-X POST $(host):31950/settings \
 	-H "content-type: application/json" \
@@ -128,6 +130,9 @@ setup-remote-flex:
 	@echo "Pushing robot-server to Flex"
 	@$(MAKE) -C ../robot-server push-ot3 host=$(host) ssh_key=$(ssh_key) 2>&1 | grep -v "Permanently added" > /dev/null
 
+	@echo "Setting performance metrics feature flag"
+	@$(MAKE) set-performance-metrics-ff host=$(host) 2>&1 > /dev/null
+
 
 .PHONY: start-remote-system-resource-tracker
 start-remote-system-resource-tracker:
@@ -140,3 +145,59 @@ start-remote-system-resource-tracker:
 		$${storage_dir:+OT_SYSTEM_RESOURCE_TRACKER_STORAGE_DIR=$$storage_dir} \
 		$${logging_level:+OT_SYSTEM_RESOURCE_TRACKER_LOGGING_LEVEL=$$logging_level} \
 		python3 -m performance_metrics.system_resource_tracker"
+
+
+.PHONY: setup-system-resource-tracker-systemd-service
+setup-system-resource-tracker-systemd-service:
+	@echo "Configuring remote file system to read/write"
+	@ssh -i $(ssh_key) root@$(host) "mount -o remount,rw /"
+
+	@echo "Pushing $(FILENAME) to remote"
+	@scp -i $(ssh_key) $(FILENAME) root@$(host):/etc/systemd/system/system-resource-tracker.service
+
+	@echo "Enabling, restarting, and checking systemd service status, then remounting filesystem as read-only"
+	@ssh -i $(ssh_key) root@$(host) "\
+		systemctl enable system-resource-tracker; \
+		systemctl restart system-resource-tracker; \
+		systemctl is-active system-resource-tracker; \
+		mount -o remount,ro /"
+
+.PHONY: setup-prod-system-resource-tracker-systemd-service
+setup-prod-system-resource-tracker-systemd-service: FILENAME=system-resource-tracker.service
+setup-prod-system-resource-tracker-systemd-service: setup-system-resource-tracker-systemd-service
+
+.PHONY: setup-dev-system-resource-tracker-systemd-service
+setup-dev-system-resource-tracker-systemd-service: FILENAME=system-resource-tracker-dev.service
+setup-dev-system-resource-tracker-systemd-service: setup-system-resource-tracker-systemd-service
+
+
+.PHONY: cleanup-remote-server
+# Default value for the data folder path
+DATA_FOLDER ?= /data/performance_metrics_data
+DEV_DATA_FOLDER ?= /data/performance_metrics_data_dev
+
+cleanup-remote-server:
+	@echo "Cleaning up performance metrics on host $(host)..."
+	
+	@ssh -i $(ssh_key) root@$(host) "\
+		echo "Configuring remote file system to read/write"; \
+		mount -o remount,rw /; \
+		echo "Stopping system-resource-tracker"; \
+		systemctl stop system-resource-tracker; \
+		echo "Disabling system-resource-tracker"; \
+		systemctl disable system-resource-tracker; \
+		echo "Reloading daemon"; \
+		systemctl daemon-reload; \
+		echo "Checking system-resource-tracker status"; \
+		systemctl is-active system-resource-tracker; \
+		echo "Removing service file, data folders, and performance_metrics package"; \
+		rm -rf \
+			/etc/systemd/system/system-resource-tracker.service \
+			$(DATA_FOLDER) \
+			$(DEV_DATA_FOLDER) \
+			/opt/opentrons-robot-server/performance_metrics*; \
+		echo "Remounting filesystem as read-only"; \
+		mount -o remount,ro /"
+
+	@echo "Unsetting performance metrics feature flag"
+	@$(MAKE) unset-performance-metrics-ff host=$(host) 2>&1 > /dev/null

--- a/performance-metrics/Makefile
+++ b/performance-metrics/Makefile
@@ -172,12 +172,12 @@ setup-dev-system-resource-tracker-systemd-service: FILENAME=system-resource-trac
 setup-dev-system-resource-tracker-systemd-service: setup-system-resource-tracker-systemd-service
 
 
-.PHONY: cleanup-remote-server
+.PHONY: cleanup-remote-flex
 # Default value for the data folder path
 DATA_FOLDER ?= /data/performance_metrics_data
 DEV_DATA_FOLDER ?= /data/performance_metrics_data_dev
 
-cleanup-remote-server:
+cleanup-remote-flex:
 	@echo "Cleaning up performance metrics on host $(host)..."
 	
 	# Note not using || to exit on error because it only looks to see 

--- a/performance-metrics/Makefile
+++ b/performance-metrics/Makefile
@@ -10,7 +10,7 @@ SHX := npx shx
 # Host key location for robot
 ssh_key ?= $(default_ssh_key)
 # Other SSH args for robot
-ssh_opts ?= $(default_ssh_opts)
+ssh_opts ?= $(default_ssh_opts) -q
 # Helper to safely bundle ssh options
 ssh_helper = $(if $(ssh_key),-i $(ssh_key)) $(ssh_opts)
 
@@ -120,14 +120,14 @@ test:
 setup-remote-flex:
 
 	@echo "Setting up remote Flex..."
-	@echo "Pushing performance_metrics to Flex"	
+	@echo "Pushing performance-metrics package to Flex"	
 
 	@$(MAKE) push-no-restart-ot3 host=$(host) ssh_key=$(ssh_key) 2>&1 | grep -v "Permanently added" > /dev/null
 
-	@echo "Pushing api to Flex"
+	@echo "Pushing api package to Flex"
 	@$(MAKE) -C ../api push-no-restart-ot3 host=$(host) ssh_key=$(ssh_key) 2>&1 | grep -v "Permanently added" > /dev/null
 
-	@echo "Pushing robot-server to Flex"
+	@echo "Pushing robot-server package to Flex and restarting robot server"
 	@$(MAKE) -C ../robot-server push-ot3 host=$(host) ssh_key=$(ssh_key) 2>&1 | grep -v "Permanently added" > /dev/null
 
 	@echo "Setting performance metrics feature flag"
@@ -149,18 +149,19 @@ start-remote-system-resource-tracker:
 
 .PHONY: setup-system-resource-tracker-systemd-service
 setup-system-resource-tracker-systemd-service:
-	@echo "Configuring remote file system to read/write"
-	@ssh -i $(ssh_key) root@$(host) "mount -o remount,rw /"
+	@echo "Setting up system resource tracker systemd service"
+	@$(call push-systemd-unit ,$(host),$(ssh_key),$(ssh_opts),$(FILENAME))
 
-	@echo "Pushing $(FILENAME) to remote"
-	@scp -i $(ssh_key) $(FILENAME) root@$(host):/etc/systemd/system/system-resource-tracker.service
 
-	@echo "Enabling, restarting, and checking systemd service status, then remounting filesystem as read-only"
+	@echo "Enabling system resource tracker service"
 	@ssh -i $(ssh_key) root@$(host) "\
-		systemctl enable system-resource-tracker; \
-		systemctl restart system-resource-tracker; \
-		systemctl is-active system-resource-tracker; \
+		mount -o remount,rw / && \
+		systemctl enable system-resource-tracker --quiet || \
 		mount -o remount,ro /"
+
+	@echo "Starting system resource tracker service"
+	@$(call restart-service,$(host),$(ssh_key),$(ssh_opts),system-resource-tracker)
+
 
 .PHONY: setup-prod-system-resource-tracker-systemd-service
 setup-prod-system-resource-tracker-systemd-service: FILENAME=system-resource-tracker.service
@@ -179,25 +180,32 @@ DEV_DATA_FOLDER ?= /data/performance_metrics_data_dev
 cleanup-remote-server:
 	@echo "Cleaning up performance metrics on host $(host)..."
 	
+	# Note not using || to exit on error because it only looks to see 
+	# if the previous command failed, whereas we want to catch any error or a successful exit
+
 	@ssh -i $(ssh_key) root@$(host) "\
-		echo "Configuring remote file system to read/write"; \
-		mount -o remount,rw /; \
-		echo "Stopping system-resource-tracker"; \
-		systemctl stop system-resource-tracker; \
-		echo "Disabling system-resource-tracker"; \
-		systemctl disable system-resource-tracker; \
-		echo "Reloading daemon"; \
-		systemctl daemon-reload; \
-		echo "Checking system-resource-tracker status"; \
-		systemctl is-active system-resource-tracker; \
-		echo "Removing service file, data folders, and performance_metrics package"; \
+		trap 'echo \"Remounting filesystem as read-only\" && mount -o remount,ro /' EXIT ERR && \
+		echo 'Configuring remote file system to read/write' && \
+		mount -o remount,rw / && \
+		echo 'Stopping system-resource-tracker' && \
+		systemctl stop system-resource-tracker && \
+		echo 'Disabling system-resource-tracker' && \
+		systemctl disable system-resource-tracker && \
+		echo 'Removing service file, data folders, and performance_metrics package' && \
 		rm -rf \
 			/etc/systemd/system/system-resource-tracker.service \
 			$(DATA_FOLDER) \
 			$(DEV_DATA_FOLDER) \
-			/opt/opentrons-robot-server/performance_metrics*; \
-		echo "Remounting filesystem as read-only"; \
-		mount -o remount,ro /"
+			/opt/opentrons-robot-server/performance_metrics* && \
+		echo 'Reloading daemon' && \
+		systemctl daemon-reload && \
+		echo 'Checking system-resource-tracker status' && \
+		if systemctl is-active system-resource-tracker --quiet; then \
+			echo 'Error: system-resource-tracker is still active'; \
+			exit 1; \
+		else \
+			echo 'system-resource-tracker is not active'; \
+		fi"		
 
 	@echo "Unsetting performance metrics feature flag"
 	@$(MAKE) unset-performance-metrics-ff host=$(host) 2>&1 > /dev/null

--- a/performance-metrics/Pipfile
+++ b/performance-metrics/Pipfile
@@ -6,6 +6,7 @@ name        = "pypi"
 [packages]
 performance-metrics = {file = ".", editable = true}
 psutil = "==6.0.0"
+systemd-python = "234"
 
 [dev-packages]
 pytest  = "==7.4.4"

--- a/performance-metrics/Pipfile.lock
+++ b/performance-metrics/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "25d7d44e0352eca124e333eb37fae2f3c35173efdd07b1aeb0558d75fdd07727"
+            "sha256": "a123325c3bebd1451774ebfadc532a4ca78a92897b80cf1d20ded030e145bac2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -43,6 +43,13 @@
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==6.0.0"
+        },
+        "systemd-python": {
+            "hashes": [
+                "sha256:fd0e44bf70eadae45aadc292cb0a7eb5b0b6372cd1b391228047d33895db83e7"
+            ],
+            "index": "pypi",
+            "version": "==234"
         }
     },
     "develop": {

--- a/performance-metrics/src/performance_metrics/system_resource_tracker/__main__.py
+++ b/performance-metrics/src/performance_metrics/system_resource_tracker/__main__.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-import systemd.daemon
+import systemd.daemon  # type: ignore [import-untyped]
 from .._logging_config import log_init, LOGGER_NAME
 from ._config import SystemResourceTrackerConfiguration
 from ._system_resource_tracker import SystemResourceTracker

--- a/performance-metrics/src/performance_metrics/system_resource_tracker/__main__.py
+++ b/performance-metrics/src/performance_metrics/system_resource_tracker/__main__.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+import systemd.daemon
 from .._logging_config import log_init, LOGGER_NAME
 from ._config import SystemResourceTrackerConfiguration
 from ._system_resource_tracker import SystemResourceTracker
@@ -20,6 +21,9 @@ def main() -> None:
     tracker = SystemResourceTracker(config)
 
     logger.info("Starting system resource tracker...")
+
+    systemd.daemon.notify("READY=1")
+
     try:
         while True:
             tracker.get_and_store_system_data_snapshots()

--- a/performance-metrics/system-resource-tracker-dev.service
+++ b/performance-metrics/system-resource-tracker-dev.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Opentrons System Resource Tracker
+After=opentrons-robot-server.service
+
+[Service]
+Type=notify
+ExecStart=python3 -m performance_metrics.system_resource_tracker
+StateDirectory=system-resource-tracker
+Environment=PYTHONPATH=/opt/opentrons-robot-server
+Environment=OT_SYSTEM_RESOURCE_TRACKER_ENABLED=true
+Environment=OT_SYSTEM_RESOURCE_TRACKER_STORAGE_DIR=/data/performance_metrics_data_dev/
+Environment=OT_SYSTEM_RESOURCE_TRACKER_REFRESH_INTERVAL=5.0
+Environment=OT_SYSTEM_RESOURCE_TRACKER_LOGGING_LEVEL=DEBUG
+
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/performance-metrics/system-resource-tracker.service
+++ b/performance-metrics/system-resource-tracker.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Opentrons System Resource Tracker
+After=opentrons-robot-server.service
+
+[Service]
+Type=notify
+ExecStart=python3 -m performance_metrics.system_resource_tracker
+StateDirectory=system-resource-tracker
+Environment=PYTHONPATH=/opt/opentrons-robot-server
+Environment=OT_SYSTEM_RESOURCE_TRACKER_ENABLED=true
+Environment=OT_SYSTEM_RESOURCE_TRACKER_REFRESH_INTERVAL=15.0
+
+Restart=no
+TimeoutSec=10s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Overview

Add the definition of systemd service files and scripts to ensure that they work

Closes [EXEC-596](https://opentrons.atlassian.net/browse/EXEC-596)
 
# Changelog

- Defined 2 different service files a prod and dev
- Added systemd-python so systemd can be notified when service is ready
- Added some helper scripts for setting up and cleaning up on remote server

# Review requests

Take a look at my service files. This is my first time creating them. 
I read docs on how to do it and they work but would like some special attention paid to them.

# Risk assessment

Still low, nothing is installed or running by default. You have to run scripts to get them on the robot

# Test Plan

**Putting this at the end since it's long**

- [ ] pull this branch
- [ ] Go into `performance-metrics` directory
- [ ] run `make teardown && make setup` as dependencies have changed
- [ ] Run `make setup-performance-metrics-project-on-remote-flex host=<robot-ip> ssh_key=<key-path>`
- [ ] ssh to robot 
    - [ ] Run `cat /data/feature_flags.json` and ensure `enabledPerformanceMetrics` is set to `true`
    - [ ] exit ssh
- [ ] Run `make cleanup-remote-server host=<robot-ip> ssh_key=<key-path>`
  - [ ] As long as you haven't already configured the service the output should look like this:
```
Cleaning up performance metrics on host 10.10.10.151...
Configuring remote file system to read/write
Stopping system-resource-tracker
Failed to stop system-resource-tracker.service: Unit system-resource-tracker.service not loaded.
Disabling system-resource-tracker
Failed to disable unit: Unit file system-resource-tracker.service does not exist.
Reloading daemon
Checking system-resource-tracker status
inactive
Removing service file, data folders, and performance_metrics package
Remounting filesystem as read-only
Unsetting performance metrics feature flag
```
- [ ] Run `make setup-performance-metrics-project-on-remote-flex host=<robot-ip> ssh_key=<key-path>` as the clean command removed and unset everything
- [ ] Run `make setup-prod-system-resource-tracker-systemd-service host=<robot-ip> ssh_key=<key-path>`
  - [ ] You should get output that looks like this
```
Configuring remote file system to read/write
Pushing system-resource-tracker.service to remote
system-resource-tracker.service             100%  445    63.8KB/s   00:00    
Enabling service
Restarting service
Checking service status
active
Configuring remote file system to read-only
```
- [ ] ssh into robot
  - [ ] Run `cat /data/feature_flags.json` and ensure `enabledPerformanceMetrics` is set to `true`
  - [ ] Run `cat /etc/systemd/system/system-resource-tracker.service` and confirm that the output matches the `system-resource-tracker.service` file in the repo
  - [ ] Run `systemctl status system-resource-tracker | cat` your output should look something like this:
```
● system-resource-tracker.service - Opentrons System Resource Tracker
     Loaded: loaded (/etc/systemd/system/system-resource-tracker.service; enabled; vendor preset: disabled)
     Active: active (running) since Tue 2024-07-09 17:40:20 UTC; 6min ago
   Main PID: 43800 (python3)
      Tasks: 1 (limit: 1761)
     Memory: 9.6M
     CGroup: /system.slice/system-resource-tracker.service
             └─ 43800 python3 -m performance_metrics.system_resource_tracker

Jul 09 17:40:20 9608de python3[43800]: process_filters=('/opt/opentrons*', 'python3*')
Jul 09 17:40:20 9608de python3[43800]: refresh_interval=15.0
Jul 09 17:40:20 9608de python3[43800]: storage_dir=/data/performance_metrics_data
Jul 09 17:40:20 9608de python3[43800]: logging_level=INFO
Jul 09 17:40:20 9608de python3[43800]: 2024-07-09 17:40:20,176 - _metrics_store - setup() - INFO - Setting up metrics store for system_resource_data at /data/performance_metrics_data
Jul 09 17:40:20 9608de /opt/opentrons-robot-server/performance_metrics/system_resource_tracker/__main__.py[43800]: 2024-07-09 17:40:20,174 - __main__ - main() - INFO - Running with the following configuration: 
                                                                                                                   enabled=True
                                                                                                                   process_filters=('/opt/opentrons*', 'python3*')
                                                                                                                   refresh_interval=15.0
                                                                                                                   storage_dir=/data/performance_metrics_data
                                                                                                                   logging_level=INFO
Jul 09 17:40:20 9608de /opt/opentrons-robot-server/performance_metrics/system_resource_tracker/__main__.py[43800]: 2024-07-09 17:40:20,176 - _metrics_store - setup() - INFO - Setting up metrics store for system_resource_data at /data/performance_metrics_data
Jul 09 17:40:20 9608de python3[43800]: 2024-07-09 17:40:20,296 - __main__ - main() - INFO - Starting system resource tracker...
Jul 09 17:40:20 9608de /opt/opentrons-robot-server/performance_metrics/system_resource_tracker/__main__.py[43800]: 2024-07-09 17:40:20,296 - __main__ - main() - INFO - Starting system resource tracker...
Jul 09 17:40:20 9608de systemd[1]: Started Opentrons System Resource Tracker.
```
  - [ ] Run `ls -l /data/performance_metrics_data/` and take note of the size of system_resource_data
  - [ ] Wait like 30 seconds and run ls command again. You should see that `system_resource_data` gets larger
  - [ ] exit ssh
- [ ] Run `make cleanup-remote-server host=<robot-ip> ssh_key=<key-path>`
  - [ ] You should get this output
```
Cleaning up performance metrics on host 10.10.10.151...
Configuring remote file system to read/write
Stopping system-resource-tracker
Disabling system-resource-tracker
Removed /etc/systemd/system/multi-user.target.wants/system-resource-tracker.service.
Reloading daemon
Checking system-resource-tracker status
inactive
Removing service file, data folders, and performance_metrics package
Remounting filesystem as read-only
Unsetting performance metrics feature flag
```

[EXEC-596]: https://opentrons.atlassian.net/browse/EXEC-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ