### PR TITLE
fix(app): odd: keep bullets on runningprotocol low

### DIFF
--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -173,10 +173,15 @@ export function RunningProtocol(): JSX.Element {
         <OpenDoorAlertModal />
       ) : null}
       {runStatus === RUN_STATUS_STOP_REQUESTED ? <CancelingRunModal /> : null}
+      {/* note: this zindex is here to establish a zindex context for the bullets
+          so they're relatively-above this flex but not anything else like error
+          recovery
+        */}
       <Flex
         flexDirection={DIRECTION_COLUMN}
         position={POSITION_RELATIVE}
         overflow={OVERFLOW_HIDDEN}
+        zIndex="0"
       >
         {robotSideAnalysis != null ? (
           <StepMeter


### PR DESCRIPTION
These little bullets that establish the ability to swipe left and right need to be relatively above the rest of the runningprotocol screen yes but they shouldn't be above anything else. So create an explicit z-stacking context for the content part of running protocol.

I'm not quite sure why this is now necessary and wasn't previously, but the rules around what creates an implicit stacking context are complex so we probably changed something 8 components away that removed whatever stacking context existed previously.

## Testing
On ODD:
- Note that the bullets look correct on running protocol
- Note that the bullets are not displayed on top of error recovery anymore
- Note that the other running protocol modals (or "modals", since most of them don't actually use the modal root) still display correctly. This is the cancel-confirmation modal and the intervention modal.