### PR TITLE
feat(protocol-designer): put comment step behind ff

### DIFF
--- a/protocol-designer/src/components/StepCreationButton.tsx
+++ b/protocol-designer/src/components/StepCreationButton.tsx
@@ -21,6 +21,7 @@ import {
   selectors as stepFormSelectors,
   getIsModuleOnDeck,
 } from '../step-forms'
+import { getEnableComment } from '../feature-flags/selectors'
 import {
   ConfirmDeleteModal,
   CLOSE_UNSAVED_STEP_FORM,
@@ -105,19 +106,33 @@ export function StepButtonItem(props: StepButtonItemProps): JSX.Element {
 }
 
 export const StepCreationButton = (): JSX.Element => {
+  const enableComment = useSelector(getEnableComment)
+
   const getSupportedSteps = (): Array<
     Exclude<StepType, 'manualIntervention'>
-  > => [
-    'comment',
-    'moveLabware',
-    'moveLiquid',
-    'mix',
-    'pause',
-    'heaterShaker',
-    'magnet',
-    'temperature',
-    'thermocycler',
-  ]
+  > =>
+    enableComment
+      ? [
+          'comment',
+          'moveLabware',
+          'moveLiquid',
+          'mix',
+          'pause',
+          'heaterShaker',
+          'magnet',
+          'temperature',
+          'thermocycler',
+        ]
+      : [
+          'moveLabware',
+          'moveLiquid',
+          'mix',
+          'pause',
+          'heaterShaker',
+          'magnet',
+          'temperature',
+          'thermocycler',
+        ]
 
   const currentFormIsPresaved = useSelector(
     stepFormSelectors.getCurrentFormIsPresaved
@@ -131,7 +146,7 @@ export const StepCreationButton = (): JSX.Element => {
     Exclude<StepType, 'manualIntervention'>,
     boolean
   > = {
-    comment: true,
+    comment: enableComment,
     moveLabware: true,
     moveLiquid: true,
     mix: true,

--- a/protocol-designer/src/components/__tests__/StepCreationButton.test.tsx
+++ b/protocol-designer/src/components/__tests__/StepCreationButton.test.tsx
@@ -9,10 +9,12 @@ import {
 } from '../../step-forms/selectors'
 import { getIsMultiSelectMode } from '../../ui/steps'
 import { i18n } from '../../localization'
+import { getEnableComment } from '../../feature-flags/selectors'
 import { StepCreationButton } from '../StepCreationButton'
 
 vi.mock('../../step-forms/selectors')
 vi.mock('../../ui/steps')
+vi.mock('../../feature-flags/selectors')
 
 const render = () => {
   return renderWithProviders(<StepCreationButton />, { i18nInstance: i18n })[0]
@@ -20,6 +22,7 @@ const render = () => {
 
 describe('StepCreationButton', () => {
   beforeEach(() => {
+    vi.mocked(getEnableComment).mockReturnValue(true)
     vi.mocked(getCurrentFormIsPresaved).mockReturnValue(false)
     vi.mocked(getCurrentFormHasUnsavedChanges).mockReturnValue(false)
     vi.mocked(getIsMultiSelectMode).mockReturnValue(false)
@@ -34,6 +37,7 @@ describe('StepCreationButton', () => {
     render()
     const addStep = screen.getByRole('button', { name: '+ Add Step' })
     fireEvent.click(addStep)
+    screen.getByText('comment')
     screen.getByText('move labware')
     screen.getByText('transfer')
     screen.getByText('mix')

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -27,6 +27,7 @@ const initialFlags: Flags = {
     process.env.OT_PD_ENABLE_ABSORBANCE_READER === '1' || false,
   OT_PD_ENABLE_REDESIGN: process.env.OT_PD_ENABLE_REDESIGN === '1' || false,
   OT_PD_ENABLE_MOAM: process.env.OT_PD_ENABLE_MOAM === '1' || false,
+  OT_PD_ENABLE_COMMENT: process.env.OT_PD_ENABLE_COMMENT === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -37,3 +37,7 @@ export const getEnableMoam: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_MOAM ?? false
 )
+export const getEnableComment: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_COMMENT ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -32,6 +32,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_ABSORBANCE_READER'
   | 'OT_PD_ENABLE_REDESIGN'
   | 'OT_PD_ENABLE_MOAM'
+  | 'OT_PD_ENABLE_COMMENT'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',
@@ -43,5 +44,6 @@ export const allFlags: FlagTypes[] = [
   'OT_PD_ENABLE_ABSORBANCE_READER',
   'OT_PD_ENABLE_REDESIGN',
   'OT_PD_ENABLE_MOAM',
+  'OT_PD_ENABLE_COMMENT',
 ]
 export type Flags = Partial<Record<FlagTypes, boolean | null | undefined>>

--- a/protocol-designer/src/localization/en/feature_flags.json
+++ b/protocol-designer/src/localization/en/feature_flags.json
@@ -23,5 +23,9 @@
   "OT_PD_ENABLE_MOAM": {
     "title": "Enable multiple modules",
     "description": "Enable multiple heater-shakers and magnetic blocks for Flex only."
+  },
+  "OT_PD_ENABLE_COMMENT": {
+    "title": "Enable comment step",
+    "description": "You can add comments anywhere between timeline steps."
   }
 }

--- a/protocol-designer/src/localization/en/tooltip.json
+++ b/protocol-designer/src/localization/en/tooltip.json
@@ -15,6 +15,7 @@
   "y_position_value": "A negative value moves towards the front",
 
   "step_description": {
+    "comment": "Add a comment anywhere between steps in your protocol",
     "heaterShaker": "Set heat, shake, or labware latch commands for the Heater-Shaker module",
     "magnet": "Engage or disengage the Magnetic module.",
     "mix": "Mix contents of wells/tubes.",


### PR DESCRIPTION
closes AUTH-570

# Overview

Trying to keep PD in edge clean of new features so we can do potential small releases off of edge before the PD redesign release. So I put the comment command step behind a ff!

# Test Plan

create a flex or ot-2 protocol and go to the timeline. see that Comment does not show up. Then turn on the comment ff and see that the comment step does show up.

# Changelog

- create comment ff and put comment step creation button behind ff
- add test case

# Review requests

see test plan

# Risk assessment

low