### PR TITLE
feat(app-shell): add EULA to desktop app help menu

### DIFF
--- a/app-shell/src/menu.ts
+++ b/app-shell/src/menu.ts
@@ -8,6 +8,8 @@ import { LOG_DIR } from './log'
 const PRODUCT_NAME: string = _PKG_PRODUCT_NAME_
 const BUGS_URL: string = _PKG_BUGS_URL_
 
+const EULA_URL = 'https://opentrons.com/eula' as const
+
 // file or application menu
 const firstMenu: MenuItemConstructorOptions = {
   role: process.platform === 'darwin' ? 'appMenu' : 'fileMenu',
@@ -40,6 +42,13 @@ const helpMenu: MenuItemConstructorOptions = {
       click: () => {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         shell.openExternal(BUGS_URL)
+      },
+    },
+    {
+      label: 'View Privacy Policy',
+      click: () => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        shell.openExternal(EULA_URL)
       },
     },
   ],

--- a/app-shell/src/menu.ts
+++ b/app-shell/src/menu.ts
@@ -47,8 +47,11 @@ const helpMenu: MenuItemConstructorOptions = {
     {
       label: 'View Privacy Policy',
       click: () => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        shell.openExternal(EULA_URL)
+        shell.openExternal(EULA_URL).catch((e: Error) => {
+          console.error(
+            `could not open end user license agreement: ${e.message}`
+          )
+        })
       },
     },
   ],


### PR DESCRIPTION
# Overview

This PR adds a link to the end user license agreement to the desktop app's help menu.

closes AUTH-536

# Changelog

- Add link to EULA in desktop app help menu


# Review requests

Open up desktop app, open help menu, make sure link to EULA agreement works.

# Risk assessment

Low