### PR TITLE
fix(app): odd: fix ER fundamental layout issues

### DIFF
--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux'
 import {
   ALIGN_CENTER,
   BORDERS,
-  Box,
   COLORS,
   Flex,
   Icon,
@@ -15,6 +14,7 @@ import {
   POSITION_RELATIVE,
   POSITION_STICKY,
   SPACING,
+  DIRECTION_COLUMN,
 } from '@opentrons/components'
 
 import { getIsOnDevice } from '../../redux/config'
@@ -143,8 +143,9 @@ export function InterventionModal({
   return (
     <Flex {...WRAPPER_STYLE}>
       <Flex {...BASE_STYLE} zIndex={10}>
-        <Box
+        <Flex
           {...modalStyle}
+          flexDirection={DIRECTION_COLUMN}
           border={border}
           onClick={(e: React.MouseEvent) => {
             e.stopPropagation()
@@ -165,7 +166,7 @@ export function InterventionModal({
             </Flex>
           </Flex>
           {children}
-        </Box>
+        </Flex>
       </Flex>
     </Flex>
   )

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
@@ -40,6 +40,6 @@ const STYLE = css`
   width: 100%;
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     gap: none;
-    height: 29.25rem;
+    height: 100%;
   }
 `

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryFooterButtons.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryFooterButtons.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
 import {
-  ALIGN_CENTER,
+  ALIGN_FLEX_END,
+  Box,
   Flex,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
@@ -35,7 +36,7 @@ export function RecoveryFooterButtons(
       width="100%"
       height="100%"
       justifyContent={JUSTIFY_SPACE_BETWEEN}
-      alignItems={ALIGN_CENTER}
+      alignItems={ALIGN_FLEX_END}
       gridGap={SPACING.spacing8}
     >
       <RecoveryGoBackButton {...props} />
@@ -50,7 +51,7 @@ function RecoveryGoBackButton({
   const showGoBackBtn = secondaryBtnOnClick != null
   const { t } = useTranslation('error_recovery')
   return showGoBackBtn ? (
-    <Flex marginTop="auto">
+    <Flex>
       <SmallButton
         buttonType="tertiaryLowLight"
         buttonText={t('go_back')}
@@ -62,7 +63,9 @@ function RecoveryGoBackButton({
         {t('go_back')}
       </SecondaryButton>
     </Flex>
-  ) : null
+  ) : (
+    <Box />
+  )
 }
 
 function PrimaryButtonGroup(props: RecoveryFooterButtonProps): JSX.Element {
@@ -73,13 +76,13 @@ function PrimaryButtonGroup(props: RecoveryFooterButtonProps): JSX.Element {
 
   if (!renderTertiaryBtn) {
     return (
-      <Flex marginTop="auto">
+      <Flex>
         <RecoveryPrimaryBtn {...props} />
       </Flex>
     )
   } else {
     return (
-      <Flex gridGap={SPACING.spacing8} marginTop="auto">
+      <Flex gridGap={SPACING.spacing8}>
         <RecoveryTertiaryBtn {...props} />
         <RecoveryPrimaryBtn {...props} />
       </Flex>
@@ -109,7 +112,6 @@ function RecoveryPrimaryBtn({
         buttonType="primary"
         buttonText={primaryBtnTextOverride ?? t('continue')}
         onClick={primaryBtnOnClick}
-        marginTop="auto"
       />
       <PrimaryButton
         css={DESKTOP_ONLY_BUTTON}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryInterventionModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryInterventionModal.tsx
@@ -53,11 +53,9 @@ const ODD_STYLE = `
 
 const SMALL_MODAL_STYLE = css`
   height: 25.25rem;
-
   ${ODD_STYLE}
 `
 const LARGE_MODAL_STYLE = css`
   height: 30rem;
-
   ${ODD_STYLE}
 `


### PR DESCRIPTION
I love Box. I don't know why. I always want to use it and every single time it breaks something. This is one of those times

- Remove Box as the container for intervention modal because it makes all of our common tools for layout not function
- Make the ODD containers 100% instead of explicit size everywhere because if you are using the right kind of container they won't overflow anyway
- 3am going back for more <Box />: inRecovery FooterButtons, add a small dummy element to the button row when there is no "go back" button so the primary button is still on the right

## Testing
all on ODD:
- There shouldn't be scrollbars in the error recovery components anymore
- If there's no "go back" button, the continue button should still be on the right