### PR TITLE
refactor(app): enable recovery errors for failed pickUpTip retry commands

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -217,7 +217,7 @@ describe('useRecoveryCommands', () => {
 
     expect(mockChainRunCommands).toHaveBeenCalledWith(
       [buildPickUpTipsCmd],
-      true
+      false
     )
   })
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -84,7 +84,6 @@ export function useRecoveryCommands({
   }, [chainRunRecoveryCommands])
 
   // Pick up the user-selected tips
-  // TODO(jh, 06-14-24): Do not ignore pickUpTip errors once Pipettes can support tip pick up.
   const pickUpTips = React.useCallback((): Promise<CommandData[]> => {
     const { selectedTipLocations, failedLabware } = failedLabwareUtils
 
@@ -97,7 +96,7 @@ export function useRecoveryCommands({
     if (pickUpTipCmd == null) {
       return Promise.reject(new Error('Invalid use of pickUpTips command'))
     } else {
-      return chainRunRecoveryCommands([pickUpTipCmd], true)
+      return chainRunRecoveryCommands([pickUpTipCmd])
     }
   }, [chainRunRecoveryCommands, failedCommand, failedLabwareUtils])
 


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

We initially disabled error handling for pickUpTip retries back when the pipette would cache only the erroneous failed pick up tip values, since this was effectively blocking all of error recovery at the time. Because that issue has been fixed, let's properly error handle, so if a fixit pickUpTip command fails with no tip detected, we fail appropriately.

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Enter error recovery by not having a tip attached. Retry the failed command, but don't place a tip for the pipette to pick up. Verify the recovery action fails. Now retry with a tip placed and verify things work as expected. 
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
