### PR TITLE
build: disable sign without failing builds

### DIFF
--- a/app-shell/scripts/windows-custom-sign.js
+++ b/app-shell/scripts/windows-custom-sign.js
@@ -5,6 +5,10 @@
 const { execSync } = require('node:child_process')
 
 exports.default = async configuration => {
+  const { WINDOWS_SIGN } = process.env
+  if (WINDOWS_SIGN !== 'true') {
+    return
+  }
   const signCmd = `smctl sign --keypair-alias="${String(
     process.env.SM_KEYPAIR_ALIAS
   )}" --input "${String(configuration.path)}" --certificate="${String(


### PR DESCRIPTION
Edge needs to be able to produce builds that aren't signed now.
