### PR TITLE
RQA-2830 App cannot analyze due to mismatched build architecture of dmg and bundled python

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -123,7 +123,7 @@ dist-posix: package-deps
 
 .PHONY: dist-osx
 dist-osx: package-deps
-	$(builder) --mac
+	$(builder) --mac --x64
 	$(MAKE) _dist-collect-artifacts
 
 .PHONY: dist-linux

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -1,4 +1,5 @@
 'use strict'
+const { arch } = require('os')
 const path = require('path')
 
 const {
@@ -56,6 +57,7 @@ module.exports = async () => ({
   asar: true,
   mac: {
     target: process.platform === 'darwin' ? ['dmg', 'zip'] : ['zip'],
+    arch: ['x64'],
     category: 'public.app-category.productivity',
     type: DEV_MODE ? 'development' : 'distribution',
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -57,7 +57,6 @@ module.exports = async () => ({
   asar: true,
   mac: {
     target: process.platform === 'darwin' ? ['dmg', 'zip'] : ['zip'],
-    arch: ['x64'],
     category: 'public.app-category.productivity',
     type: DEV_MODE ? 'development' : 'distribution',
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -1,5 +1,4 @@
 'use strict'
-const { arch } = require('os')
 const path = require('path')
 
 const {

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -118,7 +118,16 @@ module.exports = function beforeBuild(context) {
 
       // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
       // implementation of this install
-      return execa(HOST_PYTHON, [
+      console.log(
+        `Installing python native deps using ${path.join(
+          PYTHON_DESTINATION,
+          'python3.10'
+        )}`
+      )
+      const invokablePython = platformName.includes('darwin')
+        ? path.join(PYTHON_DESTINATION, 'python/bin/python3.10')
+        : HOST_PYTHON
+      return execa(invokablePython, [
         '-m',
         'pip',
         'install',

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -116,9 +116,15 @@ module.exports = function beforeBuild(context) {
           ? PYTHON_SITE_PACKAGES_TARGET_WINDOWS
           : PYTHON_SITE_PACKAGES_TARGET_POSIX
 
-      // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
-      // implementation of this install
-      return execa(HOST_PYTHON, [
+      const downloadedPythonPath = path.join(
+        PYTHON_DESTINATION,
+        'bin',
+        'python'
+      )
+      // Install packages using the downloaded Python
+      return execa('arch', [
+        '-x86_64',
+        downloadedPythonPath,
         '-m',
         'pip',
         'install',

--- a/app-shell/scripts/before-pack.js
+++ b/app-shell/scripts/before-pack.js
@@ -116,15 +116,9 @@ module.exports = function beforeBuild(context) {
           ? PYTHON_SITE_PACKAGES_TARGET_WINDOWS
           : PYTHON_SITE_PACKAGES_TARGET_POSIX
 
-      const downloadedPythonPath = path.join(
-        PYTHON_DESTINATION,
-        'bin',
-        'python'
-      )
-      // Install packages using the downloaded Python
-      return execa('arch', [
-        '-x86_64',
-        downloadedPythonPath,
+      // TODO(mc, 2022-05-16): explore virtualenvs for a more reliable
+      // implementation of this install
+      return execa(HOST_PYTHON, [
         '-m',
         'pip',
         'install',


### PR DESCRIPTION
# Overview

- <https://opentrons.atlassian.net/browse/RQA-2830>
- `macos-11` GitHub runner was intel and now we use macos-latest that is arm [doc](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- specify --x64 argument to electron-builder
- ~~per [doc](https://github.com/actions/setup-python?tab=readme-ov-file#supported-architectures) x64 python should be installed so the pip install will be the right platform.  I'm not confident in this.~~
- see comment, we need to use the python we download on mac to do the pip install so the installed packages match the platform correctly

## Test Plan

- [x] build locally and see that it works
- [ ] watch CI and install the built package
- [ ] validate that once the package dmg is x64 that analysis works (python has packages with the right arch)

# Review requests

- This the right approach?

# Risk assessment

High because our .dmg currently cannot analyze protocols 2.0.0-alpha.0 internal release build.