### PR TITLE
chore(ci): Add user input to enable/disable opening an analyses snapshot PR

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -40,7 +40,7 @@ jobs:
       # If we're running because of workflow_dispatch, use the user input to decide
       # whether to open a PR on failure. Otherwise, there is no user input, so always
       # open a PR on failure.
-      OPEN_PR_ON_FAILURE: ${{ github.event_name == 'workflow_dispatch' && github.events.inputs.OPEN_PR_ON_FAILURE || true }}
+      OPEN_PR_ON_FAILURE: ${{ (github.event_name == 'workflow_dispatch' && github.events.inputs.OPEN_PR_ON_FAILURE) || (github.event_name != 'workflow_dispatch') }}
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -12,7 +12,7 @@ on:
         required: true
         default: 'edge'
       OPEN_PR_ON_FAILURE:
-        description: 'If the test fails, whether to automatically open a PR to update the snapshots.'
+        description: 'If the test fails, open a PR to update the snapshots'
         type: boolean
         required: true
         default: false

--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -11,8 +11,13 @@ on:
         description: 'Branch or tag that provides the snapshot and test code at test runtime'
         required: true
         default: 'edge'
+      OPEN_PR_ON_FAILURE:
+        description: 'If the test fails, whether to automatically open a PR to update the snapshots.'
+        type: boolean
+        required: true
+        default: false
   schedule:
-    - cron:  '26 7 * * *' # 7:26 AM UTC
+    - cron: '26 7 * * *' # 7:26 AM UTC
   pull_request:
     paths:
       - 'api/**'
@@ -32,66 +37,70 @@ jobs:
     env:
       ANALYSIS_REF: ${{ github.event.inputs.ANALYSIS_REF || github.head_ref || 'edge' }}
       SNAPSHOT_REF: ${{ github.event.inputs.SNAPSHOT_REF || github.head_ref || 'edge' }}
+      # If we're running because of workflow_dispatch, use the user input to decide
+      # whether to open a PR on failure. Otherwise, there is no user input, so always
+      # open a PR on failure.
+      OPEN_PR_ON_FAILURE: ${{ github.event_name == 'workflow_dispatch' && github.events.inputs.OPEN_PR_ON_FAILURE || true }}
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ env.SNAPSHOT_REF }}
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.SNAPSHOT_REF }}
 
-    - name: Docker Build
-      working-directory: analyses-snapshot-testing
-      run: make build-opentrons-analysis
+      - name: Docker Build
+        working-directory: analyses-snapshot-testing
+        run: make build-opentrons-analysis
 
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-        cache: 'pipenv'
-        cache-dependency-path: analyses-snapshot-testing/Pipfile.lock
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pipenv'
+          cache-dependency-path: analyses-snapshot-testing/Pipfile.lock
 
-    - name: Setup Python Dependencies
-      working-directory: analyses-snapshot-testing
-      run: make setup
+      - name: Setup Python Dependencies
+        working-directory: analyses-snapshot-testing
+        run: make setup
 
-    - name: Run Test
-      id: run_test
-      working-directory: analyses-snapshot-testing
-      run: make snapshot-test
+      - name: Run Test
+        id: run_test
+        working-directory: analyses-snapshot-testing
+        run: make snapshot-test
 
-    - name: Upload Report
-      if: '!cancelled()'
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-report
-        path: analyses-snapshot-testing/results/
+      - name: Upload Report
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: analyses-snapshot-testing/results/
 
-    - name: Handle Test Failure
-      id: handle_failure
-      if: always() && steps.run_test.outcome == 'failure'
-      working-directory: analyses-snapshot-testing
-      run: make snapshot-test-update
+      - name: Handle Test Failure
+        id: handle_failure
+        if: always() && steps.run_test.outcome == 'failure'
+        working-directory: analyses-snapshot-testing
+        run: make snapshot-test-update
 
-    - name: Create Snapshot update Request
-      id: create_pull_request
-      if: always() && steps.handle_failure.outcome == 'success'
-      uses: peter-evans/create-pull-request@v6
-      with:
+      - name: Create Snapshot update Request
+        id: create_pull_request
+        if: always() && steps.handle_failure.outcome == 'success' && env.OPEN_PR_ON_FAILURE
+        uses: peter-evans/create-pull-request@v6
+        with:
           commit-message: 'fix(analyses-snapshot-testing): snapshot failure capture'
           title: 'fix(analyses-snapshot-testing): ${{ env.ANALYSIS_REF }} snapshot failure capture'
           body: 'This PR is an automated snapshot update request. Please review the changes and merge if they are acceptable or find your bug and fix it.'
           branch: 'analyses-snapshot-testing/${{ env.ANALYSIS_REF }}-from-${{ env.SNAPSHOT_REF}}'
           base: ${{ env.SNAPSHOT_REF}}
 
-    - name: Comment on PR
-      if: always() && steps.create_pull_request.outcome == 'success' && github.event_name == 'pull_request'
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const message = 'A PR has been opened to address analyses snapshot changes. Please review the changes here: https://github.com/${{ github.repository }}/pull/${{ steps.create-pull-request.outputs.pull-request-number }}';
-          github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-            body: message
-          });
+      - name: Comment on PR
+        if: always() && steps.create_pull_request.outcome == 'success' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = 'A PR has been opened to address analyses snapshot changes. Please review the changes here: https://github.com/${{ github.repository }}/pull/${{ steps.create-pull-request.outputs.pull-request-number }}';
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            });


### PR DESCRIPTION
# Overview

Sometimes when you're running the analyses snapshot tests, you just want to run it and see the result without automatically opening a PR. This adds a checkbox to the "Run workflow" UI to do that.

# Test Plan

* [ ] It works with the checkbox deselected
* [ ] It works with the checkbox selected

# Risk assessment

Low.