### PR TITLE
chore: Restart robot-server in `make push`

### DIFF
--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -174,6 +174,7 @@ push: wheel
 .PHONY: push-ot3
 push-ot3: sdist
 	$(call push-python-sdist,$(host),$(ssh_key),$(ssh_opts),$(sdist_file),"/opt/opentrons-robot-server","robot_server",,,$(version_file))
+	$(call restart-service,$(host),$(ssh_key),$(ssh_opts),opentrons-robot-server)
 
 .PHONY: install-key
 install-key:


### PR DESCRIPTION
# Overview

Currently, pushing to an OT-2 (`make push` or `make -C robot-server push`) automatically restarts the opentrons-robot-server service, but pushing to a Flex `make push-ot3` or `make -C robot-server push-ot3`) does not. This PR changes the Flex push behavior to be consistent.

# Test Plan

- [x] Run it and make sure it works.

# Risk assessment

None.