### PR TITLE
fix(abr-testing): increase number of lines of logs saved during error

### DIFF
--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -464,6 +464,7 @@ if __name__ == "__main__":
     email = args.email[0]
     board_id = args.board_id[0]
     reporter_id = args.reporter_id[0]
+    file_paths = read_robot_logs.get_logs(storage_directory, ip)
     ticket = jira_tool.JiraTicket(url, api_token, email)
     ticket.issues_on_board(board_id)
     users_file_path = ticket.get_jira_users(storage_directory)
@@ -496,7 +497,6 @@ if __name__ == "__main__":
     saved_file_path_calibration, calibration = read_robot_logs.get_calibration_offsets(
         ip, storage_directory
     )
-    file_paths = read_robot_logs.get_logs(storage_directory, ip)
 
     print(f"Making ticket for {summary}.")
     # TODO: make argument or see if I can get rid of with using board_id.

--- a/abr-testing/abr_testing/data_collection/read_robot_logs.py
+++ b/abr-testing/abr_testing/data_collection/read_robot_logs.py
@@ -569,23 +569,32 @@ def get_calibration_offsets(
 
 def get_logs(storage_directory: str, ip: str) -> List[str]:
     """Get Robot logs."""
-    log_types = ["api.log", "server.log", "serial.log", "touchscreen.log"]
+    log_types: List[Dict[str, Any]] = [
+        {"log type": "api.log", "records": 1000},
+        {"log type": "server.log", "records": 10000},
+        {"log type": "serial.log", "records": 10000},
+        {"log type": "touchscreen.log", "records": 1000},
+    ]
     all_paths = []
     for log_type in log_types:
         try:
+            log_type_name = log_type["log type"]
+            print(log_type_name)
+            log_records = int(log_type["records"])
+            print(log_records)
             response = requests.get(
-                f"http://{ip}:31950/logs/{log_type}",
-                headers={"log_identifier": log_type},
-                params={"records": 5000},
+                f"http://{ip}:31950/logs/{log_type_name}",
+                headers={"log_identifier": log_type_name},
+                params={"records": log_records},
             )
             response.raise_for_status()
             log_data = response.text
-            log_name = ip + "_" + log_type.split(".")[0] + ".log"
+            log_name = ip + "_" + log_type_name.split(".")[0] + ".log"
             file_path = os.path.join(storage_directory, log_name)
             with open(file_path, mode="w", encoding="utf-8") as file:
                 file.write(log_data)
         except RuntimeError:
-            print(f"Request exception. Did not save {log_type}")
+            print(f"Request exception. Did not save {log_type_name}")
             continue
         all_paths.append(file_path)
     # Get weston.log using scp


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Increase record # for log downloading during ABR error

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

- moved get_logs to beginning of error script so logs are pulled immediately
- increase number of lines pulled for each log type

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
