### PR TITLE
feat(robot-server): Add `/clientData` endpoints

### DIFF
--- a/robot-server/robot_server/client_data/__init__.py
+++ b/robot-server/robot_server/client_data/__init__.py
@@ -1,0 +1,1 @@
+"""Support for the `/clientData` endpoints."""

--- a/robot-server/robot_server/client_data/router.py
+++ b/robot-server/robot_server/client_data/router.py
@@ -1,0 +1,68 @@
+"""Endpoint functions for the `/clientData` endpoints."""
+
+import textwrap
+import fastapi
+
+from robot_server.client_data.store import (
+    ClientData,
+    ClientDataStore,
+    get_client_data_store,
+)
+from robot_server.service.json_api.request import RequestModel
+from robot_server.service.json_api.response import SimpleBody
+
+router = fastapi.APIRouter()
+
+
+@router.put(
+    path="/clientData",
+    summary="Store client-defined data",
+    description=textwrap.dedent(
+        """\
+        Store a small amount of arbitrary client-defined data.
+
+        This endpoint is experimental and may be changed or removed without warning.
+
+        This is intended to help coordinate between multiple clients accessing the same
+        robot, and to help clients pick up from where they left off if they're closed
+        and reopened. For example, suppose your client shows a user interface for
+        physically setting up the deck with labware, step by step. You could use this
+        to store which step the user is currently on.
+
+        The data is stored as a single shared JSON object. Each `PUT` request overwrites
+        the whole thing. To update the data, do a read-modify-write with
+        `GET /clientData`. By convention, you should encapsulate your data in a
+        uniquely-named sub-object so it can coexist with other clients'. For example:
+
+        ```json
+        {
+          "data": {
+            "exampleOrganizationName/deckSetupWizard/v2": {
+              "currentDeckSetupStep": 3,
+              "deckSetupSteps": { /* ... */ }
+            }
+          }
+        }
+        ```
+
+        The data is cleared when the robot reboots.
+        """
+    ),
+)
+async def put_client_data(  # noqa: D103
+    request_body: RequestModel[ClientData],
+    store: ClientDataStore = fastapi.Depends(get_client_data_store),
+) -> SimpleBody[ClientData]:
+    store.put(request_body.data)
+    return SimpleBody(data=store.get())
+
+
+@router.get(
+    path="/clientData",
+    summary="Get client-defined data",
+    description="Return the currently-stored client data. See `PUT /clientData`.",
+)
+async def get_client_data(  # noqa: D103
+    store: ClientDataStore = fastapi.Depends(get_client_data_store),
+) -> SimpleBody[ClientData]:
+    return SimpleBody(data=store.get())

--- a/robot-server/robot_server/client_data/router.py
+++ b/robot-server/robot_server/client_data/router.py
@@ -1,6 +1,8 @@
 """Endpoint functions for the `/clientData` endpoints."""
 
 import textwrap
+from typing import Annotated, Literal
+
 import fastapi
 
 from robot_server.client_data.store import (
@@ -8,14 +10,38 @@ from robot_server.client_data.store import (
     ClientDataStore,
     get_client_data_store,
 )
+from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.service.json_api.request import RequestModel
-from robot_server.service.json_api.response import SimpleBody
+from robot_server.service.json_api.response import SimpleBody, SimpleEmptyBody
 
 router = fastapi.APIRouter()
 
 
+Key = Annotated[
+    str,
+    fastapi.Path(
+        regex="^[a-zA-Z0-9-_]*$",
+        description=(
+            "A key for storing and retrieving the piece of data."
+            " This should be chosen to avoid colliding with other clients,"
+            " and to unambiguously identify the data stored inside."
+            " The allowed characters are restricted to avoid any that"
+            " are special in URLs or MQTT topics."
+        ),
+        examples=["exampleOrganization-userNotes-v2"],
+    ),
+]
+
+
+class ClientDataKeyDoesNotExist(ErrorDetails):
+    """An error returned if trying to access a client data key that doesn't exist."""
+
+    id: Literal["ClientDataKeyDoesNotExist"] = "ClientDataKeyDoesNotExist"
+    title: str = "Client Data Key Does Not Exist"
+
+
 @router.put(
-    path="/clientData",
+    path="/clientData/{key}",
     summary="Store client-defined data",
     description=textwrap.dedent(
         """\
@@ -29,40 +55,74 @@ router = fastapi.APIRouter()
         physically setting up the deck with labware, step by step. You could use this
         to store which step the user is currently on.
 
-        The data is stored as a single shared JSON object. Each `PUT` request overwrites
-        the whole thing. To update the data, do a read-modify-write with
-        `GET /clientData`. By convention, you should encapsulate your data in a
-        uniquely-named sub-object so it can coexist with other clients'. For example:
-
-        ```json
-        {
-          "data": {
-            "exampleOrganizationName/deckSetupWizard/v2": {
-              "currentDeckSetupStep": 3,
-              "deckSetupSteps": { /* ... */ }
-            }
-          }
-        }
-        ```
-
         The data is cleared when the robot reboots.
         """
     ),
 )
 async def put_client_data(  # noqa: D103
+    key: Key,
     request_body: RequestModel[ClientData],
     store: ClientDataStore = fastapi.Depends(get_client_data_store),
 ) -> SimpleBody[ClientData]:
-    store.put(request_body.data)
-    return SimpleBody(data=store.get())
+    store.put(key, request_body.data)
+    return SimpleBody.construct(data=store.get(key))
 
 
 @router.get(
-    path="/clientData",
+    path="/clientData/{key}",
     summary="Get client-defined data",
-    description="Return the currently-stored client data. See `PUT /clientData`.",
+    description="Return the currently-stored client data at the given key. See `PUT /clientData` for background.",
+    responses={
+        fastapi.status.HTTP_200_OK: {"model": SimpleBody[ClientData]},
+        fastapi.status.HTTP_404_NOT_FOUND: {
+            "model": ErrorBody[ClientDataKeyDoesNotExist]
+        },
+    },
 )
 async def get_client_data(  # noqa: D103
+    key: Key,
     store: ClientDataStore = fastapi.Depends(get_client_data_store),
 ) -> SimpleBody[ClientData]:
-    return SimpleBody(data=store.get())
+    try:
+        return SimpleBody.construct(data=store.get(key))
+    except KeyError as e:
+        raise ClientDataKeyDoesNotExist.from_exc(e).as_error(
+            fastapi.status.HTTP_404_NOT_FOUND
+        ) from e
+
+
+@router.delete(
+    path="/clientData/{key}",
+    summary="Delete client-defined data",
+    description="Delete the client-defined data at the given key. See `PUT /clientData` for background.",
+    responses={
+        fastapi.status.HTTP_200_OK: {"model": SimpleBody[ClientData]},
+        fastapi.status.HTTP_404_NOT_FOUND: {
+            "model": ErrorBody[ClientDataKeyDoesNotExist]
+        },
+    },
+)
+async def delete_client_data(  # noqa: D103
+    key: Key,
+    store: ClientDataStore = fastapi.Depends(get_client_data_store),
+) -> SimpleEmptyBody:
+    try:
+        store.delete(key)
+    except KeyError as e:
+        raise ClientDataKeyDoesNotExist.from_exc(e).as_error(
+            fastapi.status.HTTP_404_NOT_FOUND
+        ) from e
+    else:
+        return SimpleEmptyBody.construct()
+
+
+@router.delete(
+    path="/clientData",
+    summary="Delete all client-defined data",
+    description="Delete all client-defined data. See `PUT /clientData` for background.",
+)
+async def delete_all_client_data(  # noqa: D103
+    store: ClientDataStore = fastapi.Depends(get_client_data_store),
+) -> SimpleEmptyBody:
+    store.delete_all()
+    return SimpleEmptyBody.construct()

--- a/robot-server/robot_server/client_data/store.py
+++ b/robot-server/robot_server/client_data/store.py
@@ -16,15 +16,29 @@ class ClientDataStore:
     """An in-memory store for client-defined JSON objects."""
 
     def __init__(self) -> None:
-        self._current_data: ClientData = {}
+        self._current_data: dict[str, ClientData] = {}
 
-    def put(self, new_data: ClientData) -> None:
-        """Replace the stored data."""
-        self._current_data = new_data
+    def put(self, key: str, new_data: ClientData) -> None:
+        """Store new data at the given key, replacing any data that already exists."""
+        self._current_data[key] = new_data
 
-    def get(self) -> ClientData:
-        """Return the currently-stored data."""
-        return self._current_data
+    def get(self, key: str) -> ClientData:
+        """Return the currently-stored data.
+
+        If the given key has no data, raise `KeyError`.
+        """
+        return self._current_data[key]
+
+    def delete(self, key: str) -> None:
+        """Delete the data at the given key.
+
+        If the given key has no data, raise `KeyError`.
+        """
+        del self._current_data[key]
+
+    def delete_all(self) -> None:
+        """Delete all data from the store."""
+        self._current_data.clear()
 
 
 _app_state_accessor = AppStateAccessor[ClientDataStore]("client_data_store")

--- a/robot-server/robot_server/client_data/store.py
+++ b/robot-server/robot_server/client_data/store.py
@@ -1,0 +1,41 @@
+"""An in-memory store for arbitrary client-defined JSON objects."""
+
+import fastapi
+
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+
+
+ClientData = dict[str, object]
+
+
+class ClientDataStore:
+    """An in-memory store for client-defined JSON objects."""
+
+    def __init__(self) -> None:
+        self._current_data: ClientData = {}
+
+    def put(self, new_data: ClientData) -> None:
+        """Replace the stored data."""
+        self._current_data = new_data
+
+    def get(self) -> ClientData:
+        """Return the currently-stored data."""
+        return self._current_data
+
+
+_app_state_accessor = AppStateAccessor[ClientDataStore]("client_data_store")
+
+
+async def get_client_data_store(
+    app_state: AppState = fastapi.Depends(get_app_state),
+) -> ClientDataStore:
+    """A FastAPI dependency to return the server's singleton `ClientDataStore`."""
+    store = _app_state_accessor.get_from(app_state)
+    if store is None:
+        store = ClientDataStore()
+        _app_state_accessor.set_on(app_state, store)
+    return store

--- a/robot-server/robot_server/router.py
+++ b/robot-server/robot_server/router.py
@@ -5,6 +5,7 @@ from .constants import V1_TAG
 from .errors.error_responses import LegacyErrorResponse
 from .versioning import check_version_header
 
+from .client_data.router import router as client_data_router
 from .commands.router import commands_router
 from .deck_configuration.router import router as deck_configuration_router
 from .health.router import health_router
@@ -45,6 +46,12 @@ router.include_router(
             "model": LegacyErrorResponse,
         }
     },
+)
+
+router.include_router(
+    router=client_data_router,
+    tags=["Client Data"],
+    dependencies=[Depends(check_version_header)],
 )
 
 router.include_router(

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -129,6 +129,8 @@ def _clean_server_state(base_url: str) -> None:
 
             await _reset_deck_configuration(robot_client)
 
+            await _delete_client_data(robot_client)
+
     asyncio.run(_clean_server_state_async())
 
 
@@ -153,6 +155,10 @@ async def _delete_all_sessions(robot_client: RobotClient) -> None:
     session_ids = [s["id"] for s in all_sessions_response.json()["data"]]
     for session_id in session_ids:
         await robot_client.delete_session(session_id)
+
+
+async def _delete_client_data(robot_client: RobotClient) -> None:
+    await robot_client.put_client_data({})
 
 
 async def _reset_deck_configuration(robot_client: RobotClient) -> None:

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -158,7 +158,7 @@ async def _delete_all_sessions(robot_client: RobotClient) -> None:
 
 
 async def _delete_client_data(robot_client: RobotClient) -> None:
-    await robot_client.put_client_data({})
+    await robot_client.delete_all_client_data()
 
 
 async def _reset_deck_configuration(robot_client: RobotClient) -> None:

--- a/robot-server/tests/integration/http_api/test_client_data.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_client_data.tavern.yaml
@@ -1,0 +1,50 @@
+test_name: Test getting and setting client data.
+
+marks:
+  - usefixtures:
+      - ot3_server_base_url
+
+stages:
+  - name: Check the initial client data
+    request:
+      method: GET
+      url: '{ot3_server_base_url}/clientData'
+    response:
+      status_code: 200
+      json:
+        data: {}
+
+  - name: Set client data
+    request:
+      method: PUT
+      url: '{ot3_server_base_url}/clientData'
+      json:
+        data: &put_data
+          stringField: string value
+          numberField: 123.456
+          boolField: true
+          nullField: null
+          objectField:
+            key: value
+    response:
+      status_code: 200
+      json:
+        data: *put_data
+
+  - name: Check that it rejects non-object data
+    request:
+      method: PUT
+      url: '{ot3_server_base_url}/clientData'
+      json:
+        data: This is a string and not an object.
+    response:
+      status_code: 422
+
+  - name: Retrieve client data
+    request:
+      method: GET
+      url: '{ot3_server_base_url}/clientData'
+    response:
+      status_code: 200
+      json:
+        data: *put_data

--- a/robot-server/tests/integration/http_api/test_client_data.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_client_data.tavern.yaml
@@ -1,4 +1,4 @@
-test_name: Test getting and setting client data.
+test_name: Test getting and setting client data
 
 marks:
   - usefixtures:
@@ -8,16 +8,14 @@ stages:
   - name: Check the initial client data
     request:
       method: GET
-      url: '{ot3_server_base_url}/clientData'
+      url: '{ot3_server_base_url}/clientData/foo'
     response:
-      status_code: 200
-      json:
-        data: {}
+      status_code: 404
 
   - name: Set client data
     request:
       method: PUT
-      url: '{ot3_server_base_url}/clientData'
+      url: '{ot3_server_base_url}/clientData/foo'
       json:
         data: &put_data
           stringField: string value
@@ -31,10 +29,10 @@ stages:
       json:
         data: *put_data
 
-  - name: Check that it rejects non-object data
+  - name: Check that PUT rejects non-object data
     request:
       method: PUT
-      url: '{ot3_server_base_url}/clientData'
+      url: '{ot3_server_base_url}/clientData/foo'
       json:
         data: This is a string and not an object.
     response:
@@ -43,8 +41,70 @@ stages:
   - name: Retrieve client data
     request:
       method: GET
-      url: '{ot3_server_base_url}/clientData'
+      url: '{ot3_server_base_url}/clientData/foo'
     response:
       status_code: 200
       json:
         data: *put_data
+
+  - name: Check that trailing slashes are ignored
+    request:
+      method: GET
+      url: '{ot3_server_base_url}/clientData/foo/'
+      follow_redirects: true # FastAPI redirects when given a trailing slash.
+    response:
+      status_code: 200
+      json:
+        data: *put_data
+
+  - name: Delete client data
+    request:
+      method: DELETE
+      url: '{ot3_server_base_url}/clientData/foo'
+    response:
+      status_code: 200
+
+  - name: Check that it was deleted
+    request:
+      method: GET
+      url: '{ot3_server_base_url}/clientData/foo'
+    response:
+      status_code: 404
+
+---
+test_name: Test client data key validation
+
+marks:
+  - usefixtures:
+      - ot3_server_base_url
+  - parametrize:
+      key:
+        - bad_key
+        - expected_status_code
+      vals:
+        - ['foo/bar', 404]
+        - ['foo*', 422]
+
+stages:
+  - name: Check that PUT rejects bad keys
+    request:
+      method: PUT
+      url: '{ot3_server_base_url}/clientData/{bad_key}'
+      json:
+        data: {}
+    response:
+      status_code: !int '{expected_status_code}'
+
+  - name: Check that GET rejects bad keys
+    request:
+      method: GET
+      url: '{ot3_server_base_url}/clientData/{bad_key}'
+    response:
+      status_code: !int '{expected_status_code}'
+
+  - name: Check that DELETE rejects bad keys
+    request:
+      method: DELETE
+      url: '{ot3_server_base_url}/clientData/{bad_key}'
+    response:
+      status_code: !int '{expected_status_code}'

--- a/robot-server/tests/integration/http_api/test_client_data.tavern.yaml
+++ b/robot-server/tests/integration/http_api/test_client_data.tavern.yaml
@@ -84,6 +84,8 @@ marks:
       vals:
         - ['foo/bar', 404]
         - ['foo*', 422]
+        - ['+', 422] # "+" is a wildcard in MQTT, but HTTP-brained code might decode it as a space.
+        - ['foo+bar', 422]
 
 stages:
   - name: Check that PUT rejects bad keys

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -349,10 +349,8 @@ class RobotClient:
         response.raise_for_status()
         return response
 
-    async def put_client_data(self, new_data: Dict[str, object]) -> Response:
-        response = await self.httpx_client.put(
-            url=f"{self.base_url}/clientData", json={"data": new_data}
-        )
+    async def delete_all_client_data(self) -> Response:
+        response = await self.httpx_client.delete(url=f"{self.base_url}/clientData")
         response.raise_for_status()
         return response
 

--- a/robot-server/tests/integration/robot_client.py
+++ b/robot-server/tests/integration/robot_client.py
@@ -349,6 +349,13 @@ class RobotClient:
         response.raise_for_status()
         return response
 
+    async def put_client_data(self, new_data: Dict[str, object]) -> Response:
+        response = await self.httpx_client.put(
+            url=f"{self.base_url}/clientData", json={"data": new_data}
+        )
+        response.raise_for_status()
+        return response
+
 
 async def poll_until_run_completes(
     robot_client: RobotClient, run_id: str, poll_interval: float = _RUN_POLL_INTERVAL


### PR DESCRIPTION
# Overview

This adds HTTP endpoints to store and retrieve a small amount of arbitrary client-defined data.

The immediate problem is that we want to prevent multiple clients from simultaneously driving error recovery. This solves that by giving clients a space to voluntarily coordinate with each other. The idea is that when a client enters recovery mode, it will store some data in here that says "client `abc123` is recovering from command `def456`," and when it exits recovery mode, it'll remove that data.

This goes towards EXEC-421. Fully closing it requires MQTT support, which I'll add in a second PR.

# Rationale

## Generality

I'm leaping to a general `/clientData` solution because I feel like this is a problem that we've danced around before. For example:

* We have these things called "maintenance runs" that need careful rules to overlap with "regular runs," which are separate. We need all of this because the presence of a "current regular run" is load-bearing: it's the app's only way to know that the robot is being set up to run a protocol, and to know which that protocol is. If we had `/clientData` at the time, we could have had one unified idea of "a run," and only one run at a time.
* If you close and reopen the app in the middle of a maintenance flow, you'll lose your progress and probably be met with a confusing "robot in use" modal when you reconnect. `/clientData` can help the client pick up where it left off, instead.
* If another client is doing something with the robot, you'll get a "robot in use" modal, but it can't show you *who's* using it or *why.* `/clientData` can provide those details. It can also help us go further and mirror activity across all connected clients, making the "robot in use" modal unnecessary in the first place.

## JWTs

We've [talked](https://opentrons.slack.com/archives/C06M9F26YGH/p1714071144451199) about using JWTs for this. I'm not doing that here basically because I don't understand that vision well enough to work on it independently, but I'm happy to give it a shot if we think it's important.

## Atomicity

This is a separate endpoint from the ones that actually control the robot, like `POST /runs/{id}/actions`. This is good because it means we can use it for concepts that the robot doesn't know or care about. But it's bad because when a client *does* want to associate a data update closely with a control action, there's no guarantee that those two operations will be done atomically.

To solve this, we could do things like:

* Add support to the control endpoints to atomically update `/clientData` in the same request.
* Add support to the control endpoints to reject the request if the current `clientData` no longer matches what the client thinks it is. (Something like the HTTP `If-Match` header.)

# Test plan

I added a Tavern integration test.

I did *not* add our usual unit tests for the store and endpoint functions. They'd be really trivial and wouldn't give us any additional coverage over the Tavern test. I'm happy to add them if anyone finds their absence confusing.

# Review requests

Does this API make sense?

It would also be easy to namespace with URL paths instead of JSON keys, like `PUT`/`GET` `/clientData/<client-defined key>`. Should we do that instead?

We've talked about using JWTs instead of this, or in addition to this. Is there anything that we should change about this now to make it easier for us to transition to JWTs later?

# Risk assessment

Low.