### PR TITLE
fix(app): fix ODD current run redirect whitescreen

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -201,8 +201,8 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                 </>
               )}
             </Box>
+            <TopLevelRedirects />
           </ErrorBoundary>
-          <TopLevelRedirects />
         </OnDeviceLocalizationProvider>
       </InitialLoadingScreen>
     </ApiHostProvider>
@@ -275,7 +275,9 @@ export function OnDeviceDisplayAppRoutes(): JSX.Element {
 function TopLevelRedirects(): JSX.Element | null {
   const currentRunRoute = useCurrentRunRoute()
   return currentRunRoute != null ? (
-    <Route element={<Navigate to={currentRunRoute} />} />
+    <Routes>
+      <Route path="*" element={<Navigate to={currentRunRoute} />} />
+    </Routes>
   ) : null
 }
 


### PR DESCRIPTION
# Overview

wraps the ODD current run redirect Route in a Routes component to fix the whitescreen error "A <Route> is only ever to be used as the child of <Routes> element, never rendered directly. Please wrap your <Route> in a <Routes>." Moves the TopLevelRedirects component inside of the ErrorBoundary to avoid whitescreens (though reload would still trigger the error boundary in this case)

# Test Plan

verified the whitescreen and error resolved, navigation happens when a current run exists

# Changelog

 -  Fix ODD current run redirect whitescreen

# Review requests

smoke test starting/cancelling a run on ODD

# Risk assessment

low
