### PR TITLE
feat(app): add the protocol run's current action count to the ODD

### DIFF
--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/RunningProtocolCommandList.tsx
@@ -18,6 +18,7 @@ import {
   SPACING,
   LegacyStyledText,
   TYPOGRAPHY,
+  StyledText,
 } from '@opentrons/components'
 import { RUN_STATUS_RUNNING, RUN_STATUS_IDLE } from '@opentrons/api-client'
 
@@ -221,8 +222,15 @@ export function RunningProtocolCommandList({
                 <Flex
                   key={command.id}
                   alignItems={ALIGN_CENTER}
-                  gridGap={SPACING.spacing8}
+                  gridGap={SPACING.spacing12}
                 >
+                  <StyledText
+                    minWidth={SPACING.spacing16}
+                    oddStyle="bodyTextRegular"
+                    height="1.75rem"
+                  >
+                    {index + 1}
+                  </StyledText>
                   <Flex
                     padding={`${SPACING.spacing12} ${SPACING.spacing24}`}
                     alignItems={ALIGN_CENTER}

--- a/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunningProtocolCommandList.test.tsx
+++ b/app/src/organisms/OnDeviceDisplay/RunningProtocol/__tests__/RunningProtocolCommandList.test.tsx
@@ -63,6 +63,11 @@ describe('RunningProtocolCommandList', () => {
     expect(mockShowModal).toHaveBeenCalled()
   })
 
+  it("it displays the run's current action number", () => {
+    render({ ...props, currentRunCommandIndex: 11 })
+    screen.getByText(12)
+  })
+
   // ToDo (kj:04/10/2023) once we fix the track event stuff, we can implement tests
   it.todo('when tapping play button, track event mock function is called')
 })


### PR DESCRIPTION
Closes [EXEC-561](https://opentrons.atlassian.net/browse/EXEC-561)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The current run action is displayed on the desktop app but is missing from the ODD. This adds it to the RunningProtocolCommandList. 

After a convo with Sue, we will probably want to revisit how we exactly get this number, as it's not technically the current step, but Design is ok with this for now.

<img width="1184" alt="Screenshot 2024-07-19 at 4 23 06 PM" src="https://github.com/user-attachments/assets/549f0a4c-28fb-407c-a353-6b4079081603">

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run a protocol. Check the ODD command list.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added an action count number to each running protocol command on the ODD. 
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-561]: https://opentrons.atlassian.net/browse/EXEC-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ