### PR TITLE
fix(app): fix link for setting up new robot

### DIFF
--- a/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
+++ b/app/src/pages/Devices/DevicesLanding/NewRobotSetupHelp.tsx
@@ -16,8 +16,7 @@ import { getTopPortalEl } from '../../../App/portal'
 import { LegacyModal } from '../../../molecules/LegacyModal'
 import { ExternalLink } from '../../../atoms/Link/ExternalLink'
 
-const NEW_ROBOT_SETUP_SUPPORT_ARTICLE_HREF =
-  'https://support.opentrons.com/s/ot2-get-started'
+const NEW_ROBOT_SETUP_SUPPORT_ARTICLE_HREF = 'https://support.opentrons.com/s/'
 
 export function NewRobotSetupHelp(): JSX.Element {
   const { t } = useTranslation(['devices_landing', 'shared'])

--- a/app/src/pages/Devices/DevicesLanding/__tests__/NewRobotSetupHelp.test.tsx
+++ b/app/src/pages/Devices/DevicesLanding/__tests__/NewRobotSetupHelp.test.tsx
@@ -43,4 +43,15 @@ describe('NewRobotSetupHelp', () => {
 
     expect(screen.queryByText('How to setup a new robot')).toBeFalsy()
   })
+
+  it('renders the link and it has the correct href attribute', () => {
+    render()
+    const link = screen.getByText('See how to set up a new robot')
+    fireEvent.click(link)
+    const targetLinkUrl = 'https://support.opentrons.com/s/'
+    const supportLink = screen.getByRole('link', {
+      name: 'Learn more about setting up a new robot',
+    })
+    expect(supportLink).toHaveAttribute('href', targetLinkUrl)
+  })
 })


### PR DESCRIPTION
RQA-2844

# Overview

On desktop devices page, clicking 'See how to set up a new robot' opens a modal with a link to support for setting up a new robot. Instead of linking to the OT-2 setup support page, we will now link to the top level Opentrons support link.

# Test Plan

- navigate to desktop app devices page
- click 'See how to set up a new robot' at top right of page
- click link for 'Learn more about setting up a new robot'
- verify that link pushes to https://support.opentrons.com/s/

# Changelog

- update link

# Review requests

see test plan

# Risk assessment

low