### PR TITLE
fix(app): disallow 8-channel 384 well selection if no starting well selected

### DIFF
--- a/app/src/organisms/WellSelection/Selection384Wells.tsx
+++ b/app/src/organisms/WellSelection/Selection384Wells.tsx
@@ -155,6 +155,7 @@ export function Selection384Wells({
             selectWells={selectWells}
             startingWellState={startingWellState}
             setStartingWellState={setStartingWellState}
+            wells={wells}
           />
         )}
         <ButtonControls
@@ -235,6 +236,7 @@ function StartingWell({
   selectWells,
   startingWellState,
   setStartingWellState,
+  wells,
 }: {
   channels: PipetteChannels
   deselectWells: (wells: string[]) => void
@@ -243,6 +245,7 @@ function StartingWell({
   setStartingWellState: React.Dispatch<
     React.SetStateAction<Record<StartingWellOption, boolean>>
   >
+  wells: string[]
 }): JSX.Element {
   const { t, i18n } = useTranslation('quick_transfer')
 
@@ -251,6 +254,9 @@ function StartingWell({
 
   // on mount, select A1 well group for 96-channel
   React.useEffect(() => {
+    // deselect all wells on mount; clears well selection when navigating back within quick transfer flow
+    // otherwise, selected wells and lastSelectedIndex pointer will be out of sync
+    deselectWells(wells)
     if (channels === 96) {
       selectWells({ A1: null })
     }

--- a/app/src/organisms/WellSelection/Selection384Wells.tsx
+++ b/app/src/organisms/WellSelection/Selection384Wells.tsx
@@ -98,8 +98,7 @@ export function Selection384Wells({
 
     if (selectBy === 'columns') {
       if (channels === 8) {
-        // for 8-channel, select first and second member of column (all rows) unless only one starting well option is selected
-        if (startingWellState.A1 === startingWellState.B1) {
+        if (startingWellState.A1 && startingWellState.B1) {
           selectWells({
             [columns[nextIndex][0]]: null,
             [columns[nextIndex][1]]: null,
@@ -152,7 +151,6 @@ export function Selection384Wells({
         ) : (
           <StartingWell
             channels={channels}
-            columns={columns}
             deselectWells={deselectWells}
             selectWells={selectWells}
             startingWellState={startingWellState}
@@ -163,8 +161,16 @@ export function Selection384Wells({
           channels={channels}
           handleMinus={handleMinus}
           handlePlus={handlePlus}
-          lastSelectedIndex={lastSelectedIndex}
-          selectBy={selectBy}
+          minusDisabled={lastSelectedIndex == null}
+          plusDisabled={
+            // disable 8-channel plus if no starting well selected
+            (channels === 8 &&
+              !startingWellState.A1 &&
+              !startingWellState.B1) ||
+            (selectBy === 'columns'
+              ? lastSelectedIndex === COLUMN_COUNT_384 - 1
+              : lastSelectedIndex === WELL_COUNT_384 - 1)
+          }
         />
       </Flex>
     </Flex>
@@ -225,14 +231,12 @@ type StartingWellOption = 'A1' | 'B1' | 'A2' | 'B2'
 
 function StartingWell({
   channels,
-  columns,
   deselectWells,
   selectWells,
   startingWellState,
   setStartingWellState,
 }: {
   channels: PipetteChannels
-  columns: string[][]
   deselectWells: (wells: string[]) => void
   selectWells: (wellGroup: WellGroup) => void
   startingWellState: Record<StartingWellOption, boolean>
@@ -288,8 +292,8 @@ interface ButtonControlsProps {
   channels: PipetteChannels
   handleMinus: () => void
   handlePlus: () => void
-  lastSelectedIndex: number | null
-  selectBy: 'columns' | 'wells'
+  minusDisabled: boolean
+  plusDisabled: boolean
 }
 
 function ButtonControls(props: ButtonControlsProps): JSX.Element {
@@ -297,8 +301,8 @@ function ButtonControls(props: ButtonControlsProps): JSX.Element {
     channels,
     handleMinus,
     handlePlus,
-    lastSelectedIndex,
-    selectBy,
+    minusDisabled,
+    plusDisabled,
   } = props
   const { t, i18n } = useTranslation('quick_transfer')
 
@@ -313,18 +317,14 @@ function ButtonControls(props: ButtonControlsProps): JSX.Element {
         </LegacyStyledText>
         <Flex gridGap={SPACING.spacing16}>
           <IconButton
-            disabled={lastSelectedIndex == null}
+            disabled={minusDisabled}
             onClick={handleMinus}
             iconName="minus"
             hasBackground
             flex="1"
           />
           <IconButton
-            disabled={
-              selectBy === 'columns'
-                ? lastSelectedIndex === COLUMN_COUNT_384 - 1
-                : lastSelectedIndex === WELL_COUNT_384 - 1
-            }
+            disabled={plusDisabled}
             onClick={handlePlus}
             iconName="plus"
             hasBackground


### PR DESCRIPTION
# Overview

disables the plus button for 8-channel 384 well selection when no starting well selected. also fixes a 384 well edge case when navigating back through the quick transfer flow - deselects all wells on 384 well selection mount to keep the the last selected index pointer in sync with the selected wells.

closes RQA-2854

<img width="1136" alt="Screen Shot 2024-07-15 at 12 13 13 PM" src="https://github.com/user-attachments/assets/aeaa977b-b621-4b2a-8885-9000704ab917">

# Test Plan

manually verified the fix

# Changelog

 - Disallows 8-channel 384 well selection if no starting well selected

# Review requests

is this the behavior we want

# Risk assessment

low
