### PR TITLE
docs(api): fix typo calling `pick_up_tip` instead of `drop_tip`

### DIFF
--- a/api/docs/v2/basic_commands/pipette_tips.rst
+++ b/api/docs/v2/basic_commands/pipette_tips.rst
@@ -79,7 +79,7 @@ Dropping a Tip
 
 To drop a tip in the pipette's trash container, call the :py:meth:`~.InstrumentContext.drop_tip` method with no arguments::
     
-    pipette.pick_up_tip()
+    pipette.drop_tip()
 
 You can specify where to drop the tip by passing in a location. For example, this code drops a tip in the trash bin and returns another tip to to a previously used well in a tip rack::
 


### PR DESCRIPTION

# Overview

🔥 Docs hotfix for a typo in the Dropping a Tip section.

Will deploy post-approval and then regular-merge to `edge`.

# Test Plan

[Sandbox](http://sandbox.docs.opentrons.com/docs-hotfix-pick-up-is-not-drop/v2/basic_commands/pipette_tips.html#dropping-a-tip)

# Changelog

1-liner.

# Risk assessment

nil.