### PR TITLE
fix(scripts): setuptools v71 removed the need for extern (#15717)

### DIFF
--- a/scripts/python_build_utils.py
+++ b/scripts/python_build_utils.py
@@ -54,9 +54,18 @@ def normalize_version(package, project, extra_tag='', git_dir=None):
     # the way they vendor dependencies, like the packaging module that
     # provides the way to normalize version numbers for wheel file names. So
     # we try all the possible ways to find it.
+    # Since 71.0.0 they have removed the need for extern
+    # So depending on the version of 3.10 you're building on you may or may not
+    # need to use the extern or import it directly
     try:
-        # new way
-        from setuptools.extern import packaging
+        import setuptools
+        major, minor, patch = [int(x, 10) for x in setuptools.__version__.split('.')]
+        if major < 71:
+            # new way
+            from setuptools.extern import packaging
+        else:
+            # new new way
+            import packaging
     except ImportError:
         # old way
         from pkg_resources.extern import packaging


### PR DESCRIPTION
## `cherry-pick` afaa7177fe

Must update `chore_release-7.4.0` so that Linux app builds work due to a change in setuptools.  To understand the changes see #15717