### PR TITLE
feat(app): "Ignore this error" during Error Recovery

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/FillWellAndSkip.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/FillWellAndSkip.tsx
@@ -86,7 +86,7 @@ export function SkipToNextStep(
     proceedToRouteAndStep,
   } = routeUpdateActions
   const { selectedRecoveryOption } = currentRecoveryOptionUtils
-  const { skipFailedCommand, resumeRun } = recoveryCommands
+  const { skipFailedCommand } = recoveryCommands
   const { ROBOT_SKIPPING_STEP, IGNORE_AND_SKIP } = RECOVERY_MAP
   const { t } = useTranslation('error_recovery')
 
@@ -100,11 +100,9 @@ export function SkipToNextStep(
   }
 
   const primaryBtnOnClick = (): Promise<void> => {
-    return setRobotInMotion(true, ROBOT_SKIPPING_STEP.ROUTE)
-      .then(() => skipFailedCommand())
-      .then(() => {
-        resumeRun()
-      })
+    return setRobotInMotion(true, ROBOT_SKIPPING_STEP.ROUTE).then(() => {
+      skipFailedCommand()
+    })
   }
 
   const buildBodyText = (): JSX.Element => {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SkipStepNewTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SkipStepNewTips.tsx
@@ -48,17 +48,15 @@ export function SkipStepNewTips(
 
 export function SkipStepWithNewTips(props: RecoveryContentProps): JSX.Element {
   const { recoveryCommands, routeUpdateActions } = props
-  const { skipFailedCommand, resumeRun } = recoveryCommands
+  const { skipFailedCommand } = recoveryCommands
   const { setRobotInMotion } = routeUpdateActions
   const { ROBOT_SKIPPING_STEP } = RECOVERY_MAP
   const { t } = useTranslation('error_recovery')
 
   const primaryBtnOnClick = (): Promise<void> => {
-    return setRobotInMotion(true, ROBOT_SKIPPING_STEP.ROUTE)
-      .then(() => skipFailedCommand())
-      .then(() => {
-        resumeRun()
-      })
+    return setRobotInMotion(true, ROBOT_SKIPPING_STEP.ROUTE).then(() => {
+      skipFailedCommand()
+    })
   }
 
   const buildBodyText = (): JSX.Element => {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SkipStepSameTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SkipStepSameTips.tsx
@@ -29,17 +29,15 @@ export function SkipStepSameTips(props: RecoveryContentProps): JSX.Element {
 
 export function SkipStepSameTipsInfo(props: RecoveryContentProps): JSX.Element {
   const { routeUpdateActions, recoveryCommands } = props
-  const { skipFailedCommand, resumeRun } = recoveryCommands
+  const { skipFailedCommand } = recoveryCommands
   const { setRobotInMotion } = routeUpdateActions
   const { ROBOT_SKIPPING_STEP } = RECOVERY_MAP
   const { t } = useTranslation('error_recovery')
 
   const primaryBtnOnClick = (): Promise<void> => {
-    return setRobotInMotion(true, ROBOT_SKIPPING_STEP.ROUTE)
-      .then(() => skipFailedCommand())
-      .then(() => {
-        resumeRun()
-      })
+    return setRobotInMotion(true, ROBOT_SKIPPING_STEP.ROUTE).then(() => {
+      skipFailedCommand()
+    })
   }
 
   const buildBodyText = (): JSX.Element => {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/FillWellAndSkip.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/FillWellAndSkip.test.tsx
@@ -141,14 +141,12 @@ describe('SkipToNextStep', () => {
   let mockGoBackPrevStep: Mock
   let mockProceedToRouteAndStep: Mock
   let mockSkipFailedCommand: Mock
-  let mockResumeRun: Mock
 
   beforeEach(() => {
     mockSetRobotInMotion = vi.fn(() => Promise.resolve())
     mockGoBackPrevStep = vi.fn()
     mockProceedToRouteAndStep = vi.fn()
     mockSkipFailedCommand = vi.fn(() => Promise.resolve())
-    mockResumeRun = vi.fn()
 
     props = {
       ...mockRecoveryContentProps,
@@ -159,7 +157,6 @@ describe('SkipToNextStep', () => {
       } as any,
       recoveryCommands: {
         skipFailedCommand: mockSkipFailedCommand,
-        resumeRun: mockResumeRun,
       } as any,
     }
   })
@@ -197,15 +194,9 @@ describe('SkipToNextStep', () => {
     await waitFor(() => {
       expect(mockSkipFailedCommand).toHaveBeenCalled()
     })
-    await waitFor(() => {
-      expect(mockResumeRun).toHaveBeenCalled()
-    })
 
     expect(mockSetRobotInMotion.mock.invocationCallOrder[0]).toBeLessThan(
       mockSkipFailedCommand.mock.invocationCallOrder[0]
-    )
-    expect(mockSkipFailedCommand.mock.invocationCallOrder[0]).toBeLessThan(
-      mockResumeRun.mock.invocationCallOrder[0]
     )
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SkipStepNewTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SkipStepNewTips.test.tsx
@@ -124,12 +124,10 @@ describe('SkipStepWithNewTips', () => {
   let props: React.ComponentProps<typeof SkipStepWithNewTips>
   let mockSetRobotInMotion: Mock
   let mockSkipFailedCommand: Mock
-  let mockResumeRun: Mock
 
   beforeEach(() => {
     mockSetRobotInMotion = vi.fn(() => Promise.resolve())
     mockSkipFailedCommand = vi.fn(() => Promise.resolve())
-    mockResumeRun = vi.fn()
 
     props = {
       ...mockRecoveryContentProps,
@@ -138,7 +136,6 @@ describe('SkipStepWithNewTips', () => {
       } as any,
       recoveryCommands: {
         skipFailedCommand: mockSkipFailedCommand,
-        resumeRun: mockResumeRun,
       } as any,
     }
   })
@@ -169,15 +166,9 @@ describe('SkipStepWithNewTips', () => {
     await waitFor(() => {
       expect(mockSkipFailedCommand).toHaveBeenCalled()
     })
-    await waitFor(() => {
-      expect(mockResumeRun).toHaveBeenCalled()
-    })
 
     expect(mockSetRobotInMotion.mock.invocationCallOrder[0]).toBeLessThan(
       mockSkipFailedCommand.mock.invocationCallOrder[0]
-    )
-    expect(mockSkipFailedCommand.mock.invocationCallOrder[0]).toBeLessThan(
-      mockResumeRun.mock.invocationCallOrder[0]
     )
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SkipStepSameTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/SkipStepSameTips.test.tsx
@@ -72,12 +72,10 @@ describe('SkipStepSameTipsInfo', () => {
   let props: React.ComponentProps<typeof SkipStepSameTipsInfo>
   let mockSetRobotInMotion: Mock
   let mockSkipFailedCommand: Mock
-  let mockResumeRun: Mock
 
   beforeEach(() => {
     mockSetRobotInMotion = vi.fn(() => Promise.resolve())
     mockSkipFailedCommand = vi.fn(() => Promise.resolve())
-    mockResumeRun = vi.fn()
 
     props = {
       ...mockRecoveryContentProps,
@@ -86,7 +84,6 @@ describe('SkipStepSameTipsInfo', () => {
       } as any,
       recoveryCommands: {
         skipFailedCommand: mockSkipFailedCommand,
-        resumeRun: mockResumeRun,
       } as any,
     }
   })
@@ -114,18 +111,13 @@ describe('SkipStepSameTipsInfo', () => {
         RECOVERY_MAP.ROBOT_SKIPPING_STEP.ROUTE
       )
     })
+
     await waitFor(() => {
       expect(mockSkipFailedCommand).toHaveBeenCalled()
-    })
-    await waitFor(() => {
-      expect(mockResumeRun).toHaveBeenCalled()
     })
 
     expect(mockSetRobotInMotion.mock.invocationCallOrder[0]).toBeLessThan(
       mockSkipFailedCommand.mock.invocationCallOrder[0]
-    )
-    expect(mockSkipFailedCommand.mock.invocationCallOrder[0]).toBeLessThan(
-      mockResumeRun.mock.invocationCallOrder[0]
     )
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -221,25 +221,23 @@ describe('useRecoveryCommands', () => {
     )
   })
 
-  it('should call skipFailedCommand and resolve after a timeout', async () => {
+  it('should call skipFailedCommand and show success toast on success', async () => {
     const { result } = renderHook(() =>
       useRecoveryCommands({
         runId: mockRunId,
         failedCommand: mockFailedCommand,
         failedLabwareUtils: mockFailedLabwareUtils,
         routeUpdateActions: mockRouteUpdateActions,
-        recoveryToastUtils: {} as any,
+        recoveryToastUtils: { makeSuccessToast: mockMakeSuccessToast } as any,
       })
     )
-
-    const consoleSpy = vi.spyOn(console, 'log')
 
     await act(async () => {
       await result.current.skipFailedCommand()
     })
 
-    expect(consoleSpy).toHaveBeenCalledWith('SKIPPING TO NEXT STEP')
-    expect(result.current.skipFailedCommand()).resolves.toBeUndefined()
+    expect(mockResumeRunFromRecovery).toHaveBeenCalledWith(mockRunId)
+    expect(mockMakeSuccessToast).toHaveBeenCalled()
   })
 
   it('should call ignoreErrorKindThisRun and resolve immediately', async () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -29,8 +29,8 @@ export interface UseRecoveryCommandsResult {
   resumeRun: () => void
   /* A terminal recovery command that causes ER to exit as the run status becomes "stop-requested" */
   cancelRun: () => void
-  /* A non-terminal recovery command, but should generally be chained with a resumeRun. */
-  skipFailedCommand: () => Promise<void>
+  /* A terminal recovery command, that causes ER to exit as the run status becomes "running" */
+  skipFailedCommand: () => void
   /* A non-terminal recovery command. Ignore this errorKind for the rest of this run. */
   ignoreErrorKindThisRun: () => Promise<void>
   /* A non-terminal recovery command */
@@ -111,16 +111,11 @@ export function useRecoveryCommands({
     stopRun(runId)
   }, [runId])
 
-  // TODO(jh, 06-18-24): If this command is actually terminal for error recovery, remove the resumeRun currently promise
-  // chained where this is used. Also update docstring in iface.
-  const skipFailedCommand = React.useCallback((): Promise<void> => {
-    console.log('SKIPPING TO NEXT STEP')
-    return new Promise<void>(resolve => {
-      setTimeout(() => {
-        resolve()
-      }, 2000)
+  const skipFailedCommand = React.useCallback((): void => {
+    void resumeRunFromRecovery(runId).then(() => {
+      makeSuccessToast()
     })
-  }, [])
+  }, [runId, resumeRunFromRecovery, makeSuccessToast])
 
   const ignoreErrorKindThisRun = React.useCallback((): Promise<void> => {
     console.log('IGNORING ALL ERRORS OF THIS KIND THIS RUN')


### PR DESCRIPTION
Closes [EXEC-461](https://opentrons.atlassian.net/browse/EXEC-461)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds support for ignoring a specific instance of an error during error recovery. After discussion with @SyntaxColoring , we are safe with effectively issuing a "resumeRunFromRecovery" action.

https://github.com/user-attachments/assets/7c097c39-a0df-4f26-8c1d-e4226cd1c686

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- See video. A few recovery flows allow for ignoring, including "overpressure while dispensing", "no liquid detected", and "general error".
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added the ability to ignore an error once during Error Recovery.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low - it's essentially existing behavior with some toasts.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-461]: https://opentrons.atlassian.net/browse/EXEC-461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ