### PR TITLE
fix(api): check for nozzle map configuration when executing complex commands

### DIFF
--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -16,6 +16,7 @@ from typing import (
 from opentrons.protocol_api.labware import Labware, Well
 from opentrons import types
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
 
 
 if TYPE_CHECKING:
@@ -409,7 +410,11 @@ class TransferPlan:
         # then avoid iterating through its Wells.
         # ii. if using single channel pipettes, flatten a multi-dimensional
         # list of Wells into a 1 dimensional list of Wells
-        if self._instr.channels > 1:
+        if (
+            self._instr.channels > 1
+            and self._instr._core.get_nozzle_map().configuration
+            == NozzleConfigurationType.FULL
+        ):
             sources, dests = self._multichannel_transfer(sources, dests)
         else:
             if isinstance(sources, List) and isinstance(sources[0], List):

--- a/api/src/opentrons/protocols/advanced_control/transfers.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
     from opentrons.protocol_api import InstrumentContext
     from opentrons.protocols.execution.dev_types import Dictable
 
+_PARTIAL_TIP_SUPPORT_ADDED = APIVersion(2, 18)
+"""The version after which partial tip support and nozzle maps were made available."""
+
 
 class MixStrategy(enum.Enum):
     BOTH = enum.auto()
@@ -410,10 +413,14 @@ class TransferPlan:
         # then avoid iterating through its Wells.
         # ii. if using single channel pipettes, flatten a multi-dimensional
         # list of Wells into a 1 dimensional list of Wells
+        pipette_configuration_type = NozzleConfigurationType.FULL
+        if self._api_version >= _PARTIAL_TIP_SUPPORT_ADDED:
+            pipette_configuration_type = (
+                self._instr._core.get_nozzle_map().configuration
+            )
         if (
             self._instr.channels > 1
-            and self._instr._core.get_nozzle_map().configuration
-            == NozzleConfigurationType.FULL
+            and pipette_configuration_type == NozzleConfigurationType.FULL
         ):
             sources, dests = self._multichannel_transfer(sources, dests)
         else:

--- a/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
+++ b/api/tests/opentrons/protocol_api_integration/test_pipette_movement_deck_conflicts.py
@@ -124,7 +124,7 @@ def test_close_shave_deck_conflicts_for_96_ch_a12_column_configuration() -> None
         adapter="opentrons_flex_96_tiprack_adapter",
     )
     tiprack_8 = protocol_context.load_labware("opentrons_flex_96_tiprack_200ul", "B2")
-    hs = protocol_context.load_module("heaterShakerModuleV1", "D1")
+    hs = protocol_context.load_module("heaterShakerModuleV1", "C1")
     hs_adapter = hs.load_adapter("opentrons_96_deep_well_adapter")
     deepwell = hs_adapter.load_labware("nest_96_wellplate_2ml_deep")
     protocol_context.load_trash_bin("A3")


### PR DESCRIPTION
# Overview
Addresses RQA-2867

Previously any multi channel pipettes would not allow you to pass wells for transfers that were not in Row A. This allows partial configurations to be passed any well to target directly during transfers/consolidate/distribute/mix, similar to a single channel transfer. 

# Test Plan

Ensure OT-2 and Flex can utilize complex commands in protocols with expected movement results.

# Changelog

# Review requests

# Risk assessment
Because this allows users to pass any well, if they incorrectly count the wells they must index by it can lead to movement that does not behave in a desired fashion. However, conflict check will prevent executing layouts that would create a collision, so the safety risk is low.