### PR TITLE
feat(app): add error recovery "error while dispensing" flows to desktop

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -17,7 +17,7 @@
   "continue_to_drop_tip": "Continue to drop tip",
   "error": "Error",
   "error_on_robot": "Error on {{robot}}",
-  "failed_dispense_step_not_completed": "<block>The failed dispense step will not be completed. The run will continue from the next step.</block><block>Close the robot door before proceeding.</block>",
+  "failed_dispense_step_not_completed": "<block>The failed dispense step will not be completed. The run will continue from the next step with the attached tips.</block><block>Close the robot door before proceeding.</block>",
   "failed_step": "Failed step",
   "first_take_any_necessary_actions": "<block>First, take any necessary actions to prepare the robot to retry the failed step.</block><block>Then, close the robot door before proceeding.</block>",
   "go_back": "Go back",

--- a/app/src/organisms/DropTipWizardFlows/DropTipWizard.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizard.tsx
@@ -318,10 +318,14 @@ export const DropTipWizardContent = (
   }
 
   function buildSuccess(): JSX.Element {
+    const { tipDropComplete } = fixitCommandTypeUtils?.buttonOverrides ?? {}
+
     // Route to the drop tip route if user is at the blowout success screen, otherwise proceed conditionally.
     const handleProceed = (): void => {
       if (currentStep === BLOWOUT_SUCCESS) {
         void proceedToRoute(DT_ROUTES.DROP_TIP)
+      } else if (tipDropComplete != null) {
+        tipDropComplete()
       } else {
         proceedWithConditionalClose()
       }

--- a/app/src/organisms/DropTipWizardFlows/types.ts
+++ b/app/src/organisms/DropTipWizardFlows/types.ts
@@ -27,6 +27,7 @@ interface ErrorOverrides {
 
 interface ButtonOverrides {
   goBackBeforeBeginning: () => void
+  tipDropComplete: (() => void) | null
 }
 
 export interface FixitCommandTypeUtils {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -30,7 +30,7 @@ import { DT_ROUTES } from '../../DropTipWizardFlows/constants'
 import { SelectRecoveryOption } from './SelectRecoveryOption'
 
 import type { PipetteWithTip } from '../../DropTipWizardFlows'
-import type { RecoveryContentProps } from '../types'
+import type { RecoveryContentProps, RecoveryRoute, RouteStep } from '../types'
 import type { FixitCommandTypeUtils } from '../../DropTipWizardFlows/types'
 
 // The Drop Tip flow entry point. Includes entry from SelectRecoveryOption and CancelRun.
@@ -251,6 +251,7 @@ export function useDropTipFlowUtils({
   const { t } = useTranslation('error_recovery')
   const {
     RETRY_NEW_TIPS,
+    SKIP_STEP_WITH_NEW_TIPS,
     ERROR_WHILE_RECOVERING,
     DROP_TIP_FLOWS,
   } = RECOVERY_MAP
@@ -263,9 +264,32 @@ export function useDropTipFlowUtils({
   const buildTipDropCompleteBtn = (): string => {
     switch (selectedRecoveryOption) {
       case RETRY_NEW_TIPS.ROUTE:
+      case SKIP_STEP_WITH_NEW_TIPS.ROUTE:
         return t('proceed_to_tip_selection')
       default:
         return t('proceed_to_cancel')
+    }
+  }
+
+  const buildTipDropCompleteRouting = (): (() => void) | null => {
+    const routeTo = (selectedRoute: RecoveryRoute, step: RouteStep): void => {
+      void proceedToRouteAndStep(selectedRoute, step)
+    }
+
+    switch (selectedRecoveryOption) {
+      case RETRY_NEW_TIPS.ROUTE:
+        return () => {
+          routeTo(selectedRecoveryOption, RETRY_NEW_TIPS.STEPS.REPLACE_TIPS)
+        }
+      case SKIP_STEP_WITH_NEW_TIPS.ROUTE:
+        return () => {
+          routeTo(
+            selectedRecoveryOption,
+            SKIP_STEP_WITH_NEW_TIPS.STEPS.REPLACE_TIPS
+          )
+        }
+      default:
+        return null
     }
   }
 
@@ -303,6 +327,7 @@ export function useDropTipFlowUtils({
       goBackBeforeBeginning: () => {
         return proceedToRouteAndStep(DROP_TIP_FLOWS.ROUTE)
       },
+      tipDropComplete: buildTipDropCompleteRouting(),
     }
   }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
@@ -264,11 +264,34 @@ describe('useDropTipFlowUtils', () => {
   })
 
   it('should return the correct button overrides', () => {
-    const { result } = renderHook(() => useDropTipFlowUtils(mockProps))
+    const { result } = renderHook(() =>
+      useDropTipFlowUtils({
+        ...mockProps,
+        recoveryMap: {
+          route: RETRY_NEW_TIPS.ROUTE,
+          step: RETRY_NEW_TIPS.STEPS.DROP_TIPS,
+        },
+        currentRecoveryOptionUtils: {
+          selectedRecoveryOption: RETRY_NEW_TIPS.ROUTE,
+        } as any,
+      })
+    )
+    const { tipDropComplete } = result.current.buttonOverrides
 
     result.current.buttonOverrides.goBackBeforeBeginning()
 
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(DROP_TIP_FLOWS.ROUTE)
+
+    expect(tipDropComplete).toBeDefined()
+
+    if (tipDropComplete != null) {
+      tipDropComplete()
+    }
+
+    expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+      RETRY_NEW_TIPS.ROUTE,
+      RETRY_NEW_TIPS.STEPS.REPLACE_TIPS
+    )
   })
 
   it(`should return correct route overrides when the route is ${DROP_TIP_FLOWS.STEPS.CHOOSE_TIP_DROP}`, () => {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/SelectTips.tsx
@@ -12,7 +12,12 @@ import { TipSelection } from './TipSelection'
 import type { RecoveryContentProps } from '../types'
 
 export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
-  const { failedPipetteInfo, routeUpdateActions, recoveryCommands } = props
+  const {
+    failedPipetteInfo,
+    routeUpdateActions,
+    recoveryCommands,
+    isOnDevice,
+  } = props
   const { ROBOT_PICKING_UP_TIPS } = RECOVERY_MAP
   const { pickUpTips } = recoveryCommands
   const {
@@ -33,6 +38,22 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
     setShowTipSelectModal(!showTipSelectModal)
   }
 
+  const buildTertiaryBtnProps = (): {
+    tertiaryBtnDisabled?: boolean
+    tertiaryBtnOnClick?: () => void
+    tertiaryBtnText?: string
+  } => {
+    if (isOnDevice) {
+      return {
+        tertiaryBtnDisabled: failedPipetteInfo?.data.channels === 96,
+        tertiaryBtnOnClick: toggleModal,
+        tertiaryBtnText: t('change_location'),
+      }
+    } else {
+      return {}
+    }
+  }
+
   return (
     <>
       {showTipSelectModal && (
@@ -50,15 +71,13 @@ export function SelectTips(props: RecoveryContentProps): JSX.Element | null {
             type="location"
             bannerText={t('replace_tips_and_select_location')}
           />
-          <TipSelection {...props} allowTipSelection={false} />
+          <TipSelection {...props} allowTipSelection={!isOnDevice} />
         </TwoColumn>
         <RecoveryFooterButtons
           primaryBtnOnClick={primaryBtnOnClick}
           secondaryBtnOnClick={goBackPrevStep}
           primaryBtnTextOverride={t('pick_up_tips')}
-          tertiaryBtnDisabled={failedPipetteInfo?.data.channels === 96}
-          tertiaryBtnOnClick={toggleModal}
-          tertiaryBtnText={t('change_location')}
+          {...buildTertiaryBtnProps()}
         />
       </RecoverySingleColumnContentWrapper>
     </>


### PR DESCRIPTION
Closes [EXEC-559](https://opentrons.atlassian.net/browse/EXEC-559)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview


https://github.com/user-attachments/assets/cb73d6e1-4638-4a0e-90c8-47a2c6029bfa

Primarily a presentation refactor. The desktop tip selector needed some slight changes: design wants the desktop tip selector not to have a separate modal and allow for selecting tips on the smaller tip selector. You can see these changes in the `SelectTips` diff. 

Also, the "sometimes route to somewhere else in ER after completing drop tip and don't just cancel the run" got lost in a previous PR due to merge conflicts, so that's added back/functioning now. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- See video above for the desktop flow.
- Confirmed the ODD flow works as expected.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added recovery "error while dispensing" flows to the desktop app
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-559]: https://opentrons.atlassian.net/browse/EXEC-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ