### PR TITLE
feat(robot-server): fetch all CSV files used with a protocol's recent analyses

### DIFF
--- a/robot-server/tests/integration/http_api/protocols/test_analyses_with_csv_file_parameters.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_analyses_with_csv_file_parameters.tavern.yaml
@@ -15,6 +15,8 @@ stages:
       save:
         json:
           csv_file_id: data.id
+          csv_file_name: data.name
+          file_created_at: data.createdAt
       status_code:
       # If the file exists on the test server then accept 200 else 201.
       # We have to do this because the persistent storage is scoped to a test session and
@@ -97,3 +99,38 @@ stages:
                   file:
                     id: '{csv_file_id}'
                     name: ''
+
+  - name: Wait until analysis is completed
+    max_retries: 5
+    delay_after: 1
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}'
+    response:
+      status_code: 200
+      json:
+        data:
+          analyses: []
+          analysisSummaries:
+            - id: '{analysis_id}'
+              status: completed
+          id: !anything
+          protocolType: !anything
+          files: !anything
+          createdAt: !anything
+          robotType: !anything
+          protocolKind: !anything
+          metadata: !anything
+        links: !anything
+
+  - name: Get the data file used by protocol ID
+    request:
+      url: '{ot2_server_base_url}/protocols/{protocol_id}/dataFiles'
+    response:
+      strict:
+        - json:off
+      status_code: 200
+      json:
+        data:
+          - id: '{csv_file_id}'
+            name: '{csv_file_name}'
+            createdAt: '{file_created_at}'

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -32,7 +32,7 @@ from robot_server.protocols.protocol_store import (
     ProtocolNotFoundError,
     ProtocolUsedByRunError,
 )
-from robot_server.protocols.rtp_resources import CsvParameterResource
+from robot_server.protocols.rtp_resources import CSVParameterResource
 
 from robot_server.runs.run_store import RunStore
 
@@ -597,12 +597,12 @@ async def test_get_referenced_data_files(
         completed_analysis_resource=analysis_resource1,
         primitive_rtp_resources=[],
         csv_rtp_resources=[
-            CsvParameterResource(
+            CSVParameterResource(
                 analysis_id="analysis-id-1",
                 parameter_variable_name="csv-var",
                 file_id="data-file-id",
             ),
-            CsvParameterResource(
+            CSVParameterResource(
                 analysis_id="analysis-id-1",
                 parameter_variable_name="csv-var",
                 file_id="data-file-id-2",


### PR DESCRIPTION
Closes AUTH-428

# Overview

Adds a new endpoint `GET /protocols/{protocolId}/dataFiles` which provides a list of all data files used as CSV parameters for the provided protocol. It determines the files used based on the CSV files used and saved in previous analyses. 

Example response:
```
{
    "data": [
        {
            "id": "981ad463-c020-416a-8fd1-1853a353b8e7",
            "name": "sample.csv",
            "createdAt": "2024-07-23T19:37:47.689700+00:00"
        },
        {
            "id": "c326c4ab-9dff-4911-9ec3-07d9012cd4ad",
            "name": "color_srgb_2.csv",
            "createdAt": "2024-07-23T19:38:24.316187+00:00"
        }
    ],
    "meta": {
        "cursor": 0,
        "totalLength": 2
    }
}
```


Note- this endpoint will eventually return files used in the protocol's runs as well; just not in this PR

# Test Plan

- Upload some data files and use them as csv params for a protocol with CSV params. Use different files in different analysis.
- Check that the new endpoint returns the correct list of data files used

# Review requests

Usual code sanity check

# Risk assessment

Low. New endpoint and isolated feature.
