### PR TITLE
refactor(shared-data): remove outdated id fields from JSON v6 fixtures

### DIFF
--- a/shared-data/protocol/fixtures/6/heaterShakerCommands.json
+++ b/shared-data/protocol/fixtures/6/heaterShakerCommands.json
@@ -1241,7 +1241,7 @@
   "commands": [
     {
       "commandType": "loadPipette",
-      "id": "0abc123",
+      "key": "0abc123",
       "params": {
         "pipetteId": "pipetteId",
         "mount": "left"
@@ -1249,7 +1249,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "1abc123",
+      "key": "1abc123",
       "params": {
         "moduleId": "magneticModuleId",
         "location": { "slotName": "3" }
@@ -1257,7 +1257,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "2abc123",
+      "key": "2abc123",
       "params": {
         "moduleId": "heaterShakerId",
         "location": { "slotName": "1" }
@@ -1265,7 +1265,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "3abc123",
+      "key": "3abc123",
       "params": {
         "labwareId": "sourcePlateId",
         "location": {
@@ -1275,7 +1275,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "4abc123",
+      "key": "4abc123",
       "params": {
         "labwareId": "destPlateId",
         "location": {
@@ -1285,7 +1285,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "5abc123",
+      "key": "5abc123",
       "params": {
         "labwareId": "tipRackId",
         "location": { "slotName": "8" }
@@ -1293,7 +1293,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "6abc123",
+      "key": "6abc123",
       "params": {
         "labwareId": "fixedTrash",
         "location": {
@@ -1303,7 +1303,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "id": "7abc123",
+      "key": "7abc123",
       "params": {
         "liquidId": "waterId",
         "labwareId": "sourcePlateId",
@@ -1316,7 +1316,7 @@
 
     {
       "commandType": "pickUpTip",
-      "id": "8abc123",
+      "key": "8abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "tipRackId",
@@ -1325,7 +1325,7 @@
     },
     {
       "commandType": "aspirate",
-      "id": "9abc123",
+      "key": "9abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "sourcePlateId",
@@ -1340,14 +1340,14 @@
     },
     {
       "commandType": "delay",
-      "id": "10abc123",
+      "key": "10abc123",
       "params": {
         "seconds": 42
       }
     },
     {
       "commandType": "dispense",
-      "id": "11abc123",
+      "key": "11abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1362,7 +1362,7 @@
     },
     {
       "commandType": "heaterShaker/setAndWaitForShakeSpeed",
-      "id": "13abc123",
+      "key": "13abc123",
       "params": {
         "moduleId": "heaterShakerId",
         "rpm": 2000
@@ -1370,7 +1370,7 @@
     },
     {
       "commandType": "heaterShaker/setTargetTemperature",
-      "id": "14abc123",
+      "key": "14abc123",
       "params": {
         "moduleId": "heaterShakerId",
         "celsius": 42
@@ -1378,28 +1378,28 @@
     },
     {
       "commandType": "heaterShaker/waitForTemperature",
-      "id": "15abc123",
+      "key": "15abc123",
       "params": {
         "moduleId": "heaterShakerId"
       }
     },
     {
       "commandType": "heaterShaker/openLabwareLatch",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "moduleId": "heaterShakerId"
       }
     },
     {
       "commandType": "heaterShaker/closeLabwareLatch",
-      "id": "17abc123",
+      "key": "17abc123",
       "params": {
         "moduleId": "heaterShakerId"
       }
     },
     {
       "commandType": "heaterShaker/deactivateHeater",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "moduleId": "heaterShakerId"
       }

--- a/shared-data/protocol/fixtures/6/heaterShakerCommandsWithResultsKey.json
+++ b/shared-data/protocol/fixtures/6/heaterShakerCommandsWithResultsKey.json
@@ -2494,7 +2494,7 @@
   },
   "commands": [
     {
-      "id": "0",
+      "key": "0",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -2502,7 +2502,7 @@
       }
     },
     {
-      "id": "1",
+      "key": "1",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -2510,7 +2510,7 @@
       }
     },
     {
-      "id": "2",
+      "key": "2",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e012450-3412-11eb-ad93-ed232a2337cf:heaterShakerModuleType",
@@ -2523,7 +2523,7 @@
       }
     },
     {
-      "id": "5",
+      "key": "5",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "fixedTrash",
@@ -2590,7 +2590,7 @@
       }
     },
     {
-      "id": "6",
+      "key": "6",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1",
@@ -3622,7 +3622,7 @@
       }
     },
     {
-      "id": "7",
+      "key": "7",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
@@ -3691,7 +3691,7 @@
       }
     },
     {
-      "id": "8",
+      "key": "8",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",

--- a/shared-data/protocol/fixtures/6/multipleTempModules.json
+++ b/shared-data/protocol/fixtures/6/multipleTempModules.json
@@ -4561,7 +4561,7 @@
   },
   "commands": [
     {
-      "id": "0",
+      "key": "0",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -4569,7 +4569,7 @@
       }
     },
     {
-      "id": "1",
+      "key": "1",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -4577,7 +4577,7 @@
       }
     },
     {
-      "id": "2",
+      "key": "2",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType",
@@ -4590,7 +4590,7 @@
       }
     },
     {
-      "id": "3",
+      "key": "3",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e0283e0-3412-11eb-ad93-ed232a2337cf:temperatureModuleType1",
@@ -4603,7 +4603,7 @@
       }
     },
     {
-      "id": "4",
+      "key": "4",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e039550-3412-11eb-ad93-ed232a2337cf:temperatureModuleType2",
@@ -4616,7 +4616,7 @@
       }
     },
     {
-      "id": "5",
+      "key": "5",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "fixedTrash",
@@ -4683,7 +4683,7 @@
       }
     },
     {
-      "id": "6",
+      "key": "6",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1",
@@ -5715,7 +5715,7 @@
       }
     },
     {
-      "id": "7",
+      "key": "7",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
@@ -5784,7 +5784,7 @@
       }
     },
     {
-      "id": "8",
+      "key": "8",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -6815,7 +6815,7 @@
       }
     },
     {
-      "id": "9",
+      "key": "9",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1",
@@ -7121,7 +7121,7 @@
       }
     },
     {
-      "id": "10",
+      "key": "10",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1",
@@ -8160,7 +8160,7 @@
       }
     },
     {
-      "id": "11",
+      "key": "11",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -9191,7 +9191,7 @@
       }
     },
     {
-      "id": "12",
+      "key": "12",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1",
@@ -10223,7 +10223,7 @@
       }
     },
     {
-      "id": "13",
+      "key": "13",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b",
@@ -10529,7 +10529,7 @@
       }
     },
     {
-      "id": "14",
+      "key": "14",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10538,7 +10538,7 @@
       }
     },
     {
-      "id": "15",
+      "key": "15",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10553,7 +10553,7 @@
       }
     },
     {
-      "id": "16",
+      "key": "16",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10568,7 +10568,7 @@
       }
     },
     {
-      "id": "17",
+      "key": "17",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10577,7 +10577,7 @@
       }
     },
     {
-      "id": "18",
+      "key": "18",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10586,7 +10586,7 @@
       }
     },
     {
-      "id": "19",
+      "key": "19",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10601,7 +10601,7 @@
       }
     },
     {
-      "id": "20",
+      "key": "20",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10616,7 +10616,7 @@
       }
     },
     {
-      "id": "21",
+      "key": "21",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10625,7 +10625,7 @@
       }
     },
     {
-      "id": "22",
+      "key": "22",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10634,7 +10634,7 @@
       }
     },
     {
-      "id": "23",
+      "key": "23",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10649,7 +10649,7 @@
       }
     },
     {
-      "id": "24",
+      "key": "24",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10664,7 +10664,7 @@
       }
     },
     {
-      "id": "25",
+      "key": "25",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10673,7 +10673,7 @@
       }
     },
     {
-      "id": "26",
+      "key": "26",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10682,7 +10682,7 @@
       }
     },
     {
-      "id": "27",
+      "key": "27",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10697,7 +10697,7 @@
       }
     },
     {
-      "id": "28",
+      "key": "28",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10712,7 +10712,7 @@
       }
     },
     {
-      "id": "29",
+      "key": "29",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10721,7 +10721,7 @@
       }
     },
     {
-      "id": "30",
+      "key": "30",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10730,7 +10730,7 @@
       }
     },
     {
-      "id": "31",
+      "key": "31",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10745,7 +10745,7 @@
       }
     },
     {
-      "id": "32",
+      "key": "32",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10760,7 +10760,7 @@
       }
     },
     {
-      "id": "33",
+      "key": "33",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10769,7 +10769,7 @@
       }
     },
     {
-      "id": "34",
+      "key": "34",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10778,7 +10778,7 @@
       }
     },
     {
-      "id": "35",
+      "key": "35",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10793,7 +10793,7 @@
       }
     },
     {
-      "id": "36",
+      "key": "36",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10808,7 +10808,7 @@
       }
     },
     {
-      "id": "37",
+      "key": "37",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10817,7 +10817,7 @@
       }
     },
     {
-      "id": "38",
+      "key": "38",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10826,7 +10826,7 @@
       }
     },
     {
-      "id": "39",
+      "key": "39",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10841,7 +10841,7 @@
       }
     },
     {
-      "id": "40",
+      "key": "40",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10856,7 +10856,7 @@
       }
     },
     {
-      "id": "41",
+      "key": "41",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10865,7 +10865,7 @@
       }
     },
     {
-      "id": "42",
+      "key": "42",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10874,7 +10874,7 @@
       }
     },
     {
-      "id": "43",
+      "key": "43",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10889,7 +10889,7 @@
       }
     },
     {
-      "id": "44",
+      "key": "44",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10904,7 +10904,7 @@
       }
     },
     {
-      "id": "45",
+      "key": "45",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10913,7 +10913,7 @@
       }
     },
     {
-      "id": "46",
+      "key": "46",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10922,7 +10922,7 @@
       }
     },
     {
-      "id": "47",
+      "key": "47",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10937,7 +10937,7 @@
       }
     },
     {
-      "id": "48",
+      "key": "48",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10952,7 +10952,7 @@
       }
     },
     {
-      "id": "49",
+      "key": "49",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10961,7 +10961,7 @@
       }
     },
     {
-      "id": "50",
+      "key": "50",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10970,7 +10970,7 @@
       }
     },
     {
-      "id": "51",
+      "key": "51",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10985,7 +10985,7 @@
       }
     },
     {
-      "id": "52",
+      "key": "52",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -11000,7 +11000,7 @@
       }
     },
     {
-      "id": "53",
+      "key": "53",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -11009,7 +11009,7 @@
       }
     },
     {
-      "id": "54",
+      "key": "54",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -11018,7 +11018,7 @@
       }
     },
     {
-      "id": "55",
+      "key": "55",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -11033,7 +11033,7 @@
       }
     },
     {
-      "id": "56",
+      "key": "56",
       "commandType": "dispense",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -11048,7 +11048,7 @@
       }
     },
     {
-      "id": "57",
+      "key": "57",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",

--- a/shared-data/protocol/fixtures/6/multipleTipracks.json
+++ b/shared-data/protocol/fixtures/6/multipleTipracks.json
@@ -1967,7 +1967,7 @@
   "commands": [
     {
       "commandType": "loadPipette",
-      "id": "0abc1",
+      "key": "0abc1",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
         "mount": "left"
@@ -1978,7 +1978,7 @@
     },
     {
       "commandType": "loadPipette",
-      "id": "0abc2",
+      "key": "0abc2",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
         "mount": "right"
@@ -1989,7 +1989,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "0abc3",
+      "key": "0abc3",
       "params": {
         "labwareId": "fixedTrash",
         "location": { "slotName": "12" }
@@ -2043,7 +2043,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "0abc4",
+      "key": "0abc4",
       "params": {
         "labwareId": "50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1",
         "location": { "slotName": "1" }
@@ -3069,7 +3069,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "0abc5",
+      "key": "0abc5",
       "params": {
         "labwareId": "9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1",
         "location": { "slotName": "10" }
@@ -3266,7 +3266,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "0abc6",
+      "key": "0abc6",
       "params": {
         "labwareId": "e24818a0-0042-11ec-8258-f7ffdf5ad45a",
         "location": { "slotName": "2" }
@@ -4291,7 +4291,7 @@
       }
     },
     {
-      "id": "0",
+      "key": "0",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -4300,7 +4300,7 @@
       }
     },
     {
-      "id": "1",
+      "key": "1",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -4315,7 +4315,7 @@
       }
     },
     {
-      "id": "2",
+      "key": "2",
       "commandType": "dispense",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -4330,7 +4330,7 @@
       }
     },
     {
-      "id": "3",
+      "key": "3",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -4339,7 +4339,7 @@
       }
     },
     {
-      "id": "4",
+      "key": "4",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4348,7 +4348,7 @@
       }
     },
     {
-      "id": "5",
+      "key": "5",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4363,7 +4363,7 @@
       }
     },
     {
-      "id": "6",
+      "key": "6",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4378,7 +4378,7 @@
       }
     },
     {
-      "id": "7",
+      "key": "7",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4387,7 +4387,7 @@
       }
     },
     {
-      "id": "8",
+      "key": "8",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4396,7 +4396,7 @@
       }
     },
     {
-      "id": "9",
+      "key": "9",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4411,7 +4411,7 @@
       }
     },
     {
-      "id": "10",
+      "key": "10",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4426,7 +4426,7 @@
       }
     },
     {
-      "id": "11",
+      "key": "11",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4435,7 +4435,7 @@
       }
     },
     {
-      "id": "12",
+      "key": "12",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4444,7 +4444,7 @@
       }
     },
     {
-      "id": "13",
+      "key": "13",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4459,7 +4459,7 @@
       }
     },
     {
-      "id": "14",
+      "key": "14",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4474,7 +4474,7 @@
       }
     },
     {
-      "id": "15",
+      "key": "15",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4483,7 +4483,7 @@
       }
     },
     {
-      "id": "16",
+      "key": "16",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4492,7 +4492,7 @@
       }
     },
     {
-      "id": "17",
+      "key": "17",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4507,7 +4507,7 @@
       }
     },
     {
-      "id": "18",
+      "key": "18",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4522,7 +4522,7 @@
       }
     },
     {
-      "id": "19",
+      "key": "19",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4531,7 +4531,7 @@
       }
     },
     {
-      "id": "20",
+      "key": "20",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4540,7 +4540,7 @@
       }
     },
     {
-      "id": "21",
+      "key": "21",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4555,7 +4555,7 @@
       }
     },
     {
-      "id": "22",
+      "key": "22",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4570,7 +4570,7 @@
       }
     },
     {
-      "id": "23",
+      "key": "23",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4579,7 +4579,7 @@
       }
     },
     {
-      "id": "24",
+      "key": "24",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4588,7 +4588,7 @@
       }
     },
     {
-      "id": "25",
+      "key": "25",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4603,7 +4603,7 @@
       }
     },
     {
-      "id": "26",
+      "key": "26",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4618,7 +4618,7 @@
       }
     },
     {
-      "id": "27",
+      "key": "27",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4627,7 +4627,7 @@
       }
     },
     {
-      "id": "28",
+      "key": "28",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4636,7 +4636,7 @@
       }
     },
     {
-      "id": "29",
+      "key": "29",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4651,7 +4651,7 @@
       }
     },
     {
-      "id": "30",
+      "key": "30",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4666,7 +4666,7 @@
       }
     },
     {
-      "id": "31",
+      "key": "31",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4675,7 +4675,7 @@
       }
     },
     {
-      "id": "32",
+      "key": "32",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4684,7 +4684,7 @@
       }
     },
     {
-      "id": "33",
+      "key": "33",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4699,7 +4699,7 @@
       }
     },
     {
-      "id": "34",
+      "key": "34",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4714,7 +4714,7 @@
       }
     },
     {
-      "id": "35",
+      "key": "35",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4723,7 +4723,7 @@
       }
     },
     {
-      "id": "36",
+      "key": "36",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4732,7 +4732,7 @@
       }
     },
     {
-      "id": "37",
+      "key": "37",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4747,7 +4747,7 @@
       }
     },
     {
-      "id": "38",
+      "key": "38",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4762,7 +4762,7 @@
       }
     },
     {
-      "id": "39",
+      "key": "39",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4771,7 +4771,7 @@
       }
     },
     {
-      "id": "40",
+      "key": "40",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4780,7 +4780,7 @@
       }
     },
     {
-      "id": "41",
+      "key": "41",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4795,7 +4795,7 @@
       }
     },
     {
-      "id": "42",
+      "key": "42",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4810,7 +4810,7 @@
       }
     },
     {
-      "id": "43",
+      "key": "43",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4819,7 +4819,7 @@
       }
     },
     {
-      "id": "44",
+      "key": "44",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4828,7 +4828,7 @@
       }
     },
     {
-      "id": "45",
+      "key": "45",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4843,7 +4843,7 @@
       }
     },
     {
-      "id": "46",
+      "key": "46",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4858,7 +4858,7 @@
       }
     },
     {
-      "id": "47",
+      "key": "47",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4867,7 +4867,7 @@
       }
     },
     {
-      "id": "48",
+      "key": "48",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4876,7 +4876,7 @@
       }
     },
     {
-      "id": "49",
+      "key": "49",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4891,7 +4891,7 @@
       }
     },
     {
-      "id": "50",
+      "key": "50",
       "commandType": "moveToWell",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4908,14 +4908,14 @@
       }
     },
     {
-      "id": "51",
+      "key": "51",
       "commandType": "delay",
       "params": {
         "seconds": 1
       }
     },
     {
-      "id": "52",
+      "key": "52",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -4930,7 +4930,7 @@
       }
     },
     {
-      "id": "53",
+      "key": "53",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",

--- a/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json
+++ b/shared-data/protocol/fixtures/6/multipleTipracksWithTC.json
@@ -3012,7 +3012,7 @@
   },
   "commands": [
     {
-      "id": "0abc1",
+      "key": "0abc1",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -3023,7 +3023,7 @@
       }
     },
     {
-      "id": "0abc2",
+      "key": "0abc2",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -3035,7 +3035,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "00abc2",
+      "key": "00abc2",
       "params": {
         "moduleId": "18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType",
         "location": {
@@ -3047,7 +3047,7 @@
       }
     },
     {
-      "id": "0abc3",
+      "key": "0abc3",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "fixedTrash",
@@ -3103,7 +3103,7 @@
       }
     },
     {
-      "id": "0abc4",
+      "key": "0abc4",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "50d3ebb0-0042-11ec-8258-f7ffdf5ad45a:opentrons/opentrons_96_tiprack_300ul/1",
@@ -4131,7 +4131,7 @@
       }
     },
     {
-      "id": "0abc5",
+      "key": "0abc5",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "9fbc1db0-0042-11ec-8258-f7ffdf5ad45a:opentrons/nest_12_reservoir_15ml/1",
@@ -4330,7 +4330,7 @@
       }
     },
     {
-      "id": "0abc6",
+      "key": "0abc6",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "e24818a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -5358,7 +5358,7 @@
       }
     },
     {
-      "id": "0abc7",
+      "key": "0abc7",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "1dc0c050-0122-11ec-88a3-f1745cf9b36c:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -6383,7 +6383,7 @@
       }
     },
     {
-      "id": "7",
+      "key": "7",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -6392,7 +6392,7 @@
       }
     },
     {
-      "id": "8",
+      "key": "8",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -6407,7 +6407,7 @@
       }
     },
     {
-      "id": "9",
+      "key": "9",
       "commandType": "dispense",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -6422,7 +6422,7 @@
       }
     },
     {
-      "id": "10",
+      "key": "10",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "50d23e00-0042-11ec-8258-f7ffdf5ad45a",
@@ -6431,7 +6431,7 @@
       }
     },
     {
-      "id": "11",
+      "key": "11",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6440,7 +6440,7 @@
       }
     },
     {
-      "id": "12",
+      "key": "12",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6455,7 +6455,7 @@
       }
     },
     {
-      "id": "13",
+      "key": "13",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6470,7 +6470,7 @@
       }
     },
     {
-      "id": "14",
+      "key": "14",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6479,7 +6479,7 @@
       }
     },
     {
-      "id": "15",
+      "key": "15",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6488,7 +6488,7 @@
       }
     },
     {
-      "id": "16",
+      "key": "16",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6503,7 +6503,7 @@
       }
     },
     {
-      "id": "17",
+      "key": "17",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6518,7 +6518,7 @@
       }
     },
     {
-      "id": "18",
+      "key": "18",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6527,7 +6527,7 @@
       }
     },
     {
-      "id": "19",
+      "key": "19",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6536,7 +6536,7 @@
       }
     },
     {
-      "id": "20",
+      "key": "20",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6551,7 +6551,7 @@
       }
     },
     {
-      "id": "21",
+      "key": "21",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6566,7 +6566,7 @@
       }
     },
     {
-      "id": "22",
+      "key": "22",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6575,7 +6575,7 @@
       }
     },
     {
-      "id": "23",
+      "key": "23",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6584,7 +6584,7 @@
       }
     },
     {
-      "id": "24",
+      "key": "24",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6599,7 +6599,7 @@
       }
     },
     {
-      "id": "25",
+      "key": "25",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6614,7 +6614,7 @@
       }
     },
     {
-      "id": "26",
+      "key": "26",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6623,7 +6623,7 @@
       }
     },
     {
-      "id": "27",
+      "key": "27",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6632,7 +6632,7 @@
       }
     },
     {
-      "id": "28",
+      "key": "28",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6647,7 +6647,7 @@
       }
     },
     {
-      "id": "29",
+      "key": "29",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6662,7 +6662,7 @@
       }
     },
     {
-      "id": "30",
+      "key": "30",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6671,7 +6671,7 @@
       }
     },
     {
-      "id": "31",
+      "key": "31",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6680,7 +6680,7 @@
       }
     },
     {
-      "id": "32",
+      "key": "32",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6695,7 +6695,7 @@
       }
     },
     {
-      "id": "33",
+      "key": "33",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6710,7 +6710,7 @@
       }
     },
     {
-      "id": "34",
+      "key": "34",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6719,7 +6719,7 @@
       }
     },
     {
-      "id": "35",
+      "key": "35",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6728,7 +6728,7 @@
       }
     },
     {
-      "id": "36",
+      "key": "36",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6743,7 +6743,7 @@
       }
     },
     {
-      "id": "37",
+      "key": "37",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6758,7 +6758,7 @@
       }
     },
     {
-      "id": "38",
+      "key": "38",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6767,7 +6767,7 @@
       }
     },
     {
-      "id": "39",
+      "key": "39",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6776,7 +6776,7 @@
       }
     },
     {
-      "id": "40",
+      "key": "40",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6791,7 +6791,7 @@
       }
     },
     {
-      "id": "41",
+      "key": "41",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6806,7 +6806,7 @@
       }
     },
     {
-      "id": "42",
+      "key": "42",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6815,7 +6815,7 @@
       }
     },
     {
-      "id": "43",
+      "key": "43",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6824,7 +6824,7 @@
       }
     },
     {
-      "id": "44",
+      "key": "44",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6839,7 +6839,7 @@
       }
     },
     {
-      "id": "45",
+      "key": "45",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6854,7 +6854,7 @@
       }
     },
     {
-      "id": "46",
+      "key": "46",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6863,7 +6863,7 @@
       }
     },
     {
-      "id": "47",
+      "key": "47",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6872,7 +6872,7 @@
       }
     },
     {
-      "id": "48",
+      "key": "48",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6887,7 +6887,7 @@
       }
     },
     {
-      "id": "49",
+      "key": "49",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6902,7 +6902,7 @@
       }
     },
     {
-      "id": "50",
+      "key": "50",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6911,7 +6911,7 @@
       }
     },
     {
-      "id": "51",
+      "key": "51",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6920,7 +6920,7 @@
       }
     },
     {
-      "id": "52",
+      "key": "52",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6935,7 +6935,7 @@
       }
     },
     {
-      "id": "53",
+      "key": "53",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6950,7 +6950,7 @@
       }
     },
     {
-      "id": "54",
+      "key": "54",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6959,7 +6959,7 @@
       }
     },
     {
-      "id": "55",
+      "key": "55",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6968,7 +6968,7 @@
       }
     },
     {
-      "id": "56",
+      "key": "56",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -6983,7 +6983,7 @@
       }
     },
     {
-      "id": "57",
+      "key": "57",
       "commandType": "moveToWell",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -7000,14 +7000,14 @@
       }
     },
     {
-      "id": "58",
+      "key": "58",
       "commandType": "delay",
       "params": {
         "seconds": 1
       }
     },
     {
-      "id": "59",
+      "key": "59",
       "commandType": "dispense",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -7022,7 +7022,7 @@
       }
     },
     {
-      "id": "60",
+      "key": "60",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "c235a5a0-0042-11ec-8258-f7ffdf5ad45a",
@@ -7031,14 +7031,14 @@
       }
     },
     {
-      "id": "61",
+      "key": "61",
       "commandType": "thermocycler/closeLid",
       "params": {
         "moduleId": "18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType"
       }
     },
     {
-      "id": "62",
+      "key": "62",
       "commandType": "thermocycler/setTargetLidTemperature",
       "params": {
         "moduleId": "18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType",
@@ -7046,7 +7046,7 @@
       }
     },
     {
-      "id": "63",
+      "key": "63",
       "commandType": "thermocycler/waitForLidTemperature",
       "params": {
         "moduleId": "18f0c1b0-0122-11ec-88a3-f1745cf9b36c:thermocyclerModuleType",

--- a/shared-data/protocol/fixtures/6/oneTiprack.json
+++ b/shared-data/protocol/fixtures/6/oneTiprack.json
@@ -1224,7 +1224,7 @@
   },
   "commands": [
     {
-      "id": "0abc1",
+      "key": "0abc1",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "pipetteId",
@@ -1232,7 +1232,7 @@
       }
     },
     {
-      "id": "0abc2",
+      "key": "0abc2",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "fixedTrash",
@@ -1242,7 +1242,7 @@
       }
     },
     {
-      "id": "0abc3",
+      "key": "0abc3",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "tiprackId",
@@ -1252,7 +1252,7 @@
       }
     },
     {
-      "id": "0abc4",
+      "key": "0abc4",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "sourcePlateId",
@@ -1262,7 +1262,7 @@
       }
     },
     {
-      "id": "0abc4",
+      "key": "0abc4",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "destPlateId",
@@ -1272,7 +1272,7 @@
       }
     },
     {
-      "id": "0",
+      "key": "0",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "pipetteId",
@@ -1281,7 +1281,7 @@
       }
     },
     {
-      "id": "1",
+      "key": "1",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "pipetteId",
@@ -1296,14 +1296,14 @@
       }
     },
     {
-      "id": "2",
+      "key": "2",
       "commandType": "delay",
       "params": {
         "seconds": 42
       }
     },
     {
-      "id": "3",
+      "key": "3",
       "commandType": "dispense",
       "params": {
         "pipetteId": "pipetteId",
@@ -1318,7 +1318,7 @@
       }
     },
     {
-      "id": "4",
+      "key": "4",
       "commandType": "touchTip",
       "params": {
         "pipetteId": "pipetteId",
@@ -1331,7 +1331,7 @@
       }
     },
     {
-      "id": "5",
+      "key": "5",
       "commandType": "blowout",
       "params": {
         "pipetteId": "pipetteId",
@@ -1345,7 +1345,7 @@
       }
     },
     {
-      "id": "7",
+      "key": "7",
       "commandType": "moveToWell",
       "params": {
         "pipetteId": "pipetteId",
@@ -1357,7 +1357,7 @@
       }
     },
     {
-      "id": "8",
+      "key": "8",
       "commandType": "moveToWell",
       "params": {
         "pipetteId": "pipetteId",
@@ -1376,7 +1376,7 @@
       }
     },
     {
-      "id": "9",
+      "key": "9",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "pipetteId",

--- a/shared-data/protocol/fixtures/6/simpleV6.json
+++ b/shared-data/protocol/fixtures/6/simpleV6.json
@@ -1239,7 +1239,7 @@
   "commands": [
     {
       "commandType": "loadPipette",
-      "id": "0abc123",
+      "key": "0abc123",
       "params": {
         "pipetteId": "pipetteId",
         "mount": "left"
@@ -1247,7 +1247,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "1abc123",
+      "key": "1abc123",
       "params": {
         "moduleId": "magneticModuleId",
         "location": { "slotName": "3" }
@@ -1255,7 +1255,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "2abc123",
+      "key": "2abc123",
       "params": {
         "moduleId": "temperatureModuleId",
         "location": { "slotName": "1" }
@@ -1263,7 +1263,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "3abc123",
+      "key": "3abc123",
       "params": {
         "labwareId": "sourcePlateId",
         "location": {
@@ -1273,7 +1273,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "4abc123",
+      "key": "4abc123",
       "params": {
         "labwareId": "destPlateId",
         "location": {
@@ -1283,7 +1283,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "5abc123",
+      "key": "5abc123",
       "params": {
         "labwareId": "tipRackId",
         "location": { "slotName": "8" }
@@ -1291,7 +1291,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "id": "7abc123",
+      "key": "7abc123",
       "params": {
         "liquidId": "waterId",
         "labwareId": "sourcePlateId",
@@ -1303,12 +1303,12 @@
     },
     {
       "commandType": "home",
-      "id": "00abc123",
+      "key": "00abc123",
       "params": {}
     },
     {
       "commandType": "pickUpTip",
-      "id": "8abc123",
+      "key": "8abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "tipRackId",
@@ -1317,7 +1317,7 @@
     },
     {
       "commandType": "aspirate",
-      "id": "9abc123",
+      "key": "9abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "sourcePlateId",
@@ -1332,14 +1332,14 @@
     },
     {
       "commandType": "delay",
-      "id": "10abc123",
+      "key": "10abc123",
       "params": {
         "seconds": 42
       }
     },
     {
       "commandType": "dispense",
-      "id": "11abc123",
+      "key": "11abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1354,7 +1354,7 @@
     },
     {
       "commandType": "touchTip",
-      "id": "12abc123",
+      "key": "12abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1369,7 +1369,7 @@
     },
     {
       "commandType": "blowout",
-      "id": "13abc123",
+      "key": "13abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1383,7 +1383,7 @@
     },
     {
       "commandType": "moveToWell",
-      "id": "15abc123",
+      "key": "15abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1392,7 +1392,7 @@
     },
     {
       "commandType": "moveToWell",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1408,7 +1408,7 @@
     },
     {
       "commandType": "dropTip",
-      "id": "17abc123",
+      "key": "17abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "fixedTrash",
@@ -1417,7 +1417,7 @@
     },
     {
       "commandType": "waitForResume",
-      "id": "18abc123",
+      "key": "18abc123",
       "params": {
         "message": "pause command"
       }
@@ -1425,7 +1425,7 @@
 
     {
       "commandType": "moveToCoordinates",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "pipetteId": "pipetteId",
         "coordinates": { "x": 0, "y": 0, "z": 0 },
@@ -1436,7 +1436,7 @@
     },
     {
       "commandType": "moveRelative",
-      "id": "18abc123",
+      "key": "18abc123",
       "params": {
         "pipetteId": "pipetteId",
         "axis": "x",
@@ -1445,7 +1445,7 @@
     },
     {
       "commandType": "moveRelative",
-      "id": "19abc123",
+      "key": "19abc123",
       "params": {
         "pipetteId": "pipetteId",
         "axis": "y",
@@ -1454,14 +1454,14 @@
     },
     {
       "commandType": "savePosition",
-      "id": "21abc123",
+      "key": "21abc123",
       "params": {
         "pipetteId": "pipetteId"
       }
     },
     {
       "commandType": "moveRelative",
-      "id": "20abc123",
+      "key": "20abc123",
       "params": {
         "pipetteId": "pipetteId",
         "axis": "z",
@@ -1470,7 +1470,7 @@
     },
     {
       "commandType": "savePosition",
-      "id": "21abc123",
+      "key": "21abc123",
       "params": {
         "pipetteId": "pipetteId",
         "positionId": "positionId"

--- a/shared-data/protocol/fixtures/6/tempAndMagModuleCommands.json
+++ b/shared-data/protocol/fixtures/6/tempAndMagModuleCommands.json
@@ -1238,7 +1238,7 @@
   "commands": [
     {
       "commandType": "loadPipette",
-      "id": "0abc123",
+      "key": "0abc123",
       "params": {
         "pipetteId": "pipetteId",
         "mount": "left"
@@ -1246,7 +1246,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "1abc123",
+      "key": "1abc123",
       "params": {
         "moduleId": "magneticModuleId",
         "location": { "slotName": "3" }
@@ -1254,7 +1254,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "2abc123",
+      "key": "2abc123",
       "params": {
         "moduleId": "temperatureModuleId",
         "location": { "slotName": "1" }
@@ -1262,7 +1262,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "3abc123",
+      "key": "3abc123",
       "params": {
         "labwareId": "sourcePlateId",
         "location": {
@@ -1272,7 +1272,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "4abc123",
+      "key": "4abc123",
       "params": {
         "labwareId": "destPlateId",
         "location": {
@@ -1282,7 +1282,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "5abc123",
+      "key": "5abc123",
       "params": {
         "labwareId": "tipRackId",
         "location": { "slotName": "8" }
@@ -1290,7 +1290,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "6abc123",
+      "key": "6abc123",
       "params": {
         "labwareId": "fixedTrash",
         "location": {
@@ -1300,7 +1300,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "id": "7abc123",
+      "key": "7abc123",
       "params": {
         "liquidId": "waterId",
         "labwareId": "sourcePlateId",
@@ -1313,7 +1313,7 @@
 
     {
       "commandType": "pickUpTip",
-      "id": "8abc123",
+      "key": "8abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "tipRackId",
@@ -1322,7 +1322,7 @@
     },
     {
       "commandType": "aspirate",
-      "id": "9abc123",
+      "key": "9abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "sourcePlateId",
@@ -1337,14 +1337,14 @@
     },
     {
       "commandType": "delay",
-      "id": "10abc123",
+      "key": "10abc123",
       "params": {
         "seconds": 42
       }
     },
     {
       "commandType": "dispense",
-      "id": "11abc123",
+      "key": "11abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1359,7 +1359,7 @@
     },
     {
       "commandType": "temperatureModule/setTargetTemperature",
-      "id": "12abc123",
+      "key": "12abc123",
       "params": {
         "moduleId": "temperatureModuleId",
         "celsius": 80
@@ -1367,7 +1367,7 @@
     },
     {
       "commandType": "temperatureModule/waitForTemperature",
-      "id": "13abc123",
+      "key": "13abc123",
       "params": {
         "moduleId": "temperatureModuleId",
         "celsius": 80
@@ -1375,14 +1375,14 @@
     },
     {
       "commandType": "temperatureModule/deactivate",
-      "id": "14abc123",
+      "key": "14abc123",
       "params": {
         "moduleId": "temperatureModuleId"
       }
     },
     {
       "commandType": "magneticModule/engage",
-      "id": "15abc123",
+      "key": "15abc123",
       "params": {
         "moduleId": "magneticModuleId",
         "height": 10
@@ -1390,7 +1390,7 @@
     },
     {
       "commandType": "magneticModule/disengage",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "moduleId": "magneticModuleId"
       }

--- a/shared-data/protocol/fixtures/6/transferSettings.json
+++ b/shared-data/protocol/fixtures/6/transferSettings.json
@@ -4561,7 +4561,7 @@
   },
   "commands": [
     {
-      "id": "0",
+      "key": "0",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -4569,7 +4569,7 @@
       }
     },
     {
-      "id": "1",
+      "key": "1",
       "commandType": "loadPipette",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -4577,7 +4577,7 @@
       }
     },
     {
-      "id": "2",
+      "key": "2",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e012450-3412-11eb-ad93-ed232a2337cf:magneticModuleType",
@@ -4590,7 +4590,7 @@
       }
     },
     {
-      "id": "3",
+      "key": "3",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e0283e0-3412-11eb-ad93-ed232a2337cf:temperatureModuleType",
@@ -4603,7 +4603,7 @@
       }
     },
     {
-      "id": "4",
+      "key": "4",
       "commandType": "loadModule",
       "params": {
         "moduleId": "3e039550-3412-11eb-ad93-ed232a2337cf:thermocyclerModuleType",
@@ -4616,7 +4616,7 @@
       }
     },
     {
-      "id": "5",
+      "key": "5",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "fixedTrash",
@@ -4683,7 +4683,7 @@
       }
     },
     {
-      "id": "6",
+      "key": "6",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "3e047fb0-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_tiprack_1000ul/1",
@@ -5715,7 +5715,7 @@
       }
     },
     {
-      "id": "7",
+      "key": "7",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "5ae317e0-3412-11eb-ad93-ed232a2337cf:opentrons/nest_1_reservoir_195ml/1",
@@ -5784,7 +5784,7 @@
       }
     },
     {
-      "id": "8",
+      "key": "8",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "aac5d680-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -6815,7 +6815,7 @@
       }
     },
     {
-      "id": "9",
+      "key": "9",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "60e8b050-3412-11eb-ad93-ed232a2337cf:opentrons/corning_24_wellplate_3.4ml_flat/1",
@@ -7121,7 +7121,7 @@
       }
     },
     {
-      "id": "10",
+      "key": "10",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "ada13110-3412-11eb-ad93-ed232a2337cf:opentrons/opentrons_96_aluminumblock_generic_pcr_strip_200ul/1",
@@ -8160,7 +8160,7 @@
       }
     },
     {
-      "id": "11",
+      "key": "11",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "b0103540-3412-11eb-ad93-ed232a2337cf:opentrons/nest_96_wellplate_100ul_pcr_full_skirt/1",
@@ -9191,7 +9191,7 @@
       }
     },
     {
-      "id": "12",
+      "key": "12",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "faa13a50-a9bf-11eb-bce6-9f1d5b9c1a1b:opentrons/opentrons_96_tiprack_20ul/1",
@@ -10223,7 +10223,7 @@
       }
     },
     {
-      "id": "13",
+      "key": "13",
       "commandType": "loadLabware",
       "params": {
         "labwareId": "53d3b350-a9c0-11eb-bce6-9f1d5b9c1a1b",
@@ -10529,7 +10529,7 @@
       }
     },
     {
-      "id": "14",
+      "key": "14",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10538,7 +10538,7 @@
       }
     },
     {
-      "id": "15",
+      "key": "15",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10553,7 +10553,7 @@
       }
     },
     {
-      "id": "16",
+      "key": "16",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10568,7 +10568,7 @@
       }
     },
     {
-      "id": "17",
+      "key": "17",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10577,7 +10577,7 @@
       }
     },
     {
-      "id": "18",
+      "key": "18",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10586,7 +10586,7 @@
       }
     },
     {
-      "id": "19",
+      "key": "19",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10601,7 +10601,7 @@
       }
     },
     {
-      "id": "20",
+      "key": "20",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10616,7 +10616,7 @@
       }
     },
     {
-      "id": "21",
+      "key": "21",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10625,7 +10625,7 @@
       }
     },
     {
-      "id": "22",
+      "key": "22",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10634,7 +10634,7 @@
       }
     },
     {
-      "id": "23",
+      "key": "23",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10649,7 +10649,7 @@
       }
     },
     {
-      "id": "24",
+      "key": "24",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10664,7 +10664,7 @@
       }
     },
     {
-      "id": "25",
+      "key": "25",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10673,7 +10673,7 @@
       }
     },
     {
-      "id": "26",
+      "key": "26",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10682,7 +10682,7 @@
       }
     },
     {
-      "id": "27",
+      "key": "27",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10697,7 +10697,7 @@
       }
     },
     {
-      "id": "28",
+      "key": "28",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10712,7 +10712,7 @@
       }
     },
     {
-      "id": "29",
+      "key": "29",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10721,7 +10721,7 @@
       }
     },
     {
-      "id": "30",
+      "key": "30",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10730,7 +10730,7 @@
       }
     },
     {
-      "id": "31",
+      "key": "31",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10745,7 +10745,7 @@
       }
     },
     {
-      "id": "32",
+      "key": "32",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10760,7 +10760,7 @@
       }
     },
     {
-      "id": "33",
+      "key": "33",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10769,7 +10769,7 @@
       }
     },
     {
-      "id": "34",
+      "key": "34",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10778,7 +10778,7 @@
       }
     },
     {
-      "id": "35",
+      "key": "35",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10793,7 +10793,7 @@
       }
     },
     {
-      "id": "36",
+      "key": "36",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10808,7 +10808,7 @@
       }
     },
     {
-      "id": "37",
+      "key": "37",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10817,7 +10817,7 @@
       }
     },
     {
-      "id": "38",
+      "key": "38",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10826,7 +10826,7 @@
       }
     },
     {
-      "id": "39",
+      "key": "39",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10841,7 +10841,7 @@
       }
     },
     {
-      "id": "40",
+      "key": "40",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10856,7 +10856,7 @@
       }
     },
     {
-      "id": "41",
+      "key": "41",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10865,7 +10865,7 @@
       }
     },
     {
-      "id": "42",
+      "key": "42",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10874,7 +10874,7 @@
       }
     },
     {
-      "id": "43",
+      "key": "43",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10889,7 +10889,7 @@
       }
     },
     {
-      "id": "44",
+      "key": "44",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10904,7 +10904,7 @@
       }
     },
     {
-      "id": "45",
+      "key": "45",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10913,7 +10913,7 @@
       }
     },
     {
-      "id": "46",
+      "key": "46",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10922,7 +10922,7 @@
       }
     },
     {
-      "id": "47",
+      "key": "47",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10937,7 +10937,7 @@
       }
     },
     {
-      "id": "48",
+      "key": "48",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10952,7 +10952,7 @@
       }
     },
     {
-      "id": "49",
+      "key": "49",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10961,7 +10961,7 @@
       }
     },
     {
-      "id": "50",
+      "key": "50",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10970,7 +10970,7 @@
       }
     },
     {
-      "id": "51",
+      "key": "51",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -10985,7 +10985,7 @@
       }
     },
     {
-      "id": "52",
+      "key": "52",
       "commandType": "dispense",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -11000,7 +11000,7 @@
       }
     },
     {
-      "id": "53",
+      "key": "53",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "3dff4f90-3412-11eb-ad93-ed232a2337cf",
@@ -11009,7 +11009,7 @@
       }
     },
     {
-      "id": "54",
+      "key": "54",
       "commandType": "pickUpTip",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -11018,7 +11018,7 @@
       }
     },
     {
-      "id": "55",
+      "key": "55",
       "commandType": "aspirate",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -11033,7 +11033,7 @@
       }
     },
     {
-      "id": "56",
+      "key": "56",
       "commandType": "dispense",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",
@@ -11048,7 +11048,7 @@
       }
     },
     {
-      "id": "57",
+      "key": "57",
       "commandType": "dropTip",
       "params": {
         "pipetteId": "4da579b0-a9bf-11eb-bce6-9f1d5b9c1a1b",

--- a/shared-data/protocol/types/schemaV6/command/index.ts
+++ b/shared-data/protocol/types/schemaV6/command/index.ts
@@ -21,6 +21,7 @@ export * from './timing'
 export type CommandStatus = 'queued' | 'running' | 'succeeded' | 'failed'
 export interface CommonCommandRunTimeInfo {
   key?: string
+  id: string
   status: CommandStatus
   error?: RunCommandError | null
   createdAt: string

--- a/shared-data/protocol/types/schemaV6/command/index.ts
+++ b/shared-data/protocol/types/schemaV6/command/index.ts
@@ -21,7 +21,6 @@ export * from './timing'
 export type CommandStatus = 'queued' | 'running' | 'succeeded' | 'failed'
 export interface CommonCommandRunTimeInfo {
   key?: string
-  id: string
   status: CommandStatus
   error?: RunCommandError | null
   createdAt: string


### PR DESCRIPTION
replace all instances of Command `id` with `key` in the v6 protocol fixtures

close EXEC-221

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

Just changed all of v6 fixtures to have a "key" field in Command rather than an "id" field
Updated `shared-data/protocol/fixtures/types/schemaV6/command/index.ts` to properly recognize the key field.

# Review requests

<!--
Describe any requests for your reviewers here.
-->

This ticket is like 2 years old so I don't even know if this matters anymore but here it is.

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
Low
