### PR TITLE
chore(app): wire up NoLiquidDetected ER on desktop

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react'
 import head from 'lodash/head'
+import {css} from 'styled-components'
 import { useTranslation } from 'react-i18next'
 
 import {
   DIRECTION_COLUMN,
   Flex,
   SPACING,
-  LegacyStyledText,
+  StyledText, 
+  RESPONSIVENESS
 } from '@opentrons/components'
 
 import { ODD_SECTION_TITLE_STYLE, RECOVERY_MAP, ODD_ONLY, DESKTOP_ONLY } from '../constants'
@@ -82,16 +84,37 @@ export function IgnoreErrorStepHome({
   }
 
   return (
-    <RecoverySingleColumnContentWrapper>
-      <LegacyStyledText css={ODD_SECTION_TITLE_STYLE} as="h4SemiBold">
+    <RecoverySingleColumnContentWrapper css={DESKTOP_ONLY_GRID_GAP}>
+      <StyledText css={ODD_SECTION_TITLE_STYLE} oddStyle="level4HeaderSemiBold" desktopStyle='headingSmallSemiBold'>
         {t('ignore_similar_errors_later_in_run')}
-      </LegacyStyledText>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
+      </StyledText>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4} css={ODD_ONLY}>
         <IgnoreOptions
           ignoreOptions={IGNORE_OPTIONS_IN_ORDER}
           setSelectedOption={setSelectedOption}
           selectedOption={selectedOption}
         />
+      </Flex>
+      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4} css={DESKTOP_ONLY}>
+      <RecoveryRadioGroup
+        value={selectedOption}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          setSelectedOption(e.currentTarget.value as IgnoreOption)
+        }}
+        options={IGNORE_OPTIONS_IN_ORDER.map((option) => {
+          return {
+            value: t(option),
+            children: (
+              <StyledText
+              css={RADIO_GROUP_MARGIN}
+                desktopStyle="bodyDefaultRegular"
+              >
+                {t(option)}
+              </StyledText>
+            ),
+          }
+        })}
+      />
       </Flex>
       <RecoveryFooterButtons
         primaryBtnOnClick={primaryOnClick}
@@ -118,9 +141,8 @@ export function IgnoreOptions({
   return ignoreOptions.map(ignoreOption => {
     const copyText = t(ignoreOption)
 
-    return (
-      <Felx>
-      <RadioButton css={ODD_ONLY}
+    return (     
+      <RadioButton
         key={`ignore_option_${ignoreOption}`}
         buttonLabel={copyText}
         buttonValue={copyText}
@@ -129,37 +151,6 @@ export function IgnoreOptions({
         }}
         isSelected={ignoreOption === selectedOption}
       />
- <RecoveryRadioGroup css={DESKTOP_ONLY}
-      value={selected}
-      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-        setSelected(e.currentTarget.value as RemovalOptions)
-      }}
-      options={[
-        {
-          value: t('begin_removal'),
-          children: (
-            <StyledText
-              desktopStyle="bodyDefaultRegular"
-              css={RADIO_GROUP_MARGIN}
-            >
-              {t('begin_removal')}
-            </StyledText>
-          ),
-        },
-        {
-          value: t('skip'),
-          children: (
-            <StyledText
-              desktopStyle="bodyDefaultRegular"
-              css={RADIO_GROUP_MARGIN}
-            >
-              {t('skip')}
-            </StyledText>
-          ),
-        },
-      ]}
-    />
-    </Felx>
     )
   })
 }
@@ -170,3 +161,15 @@ const IGNORE_OPTIONS_IN_ORDER: IgnoreOption[] = [
   'ignore_only_this_error',
   'ignore_all_errors_of_this_type',
 ]
+
+const RADIO_GROUP_MARGIN = css`
+@media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+  margin-left: 0.5rem;
+}
+`
+
+const DESKTOP_ONLY_GRID_GAP = css`
+@media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+  gap: 0rem;
+}
+`

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -1,17 +1,22 @@
 import * as React from 'react'
 import head from 'lodash/head'
-import {css} from 'styled-components'
+import { css } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 
 import {
   DIRECTION_COLUMN,
   Flex,
   SPACING,
-  StyledText, 
-  RESPONSIVENESS
+  StyledText,
+  RESPONSIVENESS,
 } from '@opentrons/components'
 
-import { ODD_SECTION_TITLE_STYLE, RECOVERY_MAP, ODD_ONLY, DESKTOP_ONLY } from '../constants'
+import {
+  ODD_SECTION_TITLE_STYLE,
+  RECOVERY_MAP,
+  ODD_ONLY,
+  DESKTOP_ONLY,
+} from '../constants'
 import { SelectRecoveryOption } from './SelectRecoveryOption'
 import {
   RecoveryFooterButtons,
@@ -85,36 +90,48 @@ export function IgnoreErrorStepHome({
 
   return (
     <RecoverySingleColumnContentWrapper css={DESKTOP_ONLY_GRID_GAP}>
-      <StyledText css={ODD_SECTION_TITLE_STYLE} oddStyle="level4HeaderSemiBold" desktopStyle='headingSmallSemiBold'>
+      <StyledText
+        css={ODD_SECTION_TITLE_STYLE}
+        oddStyle="level4HeaderSemiBold"
+        desktopStyle="headingSmallSemiBold"
+      >
         {t('ignore_similar_errors_later_in_run')}
       </StyledText>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4} css={ODD_ONLY}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing4}
+        css={ODD_ONLY}
+      >
         <IgnoreOptions
           ignoreOptions={IGNORE_OPTIONS_IN_ORDER}
           setSelectedOption={setSelectedOption}
           selectedOption={selectedOption}
         />
       </Flex>
-      <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4} css={DESKTOP_ONLY}>
-      <RecoveryRadioGroup
-        value={selectedOption}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          setSelectedOption(e.currentTarget.value as IgnoreOption)
-        }}
-        options={IGNORE_OPTIONS_IN_ORDER.map((option) => {
-          return {
-            value: t(option),
-            children: (
-              <StyledText
-              css={RADIO_GROUP_MARGIN}
-                desktopStyle="bodyDefaultRegular"
-              >
-                {t(option)}
-              </StyledText>
-            ),
-          }
-        })}
-      />
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing4}
+        css={DESKTOP_ONLY}
+      >
+        <RecoveryRadioGroup
+          value={selectedOption}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setSelectedOption(e.currentTarget.value as IgnoreOption)
+          }}
+          options={IGNORE_OPTIONS_IN_ORDER.map(option => {
+            return {
+              value: t(option),
+              children: (
+                <StyledText
+                  css={RADIO_GROUP_MARGIN}
+                  desktopStyle="bodyDefaultRegular"
+                >
+                  {t(option)}
+                </StyledText>
+              ),
+            }
+          })}
+        />
       </Flex>
       <RecoveryFooterButtons
         primaryBtnOnClick={primaryOnClick}
@@ -141,7 +158,7 @@ export function IgnoreOptions({
   return ignoreOptions.map(ignoreOption => {
     const copyText = t(ignoreOption)
 
-    return (     
+    return (
       <RadioButton
         key={`ignore_option_${ignoreOption}`}
         buttonLabel={copyText}
@@ -163,13 +180,13 @@ const IGNORE_OPTIONS_IN_ORDER: IgnoreOption[] = [
 ]
 
 const RADIO_GROUP_MARGIN = css`
-@media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
-  margin-left: 0.5rem;
-}
+  @media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+    margin-left: 0.5rem;
+  }
 `
 
 const DESKTOP_ONLY_GRID_GAP = css`
-@media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
-  gap: 0rem;
-}
+  @media not (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+    gap: 0rem;
+  }
 `

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -9,11 +9,12 @@ import {
   LegacyStyledText,
 } from '@opentrons/components'
 
-import { ODD_SECTION_TITLE_STYLE, RECOVERY_MAP } from '../constants'
+import { ODD_SECTION_TITLE_STYLE, RECOVERY_MAP, ODD_ONLY, DESKTOP_ONLY } from '../constants'
 import { SelectRecoveryOption } from './SelectRecoveryOption'
 import {
   RecoveryFooterButtons,
   RecoverySingleColumnContentWrapper,
+  RecoveryRadioGroup,
 } from '../shared'
 import { RadioButton } from '../../../atoms/buttons'
 
@@ -118,7 +119,8 @@ export function IgnoreOptions({
     const copyText = t(ignoreOption)
 
     return (
-      <RadioButton
+      <Felx>
+      <RadioButton css={ODD_ONLY}
         key={`ignore_option_${ignoreOption}`}
         buttonLabel={copyText}
         buttonValue={copyText}
@@ -127,6 +129,37 @@ export function IgnoreOptions({
         }}
         isSelected={ignoreOption === selectedOption}
       />
+ <RecoveryRadioGroup css={DESKTOP_ONLY}
+      value={selected}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        setSelected(e.currentTarget.value as RemovalOptions)
+      }}
+      options={[
+        {
+          value: t('begin_removal'),
+          children: (
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              css={RADIO_GROUP_MARGIN}
+            >
+              {t('begin_removal')}
+            </StyledText>
+          ),
+        },
+        {
+          value: t('skip'),
+          children: (
+            <StyledText
+              desktopStyle="bodyDefaultRegular"
+              css={RADIO_GROUP_MARGIN}
+            >
+              {t('skip')}
+            </StyledText>
+          ),
+        },
+      ]}
+    />
+    </Felx>
     )
   })
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -120,7 +120,7 @@ export function IgnoreErrorStepHome({
           }}
           options={IGNORE_OPTIONS_IN_ORDER.map(option => {
             return {
-              value: t(option),
+              value: option,
               children: (
                 <StyledText
                   css={RADIO_GROUP_MARGIN}

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -146,9 +146,6 @@ export function BeginRemoval({
         css={DESKTOP_ONLY}
       >
         <RecoveryRadioGroup
-          // css={css`
-          //   padding: ${SPACING.spacing4};
-          // `}
           value={selected}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             setSelected(e.currentTarget.value as RemovalOptions)

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -146,9 +146,9 @@ export function BeginRemoval({
         css={DESKTOP_ONLY}
       >
         <RecoveryRadioGroup
-          css={css`
-            padding: ${SPACING.spacing4};
-          `}
+          // css={css`
+          //   padding: ${SPACING.spacing4};
+          // `}
           value={selected}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             setSelected(e.currentTarget.value as RemovalOptions)

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -148,6 +148,7 @@ export function DesktopRecoveryOptions({
 }: RecoveryOptionsProps): JSX.Element {
   return (
     <RecoveryRadioGroup
+      css={RADIO_GAP}
       onChange={e => {
         setSelectedRoute(e.currentTarget.value)
       }}
@@ -221,3 +222,7 @@ export const GENERAL_ERROR_OPTIONS: RecoveryRoute[] = [
   RECOVERY_MAP.RETRY_FAILED_COMMAND.ROUTE,
   RECOVERY_MAP.CANCEL_RUN.ROUTE,
 ]
+
+const RADIO_GAP = `
+  gap: ${SPACING.spacing4};
+`

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/IgnoreErrorSkipStep.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/IgnoreErrorSkipStep.test.tsx
@@ -117,7 +117,7 @@ describe('IgnoreErrorStepHome', () => {
 
   it('calls ignoreAlways when "ignore_all_errors_of_this_type" is selected and primary button is clicked', async () => {
     renderIgnoreErrorStepHome(props)
-    fireEvent.click(screen.getByText('Ignore all errors of this type'))
+    fireEvent.click(screen.queryAllByText('Ignore all errors of this type')[0])
     clickButtonLabeled('Continue')
     await waitFor(() => {
       expect(mockIgnoreErrorKindThisRun).toHaveBeenCalled()

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/IgnoreErrorSkipStep.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/IgnoreErrorSkipStep.test.tsx
@@ -105,7 +105,7 @@ describe('IgnoreErrorStepHome', () => {
 
   it('calls ignoreOnce when "ignore_only_this_error" is selected and primary button is clicked', async () => {
     renderIgnoreErrorStepHome(props)
-    fireEvent.click(screen.getByText('Ignore only this error'))
+    fireEvent.click(screen.queryAllByText('Ignore only this error')[0])
     clickButtonLabeled('Continue')
     await waitFor(() => {
       expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
@@ -46,9 +46,9 @@ export function TwoColTextAndFailedStepNextStep(
         <Flex
           flexDirection={DIRECTION_COLUMN}
           css={css`
-            gap:${SPACING.spacing16};
+            gap: ${SPACING.spacing16};
             @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-            gap:${SPACING.spacing8}
+              gap: ${SPACING.spacing8};
             }
           `}
         >

--- a/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/TwoColTextAndFailedStepNextStep.tsx
@@ -46,9 +46,9 @@ export function TwoColTextAndFailedStepNextStep(
         <Flex
           flexDirection={DIRECTION_COLUMN}
           css={css`
-            gap=${SPACING.spacing16};
+            gap:${SPACING.spacing16};
             @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-            gap=${SPACING.spacing8}
+            gap:${SPACING.spacing8}
             }
           `}
         >


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-556.
Wire up desktop designs for NoLiquidDetected ER flow. 

# Test Plan

- Make sure designs match desktop app and logic works as expected. 
- Make sure designs match ODD app and logic works as expected. 


# Risk assessment

low. mainly css changes. should affect desktop app only.