### PR TITLE
fix(api): prevent stalls on PickUpTip Protocol API command

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1808,6 +1808,8 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
         instrument = self._pipette_handler.get_pipette(realmount)
 
+        self._move_to_plunger_bottom(realmount, rate=1.0)
+
         if (
             self.gantry_load == GantryLoad.HIGH_THROUGHPUT
             and instrument.nozzle_manager.current_configuration.configuration

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1808,7 +1808,7 @@ class OT3API(
         realmount = OT3Mount.from_mount(mount)
         instrument = self._pipette_handler.get_pipette(realmount)
 
-        self._move_to_plunger_bottom(realmount, rate=1.0)
+        await self._move_to_plunger_bottom(realmount, rate=1.0)
 
         if (
             self.gantry_load == GantryLoad.HIGH_THROUGHPUT

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -222,6 +222,8 @@ class HardwareTipHandler(TipHandler):
             nominal_fallback=nominal_tip_geometry.length,
         )
 
+        await self._hardware_api._move_to_plunger_bottom(hw_mount, rate=1.0)
+
         await self._hardware_api.tip_pickup_moves(
             mount=hw_mount, presses=None, increment=None
         )

--- a/api/src/opentrons/protocol_engine/execution/tip_handler.py
+++ b/api/src/opentrons/protocol_engine/execution/tip_handler.py
@@ -222,8 +222,6 @@ class HardwareTipHandler(TipHandler):
             nominal_fallback=nominal_tip_geometry.length,
         )
 
-        await self._hardware_api._move_to_plunger_bottom(hw_mount, rate=1.0)
-
         await self._hardware_api.tip_pickup_moves(
             mount=hw_mount, presses=None, increment=None
         )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -647,7 +647,7 @@ async def test_pickup_moves(
             assert move_call_list == [(OT3Mount.LEFT, Point(z=end_z_retract_dist))]
         # pick up tip should have two calls to move_to_plunger_bottom, one before and one after
         # the tip pickup
-        assert len(mock_move_to_plunger_bottom.call_args_list) == 2
+        assert len(mock_move_to_plunger_bottom.call_args_list) == 3
         mock_move_to_plunger_bottom.reset_mock()
         mock_move_rel.reset_mock()
 
@@ -662,7 +662,7 @@ async def test_pickup_moves(
             ]
         else:
             assert move_call_list == [(OT3Mount.LEFT, Point(z=end_z_retract_dist))]
-    assert len(mock_move_to_plunger_bottom.call_args_list) == 0
+    assert len(mock_move_to_plunger_bottom.call_args_list) == 1
 
 
 @pytest.mark.parametrize("load_configs", load_pipette_configs)


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

Recently in ABR testing, we've seen significant stalls surface from the head boards. One possible culprit is `_move_to_plunger_bottom()` now occurring after `tip_pickup_moves()`. This PR moves `_move_to_plunger_bottom()` back to before `tip_pickup_moves()`.

Closes RABR-431.

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

This branch can now be run on ABR3 to determine if the method call order is indeed the cause of the stall issue.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
