### PR TITLE
fix(app): add fallback text to recovery success toasts

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryToasts.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryToasts.test.tsx
@@ -86,7 +86,7 @@ describe('useRecoveryToasts', () => {
 
     result.current.makeSuccessToast()
     expect(mockMakeToast).toHaveBeenCalledWith(
-      TEST_COMMAND,
+      'Retrying step 1 succeeded.',
       'success',
       expect.objectContaining({
         closeButton: true,
@@ -114,6 +114,32 @@ describe('useRecoveryToasts', () => {
         disableTimeout: true,
         displayType: 'odd',
         heading: undefined,
+      })
+    )
+  })
+
+  it('should use recoveryToastText when desktopFullCommandText is null', () => {
+    vi.mocked(useCommandTextString).mockReturnValue({
+      commandText: '',
+      stepTexts: undefined,
+    })
+
+    const { result } = renderHook(() =>
+      useRecoveryToasts({
+        ...DEFAULT_PROPS,
+        commandTextData: { commands: [] } as any,
+      })
+    )
+
+    result.current.makeSuccessToast()
+    expect(mockMakeToast).toHaveBeenCalledWith(
+      expect.any(String),
+      'success',
+      expect.objectContaining({
+        closeButton: true,
+        disableTimeout: true,
+        displayType: 'desktop',
+        heading: expect.any(String),
       })
     )
   })
@@ -177,12 +203,29 @@ describe('useRecoveryFullCommandText', () => {
     const { result } = renderHook(() =>
       useRecoveryFullCommandText({
         robotType: FLEX_ROBOT_TYPE,
-        stepNumber: 1,
+        stepNumber: 0,
         commandTextData: { commands: [TEST_COMMAND] } as any,
       })
     )
 
     expect(result.current).toBe(TEST_COMMAND)
+  })
+
+  it('should return null when relevantCmd is null', () => {
+    vi.mocked(useCommandTextString).mockReturnValue({
+      commandText: '',
+      stepTexts: undefined,
+    })
+
+    const { result } = renderHook(() =>
+      useRecoveryFullCommandText({
+        robotType: FLEX_ROBOT_TYPE,
+        stepNumber: 1,
+        commandTextData: { commands: [] } as any,
+      })
+    )
+
+    expect(result.current).toBeNull()
   })
 
   it('should return stepNumber if it is a string', () => {
@@ -206,7 +249,7 @@ describe('useRecoveryFullCommandText', () => {
     const { result } = renderHook(() =>
       useRecoveryFullCommandText({
         robotType: FLEX_ROBOT_TYPE,
-        stepNumber: 1,
+        stepNumber: 0,
         commandTextData: {
           commands: [TC_COMMAND],
         } as any,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryToasts.ts
@@ -40,9 +40,11 @@ export function useRecoveryToasts({
     selectedRecoveryOption,
   })
 
-  // The "body" of the toast message. On ODD, this is the recovery-specific text. On desktop, this is the full command text.
+  // The "body" of the toast message.  On desktop, this is the full command text, if present. Otherwise, this is the recovery-specific text.
   const bodyText =
-    displayType === 'desktop' ? desktopFullCommandText : recoveryToastText
+    displayType === 'desktop' && desktopFullCommandText != null
+      ? desktopFullCommandText
+      : recoveryToastText
   // The "heading" of the toast message. Currently, this text is only present on the desktop toasts.
   const headingText = displayType === 'desktop' ? recoveryToastText : undefined
 
@@ -97,7 +99,7 @@ type UseRecoveryFullCommandTextParams = Omit<
 // Return the full command text of the recovery command that is "retried" or "skipped".
 export function useRecoveryFullCommandText(
   props: UseRecoveryFullCommandTextParams
-): string {
+): string | null {
   const { commandTextData, stepNumber } = props
 
   const relevantCmdIdx = typeof stepNumber === 'number' ? stepNumber : -1
@@ -110,12 +112,16 @@ export function useRecoveryFullCommandText(
 
   if (typeof stepNumber === 'string') {
     return stepNumber
+  }
+  // Occurs when the relevantCmd doesn't exist, ex, we "skip" the last command of a run.
+  else if (relevantCmd === null) {
+    return null
   } else {
     return truncateIfTCCommand(commandText, stepTexts != null)
   }
 }
 
-// Return the user-facing step number. If the step number cannot be determined, return '?'.
+// Return the user-facing step number, 0 indexed. If the step number cannot be determined, return '?'.
 export function getStepNumber(
   selectedRecoveryOption: BuildToast['selectedRecoveryOption'],
   currentStepCount: BuildToast['currentStepCount']


### PR DESCRIPTION
Closes [EXEC-624](https://opentrons.atlassian.net/browse/EXEC-624)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If error recovery occurs for a step not in protocol analysis, or error recovery results in skipping to a command when the user is recovering from the last command of the run, there is no command text. As a fallback in these spots, let's just not show the full command text and just show the recovery action text. Note that this never occurrs on the ODD, since we never show the full command text.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Run a protocol and throw an error on the last step. On the desktop app, recover from that error. Verify there is no "null" text now.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Fixed instances of null success toast text on the desktop app during Error Recovery.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-624]: https://opentrons.atlassian.net/browse/EXEC-624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ