### PR TITLE
refactor(app): Desktop implementation for SelectRecoveryOption

### DIFF
--- a/app/src/molecules/InterventionModal/OneColumn.stories.tsx
+++ b/app/src/molecules/InterventionModal/OneColumn.stories.tsx
@@ -1,15 +1,6 @@
 import * as React from 'react'
 
-import {
-  LegacyStyledText,
-  Box,
-  Flex,
-  BORDERS,
-  RESPONSIVENESS,
-  SPACING,
-  ALIGN_CENTER,
-  JUSTIFY_CENTER,
-} from '@opentrons/components'
+import { Box, RESPONSIVENESS } from '@opentrons/components'
 
 import { OneColumn as OneColumnComponent } from './'
 import { StandIn } from './story-utils/StandIn'

--- a/app/src/molecules/InterventionModal/OneColumn.stories.tsx
+++ b/app/src/molecules/InterventionModal/OneColumn.stories.tsx
@@ -7,7 +7,7 @@ import { StandInContent } from './story-utils/StandIn'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
-const meta: Meta<React.ComponentProps<OneColumnComponent>> = {
+const meta: Meta<React.ComponentProps<typeof OneColumnComponent>> = {
   title: 'App/Molecules/InterventionModal/OneColumn',
   component: OneColumnComponent,
   render: args => (
@@ -28,6 +28,6 @@ const meta: Meta<React.ComponentProps<OneColumnComponent>> = {
 
 export default meta
 
-export type Story = StoryObj<OneColumnComponent>
+export type Story = StoryObj<typeof OneColumnComponent>
 
 export const ExampleOneColumn: Story = { args: {} }

--- a/app/src/molecules/InterventionModal/OneColumn.stories.tsx
+++ b/app/src/molecules/InterventionModal/OneColumn.stories.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Box, RESPONSIVENESS } from '@opentrons/components'
 
 import { OneColumn as OneColumnComponent } from './'
-import { StandIn } from './story-utils/StandIn'
+import { StandInContent } from './story-utils/StandIn'
 
 import type { Meta, StoryObj } from '@storybook/react'
 
@@ -20,7 +20,7 @@ const meta: Meta<React.ComponentProps<OneColumnComponent>> = {
       `}
     >
       <OneColumnComponent>
-        <StandIn>This is a standin for another component</StandIn>
+        <StandInContent>This is a standin for another component</StandInContent>
       </OneColumnComponent>
     </Box>
   ),

--- a/app/src/molecules/InterventionModal/OneColumn.stories.tsx
+++ b/app/src/molecules/InterventionModal/OneColumn.stories.tsx
@@ -12,26 +12,9 @@ import {
 } from '@opentrons/components'
 
 import { OneColumn as OneColumnComponent } from './'
+import { StandIn } from './story-utils/StandIn'
 
 import type { Meta, StoryObj } from '@storybook/react'
-
-function StandInContent(): JSX.Element {
-  return (
-    <Flex
-      border={'4px dashed #A864FFFF'}
-      borderRadius={BORDERS.borderRadius8}
-      margin={SPACING.spacing16}
-      height="104px"
-      backgroundColor="#A864FF19"
-      alignItems={ALIGN_CENTER}
-      justifyContent={JUSTIFY_CENTER}
-    >
-      <LegacyStyledText as="h1">
-        This is a standin for some other component
-      </LegacyStyledText>
-    </Flex>
-  )
-}
 
 const meta: Meta<React.ComponentProps<OneColumnComponent>> = {
   title: 'App/Molecules/InterventionModal/OneColumn',
@@ -46,7 +29,7 @@ const meta: Meta<React.ComponentProps<OneColumnComponent>> = {
       `}
     >
       <OneColumnComponent>
-        <StandInContent />
+        <StandIn>This is a standin for another component</StandIn>
       </OneColumnComponent>
     </Box>
   ),

--- a/app/src/molecules/InterventionModal/OneColumn.tsx
+++ b/app/src/molecules/InterventionModal/OneColumn.tsx
@@ -1,11 +1,28 @@
 import * as React from 'react'
 
-import { Box } from '@opentrons/components'
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  JUSTIFY_SPACE_BETWEEN,
+} from '@opentrons/components'
+import type { StyleProps } from '@opentrons/components'
 
-export interface OneColumnProps {
+export interface OneColumnProps extends StyleProps {
   children: React.ReactNode
 }
 
-export function OneColumn({ children }: OneColumnProps): JSX.Element {
-  return <Box width="100%">{children}</Box>
+export function OneColumn({
+  children,
+  ...styleProps
+}: OneColumnProps): JSX.Element {
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      width="100%"
+      {...styleProps}
+    >
+      {children}
+    </Flex>
+  )
 }

--- a/app/src/molecules/InterventionModal/OneColumnOrTwoColumn.stories.tsx
+++ b/app/src/molecules/InterventionModal/OneColumnOrTwoColumn.stories.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+
+import { OneColumnOrTwoColumn } from './'
+
+import { StandInContent } from './story-utils/StandIn'
+import { VisibleContainer } from './story-utils/VisibleContainer'
+import { css } from 'styled-components'
+import {
+  RESPONSIVENESS,
+  Flex,
+  ALIGN_CENTER,
+  JUSTIFY_SPACE_AROUND,
+  DIRECTION_COLUMN,
+} from '@opentrons/components'
+
+import type { Meta, StoryObj } from '@storybook/react'
+
+function Wrapper(props: {}): JSX.Element {
+  return (
+    <OneColumnOrTwoColumn>
+      <StandInContent>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          alignItems={ALIGN_CENTER}
+          justifyContent={JUSTIFY_SPACE_AROUND}
+          height="100%"
+        >
+          This component is the only one shown on the ODD.
+        </Flex>
+      </StandInContent>
+      <StandInContent>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          alignItems={ALIGN_CENTER}
+          justifyContent={JUSTIFY_SPACE_AROUND}
+          height="100%"
+        >
+          This component is shown in the right column on desktop.
+        </Flex>
+      </StandInContent>
+    </OneColumnOrTwoColumn>
+  )
+}
+
+const meta: Meta<React.ComponentProps<typeof Wrapper>> = {
+  title: 'App/Molecules/InterventionModal/OneColumnOrTwoColumn',
+  component: Wrapper,
+  decorators: [
+    Story => (
+      <VisibleContainer
+        css={css`
+          min-width: min(max-content, 100vw);
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            width: 500px;
+          }
+        `}
+      >
+        <Story />
+      </VisibleContainer>
+    ),
+  ],
+}
+
+export default meta
+
+type Story = StoryObj<typeof Wrapper>
+
+export const OneOrTwoColumn: Story = {}

--- a/app/src/molecules/InterventionModal/OneColumnOrTwoColumn.tsx
+++ b/app/src/molecules/InterventionModal/OneColumnOrTwoColumn.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+
+import { css } from 'styled-components'
+import {
+  Flex,
+  Box,
+  DIRECTION_ROW,
+  SPACING,
+  WRAP,
+  RESPONSIVENESS,
+} from '@opentrons/components'
+import type { StyleProps } from '@opentrons/components'
+import { TWO_COLUMN_ELEMENT_MIN_WIDTH } from './constants'
+
+export interface OneColumnOrTwoColumnProps extends StyleProps {
+  children: [React.ReactNode, React.ReactNode]
+}
+
+export function OneColumnOrTwoColumn({
+  children: [leftOrSingleElement, optionallyDisplayedRightElement],
+  ...styleProps
+}: OneColumnOrTwoColumnProps): JSX.Element {
+  return (
+    <Flex
+      flexDirection={DIRECTION_ROW}
+      gap={SPACING.spacing40}
+      flexWrap={WRAP}
+      {...styleProps}
+    >
+      <Box
+        flex="1"
+        css={css`
+          min-width: ${TWO_COLUMN_ELEMENT_MIN_WIDTH};
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            min-width: none;
+            width: 100%;
+          }
+        `}
+      >
+        {leftOrSingleElement}
+      </Box>
+      <Box
+        flex="1"
+        minWidth={TWO_COLUMN_ELEMENT_MIN_WIDTH}
+        css={css`
+          @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+            display: none;
+          }
+        `}
+      >
+        {optionallyDisplayedRightElement}
+      </Box>
+    </Flex>
+  )
+}

--- a/app/src/molecules/InterventionModal/TwoColumn.tsx
+++ b/app/src/molecules/InterventionModal/TwoColumn.tsx
@@ -1,20 +1,28 @@
 import * as React from 'react'
 
 import { Flex, Box, DIRECTION_ROW, SPACING, WRAP } from '@opentrons/components'
+import type { StyleProps } from '@opentrons/components'
+import { TWO_COLUMN_ELEMENT_MIN_WIDTH } from './constants'
 
-export interface TwoColumnProps {
+export interface TwoColumnProps extends StyleProps {
   children: [React.ReactNode, React.ReactNode]
 }
 
 export function TwoColumn({
   children: [leftElement, rightElement],
+  ...styleProps
 }: TwoColumnProps): JSX.Element {
   return (
-    <Flex flexDirection={DIRECTION_ROW} gap={SPACING.spacing40} flexWrap={WRAP}>
-      <Box flex="1" minWidth="17.1875rem">
+    <Flex
+      flexDirection={DIRECTION_ROW}
+      gap={SPACING.spacing40}
+      flexWrap={WRAP}
+      {...styleProps}
+    >
+      <Box flex="1" minWidth={TWO_COLUMN_ELEMENT_MIN_WIDTH}>
         {leftElement}
       </Box>
-      <Box flex="1" minWidth="17.1875rem">
+      <Box flex="1" minWidth={TWO_COLUMN_ELEMENT_MIN_WIDTH}>
         {rightElement}
       </Box>
     </Flex>

--- a/app/src/molecules/InterventionModal/constants.ts
+++ b/app/src/molecules/InterventionModal/constants.ts
@@ -1,0 +1,1 @@
+export const TWO_COLUMN_ELEMENT_MIN_WIDTH = '17.1875rem' as const

--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -23,6 +23,7 @@ import type { IconName } from '@opentrons/components'
 import { ModalContentOneColSimpleButtons } from './ModalContentOneColSimpleButtons'
 import { TwoColumn } from './TwoColumn'
 import { OneColumn } from './OneColumn'
+import { OneColumnOrTwoColumn } from './OneColumnOrTwoColumn'
 import { ModalContentMixed } from './ModalContentMixed'
 import { DescriptionContent } from './DescriptionContent'
 import { DeckMapContent } from './DeckMapContent'
@@ -31,6 +32,7 @@ export {
   ModalContentOneColSimpleButtons,
   TwoColumn,
   OneColumn,
+  OneColumnOrTwoColumn,
   ModalContentMixed,
   DescriptionContent,
   DeckMapContent,

--- a/app/src/molecules/InterventionModal/story-utils/StandIn.tsx
+++ b/app/src/molecules/InterventionModal/story-utils/StandIn.tsx
@@ -1,13 +1,19 @@
 import * as React from 'react'
 import { Box, BORDERS } from '@opentrons/components'
 
-export function StandInContent(): JSX.Element {
+export function StandInContent({
+  children,
+}: {
+  children?: React.ReactNode
+}): JSX.Element {
   return (
     <Box
       border={'4px dashed #A864FFFF'}
       borderRadius={BORDERS.borderRadius8}
       height="104px"
       backgroundColor="#A864FF19"
-    />
+    >
+      {children}
+    </Box>
   )
 }

--- a/app/src/molecules/InterventionModal/story-utils/VisibleContainer.tsx
+++ b/app/src/molecules/InterventionModal/story-utils/VisibleContainer.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react'
 
 import { Box, BORDERS, SPACING } from '@opentrons/components'
+import type { StyleProps } from '@opentrons/components'
 
-export interface VisibleContainerProps {
+export interface VisibleContainerProps extends StyleProps {
   children: JSX.Element | JSX.Element[]
 }
 
 export function VisibleContainer({
   children,
+  ...styleProps
 }: VisibleContainerProps): JSX.Element {
   return (
     <Box
@@ -18,6 +20,7 @@ export function VisibleContainer({
       maxWidth="100vp"
       maxHeight="100vp"
       padding={SPACING.spacing32}
+      {...styleProps}
     >
       {children}
     </Box>

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryDoorOpen.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryDoorOpen.tsx
@@ -16,7 +16,10 @@ import {
 } from '@opentrons/components'
 import { RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR } from '@opentrons/api-client'
 
-import { RecoveryContentWrapper, RecoveryFooterButtons } from './shared'
+import {
+  RecoverySingleColumnContentWrapper,
+  RecoveryFooterButtons,
+} from './shared'
 
 import type { RecoveryContentProps } from './types'
 
@@ -31,7 +34,7 @@ export function RecoveryDoorOpen({
   const { t } = useTranslation('error_recovery')
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <Flex
         padding={SPACING.spacing40}
         gridGap={SPACING.spacing24}
@@ -70,7 +73,7 @@ export function RecoveryDoorOpen({
           isLoadingPrimaryBtnAction={isResumeRecoveryLoading}
         />
       </Flex>
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryError.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryError.tsx
@@ -13,7 +13,7 @@ import {
 } from '@opentrons/components'
 
 import { RECOVERY_MAP } from './constants'
-import { RecoveryContentWrapper } from './shared'
+import { RecoverySingleColumnContentWrapper } from './shared'
 
 import type { RecoveryContentProps } from './types'
 import { SmallButton } from '../../atoms/buttons'
@@ -168,7 +168,7 @@ export function ErrorContent({
   btnOnClick: () => void
 }): JSX.Element | null {
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <Flex
         padding={SPACING.spacing40}
         gridGap={SPACING.spacing24}
@@ -196,6 +196,6 @@ export function ErrorContent({
       <Flex justifyContent={JUSTIFY_END}>
         <SmallButton onClick={btnOnClick} buttonText={btnText} />
       </Flex>
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/CancelRun.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/CancelRun.tsx
@@ -12,7 +12,10 @@ import {
 } from '@opentrons/components'
 
 import { RECOVERY_MAP } from '../constants'
-import { RecoveryFooterButtons, RecoveryContentWrapper } from '../shared'
+import {
+  RecoveryFooterButtons,
+  RecoverySingleColumnContentWrapper,
+} from '../shared'
 import { SelectRecoveryOption } from './SelectRecoveryOption'
 
 import type { RecoveryContentProps } from '../types'
@@ -56,7 +59,7 @@ function CancelRunConfirmation({
   })
 
   return (
-    <RecoveryContentWrapper
+    <RecoverySingleColumnContentWrapper
       gridGap={SPACING.spacing24}
       alignItems={ALIGN_CENTER}
     >
@@ -90,7 +93,7 @@ function CancelRunConfirmation({
         primaryBtnTextOverride={t('confirm')}
         isLoadingPrimaryBtnAction={showBtnLoadingState}
       />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/FillWellAndSkip.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/FillWellAndSkip.tsx
@@ -12,7 +12,7 @@ import { RECOVERY_MAP } from '../constants'
 import { CancelRun } from './CancelRun'
 import {
   RecoveryFooterButtons,
-  RecoveryContentWrapper,
+  RecoverySingleColumnContentWrapper,
   LeftColumnLabwareInfo,
   TwoColTextAndFailedStepNextStep,
 } from '../shared'
@@ -49,7 +49,7 @@ export function FillWell(props: RecoveryContentProps): JSX.Element | null {
   const { goBackPrevStep, proceedNextStep } = routeUpdateActions
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <TwoColumn>
         <Flex gridGap={SPACING.spacing8} flexDirection={DIRECTION_COLUMN}>
           <LeftColumnLabwareInfo
@@ -68,7 +68,7 @@ export function FillWell(props: RecoveryContentProps): JSX.Element | null {
         primaryBtnOnClick={proceedNextStep}
         secondaryBtnOnClick={goBackPrevStep}
       />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -11,7 +11,10 @@ import {
 
 import { ODD_SECTION_TITLE_STYLE, RECOVERY_MAP } from '../constants'
 import { SelectRecoveryOption } from './SelectRecoveryOption'
-import { RecoveryFooterButtons, RecoveryContentWrapper } from '../shared'
+import {
+  RecoveryFooterButtons,
+  RecoverySingleColumnContentWrapper,
+} from '../shared'
 import { RadioButton } from '../../../atoms/buttons'
 
 import type { RecoveryContentProps } from '../types'
@@ -78,7 +81,7 @@ export function IgnoreErrorStepHome({
   }
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <LegacyStyledText css={ODD_SECTION_TITLE_STYLE} as="h4SemiBold">
         {t('ignore_similar_errors_later_in_run')}
       </LegacyStyledText>
@@ -93,7 +96,7 @@ export function IgnoreErrorStepHome({
         primaryBtnOnClick={primaryOnClick}
         secondaryBtnOnClick={goBackPrevStep}
       />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -12,7 +12,10 @@ import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { RadioButton } from '../../../atoms/buttons'
 import { ODD_SECTION_TITLE_STYLE, RECOVERY_MAP } from '../constants'
-import { RecoveryFooterButtons, RecoveryContentWrapper } from '../shared'
+import {
+  RecoveryFooterButtons,
+  RecoverySingleColumnContentWrapper,
+} from '../shared'
 import { DropTipWizardFlows } from '../../DropTipWizardFlows'
 import { DT_ROUTES } from '../../DropTipWizardFlows/constants'
 import { SelectRecoveryOption } from './SelectRecoveryOption'
@@ -87,7 +90,7 @@ export function BeginRemoval({
   }
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <LegacyStyledText css={ODD_SECTION_TITLE_STYLE} as="h4SemiBold">
         {t('you_may_want_to_remove', { mount })}
       </LegacyStyledText>
@@ -110,7 +113,7 @@ export function BeginRemoval({
         />
       </Flex>
       <RecoveryFooterButtons primaryBtnOnClick={primaryOnClick} />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 
@@ -158,7 +161,7 @@ function DropTipFlowsContainer(
   const fixitCommandTypeUtils = useDropTipFlowUtils(props)
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <DropTipWizardFlows
         robotType={isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE}
         closeFlow={onCloseFlow}
@@ -166,7 +169,7 @@ function DropTipFlowsContainer(
         instrumentModelSpecs={specs}
         fixitCommandTypeUtils={fixitCommandTypeUtils}
       />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -117,7 +117,11 @@ export function ODDRecoveryOptions({
   getRecoveryOptionCopy,
 }: RecoveryOptionsProps): JSX.Element {
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      gridGap={SPACING.spacing4}
+      width="100%"
+    >
       {validRecoveryOptions.map((recoveryOption: RecoveryRoute) => {
         const optionName = getRecoveryOptionCopy(recoveryOption)
         return (

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -13,6 +13,8 @@ import {
   RECOVERY_MAP,
   ERROR_KINDS,
   ODD_SECTION_TITLE_STYLE,
+  ODD_ONLY,
+  DESKTOP_ONLY,
 } from '../constants'
 import { RadioButton } from '../../../atoms/buttons'
 import {
@@ -49,7 +51,6 @@ export function SelectRecoveryOptionHome({
   tipStatusUtils,
   currentRecoveryOptionUtils,
   getRecoveryOptionCopy,
-  isOnDevice,
   ...rest
 }: RecoveryContentProps): JSX.Element | null {
   const { t } = useTranslation('error_recovery')
@@ -80,21 +81,22 @@ export function SelectRecoveryOptionHome({
         >
           {t('choose_a_recovery_action')}
         </StyledText>
-        {isOnDevice ? (
+        <Flex css={ODD_ONLY}>
           <ODDRecoveryOptions
             validRecoveryOptions={validRecoveryOptions}
             setSelectedRoute={setSelectedRoute}
             selectedRoute={selectedRoute}
             getRecoveryOptionCopy={getRecoveryOptionCopy}
           />
-        ) : (
+        </Flex>
+        <Flex css={DESKTOP_ONLY}>
           <DesktopRecoveryOptions
             validRecoveryOptions={validRecoveryOptions}
             setSelectedRoute={setSelectedRoute}
             selectedRoute={selectedRoute}
             getRecoveryOptionCopy={getRecoveryOptionCopy}
           />
-        )}
+        </Flex>
       </Flex>
       <FailedStepNextStep {...rest} />
     </RecoveryODDOneDesktopTwoColumnContentWrapper>

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -151,7 +151,11 @@ export function DesktopRecoveryOptions({
           ({
             value: option,
             children: (
-              <StyledText role="label" htmlFor={option}>
+              <StyledText
+                desktopStyle="bodyDefaultRegular"
+                role="label"
+                htmlFor={option}
+              >
                 {getRecoveryOptionCopy(option)}
               </StyledText>
             ),

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -15,7 +15,10 @@ import {
   ODD_SECTION_TITLE_STYLE,
 } from '../constants'
 import { RadioButton } from '../../../atoms/buttons'
-import { RecoveryFooterButtons, RecoveryContentWrapper } from '../shared'
+import {
+  RecoveryFooterButtons,
+  RecoverySingleColumnContentWrapper,
+} from '../shared'
 
 import type { ErrorKind, RecoveryContentProps, RecoveryRoute } from '../types'
 import type { PipetteWithTip } from '../../DropTipWizardFlows'
@@ -58,7 +61,7 @@ export function SelectRecoveryOptionHome({
   useCurrentTipStatus(determineTipStatus)
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <LegacyStyledText css={ODD_SECTION_TITLE_STYLE} as="h4SemiBold">
         {t('choose_a_recovery_action')}
       </LegacyStyledText>
@@ -76,7 +79,7 @@ export function SelectRecoveryOptionHome({
           void proceedToRouteAndStep(selectedRoute as RecoveryRoute)
         }}
       />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/IgnoreErrorSkipStep.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/IgnoreErrorSkipStep.test.tsx
@@ -20,7 +20,9 @@ vi.mock('../shared', async () => {
   const actual = await vi.importActual('../shared')
   return {
     ...actual,
-    RecoveryContentWrapper: vi.fn(({ children }) => <div>{children}</div>),
+    RecoverySingleColumnContentWrapper: vi.fn(({ children }) => (
+      <div>{children}</div>
+    )),
   }
 })
 vi.mock('../SelectRecoveryOption')

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SelectRecoveryOptions.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SelectRecoveryOptions.test.tsx
@@ -112,13 +112,13 @@ describe('SelectRecoveryOption', () => {
 
     screen.getByText('Choose a recovery action')
 
-    const retryStepOption = screen.getByRole('label', { name: 'Retry step' })
+    const retryStepOption = screen.getAllByRole('label', { name: 'Retry step' })
     clickButtonLabeled('Continue')
     expect(
       screen.queryByRole('button', { name: 'Go back' })
     ).not.toBeInTheDocument()
 
-    fireEvent.click(retryStepOption)
+    fireEvent.click(retryStepOption[0])
     clickButtonLabeled('Continue')
 
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
@@ -136,14 +136,14 @@ describe('SelectRecoveryOption', () => {
 
     screen.getByText('Choose a recovery action')
 
-    const retryNewTips = screen.getByRole('label', {
+    const retryNewTips = screen.getAllByRole('label', {
       name: 'Retry with new tips',
     })
     expect(
       screen.queryByRole('button', { name: 'Go back' })
     ).not.toBeInTheDocument()
 
-    fireEvent.click(retryNewTips)
+    fireEvent.click(retryNewTips[0])
     clickButtonLabeled('Continue')
 
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(RETRY_NEW_TIPS.ROUTE)
@@ -159,11 +159,11 @@ describe('SelectRecoveryOption', () => {
 
     screen.getByText('Choose a recovery action')
 
-    const fillManuallyAndSkip = screen.getByRole('label', {
+    const fillManuallyAndSkip = screen.getAllByRole('label', {
       name: 'Manually fill well and skip to next step',
     })
 
-    fireEvent.click(fillManuallyAndSkip)
+    fireEvent.click(fillManuallyAndSkip[0])
     clickButtonLabeled('Continue')
 
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
@@ -181,11 +181,11 @@ describe('SelectRecoveryOption', () => {
 
     screen.getByText('Choose a recovery action')
 
-    const retrySameTips = screen.getByRole('label', {
+    const retrySameTips = screen.getAllByRole('label', {
       name: 'Retry with same tips',
     })
 
-    fireEvent.click(retrySameTips)
+    fireEvent.click(retrySameTips[0])
     clickButtonLabeled('Continue')
 
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
@@ -203,11 +203,11 @@ describe('SelectRecoveryOption', () => {
 
     screen.getByText('Choose a recovery action')
 
-    const skipStepWithSameTips = screen.getByRole('label', {
+    const skipStepWithSameTips = screen.getAllByRole('label', {
       name: 'Skip to next step with same tips',
     })
 
-    fireEvent.click(skipStepWithSameTips)
+    fireEvent.click(skipStepWithSameTips[0])
     clickButtonLabeled('Continue')
 
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SelectRecoveryOptions.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SelectRecoveryOptions.test.tsx
@@ -8,7 +8,8 @@ import { i18n } from '../../../../i18n'
 import { mockRecoveryContentProps } from '../../__fixtures__'
 import {
   SelectRecoveryOption,
-  RecoveryOptions,
+  ODDRecoveryOptions,
+  DesktopRecoveryOptions,
   getRecoveryOptions,
   GENERAL_ERROR_OPTIONS,
   OVERPRESSURE_WHILE_ASPIRATING_OPTIONS,
@@ -24,15 +25,25 @@ import type { Mock } from 'vitest'
 const renderSelectRecoveryOption = (
   props: React.ComponentProps<typeof SelectRecoveryOption>
 ) => {
-  return renderWithProviders(<SelectRecoveryOption {...props} />, {
+  return renderWithProviders(
+    <SelectRecoveryOption {...{ ...mockRecoveryContentProps, ...props }} />,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+const renderODDRecoveryOptions = (
+  props: React.ComponentProps<typeof ODDRecoveryOptions>
+) => {
+  return renderWithProviders(<ODDRecoveryOptions {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
-
-const renderRecoveryOptions = (
-  props: React.ComponentProps<typeof RecoveryOptions>
+const renderDesktopRecoveryOptions = (
+  props: React.ComponentProps<typeof DesktopRecoveryOptions>
 ) => {
-  return renderWithProviders(<RecoveryOptions {...props} />, {
+  return renderWithProviders(<DesktopRecoveryOptions {...props} />, {
     i18nInstance: i18n,
   })[0]
 }
@@ -204,117 +215,123 @@ describe('SelectRecoveryOption', () => {
     )
   })
 })
+;([
+  ['desktop', renderDesktopRecoveryOptions] as const,
+  ['odd', renderODDRecoveryOptions] as const,
+] as const).forEach(([target, renderer]) => {
+  describe(`RecoveryOptions on ${target}`, () => {
+    let props: React.ComponentProps<typeof DesktopRecoveryOptions>
+    let mockSetSelectedRoute: Mock
+    let mockGetRecoveryOptionCopy: Mock
 
-describe('RecoveryOptions', () => {
-  let props: React.ComponentProps<typeof RecoveryOptions>
-  let mockSetSelectedRoute: Mock
-  let mockGetRecoveryOptionCopy: Mock
+    beforeEach(() => {
+      mockSetSelectedRoute = vi.fn()
+      mockGetRecoveryOptionCopy = vi.fn()
+      const generalRecoveryOptions = getRecoveryOptions(
+        ERROR_KINDS.GENERAL_ERROR
+      )
 
-  beforeEach(() => {
-    mockSetSelectedRoute = vi.fn()
-    mockGetRecoveryOptionCopy = vi.fn()
-    const generalRecoveryOptions = getRecoveryOptions(ERROR_KINDS.GENERAL_ERROR)
+      props = {
+        validRecoveryOptions: generalRecoveryOptions,
+        setSelectedRoute: mockSetSelectedRoute,
+        getRecoveryOptionCopy: mockGetRecoveryOptionCopy,
+      }
 
-    props = {
-      validRecoveryOptions: generalRecoveryOptions,
-      setSelectedRoute: mockSetSelectedRoute,
-      getRecoveryOptionCopy: mockGetRecoveryOptionCopy,
-    }
-
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.RETRY_FAILED_COMMAND.ROUTE)
-      .thenReturn('Retry step')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.CANCEL_RUN.ROUTE)
-      .thenReturn('Cancel run')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE)
-      .thenReturn('Retry with new tips')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.FILL_MANUALLY_AND_SKIP.ROUTE)
-      .thenReturn('Manually fill well and skip to next step')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE)
-      .thenReturn('Retry with same tips')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE)
-      .thenReturn('Skip to next step with same tips')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE)
-      .thenReturn('Skip to next step with new tips')
-    when(mockGetRecoveryOptionCopy)
-      .calledWith(RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE)
-      .thenReturn('Ignore error and skip to next step')
-  })
-
-  it('renders valid recovery options for a general error errorKind', () => {
-    renderRecoveryOptions(props)
-
-    screen.getByRole('label', { name: 'Retry step' })
-    screen.getByRole('label', { name: 'Cancel run' })
-  })
-
-  it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING} errorKind`, () => {
-    props = {
-      ...props,
-      validRecoveryOptions: OVERPRESSURE_WHILE_ASPIRATING_OPTIONS,
-    }
-
-    renderRecoveryOptions(props)
-
-    screen.getByRole('label', { name: 'Retry with new tips' })
-    screen.getByRole('label', { name: 'Cancel run' })
-  })
-
-  it('updates the selectedRoute when a new option is selected', () => {
-    renderRecoveryOptions(props)
-
-    fireEvent.click(screen.getByRole('label', { name: 'Cancel run' }))
-
-    expect(mockSetSelectedRoute).toHaveBeenCalledWith(
-      RECOVERY_MAP.CANCEL_RUN.ROUTE
-    )
-  })
-
-  it(`renders valid recovery options for a ${ERROR_KINDS.NO_LIQUID_DETECTED} errorKind`, () => {
-    props = {
-      ...props,
-      validRecoveryOptions: NO_LIQUID_DETECTED_OPTIONS,
-    }
-
-    renderRecoveryOptions(props)
-
-    screen.getByRole('label', {
-      name: 'Manually fill well and skip to next step',
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.RETRY_FAILED_COMMAND.ROUTE)
+        .thenReturn('Retry step')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.CANCEL_RUN.ROUTE)
+        .thenReturn('Cancel run')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.RETRY_NEW_TIPS.ROUTE)
+        .thenReturn('Retry with new tips')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.FILL_MANUALLY_AND_SKIP.ROUTE)
+        .thenReturn('Manually fill well and skip to next step')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.RETRY_SAME_TIPS.ROUTE)
+        .thenReturn('Retry with same tips')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.SKIP_STEP_WITH_SAME_TIPS.ROUTE)
+        .thenReturn('Skip to next step with same tips')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.SKIP_STEP_WITH_NEW_TIPS.ROUTE)
+        .thenReturn('Skip to next step with new tips')
+      when(mockGetRecoveryOptionCopy)
+        .calledWith(RECOVERY_MAP.IGNORE_AND_SKIP.ROUTE)
+        .thenReturn('Ignore error and skip to next step')
     })
-    screen.getByRole('label', { name: 'Ignore error and skip to next step' })
-    screen.getByRole('label', { name: 'Cancel run' })
-  })
 
-  it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE} errorKind`, () => {
-    props = {
-      ...props,
-      validRecoveryOptions: OVERPRESSURE_PREPARE_TO_ASPIRATE,
-    }
+    it('renders valid recovery options for a general error errorKind', () => {
+      renderer(props)
 
-    renderRecoveryOptions(props)
+      screen.getByRole('label', { name: 'Retry step' })
+      screen.getByRole('label', { name: 'Cancel run' })
+    })
 
-    screen.getByRole('label', { name: 'Retry with new tips' })
-    screen.getByRole('label', { name: 'Retry with same tips' })
-    screen.getByRole('label', { name: 'Cancel run' })
-  })
+    it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_ASPIRATING} errorKind`, () => {
+      props = {
+        ...props,
+        validRecoveryOptions: OVERPRESSURE_WHILE_ASPIRATING_OPTIONS,
+      }
 
-  it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING} errorKind`, () => {
-    props = {
-      ...props,
-      validRecoveryOptions: OVERPRESSURE_WHILE_DISPENSING_OPTIONS,
-    }
+      renderer(props)
 
-    renderRecoveryOptions(props)
+      screen.getByRole('label', { name: 'Retry with new tips' })
+      screen.getByRole('label', { name: 'Cancel run' })
+    })
 
-    screen.getByRole('label', { name: 'Skip to next step with same tips' })
-    screen.getByRole('label', { name: 'Skip to next step with new tips' })
-    screen.getByRole('label', { name: 'Cancel run' })
+    it('updates the selectedRoute when a new option is selected', () => {
+      renderer(props)
+
+      fireEvent.click(screen.getByRole('label', { name: 'Cancel run' }))
+
+      expect(mockSetSelectedRoute).toHaveBeenCalledWith(
+        RECOVERY_MAP.CANCEL_RUN.ROUTE
+      )
+    })
+
+    it(`renders valid recovery options for a ${ERROR_KINDS.NO_LIQUID_DETECTED} errorKind`, () => {
+      props = {
+        ...props,
+        validRecoveryOptions: NO_LIQUID_DETECTED_OPTIONS,
+      }
+
+      renderer(props)
+
+      screen.getByRole('label', {
+        name: 'Manually fill well and skip to next step',
+      })
+      screen.getByRole('label', { name: 'Ignore error and skip to next step' })
+      screen.getByRole('label', { name: 'Cancel run' })
+    })
+
+    it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_PREPARE_TO_ASPIRATE} errorKind`, () => {
+      props = {
+        ...props,
+        validRecoveryOptions: OVERPRESSURE_PREPARE_TO_ASPIRATE,
+      }
+
+      renderer(props)
+
+      screen.getByRole('label', { name: 'Retry with new tips' })
+      screen.getByRole('label', { name: 'Retry with same tips' })
+      screen.getByRole('label', { name: 'Cancel run' })
+    })
+
+    it(`renders valid recovery options for a ${ERROR_KINDS.OVERPRESSURE_WHILE_DISPENSING} errorKind`, () => {
+      props = {
+        ...props,
+        validRecoveryOptions: OVERPRESSURE_WHILE_DISPENSING_OPTIONS,
+      }
+
+      renderer(props)
+
+      screen.getByRole('label', { name: 'Skip to next step with same tips' })
+      screen.getByRole('label', { name: 'Skip to next step with new tips' })
+      screen.getByRole('label', { name: 'Cancel run' })
+    })
   })
 })
 

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -157,7 +157,6 @@ export function RunPausedSplash(
             flexDirection={DIRECTION_COLUMN}
             alignItems={ALIGN_FLEX_END}
             justifyContent={JUSTIFY_SPACE_BETWEEN}
-            height="25rem"
           >
             <Flex
               borderRadius={BORDERS.borderRadius8}

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -30,7 +30,7 @@ import { LargeButton } from '../../atoms/buttons'
 import { RECOVERY_MAP } from './constants'
 import {
   RecoveryInterventionModal,
-  RecoveryContentWrapper,
+  RecoverySingleColumnContentWrapper,
   StepInfo,
 } from './shared'
 
@@ -151,7 +151,7 @@ export function RunPausedSplash(
         titleHeading={buildTitleHeadingDesktop()}
         isOnDevice={isOnDevice}
       >
-        <RecoveryContentWrapper>
+        <RecoverySingleColumnContentWrapper>
           <Flex
             gridGap={SPACING.spacing24}
             flexDirection={DIRECTION_COLUMN}
@@ -206,7 +206,7 @@ export function RunPausedSplash(
               </StyledText>
             </PrimaryButton>
           </Flex>
-        </RecoveryContentWrapper>
+        </RecoverySingleColumnContentWrapper>
       </RecoveryInterventionModal>
     )
   }

--- a/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
@@ -73,7 +73,7 @@ export const mockRecoveryContentProps: RecoveryContentProps = {
   failedPipetteInfo: {} as any,
   deckMapUtils: { setSelectedLocation: () => {} } as any,
   stepCounts: {} as any,
-  protocolAnalysis: { commands: [mockFailedCommand] } as any,
+  protocolAnalysis: mockRobotSideAnalysis,
   trackExternalMap: () => null,
   hasLaunchedRecovery: true,
   getRecoveryOptionCopy: () => 'MOCK_COPY',

--- a/app/src/organisms/ErrorRecoveryFlows/constants.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/constants.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components'
 
-import { SPACING, TYPOGRAPHY } from '@opentrons/components'
+import { SPACING, TYPOGRAPHY, RESPONSIVENESS } from '@opentrons/components'
 
 import type { StepOrder } from './types'
 
@@ -210,4 +210,15 @@ export const BODY_TEXT_STYLE = css`
 
 export const ODD_SECTION_TITLE_STYLE = css`
   margin-bottom: ${SPACING.spacing16};
+`
+
+export const ODD_ONLY = css`
+  @media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+    display: none;
+  }
+`
+export const DESKTOP_ONLY = css`
+  @media (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+    display: none;
+  }
 `

--- a/app/src/organisms/ErrorRecoveryFlows/shared/FailedStepNextStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/FailedStepNextStep.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import { useTranslation } from 'react-i18next'
+import { CategorizedStepContent } from '../../../molecules/InterventionModal'
+import type { RecoveryContentProps } from '../types'
+
+export function FailedStepNextStep({
+  stepCounts,
+  failedCommand,
+  commandsAfterFailedCommand,
+  protocolAnalysis,
+  robotType,
+}: Pick<
+  RecoveryContentProps,
+  | 'stepCounts'
+  | 'failedCommand'
+  | 'commandsAfterFailedCommand'
+  | 'protocolAnalysis'
+  | 'robotType'
+>): JSX.Element {
+  const { t } = useTranslation('error_recovery')
+
+  const nthStepAfter = (n: number): number | undefined =>
+    stepCounts.currentStepNumber == null
+      ? undefined
+      : stepCounts.currentStepNumber + n
+  const nthCommand = (n: number): typeof failedCommand =>
+    commandsAfterFailedCommand != null
+      ? n < commandsAfterFailedCommand.length
+        ? commandsAfterFailedCommand[n]
+        : null
+      : null
+
+  const commandsAfter = [nthCommand(0), nthCommand(1)] as const
+
+  const indexedCommandsAfter = [
+    commandsAfter[0] != null
+      ? { command: commandsAfter[0], index: nthStepAfter(1) }
+      : null,
+    commandsAfter[1] != null
+      ? { command: commandsAfter[1], index: nthStepAfter(2) }
+      : null,
+  ] as const
+  return (
+    <CategorizedStepContent
+      commandTextData={protocolAnalysis}
+      robotType={robotType}
+      topCategoryHeadline={t('failed_step')}
+      topCategory="failed"
+      topCategoryCommand={
+        failedCommand == null
+          ? null
+          : {
+              command: failedCommand,
+              index: stepCounts.currentStepNumber ?? undefined,
+            }
+      }
+      bottomCategoryHeadline={t('next_step')}
+      bottomCategory="future"
+      bottomCategoryCommands={indexedCommandsAfter}
+    />
+  )
+}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
@@ -104,8 +104,8 @@ export function RecoveryODDOneDesktopTwoColumnContentWrapper({
 const STYLE = css`
   gap: ${SPACING.spacing24};
   width: 100%;
+  height: 100%;
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     gap: none;
-    height: 100%;
   }
 `

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryContentWrapper.tsx
@@ -10,19 +10,34 @@ import {
   Flex,
   RESPONSIVENESS,
 } from '@opentrons/components'
-
 import type { StyleProps } from '@opentrons/components'
+import {
+  OneColumn,
+  TwoColumn,
+  OneColumnOrTwoColumn,
+} from '../../../molecules/InterventionModal'
+import { RecoveryFooterButtons } from './RecoveryFooterButtons'
 
-interface SingleColumnContentWrapperProps extends StyleProps {
+interface SingleColumnContentWrapperProps {
   children: React.ReactNode
+  footerDetails?: React.ComponentProps<typeof RecoveryFooterButtons>
+}
+
+interface TwoColumnContentWrapperProps {
+  children: [React.ReactNode, React.ReactNode]
+  footerDetails?: React.ComponentProps<typeof RecoveryFooterButtons>
+}
+
+interface OneOrTwoColumnContentWrapperProps {
+  children: [React.ReactNode, React.ReactNode]
+  footerDetails?: React.ComponentProps<typeof RecoveryFooterButtons>
 }
 // For flex-direction: column recovery content with one column only.
-//
-// For ODD use only.
-export function RecoveryContentWrapper({
+export function RecoverySingleColumnContentWrapper({
   children,
+  footerDetails,
   ...styleProps
-}: SingleColumnContentWrapperProps): JSX.Element {
+}: SingleColumnContentWrapperProps & StyleProps): JSX.Element {
   return (
     <Flex
       flexDirection={DIRECTION_COLUMN}
@@ -30,7 +45,58 @@ export function RecoveryContentWrapper({
       css={STYLE}
       {...styleProps}
     >
-      {children}
+      <OneColumn css={STYLE} {...styleProps}>
+        {children}
+      </OneColumn>
+      {footerDetails != null ? (
+        <RecoveryFooterButtons {...footerDetails} />
+      ) : null}
+    </Flex>
+  )
+}
+
+// For two-column recovery content
+export function RecoveryTwoColumnContentWrapper({
+  children,
+  footerDetails,
+}: TwoColumnContentWrapperProps): JSX.Element {
+  const [leftChild, rightChild] = children
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+      css={STYLE}
+    >
+      <TwoColumn css={STYLE}>
+        {leftChild}
+        {rightChild}
+      </TwoColumn>
+      {footerDetails != null ? (
+        <RecoveryFooterButtons {...footerDetails} />
+      ) : null}
+    </Flex>
+  )
+}
+
+// For recovery content with one column on ODD and two columns on desktop
+export function RecoveryODDOneDesktopTwoColumnContentWrapper({
+  children: [leftOrSingleElement, optionallyShownRightElement],
+  footerDetails,
+}: OneOrTwoColumnContentWrapperProps): JSX.Element {
+  return (
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      height="100%"
+      width="100%"
+      justifyContent={JUSTIFY_SPACE_BETWEEN}
+    >
+      <OneColumnOrTwoColumn css={STYLE}>
+        {leftOrSingleElement}
+        {optionallyShownRightElement}
+      </OneColumnOrTwoColumn>
+      {footerDetails != null ? (
+        <RecoveryFooterButtons {...footerDetails} />
+      ) : null}
     </Flex>
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import { css } from 'styled-components'
 import type { ChangeEventHandler } from 'react'
 import { RadioGroup, SPACING, Flex } from '@opentrons/components'
 
@@ -30,7 +29,6 @@ export function RecoveryRadioGroup<T extends string>(
 ): JSX.Element {
   return (
     <RadioGroup
-      css={css``}
       {...props}
       options={props.options.map(radioOption => ({
         name: '',

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import type { ChangeEventHandler } from 'react'
+import { RadioGroup } from '@opentrons/components'
+
+// note: this typescript stuff is so that e.currentTarget.value in the ChangeEventHandler
+// is deduced to a union of the values of the options passed to the radiogroup rather than
+// just string
+export interface Target<T> extends Omit<HTMLInputElement, 'value'> {
+  value: T
+}
+
+export type Options<T extends string = never> = Array<{
+  value: T
+  children: React.ReactNode
+}>
+
+export interface RecoveryRadioGroupProps<T extends string>
+  extends Omit<
+    React.ComponentProps<typeof RadioGroup>,
+    'labelTextClassName' | 'options' | 'onchange'
+  > {
+  options: Options<T>
+  onChange: ChangeEventHandler<Target<T>>
+}
+
+export function RecoveryRadioGroup<T extends string>(
+  props: RecoveryRadioGroupProps<T>
+): JSX.Element {
+  return (
+    <RadioGroup
+      {...props}
+      options={props.options.map(radioOption => ({
+        name: '',
+        value: radioOption.value,
+        children: radioOption.children,
+      }))}
+    />
+  )
+}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryRadioGroup.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react'
+
+import { css } from 'styled-components'
 import type { ChangeEventHandler } from 'react'
-import { RadioGroup } from '@opentrons/components'
+import { RadioGroup, SPACING, Flex } from '@opentrons/components'
 
 // note: this typescript stuff is so that e.currentTarget.value in the ChangeEventHandler
 // is deduced to a union of the values of the options passed to the radiogroup rather than
@@ -28,11 +30,14 @@ export function RecoveryRadioGroup<T extends string>(
 ): JSX.Element {
   return (
     <RadioGroup
+      css={css``}
       {...props}
       options={props.options.map(radioOption => ({
         name: '',
         value: radioOption.value,
-        children: radioOption.children,
+        children: (
+          <Flex marginY={SPACING.spacing4}>{radioOption.children}</Flex>
+        ),
       }))}
     />
   )

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ReplaceTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ReplaceTips.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { Flex } from '@opentrons/components'
 
 import { useTranslation } from 'react-i18next'
-import { RecoveryContentWrapper } from './RecoveryContentWrapper'
+import { RecoverySingleColumnContentWrapper } from './RecoveryContentWrapper'
 import { TwoColumn, DeckMapContent } from '../../../molecules/InterventionModal'
 import { RecoveryFooterButtons } from './RecoveryFooterButtons'
 import { LeftColumnLabwareInfo } from './LeftColumnLabwareInfo'
@@ -36,7 +36,7 @@ export function ReplaceTips(props: RecoveryContentProps): JSX.Element | null {
   }
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <TwoColumn>
         <LeftColumnLabwareInfo
           {...props}
@@ -49,6 +49,6 @@ export function ReplaceTips(props: RecoveryContentProps): JSX.Element | null {
         </Flex>
       </TwoColumn>
       <RecoveryFooterButtons primaryBtnOnClick={primaryOnClick} />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { RECOVERY_MAP } from '../constants'
-import { RecoveryContentWrapper } from './RecoveryContentWrapper'
+import { RecoverySingleColumnContentWrapper } from './RecoveryContentWrapper'
 import { TwoColumn } from '../../../molecules/InterventionModal'
 import { RecoveryFooterButtons } from './RecoveryFooterButtons'
 import { LeftColumnLabwareInfo } from './LeftColumnLabwareInfo'
@@ -42,7 +42,7 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
           toggleModal={toggleModal}
         />
       )}
-      <RecoveryContentWrapper>
+      <RecoverySingleColumnContentWrapper>
         <TwoColumn>
           <LeftColumnLabwareInfo
             {...props}
@@ -60,7 +60,7 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
           tertiaryBtnOnClick={toggleModal}
           tertiaryBtnText={t('change_location')}
         />
-      </RecoveryContentWrapper>
+      </RecoverySingleColumnContentWrapper>
     </>
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 import {
   DIRECTION_COLUMN,
@@ -10,11 +9,9 @@ import {
 } from '@opentrons/components'
 
 import { RecoveryContentWrapper } from './RecoveryContentWrapper'
-import {
-  TwoColumn,
-  CategorizedStepContent,
-} from '../../../molecules/InterventionModal'
+import { TwoColumn } from '../../../molecules/InterventionModal'
 import { RecoveryFooterButtons } from './RecoveryFooterButtons'
+import { FailedStepNextStep } from './FailedStepNextStep'
 
 import type { RecoveryContentProps } from '../types'
 
@@ -24,50 +21,24 @@ type TwoColTextAndFailedStepNextStepProps = RecoveryContentProps & {
   primaryBtnCopy: string
   primaryBtnOnClick: () => void
   secondaryBtnOnClickOverride?: () => void
-  secondaryBtnOnClickCopyOverride?: string
 }
 
 /**
  * Left Column: Title + body text
  * Right column: FailedStepNextStep
  */
-export function TwoColTextAndFailedStepNextStep({
-  leftColBodyText,
-  leftColTitle,
-  primaryBtnCopy,
-  primaryBtnOnClick,
-  secondaryBtnOnClickOverride,
-  secondaryBtnOnClickCopyOverride,
-  routeUpdateActions,
-  failedCommand,
-  stepCounts,
-  commandsAfterFailedCommand,
-  protocolAnalysis,
-  robotType,
-}: TwoColTextAndFailedStepNextStepProps): JSX.Element | null {
+export function TwoColTextAndFailedStepNextStep(
+  props: TwoColTextAndFailedStepNextStepProps
+): JSX.Element | null {
+  const {
+    leftColBodyText,
+    leftColTitle,
+    primaryBtnCopy,
+    primaryBtnOnClick,
+    secondaryBtnOnClickOverride,
+    routeUpdateActions,
+  } = props
   const { goBackPrevStep } = routeUpdateActions
-  const { t } = useTranslation('error_recovery')
-  const nthStepAfter = (n: number): number | undefined =>
-    stepCounts.currentStepNumber == null
-      ? undefined
-      : stepCounts.currentStepNumber + n
-  const nthCommand = (n: number): typeof failedCommand =>
-    commandsAfterFailedCommand != null
-      ? n < commandsAfterFailedCommand.length
-        ? commandsAfterFailedCommand[n]
-        : null
-      : null
-
-  const commandsAfter = [nthCommand(0), nthCommand(1)] as const
-
-  const indexedCommandsAfter = [
-    commandsAfter[0] != null
-      ? { command: commandsAfter[0], index: nthStepAfter(1) }
-      : null,
-    commandsAfter[1] != null
-      ? { command: commandsAfter[1], index: nthStepAfter(2) }
-      : null,
-  ] as const
 
   return (
     <RecoveryContentWrapper>
@@ -77,7 +48,7 @@ export function TwoColTextAndFailedStepNextStep({
           css={css`
             gap=${SPACING.spacing16};
             @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-               gap=${SPACING.spacing8}
+            gap=${SPACING.spacing8}
             }
           `}
         >
@@ -94,23 +65,7 @@ export function TwoColTextAndFailedStepNextStep({
             {leftColBodyText}
           </StyledText>
         </Flex>
-        <CategorizedStepContent
-          commandTextData={protocolAnalysis}
-          robotType={robotType}
-          topCategoryHeadline={t('failed_step')}
-          topCategory="failed"
-          topCategoryCommand={
-            failedCommand == null
-              ? null
-              : {
-                  command: failedCommand,
-                  index: stepCounts.currentStepNumber ?? undefined,
-                }
-          }
-          bottomCategoryHeadline={t('next_step')}
-          bottomCategory="future"
-          bottomCategoryCommands={indexedCommandsAfter}
-        />
+        <FailedStepNextStep {...props} />
       </TwoColumn>
       <RecoveryFooterButtons
         primaryBtnOnClick={primaryBtnOnClick}

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
@@ -8,7 +8,7 @@ import {
   RESPONSIVENESS,
 } from '@opentrons/components'
 
-import { RecoveryContentWrapper } from './RecoveryContentWrapper'
+import { RecoverySingleColumnContentWrapper } from './RecoveryContentWrapper'
 import { TwoColumn } from '../../../molecules/InterventionModal'
 import { RecoveryFooterButtons } from './RecoveryFooterButtons'
 import { FailedStepNextStep } from './FailedStepNextStep'
@@ -41,7 +41,7 @@ export function TwoColTextAndFailedStepNextStep(
   const { goBackPrevStep } = routeUpdateActions
 
   return (
-    <RecoveryContentWrapper>
+    <RecoverySingleColumnContentWrapper>
       <TwoColumn>
         <Flex
           flexDirection={DIRECTION_COLUMN}
@@ -72,6 +72,6 @@ export function TwoColTextAndFailedStepNextStep(
         primaryBtnTextOverride={primaryBtnCopy}
         secondaryBtnOnClick={secondaryBtnOnClickOverride ?? goBackPrevStep}
       />
-    </RecoveryContentWrapper>
+    </RecoverySingleColumnContentWrapper>
   )
 }

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StepInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StepInfo.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { screen } from '@testing-library/react'
 
 import { renderWithProviders } from '../../../../__testing-utils__'
-import { mockRecoveryContentProps } from '../../__fixtures__'
+import { mockRecoveryContentProps, mockFailedCommand } from '../../__fixtures__'
 import { i18n } from '../../../../i18n'
 import { StepInfo } from '../StepInfo'
 import { CommandText } from '../../../../molecules/Command'
@@ -21,7 +21,10 @@ describe('StepInfo', () => {
 
   beforeEach(() => {
     props = {
-      ...mockRecoveryContentProps,
+      ...{
+        ...mockRecoveryContentProps,
+        protocolAnalysis: { commands: [mockFailedCommand] } as any,
+      },
       textStyle: 'h4',
       stepCounts: {
         currentStepNumber: 5,

--- a/app/src/organisms/ErrorRecoveryFlows/shared/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/index.ts
@@ -1,8 +1,8 @@
 export { RecoveryFooterButtons } from './RecoveryFooterButtons'
 export {
-    RecoverySingleColumnContentWrapper,
-    RecoveryTwoColumnContentWrapper,
-    RecoveryODDOneDesktopTwoColumnContentWrapper,
+  RecoverySingleColumnContentWrapper,
+  RecoveryTwoColumnContentWrapper,
+  RecoveryODDOneDesktopTwoColumnContentWrapper,
 } from './RecoveryContentWrapper'
 export { ReplaceTips } from './ReplaceTips'
 export { SelectTips } from './SelectTips'

--- a/app/src/organisms/ErrorRecoveryFlows/shared/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/index.ts
@@ -1,5 +1,9 @@
 export { RecoveryFooterButtons } from './RecoveryFooterButtons'
-export { RecoveryContentWrapper } from './RecoveryContentWrapper'
+export {
+    RecoverySingleColumnContentWrapper,
+    RecoveryTwoColumnContentWrapper,
+    RecoveryODDOneDesktopTwoColumnContentWrapper,
+} from './RecoveryContentWrapper'
 export { ReplaceTips } from './ReplaceTips'
 export { SelectTips } from './SelectTips'
 export { TwoColTextAndFailedStepNextStep } from './TwoColTextAndFailedStepNextStep'
@@ -9,5 +13,7 @@ export { TipSelectionModal } from './TipSelectionModal'
 export { StepInfo } from './StepInfo'
 export { useErrorDetailsModal, ErrorDetailsModal } from './ErrorDetailsModal'
 export { RecoveryInterventionModal } from './RecoveryInterventionModal'
+export { FailedStepNextStep } from './FailedStepNextStep'
+export { RecoveryRadioGroup } from './RecoveryRadioGroup'
 
 export type { RecoveryInterventionModalProps } from './RecoveryInterventionModal'

--- a/components/src/forms/RadioGroup.tsx
+++ b/components/src/forms/RadioGroup.tsx
@@ -50,7 +50,7 @@ export function RadioGroup(props: RadioGroupProps): JSX.Element {
         const useStyleUpdates =
           props.useBlueChecked && radio.value === props.value
         return (
-          <label key={radio.value} className={itemClassName}>
+          <label key={radio.value} id={radio.value} className={itemClassName}>
             <div
               className={cx(styles.checkbox_icon, {
                 [styles.checked]: useStyleUpdates,


### PR DESCRIPTION
This PR got away from me a little bit (and I still have to test it - the sum of these two is why it's in draft). It's probably best to view it commit by commit.

Overall, the point is to implement the desktop styling for the SelectRecoveryOption component of error recovery, here: https://www.figma.com/design/8dMeu8MuPfXoORtOV6cACO/Feature%3A-Error-Recovery-August-Release?node-id=4829-78111&t=bTwOek0mZSA61ugm-4 . This is a little weird because it is exactly semantically equivalent to the ODD panel, but has a very different styling - two columns instead of one. It also uses the radio buttons that we use only in OT-2 tip length calibration method selection, which are old and use cssmodules and need a cleanup.

The approach here was to add some fundamental structure components to InterventionModal that will render two columns on desktop (as the TwoColumn structure, including min-size and wrap) and one column on the ODD at full width. Then, we can build on top of that in ErrorRecovery, with the big difference being that the ErrorRecovery component also folds in the standard ER footer (or will - already had to find/replace a bunch of stuff, going to move other components over to specifying their footers through the wrapper as we update their styles).

There were also some incidental refactors. By commit, 
- 981e82802c06c1c5890fe2cb45ce24ec704a6775 : we have these utility components for visualizing structure components; make them handle sometimes being size limited and sometimes not being
- a7917e746138d314a0b76f4398fc0bcef5ec4877 : Add a wrapper around the RadioGroup component. We're going to need to update these styles further (that's a todo) but we don't want to, or I don't want to, have to mess with cssmodules. Also I think @TamarZanzouri is touching this stuff at the same time, so keep it isolated and droppable. Did I let the worms in my brain drive and make a typescript wrapper for getting the change events to take an inferred union of button values? Yes. Also note the one change to the underlying component to specify IDs so that we can use aria label linking in the passed components, which is both good practice and allows tests to work later.
- e835f8604e5bcaf3430b67d21155562919a883d5 The error recovery component for viewing failed and next commands was bundled with presenting text in the left column, which is not what we want this panel to have, so split it out.
- 699cb79b035aa157aca8544b9bddb9d5035eaedf The first fun one: Add a component that can responsively present one or two columns, and by "responsively" i mean abuse css mediaquery to only do it on touchscreen and maintain the two-column responsive presentation through desktop resizes. Best appreciated in storybook.
- 52150cbdcd24fa87c1bb754b6d1296444b4ed691 Simultaneous refactor and feature - we had a RecoveryContentWrapper but it was really just a single column, this isn't helpful, add a single and twocolumn version (lots of find and replace since I changed the name) and then add a OneOrTwoColumn on top of that. These wrappers also encompass rendering footers because the footer needs to be in different places in one or two column
- 00f38e8e4db80b1c16f2c4395b36c963a5bffa25 Use all that stuff to render SelectRecoveryOption! Note that the tests now run on both presentations and it all works because of that aria label stuff.

## Todo
- [x] Visual tests, at all (this is why it's a draft)