### PR TITLE
refactor(app): Componentize "intervention info"

### DIFF
--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionContent.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionContent.stories.tsx
@@ -1,0 +1,126 @@
+import * as React from 'react'
+import { ICON_DATA_BY_NAME } from '@opentrons/components'
+import { InterventionContent } from '.'
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { TwoColumn } from '../TwoColumn'
+import { StandInContent } from '../story-utils/StandIn'
+import { VisibleContainer } from '../story-utils/VisibleContainer'
+
+const meta: Meta<typeof InterventionContent> = {
+  title:
+    'App/Molecules/InterventionModal/InterventionContent/InterventionContent',
+  component: InterventionContent,
+  argTypes: {
+    headline: {
+      control: {
+        type: 'text',
+      },
+    },
+    infoProps: {
+      control: {
+        type: 'object',
+      },
+      type: {
+        control: {
+          type: 'select',
+        },
+        options: [
+          'location',
+          'location-arrow-location',
+          'location-colon-location',
+        ],
+      },
+      labwareName: {
+        control: 'text',
+      },
+      currentLocationProps: {
+        control: {
+          type: 'object',
+        },
+        slotName: {
+          control: 'text',
+        },
+        iconName: {
+          control: {
+            type: 'select',
+          },
+          options: Object.keys(ICON_DATA_BY_NAME),
+        },
+      },
+      newLocationProps: {
+        control: {
+          type: 'object',
+        },
+        slotName: {
+          control: 'text',
+        },
+        iconName: {
+          control: {
+            type: 'select',
+          },
+          options: Object.keys(ICON_DATA_BY_NAME),
+        },
+      },
+      labwareNickname: {
+        control: {
+          type: 'text',
+        },
+      },
+    },
+    notificationProps: {
+      control: {
+        type: 'object',
+      },
+      type: {
+        control: {
+          type: 'select',
+        },
+        options: ['alert', 'error', 'neutral', 'success'],
+      },
+      heading: {
+        control: {
+          type: 'text',
+        },
+      },
+      message: {
+        control: {
+          type: 'text',
+        },
+      },
+    },
+  },
+  decorators: [
+    Story => (
+      <VisibleContainer>
+        <TwoColumn>
+          <Story />
+          <StandInContent />
+        </TwoColumn>
+      </VisibleContainer>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof InterventionContent>
+
+export const InterventionContentStory: Story = {
+  args: {
+    headline: 'You have something to do',
+    infoProps: {
+      type: 'location',
+      labwareName: 'Biorad Plate 200ML',
+      labwareNickname: 'The biggest plate I have',
+      currentLocationProps: {
+        slotName: 'C2',
+      },
+    },
+    notificationProps: {
+      type: 'alert',
+      heading: 'An alert',
+      message: 'Oh no',
+    },
+  },
+}

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionContent.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionContent.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { ICON_DATA_BY_NAME } from '@opentrons/components'
 import { InterventionContent } from '.'
-import type { Meta, StoryObj } from '@storybook/react'
-
 import { TwoColumn } from '../TwoColumn'
 import { StandInContent } from '../story-utils/StandIn'
 import { VisibleContainer } from '../story-utils/VisibleContainer'
+
+import type { Meta, StoryObj } from '@storybook/react'
 
 const meta: Meta<typeof InterventionContent> = {
   title:

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -2,13 +2,13 @@ import * as React from 'react'
 
 import { Box, ICON_DATA_BY_NAME } from '@opentrons/components'
 
-import { Move } from './Move'
+import { InterventionInfo } from './InterventionInfo'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
-const meta: Meta<typeof Move> = {
-  title: 'App/Organisms/InterventionModal/InterventionStep/Move',
-  component: Move,
+const meta: Meta<typeof InterventionInfo> = {
+  title: 'App/Molecules/InterventionModal/InterventionContent/InterventionInfo',
+  component: InterventionInfo,
   argTypes: {
     type: {
       control: {
@@ -52,7 +52,7 @@ const meta: Meta<typeof Move> = {
 
 export default meta
 
-type Story = StoryObj<typeof Move>
+type Story = StoryObj<typeof InterventionInfo>
 
 export const MoveBetweenSlots: Story = {
   args: {
@@ -67,7 +67,7 @@ export const MoveBetweenSlots: Story = {
   },
   render: args => (
     <Box width="27rem">
-      <Move {...args} />
+      <InterventionInfo {...args} />
     </Box>
   ),
 }
@@ -82,7 +82,7 @@ export const Refill: Story = {
   },
   render: args => (
     <Box width="27rem">
-      <Move {...args} />
+      <InterventionInfo {...args} />
     </Box>
   ),
 }
@@ -100,7 +100,7 @@ export const Select: Story = {
   },
   render: args => (
     <Box width="27rem">
-      <Move {...args} />
+      <InterventionInfo {...args} />
     </Box>
   ),
 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -13,8 +13,12 @@ const meta: Meta<typeof InterventionInfo> = {
     type: {
       control: {
         type: 'select',
-        options: ['move', 'refill', 'select'],
       },
+      options: [
+        'location',
+        'location-arrow-location',
+        'location-column-location',
+      ],
     },
     labwareName: {
       control: 'text',
@@ -29,8 +33,8 @@ const meta: Meta<typeof InterventionInfo> = {
       iconName: {
         control: {
           type: 'select',
-          options: Object.keys(ICON_DATA_BY_NAME),
         },
+        options: Object.keys(ICON_DATA_BY_NAME),
       },
     },
     newLocationProps: {
@@ -43,11 +47,23 @@ const meta: Meta<typeof InterventionInfo> = {
       iconName: {
         control: {
           type: 'select',
-          options: Object.keys(ICON_DATA_BY_NAME),
         },
+        options: Object.keys(ICON_DATA_BY_NAME),
+      },
+    },
+    labwareNickname: {
+      control: {
+        type: 'text',
       },
     },
   },
+  decorators: [
+    Story => (
+      <Box width="27rem">
+        <Story />
+      </Box>
+    ),
+  ],
 }
 
 export default meta
@@ -56,7 +72,7 @@ type Story = StoryObj<typeof InterventionInfo>
 
 export const MoveBetweenSlots: Story = {
   args: {
-    type: 'move',
+    type: 'location-arrow-location',
     labwareName: 'Plate',
     currentLocationProps: {
       slotName: 'A1',
@@ -65,31 +81,21 @@ export const MoveBetweenSlots: Story = {
       slotName: 'B2',
     },
   },
-  render: args => (
-    <Box width="27rem">
-      <InterventionInfo {...args} />
-    </Box>
-  ),
 }
 
 export const Refill: Story = {
   args: {
-    type: 'refill',
+    type: 'location',
     labwareName: 'Tip Rack',
     currentLocationProps: {
       slotName: 'A1',
     },
   },
-  render: args => (
-    <Box width="27rem">
-      <InterventionInfo {...args} />
-    </Box>
-  ),
 }
 
 export const Select: Story = {
   args: {
-    type: 'select',
+    type: 'location-colon-location',
     labwareName: 'Well',
     currentLocationProps: {
       slotName: 'A1',
@@ -98,9 +104,4 @@ export const Select: Story = {
       slotName: 'B1',
     },
   },
-  render: args => (
-    <Box width="27rem">
-      <InterventionInfo {...args} />
-    </Box>
-  ),
 }

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof InterventionInfo> = {
       options: [
         'location',
         'location-arrow-location',
-        'location-column-location',
+        'location-colon-location',
       ],
     },
     labwareName: {

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -47,7 +47,12 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             oddStyle="hidden"
             desktopStyle="bodyDefaultRegular"
             color={COLORS.grey60}
-            css={LINE_CLAMP_STYLE}
+            css={css`
+              ${LINE_CLAMP_STYLE}
+              @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+                display: none;
+              }
+            `}
           >
             {props.labwareNickname}{' '}
           </StyledText>

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -35,7 +35,11 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
       css={CARD_STYLE}
     >
       <Flex flexDirection={DIRECTION_COLUMN}>
-        <StyledText oddStyle="bodyTextBold" desktopStyle="bodyDefaultSemiBold">
+        <StyledText
+          oddStyle="bodyTextBold"
+          desktopStyle="bodyDefaultSemiBold"
+          css={LINE_CLAMP_STYLE}
+        >
           {props.labwareName}
         </StyledText>
         {props.labwareNickname != null ? (
@@ -43,6 +47,7 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
             oddStyle="hidden"
             desktopStyle="bodyDefaultRegular"
             color={COLORS.grey60}
+            css={LINE_CLAMP_STYLE}
           >
             {props.labwareNickname}{' '}
           </StyledText>
@@ -147,4 +152,13 @@ const CARD_STYLE = css`
     background-color: ${COLORS.grey35};
     border-radius: ${BORDERS.borderRadius8};
   }
+`
+
+const LINE_CLAMP_STYLE = css`
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  -webkit-line-clamp: 2;
 `

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -131,8 +131,12 @@ const buildLocColonLoc = (props: InterventionInfoProps): JSX.Element => {
 }
 
 const ICON_STYLE = css`
-  width: ${SPACING.spacing40};
-  height: ${SPACING.spacing40};
+  width: ${SPACING.spacing24};
+  height: ${SPACING.spacing24};
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    width: ${SPACING.spacing40};
+    height: ${SPACING.spacing40};
+  }
 `
 
 const CARD_STYLE = css`

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -39,7 +39,11 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
           {props.labwareName}
         </StyledText>
         {props.labwareNickname != null ? (
-          <StyledText oddStyle="hidden" desktopStyle="bodyDefaultRegular">
+          <StyledText
+            oddStyle="hidden"
+            desktopStyle="bodyDefaultRegular"
+            color={COLORS.grey60}
+          >
             {props.labwareNickname}{' '}
           </StyledText>
         ) : null}

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -15,14 +15,14 @@ import {
 
 import type { LocationIconProps } from '@opentrons/components'
 
-export interface MoveProps {
+export interface InterventionInfoProps {
   type: 'move' | 'refill' | 'select'
   labwareName: string
   currentLocationProps: LocationIconProps
   newLocationProps?: LocationIconProps
 }
 
-export function Move(props: MoveProps): JSX.Element {
+export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
   const content = buildContent(props)
 
   return (
@@ -33,7 +33,7 @@ export function Move(props: MoveProps): JSX.Element {
   )
 }
 
-const buildContent = (props: MoveProps): JSX.Element => {
+const buildContent = (props: InterventionInfoProps): JSX.Element => {
   switch (props.type) {
     case 'move':
       return buildMove(props)
@@ -44,7 +44,7 @@ const buildContent = (props: MoveProps): JSX.Element => {
   }
 }
 
-const buildMove = (props: MoveProps): JSX.Element => {
+const buildMove = (props: InterventionInfoProps): JSX.Element => {
   const { currentLocationProps, newLocationProps } = props
 
   if (newLocationProps != null) {
@@ -60,7 +60,9 @@ const buildMove = (props: MoveProps): JSX.Element => {
   }
 }
 
-const buildRefill = ({ currentLocationProps }: MoveProps): JSX.Element => {
+const buildRefill = ({
+  currentLocationProps,
+}: InterventionInfoProps): JSX.Element => {
   return (
     <Flex gridGap={SPACING.spacing8}>
       <LocationIcon {...currentLocationProps} />
@@ -68,7 +70,7 @@ const buildRefill = ({ currentLocationProps }: MoveProps): JSX.Element => {
   )
 }
 
-const buildSelect = (props: MoveProps): JSX.Element => {
+const buildSelect = (props: InterventionInfoProps): JSX.Element => {
   const { currentLocationProps, newLocationProps } = props
 
   if (newLocationProps != null) {

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -9,15 +9,18 @@ import {
   BORDERS,
   SPACING,
   DIRECTION_COLUMN,
-  LegacyStyledText,
+  StyledText,
   ALIGN_CENTER,
+  RESPONSIVENESS,
 } from '@opentrons/components'
+import { Divider } from '../../../atoms/structure/Divider'
 
 import type { LocationIconProps } from '@opentrons/components'
 
 export interface InterventionInfoProps {
-  type: 'move' | 'refill' | 'select'
+  type: 'location-arrow-location' | 'location-colon-location' | 'location'
   labwareName: string
+  labwareNickname?: string
   currentLocationProps: LocationIconProps
   newLocationProps?: LocationIconProps
 }
@@ -26,8 +29,29 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
   const content = buildContent(props)
 
   return (
-    <Flex css={CARD_STYLE}>
-      <LegacyStyledText as="pBold">{props.labwareName}</LegacyStyledText>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      padding={SPACING.spacing16}
+      css={CARD_STYLE}
+    >
+      <Flex flexDirection={DIRECTION_COLUMN}>
+        <StyledText oddStyle="bodyTextBold" desktopStyle="bodyDefaultSemiBold">
+          {props.labwareName}
+        </StyledText>
+        {props.labwareNickname != null ? (
+          <StyledText oddStyle="hidden" desktopStyle="bodyDefaultRegular">
+            {props.labwareNickname}{' '}
+          </StyledText>
+        ) : null}
+      </Flex>
+      <Divider
+        borderColor={COLORS.grey35}
+        css={`
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            display: none;
+          }
+        `}
+      />
       {content}
     </Flex>
   )
@@ -35,32 +59,40 @@ export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
 
 const buildContent = (props: InterventionInfoProps): JSX.Element => {
   switch (props.type) {
-    case 'move':
-      return buildMove(props)
-    case 'refill':
-      return buildRefill(props)
-    case 'select':
-      return buildSelect(props)
+    case 'location-arrow-location':
+      return buildLocArrowLoc(props)
+    case 'location-colon-location':
+      return buildLocColonLoc(props)
+    case 'location':
+      return buildLoc(props)
   }
 }
 
-const buildMove = (props: InterventionInfoProps): JSX.Element => {
+const buildLocArrowLoc = (props: InterventionInfoProps): JSX.Element => {
   const { currentLocationProps, newLocationProps } = props
 
   if (newLocationProps != null) {
     return (
-      <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
+      <Flex
+        alignItems={ALIGN_CENTER}
+        css={`
+          gap: ${SPACING.spacing4};
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            gap: ${SPACING.spacing8};
+          }
+        `}
+      >
         <LocationIcon {...currentLocationProps} />
         <Icon name="arrow-right" css={ICON_STYLE} />
         <LocationIcon {...newLocationProps} />
       </Flex>
     )
   } else {
-    return buildRefill(props)
+    return buildLoc(props)
   }
 }
 
-const buildRefill = ({
+const buildLoc = ({
   currentLocationProps,
 }: InterventionInfoProps): JSX.Element => {
   return (
@@ -70,19 +102,27 @@ const buildRefill = ({
   )
 }
 
-const buildSelect = (props: InterventionInfoProps): JSX.Element => {
+const buildLocColonLoc = (props: InterventionInfoProps): JSX.Element => {
   const { currentLocationProps, newLocationProps } = props
 
   if (newLocationProps != null) {
     return (
-      <Flex gridGap={SPACING.spacing8}>
+      <Flex
+        alignItems={ALIGN_CENTER}
+        css={`
+          gap: ${SPACING.spacing4};
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            gap: ${SPACING.spacing8};
+          }
+        `}
+      >
         <LocationIcon {...currentLocationProps} />
         <Icon name="colon" css={ICON_STYLE} />
         <LocationIcon {...newLocationProps} />
       </Flex>
     )
   } else {
-    return buildRefill(props)
+    return buildLoc(props)
   }
 }
 
@@ -92,9 +132,11 @@ const ICON_STYLE = css`
 `
 
 const CARD_STYLE = css`
-  flex-direction: ${DIRECTION_COLUMN};
-  background-color: ${COLORS.grey35};
-  padding: ${SPACING.spacing16};
-  grid-gap: ${SPACING.spacing8};
-  border-radius: ${BORDERS.borderRadius8};
+  background-color: ${COLORS.grey20};
+  border-radius: ${BORDERS.borderRadius4};
+  gap: ${SPACING.spacing8};
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    background-color: ${COLORS.grey35};
+    border-radius: ${BORDERS.borderRadius8};
+  }
 `

--- a/app/src/molecules/InterventionModal/InterventionContent/index.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/index.tsx
@@ -1,3 +1,56 @@
-export { InterventionInfo } from './InterventionInfo'
+import * as React from 'react'
+import {
+  Flex,
+  StyledText,
+  DIRECTION_COLUMN,
+  SPACING,
+  RESPONSIVENESS,
+} from '@opentrons/components'
+import { InlineNotification } from '../../../atoms/InlineNotification'
 
+import { InterventionInfo } from './InterventionInfo'
 export type { InterventionInfoProps } from './InterventionInfo'
+export { InterventionInfo }
+
+export interface InterventionContentProps {
+  headline: string
+  infoProps: React.ComponentProps<typeof InterventionInfo>
+  notificationProps?: React.ComponentProps<typeof InlineNotification>
+}
+
+export function InterventionContent({
+  headline,
+  infoProps,
+  notificationProps,
+}: InterventionContentProps): JSX.Element {
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      css={`
+        gap: ${SPACING.spacing16};
+        width: 100%;
+        @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+          gap: ${SPACING.spacing8};
+          width: 27rem;
+        }
+      `}
+    >
+      <StyledText oddStyle="level4HeaderSemiBold">{headline}</StyledText>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        css={`
+          gap: ${SPACING.spacing16};
+          width: 100%;
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            gap: ${SPACING.spacing24};
+          }
+        `}
+      >
+        <InterventionInfo {...infoProps} />
+        {notificationProps ? (
+          <InlineNotification {...notificationProps} />
+        ) : null}
+      </Flex>
+    </Flex>
+  )
+}

--- a/app/src/molecules/InterventionModal/InterventionContent/index.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/index.tsx
@@ -35,7 +35,12 @@ export function InterventionContent({
         }
       `}
     >
-      <StyledText oddStyle="level4HeaderSemiBold">{headline}</StyledText>
+      <StyledText
+        oddStyle="level4HeaderSemiBold"
+        desktopStyle="headingSmallBold"
+      >
+        {headline}
+      </StyledText>
       <Flex
         flexDirection={DIRECTION_COLUMN}
         css={`

--- a/app/src/molecules/InterventionModal/InterventionContent/index.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/index.tsx
@@ -1,0 +1,3 @@
+export { InterventionInfo } from './InterventionInfo'
+
+export type { InterventionInfoProps } from './InterventionInfo'

--- a/app/src/molecules/InterventionModal/InterventionStep/index.tsx
+++ b/app/src/molecules/InterventionModal/InterventionStep/index.tsx
@@ -1,3 +1,0 @@
-export { Move } from './Move'
-
-export type { MoveProps } from './Move'

--- a/app/src/molecules/InterventionModal/story-utils/StandIn.tsx
+++ b/app/src/molecules/InterventionModal/story-utils/StandIn.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
-import { Box, BORDERS, SPACING } from '@opentrons/components'
+import { Box, BORDERS } from '@opentrons/components'
 
 export function StandInContent(): JSX.Element {
   return (
     <Box
       border={'4px dashed #A864FFFF'}
       borderRadius={BORDERS.borderRadius8}
-      margin={SPACING.spacing16}
       height="104px"
       backgroundColor="#A864FF19"
     />

--- a/app/src/molecules/InterventionModal/story-utils/VisibleContainer.tsx
+++ b/app/src/molecules/InterventionModal/story-utils/VisibleContainer.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+
+import { Box, BORDERS, SPACING } from '@opentrons/components'
+
+export interface VisibleContainerProps {
+  children: JSX.Element | JSX.Element[]
+}
+
+export function VisibleContainer({
+  children,
+}: VisibleContainerProps): JSX.Element {
+  return (
+    <Box
+      border={BORDERS.lineBorder}
+      borderColor="#A864FFFF"
+      minWidth="max-content"
+      minHeight="max-content"
+      maxWidth="100vp"
+      maxHeight="100vp"
+      padding={SPACING.spacing32}
+    >
+      {children}
+    </Box>
+  )
+}

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/FillWellAndSkip.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/FillWellAndSkip.tsx
@@ -63,7 +63,7 @@ export function FillWell(props: RecoveryContentProps): JSX.Element | null {
               title={t('manually_fill_liquid_in_well', {
                 well: failedLabwareUtils.relevantWellName,
               })}
-              moveType="refill"
+              type="location"
             />
           </Flex>
           <Flex marginTop="1.742rem">

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -14,7 +14,7 @@ import type { RecoveryContentProps } from '../types'
 
 type LeftColumnLabwareInfoProps = RecoveryContentProps & {
   title: string
-  moveType: React.ComponentProps<typeof InterventionInfo>['type']
+  type: React.ComponentProps<typeof InterventionInfo>['type']
   /* Renders a warning InlineNotification if provided. */
   bannerText?: string
 }
@@ -24,7 +24,7 @@ export function LeftColumnLabwareInfo({
   title,
   failedLabwareUtils,
   isOnDevice,
-  moveType,
+  type,
   bannerText,
 }: LeftColumnLabwareInfoProps): JSX.Element | null {
   const { failedLabwareName, failedLabware } = failedLabwareUtils
@@ -48,7 +48,7 @@ export function LeftColumnLabwareInfo({
         <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
           <LegacyStyledText as="h4SemiBold">{title}</LegacyStyledText>
           <InterventionInfo
-            type={moveType}
+            type={type}
             labwareName={failedLabwareName ?? ''}
             currentLocationProps={{ slotName: buildLabwareLocationSlotName() }}
           />

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -1,20 +1,12 @@
 import * as React from 'react'
 
-import {
-  DIRECTION_COLUMN,
-  Flex,
-  SPACING,
-  LegacyStyledText,
-} from '@opentrons/components'
-
-import { InterventionInfo } from '../../../molecules/InterventionModal/InterventionContent'
-import { InlineNotification } from '../../../atoms/InlineNotification'
+import { InterventionContent } from '../../../molecules/InterventionModal/InterventionContent'
 
 import type { RecoveryContentProps } from '../types'
 
 type LeftColumnLabwareInfoProps = RecoveryContentProps & {
   title: string
-  type: React.ComponentProps<typeof InterventionInfo>['type']
+  type: React.ComponentProps<typeof InterventionContent>['infoProps']['type']
   /* Renders a warning InlineNotification if provided. */
   bannerText?: string
 }
@@ -46,27 +38,18 @@ export function LeftColumnLabwareInfo({
     }
   }
 
-  if (isOnDevice) {
-    return (
-      <Flex gridGap={SPACING.spacing24} flexDirection={DIRECTION_COLUMN}>
-        <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
-          <LegacyStyledText as="h4SemiBold">{title}</LegacyStyledText>
-          <InterventionInfo
-            type={type}
-            labwareName={failedLabwareName ?? ''}
-            labwareNickname={failedLabwareNickname ?? ''}
-            currentLocationProps={{ slotName: buildLabwareLocationSlotName() }}
-          />
-        </Flex>
-        {bannerText != null ? (
-          <InlineNotification
-            type="alert"
-            heading={bannerText}
-          ></InlineNotification>
-        ) : null}
-      </Flex>
-    )
-  } else {
-    return null
-  }
+  return (
+    <InterventionContent
+      headline={title}
+      infoProps={{
+        type,
+        labwareName: failedLabwareName ?? '',
+        labwareNickname: failedLabwareNickname ?? '',
+        currentLocationProps: { slotName: buildLabwareLocationSlotName() },
+      }}
+      notificationProps={
+        bannerText ? { type: 'alert', heading: bannerText } : undefined
+      }
+    />
+  )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -27,7 +27,11 @@ export function LeftColumnLabwareInfo({
   type,
   bannerText,
 }: LeftColumnLabwareInfoProps): JSX.Element | null {
-  const { failedLabwareName, failedLabware } = failedLabwareUtils
+  const {
+    failedLabwareName,
+    failedLabware,
+    failedLabwareNickname,
+  } = failedLabwareUtils
 
   const buildLabwareLocationSlotName = (): string => {
     const location = failedLabware?.location
@@ -50,6 +54,7 @@ export function LeftColumnLabwareInfo({
           <InterventionInfo
             type={type}
             labwareName={failedLabwareName ?? ''}
+            labwareNickname={failedLabwareNickname ?? ''}
             currentLocationProps={{ slotName: buildLabwareLocationSlotName() }}
           />
         </Flex>

--- a/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/LeftColumnLabwareInfo.tsx
@@ -7,14 +7,14 @@ import {
   LegacyStyledText,
 } from '@opentrons/components'
 
-import { Move } from '../../../molecules/InterventionModal/InterventionStep'
+import { InterventionInfo } from '../../../molecules/InterventionModal/InterventionContent'
 import { InlineNotification } from '../../../atoms/InlineNotification'
 
 import type { RecoveryContentProps } from '../types'
 
 type LeftColumnLabwareInfoProps = RecoveryContentProps & {
   title: string
-  moveType: React.ComponentProps<typeof Move>['type']
+  moveType: React.ComponentProps<typeof InterventionInfo>['type']
   /* Renders a warning InlineNotification if provided. */
   bannerText?: string
 }
@@ -47,7 +47,7 @@ export function LeftColumnLabwareInfo({
       <Flex gridGap={SPACING.spacing24} flexDirection={DIRECTION_COLUMN}>
         <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
           <LegacyStyledText as="h4SemiBold">{title}</LegacyStyledText>
-          <Move
+          <InterventionInfo
             type={moveType}
             labwareName={failedLabwareName ?? ''}
             currentLocationProps={{ slotName: buildLabwareLocationSlotName() }}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ReplaceTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ReplaceTips.tsx
@@ -43,7 +43,7 @@ export function ReplaceTips(props: RecoveryContentProps): JSX.Element | null {
           <LeftColumnLabwareInfo
             {...props}
             title={buildTitle()}
-            moveType="refill"
+            type="location"
             bannerText={t('replace_tips_and_select_location')}
           />
           <Flex marginTop="1.742rem">

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
@@ -53,7 +53,7 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
             <LeftColumnLabwareInfo
               {...props}
               title={t('select_tip_pickup_location')}
-              moveType="refill"
+              type="location"
               bannerText={t('replace_tips_and_select_location')}
             />
             <TipSelection {...props} allowTipSelection={false} />

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
@@ -6,10 +6,10 @@ import { renderWithProviders } from '../../../../__testing-utils__'
 import { mockRecoveryContentProps } from '../../__fixtures__'
 import { i18n } from '../../../../i18n'
 import { LeftColumnLabwareInfo } from '../LeftColumnLabwareInfo'
-import { Move } from '../../../../molecules/InterventionModal/InterventionStep'
+import { InterventionInfo } from '../../../../molecules/InterventionModal/InterventionContent/InterventionInfo'
 import { InlineNotification } from '../../../../atoms/InlineNotification'
 
-vi.mock('../../../../molecules/InterventionModal/InterventionStep')
+vi.mock('../../../../molecules/InterventionModal/InterventionInfo')
 vi.mock('../../../../atoms/InlineNotification')
 
 const render = (props: React.ComponentProps<typeof LeftColumnLabwareInfo>) => {
@@ -35,18 +35,18 @@ describe('LeftColumnLabwareInfo', () => {
       bannerText: 'MOCK_BANNER_TEXT',
     }
 
-    vi.mocked(Move).mockReturnValue(<div>MOCK_MOVE</div>)
+    vi.mocked(InterventionInfo).mockReturnValue(<div>MOCK_MOVE</div>)
     vi.mocked(InlineNotification).mockReturnValue(
       <div>MOCK_INLINE_NOTIFICATION</div>
     )
   })
 
-  it('renders the title, Move component, and InlineNotification when bannerText is provided', () => {
+  it('renders the title, InterventionInfo component, and InlineNotification when bannerText is provided', () => {
     render(props)
 
     screen.getByText('MOCK_TITLE')
     screen.getByText('MOCK_MOVE')
-    expect(vi.mocked(Move)).toHaveBeenCalledWith(
+    expect(vi.mocked(InterventionInfo)).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'refill',
         labwareName: 'MOCK_LW_NAME',
@@ -78,7 +78,7 @@ describe('LeftColumnLabwareInfo', () => {
     props.failedLabwareUtils.failedLabware.location = 'offDeck'
     render(props)
 
-    expect(vi.mocked(Move)).toHaveBeenCalledWith(
+    expect(vi.mocked(InterventionInfo)).toHaveBeenCalledWith(
       expect.objectContaining({
         currentLocationProps: { slotName: '' },
       }),

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/LeftColumnLabwareInfo.test.tsx
@@ -9,7 +9,9 @@ import { LeftColumnLabwareInfo } from '../LeftColumnLabwareInfo'
 import { InterventionInfo } from '../../../../molecules/InterventionModal/InterventionContent/InterventionInfo'
 import { InlineNotification } from '../../../../atoms/InlineNotification'
 
-vi.mock('../../../../molecules/InterventionModal/InterventionInfo')
+vi.mock(
+  '../../../../molecules/InterventionModal/InterventionContent/InterventionInfo'
+)
 vi.mock('../../../../atoms/InlineNotification')
 
 const render = (props: React.ComponentProps<typeof LeftColumnLabwareInfo>) => {
@@ -31,7 +33,7 @@ describe('LeftColumnLabwareInfo', () => {
           location: { slotName: 'A1' },
         },
       } as any,
-      moveType: 'refill',
+      type: 'location',
       bannerText: 'MOCK_BANNER_TEXT',
     }
 
@@ -48,7 +50,7 @@ describe('LeftColumnLabwareInfo', () => {
     screen.getByText('MOCK_MOVE')
     expect(vi.mocked(InterventionInfo)).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'refill',
+        type: 'location',
         labwareName: 'MOCK_LW_NAME',
         currentLocationProps: { slotName: 'A1' },
       }),

--- a/components/src/atoms/StyledText/StyledText.tsx
+++ b/components/src/atoms/StyledText/StyledText.tsx
@@ -111,6 +111,14 @@ const helixProductStyleMap = {
       }
     `,
   },
+  hidden: {
+    as: 'none',
+    style: css`
+      @media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+        display: none;
+      }
+    `,
+  },
 } as const
 
 const ODDStyleMap = {
@@ -246,6 +254,14 @@ const ODDStyleMap = {
     style: css`
       @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
         ${TYPOGRAPHY.smallBodyTextBold}
+      }
+    `,
+  },
+  hidden: {
+    as: 'none',
+    style: css`
+      @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+        display: none;
       }
     `,
   },


### PR DESCRIPTION
Intervention info is the name of the grey block with the labware name and the labware icon, and this makes it a component and updates its style.

There's also a new content component called `InterventionInfoComponent` that mostly exists to hold the intervention info. This is used in Error Recovery, when you pick tips in a rack to pick up or tipracks to use.

## Review
Seem like good changes?
## Testing
- In Error Recovery ODD, do pick up new tip / refill well flows and check that it works out nicely
- Unfortunately you can't really get to the relevant screens on desktop so Storybook will have to suffice
- DQA

Storybook will be at https://s3-us-west-2.amazonaws.com/opentrons-components/exec-500-intervention-content/index.html?path=/docs/app-molecules-interventionmodal-interventioncontent-interventioncontent--docs

Closes EXEC-500
Closes EXEC-530