### PR TITLE
fix(hardware-testing): fix call to capacitive probe

### DIFF
--- a/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_capacitance.py
+++ b/hardware-testing/hardware_testing/production_qc/ninety_six_assembly_qc_ot3/test_capacitance.py
@@ -173,7 +173,6 @@ async def run(api: OT3API, report: CSVReport, section: str) -> None:
                 NodeId.pipette_left,
                 NodeId.head_l,
                 distance=distance,
-                plunger_speed=speed,
                 mount_speed=speed,
                 sensor_id=sensor_id,
                 relative_threshold_pf=default_probe_cfg.sensor_threshold_pf,


### PR DESCRIPTION
Now that the call to `tool_sensors::capacitive_probe` has changed, just update the calls in the hardware testing repo