### PR TITLE
fix(app): prevent eternal intervention purgatory

### DIFF
--- a/app/src/organisms/RunProgressMeter/index.tsx
+++ b/app/src/organisms/RunProgressMeter/index.tsx
@@ -31,7 +31,7 @@ import {
 } from '@opentrons/api-client'
 
 import { useMostRecentCompletedAnalysis } from '../LabwarePositionCheck/useMostRecentCompletedAnalysis'
-import { getTopPortalEl } from '../../App/portal'
+import { getModalPortalEl } from '../../App/portal'
 import { Tooltip } from '../../atoms/Tooltip'
 import { CommandText } from '../../molecules/Command'
 import { useRunStatus } from '../RunTimeControl/hooks'
@@ -175,7 +175,7 @@ export function RunProgressMeter(props: RunProgressMeterProps): JSX.Element {
               run={runData}
               analysis={analysis}
             />,
-            getTopPortalEl()
+            getModalPortalEl()
           )
         : null}
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>


### PR DESCRIPTION

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

If you click on a run that has an intervention modal due to a pause, move labware, etc., you shouldn't have to stare at that run until you close or your app, deal with the robot, or contemplate your navigation actions for all eternity. Navigating away should be a legitimate option.

### Before

<img width="1023" alt="Screenshot 2024-07-24 at 4 22 50 PM" src="https://github.com/user-attachments/assets/b7cc43cd-bb0c-4494-94bc-7db64571a66e">

### After

<img width="1020" alt="Screenshot 2024-07-24 at 4 22 33 PM" src="https://github.com/user-attachments/assets/98d315c8-5981-41f5-b3d9-7277d1754aad">


<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- See pics
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Non-navigable intervention modals are now navigable.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
