### PR TITLE
feat(app): anonymize pipette names for pipetteSpecsV2

### DIFF
--- a/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
+++ b/app/src/organisms/QuickTransferFlow/SelectPipette.tsx
@@ -8,8 +8,9 @@ import {
   DIRECTION_COLUMN,
 } from '@opentrons/components'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
-import { getPipetteSpecsV2, RIGHT, LEFT } from '@opentrons/shared-data'
+import { RIGHT, LEFT } from '@opentrons/shared-data'
 import { RadioButton } from '../../atoms/buttons'
+import { usePipetteSpecsV2 } from '../../resources/instruments/hooks'
 import { ChildNavigation } from '../ChildNavigation'
 
 import type { PipetteData, Mount } from '@opentrons/api-client'
@@ -35,16 +36,12 @@ export function SelectPipette(props: SelectPipetteProps): JSX.Element {
   const leftPipette = attachedInstruments?.data.find(
     (i): i is PipetteData => i.ok && i.mount === LEFT
   )
-  const leftPipetteSpecs =
-    leftPipette != null ? getPipetteSpecsV2(leftPipette.instrumentModel) : null
+  const leftPipetteSpecs = usePipetteSpecsV2(leftPipette?.instrumentModel)
 
   const rightPipette = attachedInstruments?.data.find(
     (i): i is PipetteData => i.ok && i.mount === RIGHT
   )
-  const rightPipetteSpecs =
-    rightPipette != null
-      ? getPipetteSpecsV2(rightPipette.instrumentModel)
-      : null
+  const rightPipetteSpecs = usePipetteSpecsV2(rightPipette?.instrumentModel)
 
   // automatically select 96 channel if it is attached
   const [selectedPipette, setSelectedPipette] = React.useState<

--- a/app/src/organisms/QuickTransferFlow/__tests__/SelectPipette.test.tsx
+++ b/app/src/organisms/QuickTransferFlow/__tests__/SelectPipette.test.tsx
@@ -5,9 +5,12 @@ import { useInstrumentsQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '../../../__testing-utils__'
 import { i18n } from '../../../i18n'
+import { useIsOEMMode } from '../../../resources/robot-settings/hooks'
 import { SelectPipette } from '../SelectPipette'
 
 vi.mock('@opentrons/react-api-client')
+vi.mock('../../../resources/robot-settings/hooks')
+
 const render = (props: React.ComponentProps<typeof SelectPipette>) => {
   return renderWithProviders(<SelectPipette {...props} />, {
     i18nInstance: i18n,
@@ -53,6 +56,7 @@ describe('SelectPipette', () => {
         ],
       },
     } as any)
+    vi.mocked(useIsOEMMode).mockReturnValue(false)
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/resources/instruments/hooks.ts
+++ b/app/src/resources/instruments/hooks.ts
@@ -2,6 +2,7 @@ import {
   getGripperDisplayName,
   getPipetteModelSpecs,
   getPipetteNameSpecs,
+  getPipetteSpecsV2,
   GRIPPER_MODELS,
 } from '@opentrons/shared-data'
 import { useIsOEMMode } from '../robot-settings/hooks'
@@ -12,6 +13,7 @@ import type {
   PipetteModelSpecs,
   PipetteName,
   PipetteNameSpecs,
+  PipetteV2Specs,
 } from '@opentrons/shared-data'
 
 export function usePipetteNameSpecs(
@@ -44,6 +46,22 @@ export function usePipetteModelSpecs(
   if (modelSpecificFields == null || pipetteNameSpecs == null) return null
 
   return { ...modelSpecificFields, displayName: pipetteNameSpecs.displayName }
+}
+
+export function usePipetteSpecsV2(
+  name?: PipetteName | PipetteModel
+): PipetteV2Specs | null {
+  const isOEMMode = useIsOEMMode()
+  const pipetteSpecs = getPipetteSpecsV2(name)
+
+  if (pipetteSpecs == null) return null
+
+  const brandedDisplayName = pipetteSpecs.displayName
+  const anonymizedDisplayName = pipetteSpecs.displayName.replace('Flex ', '')
+
+  const displayName = isOEMMode ? anonymizedDisplayName : brandedDisplayName
+
+  return { ...pipetteSpecs, displayName }
 }
 
 export function useGripperDisplayName(gripperModel: GripperModel): string {

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -191,7 +191,7 @@ or PipetteModel such as 'p300_single_v1.3' and converts it to channels,
 model, and version in order to return the correct pipette schema v2 json files. 
 **/
 export const getPipetteSpecsV2 = (
-  name: PipetteName | PipetteModel
+  name?: PipetteName | PipetteModel
 ): PipetteV2Specs | null => {
   if (name == null) {
     return null


### PR DESCRIPTION
# Overview

creates a wrapper hook usePipetteSpecsV2 that anonymizes pipette specs v2 display names when ODD is in OEM mode

closes PLAT-296

<img width="1136" alt="Screen Shot 2024-07-15 at 4 54 01 PM" src="https://github.com/user-attachments/assets/ea39c211-9b9f-4646-87d1-01b7e611b316">


# Test Plan

verified anonymous name substitution in quick transfer pipette select

# Changelog

 - Anonymizes pipette display names for pipetteSpecsV2

# Review requests

check the pipette display name in quick transfer pipette select for anonymization

# Risk assessment

low
