### PR TITLE
feat(shared-data): bump gripper model version (#15413)

### DIFF
--- a/api/src/opentrons/config/gripper_config.py
+++ b/api/src/opentrons/config/gripper_config.py
@@ -24,7 +24,12 @@ def info_num_to_model(num: str) -> GripperModel:
     # PVT will now be 1.2
     model_map = {
         "0": {"0": GripperModel.v1, "1": GripperModel.v1},
-        "1": {"0": GripperModel.v1, "1": GripperModel.v1_1, "2": GripperModel.v1_2},
+        "1": {
+            "0": GripperModel.v1,
+            "1": GripperModel.v1_1,
+            "2": GripperModel.v1_2,
+            "3": GripperModel.v1_3,
+        },
     }
     return model_map[major_model][minor_model]
 

--- a/shared-data/gripper/definitions/1/gripperV1.3.json
+++ b/shared-data/gripper/definitions/1/gripperV1.3.json
@@ -1,0 +1,29 @@
+{
+  "$otSharedSchema": "gripper/schemas/1",
+  "model": "gripperV1.3",
+  "schemaVersion": 1,
+  "displayName": "Flex Gripper",
+  "gripForceProfile": {
+    "polynomial": [
+      [0, 3.759869],
+      [1, 0.81005],
+      [2, 0.04597701]
+    ],
+    "defaultGripForce": 15.0,
+    "defaultIdleForce": 10.0,
+    "defaultHomeForce": 12.0,
+    "min": 2.0,
+    "max": 30.0
+  },
+  "geometry": {
+    "baseOffsetFromMount": [19.5, -74.325, -94.825],
+    "jawCenterOffsetFromBase": [0.0, 0.0, -86.475],
+    "pinOneOffsetFromBase": [6.0, -54.0, -98.475],
+    "pinTwoOffsetFromBase": [6.0, 54.0, -98.475],
+    "jawWidth": {
+      "min": 60.0,
+      "max": 92.0
+    },
+    "maxAllowedGripError": 3.0
+  }
+}

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -47,7 +47,13 @@ export const MAGNETIC_BLOCK_V1: 'magneticBlockV1' = 'magneticBlockV1'
 export const GRIPPER_V1: 'gripperV1' = 'gripperV1'
 export const GRIPPER_V1_1: 'gripperV1.1' = 'gripperV1.1'
 export const GRIPPER_V1_2: 'gripperV1.2' = 'gripperV1.2'
-export const GRIPPER_MODELS = [GRIPPER_V1, GRIPPER_V1_1, GRIPPER_V1_2]
+export const GRIPPER_V1_3: 'gripperV1.3' = 'gripperV1.3'
+export const GRIPPER_MODELS = [
+  GRIPPER_V1,
+  GRIPPER_V1_1,
+  GRIPPER_V1_2,
+  GRIPPER_V1_3,
+]
 
 // robot display name
 export const OT2_DISPLAY_NAME: 'Opentrons OT-2' = 'Opentrons OT-2'

--- a/shared-data/js/gripper.ts
+++ b/shared-data/js/gripper.ts
@@ -1,8 +1,14 @@
 import gripperV1 from '../gripper/definitions/1/gripperV1.json'
 import gripperV1_1 from '../gripper/definitions/1/gripperV1.1.json'
 import gripperV1_2 from '../gripper/definitions/1/gripperV1.2.json'
+import gripperV1_3 from '../gripper/definitions/1/gripperV1.3.json'
 
-import { GRIPPER_V1, GRIPPER_V1_1, GRIPPER_V1_2 } from './constants'
+import {
+  GRIPPER_V1,
+  GRIPPER_V1_1,
+  GRIPPER_V1_2,
+  GRIPPER_V1_3,
+} from './constants'
 
 import type { GripperModel, GripperDefinition } from './types'
 
@@ -16,6 +22,8 @@ export const getGripperDef = (
       return gripperV1_1 as GripperDefinition
     case GRIPPER_V1_2:
       return gripperV1_2 as GripperDefinition
+    case GRIPPER_V1_3:
+      return gripperV1_3 as GripperDefinition
     default:
       console.warn(
         `Could not find a gripper with model ${gripperModel}, falling back to most recent definition: ${GRIPPER_V1_2}`

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -22,6 +22,7 @@ import {
   GRIPPER_V1,
   GRIPPER_V1_1,
   GRIPPER_V1_2,
+  GRIPPER_V1_3,
   EXTENSION,
   MAGNETIC_BLOCK_V1,
 } from './constants'
@@ -230,6 +231,7 @@ export type GripperModel =
   | typeof GRIPPER_V1
   | typeof GRIPPER_V1_1
   | typeof GRIPPER_V1_2
+  | typeof GRIPPER_V1_3
 
 export type ModuleModelWithLegacy =
   | ModuleModel

--- a/shared-data/python/opentrons_shared_data/gripper/gripper_definition.py
+++ b/shared-data/python/opentrons_shared_data/gripper/gripper_definition.py
@@ -24,6 +24,7 @@ class GripperModel(str, Enum):
     v1 = "gripperV1"
     v1_1 = "gripperV1.1"
     v1_2 = "gripperV1.2"
+    v1_3 = "gripperV1.3"
 
     def __str__(self) -> str:
         """Model name."""
@@ -31,6 +32,7 @@ class GripperModel(str, Enum):
             self.__class__.v1: "gripperV1",
             self.__class__.v1_1: "gripperV1.1",
             self.__class__.v1_2: "gripperV1.2",
+            self.__class__.v1_3: "gripperV1.3",
         }
         return enum_to_str[self]
 


### PR DESCRIPTION
## git cherry-pick 4f90e28b7ebf2a07a5a4445c43cf819a1833ae8f


- #15413 was the edge PR
- This is the only commit needed in the 7.5.0 release to allow for the new gripper model.
- There are no changes to buildroot, oe-core, or ot3-firmware