### PR TITLE
refactor(shared-data): remove outdated id fields from JSON v7-v8 fixtures

### DIFF
--- a/shared-data/protocol/fixtures/7/simpleV7.json
+++ b/shared-data/protocol/fixtures/7/simpleV7.json
@@ -1208,7 +1208,7 @@
   "commands": [
     {
       "commandType": "loadPipette",
-      "id": "0abc123",
+      "key": "0abc123",
       "params": {
         "pipetteId": "pipetteId",
         "pipetteName": "p1000_96",
@@ -1217,7 +1217,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "1abc123",
+      "key": "1abc123",
       "params": {
         "moduleId": "magneticModuleId",
         "model": "magneticModuleV2",
@@ -1226,7 +1226,7 @@
     },
     {
       "commandType": "loadModule",
-      "id": "2abc123",
+      "key": "2abc123",
       "params": {
         "moduleId": "temperatureModuleId",
         "model": "temperatureModuleV2",
@@ -1235,7 +1235,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "3abc123",
+      "key": "3abc123",
       "params": {
         "labwareId": "sourcePlateId",
         "loadName": "armadillo_96_wellplate_200ul_pcr_full_skirt",
@@ -1249,7 +1249,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "4abc123",
+      "key": "4abc123",
       "params": {
         "labwareId": "destPlateId",
         "loadName": "armadillo_96_wellplate_200ul_pcr_full_skirt",
@@ -1263,7 +1263,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "5abc123",
+      "key": "5abc123",
       "params": {
         "labwareId": "tipRackId",
         "location": { "slotName": "8" },
@@ -1275,7 +1275,7 @@
     },
     {
       "commandType": "loadLabware",
-      "id": "6abc123",
+      "key": "6abc123",
       "params": {
         "labwareId": "fixedTrash",
         "location": {
@@ -1289,7 +1289,7 @@
     },
     {
       "commandType": "loadLiquid",
-      "id": "7abc123",
+      "key": "7abc123",
       "params": {
         "liquidId": "waterId",
         "labwareId": "sourcePlateId",
@@ -1301,12 +1301,12 @@
     },
     {
       "commandType": "home",
-      "id": "00abc123",
+      "key": "00abc123",
       "params": {}
     },
     {
       "commandType": "pickUpTip",
-      "id": "8abc123",
+      "key": "8abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "tipRackId",
@@ -1315,7 +1315,7 @@
     },
     {
       "commandType": "aspirate",
-      "id": "9abc123",
+      "key": "9abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "sourcePlateId",
@@ -1330,14 +1330,14 @@
     },
     {
       "commandType": "waitForDuration",
-      "id": "10abc123",
+      "key": "10abc123",
       "params": {
         "seconds": 42
       }
     },
     {
       "commandType": "dispense",
-      "id": "11abc123",
+      "key": "11abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1352,7 +1352,7 @@
     },
     {
       "commandType": "touchTip",
-      "id": "12abc123",
+      "key": "12abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1365,7 +1365,7 @@
     },
     {
       "commandType": "blowout",
-      "id": "13abc123",
+      "key": "13abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1379,7 +1379,7 @@
     },
     {
       "commandType": "moveToCoordinates",
-      "id": "14abc123",
+      "key": "14abc123",
       "params": {
         "pipetteId": "pipetteId",
         "coordinates": { "x": 100, "y": 100, "z": 100 }
@@ -1387,7 +1387,7 @@
     },
     {
       "commandType": "moveToWell",
-      "id": "15abc123",
+      "key": "15abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1396,7 +1396,7 @@
     },
     {
       "commandType": "moveToWell",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "destPlateId",
@@ -1411,7 +1411,7 @@
     },
     {
       "commandType": "dropTip",
-      "id": "17abc123",
+      "key": "17abc123",
       "params": {
         "pipetteId": "pipetteId",
         "labwareId": "fixedTrash",
@@ -1420,7 +1420,7 @@
     },
     {
       "commandType": "waitForResume",
-      "id": "18abc123",
+      "key": "18abc123",
       "params": {
         "message": "pause command"
       }
@@ -1428,7 +1428,7 @@
 
     {
       "commandType": "moveToCoordinates",
-      "id": "16abc123",
+      "key": "16abc123",
       "params": {
         "pipetteId": "pipetteId",
         "coordinates": { "x": 0, "y": 0, "z": 0 },
@@ -1438,7 +1438,7 @@
     },
     {
       "commandType": "moveRelative",
-      "id": "18abc123",
+      "key": "18abc123",
       "params": {
         "pipetteId": "pipetteId",
         "axis": "x",
@@ -1447,7 +1447,7 @@
     },
     {
       "commandType": "moveRelative",
-      "id": "19abc123",
+      "key": "19abc123",
       "params": {
         "pipetteId": "pipetteId",
         "axis": "y",
@@ -1456,14 +1456,14 @@
     },
     {
       "commandType": "savePosition",
-      "id": "21abc123",
+      "key": "21abc123",
       "params": {
         "pipetteId": "pipetteId"
       }
     },
     {
       "commandType": "moveRelative",
-      "id": "20abc123",
+      "key": "20abc123",
       "params": {
         "pipetteId": "pipetteId",
         "axis": "z",
@@ -1472,7 +1472,7 @@
     },
     {
       "commandType": "savePosition",
-      "id": "21abc123",
+      "key": "21abc123",
       "params": {
         "pipetteId": "pipetteId",
         "positionId": "positionId"


### PR DESCRIPTION
replace all instances of Command `id` with `key` in the v7 protocol fixtures(v8 doesn't have any instances of `id`)
continuation of #15690 
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
