### PR TITLE
fix(protocol-designer): pipette channel change patch does not rely on…

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -113,13 +113,16 @@ const updatePatchOnPipetteChannelChange = (
     }
     // multi-channel to single-channel: convert primary wells to all wells
     const labwareId = appliedPatch.labware
-    const labwareDef = labwareEntities[labwareId].def
-    update = {
-      wells: getAllWellsFromPrimaryWells(
-        appliedPatch.wells,
-        labwareDef,
-        channels
-      ),
+
+    if (labwareId != null) {
+      const labwareDef = labwareEntities[labwareId].def
+      update = {
+        wells: getAllWellsFromPrimaryWells(
+          appliedPatch.wells,
+          labwareDef,
+          channels
+        ),
+      }
     }
   }
 


### PR DESCRIPTION
… labware

closes RQA-2861

# Overview

This is a bug in production currently and has been in production since 8.1.0. We decided that its big enough to warrant a fix in the hot fix. Basically, you can't switch pipettes in a mix step if its between a single vs 8 channel.

# Test Plan

Create a flex or ot-2 protocol and add 2 pipettes, one is a single channel the other is an 8-channel. Go to the deckmap and add a mix step. Do not add a labware to the mix step and see that you can successfully change the pipette selection between the 2 pipettes.

# Changelog

- do not update labware if labware has not been added

# Review requests

see test plan

# Risk assessment

low
