### PR TITLE
fix(app): support layered WellSelection

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/shared/TipSelection.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TipSelection.tsx
@@ -9,7 +9,6 @@ export type TipSelectionProps = RecoveryContentProps & {
   allowTipSelection: boolean
 }
 
-// TODO(jh, 06-13-24): EXEC-535.
 export function TipSelection(props: TipSelectionProps): JSX.Element {
   const { failedLabwareUtils, failedPipetteInfo, allowTipSelection } = props
 

--- a/app/src/organisms/WellSelection/utils.ts
+++ b/app/src/organisms/WellSelection/utils.ts
@@ -27,6 +27,17 @@ export function clientRectToBoundingRect(rect: ClientRect): BoundingRect {
 }
 
 export const getCollidingWells = (rectPositions: GenericRect): WellGroup => {
+  const isElementVisible = (element: HTMLElement): boolean => {
+    const rect = element.getBoundingClientRect()
+    // If multiple well elements occupy the same x,y coordinate space, document.elementFromPoint() selects
+    // ONLY the "topmost" well element, accounting for z-index, stacking order, visibility, and opacity.
+    const elementAtPoint = document.elementFromPoint(
+      rect.left + rect.width / 2,
+      rect.top + rect.height / 2
+    )
+    return element.contains(elementAtPoint)
+  }
+
   // Returns set of selected wells under a collision rect
   const { x0, y0, x1, y1 } = rectPositions
   const selectionBoundingRect = {
@@ -41,12 +52,26 @@ export const getCollidingWells = (rectPositions: GenericRect): WellGroup => {
       `[${INTERACTIVE_WELL_DATA_ATTRIBUTE}]`
     ),
   ]
-  const collidedElems = selectableElems.filter((selectableElem, i) =>
-    rectCollision(
-      selectionBoundingRect,
-      clientRectToBoundingRect(selectableElem.getBoundingClientRect())
+
+  const collidedElems = selectableElems.filter(selectableElem => {
+    const rect = selectableElem.getBoundingClientRect()
+
+    // Check if the element is in the viewport and not obscured.
+    const isInViewport =
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <=
+        (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+
+    const isVisible = isInViewport && isElementVisible(selectableElem)
+
+    return (
+      isVisible &&
+      rectCollision(selectionBoundingRect, clientRectToBoundingRect(rect))
     )
-  )
+  })
+
   const collidedWellData = collidedElems.reduce(
     (acc: WellGroup, elem): WellGroup => {
       if (

--- a/app/src/organisms/WellSelection/utils.ts
+++ b/app/src/organisms/WellSelection/utils.ts
@@ -26,6 +26,7 @@ export function clientRectToBoundingRect(rect: ClientRect): BoundingRect {
   }
 }
 
+// TODO(jh, 07-17-24): Consider checking specific well labels instead of elementAtPoint as a more robust alternative.
 export const getCollidingWells = (rectPositions: GenericRect): WellGroup => {
   const isElementVisible = (element: HTMLElement): boolean => {
     const rect = element.getBoundingClientRect()


### PR DESCRIPTION
Closes [EXEC-534](https://opentrons.atlassian.net/browse/EXEC-534)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

`WellSelection` utilizes a helper function, `getCollidingWells`, which selects multiple wells in case a user happens to click multiple bounding rects. This helper detects clicks using the DOM, a class tag, and the document x,y coordinate space. It works as intended, but it doesn't account for one edge case: a `WellSelection` component renders above a second `WellSelection` component with at least partial overlap in the x,y coordinate space. In this instance, `getCollidingWells` detects multiple wells were selected, which leads to surprising behavior (video). The simplest solution is to effectively select "visible" wells only, utilizing `document.elementFromPoint()` to accomplish this task.

### Current Behavior

https://github.com/user-attachments/assets/8171acc7-abff-4ea3-b054-4d62190e4d1e

### Fixed Behavior 

https://github.com/user-attachments/assets/51f3e1a2-1cb0-46a1-849e-d4bf2e445784


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- See video above.
- Verify`WellSelection` behavior remains unchanged in quick transfer flows.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Properly select wells from multi-layered WellSelections. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low - Changes are easy to validate.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-534]: https://opentrons.atlassian.net/browse/EXEC-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ