### PR TITLE
feat(api): default to sending api logs to opentrons

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -722,6 +722,15 @@ def _migrate33to34(previous: SettingsMap) -> SettingsMap:
     newmap = {k: v for k, v in previous.items() if k not in removals}
     return newmap
 
+def _migrate34to35(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 35 of the feature flags file.
+
+    - sets the disableLogAggregation config element default to false.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["disableLogAggregation"] = False
+    return newmap
+
 
 _MIGRATIONS = [
     _migrate0to1,
@@ -758,6 +767,7 @@ _MIGRATIONS = [
     _migrate31to32,
     _migrate32to33,
     _migrate33to34,
+    _migrate34to35,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -8,7 +8,7 @@ from opentrons.config.advanced_settings import _migrate, _ensure
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 34
+    return 35
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -20,7 +20,7 @@ def default_file_settings() -> Dict[str, Any]:
         "deckCalibrationDots": None,
         "disableHomeOnBoot": None,
         "useOldAspirationFunctions": None,
-        "disableLogAggregation": None,
+        "disableLogAggregation": False,
         "enableDoorSafetySwitch": None,
         "enableOT3HardwareController": None,
         "rearPanelIntegration": True,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
