### PR TITLE
Making the scale script usable for robots not doing liquid measurement.

### DIFF
--- a/abr-testing/abr_testing/tools/abr_scale.py
+++ b/abr-testing/abr_testing/tools/abr_scale.py
@@ -34,7 +34,7 @@ def get_protocol_step_as_int(
         # create an dict copying the contents of IP_N_Volumes
         try:
             ip_file = json.load(open(ip_json_file))
-            try:    
+            try:
                 # grab IP and volume from the dict
                 tot_info = ip_file["information"]
                 robot_info = tot_info[robot]

--- a/abr-testing/abr_testing/tools/abr_scale.py
+++ b/abr-testing/abr_testing/tools/abr_scale.py
@@ -34,19 +34,29 @@ def get_protocol_step_as_int(
         # create an dict copying the contents of IP_N_Volumes
         try:
             ip_file = json.load(open(ip_json_file))
+            try:    
+                # grab IP and volume from the dict
+                tot_info = ip_file["information"]
+                robot_info = tot_info[robot]
+                IP_add = robot_info["IP"]
+                exp_volume = robot_info["volume"]
+                # sets return variables equal to those grabbed from the sheet
+                ip = IP_add
+                expected_liquid_moved = float(exp_volume)
+            except KeyError:
+                ip = input("Robot IP: ")
+                while True:
+                    try:
+                        expected_liquid_moved = float(input("Expected volume moved: "))
+                        if expected_liquid_moved >= 0 or expected_liquid_moved <= 0:
+                            break
+                    except ValueError:
+                        print("Expected liquid moved volume should be an float.")
         except FileNotFoundError:
             print(
                 f"Please add json file with robot IPs and expected volumes to: {storage_directory}."
             )
             sys.exit()
-        # grab IP and volume from the dict
-        tot_info = ip_file["information"]
-        robot_info = tot_info[robot]
-        IP_add = robot_info["IP"]
-        exp_volume = robot_info["volume"]
-        # sets return variables equal to those grabbed from the sheet
-        ip = IP_add
-        expected_liquid_moved = float(exp_volume)
 
     return protocol_step, expected_liquid_moved, ip
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
When I updated the scale script to grab IP's and expected volumes moved automatically I did not add a way for the scale to be used with samples from robots not doing liquid measurement. This update allows a user to input a robot not in the IP and Volume json file and not cause the script to error out.-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
added error recovery when the script cannot find specified robot in JSON file.
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
