### PR TITLE
feat(robot-server): Notify clients of updates to `GET /clientData/{key}`

### DIFF
--- a/robot-server/robot_server/client_data/store.py
+++ b/robot-server/robot_server/client_data/store.py
@@ -29,6 +29,10 @@ class ClientDataStore:
         """
         return self._current_data[key]
 
+    def get_keys(self) -> list[str]:
+        """Return the keys that currently have data stored."""
+        return list(self._current_data.keys())
+
     def delete(self, key: str) -> None:
         """Delete the data at the given key.
 

--- a/robot-server/robot_server/service/notifications/__init__.py
+++ b/robot-server/robot_server/service/notifications/__init__.py
@@ -15,7 +15,6 @@ from .publishers import (
     get_runs_publisher,
     get_deck_configuration_publisher,
 )
-from .topics import Topics
 
 __all__ = [
     # main export
@@ -35,5 +34,4 @@ __all__ = [
     "get_deck_configuration_publisher",
     # for testing
     "PublisherNotifier",
-    "Topics",
 ]

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -7,6 +7,8 @@ from fastapi import Depends
 from typing import Any, Dict, Optional
 from enum import Enum
 
+
+from .topics import TopicName
 from ..json_api import NotifyRefetchBody, NotifyUnsubscribeBody
 from server_utils.fastapi_utils.app_state import (
     AppState,
@@ -80,7 +82,7 @@ class NotificationClient:
         self._client.loop_stop()
         await to_thread.run_sync(self._client.disconnect)
 
-    async def publish_advise_refetch_async(self, topic: str) -> None:
+    async def publish_advise_refetch_async(self, topic: TopicName) -> None:
         """Asynchronously publish a refetch message on a specific topic to the MQTT broker.
 
         Args:
@@ -88,7 +90,7 @@ class NotificationClient:
         """
         await to_thread.run_sync(self.publish_advise_refetch, topic)
 
-    async def publish_advise_unsubscribe_async(self, topic: str) -> None:
+    async def publish_advise_unsubscribe_async(self, topic: TopicName) -> None:
         """Asynchronously publish an unsubscribe message on a specific topic to the MQTT broker.
 
         Args:

--- a/robot-server/robot_server/service/notifications/publishers/client_data_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/client_data_publisher.py
@@ -1,0 +1,29 @@
+from typing import Annotated
+import fastapi
+from robot_server.service.notifications import topics
+from robot_server.service.notifications.notification_client import (
+    NotificationClient,
+    get_notification_client,
+)
+
+
+class ClientDataPublisher:
+    """Publishes clientData topics."""
+
+    def __init__(self, client: NotificationClient) -> None:
+        self._client = client
+
+    async def publish_client_data(self, client_data_key: str) -> None:
+        """Publish the equivalent of `GET /clientData/{key}`."""
+        await self._client.publish_advise_refetch_async(
+            topics.client_data(client_data_key)
+        )
+
+
+async def get_client_data_publisher(
+    notification_client: Annotated[
+        NotificationClient, fastapi.Depends(get_notification_client)
+    ],
+) -> ClientDataPublisher:
+    """Return a ClientDataPublisher for use by FastAPI endpoints."""
+    return ClientDataPublisher(notification_client)

--- a/robot-server/robot_server/service/notifications/publishers/deck_configuration_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/deck_configuration_publisher.py
@@ -6,7 +6,7 @@ from server_utils.fastapi_utils.app_state import (
     get_app_state,
 )
 from ..notification_client import NotificationClient, get_notification_client
-from ..topics import Topics
+from .. import topics
 
 
 class DeckConfigurationPublisher:
@@ -20,7 +20,7 @@ class DeckConfigurationPublisher:
         self,
     ) -> None:
         """Publishes the equivalent of GET /deck_configuration"""
-        await self._client.publish_advise_refetch_async(topic=Topics.DECK_CONFIGURATION)
+        await self._client.publish_advise_refetch_async(topic=topics.DECK_CONFIGURATION)
 
 
 _deck_configuration_publisher_accessor: AppStateAccessor[

--- a/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/maintenance_runs_publisher.py
@@ -6,7 +6,7 @@ from server_utils.fastapi_utils.app_state import (
     get_app_state,
 )
 from ..notification_client import NotificationClient, get_notification_client
-from ..topics import Topics
+from .. import topics
 
 
 class MaintenanceRunsPublisher:
@@ -21,7 +21,7 @@ class MaintenanceRunsPublisher:
     ) -> None:
         """Publishes the equivalent of GET /maintenance_run/current_run"""
         await self._client.publish_advise_refetch_async(
-            topic=Topics.MAINTENANCE_RUNS_CURRENT_RUN
+            topic=topics.MAINTENANCE_RUNS_CURRENT_RUN
         )
 
 

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -98,27 +98,31 @@ class RunsPublisher:
 
         if self._run_hooks is not None:
             await self._client.publish_advise_refetch_async(
-                topic=f"{topics.RUNS}/{run_id}"
+                topic=topics.TopicName(f"{topics.RUNS}/{run_id}")
             )
 
     async def _publish_runs_advise_unsubscribe_async(self, run_id: str) -> None:
         """Publish an unsubscribe flag for relevant runs topics."""
         if self._run_hooks is not None:
             await self._client.publish_advise_unsubscribe_async(
-                topic=f"{topics.RUNS}/{run_id}"
+                topic=topics.TopicName(f"{topics.RUNS}/{run_id}")
             )
             await self._client.publish_advise_unsubscribe_async(
                 topic=topics.RUNS_COMMANDS_LINKS
             )
             await self._client.publish_advise_unsubscribe_async(
-                topic=f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
+                topic=topics.TopicName(
+                    f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
+                )
             )
 
     async def publish_pre_serialized_commands_notification(self, run_id: str) -> None:
         """Publishes notification for GET /runs/:runId/commandsAsPreSerializedList."""
         if self._run_hooks is not None:
             await self._client.publish_advise_refetch_async(
-                topic=f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
+                topic=topics.TopicName(
+                    f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
+                )
             )
 
     async def _handle_current_command_change(self) -> None:

--- a/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
+++ b/robot-server/robot_server/service/notifications/publishers/runs_publisher.py
@@ -11,7 +11,7 @@ from server_utils.fastapi_utils.app_state import (
 )
 from ..notification_client import NotificationClient, get_notification_client
 from ..publisher_notifier import PublisherNotifier, get_pe_publisher_notifier
-from ..topics import Topics
+from .. import topics
 
 
 @dataclass
@@ -89,36 +89,36 @@ class RunsPublisher:
         (regardless of query parameters).
         """
         await self._client.publish_advise_refetch_async(
-            topic=Topics.RUNS_COMMANDS_LINKS
+            topic=topics.RUNS_COMMANDS_LINKS
         )
 
     async def _publish_runs_advise_refetch_async(self, run_id: str) -> None:
         """Publish a refetch flag for relevant runs topics."""
-        await self._client.publish_advise_refetch_async(topic=Topics.RUNS)
+        await self._client.publish_advise_refetch_async(topic=topics.RUNS)
 
         if self._run_hooks is not None:
             await self._client.publish_advise_refetch_async(
-                topic=f"{Topics.RUNS}/{run_id}"
+                topic=f"{topics.RUNS}/{run_id}"
             )
 
     async def _publish_runs_advise_unsubscribe_async(self, run_id: str) -> None:
         """Publish an unsubscribe flag for relevant runs topics."""
         if self._run_hooks is not None:
             await self._client.publish_advise_unsubscribe_async(
-                topic=f"{Topics.RUNS}/{run_id}"
+                topic=f"{topics.RUNS}/{run_id}"
             )
             await self._client.publish_advise_unsubscribe_async(
-                topic=Topics.RUNS_COMMANDS_LINKS
+                topic=topics.RUNS_COMMANDS_LINKS
             )
             await self._client.publish_advise_unsubscribe_async(
-                topic=f"{Topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
+                topic=f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
             )
 
     async def publish_pre_serialized_commands_notification(self, run_id: str) -> None:
         """Publishes notification for GET /runs/:runId/commandsAsPreSerializedList."""
         if self._run_hooks is not None:
             await self._client.publish_advise_refetch_async(
-                topic=f"{Topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
+                topic=f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/{run_id}"
             )
 
     async def _handle_current_command_change(self) -> None:

--- a/robot-server/robot_server/service/notifications/topics.py
+++ b/robot-server/robot_server/service/notifications/topics.py
@@ -1,18 +1,43 @@
-"""Notification topics."""
-from enum import Enum
+"""MQTT topics for server-emitted notifications.
+
+These are the MQTT functional equivalent of HTTP endpoints.
+Each topic should generally be named after the HTTP endpoint whose data it's reflecting.
+
+It's helpful to have these centralized in this one file so we can see all the topics
+that we currently support.
+"""
+
+from typing import NewType
+import re
 
 
-_TOPIC_BASE = "robot-server"
+TopicName = NewType("TopicName", str)
+"""A string suitable for the server to use as an MQTT topic to publish on."""
 
 
-class Topics(str, Enum):
-    """Notification Topics
+_TOPIC_BASE = TopicName("robot-server")
 
-    MQTT functional equivalent of endpoints.
-    """
 
-    MAINTENANCE_RUNS_CURRENT_RUN = f"{_TOPIC_BASE}/maintenance_runs/current_run"
-    RUNS_COMMANDS_LINKS = f"{_TOPIC_BASE}/runs/commands_links"
-    RUNS = f"{_TOPIC_BASE}/runs"
-    DECK_CONFIGURATION = f"{_TOPIC_BASE}/deck_configuration"
-    RUNS_PRE_SERIALIZED_COMMANDS = f"{_TOPIC_BASE}/runs/pre_serialized_commands"
+def _is_valid_topic_name_segment(segment: str) -> bool:
+    """Return whether a string is valid as a segment in an MQTT topic name."""
+    return not re.match("[/#+]", segment)
+
+
+MAINTENANCE_RUNS_CURRENT_RUN = TopicName(f"{_TOPIC_BASE}/maintenance_runs/current_run")
+RUNS_COMMANDS_LINKS = TopicName(f"{_TOPIC_BASE}/runs/commands_links")
+# todo(mm, 2024-07-24): We actually publish on subtopics of /runs. Convert this to a
+# function like we do for clientData.
+RUNS = TopicName(f"{_TOPIC_BASE}/runs")
+DECK_CONFIGURATION = TopicName(f"{_TOPIC_BASE}/deck_configuration")
+RUNS_PRE_SERIALIZED_COMMANDS = TopicName(f"{_TOPIC_BASE}/runs/pre_serialized_commands")
+
+
+def client_data(key: str) -> TopicName:
+    """Return the dynamic MQTT topic name for the given clientData key."""
+    base = f"{_TOPIC_BASE}/clientData"
+    if _is_valid_topic_name_segment(key):
+        return TopicName(f"{base}/{key}")
+    else:
+        raise ValueError(
+            f"{repr(key)} is not valid as a segment in an MQTT topic name."
+        )

--- a/robot-server/robot_server/service/notifications/topics.py
+++ b/robot-server/robot_server/service/notifications/topics.py
@@ -18,9 +18,9 @@ TopicName = NewType("TopicName", str)
 _TOPIC_BASE = TopicName("robot-server")
 
 
-def _is_valid_topic_name_segment(segment: str) -> bool:
-    """Return whether a string is valid as a segment in an MQTT topic name."""
-    return not re.match("[/#+]", segment)
+def _is_valid_topic_name_level(level: str) -> bool:
+    """Return whether a string is valid as a level (segment) in an MQTT topic name."""
+    return not re.match("[/#+]", level)
 
 
 MAINTENANCE_RUNS_CURRENT_RUN = TopicName(f"{_TOPIC_BASE}/maintenance_runs/current_run")
@@ -35,7 +35,7 @@ RUNS_PRE_SERIALIZED_COMMANDS = TopicName(f"{_TOPIC_BASE}/runs/pre_serialized_com
 def client_data(key: str) -> TopicName:
     """Return the dynamic MQTT topic name for the given clientData key."""
     base = f"{_TOPIC_BASE}/clientData"
-    if _is_valid_topic_name_segment(key):
+    if _is_valid_topic_name_level(key):
         return TopicName(f"{base}/{key}")
     else:
         raise ValueError(

--- a/robot-server/tests/service/notifications/publishers/test_deck_configuration_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_deck_configuration_publisher.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from robot_server.service.notifications import DeckConfigurationPublisher, Topics
+from robot_server.service.notifications import DeckConfigurationPublisher, topics
 
 
 @pytest.fixture
@@ -27,5 +27,5 @@ async def test_publish_current_maintenance_run(
     """It should publish a notify flag for deck configuration updates."""
     await deck_configuration_publisher.publish_deck_configuration()
     notification_client.publish_advise_refetch_async.assert_awaited_once_with(
-        topic=Topics.DECK_CONFIGURATION
+        topic=topics.DECK_CONFIGURATION
     )

--- a/robot-server/tests/service/notifications/publishers/test_maintenance_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_maintenance_runs_publisher.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from robot_server.service.notifications import MaintenanceRunsPublisher, Topics
+from robot_server.service.notifications import MaintenanceRunsPublisher, topics
 
 
 @pytest.fixture
@@ -26,5 +26,5 @@ async def test_publish_current_maintenance_run(
     """It should publish a notify flag for maintenance runs."""
     await maintenance_runs_publisher.publish_current_maintenance_run()
     notification_client.publish_advise_refetch_async.assert_awaited_once_with(
-        topic=Topics.MAINTENANCE_RUNS_CURRENT_RUN
+        topic=topics.MAINTENANCE_RUNS_CURRENT_RUN
     )

--- a/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
+++ b/robot-server/tests/service/notifications/publishers/test_runs_publisher.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 
 from opentrons.protocol_engine import CommandPointer, EngineStatus
 
-from robot_server.service.notifications import RunsPublisher, Topics
+from robot_server.service.notifications import RunsPublisher, topics
 from robot_server.service.notifications.notification_client import NotificationClient
 from robot_server.service.notifications.publisher_notifier import PublisherNotifier
 
@@ -70,9 +70,9 @@ async def test_initialize(
     assert runs_publisher._engine_state_slice.recovery_target_command is None
     assert runs_publisher._engine_state_slice.state_summary_status is None
 
-    notification_client.publish_advise_refetch_async.assert_any_await(topic=Topics.RUNS)
+    notification_client.publish_advise_refetch_async.assert_any_await(topic=topics.RUNS)
     notification_client.publish_advise_refetch_async.assert_any_await(
-        topic=f"{Topics.RUNS}/1234"
+        topic=f"{topics.RUNS}/1234"
     )
 
 
@@ -86,18 +86,18 @@ async def test_clean_up_current_run(
 
     await runs_publisher.clean_up_run(run_id="1234")
 
-    notification_client.publish_advise_refetch_async.assert_any_await(topic=Topics.RUNS)
+    notification_client.publish_advise_refetch_async.assert_any_await(topic=topics.RUNS)
     notification_client.publish_advise_refetch_async.assert_any_await(
-        topic=f"{Topics.RUNS}/1234"
+        topic=f"{topics.RUNS}/1234"
     )
     notification_client.publish_advise_unsubscribe_async.assert_any_await(
-        topic=f"{Topics.RUNS}/1234"
+        topic=f"{topics.RUNS}/1234"
     )
     notification_client.publish_advise_unsubscribe_async.assert_any_await(
-        topic=Topics.RUNS_COMMANDS_LINKS
+        topic=topics.RUNS_COMMANDS_LINKS
     )
     notification_client.publish_advise_unsubscribe_async.assert_any_await(
-        topic=f"{Topics.RUNS_PRE_SERIALIZED_COMMANDS}/1234"
+        topic=f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/1234"
     )
 
 
@@ -132,7 +132,7 @@ async def test_handle_current_command_change(
     await runs_publisher._handle_current_command_change()
 
     notification_client.publish_advise_refetch_async.assert_any_await(
-        topic=Topics.RUNS_COMMANDS_LINKS
+        topic=topics.RUNS_COMMANDS_LINKS
     )
 
 
@@ -167,7 +167,7 @@ async def test_handle_recovery_target_command_change(
     await runs_publisher._handle_recovery_target_command_change()
 
     notification_client.publish_advise_refetch_async.assert_any_await(
-        topic=Topics.RUNS_COMMANDS_LINKS
+        topic=topics.RUNS_COMMANDS_LINKS
     )
 
 
@@ -203,9 +203,9 @@ async def test_handle_engine_status_change(
 
     await runs_publisher._handle_engine_status_change()
 
-    notification_client.publish_advise_refetch_async.assert_any_await(topic=Topics.RUNS)
+    notification_client.publish_advise_refetch_async.assert_any_await(topic=topics.RUNS)
     notification_client.publish_advise_refetch_async.assert_any_await(
-        topic=f"{Topics.RUNS}/1234"
+        topic=f"{topics.RUNS}/1234"
     )
 
 
@@ -231,5 +231,5 @@ async def test_publish_pre_serialized_commannds_notif(
     assert notification_client.publish_advise_refetch_async.call_count == 3
 
     notification_client.publish_advise_refetch_async.assert_any_await(
-        topic=f"{Topics.RUNS_PRE_SERIALIZED_COMMANDS}/1234"
+        topic=f"{topics.RUNS_PRE_SERIALIZED_COMMANDS}/1234"
     )


### PR DESCRIPTION
# Overview

This connects the endpoints added in #15727 to our notifications mechanism, closing EXEC-421.

# Test Plan

I've tested this manually with Postman.

We don't currently have a way of automatically testing our notifications system. Although Tavern supports MQTT, it needs an external broker in between it and the server under test. On real robots, Mosquitto fills that role, but in our dev environments, we don't have anything.

I haven't added endpoint-level unit tests because these endpoints are so trivial and I feel like the effort would be better spent on setting up an MQTT broker in our dev environments, but I'm happy to add them if we're not comfortable with this.

# Review requests

# Risk assessment

Low.