### PR TITLE
refactor(api): Change error message for `opentrons_simulate` reading new JSON protocols

### DIFF
--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -288,7 +288,7 @@ def get_arguments(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     return parser
 
 
-def execute(  # noqa: C901
+def execute(
     protocol_file: Union[BinaryIO, TextIO],
     protocol_name: str,
     propagate_logs: bool = False,

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -394,7 +394,9 @@ def execute(
             extra_data=extra_data,
         )
     except parse.JSONSchemaVersionTooNewError as e:
-        # See https://opentrons.atlassian.net/browse/PLAT-94
+        # opentrons.protocols.parse() doesn't support new JSON protocols.
+        # The code to do that should be moved from opentrons.protocol_reader.
+        # See https://opentrons.atlassian.net/browse/PLAT-94.
         raise NotImplementedError(_JSON_TOO_NEW_MESSAGE) from e
 
     if protocol.api_level < APIVersion(2, 0):

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -394,11 +394,8 @@ def execute(  # noqa: C901
             extra_data=extra_data,
         )
     except parse.JSONSchemaVersionTooNewError as e:
-        if e.attempted_schema_version == 6:
-            # See Jira RCORE-535.
-            raise NotImplementedError(_JSON_TOO_NEW_MESSAGE) from e
-        else:
-            raise
+        # See https://opentrons.atlassian.net/browse/PLAT-94
+        raise NotImplementedError(_JSON_TOO_NEW_MESSAGE) from e
 
     if protocol.api_level < APIVersion(2, 0):
         raise ApiDeprecationError(version=protocol.api_level)

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -533,11 +533,8 @@ def simulate(
             extra_data=extra_data,
         )
     except parse.JSONSchemaVersionTooNewError as e:
-        if e.attempted_schema_version == 6:
-            # See Jira RCORE-535.
-            raise NotImplementedError(_JSON_TOO_NEW_MESSAGE) from e
-        else:
-            raise
+        # See https://opentrons.atlassian.net/browse/PLAT-94.
+        raise NotImplementedError(_JSON_TOO_NEW_MESSAGE) from e
 
     if protocol.api_level < APIVersion(2, 0):
         raise ApiDeprecationError(version=protocol.api_level)

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -533,6 +533,8 @@ def simulate(
             extra_data=extra_data,
         )
     except parse.JSONSchemaVersionTooNewError as e:
+        # opentrons.protocols.parse() doesn't support new JSON protocols.
+        # The code to do that should be moved from opentrons.protocol_reader.
         # See https://opentrons.atlassian.net/browse/PLAT-94.
         raise NotImplementedError(_JSON_TOO_NEW_MESSAGE) from e
 


### PR DESCRIPTION
# Overview

Because of PLAT-94, `opentrons_simulate` and `opentrons_execute` can't deal with modern JSON protocols. We were catching this case explicitly and trying to print out a slightly more helpful error message, but for some reason, I wrote that catch to look for exactly `schema == 6` instead of `schema >= 6`. This fixes that.

This also updates the ticket reference, since things on Jira have shuffled around a bit.

# Test Plan

* [x] Run `opentrons_simulate` with a modern JSON protocol and make sure it prints this message.

# Risk assessment

Low.