### PR TITLE
fix(app): fix alert stroke disalbed styling

### DIFF
--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -51,7 +51,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       focusVisibleOutlineColor: string
       focusVisibleBackgroundColor: string
       activeIconColor?: string
-      isInverse?: boolean
       activeColor?: string
     }
   > = {
@@ -97,7 +96,6 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.white,
       disabledIconColor: COLORS.grey50,
-      isInverse: true,
       activeIconColor: COLORS.red60,
       focusVisibleOutlineColor: COLORS.blue50,
       focusVisibleBackgroundColor: COLORS.red40,

--- a/app/src/atoms/buttons/LargeButton.tsx
+++ b/app/src/atoms/buttons/LargeButton.tsx
@@ -90,13 +90,13 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     },
     alertStroke: {
       defaultColor: COLORS.white,
-      disabledColor: COLORS.grey40,
+      disabledColor: COLORS.grey50,
       activeColor: COLORS.red60,
       defaultBackgroundColor: COLORS.transparent,
       activeBackgroundColor: COLORS.red35,
-      disabledBackgroundColor: COLORS.transparent,
+      disabledBackgroundColor: COLORS.grey35,
       iconColor: COLORS.white,
-      disabledIconColor: COLORS.grey40,
+      disabledIconColor: COLORS.grey50,
       isInverse: true,
       activeIconColor: COLORS.red60,
       focusVisibleOutlineColor: COLORS.blue50,
@@ -140,9 +140,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     line-height: ${TYPOGRAPHY.lineHeight20};
     gap: ${SPACING.spacing60};
     border: ${BORDERS.borderRadius4} solid
-      ${!!LARGE_BUTTON_PROPS_BY_TYPE[buttonType].isInverse
+      ${buttonType === 'alertStroke' && !disabled
         ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor
-        : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor};
+        : 'none'};
 
     ${TYPOGRAPHY.pSemiBold}
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
update alert stroke's disabled style and modify the condition of border to not display border when a `LargeButton` is disabled

[design]
https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery-August-Release?node-id=1935-45180&t=GW9oNRW0wY7mZ4jf-4

close RQA-2836

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
Ensure that each button type in the [storybook](https://s3-us-west-2.amazonaws.com/opentrons-components/fix_RQA-2836/index.html?path=/docs/odd-atoms-buttons-largebutton--docs) matches the design

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
