### PR TITLE
fix(scripts): setuptools v71 removed the need for extern

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -56,13 +56,17 @@ def normalize_version(package, project, extra_tag='', git_dir=None):
     # the way they vendor dependencies, like the packaging module that
     # provides the way to normalize version numbers for wheel file names. So
     # we try all the possible ways to find it.
+    # Since 71.0.0 they have removed the need for extern
+    # So depending on the version of 3.10 you're building on you may or may not
+    # need to use the extern or import it directly
     try:
-        # new way
         import setuptools
         major, minor, patch = [int(x, 10) for x in setuptools.__version__.split('.')]
         if major < 71:
+            # new way
             from setuptools.extern import packaging
         else:
+            # new new way
             import packaging
     except ImportError:
         # old way

--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -58,7 +58,12 @@ def normalize_version(package, project, extra_tag='', git_dir=None):
     # we try all the possible ways to find it.
     try:
         # new way
-        from setuptools.extern import packaging
+        import setuptools
+        major, minor, patch = [int(x, 10) for x in setuptools.__version__.split('.')]
+        if major < 71:
+            from setuptools.extern import packaging
+        else:
+            import packaging
     except ImportError:
         # old way
         from pkg_resources.extern import packaging


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Version 71.0.0 removed the setuptools.extern package and release on 07/18/2024

With this we no longer need to use `from setuptools.extern import packaging` and we can just `import packaging`
However depending on the version of 3.10 you may still have 70.3.0 and packaging < 24.0 so we need to navigate around the old and new.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
