### PR TITLE
feat(step-generation): implement logic for collision detection with 96 partial pickup

### DIFF
--- a/step-generation/src/__tests__/aspirate.test.ts
+++ b/step-generation/src/__tests__/aspirate.test.ts
@@ -70,6 +70,7 @@ describe('aspirate', () => {
       tipRack: 'tiprack1Id',
       xOffset: 0,
       yOffset: 0,
+      nozzles: null,
     }
     const result = aspirate(params, invariantContext, robotStateWithTip)
     expect(getSuccessResult(result).commands).toEqual([
@@ -113,6 +114,7 @@ describe('aspirate', () => {
         tipRack: 'tiprack1Id',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -142,6 +144,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -164,6 +167,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -183,6 +187,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       initialRobotState
@@ -205,6 +210,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -231,6 +237,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       initialRobotState
@@ -265,6 +272,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -299,6 +307,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -339,6 +348,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -373,6 +383,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -413,6 +424,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -443,6 +455,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -472,6 +485,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -502,6 +516,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip
@@ -533,6 +548,7 @@ describe('aspirate', () => {
         tipRack: 'tipRack',
         xOffset: 0,
         yOffset: 0,
+        nozzles: null,
       },
       invariantContext,
       robotStateWithTip

--- a/step-generation/src/__tests__/dispense.test.ts
+++ b/step-generation/src/__tests__/dispense.test.ts
@@ -54,6 +54,8 @@ describe('dispense', () => {
         flowRate: 6,
         xOffset: 0,
         yOffset: 0,
+        tipRack: 'tiprack1Id',
+        nozzles: null,
       }
     })
     it('dispense normally (with tip)', () => {
@@ -102,6 +104,8 @@ describe('dispense', () => {
           well: 'A1',
           xOffset: 0,
           yOffset: 0,
+          tipRack: 'tiprack1Id',
+          nozzles: null,
         },
         invariantContext,
         initialRobotState

--- a/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
+++ b/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest'
+import { expect, describe, it, beforeEach } from 'vitest'
 import { getIsSafePipetteMovement } from '../utils'
 import {
   TEMPERATURE_MODULE_TYPE,
@@ -72,9 +72,6 @@ describe('getIsSafePipetteMovement', () => {
       tipState: { tipracks: {}, pipettes: {} },
       liquidState: { pipettes: {}, labware: {}, additionalEquipment: {} },
     }
-  })
-  afterEach(() => {
-    vi.resetAllMocks()
   })
 
   it('returns true when the labware id is a trash bin', () => {

--- a/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
+++ b/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
@@ -10,7 +10,6 @@ import {
 } from '@opentrons/shared-data'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
-import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 
 const mockLabwareId = 'labwareId'
 const mockPipId = 'pip'
@@ -22,8 +21,6 @@ const mockAdapter = 'adapterId'
 const mockWellName = 'A1'
 
 describe('getIsSafePipetteMovement', () => {
-  let robotState: RobotState
-  let invariantContext: InvariantContext
   let mockInvariantProperties: InvariantContext
   let mockRobotState: RobotState
   beforeEach(() => {

--- a/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
+++ b/step-generation/src/__tests__/getIsSafePipetteMovement.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, it } from 'vitest'
+import { expect, describe, it, beforeEach, afterEach, vi } from 'vitest'
 import { getIsSafePipetteMovement } from '../utils'
 import {
   TEMPERATURE_MODULE_TYPE,
@@ -10,6 +10,7 @@ import {
 } from '@opentrons/shared-data'
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '../types'
+import { getInitialRobotStateStandard, makeContext } from '../fixtures'
 
 const mockLabwareId = 'labwareId'
 const mockPipId = 'pip'
@@ -18,53 +19,67 @@ const mockTipUri = 'mockTipUri'
 const mockModule = 'moduleId'
 const mockLabware2 = 'labwareId2'
 const mockAdapter = 'adapterId'
-const mockInvariantProperties: InvariantContext = {
-  pipetteEntities: {
-    pip: {
-      name: 'p1000_96',
-      id: 'pip',
-      tiprackDefURI: ['mockDefUri'],
-      tiprackLabwareDef: [fixtureTiprack1000ul as LabwareDefinition2],
-      spec: fixtureP100096V2Specs,
-    },
-  },
-  labwareEntities: {
-    [mockLabwareId]: {
-      id: mockLabwareId,
-      labwareDefURI: 'mockDefUri',
-      def: fixture96Plate as LabwareDefinition2,
-    },
-    [mockTiprackId]: {
-      id: mockTiprackId,
-      labwareDefURI: mockTipUri,
-      def: fixtureTiprack1000ul as LabwareDefinition2,
-    },
-    [mockAdapter]: {
-      id: mockAdapter,
-      labwareDefURI: 'mockAdapterUri',
-      def: fixtureTiprackAdapter as LabwareDefinition2,
-    },
-    [mockLabware2]: {
-      id: mockLabware2,
-      labwareDefURI: 'mockDefUri',
-      def: fixture96Plate as LabwareDefinition2,
-    },
-  },
-  moduleEntities: {},
-  additionalEquipmentEntities: {},
-  config: {
-    OT_PD_DISABLE_MODULE_RESTRICTIONS: false,
-  },
-}
+const mockWellName = 'A1'
 
-const mockRobotState: RobotState = {
-  pipettes: { pip: { mount: 'left' } },
-  labware: { [mockLabwareId]: { slot: 'D2' }, [mockTiprackId]: { slot: 'A2' } },
-  modules: {},
-  tipState: { tipracks: {}, pipettes: {} },
-  liquidState: { pipettes: {}, labware: {}, additionalEquipment: {} },
-}
 describe('getIsSafePipetteMovement', () => {
+  let robotState: RobotState
+  let invariantContext: InvariantContext
+  let mockInvariantProperties: InvariantContext
+  let mockRobotState: RobotState
+  beforeEach(() => {
+    mockInvariantProperties = {
+      pipetteEntities: {
+        pip: {
+          name: 'p1000_96',
+          id: 'pip',
+          tiprackDefURI: ['mockDefUri'],
+          tiprackLabwareDef: [fixtureTiprack1000ul as LabwareDefinition2],
+          spec: fixtureP100096V2Specs,
+        },
+      },
+      labwareEntities: {
+        [mockLabwareId]: {
+          id: mockLabwareId,
+          labwareDefURI: 'mockDefUri',
+          def: fixture96Plate as LabwareDefinition2,
+        },
+        [mockTiprackId]: {
+          id: mockTiprackId,
+          labwareDefURI: mockTipUri,
+          def: fixtureTiprack1000ul as LabwareDefinition2,
+        },
+        [mockAdapter]: {
+          id: mockAdapter,
+          labwareDefURI: 'mockAdapterUri',
+          def: fixtureTiprackAdapter as LabwareDefinition2,
+        },
+        [mockLabware2]: {
+          id: mockLabware2,
+          labwareDefURI: 'mockDefUri',
+          def: fixture96Plate as LabwareDefinition2,
+        },
+      },
+      moduleEntities: {},
+      additionalEquipmentEntities: {},
+      config: {
+        OT_PD_DISABLE_MODULE_RESTRICTIONS: false,
+      },
+    }
+    mockRobotState = {
+      pipettes: { pip: { mount: 'left' } },
+      labware: {
+        [mockLabwareId]: { slot: 'D2' },
+        [mockTiprackId]: { slot: 'A2' },
+      },
+      modules: {},
+      tipState: { tipracks: {}, pipettes: {} },
+      liquidState: { pipettes: {}, labware: {}, additionalEquipment: {} },
+    }
+  })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
   it('returns true when the labware id is a trash bin', () => {
     const result = getIsSafePipetteMovement(
       {
@@ -97,7 +112,8 @@ describe('getIsSafePipetteMovement', () => {
       mockPipId,
       mockLabwareId,
       mockTipUri,
-      { x: -12, y: -100, z: 20 }
+      { x: -12, y: -100, z: 20 },
+      mockWellName
     )
     expect(result).toEqual(false)
   })
@@ -118,25 +134,31 @@ describe('getIsSafePipetteMovement', () => {
       mockPipId,
       mockLabwareId,
       mockTipUri,
-      { x: -1, y: 5, z: 20 }
+      { x: -1, y: 5, z: 20 },
+      mockWellName
     )
     expect(result).toEqual(true)
   })
   it('returns false when there is a tip that collides', () => {
     mockRobotState.tipState.tipracks = { mockTiprackId: { A1: true } }
+    mockRobotState.labware = {
+      ...mockRobotState.labware,
+      [mockAdapter]: { slot: 'D1' },
+    }
     const result = getIsSafePipetteMovement(
       mockRobotState,
       mockInvariantProperties,
       mockPipId,
       mockLabwareId,
       mockTipUri,
-      { x: -1, y: 5, z: 0 }
+      { x: -1, y: 5, z: 0 },
+      mockWellName
     )
     expect(result).toEqual(false)
   })
   it('returns false when there is a tall module nearby in a diagonal slot with adapter and labware', () => {
     mockRobotState.modules = {
-      [mockModule]: { slot: 'C1', moduleState: {} as any },
+      [mockModule]: { slot: 'D1', moduleState: {} as any },
     }
     mockRobotState.labware = {
       [mockLabwareId]: { slot: 'D2' },
@@ -160,7 +182,8 @@ describe('getIsSafePipetteMovement', () => {
       mockPipId,
       mockLabwareId,
       mockTipUri,
-      { x: 0, y: 0, z: 0 }
+      { x: 0, y: 0, z: 0 },
+      mockWellName
     )
     expect(result).toEqual(false)
   })

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -1,4 +1,4 @@
-import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
+import { COLUMN, FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 import * as errorCreators from '../../errorCreators'
 import { getPipetteWithTipMaxVol } from '../../robotStateSelectors'
 import {
@@ -12,9 +12,13 @@ import {
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
   uuid,
+  getIsSafePipetteMovement,
 } from '../../utils'
 import { COLUMN_4_SLOTS } from '../../constants'
-import type { CreateCommand } from '@opentrons/shared-data'
+import type {
+  CreateCommand,
+  NozzleConfigurationStyle,
+} from '@opentrons/shared-data'
 import type { AspirateParams } from '@opentrons/shared-data/protocol/types/schemaV3'
 import type { CommandCreator, CommandCreatorError } from '../../types'
 
@@ -22,6 +26,8 @@ export interface ExtendedAspirateParams extends AspirateParams {
   xOffset: number
   yOffset: number
   tipRack: string
+  nozzles: NozzleConfigurationStyle | null
+  test?: string
 }
 /** Aspirate with given args. Requires tip. */
 export const aspirate: CommandCreator<ExtendedAspirateParams> = (
@@ -40,6 +46,7 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
     tipRack,
     xOffset,
     yOffset,
+    nozzles,
   } = args
   const actionName = 'aspirate'
   const labwareState = prevRobotState.labware
@@ -106,6 +113,25 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
         well,
       })
     )
+  }
+
+  const is96Channel =
+    invariantContext.pipetteEntities[args.pipette]?.spec.channels === 96
+
+  if (
+    is96Channel &&
+    nozzles === COLUMN &&
+    !getIsSafePipetteMovement(
+      prevRobotState,
+      invariantContext,
+      args.pipette,
+      args.labware,
+      args.tipRack,
+      { x: xOffset, y: yOffset, z: offsetFromBottomMm },
+      args.well
+    )
+  ) {
+    errors.push(errorCreators.possiblePipetteCollision())
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -27,7 +27,6 @@ export interface ExtendedAspirateParams extends AspirateParams {
   yOffset: number
   tipRack: string
   nozzles: NozzleConfigurationStyle | null
-  test?: string
 }
 /** Aspirate with given args. Requires tip. */
 export const aspirate: CommandCreator<ExtendedAspirateParams> = (

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -82,6 +82,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
     dispenseYOffset,
     destLabware,
     sourceLabware,
+    nozzles,
   } = args
 
   const actionName = 'consolidate'
@@ -233,6 +234,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                   tipRack: args.tipRack,
                   xOffset: 0,
                   yOffset: 0,
+                  nozzles,
                 }),
                 ...(aspirateDelay != null
                   ? [
@@ -292,6 +294,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               tipRack: args.tipRack,
               xOffset: aspirateXOffset,
               yOffset: aspirateYOffset,
+              nozzles,
             }),
             ...delayAfterAspirateCommands,
             ...touchTipAfterAspirateCommand,
@@ -346,6 +349,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               aspirateYOffset,
               dispenseXOffset,
               dispenseYOffset,
+              nozzles,
             })
           : []
       const preWetTipCommands = args.preWetTip // Pre-wet tip is equivalent to a single mix, with volume equal to the consolidate volume.
@@ -366,6 +370,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
             aspirateYOffset,
             dispenseXOffset,
             dispenseYOffset,
+            nozzles,
           })
         : []
       //  can not mix in a waste chute
@@ -388,6 +393,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
               aspirateYOffset,
               dispenseXOffset,
               dispenseYOffset,
+              nozzles,
             })
           : []
 
@@ -415,6 +421,8 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
           offsetFromBottomMm: dispenseOffsetFromBottomMm,
           xOffset: dispenseXOffset,
           yOffset: dispenseYOffset,
+          nozzles,
+          tipRack: args.tipRack,
         }),
       ]
 
@@ -462,6 +470,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
                 flowRate: aspirateFlowRateUlSec,
                 offsetFromBottomMm: airGapOffsetDestWell,
                 tipRack: args.tipRack,
+                nozzles,
               }),
               ...(aspirateDelay != null
                 ? [

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -72,6 +72,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
     aspirateYOffset,
     dispenseXOffset,
     dispenseYOffset,
+    nozzles,
   } = args
 
   // TODO Ian 2018-05-03 next ~20 lines match consolidate.js
@@ -225,6 +226,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               xOffset: 0,
               yOffset: 0,
               tipRack: args.tipRack,
+              nozzles,
             }),
             ...(aspirateDelay != null
               ? [
@@ -247,6 +249,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
               isAirGap: true,
               xOffset: 0,
               yOffset: 0,
+              nozzles,
+              tipRack: args.tipRack,
             }),
             ...(dispenseDelay != null
               ? [
@@ -307,6 +311,8 @@ export const distribute: CommandCreator<DistributeArgs> = (
               offsetFromBottomMm: dispenseOffsetFromBottomMm,
               xOffset: dispenseXOffset,
               yOffset: dispenseYOffset,
+              nozzles,
+              tipRack: args.tipRack,
             }),
             ...delayAfterDispenseCommands,
             ...touchTipAfterDispenseCommand,
@@ -357,6 +363,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
                 tipRack: args.tipRack,
                 xOffset: 0,
                 yOffset: 0,
+                nozzles,
               }),
               ...(aspirateDelay != null
                 ? [
@@ -463,6 +470,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
               aspirateYOffset,
               dispenseXOffset,
               dispenseYOffset,
+              nozzles,
             })
           : []
 
@@ -491,6 +499,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
           tipRack: args.tipRack,
           xOffset: aspirateXOffset,
           yOffset: aspirateYOffset,
+          nozzles,
         }),
         ...delayAfterAspirateCommands,
         ...touchTipAfterAspirateCommand,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -3,7 +3,6 @@ import {
   LOW_VOLUME_PIPETTES,
   COLUMN,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
-  NozzleConfigurationStyle,
 } from '@opentrons/shared-data'
 import {
   repeatArray,
@@ -23,6 +22,7 @@ import {
   touchTip,
 } from '../atomic'
 
+import type { NozzleConfigurationStyle } from '@opentrons/shared-data'
 import type {
   MixArgs,
   CommandCreator,

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -3,6 +3,7 @@ import {
   LOW_VOLUME_PIPETTES,
   COLUMN,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+  NozzleConfigurationStyle,
 } from '@opentrons/shared-data'
 import {
   repeatArray,
@@ -45,6 +46,7 @@ export function mixUtil(args: {
   dispenseYOffset: number
   aspirateDelaySeconds?: number | null | undefined
   dispenseDelaySeconds?: number | null | undefined
+  nozzles: NozzleConfigurationStyle | null
 }): CurriedCommandCreator[] {
   const {
     pipette,
@@ -63,6 +65,7 @@ export function mixUtil(args: {
     aspirateYOffset,
     dispenseXOffset,
     dispenseYOffset,
+    nozzles,
   } = args
 
   const getDelayCommand = (seconds?: number | null): CurriedCommandCreator[] =>
@@ -90,6 +93,7 @@ export function mixUtil(args: {
         tipRack,
         xOffset: aspirateXOffset,
         yOffset: aspirateYOffset,
+        nozzles: null,
       }),
       ...getDelayCommand(aspirateDelaySeconds),
       curryCommandCreator(dispense, {
@@ -101,6 +105,8 @@ export function mixUtil(args: {
         flowRate: dispenseFlowRateUlSec,
         xOffset: dispenseXOffset,
         yOffset: dispenseYOffset,
+        tipRack,
+        nozzles: nozzles,
       }),
       ...getDelayCommand(dispenseDelaySeconds),
     ],
@@ -143,6 +149,7 @@ export const mix: CommandCreator<MixArgs> = (
     aspirateYOffset,
     dispenseXOffset,
     dispenseYOffset,
+    nozzles,
   } = data
 
   const is96Channel =
@@ -284,6 +291,7 @@ export const mix: CommandCreator<MixArgs> = (
         aspirateYOffset,
         dispenseXOffset,
         dispenseYOffset,
+        nozzles,
       })
       return [
         ...tipCommands,

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -432,7 +432,6 @@ export const transfer: CommandCreator<TransferArgs> = (
                     yOffset: 0,
                     tipRack: args.tipRack,
                     nozzles: args.nozzles,
-                    test: 'THIS IS A DISPENSE TEST',
                   }),
                   ...(dispenseDelay != null
                     ? [
@@ -477,7 +476,6 @@ export const transfer: CommandCreator<TransferArgs> = (
               xOffset: aspirateXOffset,
               yOffset: aspirateYOffset,
               nozzles: args.nozzles,
-              test: 'THIS IS AN ASPIRATE TEST',
             }),
           ]
           const dispenseCommand = [

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -165,36 +165,6 @@ export const transfer: CommandCreator<TransferArgs> = (
     errors.push(errorCreators.dropTipLocationDoesNotExist())
   }
 
-  if (
-    is96Channel &&
-    args.nozzles === COLUMN &&
-    !getIsSafePipetteMovement(
-      prevRobotState,
-      invariantContext,
-      args.pipette,
-      args.sourceLabware,
-      args.tipRack,
-      { x: aspirateXOffset, y: aspirateYOffset, z: aspirateOffsetFromBottomMm }
-    )
-  ) {
-    errors.push(errorCreators.possiblePipetteCollision())
-  }
-
-  if (
-    is96Channel &&
-    args.nozzles === COLUMN &&
-    !getIsSafePipetteMovement(
-      prevRobotState,
-      invariantContext,
-      args.pipette,
-      args.destLabware,
-      args.tipRack,
-      { x: dispenseXOffset, y: dispenseYOffset, z: dispenseOffsetFromBottomMm }
-    )
-  ) {
-    errors.push(errorCreators.possiblePipetteCollision())
-  }
-
   if (errors.length > 0)
     return {
       errors,
@@ -332,6 +302,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   aspirateYOffset,
                   dispenseXOffset,
                   dispenseYOffset,
+                  nozzles: args.nozzles,
                 })
               : []
           const mixBeforeAspirateCommands =
@@ -353,6 +324,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   aspirateYOffset,
                   dispenseXOffset,
                   dispenseYOffset,
+                  nozzles: args.nozzles,
                 })
               : []
           const delayAfterAspirateCommands =
@@ -421,6 +393,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                   aspirateYOffset,
                   dispenseXOffset,
                   dispenseYOffset,
+                  nozzles: args.nozzles,
                 })
               : []
 
@@ -438,6 +411,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                     tipRack,
                     xOffset: 0,
                     yOffset: 0,
+                    nozzles: args.nozzles,
                   }),
                   ...(aspirateDelay != null
                     ? [
@@ -460,6 +434,9 @@ export const transfer: CommandCreator<TransferArgs> = (
                     isAirGap: true,
                     xOffset: 0,
                     yOffset: 0,
+                    tipRack: args.tipRack,
+                    nozzles: args.nozzles,
+                    test: 'THIS IS A DISPENSE TEST',
                   }),
                   ...(dispenseDelay != null
                     ? [
@@ -503,6 +480,8 @@ export const transfer: CommandCreator<TransferArgs> = (
               tipRack,
               xOffset: aspirateXOffset,
               yOffset: aspirateYOffset,
+              nozzles: args.nozzles,
+              test: 'THIS IS AN ASPIRATE TEST',
             }),
           ]
           const dispenseCommand = [
@@ -515,6 +494,8 @@ export const transfer: CommandCreator<TransferArgs> = (
               offsetFromBottomMm: dispenseOffsetFromBottomMm,
               xOffset: dispenseXOffset,
               yOffset: dispenseYOffset,
+              tipRack: args.tipRack,
+              nozzles: args.nozzles,
             }),
           ]
 
@@ -564,6 +545,7 @@ export const transfer: CommandCreator<TransferArgs> = (
                     flowRate: aspirateFlowRateUlSec,
                     offsetFromBottomMm: airGapOffsetDestWell,
                     tipRack,
+                    nozzles: args.nozzles,
                   }),
                   ...(aspirateDelay != null
                     ? [

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -2,7 +2,6 @@ import assert from 'assert'
 import zip from 'lodash/zip'
 import {
   getWellDepth,
-  COLUMN,
   LOW_VOLUME_PIPETTES,
   GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
@@ -19,7 +18,6 @@ import {
   getTrashOrLabware,
   dispenseLocationHelper,
   moveHelper,
-  getIsSafePipetteMovement,
   getWasteChuteAddressableAreaNamePip,
   getHasWasteChute,
 } from '../../utils'
@@ -112,8 +110,6 @@ export const transfer: CommandCreator<TransferArgs> = (
   // TODO Ian 2018-04-02 following ~10 lines are identical to first lines of consolidate.js...
   const actionName = 'transfer'
   const errors: CommandCreatorError[] = []
-  const is96Channel =
-    invariantContext.pipetteEntities[args.pipette]?.spec.channels === 96
 
   if (
     !prevRobotState.pipettes[args.pipette] ||

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -18,7 +18,6 @@ export function forPickUpTip(
   const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
   // pipette now has tip(s)
   tipState.pipettes[pipetteId] = true
-
   // remove tips from tiprack
   if (pipetteSpec.channels === 1) {
     tipState.tipracks[labwareId][wellName] = false

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -10,8 +10,13 @@ import {
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   EIGHT_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
+  COLUMN,
 } from '@opentrons/shared-data'
-import { reduceCommandCreators, wasteChuteCommandsUtil } from './index'
+import {
+  getIsSafePipetteMovement,
+  reduceCommandCreators,
+  wasteChuteCommandsUtil,
+} from './index'
 import {
   aspirate,
   dispense,
@@ -26,6 +31,7 @@ import type {
   LabwareDefinition2,
   BlowoutParams,
   PipetteChannels,
+  NozzleConfigurationStyle,
 } from '@opentrons/shared-data'
 import type {
   AdditionalEquipmentEntities,
@@ -482,6 +488,8 @@ interface DispenseLocationHelperArgs {
   yOffset: number
   offsetFromBottomMm?: number
   well?: string
+  nozzles: NozzleConfigurationStyle | null
+  tipRack: string
 }
 export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> = (
   args,
@@ -497,6 +505,8 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
     well,
     xOffset,
     yOffset,
+    tipRack,
+    nozzles,
   } = args
 
   const trashOrLabware = getTrashOrLabware(
@@ -521,6 +531,8 @@ export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> 
         offsetFromBottomMm,
         xOffset,
         yOffset,
+        tipRack,
+        nozzles,
       }),
     ]
   } else if (trashOrLabware === 'wasteChute') {
@@ -615,6 +627,7 @@ interface AirGapArgs {
   blowOutLocation?: string | null
   sourceId?: string
   sourceWell?: string
+  nozzles: NozzleConfigurationStyle | null
 }
 export const airGapHelper: CommandCreator<AirGapArgs> = (
   args,
@@ -632,6 +645,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
     sourceId,
     sourceWell,
     volume,
+    nozzles,
   } = args
 
   const trashOrLabware = getTrashOrLabware(
@@ -667,6 +681,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
           tipRack,
           xOffset: 0,
           yOffset: 0,
+          nozzles,
         }),
       ]
       //  when aspirating out of multi wells for consolidate
@@ -684,6 +699,7 @@ export const airGapHelper: CommandCreator<AirGapArgs> = (
           //  NOTE: airgap aspirates happen at default x/y offset
           xOffset: 0,
           yOffset: 0,
+          nozzles,
         }),
       ]
     }

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -10,13 +10,8 @@ import {
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   EIGHT_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
-  COLUMN,
 } from '@opentrons/shared-data'
-import {
-  getIsSafePipetteMovement,
-  reduceCommandCreators,
-  wasteChuteCommandsUtil,
-} from './index'
+import { reduceCommandCreators, wasteChuteCommandsUtil } from './index'
 import {
   aspirate,
   dispense,

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -481,10 +481,10 @@ interface DispenseLocationHelperArgs {
   flowRate: number
   xOffset: number
   yOffset: number
-  offsetFromBottomMm?: number
-  well?: string
   nozzles: NozzleConfigurationStyle | null
   tipRack: string
+  offsetFromBottomMm?: number
+  well?: string
 }
 export const dispenseLocationHelper: CommandCreator<DispenseLocationHelperArgs> = (
   args,
@@ -619,10 +619,10 @@ interface AirGapArgs {
   tipRack: string
   pipetteId: string
   volume: number
+  nozzles: NozzleConfigurationStyle | null
   blowOutLocation?: string | null
   sourceId?: string
   sourceWell?: string
-  nozzles: NozzleConfigurationStyle | null
 }
 export const airGapHelper: CommandCreator<AirGapArgs> = (
   args,

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -78,7 +78,7 @@ const getPipetteBoundsAtSpecifiedMoveToPosition = (
   pipetteEntity: PipetteEntity,
   tipLength: number,
   wellTargetPoint: Point,
-  primaryNozzle: string = 'A12'
+  primaryNozzle: string = 'A12' // hardcoding A12 becasue only column pick up supported currently
 ): Point[] => {
   const {
     nozzleMap,
@@ -150,7 +150,7 @@ const getHighestZInSlot = (
   const { modules, labware } = robotState
   const { moduleEntities, labwareEntities } = invariantContext
 
-  let totalHeight = 0
+  let totalHeight: number = 0
   const moduleInSlot = Object.keys(modules).find(
     moduleId => modules[moduleId].slot === slotId
   )
@@ -167,7 +167,7 @@ const getHighestZInSlot = (
         labwareEntities[moduleDirectChildId].def.dimensions.zDimension
       totalHeight += moduleChildHeight
 
-      // check if adapter and has child
+      // check if adapter is on module and has child
       const moduleGrandchildId = Object.keys(labware).find(
         lwId => labware[lwId].slot === moduleDirectChildId
       )


### PR DESCRIPTION
Closes RAUT-1046

# Overview


This PR addresses a number of bugs to collision detection when using the 96-channel pipette with
single-column nozzle configuration. The main modifications lie in `getIsSafePipetteMovement`, which
detects the location of the pipette relative to the target labware, well, and offset, and confirms
whether any surrounding slots contain dangerous module + adapter + labware combinations.

# Test Plan

- create or upload a .json protocol to PD [example](https://github.com/user-attachments/files/16316808/Flex.LDH.96.well.kit.json)
- modify the starting deck state to introduce potential collisions and verify that high labware+module+adapter combos cause an error to be raised, and low labware does not cause issues

Some test cases that should raise a collision error:
- add a magnetic block with NEST deepwell plate directly to the left of a target aspiration or dispense
- add an Opentrons 15x 15ml Falcon tuberack directly to the left of a target aspiration or dispense

Some test cases that should not raise a collision error:
- add a temperature module with 24-tube aluminum block adapter directly to the left of a target aspiration or dispense
- add a 

# Changelog

- ensure tiprack and nozzles are passed as arguments to aspirate and dispense across complex command creators
- overhaul logic for pipette safety checks with 96-ch column configuration
- update tests

# Review requests

I added/modified some unit tests, please smoke test thoroughly. 

# Risk assessment

medium. a lot of step generation code is touched here, but it only implicates use of Flex 96-channel column configuration