### PR TITLE
refactor(api): Light refactors to CommandHistory

### DIFF
--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -19,7 +19,7 @@ class CommandEntry:
 
 @dataclass  # dataclass for __eq__() autogeneration.
 class CommandHistory:
-    """Command state container for command data."""
+    """Provides O(1) amortized access to commands of interest."""
 
     _all_command_ids: List[str]
     """All command IDs, in insertion order."""

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -151,7 +151,7 @@ class CommandHistory:
         """Clears all commands within the queued setup command ids structure."""
         self._queued_fixit_command_ids.clear()
 
-    def set_command_queued(self, command: Command) -> None:
+    def append_queued_command(self, command: Command) -> None:
         """Validate and mark a command as queued in the command history."""
         assert command.status == CommandStatus.QUEUED
         assert not self.has(command.id)

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -139,18 +139,6 @@ class CommandHistory:
         """Get the IDs of all queued fixit commands, in FIFO order."""
         return self._queued_fixit_command_ids
 
-    def clear_queue(self) -> None:
-        """Clears all commands within the queued command ids structure."""
-        self._queued_command_ids.clear()
-
-    def clear_setup_queue(self) -> None:
-        """Clears all commands within the queued setup command ids structure."""
-        self._queued_setup_command_ids.clear()
-
-    def clear_fixit_queue(self) -> None:
-        """Clears all commands within the queued setup command ids structure."""
-        self._queued_fixit_command_ids.clear()
-
     def append_queued_command(self, command: Command) -> None:
         """Validate and mark a command as queued in the command history."""
         assert command.status == CommandStatus.QUEUED
@@ -227,14 +215,16 @@ class CommandHistory:
             command_entry=CommandEntry(index=index, command=command),
         )
 
-        self._set_most_recently_completed_command_id(command.id)
-
         running_command_entry = self.get_running_command()
         if (
             running_command_entry is not None
             and running_command_entry.command.id == command.id
         ):
             self._set_running_command_id(None)
+
+        self._remove_queue_id(command.id)
+        self._remove_setup_queue_id(command.id)
+        self._set_most_recently_completed_command_id(command.id)
 
     def _add(self, command_id: str, command_entry: CommandEntry) -> None:
         """Create or update a command entry."""

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -90,10 +90,6 @@ class CommandHistory:
         except IndexError:
             return None
 
-    def get_if_present(self, command_id: str) -> Optional[CommandEntry]:
-        """Get a command entry, if present."""
-        return self._commands_by_id.get(command_id)
-
     def get_all_commands(self) -> List[Command]:
         """Get all commands."""
         return [

--- a/api/src/opentrons/protocol_engine/state/command_history.py
+++ b/api/src/opentrons/protocol_engine/state/command_history.py
@@ -39,7 +39,7 @@ class CommandHistory:
     _running_command_id: Optional[str]
     """The ID of the currently running command, if any"""
 
-    _terminal_command_id: Optional[str]
+    _most_recently_completed_command_id: Optional[str]
     """ID of the most recent command that SUCCEEDED or FAILED, if any"""
 
     def __init__(self) -> None:
@@ -49,7 +49,7 @@ class CommandHistory:
         self._queued_fixit_command_ids = OrderedSet()
         self._commands_by_id = OrderedDict()
         self._running_command_id = None
-        self._terminal_command_id = None
+        self._most_recently_completed_command_id = None
 
     def length(self) -> int:
         """Get the length of all elements added to the history."""
@@ -113,10 +113,10 @@ class CommandHistory:
         else:
             return None
 
-    def get_terminal_command(self) -> Optional[CommandEntry]:
+    def get_most_recently_completed_command(self) -> Optional[CommandEntry]:
         """Get the command most recently marked as SUCCEEDED or FAILED."""
-        if self._terminal_command_id is not None:
-            return self._commands_by_id[self._terminal_command_id]
+        if self._most_recently_completed_command_id is not None:
+            return self._commands_by_id[self._most_recently_completed_command_id]
         else:
             return None
 
@@ -210,7 +210,7 @@ class CommandHistory:
 
         self._remove_queue_id(command.id)
         self._remove_setup_queue_id(command.id)
-        self._set_terminal_command_id(command.id)
+        self._set_most_recently_completed_command_id(command.id)
 
     def set_command_failed(self, command: Command) -> None:
         """Validate and mark a command as failed in the command history."""
@@ -227,7 +227,7 @@ class CommandHistory:
             command_entry=CommandEntry(index=index, command=command),
         )
 
-        self._set_terminal_command_id(command.id)
+        self._set_most_recently_completed_command_id(command.id)
 
         running_command_entry = self.get_running_command()
         if (
@@ -266,9 +266,9 @@ class CommandHistory:
         """Remove a specific command from the queued fixit command ids structure."""
         self._queued_fixit_command_ids.discard(command_id)
 
-    def _set_terminal_command_id(self, command_id: str) -> None:
+    def _set_most_recently_completed_command_id(self, command_id: str) -> None:
         """Set the ID of the most recently dequeued command."""
-        self._terminal_command_id = command_id
+        self._most_recently_completed_command_id = command_id
 
     def _set_running_command_id(self, command_id: Optional[str]) -> None:
         """Set the ID of the currently running command."""

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -252,7 +252,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
                 failedCommandId=action.failed_command_id,
             )
 
-            self._state.command_history.set_command_queued(queued_command)
+            self._state.command_history.append_queued_command(queued_command)
 
             if action.request_hash is not None:
                 self._state.latest_protocol_command_hash = action.request_hash

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -715,7 +715,9 @@ class CommandView(HasState[CommandState]):
             else:
                 return self._state.command_history.get_prev(tail_command.command.id)
         else:
-            most_recently_finalized = self._state.command_history.get_terminal_command()
+            most_recently_finalized = (
+                self._state.command_history.get_most_recently_completed_command()
+            )
             # This iteration is effectively O(1) as we'll only ever have to iterate one or two times at most.
             while most_recently_finalized is not None:
                 next_command = self._state.command_history.get_next(

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -283,6 +283,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             else:
                 public_error_occurrence = action.error.public
 
+            prev_entry = self.state.command_history.get(action.command_id)
             self._update_to_failed(
                 command_id=action.command_id,
                 failed_at=action.failed_at,
@@ -295,7 +296,6 @@ class CommandStore(HasState[CommandState], HandlesActions):
                 action.command_id
             )
 
-            prev_entry = self.state.command_history.get(action.command_id)
             if prev_entry.command.intent == CommandIntent.SETUP:
                 other_command_ids_to_fail = list(
                     # Copy to avoid it mutating as we remove elements below.

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -297,7 +297,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
 
             prev_entry = self.state.command_history.get(action.command_id)
             if prev_entry.command.intent == CommandIntent.SETUP:
-                other_command_ids_to_fail = (
+                other_command_ids_to_fail = list(
+                    # Copy to avoid it mutating as we remove elements below.
                     self._state.command_history.get_setup_queue_ids()
                 )
                 for command_id in other_command_ids_to_fail:
@@ -309,7 +310,6 @@ class CommandStore(HasState[CommandState], HandlesActions):
                         error_recovery_type=None,
                         notes=None,
                     )
-                self._state.command_history.clear_setup_queue()
             elif (
                 prev_entry.command.intent == CommandIntent.PROTOCOL
                 or prev_entry.command.intent is None
@@ -318,7 +318,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
                     self._state.queue_status = QueueStatus.AWAITING_RECOVERY
                     self._state.recovery_target_command_id = action.command_id
                 elif action.type == ErrorRecoveryType.FAIL_RUN:
-                    other_command_ids_to_fail = (
+                    other_command_ids_to_fail = list(
+                        # Copy to avoid it mutating as we remove elements below.
                         self._state.command_history.get_queue_ids()
                     )
                     for command_id in other_command_ids_to_fail:
@@ -330,11 +331,11 @@ class CommandStore(HasState[CommandState], HandlesActions):
                             error_recovery_type=None,
                             notes=None,
                         )
-                    self._state.command_history.clear_queue()
                 else:
                     assert_never(action.type)
             elif prev_entry.command.intent == CommandIntent.FIXIT:
-                other_command_ids_to_fail = (
+                other_command_ids_to_fail = list(
+                    # Copy to avoid it mutating as we remove elements below.
                     self._state.command_history.get_fixit_queue_ids()
                 )
                 for command_id in other_command_ids_to_fail:
@@ -346,7 +347,6 @@ class CommandStore(HasState[CommandState], HandlesActions):
                         error_recovery_type=None,
                         notes=None,
                     )
-                self._state.command_history.clear_fixit_queue()
             else:
                 assert_never(prev_entry.command.intent)
 
@@ -374,7 +374,6 @@ class CommandStore(HasState[CommandState], HandlesActions):
             self._state.queue_status = QueueStatus.PAUSED
 
         elif isinstance(action, ResumeFromRecoveryAction):
-            self._state.command_history.clear_fixit_queue()
             self._state.queue_status = QueueStatus.RUNNING
             self._state.recovery_target_command_id = None
 

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -231,7 +231,7 @@ class RunOrchestrator:
         )
 
     def get_current_command(self) -> Optional[CommandPointer]:
-        """Get the current running command."""
+        """Get the "current" command, if any."""
         return self._protocol_engine.state_view.commands.get_current()
 
     def get_command_slice(

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -248,35 +248,6 @@ def test_add_to_fixit_queue(command_history: CommandHistory) -> None:
     assert command_history.get_fixit_queue_ids() == OrderedSet(["command-id"])
 
 
-def test_clear_queue(command_history: CommandHistory) -> None:
-    """It should clear all commands in the queue."""
-    command_history._add_to_queue("0")
-    command_history._add_to_queue("1")
-    command_history.clear_queue()
-    assert command_history.get_queue_ids() == OrderedSet()
-
-
-def test_clear_setup_queue(command_history: CommandHistory) -> None:
-    """It should clear all commands in the setup queue."""
-    command_history._add_to_setup_queue("0")
-    command_history._add_to_setup_queue("1")
-    command_history.clear_setup_queue()
-    assert command_history.get_setup_queue_ids() == OrderedSet()
-
-
-def test_clear_fixit_queue(command_history: CommandHistory) -> None:
-    """It should clear all commands in the setup queue."""
-    command_history.append_queued_command(
-        create_queued_command(command_id="0", intent=CommandIntent.FIXIT)
-    )
-    command_history.append_queued_command(
-        create_queued_command(command_id="1", intent=CommandIntent.FIXIT)
-    )
-    assert command_history.get_fixit_queue_ids() == OrderedSet(["0", "1"])
-    command_history.clear_fixit_queue()
-    assert command_history.get_fixit_queue_ids() == OrderedSet()
-
-
 def test_remove_id_from_queue(command_history: CommandHistory) -> None:
     """It should remove the given ID from the queue."""
     command_history._add_to_queue("0")

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -131,11 +131,11 @@ def test_get_tail_command(command_history: CommandHistory) -> None:
 
 def test_get_recently_dequeued_command(command_history: CommandHistory) -> None:
     """It should return the most recently dequeued command."""
-    assert command_history.get_terminal_command() is None
+    assert command_history.get_most_recently_completed_command() is None
     command_entry = create_queued_command_entry()
     command_history._add("0", command_entry)
-    command_history._set_terminal_command_id("0")
-    assert command_history.get_terminal_command() == command_entry
+    command_history._set_most_recently_completed_command_id("0")
+    assert command_history.get_most_recently_completed_command() == command_entry
 
 
 def test_get_running_command(command_history: CommandHistory) -> None:
@@ -182,8 +182,8 @@ def test_set_recent_dequeued_command_id(command_history: CommandHistory) -> None
     """It should set the ID of the most recently dequeued command."""
     command_entry = create_queued_command_entry()
     command_history._add("0", command_entry)
-    command_history._set_terminal_command_id("0")
-    assert command_history.get_terminal_command() == command_entry
+    command_history._set_most_recently_completed_command_id("0")
+    assert command_history.get_most_recently_completed_command() == command_entry
 
 
 def test_set_running_command_id(command_history: CommandHistory) -> None:

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -197,7 +197,7 @@ def test_set_running_command_id(command_history: CommandHistory) -> None:
 def test_set_fixit_running_command_id(command_history: CommandHistory) -> None:
     """It should set the ID of the currently running fixit command."""
     command_entry = create_queued_command()
-    command_history.set_command_queued(command_entry)
+    command_history.append_queued_command(command_entry)
     running_command = command_entry.copy(
         update={
             "status": CommandStatus.RUNNING,
@@ -213,7 +213,7 @@ def test_set_fixit_running_command_id(command_history: CommandHistory) -> None:
     fixit_command_entry = create_queued_command(
         command_id="fixit-id", intent=CommandIntent.FIXIT
     )
-    command_history.set_command_queued(fixit_command_entry)
+    command_history.append_queued_command(fixit_command_entry)
     fixit_running_command = fixit_command_entry.copy(
         update={
             "status": CommandStatus.RUNNING,
@@ -244,7 +244,7 @@ def test_add_to_setup_queue(command_history: CommandHistory) -> None:
 def test_add_to_fixit_queue(command_history: CommandHistory) -> None:
     """It should add the given ID to the setup queue."""
     fixit_command = create_queued_command(intent=CommandIntent.FIXIT)
-    command_history.set_command_queued(fixit_command)
+    command_history.append_queued_command(fixit_command)
     assert command_history.get_fixit_queue_ids() == OrderedSet(["command-id"])
 
 
@@ -266,10 +266,10 @@ def test_clear_setup_queue(command_history: CommandHistory) -> None:
 
 def test_clear_fixit_queue(command_history: CommandHistory) -> None:
     """It should clear all commands in the setup queue."""
-    command_history.set_command_queued(
+    command_history.append_queued_command(
         create_queued_command(command_id="0", intent=CommandIntent.FIXIT)
     )
-    command_history.set_command_queued(
+    command_history.append_queued_command(
         create_queued_command(command_id="1", intent=CommandIntent.FIXIT)
     )
     assert command_history.get_fixit_queue_ids() == OrderedSet(["0", "1"])

--- a/api/tests/opentrons/protocol_engine/state/test_command_history.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_history.py
@@ -81,14 +81,6 @@ def test_get_prev(command_history: CommandHistory) -> None:
     assert command_history.get_prev("1") == command_entry_1
 
 
-def test_get_if_present(command_history: CommandHistory) -> None:
-    """It should return the command entry for the given ID if it exists, None otherwise."""
-    assert command_history.get_if_present("0") is None
-    command_entry = create_queued_command_entry()
-    command_history._add("0", command_entry)
-    assert command_history.get_if_present("0") == command_entry
-
-
 def test_get_all_commands(command_history: CommandHistory) -> None:
     """It should return a list of all commands."""
     assert command_history.get_all_commands() == []

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -866,7 +866,7 @@ def test_get_current() -> None:
         created_at=datetime(year=2022, month=2, day=2),
     )
     subject = get_command_view(commands=[command_1, command_2])
-    subject.state.command_history._set_terminal_command_id(command_1.id)
+    subject.state.command_history._set_most_recently_completed_command_id(command_1.id)
 
     assert subject.get_current() == CommandPointer(
         index=1,
@@ -886,7 +886,7 @@ def test_get_current() -> None:
         created_at=datetime(year=2022, month=2, day=2),
     )
     subject = get_command_view(commands=[command_1, command_2])
-    subject.state.command_history._set_terminal_command_id(command_1.id)
+    subject.state.command_history._set_most_recently_completed_command_id(command_1.id)
 
     assert subject.get_current() == CommandPointer(
         index=1,

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -229,7 +229,7 @@ class MaintenanceRunOrchestratorStore:
         return self.run_orchestrator.get_command_slice(cursor=cursor, length=length)
 
     def get_current_command(self) -> Optional[CommandPointer]:
-        """Get the current running command."""
+        """Get the "current" command, if any."""
         return self.run_orchestrator.get_current_command()
 
     def get_command_recovery_target(self) -> Optional[CommandPointer]:


### PR DESCRIPTION
# Overview

Some light refactors to `CommandHistory` en route to EXEC-302 and EXEC-598.

# Test Plan

I'm trusting our existing automated tests.

# Changelog

See inline notes.

# Risk assessment

Low.