### PR TITLE
build: Sign windows builds via remote key storage

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -220,6 +220,10 @@ jobs:
             echo 'type=develop' >> $GITHUB_OUTPUT
           fi
 
+      - name: set summary
+        run: |
+          echo Type: ${{steps.determine-build-type.outputs.type}} Variants: ${{steps.determine-build-type.outputs.variants}}' >> $GITHUB_STEP_SUMMARY
+
   build-app:
     needs: [determine-build-type]
     if: needs.determine-build-type.outputs.variants != '[]'
@@ -297,7 +301,7 @@ jobs:
           make setup-js
 
       - name: 'Configure Windows code signing environment'
-        if: contains(matrix.platform, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
+        if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         run:
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
@@ -305,7 +309,7 @@ jobs:
           echo "C:\Program Files\DigiCert\ DigiCert Keylocker Tools" >> $GITHUB_PATH
 
       - name: 'Setup Windows code signing helpers'
-        if: contains(matrix.platform, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
+        if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: cmd
         env:
           SM_HOST: ${{ secrets.SM_HOST }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -307,7 +307,7 @@ jobs:
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
-          echo "C:\Program Files\DigiCert\ DigiCert Keylocker Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
 
       - name: 'Setup Windows code signing helpers'
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -303,7 +303,7 @@ jobs:
       - name: 'Configure Windows code signing environment'
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
         shell: bash
-        run:
+        run: |
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -185,18 +185,35 @@ jobs:
             echo "both develop builds for edge"
             echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
             echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [ "${{ format('{0}', endsWith(github.ref, 'app-build-internal')) }}" = "true" ] ; then
-            echo "internal-release builds for app-build-internal suffixes"
+          elif [ "${{ format('{0}', contains(github.ref, 'app-build-internal')) }}" = "true" ] ; then
+
             echo 'variants=["internal-release"]' >> $GITHUB_OUTPUT
-            echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [ "${{ format('{0}', endsWith(github.ref, 'app-build')) }}" = "true" ] ; then
-            echo "release develop builds for app-build suffixes"
+            if [ "${{ format('{0}', contains(github.ref, 'as-release')) }}" = "true" ] ; then
+               echo "internal-release as-release builds for app-build-internal + as-release suffixes"
+               echo 'type=as-release' >> $GITHUB_OUTPUT
+            else
+               echo "internal-release develop builds for app-build-internal suffixes"
+               echo 'type=develop' >> $GITHUB_OUTPUT
+            fi
+          elif [ "${{ format('{0}', contains(github.ref, 'app-build')) }}" = "true" ] ; then
             echo 'variants=["release"]' >> $GITHUB_OUTPUT
-            echo 'type=develop' >> $GITHUB_OUTPUT
-          elif [ "${{ format('{0}', endsWith(github.ref, 'app-build-both')) }}" = "true" ] ; then
-            echo "Both develop builds for app-build-both suffixes"
+            if [ "${{ format('{0}', contains(github.ref, 'as-release')) }}" = "true" ] ; then
+               echo "release as-release builds for app-build + as-release suffixes"
+               echo 'type=as-release' >> $GITHUB_OUTPUT
+            else
+               echo "release develop builds for app-build suffixes"
+               echo 'type=develop' >> $GITHUB_OUTPUT
+            fi
+          elif [ "${{ format('{0}', contains(github.ref, 'app-build-both')) }}" = "true" ] ; then
+
             echo 'variants=["release", "internal-release"]' >> $GITHUB_OUTPUT
-            echo 'type=develop' >> $GITHUB_OUTPUT
+            if [ "${{ format('{0}', contains(github.ref, 'as-release')) }}" = "true" ] ; then
+               echo "Both as-release builds for app-build-both + as-release suffixes"
+               echo 'type=as-release' >> $GITHUB_OUTPUT
+            else
+               echo "Both develop builds for app-build-both + as-release suffixes"
+               echo 'type=develop' >> $GITHUB_OUTPUT
+            fi
           else
             echo "No build for ref ${{github.ref}} and event ${{github.event_type}}"
             echo 'variants=[]' >> $GITHUB_OUTPUT
@@ -278,6 +295,31 @@ jobs:
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
           make setup-js
+
+      - name: 'Configure Windows code signing environment'
+        if: contains(matrix.platform, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
+        run:
+          echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+          echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+          echo "C:\Program Files\DigiCert\ DigiCert Keylocker Tools" >> $GITHUB_PATH
+
+      - name: 'Setup Windows code signing helpers'
+        if: contains(matrix.platform, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
+        shell: cmd
+        env:
+          SM_HOST: ${{ secrets.SM_HOST }}
+          SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
+          SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD}}
+          SM_API_KEY: ${{secrets.SM_API_KEY}}
+        run: |
+          curl -X GET  https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download -H "x-api-key:${{secrets.SM_API_KEY}}" -o Keylockertools-windows-x64.msi
+          msiexec /i Keylockertools-windows-x64.msi /quiet /qn
+          smksp_registrar.exe list
+          smctl.exe keypair ls
+          C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+          smksp_cert_sync.exe
+
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
         if: matrix.target == 'desktop'
@@ -285,8 +327,11 @@ jobs:
         env:
           OT_APP_MIXPANEL_ID: ${{ secrets.OT_APP_MIXPANEL_ID }}
           OT_APP_INTERCOM_ID: ${{ secrets.OT_APP_INTERCOM_ID }}
-          WIN_CSC_LINK: ${{ secrets.OT_APP_CSC_WINDOWS }}
-          WIN_CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_WINDOWS }}
+          WINDOWS_SIGN: ${{ format('{0}', contains(needs.determine-build-type.outputs.type, 'release')) }}
+          SM_HOST: ${{secrets.SM_HOST}}
+          SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
+          SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD}}
+          SM_API_KEY: ${{secrets.SM_API_KEY}}
           CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
           CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
           APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -324,6 +324,7 @@ jobs:
           smctl.exe keypair ls
           C:\Windows\System32\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
           smksp_cert_sync.exe
+          smctl.exe healthcheck --all
 
       # build the desktop app and deploy it
       - name: 'build ${{matrix.variant}} app for ${{ matrix.os }}'
@@ -338,6 +339,7 @@ jobs:
           SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD}}
           SM_API_KEY: ${{secrets.SM_API_KEY}}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{secrets.SM_CODE_SIGNING_CERT_SHA1_HASH}}
+          SM_KEYPAIR_ALIAS: ${{secrets.SM_KEYPAIR_ALIAS}}
           CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
           CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
           APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -305,7 +305,7 @@ jobs:
         shell: bash
         run: |
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
-          echo "${{ secrets.WINDOWS_CSC_B64}}" | base64 --decode > /d/opentrons_labworks_inc.p7b
+          echo "${{ secrets.WINDOWS_CSC_B64}}" | base64 --decode > /d/opentrons_labworks_inc.crt
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
           echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
@@ -341,7 +341,7 @@ jobs:
           SM_API_KEY: ${{secrets.SM_API_KEY}}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{secrets.SM_CODE_SIGNING_CERT_SHA1_HASH}}
           SM_KEYPAIR_ALIAS: ${{secrets.SM_KEYPAIR_ALIAS}}
-          WINDOWS_CSC_FILEPATH: "D:\\opentrons_labworks_inc.p7b"
+          WINDOWS_CSC_FILEPATH: "D:\\opentrons_labworks_inc.crt"
           CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
           CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
           APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -305,6 +305,7 @@ jobs:
         shell: bash
         run: |
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+          echo "${{ secrets.WINDOWS_CSC_B64}}" | base64 --decode > /d/opentrons_labworks_inc.p7b
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
           echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
           echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
@@ -340,6 +341,7 @@ jobs:
           SM_API_KEY: ${{secrets.SM_API_KEY}}
           SM_CODE_SIGNING_CERT_SHA1_HASH: ${{secrets.SM_CODE_SIGNING_CERT_SHA1_HASH}}
           SM_KEYPAIR_ALIAS: ${{secrets.SM_KEYPAIR_ALIAS}}
+          WINDOWS_CSC_FILEPATH: "D:\\opentrons_labworks_inc.p7b"
           CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
           CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
           APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -222,7 +222,7 @@ jobs:
 
       - name: set summary
         run: |
-          echo Type: ${{steps.determine-build-type.outputs.type}} Variants: ${{steps.determine-build-type.outputs.variants}}' >> $GITHUB_STEP_SUMMARY
+          echo 'Type: ${{steps.determine-build-type.outputs.type}} Variants: ${{steps.determine-build-type.outputs.variants}}' >> $GITHUB_STEP_SUMMARY
 
   build-app:
     needs: [determine-build-type]

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -337,6 +337,7 @@ jobs:
           SM_CLIENT_CERT_FILE: "D:\\Certificate_pkcs12.p12"
           SM_CLIENT_CERT_PASSWORD: ${{secrets.SM_CLIENT_CERT_PASSWORD}}
           SM_API_KEY: ${{secrets.SM_API_KEY}}
+          SM_CODE_SIGNING_CERT_SHA1_HASH: ${{secrets.SM_CODE_SIGNING_CERT_SHA1_HASH}}
           CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS }}
           CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS }}
           APPLE_ID: ${{ secrets.OT_APP_APPLE_ID }}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -302,6 +302,7 @@ jobs:
 
       - name: 'Configure Windows code signing environment'
         if: startsWith(matrix.os, 'windows') && contains(needs.determine-build-type.outputs.type, 'release')
+        shell: bash
         run:
           echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
           echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -75,7 +75,7 @@ module.exports = async () => ({
     icon: project === 'robot-stack' ? 'build/icon.ico' : 'build/three.ico',
     forceCodeSigning: WINDOWS_SIGN,
     rfc3161TimeStampServer: 'http://timestamp.digicert.com',
-    sign: 'script/windows-custom-sign.js',
+    sign: 'scripts/windows-custom-sign.js',
     signDlls: true,
     signingHashAlgorithms: ['sha256'],
   },

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -8,6 +8,7 @@ const {
 } = process.env
 const DEV_MODE = process.env.NODE_ENV !== 'production'
 const USE_PYTHON = process.env.NO_PYTHON !== 'true'
+const WINDOWS_SIGN = process.env.WINDOWS_SIGN === 'true'
 const project = process.env.OPENTRONS_PROJECT ?? 'robot-stack'
 
 // this will generate either
@@ -72,6 +73,11 @@ module.exports = async () => ({
     target: ['nsis'],
     publisherName: 'Opentrons Labworks Inc.',
     icon: project === 'robot-stack' ? 'build/icon.ico' : 'build/three.ico',
+    forceCodeSigning: WINDOWS_SIGN,
+    rfc3161TimeStampServer: 'http://timestamp.digicert.com',
+    sign: 'script/windows-custom-sign.js',
+    signDlls: true,
+    signingHashAlgorithms: ['sha256'],
   },
   nsis: {
     oneClick: false,

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -15,18 +15,21 @@ exports.default = async configuration => {
     const signProcess = execSync(signCmd, {
       stdio: 'pipe',
     })
-    const stdout = signProcess.stdout.read()
-    const stderr = signProcess.stderr.read()
-    console.log(`Sign stdout: ${stdout.toString()}`)
-    console.log(`Sign stderr: ${stderr.toString()}`)
+    console.log(`Sign success!`)
+    console.log(
+      `Sign stdout: ${signProcess?.stdout?.toString() ?? '<no output>'}`
+    )
+    console.log(
+      `Sign stderr: ${signProcess?.stderr?.toString() ?? '<no output>'}`
+    )
     console.log(`Sign code: ${signProcess.code}`)
   } catch (err) {
     console.error(`Exception running sign: ${err.status}!
 Process stdout:
- ${err.stdout.toString()}
+ ${err?.stdout?.toString() ?? '<no output>'}
 -------------
 Process stderr:
-${err.stdout.toString()}
+${err?.stdout?.toString() ?? '<no output>'}
 -------------
 `)
     throw err
@@ -37,18 +40,21 @@ ${err.stdout.toString()}
   console.log(verifyCmd)
   try {
     const verifyProcess = execSync(verifyCmd, { stdio: 'pipe' })
-    const stdout = verifyProcess.stdout.read()
-    const stderr = verifyProcess.stderr.read()
-    console.log(`Verify stdout: ${stdout}`)
-    console.log(`Verify stderr: ${stderr}`)
+    console.log(`Verify success!`)
+    console.log(
+      `Verify stdout: ${verifyProcess?.stdout?.toString() ?? '<no output>'}`
+    )
+    console.log(
+      `Verify stderr: ${verifyProcess?.stderr?.toString() ?? '<no output>'}`
+    )
   } catch (err) {
     console.error(`
 Exception running verification: ${err.status}!
 Process stdout:
- ${err.stdout.toString()}
+ ${err?.stdout?.toString() ?? '<no output>'}
 --------------
 Process stderr:
- ${err.stderr.toString()}
+ ${err?.stderr?.toString() ?? '<no output>'}
 --------------
 `)
     throw err

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -6,18 +6,22 @@ const { execSync } = require('node:child_process')
 
 exports.default = async configuration => {
   try {
-    execSync(
-      `smctl sign --fingerprint="${
-        process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
-      }" --input "${String(configuration.path)}"`,
-      {
-        stdio: 'inherit',
-      }
-    )
-    console.log(
-      `Signed ${configuration.path} with ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH}`
-    )
-  } catch (error) {
-    console.error(`Signing ${configuration.path}: failed:`, error)
-  }
+    const cmd = `smctl sign --fingerprint="${
+      process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
+    }" --input "${String(
+      configuration.path
+    )}" --exit-non-zero-on-fail --failfast --verbose`
+    console.log(cmd)
+    try {
+       const process = execSync(cmd, {
+         stdio: 'pipe',
+       })
+    } catch (err) {
+      console.log(`Exception running sign: ${err.code}`)
+    }
+    const stdout = process.stdout.read()
+    const stderr = process.stderr.read()
+    console.log(`Sign stdout: ${stdout.toString()}`)
+    console.log(`Sign stderr: ${stderr.toString()}`)
+    console.log(`Sign code: ${process.code}`)
 }

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -5,9 +5,9 @@
 const { execSync } = require('node:child_process')
 
 exports.default = async configuration => {
-  const cmd = `smctl sign --fingerprint="${
-    process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
-  }" --input "${String(
+  const signCmd = `smctl sign --keypair-alias="${String(
+    process.env.SM_KEYPAIR_ALIAS
+  )}" --input "${String(
     configuration.path
   )}" --exit-non-zero-on-fail --failfast --verbose`
   console.log(cmd)
@@ -21,11 +21,36 @@ exports.default = async configuration => {
     console.log(`Sign stderr: ${stderr.toString()}`)
     console.log(`Sign code: ${process.code}`)
   } catch (err) {
-    console.error(
-      `Exception running sign: ${
-        err.status
-      }! Output: ${err.stdout.toString()} Error: ${err.stdout.toString()}`
-    )
+    console.error(`Exception running sign: ${err.status}!
+Process stdout:
+ ${err.stdout.toString()}
+-------------
+Process stderr:
+${err.stdout.toString()}
+-------------
+`)
+    throw err
+  }
+  const verifyCmd = `smctl sign verify --fingerprint-string="${String(
+    process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
+  )}" --input="${String(configuration.path)}" --verbose`
+  console.log(verifyCmd)
+  try {
+    const verifyProcess = execSync(verifyCmd, { stdio: 'pipe' })
+    const stdout = process.stdout.read()
+    const stderr = process.stderr.read()
+    console.log(`Verify stdout: ${stdout}`)
+    console.log(`Verify stderr: ${stderr}`)
+  } catch (err) {
+    console.error(`
+Exception running verification: ${err.status}!
+Process stdout:
+ ${err.stdout.toString()}
+--------------
+Process stderr:
+ ${err.stderr.toString()}
+--------------
+`)
     throw err
   }
 }

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -7,8 +7,8 @@ const { execSync } = require('node:child_process')
 exports.default = async configuration => {
   const signCmd = `smctl sign --keypair-alias="${String(
     process.env.SM_KEYPAIR_ALIAS
-  )}" --input "${String(
-    configuration.path
+  )}" --input "${String(configuration.path)}" --certificate="${String(
+    process.env.WINDOWS_CSC_FILEPATH
   )}" --exit-non-zero-on-fail --failfast --verbose`
   console.log(signCmd)
   try {

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -21,6 +21,13 @@ exports.default = async configuration => {
     console.log(`Sign stderr: ${stderr.toString()}`)
     console.log(`Sign code: ${process.code}`)
   } catch (err) {
-    console.log(`Exception running sign: ${err.code}`)
+    console.error(
+      `Exception running sign:`,
+      err,
+      process,
+      process.stdout.toString(),
+      process.stderr.toString()
+    )
+    throw err
   }
 }

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -34,7 +34,7 @@ ${err?.stdout?.toString() ?? '<no output>'}
 `)
     throw err
   }
-  const verifyCmd = `smctl sign verify --fingerprint-string="${String(
+  const verifyCmd = `smctl sign verify --fingerprint="${String(
     process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
   )}" --input="${String(configuration.path)}" --verbose`
   console.log(verifyCmd)

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -5,23 +5,22 @@
 const { execSync } = require('node:child_process')
 
 exports.default = async configuration => {
+  const cmd = `smctl sign --fingerprint="${
+    process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
+  }" --input "${String(
+    configuration.path
+  )}" --exit-non-zero-on-fail --failfast --verbose`
+  console.log(cmd)
   try {
-    const cmd = `smctl sign --fingerprint="${
-      process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
-    }" --input "${String(
-      configuration.path
-    )}" --exit-non-zero-on-fail --failfast --verbose`
-    console.log(cmd)
-    try {
-       const process = execSync(cmd, {
-         stdio: 'pipe',
-       })
-    } catch (err) {
-      console.log(`Exception running sign: ${err.code}`)
-    }
+    const process = execSync(cmd, {
+      stdio: 'pipe',
+    })
     const stdout = process.stdout.read()
     const stderr = process.stderr.read()
     console.log(`Sign stdout: ${stdout.toString()}`)
     console.log(`Sign stderr: ${stderr.toString()}`)
     console.log(`Sign code: ${process.code}`)
+  } catch (err) {
+    console.log(`Exception running sign: ${err.code}`)
+  }
 }

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -10,16 +10,16 @@ exports.default = async configuration => {
   )}" --input "${String(
     configuration.path
   )}" --exit-non-zero-on-fail --failfast --verbose`
-  console.log(cmd)
+  console.log(signCmd)
   try {
-    const process = execSync(cmd, {
+    const signProcess = execSync(signCmd, {
       stdio: 'pipe',
     })
-    const stdout = process.stdout.read()
-    const stderr = process.stderr.read()
+    const stdout = signProcess.stdout.read()
+    const stderr = signProcess.stderr.read()
     console.log(`Sign stdout: ${stdout.toString()}`)
     console.log(`Sign stderr: ${stderr.toString()}`)
-    console.log(`Sign code: ${process.code}`)
+    console.log(`Sign code: ${signProcess.code}`)
   } catch (err) {
     console.error(`Exception running sign: ${err.status}!
 Process stdout:
@@ -37,8 +37,8 @@ ${err.stdout.toString()}
   console.log(verifyCmd)
   try {
     const verifyProcess = execSync(verifyCmd, { stdio: 'pipe' })
-    const stdout = process.stdout.read()
-    const stderr = process.stderr.read()
+    const stdout = verifyProcess.stdout.read()
+    const stderr = verifyProcess.stderr.read()
     console.log(`Verify stdout: ${stdout}`)
     console.log(`Verify stderr: ${stderr}`)
   } catch (err) {

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -22,11 +22,9 @@ exports.default = async configuration => {
     console.log(`Sign code: ${process.code}`)
   } catch (err) {
     console.error(
-      `Exception running sign:`,
-      err,
-      process,
-      process.stdout.toString(),
-      process.stderr.toString()
+      `Exception running sign: ${
+        err.status
+      }! Output: ${err.stdout.toString()} Error: ${err.stdout.toString()}`
     )
     throw err
   }

--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -1,0 +1,23 @@
+// from https://github.com/electron-userland/electron-builder/issues/7605
+
+'use strict'
+
+const { execSync } = require('node:child_process')
+
+exports.default = async configuration => {
+  try {
+    execSync(
+      `smctl sign --fingerprint="${
+        process.env.SM_CODE_SIGNING_CERT_SHA1_HASH
+      }" --input "${String(configuration.path)}"`,
+      {
+        stdio: 'inherit',
+      }
+    )
+    console.log(
+      `Signed ${configuration.path} with ${process.env.SM_CODE_SIGNING_CERT_SHA1_HASH}`
+    )
+  } catch (error) {
+    console.error(`Signing ${configuration.path}: failed:`, error)
+  }
+}


### PR DESCRIPTION
Integrates code signing with a key stored in digicert one to app build workflows.

There are a couple caveats:
- You can do this locally if you have a windows machine and if you have the right accounts and permissions. Read: you basically can't do this locally
- Digicert for some reason charges per signature. We sign a lot of stuff. Therefore, we are only going to produce signed windows builds for releases and if a dev really needs to by pushing a branch that has "as-release" in it (in the same way we only do app builds if you push a branch that has app-build in it - so building and signing both windows apps would require a branch that has app-build-both-as-release in it)
- This just doesn't work at all with electron-builder, and they don't seem to want to change things to fix it; specifically, you can only configure e-b to pass along a key link and a password, and you basically can't do that anymore. So we have to have a (thankfully simple) custom sign script.

Closes RDEVOPS-128

## to leave draft
- [x] this produces a signed installer that passes smartscreen
- [x] this only does that on branches with the right kinds of names