### PR TITLE
fix(hardware): gripper calibration fix

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1461,7 +1461,6 @@ class OT3Controller(FlexBackend):
             tool=sensor_node_for_mount(mount),
             mover=axis_to_node(moving),
             distance=distance_mm,
-            plunger_speed=speed_mm_per_s,
             mount_speed=speed_mm_per_s,
             csv_output=csv_output,
             sync_buffer_output=sync_buffer_output,

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -549,12 +549,14 @@ async def capacitive_probe(
 
     probe_distance = {mover: distance}
     probe_speed = {mover: mount_speed}
+    movers = [mover]
     if pipette_present:
         probe_distance[tool] = 0.0
         probe_speed[tool] = 0.0
+        movers.append(tool)
 
     sensor_group = _build_pass_step(
-        movers=[mover],
+        movers=movers,
         distance=probe_distance,
         speed=probe_speed,
         sensor_type=SensorType.capacitive,
@@ -564,7 +566,7 @@ async def capacitive_probe(
     if sync_buffer_output:
         sensor_group = _fix_pass_step_for_buffer(
             sensor_group,
-            movers=[mover],
+            movers=movers,
             distance=probe_distance,
             speed=probe_speed,
             sensor_type=SensorType.capacitive,

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -319,7 +319,6 @@ async def _setup_pressure_sensors(
 async def _setup_capacitive_sensors(
     messenger: CanMessenger,
     sensor_id: SensorId,
-    # node: NodeId,
     tool: InstrumentProbeTarget,
     relative_threshold_pf: float,
     sensor_driver: SensorDriver,
@@ -335,9 +334,6 @@ async def _setup_capacitive_sensors(
     for sensor in sensors:
         capacitive_sensor = CapacitiveSensor.build(
             sensor_id=sensor,
-            # this is bad and I dont like it
-            # it only works when it gets passed a InstumentProbeTarget
-            # but the function param is a NodeId ????
             node_id=tool,
             stop_threshold=relative_threshold_pf,
         )

--- a/hardware/opentrons_hardware/hardware_control/tool_sensors.py
+++ b/hardware/opentrons_hardware/hardware_control/tool_sensors.py
@@ -537,7 +537,7 @@ async def capacitive_probe(
     """
     log_files: Dict[SensorId, str] = {} if not data_files else data_files
     sensor_driver = SensorDriver()
-    pipette_present = tool is NodeId.pipette_left or tool is NodeId.pipette_right
+    pipette_present = tool in [NodeId.pipette_left, NodeId.pipette_right]
 
     capacitive_sensors = await _setup_capacitive_sensors(
         messenger,

--- a/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_tool_sensors.py
@@ -445,7 +445,7 @@ async def test_capacitive_probe(
     message_send_loopback.add_responder(move_responder)
 
     status = await capacitive_probe(
-        mock_messenger, target_node, motor_node, distance, speed, speed
+        mock_messenger, target_node, motor_node, distance, speed
     )
     assert status.motor_position == 10  # this comes from the current_position_um above
     assert status.encoder_position == 10


### PR DESCRIPTION
## Overview
There was a refactor a little while ago that sought to enable capacitive probing using the pipette for liquid level detection- in that endeavor we also broke the gripper's capacitive probing. This fixes that and should still allow us to do capacitive probing with a pipette.

Closes [RQA-218](https://opentrons.atlassian.net/browse/RQA-2818?atlOrigin=eyJpIjoiNzc2YjA5YjcyNjM3NDE1MzgwZDI3OGFkNDk4MTA4M2YiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

## Changelog

- only optionally add a `tool` entry to the move groups associated with the probing motion
- when a pipette is present, add a move for the plunger but give it 0 distance and 0 velocity- this way the plunger won't actually move and risk damaging the pressure sensor, but the move group will still be able to interact directly with the sync line

## Test Plan

- [x] calibrate a gripper successfully
- [x] calibrate a single channel pipette successfully
- [x] calibrate a multi channel pipette successfully
- [ ] calibrate a 96 channel pipette successfully

[RQA-218]: https://opentrons.atlassian.net/browse/RQA-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ