### PR TITLE
refactor(robot-server): refactor error recovery policy model

### DIFF
--- a/robot-server/robot_server/runs/error_recovery_mapping.py
+++ b/robot-server/robot_server/runs/error_recovery_mapping.py
@@ -14,7 +14,7 @@ from opentrons.protocol_engine.error_recovery_policy import (
 
 
 def create_error_recovery_policy_from_rules(
-    rules: Optional[list[ErrorRecoveryRule]],
+    rules: list[ErrorRecoveryRule],
 ) -> ErrorRecoveryPolicy:
     """Given a list of error recovery rules return an error recovery policy."""
 

--- a/robot-server/robot_server/runs/error_recovery_models.py
+++ b/robot-server/robot_server/runs/error_recovery_models.py
@@ -59,11 +59,11 @@ class MatchCriteria(BaseModel):
 class ErrorRecoveryRule(BaseModel):
     """Request/Response model for new error recovery rule creation."""
 
-    matchCriteria: list[MatchCriteria] = Field(
-        default_factory=list,
+    matchCriteria: MatchCriteria = Field(
+        ...,
         description="The criteria that must be met for this rule to be applied.",
     )
-    ifMatch: list[ReactionIfMatch] = Field(
-        default_factory=list,
+    ifMatch: ReactionIfMatch = Field(
+        ...,
         description="The specific recovery setting that will be in use if the type parameters match.",
     )

--- a/robot-server/tests/runs/test_error_recovery_mapping.py
+++ b/robot-server/tests/runs/test_error_recovery_mapping.py
@@ -89,7 +89,7 @@ def test_create_error_recovery_policy_undefined_error(
     decoy: Decoy, mock_command: LiquidProbe
 ) -> None:
     """Should return a FAIL_RUN policy when error is not defined."""
-    policy = create_error_recovery_policy_from_rules(rules=None)
+    policy = create_error_recovery_policy_from_rules(rules=[])
     exampleConfig = Config(
         robot_type="OT-3 Standard",
         deck_type=DeckType.OT3_STANDARD,
@@ -102,7 +102,7 @@ def test_create_error_recovery_policy_defined_error(
     decoy: Decoy, mock_command: LiquidProbe, mock_error_data: CommandDefinedErrorData
 ) -> None:
     """Should return a WAIT_FOR_RECOVERY policy when error is defined."""
-    policy = create_error_recovery_policy_from_rules(rules=None)
+    policy = create_error_recovery_policy_from_rules(rules=[])
     exampleConfig = Config(
         robot_type="OT-3 Standard",
         deck_type=DeckType.OT3_STANDARD,

--- a/robot-server/tests/runs/test_error_recovery_mapping.py
+++ b/robot-server/tests/runs/test_error_recovery_mapping.py
@@ -64,8 +64,8 @@ def mock_criteria(decoy: Decoy) -> MatchCriteria:
 def mock_rule(decoy: Decoy, mock_criteria: MatchCriteria) -> ErrorRecoveryRule:
     """Get a mock ErrorRecoveryRule."""
     mock = decoy.mock(cls=ErrorRecoveryRule)
-    decoy.when(mock.ifMatch).then_return([ReactionIfMatch.IGNORE_AND_CONTINUE])
-    decoy.when(mock.matchCriteria).then_return([mock_criteria])
+    decoy.when(mock.ifMatch).then_return(ReactionIfMatch.IGNORE_AND_CONTINUE)
+    decoy.when(mock.matchCriteria).then_return(mock_criteria)
     return mock
 
 
@@ -89,9 +89,7 @@ def test_create_error_recovery_policy_undefined_error(
     decoy: Decoy, mock_command: LiquidProbe
 ) -> None:
     """Should return a FAIL_RUN policy when error is not defined."""
-    rule1 = ErrorRecoveryRule(matchCriteria=[], ifMatch=[])
-
-    policy = create_error_recovery_policy_from_rules([rule1])
+    policy = create_error_recovery_policy_from_rules(rules=None)
     exampleConfig = Config(
         robot_type="OT-3 Standard",
         deck_type=DeckType.OT3_STANDARD,
@@ -104,9 +102,7 @@ def test_create_error_recovery_policy_defined_error(
     decoy: Decoy, mock_command: LiquidProbe, mock_error_data: CommandDefinedErrorData
 ) -> None:
     """Should return a WAIT_FOR_RECOVERY policy when error is defined."""
-    rule1 = ErrorRecoveryRule(matchCriteria=[], ifMatch=[])
-
-    policy = create_error_recovery_policy_from_rules([rule1])
+    policy = create_error_recovery_policy_from_rules(rules=None)
     exampleConfig = Config(
         robot_type="OT-3 Standard",
         deck_type=DeckType.OT3_STANDARD,


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Previously, an ErrorRecoveryPolicy was of the format:
```
rules
    matchCriteria
        criteria 1 (with one commandType and one errorType)
        criteria 2 (with one commandType and one errorType)
        criteria 3 (with one commandType and one errorType)
    ifMatch
        reaction 1
        reaction 2
        reaction 3
```

This PR moves it to the format of:

```
rules
    rule 1
        matchCriteria (with one commandType and one errorType)
        ifMatch reaction
    rule 2
        matchCriteria (with one commandType and one errorType)
        ifMatch reaction
```

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

Make sure old unit test pass.

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
