### PR TITLE
chore(release): internal release notes 1.5.0 to 2.0.0-alpha.1

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,6 +2,24 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.0.0-alpha.1
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.0...ot3@2.0.0-alpha.1>
+
+## Internal Release 2.0.0-alpha.0
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@1.5.0...ot3@2.0.0-alpha.0>
+
+## Internal Release 1.5.0
+
+This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.  Though designated as stable, this build contains many critical bugs and should not be used in production.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@1.1.0...ot3@1.5.0>
+
 ## Internal Release 1.5.0-alpha.1
 
 This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,6 +1,24 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.0.0-alpha.1
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.0...ot3@2.0.0-alpha.1>
+
+## Internal Release 2.0.0-alpha.0
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@1.5.0...ot3@2.0.0-alpha.0>
+
+## Internal Release 1.5.0
+
+This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.  Though designated as stable, this build contains many critical bugs and should not be used in production.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@1.1.0...ot3@1.5.0>
+
 ## Internal Release 1.5.0-alpha.1
 
 This internal release is from the `edge` branch to contain rapid dev on new features for 7.3.0. This release is for internal testing purposes and if used may require a factory reset of the robot to return to a stable version.


### PR DESCRIPTION
## Internal release notes catch up 

![image](https://github.com/Opentrons/opentrons/assets/502770/24d33498-5584-45c7-b1d3-a4915f25f21b)

### Merge to edge before cutting `2.0.0-alpha.1`

> [!NOTE]
> These feel perfunctory on most of our internal releases but there may one day be an internal release where they are not. 

