### PR TITLE
feat(app): Add Error Recovery ErrorDetails desktop support

### DIFF
--- a/app/src/assets/localization/en/error_recovery.json
+++ b/app/src/assets/localization/en/error_recovery.json
@@ -16,6 +16,7 @@
   "continue_run_now": "Continue run now",
   "continue_to_drop_tip": "Continue to drop tip",
   "error": "Error",
+  "error_details": "Error details",
   "error_on_robot": "Error on {{robot}}",
   "failed_dispense_step_not_completed": "<block>The failed dispense step will not be completed. The run will continue from the next step.</block><block>Close the robot door before proceeding.</block>",
   "failed_step": "Failed step",
@@ -40,6 +41,7 @@
   "recovery_action_failed": "{{action}} failed",
   "recovery_mode": "Recovery Mode",
   "recovery_mode_explanation": "<block>Recovery Mode provides you with guided and manual controls for handling errors at runtime.</block><br/><block>You can make changes to ensure the step in progress when the error occurred can be completed or choose to cancel the protocol. When changes are made and no subsequent errors are detected, the method completes. Depending on the conditions that caused the error, you will only be provided with appropriate options.</block>",
+  "remove_tips_from_pipette": "Remove tips from {{mount}} pipette before canceling the run?",
   "replace_tips_and_select_location": "It's best to replace tips and select the last location used for tip pickup.",
   "replace_used_tips_in_rack_location": "Replace used tips in rack location {{location}} in slot {{slot}}",
   "replace_with_new_tip_rack": "Replace with new tip rack in slot {{slot}}",
@@ -72,6 +74,5 @@
   "tip_not_detected": "Tip not detected",
   "view_error_details": "View error details",
   "view_recovery_options": "View recovery options",
-  "you_can_still_drop_tips": "You can still drop the attached tips before proceeding to tip selection.",
-  "remove_tips_from_pipette": "Remove tips from {{mount}} pipette before canceling the run?"
+  "you_can_still_drop_tips": "You can still drop the attached tips before proceeding to tip selection."
 }

--- a/app/src/molecules/InterventionModal/index.tsx
+++ b/app/src/molecules/InterventionModal/index.tsx
@@ -179,6 +179,8 @@ const ICON_STYLE = css`
   width: ${SPACING.spacing16};
   height: ${SPACING.spacing16};
   margin: ${SPACING.spacing4};
+  cursor: pointer;
+
   @media (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
     width: ${SPACING.spacing32};
     height: ${SPACING.spacing32};

--- a/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
+++ b/app/src/organisms/Devices/ProtocolRun/ProtocolRunHeader.tsx
@@ -297,7 +297,6 @@ export function ProtocolRunHeader({
     <>
       {isERActive ? (
         <ErrorRecoveryFlows
-          isFlex={true}
           runStatus={runStatus}
           runId={runId}
           failedCommand={failedCommand}

--- a/app/src/organisms/ErrorRecoveryFlows/ErrorRecoveryWizard.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/ErrorRecoveryWizard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
+import { css } from 'styled-components'
 
 import { StyledText } from '@opentrons/components'
 
@@ -101,7 +102,13 @@ export function ErrorRecoveryComponent(
   }
 
   const buildIconHeading = (): JSX.Element => (
-    <StyledText oddStyle="bodyTextSemiBold" desktopStyle="bodyDefaultSemiBold">
+    <StyledText
+      oddStyle="bodyTextSemiBold"
+      desktopStyle="bodyDefaultSemiBold"
+      css={css`
+        cursor: pointer;
+      `}
+    >
       {t('view_error_details')}
     </StyledText>
   )
@@ -119,6 +126,7 @@ export function ErrorRecoveryComponent(
     !isDoorOpen &&
     route === RECOVERY_MAP.DROP_TIP_FLOWS.ROUTE &&
     step !== RECOVERY_MAP.DROP_TIP_FLOWS.STEPS.BEGIN_REMOVAL
+  const desktopType = isLargeDesktopStyle ? 'desktop-large' : 'desktop-small'
 
   return (
     <RecoveryInterventionModal
@@ -126,11 +134,15 @@ export function ErrorRecoveryComponent(
       titleHeading={buildTitleHeading()}
       iconHeadingOnClick={toggleModal}
       iconName="information"
-      desktopType={isLargeDesktopStyle ? 'desktop-large' : 'desktop-small'}
+      desktopType={desktopType}
       isOnDevice={isOnDevice}
     >
       {showModal ? (
-        <ErrorDetailsModal {...props} toggleModal={toggleModal} />
+        <ErrorDetailsModal
+          {...props}
+          toggleModal={toggleModal}
+          desktopType={desktopType}
+        />
       ) : null}
       {buildInterventionContent()}
     </RecoveryInterventionModal>

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -11,7 +11,6 @@ import {
   StyledText,
   RESPONSIVENESS,
 } from '@opentrons/components'
-import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { RadioButton } from '../../../atoms/buttons'
 import {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -187,10 +187,10 @@ function DropTipFlowsContainer(
   props: RecoveryContentProps
 ): JSX.Element | null {
   const {
+    robotType,
     tipStatusUtils,
     routeUpdateActions,
     recoveryCommands,
-    isFlex,
     currentRecoveryOptionUtils,
   } = props
   const { DROP_TIP_FLOWS, ROBOT_CANCELING, RETRY_NEW_TIPS } = RECOVERY_MAP
@@ -229,7 +229,7 @@ function DropTipFlowsContainer(
   return (
     <RecoverySingleColumnContentWrapper>
       <DropTipWizardFlows
-        robotType={isFlex ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE}
+        robotType={robotType}
         closeFlow={onCloseFlow}
         mount={mount}
         instrumentModelSpecs={specs}

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -20,7 +20,6 @@ import {
   StyledText,
   JUSTIFY_END,
   PrimaryButton,
-  ALIGN_FLEX_END,
   SecondaryButton,
 } from '@opentrons/components'
 

--- a/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RunPausedSplash.tsx
@@ -115,7 +115,7 @@ export function RunPausedSplash(
           <Flex width="49rem" justifyContent={JUSTIFY_CENTER}>
             <StepInfo
               {...props}
-              textStyle="level3HeaderBold"
+              oddStyle="level3HeaderBold"
               overflow="hidden"
               overflowWrap={OVERFLOW_WRAP_BREAK_WORD}
               color={COLORS.white}
@@ -155,7 +155,6 @@ export function RunPausedSplash(
           <Flex
             gridGap={SPACING.spacing24}
             flexDirection={DIRECTION_COLUMN}
-            alignItems={ALIGN_FLEX_END}
             justifyContent={JUSTIFY_SPACE_BETWEEN}
           >
             <Flex
@@ -180,7 +179,7 @@ export function RunPausedSplash(
                 <StyledText desktopStyle="headingSmallBold">{title}</StyledText>
                 <StepInfo
                   {...props}
-                  textStyle="bodyDefaultRegular"
+                  desktopStyle="bodyDefaultRegular"
                   overflow="hidden"
                   overflowWrap={OVERFLOW_WRAP_BREAK_WORD}
                   textAlign={TEXT_ALIGN_CENTER}

--- a/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/__fixtures__/index.ts
@@ -58,7 +58,6 @@ export const mockRecoveryContentProps: RecoveryContentProps = {
   robotType: FLEX_ROBOT_TYPE,
   runId: 'MOCK_RUN_ID',
   isDoorOpen: false,
-  isFlex: true,
   isOnDevice: true,
   runStatus: RUN_STATUS_AWAITING_RECOVERY,
   recoveryMap: {

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/ErrorRecoveryFlows.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/ErrorRecoveryFlows.test.tsx
@@ -129,7 +129,6 @@ describe('ErrorRecovery', () => {
       runStatus: RUN_STATUS_AWAITING_RECOVERY,
       failedCommand: mockFailedCommand,
       runId: 'MOCK_RUN_ID',
-      isFlex: true,
       protocolAnalysis: {} as any,
     }
     vi.mocked(ErrorRecoveryWizard).mockReturnValue(<div>MOCK WIZARD</div>)

--- a/app/src/organisms/ErrorRecoveryFlows/constants.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/constants.ts
@@ -204,10 +204,6 @@ export const INVALID = 'INVALID' as const
  * Styling
  */
 
-export const BODY_TEXT_STYLE = css`
-  ${TYPOGRAPHY.bodyTextRegular};
-`
-
 export const ODD_SECTION_TITLE_STYLE = css`
   margin-bottom: ${SPACING.spacing16};
 `

--- a/app/src/organisms/ErrorRecoveryFlows/constants.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/constants.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components'
 
-import { SPACING, TYPOGRAPHY, RESPONSIVENESS } from '@opentrons/components'
+import { SPACING, RESPONSIVENESS } from '@opentrons/components'
 
 import type { StepOrder } from './types'
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -1,4 +1,5 @@
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { useRouteUpdateActions } from './useRouteUpdateActions'
 import { useRecoveryCommands } from './useRecoveryCommands'
@@ -56,7 +57,6 @@ export interface ERUtilsResults {
 const SUBSEQUENT_COMMAND_DEPTH = 2
 // Builds various Error Recovery utilities.
 export function useERUtils({
-  isFlex,
   failedCommand,
   runId,
   toggleERWizard,
@@ -96,7 +96,7 @@ export function useERUtils({
 
   const tipStatusUtils = useRecoveryTipStatus({
     runId,
-    isFlex,
+    isFlex: robotType === FLEX_ROBOT_TYPE,
     runRecord,
     attachedInstruments,
   })

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -106,7 +106,6 @@ export interface ErrorRecoveryFlowsProps {
   runId: string
   runStatus: RunStatus | null
   failedCommand: FailedCommand | null
-  isFlex: boolean
   protocolAnalysis: CompletedProtocolAnalysis | null
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/ErrorDetailsModal.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
+import { css } from 'styled-components'
 
 import {
   Flex,
+  StyledText,
   SPACING,
   COLORS,
   BORDERS,
@@ -12,16 +14,22 @@ import {
 
 import { useErrorName } from '../hooks'
 import { Modal } from '../../../molecules/Modal'
-import { getTopPortalEl } from '../../../App/portal'
+import { getModalPortalEl, getTopPortalEl } from '../../../App/portal'
 import { ERROR_KINDS } from '../constants'
 import { InlineNotification } from '../../../atoms/InlineNotification'
 import { StepInfo } from './StepInfo'
 import { getErrorKind } from '../utils'
+import {
+  LegacyModalShell,
+  LegacyModalHeader,
+} from '../../../molecules/LegacyModal'
 
 import type { RobotType } from '@opentrons/shared-data'
+import type { IconProps } from '@opentrons/components'
 import type { ModalHeaderBaseProps } from '../../../molecules/Modal/types'
 import type { ERUtilsResults } from '../hooks'
 import type { ErrorRecoveryFlowsProps } from '..'
+import type { DesktopSizeType } from '../types'
 
 export function useErrorDetailsModal(): {
   showModal: boolean
@@ -41,6 +49,7 @@ type ErrorDetailsModalProps = ErrorRecoveryFlowsProps &
     toggleModal: () => void
     isOnDevice: boolean
     robotType: RobotType
+    desktopType: DesktopSizeType
   }
 
 export function ErrorDetailsModal(props: ErrorDetailsModalProps): JSX.Element {
@@ -64,7 +73,101 @@ export function ErrorDetailsModal(props: ErrorDetailsModalProps): JSX.Element {
     hasExitIcon: true,
   }
 
-  return createPortal(
+  const buildModal = (): JSX.Element => {
+    if (isOnDevice) {
+      return createPortal(
+        <ErrorDetailsModalODD
+          {...props}
+          toggleModal={toggleModal}
+          modalHeader={modalHeader}
+        >
+          {getIsOverpressureErrorKind() ? <OverpressureBanner /> : null}
+        </ErrorDetailsModalODD>,
+        getTopPortalEl()
+      )
+    } else {
+      return createPortal(
+        <ErrorDetailsModalDesktop
+          {...props}
+          toggleModal={toggleModal}
+          modalHeader={modalHeader}
+        >
+          {getIsOverpressureErrorKind() ? <OverpressureBanner /> : null}
+        </ErrorDetailsModalDesktop>,
+        getModalPortalEl()
+      )
+    }
+  }
+
+  return buildModal()
+}
+
+type ErrorDetailsModalType = ErrorDetailsModalProps & {
+  children: React.ReactNode
+  modalHeader: ModalHeaderBaseProps
+  toggleModal: () => void
+  desktopType: DesktopSizeType
+}
+
+export function ErrorDetailsModalDesktop(
+  props: ErrorDetailsModalType
+): JSX.Element {
+  const { children, modalHeader, toggleModal, desktopType } = props
+  const { t } = useTranslation('error_recovery')
+
+  const buildIcon = (): IconProps => {
+    return {
+      name: 'information',
+      color: COLORS.grey60,
+      size: SPACING.spacing20,
+      marginRight: SPACING.spacing8,
+    }
+  }
+
+  const buildHeader = (): JSX.Element => {
+    return (
+      <LegacyModalHeader
+        onClose={toggleModal}
+        title={t('error_details')}
+        icon={buildIcon()}
+        color={COLORS.black90}
+        backgroundColor={COLORS.white}
+      />
+    )
+  }
+
+  return (
+    <LegacyModalShell
+      header={buildHeader()}
+      css={
+        desktopType === 'desktop-small'
+          ? DESKTOP_MODAL_STYLE_SMALL
+          : DESKTOP_MODAL_STYLE_LARGE
+      }
+    >
+      <Flex
+        padding={SPACING.spacing24}
+        gridGap={SPACING.spacing24}
+        flexDirection={DIRECTION_COLUMN}
+      >
+        <StyledText desktopStyle="headingSmallBold">
+          {modalHeader.title}
+        </StyledText>
+        {children}
+        <Flex css={DESKTOP_STEP_INFO_STYLE}>
+          <StepInfo {...props} desktopStyle="bodyDefaultRegular" />
+        </Flex>
+      </Flex>
+    </LegacyModalShell>
+  )
+}
+
+export function ErrorDetailsModalODD(
+  props: ErrorDetailsModalType
+): JSX.Element {
+  const { children, modalHeader, toggleModal } = props
+
+  return (
     <Modal
       header={modalHeader}
       onOutsideClick={toggleModal}
@@ -72,36 +175,50 @@ export function ErrorDetailsModal(props: ErrorDetailsModalProps): JSX.Element {
       gridGap={SPACING.spacing32}
     >
       <Flex gridGap={SPACING.spacing24} flexDirection={DIRECTION_COLUMN}>
-        {getIsOverpressureErrorKind() ? (
-          <OverpressureBanner isOnDevice={isOnDevice} />
-        ) : null}
+        {children}
         <Flex
           gridGap={SPACING.spacing16}
           backgroundColor={COLORS.grey35}
           borderRadius={BORDERS.borderRadius8}
           padding={`${SPACING.spacing16} ${SPACING.spacing20}`}
         >
-          <StepInfo {...props} textStyle="label" />
+          <StepInfo {...props} desktopStyle="bodyDefaultRegular" />
         </Flex>
       </Flex>
-    </Modal>,
-    getTopPortalEl()
+    </Modal>
   )
 }
 
-export function OverpressureBanner(props: {
-  isOnDevice: boolean
-}): JSX.Element | null {
+export function OverpressureBanner(): JSX.Element | null {
   const { t } = useTranslation('error_recovery')
 
-  if (props.isOnDevice) {
-    return (
-      <InlineNotification
-        type="alert"
-        heading={t('overpressure_is_usually_caused')}
-      />
-    )
-  } else {
-    return null
-  }
+  return (
+    <InlineNotification
+      type="alert"
+      heading={t('overpressure_is_usually_caused')}
+    />
+  )
 }
+
+// TODO(jh, 07-24-24): Using shared height/width constants for intervention modal sizing and the ErrorDetailsModal sizing
+// would be ideal.
+const DESKTOP_STEP_INFO_STYLE = css`
+  background-color: ${COLORS.grey30};
+  grid-gap: ${SPACING.spacing10};
+  border-radius: ${BORDERS.borderRadius4};
+  padding: ${SPACING.spacing6} ${SPACING.spacing24} ${SPACING.spacing6}
+    ${SPACING.spacing12};
+`
+
+const DESKTOP_MODAL_STYLE_BASE = css`
+  width: 47rem;
+`
+
+const DESKTOP_MODAL_STYLE_SMALL = css`
+  ${DESKTOP_MODAL_STYLE_BASE}
+  height: 26rem;
+`
+const DESKTOP_MODAL_STYLE_LARGE = css`
+  ${DESKTOP_MODAL_STYLE_BASE}
+  height: 31rem;
+`

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryInterventionModal.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryInterventionModal.tsx
@@ -8,13 +8,14 @@ import { InterventionModal } from '../../../molecules/InterventionModal'
 import { getModalPortalEl, getTopPortalEl } from '../../../App/portal'
 
 import type { ModalType } from '../../../molecules/InterventionModal'
+import type { DesktopSizeType } from '../types'
 
 export type RecoveryInterventionModalProps = Omit<
   React.ComponentProps<typeof InterventionModal>,
   'type'
 > & {
   /* If on desktop, specifies the hard-coded dimensions height of the modal. */
-  desktopType: 'desktop-small' | 'desktop-large'
+  desktopType: DesktopSizeType
   isOnDevice: boolean
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/shared/StepInfo.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/StepInfo.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 
 import { useTranslation } from 'react-i18next'
 
-import { Flex, DISPLAY_INLINE, LegacyStyledText } from '@opentrons/components'
+import { Flex, DISPLAY_INLINE, StyledText } from '@opentrons/components'
 
 import { CommandText } from '../../../molecules/Command'
 
@@ -10,15 +10,17 @@ import type { StyleProps } from '@opentrons/components'
 import type { RecoveryContentProps } from '../types'
 
 interface StepInfoProps extends StyleProps {
-  textStyle: React.ComponentProps<typeof LegacyStyledText>['as']
   stepCounts: RecoveryContentProps['stepCounts']
   failedCommand: RecoveryContentProps['failedCommand']
   robotType: RecoveryContentProps['robotType']
   protocolAnalysis: RecoveryContentProps['protocolAnalysis']
+  desktopStyle?: React.ComponentProps<typeof StyledText>['desktopStyle']
+  oddStyle?: React.ComponentProps<typeof StyledText>['oddStyle']
 }
 
 export function StepInfo({
-  textStyle,
+  desktopStyle,
+  oddStyle,
   stepCounts,
   failedCommand,
   robotType,
@@ -35,18 +37,27 @@ export function StepInfo({
   const currentCopy = currentStepNumber ?? '?'
   const totalCopy = totalStepCount ?? '?'
 
+  const desktopStyleDefaulted = desktopStyle ?? 'bodyDefaultRegular'
+  const oddStyleDefaulted = oddStyle ?? 'bodyTextRegular'
+
   return (
     <Flex display={DISPLAY_INLINE} {...styleProps}>
-      <LegacyStyledText as={textStyle} display={DISPLAY_INLINE}>
+      <StyledText
+        desktopStyle={desktopStyleDefaulted}
+        oddStyle={oddStyleDefaulted}
+        display={DISPLAY_INLINE}
+      >
         {`${t('at_step')} ${currentCopy}/${totalCopy}: `}
-      </LegacyStyledText>
+      </StyledText>
       {analysisCommand != null && protocolAnalysis != null ? (
         <CommandText
           command={analysisCommand}
           commandTextData={protocolAnalysis}
           robotType={robotType}
           display={DISPLAY_INLINE}
-          as={textStyle}
+          modernStyledTextDefaults={true}
+          desktopStyle={desktopStyleDefaulted}
+          oddStyle={oddStyleDefaulted}
         />
       ) : null}
     </Flex>

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/ErrorDetailsModal.test.tsx
@@ -44,27 +44,6 @@ describe('useErrorDetailsModal', () => {
   })
 })
 
-describe('ErrorDetailsModal', () => {
-  let props: React.ComponentProps<typeof ErrorDetailsModal>
-
-  beforeEach(() => {
-    props = {
-      ...mockRecoveryContentProps,
-      toggleModal: vi.fn(),
-      robotType: 'OT-3 Standard',
-    }
-
-    vi.mocked(StepInfo).mockReturnValue(<div>MOCK_STEP_INFO</div>)
-  })
-
-  it('renders ErrorDetailsModal', () => {
-    renderWithProviders(<ErrorDetailsModal {...props} />, {
-      i18nInstance: i18n,
-    })
-    expect(screen.getByText('MOCK_STEP_INFO')).toBeInTheDocument()
-  })
-})
-
 const render = (props: React.ComponentProps<typeof ErrorDetailsModal>) => {
   return renderWithProviders(<ErrorDetailsModal {...props} />, {
     i18nInstance: i18n,
@@ -79,6 +58,7 @@ describe('ErrorDetailsModal', () => {
       ...mockRecoveryContentProps,
       toggleModal: vi.fn(),
       robotType: 'OT-3 Standard',
+      desktopType: 'desktop-small',
     }
 
     vi.mocked(StepInfo).mockReturnValue(<div>MOCK_STEP_INFO</div>)
@@ -87,7 +67,9 @@ describe('ErrorDetailsModal', () => {
     )
   })
 
-  it('renders the modal with the correct content', () => {
+  const IS_ODD = [true, false]
+
+  it('renders the ODD modal with the correct content', () => {
     render(props)
     expect(vi.mocked(Modal)).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -102,21 +84,30 @@ describe('ErrorDetailsModal', () => {
     expect(screen.getByText('MOCK_STEP_INFO')).toBeInTheDocument()
   })
 
-  it('renders the OverpressureBanner when the error kind is an overpressure error', () => {
-    props.failedCommand = {
-      ...props.failedCommand,
-      commandType: 'aspirate',
-      error: { isDefined: true, errorType: 'overpressure' },
-    } as any
-    render(props)
+  it('renders the desktop modal with the correct content', () => {
+    render({ ...props, isOnDevice: false })
 
-    screen.getByText('MOCK_INLINE_NOTIFICATION')
+    screen.getByText('MOCK_STEP_INFO')
+    screen.getByText('Error details')
   })
 
-  it('does not render the OverpressureBanner when the error kind is not an overpressure error', () => {
-    render(props)
+  IS_ODD.forEach(isOnDevice => {
+    it('renders the OverpressureBanner when the error kind is an overpressure error', () => {
+      props.failedCommand = {
+        ...props.failedCommand,
+        commandType: 'aspirate',
+        error: { isDefined: true, errorType: 'overpressure' },
+      } as any
+      render({ ...props, isOnDevice })
 
-    expect(screen.queryByText('MOCK_INLINE_NOTIFICATION')).toBeNull()
+      screen.getByText('MOCK_INLINE_NOTIFICATION')
+    })
+
+    it('does not render the OverpressureBanner when the error kind is not an overpressure error', () => {
+      render({ ...props, isOnDevice })
+
+      expect(screen.queryByText('MOCK_INLINE_NOTIFICATION')).toBeNull()
+    })
   })
 })
 
@@ -128,7 +119,7 @@ describe('OverpressureBanner', () => {
   })
 
   it('renders the InlineNotification', () => {
-    renderWithProviders(<OverpressureBanner isOnDevice={true} />, {
+    renderWithProviders(<OverpressureBanner />, {
       i18nInstance: i18n,
     })
     expect(vi.mocked(InlineNotification)).toHaveBeenCalledWith(

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StepInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StepInfo.test.tsx
@@ -25,7 +25,7 @@ describe('StepInfo', () => {
         ...mockRecoveryContentProps,
         protocolAnalysis: { commands: [mockFailedCommand] } as any,
       },
-      desktopStyle: 'h4',
+      desktopStyle: 'bodyDefaultRegular',
       stepCounts: {
         currentStepNumber: 5,
         totalStepCount: 10,

--- a/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StepInfo.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/__tests__/StepInfo.test.tsx
@@ -25,7 +25,7 @@ describe('StepInfo', () => {
         ...mockRecoveryContentProps,
         protocolAnalysis: { commands: [mockFailedCommand] } as any,
       },
-      textStyle: 'h4',
+      desktopStyle: 'h4',
       stepCounts: {
         currentStepNumber: 5,
         totalStepCount: 10,

--- a/app/src/organisms/ErrorRecoveryFlows/types.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/types.ts
@@ -63,3 +63,5 @@ export type RecoveryContentProps = ErrorRecoveryWizardProps & {
   errorKind: ErrorKind
   isOnDevice: boolean
 }
+
+export type DesktopSizeType = 'desktop-small' | 'desktop-large'

--- a/app/src/pages/RunningProtocol/index.tsx
+++ b/app/src/pages/RunningProtocol/index.tsx
@@ -164,7 +164,6 @@ export function RunningProtocol(): JSX.Element {
       {isERActive ? (
         <ErrorRecoveryFlows
           runStatus={runStatus}
-          isFlex={true}
           runId={runId}
           failedCommand={failedCommand}
           protocolAnalysis={robotSideAnalysis}


### PR DESCRIPTION
Closes [EXEC-627](https://opentrons.atlassian.net/browse/EXEC-627)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

https://github.com/user-attachments/assets/39f2549a-fc17-454e-93ee-384d01ca0c4e

This PR creates the `ErrorDetails` modal for the desktop, which is component-wise different from the same modal on the ODD. The simplest way to achieve the result design wants is to create a modal within the stacking context of the `RecoveryInterventionModal` as we do on the ODD. Doing so requires us to bypass a lot of complicated routing logic that we'd otherwise have to consider (as explained in https://github.com/Opentrons/opentrons/pull/15679), and when possible, it would be preferable not to overcomplicate things. 

The tradeoff we face when bypassing the routing annoyances is we need to ensure the width and height are updated if the `RecoveryInterventionModal` width/height ever change in the future (so the dimensions look identical). Ideally, we'd have some shared constant here, but the width/height constants for our intervention modal are actually a part of the `InterventionModal` component itself. Figuring out a better system is worth thinking about, but this isn't an issue now, so let's revisit it at a better time.

Also, because we need to `StepInfo` for the desktop modal, I went ahead and updated the component to use `StyledText`, since this was causing text sizing issues in other places - a few fewer CSS bugs!

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- See video.
- Verified the ODD `ErrorDetails` is working as expected.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added the error details info modal to the desktop
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-627]: https://opentrons.atlassian.net/browse/EXEC-627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ