### PR TITLE
ci(app builds): fail fast false on build-app job matrix

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -207,6 +207,7 @@ jobs:
     needs: [determine-build-type]
     if: needs.determine-build-type.outputs.variants != '[]'
     strategy:
+      fail-fast: false
       matrix:
         os: ['windows-2022', 'ubuntu-22.04', 'macos-latest']
         variant: ${{fromJSON(needs.determine-build-type.outputs.variants)}}


### PR DESCRIPTION
## Use [fail-fast:false](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) 

> Currently, with Windows signing blocked, that job will always fail and then cancels the Mac and Linux builds if they have not completed.  This does not unblock release but it makes sure the Mac and Linux build jobs are allowed to finish so that their assets are available as an attachment to the workflow.

- `fail-fast: false` on the `build-app` job will stop the matrix cancelling active jobs upon any failure.
- `deploy-release-app` will not run because it has `build-app` in its `needs` array.  All matrix jobs must be successful for `build-app` to have a success outcome and satisfy the `needs` condition.


