### PR TITLE
refactor(shared-data): remove .dev_types submodules

### DIFF
--- a/api/src/opentrons/calibration_storage/helpers.py
+++ b/api/src/opentrons/calibration_storage/helpers.py
@@ -14,8 +14,8 @@ from hashlib import sha256
 from . import types as local_types
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
-    from opentrons_shared_data.pipette.dev_types import LabwareUri
+    from opentrons_shared_data.labware.types import LabwareDefinition
+    from opentrons_shared_data.pipette.types import LabwareUri
 
 
 def dict_filter_none(data: List[Tuple[str, Any]]) -> Dict[str, Any]:

--- a/api/src/opentrons/calibration_storage/ot2/models/v1.py
+++ b/api/src/opentrons/calibration_storage/ot2/models/v1.py
@@ -4,7 +4,7 @@ from typing_extensions import Literal
 from pydantic import BaseModel, Field, validator
 from datetime import datetime
 
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 
 from opentrons.types import Point
 from opentrons.calibration_storage import types

--- a/api/src/opentrons/calibration_storage/ot2/tip_length.py
+++ b/api/src/opentrons/calibration_storage/ot2/tip_length.py
@@ -7,7 +7,7 @@ from dataclasses import asdict
 from opentrons import config
 
 from .. import file_operators as io, helpers, types as local_types
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE
 from opentrons.util.helpers import utc_now
@@ -16,7 +16,7 @@ from opentrons.util.helpers import utc_now
 from .models import v1
 
 if typing.TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 log = logging.getLogger(__name__)

--- a/api/src/opentrons/calibration_storage/ot3/models/v1.py
+++ b/api/src/opentrons/calibration_storage/ot3/models/v1.py
@@ -6,7 +6,7 @@ from opentrons.hardware_control.types import OT3Mount
 from pydantic import BaseModel, Field, validator
 from datetime import datetime
 
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 
 from opentrons.types import Point
 from opentrons.calibration_storage import types

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -51,7 +51,7 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_engine.protocol_engine import code_in_error_tree
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.errors.exceptions import (

--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from opentrons.config import CONFIG
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -1,5 +1,5 @@
 from opentrons.config import advanced_settings as advs
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 
 def short_fixed_trash() -> bool:

--- a/api/src/opentrons/config/reset.py
+++ b/api/src/opentrons/config/reset.py
@@ -5,7 +5,7 @@ from enum import Enum
 from pathlib import Path
 from typing import NamedTuple, Dict, Set
 
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 from opentrons.config import IS_ROBOT
 from opentrons.calibration_storage import (
     delete_robot_deck_attitude,

--- a/api/src/opentrons/execute.py
+++ b/api/src/opentrons/execute.py
@@ -24,7 +24,7 @@ from typing import (
 )
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons import protocol_api, __version__, should_use_ot3
 
@@ -77,7 +77,7 @@ from opentrons.protocol_runner import (
 from .util import entrypoint_util
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import (
+    from opentrons_shared_data.labware.types import (
         LabwareDefinition as LabwareDefinitionDict,
     )
 

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -27,8 +27,8 @@ from opentrons_shared_data.errors.exceptions import (
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteName
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.pipette.types import PipetteName
+from opentrons_shared_data.robot.types import RobotType
 from opentrons import types as top_types
 from opentrons.config import robot_configs
 from opentrons.config.types import RobotConfig, OT3Config

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -27,7 +27,7 @@ from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     mutable_configurations,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteName
+from opentrons_shared_data.pipette.types import PipetteName
 
 from opentrons.drivers.smoothie_drivers import SmoothieDriver
 from opentrons.drivers.rpi_drivers import build_gpio_chardev
@@ -40,7 +40,7 @@ from ..types import AionotifyEvent, BoardRevision, Axis, DoorState
 from ..util import ot2_axis_to_string
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import PipetteModel
+    from opentrons_shared_data.pipette.types import PipetteModel
     from ..dev_types import (
         AttachedPipette,
         AttachedInstruments,

--- a/api/src/opentrons/hardware_control/backends/flex_protocol.py
+++ b/api/src/opentrons/hardware_control/backends/flex_protocol.py
@@ -12,7 +12,7 @@ from typing import (
     Set,
     TypeVar,
 )
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     PipetteName,
 )
 from opentrons.config.types import GantryLoad, OutputOptions

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -178,7 +178,7 @@ from opentrons_hardware.hardware_control.hepa_uv_settings import (
 )
 
 from opentrons_hardware.drivers.gpio import OT3GPIO, RemoteOT3GPIO
-from opentrons_shared_data.pipette.dev_types import PipetteName
+from opentrons_shared_data.pipette.types import PipetteName
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -47,7 +47,7 @@ from opentrons.hardware_control.types import (
     HardwareEventUnsubscriber,
 )
 
-from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from opentrons_shared_data.pipette.types import PipetteName, PipetteModel
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,

--- a/api/src/opentrons/hardware_control/backends/simulator.py
+++ b/api/src/opentrons/hardware_control/backends/simulator.py
@@ -26,7 +26,7 @@ from ..module_control import AttachedModulesControl
 from ..util import ot2_axis_to_string
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+    from opentrons_shared_data.pipette.types import PipetteName, PipetteModel
     from ..dev_types import (
         AttachedPipette,
         AttachedInstruments,

--- a/api/src/opentrons/hardware_control/dev_types.py
+++ b/api/src/opentrons/hardware_control/dev_types.py
@@ -10,7 +10,7 @@ from typing_extensions import TypedDict, Literal
 from opentrons.hardware_control.instruments.ot3.instrument_calibration import (
     GripperCalibrationOffset,
 )
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     PipetteModel,
     PipetteName,
     ChannelCount,

--- a/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/instrument_calibration.py
@@ -12,8 +12,8 @@ from opentrons.hardware_control.types import OT3Mount
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 if typing.TYPE_CHECKING:
-    from opentrons_shared_data.pipette.dev_types import LabwareUri
-    from opentrons_shared_data.labware.dev_types import (
+    from opentrons_shared_data.pipette.types import LabwareUri
+    from opentrons_shared_data.labware.types import (
         LabwareDefinition as TypeDictLabwareDef,
     )
 

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette.py
@@ -52,7 +52,7 @@ from opentrons.hardware_control.errors import InvalidCriticalPoint
 from opentrons.hardware_control import nozzle_manager
 
 
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     UlPerMmAction,
     PipetteName,
     PipetteModel,

--- a/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot2/pipette_handler.py
@@ -21,7 +21,7 @@ from opentrons_shared_data.errors.exceptions import (
     UnexpectedTipRemovalError,
     UnexpectedTipAttachError,
 )
-from opentrons_shared_data.pipette.dev_types import UlPerMmAction
+from opentrons_shared_data.pipette.types import UlPerMmAction
 from opentrons_shared_data.pipette.types import Quirks
 from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
 

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette.py
@@ -36,7 +36,7 @@ from .instrument_calibration import (
     load_pipette_offset,
     PipetteOffsetByPipetteMount,
 )
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     UlPerMmAction,
     PipetteName,
     PipetteModel,

--- a/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
+++ b/api/src/opentrons/hardware_control/instruments/ot3/pipette_handler.py
@@ -12,7 +12,7 @@ from typing import (
 )
 from typing_extensions import Final
 import numpy
-from opentrons_shared_data.pipette.dev_types import UlPerMmAction
+from opentrons_shared_data.pipette.types import UlPerMmAction
 
 from opentrons_shared_data.errors.exceptions import (
     CommandPreconditionViolated,

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.module.dev_types import (
+    from opentrons_shared_data.module.types import (
         ThermocyclerModuleType,
         MagneticModuleType,
         TemperatureModuleType,

--- a/api/src/opentrons/hardware_control/motion_utilities.py
+++ b/api/src/opentrons/hardware_control/motion_utilities.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from typing import Callable, Dict, Union, Optional, cast
 from collections import OrderedDict
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import Mount, Point
 from opentrons.calibration_storage.types import AttitudeMatrix

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -26,13 +26,13 @@ from opentrons.hardware_control.modules.module_calibration import (
 )
 
 
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     PipetteName,
 )
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
 )
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons import types as top_types
 from opentrons.config import robot_configs

--- a/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
+++ b/api/src/opentrons/hardware_control/protocols/instrument_configurer.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 from typing_extensions import Protocol
 
-from opentrons_shared_data.pipette.dev_types import PipetteName
+from opentrons_shared_data.pipette.types import PipetteName
 from opentrons.types import Mount
 from .types import MountArgType
 

--- a/api/src/opentrons/motion_planning/adjacent_slots_getters.py
+++ b/api/src/opentrons/motion_planning/adjacent_slots_getters.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Union
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName, StagingSlotName
 

--- a/api/src/opentrons/motion_planning/deck_conflict.py
+++ b/api/src/opentrons/motion_planning/deck_conflict.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import List, Mapping, NamedTuple, Optional, Set, Union
 from typing_extensions import Final
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.labware.types import LabwareUri
+from opentrons_shared_data.robot.types import RobotType
 from opentrons.motion_planning.adjacent_slots_getters import (
     get_east_west_slots,
     get_south_slot,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -30,7 +30,7 @@ from opentrons.protocol_engine.types import (
 from opentrons.protocol_engine.errors.exceptions import TipNotAttachedError
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
 from opentrons.hardware_control.nozzle_manager import NozzleMap

--- a/api/src/opentrons/protocol_api/core/engine/labware.py
+++ b/api/src/opentrons/protocol_api/core/engine/labware.py
@@ -1,7 +1,7 @@
 """ProtocolEngine-based Labware core implementations."""
 from typing import List, Optional, cast
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareParameters as LabwareParametersDict,
     LabwareDefinition as LabwareDefinitionDict,
 )

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -4,11 +4,11 @@ from typing import Dict, Optional, Type, Union, List, Tuple, TYPE_CHECKING
 
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.commands import LoadModuleResult
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import (
     DeckSlotName,

--- a/api/src/opentrons/protocol_api/core/labware.py
+++ b/api/src/opentrons/protocol_api/core/labware.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Generic, List, NamedTuple, Optional, TypeVar
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareUri,
     LabwareParameters as LabwareParametersDict,
     LabwareDefinition as LabwareDefinitionDict,

--- a/api/src/opentrons/protocol_api/core/legacy/deck.py
+++ b/api/src/opentrons/protocol_api/core/legacy/deck.py
@@ -8,8 +8,8 @@ from typing_extensions import Protocol, Final
 
 from opentrons_shared_data.deck import load as load_deck
 
-from opentrons_shared_data.deck.dev_types import SlotDefV3
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.deck.types import SlotDefV3
+from opentrons_shared_data.labware.types import LabwareUri
 
 from opentrons.hardware_control.modules.types import ModuleType
 from opentrons.motion_planning import deck_conflict

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
@@ -6,7 +6,7 @@ from opentrons.protocols.api_support.tip_tracker import TipTracker
 
 from opentrons.types import DeckSlotName, Location, Point
 from opentrons.hardware_control.nozzle_manager import NozzleMap
-from opentrons_shared_data.labware.dev_types import LabwareParameters, LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareParameters, LabwareDefinition
 
 from ..labware import AbstractLabware, LabwareLoadParams
 from .legacy_well_core import LegacyWellCore

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -1,10 +1,10 @@
 import logging
 from typing import Dict, List, Optional, Set, Union, cast, Tuple
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5, SlotDefV3
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName, StagingSlotName, Location, Mount, Point
 from opentrons.util.broker import Broker

--- a/api/src/opentrons/protocol_api/core/legacy/load_info.py
+++ b/api/src/opentrons/protocol_api/core/legacy/load_info.py
@@ -7,7 +7,7 @@ It's only for internal Opentrons use.
 
 from dataclasses import dataclass
 from typing import Optional, Union
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 from opentrons.hardware_control.dev_types import PipetteDict
 from opentrons.hardware_control.modules.types import ModuleModel

--- a/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/module_geometry.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from opentrons_shared_data import module
-from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
+from opentrons_shared_data.module.types import ModuleDefinitionV3
 from opentrons_shared_data.module import OLD_TC_GEN2_LABWARE_OFFSET
 
 from opentrons.types import Location, Point, LocationLabware

--- a/api/src/opentrons/protocol_api/core/legacy/well_geometry.py
+++ b/api/src/opentrons/protocol_api/core/legacy/well_geometry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional, cast, TYPE_CHECKING
 
 from opentrons.types import Point
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     WellDefinition,
     CircularWellDefinition,
     RectangularWellDefinition,

--- a/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy_simulator/legacy_protocol_core.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, Optional
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette.pipette_load_name_conversions import (
     convert_to_pipette_name_type,
 )

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 from typing import Generic, List, Optional, Union, Tuple, Dict, TYPE_CHECKING
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5, SlotDefV3
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName, StagingSlotName, Location, Mount, Point
 from opentrons.hardware_control import SyncHardwareAPI

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -2,7 +2,7 @@
 import asyncio
 from typing import Any, Dict, Optional, Union, cast
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 from opentrons.hardware_control import (
     HardwareControlAPI,

--- a/api/src/opentrons/protocol_api/deck.py
+++ b/api/src/opentrons/protocol_api/deck.py
@@ -2,13 +2,13 @@
 from dataclasses import dataclass
 from typing import Iterator, List, Mapping, Optional, Tuple, Union
 
-from opentrons_shared_data.deck.dev_types import SlotDefV3
+from opentrons_shared_data.deck.types import SlotDefV3
 
 from opentrons.motion_planning import adjacent_slots_getters
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError
 from opentrons.types import DeckLocation, DeckSlotName, StagingSlotName, Location, Point
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 
 from .core.common import ProtocolCore

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -15,7 +15,7 @@ import logging
 from itertools import dropwhile
 from typing import TYPE_CHECKING, Any, List, Dict, Optional, Union, Tuple, cast
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition, LabwareParameters
+from opentrons_shared_data.labware.types import LabwareDefinition, LabwareParameters
 
 from opentrons.types import Location, Point
 from opentrons.protocols.api_support.types import APIVersion

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from typing import List, Optional, Union, cast
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.module.dev_types import ModuleModel, ModuleType
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.module.types import ModuleModel, ModuleType
 
 from opentrons.legacy_broker import LegacyBroker
 from opentrons.hardware_control.modules import ThermocyclerStep

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -13,8 +13,8 @@ from typing import (
     cast,
 )
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.types import Mount, Location, DeckLocation, DeckSlotName, StagingSlotName
 from opentrons.legacy_broker import LegacyBroker

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -15,8 +15,8 @@ from typing import (
 from typing_extensions import TypeGuard
 
 from opentrons_shared_data.labware.labware_definition import LabwareRole
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError

--- a/api/src/opentrons/protocol_engine/clients/sync_client.py
+++ b/api/src/opentrons/protocol_engine/clients/sync_client.py
@@ -2,7 +2,7 @@
 
 from typing import cast, Any, Optional, overload
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from .. import commands

--- a/api/src/opentrons/protocol_engine/clients/transports.py
+++ b/api/src/opentrons/protocol_engine/clients/transports.py
@@ -3,7 +3,7 @@ from asyncio import AbstractEventLoop, run_coroutine_threadsafe
 from typing import Any, Final, overload
 from typing_extensions import Literal
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 

--- a/api/src/opentrons/protocol_engine/commands/load_pipette.py
+++ b/api/src/opentrons/protocol_engine/commands/load_pipette.py
@@ -6,12 +6,12 @@ from opentrons_shared_data.pipette.pipette_load_name_conversions import (
 )
 from opentrons_shared_data.pipette.types import PipetteGenerationType
 from opentrons_shared_data.robot import user_facing_robot_type
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 from pydantic import BaseModel, Field
 from typing import TYPE_CHECKING, Optional, Type
 from typing_extensions import Literal
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import MountType
 
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import Optional, overload, Union
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition

--- a/api/src/opentrons/protocol_engine/resources/deck_configuration_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_configuration_provider.py
@@ -1,7 +1,7 @@
 """Deck configuration resource provider."""
 from typing import List, Set, Tuple
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5, CutoutFixture
+from opentrons_shared_data.deck.types import DeckDefinitionV5, CutoutFixture
 
 from opentrons.types import DeckSlotName
 

--- a/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/deck_data_provider.py
@@ -9,7 +9,7 @@ from opentrons_shared_data.deck import (
     load as load_deck,
     DEFAULT_DECK_DEFINITION_VERSION,
 )
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName
 

--- a/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/pipette_data_provider.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, Optional, Sequence
 import re
 
-from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from opentrons_shared_data.pipette.types import PipetteName, PipetteModel
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,

--- a/api/src/opentrons/protocol_engine/slot_standardization.py
+++ b/api/src/opentrons/protocol_engine/slot_standardization.py
@@ -17,7 +17,7 @@ deck slot.
 
 from typing import Any, Callable, Dict, Type
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from . import commands
 from .types import (

--- a/api/src/opentrons/protocol_engine/state/addressable_areas.py
+++ b/api/src/opentrons/protocol_engine/state/addressable_areas.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from functools import cached_property
 from typing import Dict, List, Optional, Set, Union
 
-from opentrons_shared_data.robot.dev_types import RobotType, RobotDefinition
-from opentrons_shared_data.deck.dev_types import (
+from opentrons_shared_data.robot.types import RobotType, RobotDefinition
+from opentrons_shared_data.deck.types import (
     DeckDefinitionV5,
     SlotDefV3,
     CutoutFixture,

--- a/api/src/opentrons/protocol_engine/state/config.py
+++ b/api/src/opentrons/protocol_engine/state/config.py
@@ -1,7 +1,7 @@
 """Top-level ProtocolEngine configuration options."""
 from dataclasses import dataclass
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocol_engine.types import DeckType
 

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -9,9 +9,9 @@ from functools import cached_property
 from opentrons.types import Point, DeckSlotName, StagingSlotName, MountType
 
 from opentrons_shared_data.labware.constants import WELL_NAME_PATTERN
-from opentrons_shared_data.deck.dev_types import CutoutFixture
+from opentrons_shared_data.deck.types import CutoutFixture
 from opentrons_shared_data.pipette import PIPETTE_X_SPAN
-from opentrons_shared_data.pipette.dev_types import ChannelCount
+from opentrons_shared_data.pipette.types import ChannelCount
 
 from .. import errors
 from ..errors import (

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -15,10 +15,10 @@ from typing import (
     Union,
 )
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.gripper.constants import LABWARE_GRIP_FORCE
 from opentrons_shared_data.labware.labware_definition import LabwareRole
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 
 from opentrons.types import DeckSlotName, StagingSlotName, MountType
 from opentrons.protocols.api_support.constants import OPENTRONS_NAMESPACE

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Sequence, TypeVar
 from typing_extensions import ParamSpec
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
-from opentrons_shared_data.robot.dev_types import RobotDefinition
+from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.robot.types import RobotDefinition
 
 from opentrons.protocol_engine.types import ModuleOffsetData
 from opentrons.util.change_notifier import ChangeNotifier

--- a/api/src/opentrons/protocol_engine/types.py
+++ b/api/src/opentrons/protocol_engine/types.py
@@ -16,7 +16,7 @@ from pydantic import (
 from typing import Optional, Union, List, Dict, Any, NamedTuple, Tuple, FrozenSet
 from typing_extensions import Literal, TypeGuard
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName, StagingSlotName
 from opentrons.hardware_control.types import (
     TipStateType as HwTipStateType,
@@ -26,11 +26,11 @@ from opentrons.hardware_control.modules import (
     ModuleType as ModuleType,
 )
 
-from opentrons_shared_data.pipette.dev_types import (  # noqa: F401
+from opentrons_shared_data.pipette.types import (  # noqa: F401
     # convenience re-export of LabwareUri type
     LabwareUri as LabwareUri,
 )
-from opentrons_shared_data.module.dev_types import ModuleType as SharedDataModuleType
+from opentrons_shared_data.module.types import ModuleType as SharedDataModuleType
 
 
 # todo(mm, 2024-06-24): This monolithic status field is getting to be a bit much.
@@ -347,7 +347,7 @@ class MotorAxis(str, Enum):
     EXTENSION_JAW = "extensionJaw"
 
 
-# TODO(mc, 2022-01-18): use opentrons_shared_data.module.dev_types.ModuleModel
+# TODO(mc, 2022-01-18): use opentrons_shared_data.module.types.ModuleModel
 class ModuleModel(str, Enum):
     """All available modules' models."""
 

--- a/api/src/opentrons/protocol_reader/file_identifier.py
+++ b/api/src/opentrons/protocol_reader/file_identifier.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Sequence, Union, Optional
 
 import anyio
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.errors.exceptions import EnumeratedError, PythonException
 
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION

--- a/api/src/opentrons/protocol_reader/protocol_source.py
+++ b/api/src/opentrons/protocol_reader/protocol_source.py
@@ -7,7 +7,7 @@ from typing_extensions import Literal
 
 from opentrons.protocols.api_support.types import APIVersion
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 
 class ProtocolType(str, Enum):

--- a/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/create_simulating_orchestrator.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_engine.create_protocol_engine import create_protocol_engine
 from opentrons.protocol_reader.protocol_source import ProtocolConfig
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from .python_protocol_wrappers import SimulatingContextCreator
 from .run_orchestrator import RunOrchestrator

--- a/api/src/opentrons/protocol_runner/json_translator.py
+++ b/api/src/opentrons/protocol_runner/json_translator.py
@@ -2,7 +2,7 @@
 from typing import cast, List, Union
 from pydantic import parse_obj_as
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.protocol.models import (
     ProtocolSchemaV6,
     protocol_schema_v6,

--- a/api/src/opentrons/protocol_runner/legacy_command_mapper.py
+++ b/api/src/opentrons/protocol_runner/legacy_command_mapper.py
@@ -11,7 +11,7 @@ from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,
     HeaterShakerModuleModel,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName, Location
 from opentrons.legacy_commands import types as legacy_command_types
 from opentrons.protocol_api import InstrumentContext

--- a/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
+++ b/api/src/opentrons/protocol_runner/python_protocol_wrappers.py
@@ -4,7 +4,7 @@ from typing import Dict, Iterable, Optional, cast
 
 from anyio import to_thread
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefinitionTypedDict,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -6,10 +6,10 @@ from typing import Optional, Union, List, Dict, AsyncGenerator
 
 from anyio import move_on_after
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.errors import GeneralError
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from . import protocol_runner, RunResult, JsonRunner, PythonAndLegacyRunner
 from ..hardware_control import HardwareControlAPI

--- a/api/src/opentrons/protocols/api_support/deck_type.py
+++ b/api/src/opentrons/protocols/api_support/deck_type.py
@@ -1,6 +1,6 @@
 from typing import Sequence, Dict, Optional, Any
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 

--- a/api/src/opentrons/protocols/api_support/instrument.py
+++ b/api/src/opentrons/protocols/api_support/instrument.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional, Any
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefinitionDict,
 )
 
@@ -16,7 +16,7 @@ from opentrons.hardware_control.instruments.ot2 import (
 )
 from opentrons.protocol_api.labware import Labware
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons_shared_data.protocol.dev_types import (
+from opentrons_shared_data.protocol.types import (
     LiquidHandlingCommand,
     BlowoutLocation,
 )

--- a/api/src/opentrons/protocols/api_support/util.py
+++ b/api/src/opentrons/protocols/api_support/util.py
@@ -21,7 +21,7 @@ from opentrons import types as top_types
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.hardware_control.types import Axis
 from opentrons.hardware_control.util import ot2_axis_to_string
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.errors.exceptions import (
     APIRemoved,
     IncorrectAPIVersion,

--- a/api/src/opentrons/protocols/bundle.py
+++ b/api/src/opentrons/protocols/bundle.py
@@ -12,7 +12,7 @@ from opentrons.calibration_storage.helpers import uri_from_definition
 from .types import BundleContents
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition
 
 MAIN_PROTOCOL_FILENAME = "protocol.ot2.py"
 LABWARE_DIR = "labware"

--- a/api/src/opentrons/protocols/execution/dev_types.py
+++ b/api/src/opentrons/protocols/execution/dev_types.py
@@ -2,7 +2,7 @@ from typing import Callable, Dict, TYPE_CHECKING
 
 from typing_extensions import Protocol, TypedDict
 
-from opentrons_shared_data.protocol.dev_types import (
+from opentrons_shared_data.protocol.types import (
     BlowoutParams,
     DelayParams,
     PipetteAccessParams,

--- a/api/src/opentrons/protocols/execution/execute_json_v3.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v3.py
@@ -11,7 +11,7 @@ from opentrons_shared_data.protocol.constants import (
 
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.protocol.dev_types import (
+    from opentrons_shared_data.protocol.types import (
         JsonProtocolV3,
         JsonProtocol,
         PipetteAccessParams,

--- a/api/src/opentrons/protocols/execution/execute_json_v4.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v4.py
@@ -17,7 +17,7 @@ from opentrons_shared_data.protocol.constants import (
 
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.protocol.dev_types import (
+    from opentrons_shared_data.protocol.types import (
         JsonProtocolV4,
         JsonProtocolV5,
         MagneticModuleEngageParams,

--- a/api/src/opentrons/protocols/execution/execute_json_v5.py
+++ b/api/src/opentrons/protocols/execution/execute_json_v5.py
@@ -5,7 +5,7 @@ from opentrons.protocols.execution.types import LoadedLabware, Instruments
 from .execute_json_v3 import _get_well
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.protocol.dev_types import MoveToWellParams
+    from opentrons_shared_data.protocol.types import MoveToWellParams
 
 MODULE_LOG = logging.getLogger(__name__)
 

--- a/api/src/opentrons/protocols/geometry/labware_geometry.py
+++ b/api/src/opentrons/protocols/geometry/labware_geometry.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 from opentrons.types import Location, Point
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 class AbstractLabwareGeometry(ABC):

--- a/api/src/opentrons/protocols/labware.py
+++ b/api/src/opentrons/protocols/labware.py
@@ -17,7 +17,7 @@ from opentrons.protocols.api_support.constants import (
     STANDARD_DEFS_PATH,
     USER_DEFS_PATH,
 )
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 MODULE_LOG = logging.getLogger(__name__)

--- a/api/src/opentrons/protocols/models/json_protocol.py
+++ b/api/src/opentrons/protocols/models/json_protocol.py
@@ -13,61 +13,61 @@ from pydantic import BaseModel, Extra, Field
 from typing_extensions import Literal
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.protocol import dev_types
+from opentrons_shared_data.protocol import types
 
-CommandAspirate: dev_types.AspirateCommandId = "aspirate"
-CommandDispense: dev_types.DispenseCommandId = "dispense"
-CommandAirGap: dev_types.AirGapCommandId = "airGap"
-CommandBlowout: dev_types.BlowoutCommandId = "blowout"
-CommandTouchTip: dev_types.TouchTipCommandId = "touchTip"
-CommandPickUpTip: dev_types.PickUpTipCommandId = "pickUpTip"
-CommandDropTip: dev_types.DropTipCommandId = "dropTip"
-CommandMoveToSlot: dev_types.MoveToSlotCommandId = "moveToSlot"
-CommandMoveToWell: dev_types.MoveToWellCommandId = "moveToWell"
-CommandDelay: dev_types.DelayCommandId = "delay"
-CommandMagneticModuleEngage: dev_types.MagneticModuleEngageCommandId = (
+CommandAspirate: types.AspirateCommandId = "aspirate"
+CommandDispense: types.DispenseCommandId = "dispense"
+CommandAirGap: types.AirGapCommandId = "airGap"
+CommandBlowout: types.BlowoutCommandId = "blowout"
+CommandTouchTip: types.TouchTipCommandId = "touchTip"
+CommandPickUpTip: types.PickUpTipCommandId = "pickUpTip"
+CommandDropTip: types.DropTipCommandId = "dropTip"
+CommandMoveToSlot: types.MoveToSlotCommandId = "moveToSlot"
+CommandMoveToWell: types.MoveToWellCommandId = "moveToWell"
+CommandDelay: types.DelayCommandId = "delay"
+CommandMagneticModuleEngage: types.MagneticModuleEngageCommandId = (
     "magneticModule/engageMagnet"
 )
-CommandMagneticModuleDisengage: dev_types.MagneticModuleDisengageCommandId = (
+CommandMagneticModuleDisengage: types.MagneticModuleDisengageCommandId = (
     "magneticModule/disengageMagnet"
 )
-CommandTemperatureModuleSetTarget: dev_types.TemperatureModuleSetTargetCommandId = (
+CommandTemperatureModuleSetTarget: types.TemperatureModuleSetTargetCommandId = (
     "temperatureModule/setTargetTemperature"
 )
-CommandTemperatureModuleAwait: dev_types.TemperatureModuleAwaitCommandId = (
+CommandTemperatureModuleAwait: types.TemperatureModuleAwaitCommandId = (
     "temperatureModule/awaitTemperature"
 )
-CommandTemperatureModuleDeactivate: dev_types.TemperatureModuleDeactivateCommandId = (
+CommandTemperatureModuleDeactivate: types.TemperatureModuleDeactivateCommandId = (
     "temperatureModule/deactivate"
 )
-CommandThermocyclerSetTargetBlock: dev_types.ThermocyclerSetTargetBlockCommandId = (
+CommandThermocyclerSetTargetBlock: types.ThermocyclerSetTargetBlockCommandId = (
     "thermocycler/setTargetBlockTemperature"
 )
-CommandThermocyclerSetTargetLid: dev_types.ThermocyclerSetTargetLidCommandId = (
+CommandThermocyclerSetTargetLid: types.ThermocyclerSetTargetLidCommandId = (
     "thermocycler/setTargetLidTemperature"
 )
-CommandThermocyclerAwaitLidTemperature: dev_types.ThermocyclerAwaitLidTemperatureCommandId = (
+CommandThermocyclerAwaitLidTemperature: types.ThermocyclerAwaitLidTemperatureCommandId = (
     "thermocycler/awaitLidTemperature"
 )
-CommandThermocyclerAwaitBlockTemperature: dev_types.ThermocyclerAwaitBlockTemperatureCommandId = (
+CommandThermocyclerAwaitBlockTemperature: types.ThermocyclerAwaitBlockTemperatureCommandId = (
     "thermocycler/awaitBlockTemperature"
 )
-CommandThermocyclerDeactivateBlock: dev_types.ThermocyclerDeactivateBlockCommandId = (
+CommandThermocyclerDeactivateBlock: types.ThermocyclerDeactivateBlockCommandId = (
     "thermocycler/deactivateBlock"
 )
-CommandThermocyclerDeactivateLid: dev_types.ThermocyclerDeactivateLidCommandId = (
+CommandThermocyclerDeactivateLid: types.ThermocyclerDeactivateLidCommandId = (
     "thermocycler/deactivateLid"
 )
-CommandThermocyclerOpenLid: dev_types.ThermocyclerOpenLidCommandId = (
+CommandThermocyclerOpenLid: types.ThermocyclerOpenLidCommandId = (
     "thermocycler/openLid"
 )
-CommandThermocyclerCloseLid: dev_types.ThermocyclerCloseLidCommandId = (
+CommandThermocyclerCloseLid: types.ThermocyclerCloseLidCommandId = (
     "thermocycler/closeLid"
 )
-CommandThermocyclerRunProfile: dev_types.ThermocyclerRunProfileCommandId = (
+CommandThermocyclerRunProfile: types.ThermocyclerRunProfileCommandId = (
     "thermocycler/runProfile"
 )
-CommandThermocyclerAwaitProfile: dev_types.ThermocyclerAwaitProfileCommandId = (
+CommandThermocyclerAwaitProfile: types.ThermocyclerAwaitProfileCommandId = (
     "thermocycler/awaitProfileComplete"
 )
 

--- a/api/src/opentrons/protocols/models/json_protocol.py
+++ b/api/src/opentrons/protocols/models/json_protocol.py
@@ -58,9 +58,7 @@ CommandThermocyclerDeactivateBlock: types.ThermocyclerDeactivateBlockCommandId =
 CommandThermocyclerDeactivateLid: types.ThermocyclerDeactivateLidCommandId = (
     "thermocycler/deactivateLid"
 )
-CommandThermocyclerOpenLid: types.ThermocyclerOpenLidCommandId = (
-    "thermocycler/openLid"
-)
+CommandThermocyclerOpenLid: types.ThermocyclerOpenLidCommandId = "thermocycler/openLid"
 CommandThermocyclerCloseLid: types.ThermocyclerCloseLidCommandId = (
     "thermocycler/closeLid"
 )

--- a/api/src/opentrons/protocols/parse.py
+++ b/api/src/opentrons/protocols/parse.py
@@ -21,7 +21,7 @@ from opentrons_shared_data.protocol import (
     Schema as JSONProtocolSchema,
     load_schema as load_protocol_schema,
 )
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.ordered_set import OrderedSet
 
@@ -41,8 +41,8 @@ from .types import (
 from .bundle import extract_bundle
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
-    from opentrons_shared_data.protocol.dev_types import JsonProtocol as JsonProtocolDef
+    from opentrons_shared_data.labware.types import LabwareDefinition
+    from opentrons_shared_data.protocol.types import JsonProtocol as JsonProtocolDef
 
 MODULE_LOG = logging.getLogger(__name__)
 

--- a/api/src/opentrons/protocols/types.py
+++ b/api/src/opentrons/protocols/types.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, NamedTuple, Optional, Union, TYPE_CHECKING
 from dataclasses import dataclass
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from .api_support.definitions import MIN_SUPPORTED_VERSION
 from .api_support.types import APIVersion
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
-    from opentrons_shared_data.protocol.dev_types import (
+    from opentrons_shared_data.labware.types import LabwareDefinition
+    from opentrons_shared_data.protocol.types import (
         JsonProtocol as JsonProtocolDef,
         Metadata as JsonProtocolMetadata,
     )

--- a/api/src/opentrons/simulate.py
+++ b/api/src/opentrons/simulate.py
@@ -27,7 +27,7 @@ from typing import (
 )
 from typing_extensions import Literal
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 import opentrons
 from opentrons import should_use_ot3
@@ -76,7 +76,7 @@ from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from .util import entrypoint_util
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import (
+    from opentrons_shared_data.labware.types import (
         LabwareDefinition as LabwareDefinitionDict,
     )
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -3,7 +3,7 @@ import enum
 from math import sqrt, isclose
 from typing import TYPE_CHECKING, Any, NamedTuple, Iterator, Union, List
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from .protocols.api_support.labware_like import LabwareLike
 

--- a/api/src/opentrons/util/entrypoint_util.py
+++ b/api/src/opentrons/util/entrypoint_util.py
@@ -32,7 +32,7 @@ from opentrons.protocol_reader import ProtocolReader, ProtocolSource
 from opentrons.protocols.types import JsonProtocol, Protocol, PythonProtocol
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 log = logging.getLogger(__name__)

--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -3,7 +3,7 @@
 import functools
 from pathlib import Path
 
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 import typing
 from opentrons.config import (
     get_performance_metrics_data_dir,

--- a/api/tests/opentrons/calibration_storage/test_deck_attitude.py
+++ b/api/tests/opentrons/calibration_storage/test_deck_attitude.py
@@ -22,7 +22,7 @@ from opentrons.calibration_storage.ot2.models.v1 import (
 )
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.deck.dev_types import RobotModel
+    from opentrons_shared_data.deck.types import RobotModel
 
 
 @pytest.fixture(autouse=True)

--- a/api/tests/opentrons/calibration_storage/test_pipette_offset_ot2.py
+++ b/api/tests/opentrons/calibration_storage/test_pipette_offset_ot2.py
@@ -13,7 +13,7 @@ from opentrons.calibration_storage.ot2 import (
 )
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.deck.dev_types import RobotModel
+    from opentrons_shared_data.deck.types import RobotModel
 
 
 @pytest.fixture

--- a/api/tests/opentrons/calibration_storage/test_pipette_offset_ot3.py
+++ b/api/tests/opentrons/calibration_storage/test_pipette_offset_ot3.py
@@ -13,7 +13,7 @@ from opentrons.calibration_storage.ot3 import (
 )
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.deck.dev_types import RobotModel
+    from opentrons_shared_data.deck.types import RobotModel
 
 
 @pytest.fixture

--- a/api/tests/opentrons/calibration_storage/test_tip_length_ot2.py
+++ b/api/tests/opentrons/calibration_storage/test_tip_length_ot2.py
@@ -17,10 +17,10 @@ from opentrons.calibration_storage.ot2 import (
     clear_tip_length_calibration,
     models,
 )
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 @pytest.fixture

--- a/api/tests/opentrons/config/test_advanced_settings.py
+++ b/api/tests/opentrons/config/test_advanced_settings.py
@@ -4,7 +4,7 @@ from typing import Dict, Generator, Optional
 from unittest.mock import MagicMock, patch
 
 from opentrons.config import advanced_settings, CONFIG
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 
 @pytest.fixture

--- a/api/tests/opentrons/config/test_reset.py
+++ b/api/tests/opentrons/config/test_reset.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock, patch
 
 from opentrons.config import reset
 
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 if TYPE_CHECKING:
-    from opentrons_shared_data.deck.dev_types import RobotModel
+    from opentrons_shared_data.deck.types import RobotModel
 
 
 @pytest.fixture

--- a/api/tests/opentrons/conftest.py
+++ b/api/tests/opentrons/conftest.py
@@ -33,11 +33,11 @@ try:
 except (OSError, ModuleNotFoundError):
     aionotify = None
 
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
-from opentrons_shared_data.protocol.dev_types import JsonProtocol
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
-from opentrons_shared_data.deck.dev_types import (
+from opentrons_shared_data.robot.types import RobotTypeEnum
+from opentrons_shared_data.protocol.types import JsonProtocol
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.module.types import ModuleDefinitionV3
+from opentrons_shared_data.deck.types import (
     RobotModel,
     DeckDefinitionV3,
     DeckDefinitionV5,

--- a/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_instrument_calibration.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareUri,
     LabwareDefinition as LabwareDefDict,
 )

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -87,7 +87,7 @@ from opentrons_shared_data.pipette.types import (
 from opentrons_shared_data.pipette import (
     load_data as load_pipette_data,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteModel
+from opentrons_shared_data.pipette.types import PipetteModel
 from opentrons.hardware_control.modules import (
     Thermocycler,
     TempDeck,

--- a/api/tests/opentrons/hardware_control/test_ot3_transforms.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_transforms.py
@@ -5,7 +5,7 @@ from opentrons import types
 from opentrons.hardware_control import ot3api
 from opentrons.hardware_control.types import Axis
 from opentrons_shared_data.pipette import name_for_model
-from opentrons_shared_data.pipette.dev_types import PipetteModel
+from opentrons_shared_data.pipette.types import PipetteModel
 
 
 @pytest.mark.parametrize(

--- a/api/tests/opentrons/hardware_control/test_simulator_setup.py
+++ b/api/tests/opentrons/hardware_control/test_simulator_setup.py
@@ -7,7 +7,7 @@ from opentrons.config import robot_configs
 from opentrons.hardware_control.modules import MagDeck, Thermocycler, TempDeck
 from opentrons.hardware_control import simulator_setup, API
 from opentrons.types import Mount
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons.hardware_control.types import OT3Mount
 
 if TYPE_CHECKING:

--- a/api/tests/opentrons/motion_planning/test_adjacent_slots_getters.py
+++ b/api/tests/opentrons/motion_planning/test_adjacent_slots_getters.py
@@ -2,7 +2,7 @@
 import pytest
 from typing import List, Optional
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName, StagingSlotName
 from opentrons.motion_planning.adjacent_slots_getters import (

--- a/api/tests/opentrons/motion_planning/test_deck_conflict.py
+++ b/api/tests/opentrons/motion_planning/test_deck_conflict.py
@@ -4,8 +4,8 @@ from contextlib import nullcontext
 
 import pytest
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.labware.types import LabwareUri
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.motion_planning import deck_conflict
 

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -3,8 +3,8 @@ import pytest
 from typing import ContextManager, Any, NamedTuple, List, Tuple
 from decoy import Decoy
 from contextlib import nullcontext as does_not_raise
-from opentrons_shared_data.labware.dev_types import LabwareUri
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.labware.types import LabwareUri
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.hardware_control.nozzle_manager import NozzleConfigurationType
 from opentrons.motion_planning import deck_conflict as wrapped_deck_conflict

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -6,7 +6,7 @@ import pytest
 from decoy import Decoy
 from decoy import errors
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.hardware_control import SyncHardwareAPI
 from opentrons.hardware_control.dev_types import PipetteDict

--- a/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_labware_core.py
@@ -4,7 +4,7 @@ from typing import cast
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefDict,
     LabwareParameters as LabwareParamsDict,
     LabwareUri,

--- a/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_protocol_core.py
@@ -7,17 +7,17 @@ from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from decoy import Decoy
 
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.dev_types import (
+from opentrons_shared_data.deck.types import (
     DeckDefinitionV5,
     SlotDefV3,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefDict,
     LabwareUri,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName, StagingSlotName, Mount, MountType, Point
 from opentrons.protocol_api import OFF_DECK

--- a/api/tests/opentrons/protocol_api/core/legacy/test_deck.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_deck.py
@@ -4,7 +4,7 @@ from typing import Any
 import pytest
 from decoy import Decoy, matchers
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 
 from opentrons.motion_planning import deck_conflict
 from opentrons.protocols.api_support.deck_type import (

--- a/api/tests/opentrons/protocol_api/core/legacy/test_module_geometry.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_module_geometry.py
@@ -18,7 +18,7 @@ from opentrons.protocol_api.core.legacy.module_geometry import (
 )
 from opentrons.protocol_api.core.legacy.deck import Deck
 
-from opentrons_shared_data.module.dev_types import (
+from opentrons_shared_data.module.types import (
     ModuleDefinitionV3,
     ModuleDefinitionV1,
 )

--- a/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
+++ b/api/tests/opentrons/protocol_api/core/legacy/test_protocol_context_implementation.py
@@ -5,9 +5,9 @@ from typing import Any, Dict, cast
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.module.types import ModuleDefinitionV3
 
 from opentrons.types import DeckSlotName, StagingSlotName, Location, Mount, Point
 from opentrons.util.broker import Broker

--- a/api/tests/opentrons/protocol_api/test_deck.py
+++ b/api/tests/opentrons/protocol_api/test_deck.py
@@ -5,7 +5,7 @@ from typing import cast, Dict
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5, SlotDefV3
+from opentrons_shared_data.deck.types import DeckDefinitionV5, SlotDefV3
 
 from opentrons.motion_planning import adjacent_slots_getters as mock_adjacent_slots
 from opentrons.protocols.api_support.types import APIVersion

--- a/api/tests/opentrons/protocol_api/test_labware.py
+++ b/api/tests/opentrons/protocol_api/test_labware.py
@@ -5,7 +5,7 @@ from typing import cast
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.protocols.api_support.util import APIVersionError, UnsupportedAPIError

--- a/api/tests/opentrons/protocol_api/test_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_module_context.py
@@ -4,7 +4,7 @@ from typing import cast
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 
 from opentrons.hardware_control.modules.types import ModuleType, HeaterShakerModuleModel
 from opentrons.legacy_broker import LegacyBroker

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -5,8 +5,8 @@ from typing import cast
 import pytest
 from decoy import Decoy, matchers
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 
 from opentrons.types import Mount, DeckSlotName, StagingSlotName
 from opentrons.protocol_api import OFF_DECK

--- a/api/tests/opentrons/protocol_api/test_validation.py
+++ b/api/tests/opentrons/protocol_api/test_validation.py
@@ -10,8 +10,8 @@ from opentrons_shared_data.labware.labware_definition import (
     LabwareRole,
     Parameters as LabwareDefinitionParameters,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import Mount, DeckSlotName, StagingSlotName, Location, Point
 from opentrons.hardware_control.modules.types import (

--- a/api/tests/opentrons/protocol_api_old/core/simulator/conftest.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/conftest.py
@@ -21,8 +21,8 @@ from opentrons.protocol_api.core.legacy_simulator.legacy_protocol_core import (
     LegacyProtocolCoreSimulator,
 )
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api_old/core/simulator/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api_old/core/simulator/test_protocol_context.py
@@ -4,7 +4,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.types import Location, Mount
 from opentrons.protocol_api.core.common import LabwareCore, ProtocolCore

--- a/api/tests/opentrons/protocol_api_old/test_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_context.py
@@ -5,7 +5,7 @@ import mock
 from typing import Any, Dict
 
 from opentrons_shared_data import load_shared_data
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 from opentrons_shared_data.errors.exceptions import UnexpectedTipRemovalError
 
 import opentrons.protocol_api as papi

--- a/api/tests/opentrons/protocol_api_old/test_labware.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import WellDefinition
+from opentrons_shared_data.labware.types import WellDefinition
 
 from opentrons.hardware_control.modules.types import (
     MagneticModuleModel,

--- a/api/tests/opentrons/protocol_api_old/test_labware_load.py
+++ b/api/tests/opentrons/protocol_api_old/test_labware_load.py
@@ -1,6 +1,6 @@
 import pytest
 from opentrons import protocol_api as papi, types
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV3
+from opentrons_shared_data.deck.types import DeckDefinitionV3
 
 
 labware_name = "corning_96_wellplate_360ul_flat"

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -24,7 +24,7 @@ from opentrons.protocols.api_support.deck_type import STANDARD_OT2_DECK
 from opentrons.protocols.api_support.types import APIVersion
 
 from opentrons_shared_data.labware import load_definition as load_labware_definition
-from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
+from opentrons_shared_data.module.types import ModuleDefinitionV3
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_api_old/test_offsets.py
+++ b/api/tests/opentrons/protocol_api_old/test_offsets.py
@@ -5,7 +5,7 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import Point, Location
 
 if typing.TYPE_CHECKING:
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 def test_wells_rebuilt_with_offset(minimal_labware_def: "LabwareDefinition") -> None:

--- a/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_child_thread_transport.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.protocol_engine import ProtocolEngine, commands, DeckPoint

--- a/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
+++ b/api/tests/opentrons/protocol_engine/clients/test_sync_client.py
@@ -12,7 +12,7 @@ the subject's methods in a synchronous context in a child thread to ensure:
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 from opentrons.protocol_engine import commands

--- a/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_configure_for_volume.py
@@ -18,7 +18,7 @@ from opentrons.protocol_engine.commands.configure_for_volume import (
     ConfigureForVolumePrivateResult,
     ConfigureForVolumeImplementation,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from ..pipette_fixtures import get_default_nozzle_map
 from opentrons.types import Point
 

--- a/api/tests/opentrons/protocol_engine/commands/test_load_module.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_module.py
@@ -5,7 +5,7 @@ from decoy import Decoy
 
 from opentrons.protocol_engine.errors import LocationIsOccupiedError
 from opentrons.protocol_engine.state import StateView
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
@@ -29,7 +29,7 @@ from opentrons.hardware_control.modules.types import (
     ThermocyclerModuleModel,
     HeaterShakerModuleModel,
 )
-from opentrons_shared_data.deck.dev_types import (
+from opentrons_shared_data.deck.types import (
     DeckDefinitionV5,
     SlotDefV3,
 )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_pipette.py
@@ -2,8 +2,8 @@
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.pipette.types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons.types import MountType, Point
 
 from opentrons.protocol_engine.errors import InvalidSpecificationForRobotTypeError

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -7,7 +7,7 @@ from decoy import Decoy
 
 from opentrons_shared_data import load_shared_data
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons.protocols.models import LabwareDefinition

--- a/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_equipment_handler.py
@@ -6,9 +6,9 @@ from datetime import datetime
 from decoy import Decoy, matchers
 from typing import Any, Optional, cast, Dict
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette import pipette_definition
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.types import Mount as HwMount, MountType, DeckSlotName, Point

--- a/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
@@ -32,7 +32,7 @@ from opentrons.protocol_engine.state.module_substates.heater_shaker_module_subst
     HeaterShakerModuleSubState,
 )
 from opentrons.types import DeckSlotName
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/pipette_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/pipette_fixtures.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from opentrons.types import Point
 from opentrons.hardware_control.nozzle_manager import NozzleMap
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette.pipette_definition import ValidNozzleMaps
 
 

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_configuration_provider.py
@@ -5,7 +5,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 
 from opentrons.types import DeckSlotName
 

--- a/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_deck_data_provider.py
@@ -3,7 +3,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 from decoy import Decoy
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName
 

--- a/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_labware_data_provider.py
@@ -1,7 +1,7 @@
 """Functional tests for the LabwareDataProvider."""
 from typing import cast
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 from opentrons.calibration_storage.helpers import hash_labware_def
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_api.labware import get_labware_definition

--- a/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
+++ b/api/tests/opentrons/protocol_engine/resources/test_pipette_data_provider.py
@@ -2,7 +2,7 @@
 from typing import Dict
 from sys import maxsize
 import pytest
-from opentrons_shared_data.pipette.dev_types import PipetteNameType, PipetteModel
+from opentrons_shared_data.pipette.types import PipetteNameType, PipetteModel
 from opentrons_shared_data.pipette import pipette_definition, types as pip_types
 from opentrons_shared_data.pipette.pipette_definition import (
     PipetteBoundingBoxOffsetDefinition,

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from pydantic import BaseModel
 from typing import Optional, cast
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import MountType
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.protocol_engine import ErrorOccurrence, commands as cmd

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_state.py
@@ -4,7 +4,7 @@ The trifecta is tested here as a single unit, treating AddressableAreaState as a
 implementation detail.
 """
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 
 from opentrons.protocol_engine.actions.actions import SetDeckConfigurationAction
 from opentrons.protocol_engine.state.addressable_areas import (

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_store.py
@@ -7,7 +7,7 @@ tested together.
 
 import pytest
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.labware.labware_definition import Parameters
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName

--- a/api/tests/opentrons/protocol_engine/state/test_addressable_area_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_addressable_area_view.py
@@ -11,8 +11,8 @@ import pytest
 from decoy import Decoy
 from typing import Dict, Set, Optional, cast
 
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons.types import Point, DeckSlotName
 
 from opentrons.protocol_engine.errors import (

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -7,14 +7,14 @@ from decoy import Decoy
 from typing import cast, List, Tuple, Optional, NamedTuple
 from datetime import datetime
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons.calibration_storage.helpers import uri_from_details
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import Point, DeckSlotName, MountType
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.labware.labware_definition import (
     Dimensions as LabwareDimensions,
     Parameters as LabwareDefinitionParameters,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_store.py
@@ -4,7 +4,7 @@ import pytest
 from datetime import datetime
 
 from opentrons.calibration_storage.helpers import uri_from_details
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons.protocols.models import LabwareDefinition
 from opentrons.types import DeckSlotName
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_view.py
@@ -5,8 +5,8 @@ from typing import Dict, Optional, cast, ContextManager, Any, Union, NamedTuple,
 from contextlib import nullcontext as does_not_raise
 
 from opentrons_shared_data.deck import load as load_deck
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.pipette.types import LabwareUri
 from opentrons_shared_data.labware import load_definition
 from opentrons_shared_data.labware.labware_definition import (
     Parameters,

--- a/api/tests/opentrons/protocol_engine/state/test_module_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_store.py
@@ -2,8 +2,8 @@
 from typing import List, Set, cast, Dict, Optional
 
 import pytest
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
 from opentrons.types import DeckSlotName

--- a/api/tests/opentrons/protocol_engine/state/test_module_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view.py
@@ -17,8 +17,8 @@ from typing import (
     cast,
 )
 
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 
 from opentrons_shared_data import load_shared_data
 from opentrons.types import DeckSlotName, MountType

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -5,7 +5,7 @@ from typing import List
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import Point, MountType, DeckSlotName
 from opentrons.hardware_control.types import CriticalPoint
 from opentrons import motion_planning
@@ -29,7 +29,7 @@ from opentrons.protocol_engine.state.geometry import GeometryView
 from opentrons.protocol_engine.state.motion import MotionView
 from opentrons.protocol_engine.state.modules import ModuleView
 from opentrons.protocol_engine.state.module_substates import HeaterShakerModuleId
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 
 @pytest.fixture

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime
 from typing import Optional, Union
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette import pipette_definition
 
 from opentrons.types import DeckSlotName, MountType, Point

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_view.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 import pytest
 from typing import cast, Dict, List, Optional, Tuple, NamedTuple
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.pipette import pipette_definition
 from opentrons_shared_data.pipette.pipette_definition import ValidNozzleMaps
 

--- a/api/tests/opentrons/protocol_engine/state/test_state_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_state_store.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons.util.change_notifier import ChangeNotifier
 
 from opentrons.protocol_engine.actions import PlayAction

--- a/api/tests/opentrons/protocol_engine/state/test_tip_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_tip_state.py
@@ -20,7 +20,7 @@ from opentrons.protocol_engine.resources.pipette_data_provider import (
     LoadedStaticPipetteData,
 )
 from opentrons.types import Point
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from ..pipette_fixtures import (
     NINETY_SIX_MAP,
     NINETY_SIX_COLS,

--- a/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_create_protocol_engine.py
@@ -2,8 +2,8 @@
 import pytest
 from pytest_lazyfixture import lazy_fixture  # type: ignore[import-untyped]
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.deck.types import DeckDefinitionV5
+from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.deck import load as load_deck
 
 from opentrons.calibration_storage.helpers import uri_from_details

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -7,7 +7,7 @@ from unittest.mock import sentinel
 import pytest
 from decoy import Decoy
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI

--- a/api/tests/opentrons/protocol_engine/test_slot_standardization.py
+++ b/api/tests/opentrons/protocol_engine/test_slot_standardization.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import (

--- a/api/tests/opentrons/protocol_reader/test_file_identifier.py
+++ b/api/tests/opentrons/protocol_reader/test_file_identifier.py
@@ -7,7 +7,7 @@ from decoy import Decoy
 import pytest
 
 from opentrons_shared_data import load_shared_data
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocols import parse
 from opentrons.protocols.api_support.types import APIVersion

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_legacy_command_mapper.py
@@ -25,7 +25,7 @@ from opentrons.protocol_runner.create_simulating_orchestrator import (
 )
 from opentrons.protocol_runner.legacy_command_mapper import LegacyCommandParams
 from opentrons.types import MountType, DeckSlotName
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 
 async def simulate_and_get_commands(protocol_file: Path) -> List[commands.Command]:

--- a/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/smoke_tests/test_protocol_runner.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from decoy import matchers
 from pathlib import Path
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import MountType, DeckSlotName
 from opentrons.protocol_engine import (
     DeckSlotLocation,

--- a/api/tests/opentrons/protocol_runner/test_json_translator.py
+++ b/api/tests/opentrons/protocol_runner/test_json_translator.py
@@ -29,7 +29,7 @@ from opentrons_shared_data.protocol.models import (
     Pipette,
     Robot,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import DeckSlotName, MountType
 from opentrons.protocol_runner.json_translator import JsonTranslator
 from opentrons.protocol_engine import (

--- a/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_command_mapper.py
@@ -34,9 +34,9 @@ from opentrons.protocol_runner.legacy_command_mapper import (
     LegacyContextCommandError,
     LegacyCommandMapper,
 )
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.module.dev_types import ModuleDefinitionV3
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.module.types import ModuleDefinitionV3
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons.types import DeckSlotName, Mount, MountType
 
 

--- a/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
+++ b/api/tests/opentrons/protocol_runner/test_legacy_context_plugin.py
@@ -24,7 +24,7 @@ from opentrons.protocol_runner.legacy_context_plugin import LegacyContextPlugin
 
 from opentrons.types import DeckSlotName
 
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefinitionDict,
 )
 

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -9,11 +9,11 @@ from pathlib import Path
 from typing import List, cast, Union, Type
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.labware.dev_types import (
+from opentrons_shared_data.labware.types import (
     LabwareDefinition as LabwareDefinitionTypedDict,
 )
 from opentrons_shared_data.protocol.models import ProtocolSchemaV6, ProtocolSchemaV7
-from opentrons_shared_data.protocol.dev_types import (
+from opentrons_shared_data.protocol.types import (
     JsonProtocol as LegacyJsonProtocolDict,
 )
 from opentrons.hardware_control import API as HardwareAPI

--- a/api/tests/opentrons/protocols/api_support/test_labware_like.py
+++ b/api/tests/opentrons/protocols/api_support/test_labware_like.py
@@ -9,7 +9,7 @@ from opentrons.protocol_api.core.legacy import module_geometry
 from opentrons.protocol_api.core.legacy.deck import Deck
 from opentrons.types import Location
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 @pytest.fixture(scope="session")

--- a/api/tests/opentrons/protocols/test_parse.py
+++ b/api/tests/opentrons/protocols/test_parse.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 from typing import Any, Callable, Optional, Union, Literal
 
 import pytest
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocols.parse import (
     PythonParseMode,

--- a/api/tests/opentrons/test_execute.py
+++ b/api/tests/opentrons/test_execute.py
@@ -12,7 +12,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 from opentrons_shared_data import get_shared_data_root, load_shared_data
-from opentrons_shared_data.pipette.dev_types import PipetteModel
+from opentrons_shared_data.pipette.types import PipetteModel
 from opentrons_shared_data.pipette import (
     pipette_load_name_conversions as pipette_load_name,
     load_data as load_pipette_data,

--- a/api/tests/opentrons/util/test_entrypoint_util.py
+++ b/api/tests/opentrons/util/test_entrypoint_util.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import Callable
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 from opentrons.util.entrypoint_util import (
     FoundLabware,
     labware_from_paths,

--- a/g-code-testing/g_code_parsing/g_code_engine.py
+++ b/g-code-testing/g_code_parsing/g_code_engine.py
@@ -33,7 +33,7 @@ from g_code_parsing.g_code_program.g_code_program import (
 )
 from g_code_parsing.g_code_watcher import GCodeWatcher
 from g_code_parsing.utils import get_configuration_dir
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 Protocol = namedtuple("Protocol", ["text", "filename", "filelike"])
 

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -26,7 +26,7 @@ from opentrons.hardware_control.instruments.ot3.pipette import Pipette
 from opentrons import execute, simulate
 from opentrons.types import Point, Location, Mount
 from opentrons.config.types import OT3Config, RobotConfig
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 from hardware_testing.opentrons_api import helpers_ot3
 from opentrons.protocol_api import ProtocolContext, InstrumentContext

--- a/hardware-testing/hardware_testing/opentrons_api/p1000_gen3_ul_per_mm.py
+++ b/hardware-testing/hardware_testing/opentrons_api/p1000_gen3_ul_per_mm.py
@@ -6,7 +6,7 @@ from opentrons.hardware_control.ot3api import OT3API
 
 from opentrons.hardware_control.instruments.ot3.pipette import Pipette
 
-from opentrons_shared_data.pipette.dev_types import UlPerMm
+from opentrons_shared_data.pipette.types import UlPerMm
 
 from .types import OT3Mount
 

--- a/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc/z_stage_qc_ot3.py
@@ -23,7 +23,7 @@ from hardware_testing.data.csv_report import (
 
 from opentrons_shared_data.errors.exceptions import MoveConditionNotMetError
 from opentrons.config.advanced_settings import get_adv_setting, set_adv_setting
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 import logging
 

--- a/hardware-testing/hardware_testing/scripts/visualize_pipette_function.py
+++ b/hardware-testing/hardware_testing/scripts/visualize_pipette_function.py
@@ -31,7 +31,7 @@ from opentrons.hardware_control.instruments.ot2.instrument_calibration import (
     PipetteOffsetByPipetteMount,
 )
 from opentrons_shared_data.pipette import model_config
-from opentrons_shared_data.pipette.dev_types import PipetteModel
+from opentrons_shared_data.pipette.types import PipetteModel
 
 
 def _user_select_model(model_includes: Optional[str] = None) -> str:

--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -7,7 +7,7 @@ from typing import Union
 import fastapi
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
-from opentrons_shared_data.deck.dev_types import DeckDefinitionV5
+from opentrons_shared_data.deck.types import DeckDefinitionV5
 
 from robot_server.errors.error_responses import ErrorBody
 from robot_server.hardware import get_deck_definition

--- a/robot-server/robot_server/deck_configuration/validation.py
+++ b/robot-server/robot_server/deck_configuration/validation.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import DefaultDict, FrozenSet, List, Set, Tuple, Union, Optional
 
-from opentrons_shared_data.deck import dev_types as deck_types
+from opentrons_shared_data.deck import types as deck_types
 
 
 @dataclass(frozen=True)

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -18,7 +18,7 @@ from traceback import format_exception_only, TracebackException
 from contextlib import contextmanager, suppress
 
 from opentrons_shared_data import deck
-from opentrons_shared_data.robot.dev_types import RobotType, RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
 
 from opentrons import initialize as initialize_api, should_use_ot3
 from opentrons.config import (

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -381,7 +381,7 @@ async def get_deck_type() -> DeckType:
 
 async def get_deck_definition(
     deck_type: DeckType = Depends(get_deck_type),
-) -> deck.dev_types.DeckDefinitionV5:
+) -> deck.types.DeckDefinitionV5:
     """Return this robot's deck definition."""
     return deck.load(deck_type, version=5)
 

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -1,7 +1,7 @@
 """HTTP request and response models for /health endpoints."""
 import typing
 from pydantic import BaseModel, Field
-from opentrons_shared_data.deck.dev_types import RobotModel
+from opentrons_shared_data.deck.types import RobotModel
 from robot_server.service.json_api import BaseResponseBody
 
 

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -16,7 +16,7 @@ from robot_server.persistence.fastapi_dependencies import (
 )
 from robot_server.service.legacy.models import V1BasicResponse
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from .models import Health, HealthLinks
 

--- a/robot-server/robot_server/instruments/instrument_models.py
+++ b/robot-server/robot_server/instruments/instrument_models.py
@@ -10,7 +10,7 @@ from pydantic.generics import GenericModel
 
 from opentrons.calibration_storage.types import SourceType
 from opentrons.protocol_engine.types import Vec3f
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     PipetteName,
     PipetteModel,
     ChannelCount,

--- a/robot-server/robot_server/maintenance_runs/dependencies.py
+++ b/robot-server/robot_server/maintenance_runs/dependencies.py
@@ -1,7 +1,7 @@
 """Maintenance Run router dependency-injection wire-up."""
 from fastapi import Depends
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine import DeckType

--- a/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
+++ b/robot-server/robot_server/maintenance_runs/maintenance_run_orchestrator_store.py
@@ -31,8 +31,8 @@ from opentrons.hardware_control.types import (
     HardwareEventHandler,
 )
 
-from opentrons_shared_data.robot.dev_types import RobotType, RobotTypeEnum
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
+from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
 _log = logging.getLogger(__name__)

--- a/robot-server/robot_server/persistence/_legacy_pickle.py
+++ b/robot-server/robot_server/persistence/_legacy_pickle.py
@@ -188,7 +188,7 @@ def _get_legacy_ot_types() -> List[_LegacyTypeInfo]:
         _LegacyTypeInfo(original_name="MovementAxis", current_type=MovementAxis)
     )
 
-    from opentrons_shared_data.pipette.dev_types import PipetteNameType
+    from opentrons_shared_data.pipette.types import PipetteNameType
     _legacy_ot_types.append(
         _LegacyTypeInfo(original_name="PipetteName", current_type=PipetteNameType)
     )

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -3,7 +3,7 @@
 from enum import Enum
 
 from opentrons.protocol_engine.types import RunTimeParameter, RunTimeParamValuesType
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from pydantic import BaseModel, Field
 from typing import List, Optional, Union, NamedTuple
 from typing_extensions import Literal

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -6,7 +6,7 @@ from logging import getLogger
 from typing import Dict, List, Optional
 from typing_extensions import Final
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons.protocol_engine.types import (
     RunTimeParameter,

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Optional, List
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 import opentrons.protocol_runner.create_simulating_orchestrator as simulating_runner
 from opentrons.protocol_engine.errors import ErrorOccurrence

--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -10,7 +10,7 @@ from opentrons.protocol_reader import (
     ProtocolFileRole as ProtocolFileRole,
 )
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from robot_server.service.json_api import ResourceModel
 from .analysis_models import AnalysisSummary

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -31,7 +31,7 @@ from opentrons.protocol_reader import (
     FileReaderWriter,
     FileHasher,
 )
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from robot_server.errors.error_responses import ErrorDetails, ErrorBody
 from robot_server.hardware import get_robot_type

--- a/robot-server/robot_server/robot/calibration/check/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/check/user_flow.py
@@ -35,7 +35,7 @@ from opentrons.protocols.api_support.deck_type import (
     guess_from_global_config as guess_deck_type_from_global_config,
 )
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 from robot_server.robot.calibration.constants import (
     MOVE_TO_DECK_SAFETY_BUFFER,

--- a/robot-server/robot_server/robot/calibration/deck/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/deck/user_flow.py
@@ -41,8 +41,8 @@ from opentrons.protocols.api_support.deck_type import (
 from opentrons.types import Mount, Point, Location
 from opentrons.util import linal
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.pipette.types import LabwareUri
 
 from robot_server.robot.calibration.constants import TIP_RACK_LOOKUP_BY_MAX_VOL
 from robot_server.service.errors import RobotServerError

--- a/robot-server/robot_server/robot/calibration/helper_classes.py
+++ b/robot-server/robot_server/robot/calibration/helper_classes.py
@@ -5,7 +5,7 @@ from enum import Enum
 from dataclasses import dataclass, fields
 from pydantic import BaseModel, Field
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons.protocol_api import labware
 from opentrons.types import DeckLocation
 

--- a/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/pipette_offset/user_flow.py
@@ -29,7 +29,7 @@ from opentrons.hardware_control import HardwareControlAPI, CriticalPoint, Pipett
 from opentrons.protocols.api_support.deck_type import (
     guess_from_global_config as guess_deck_type_from_global_config,
 )
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 from opentrons.protocol_api import labware
 from opentrons.protocol_api.core.legacy.deck import Deck
 from opentrons.types import Mount, Point, Location
@@ -56,7 +56,7 @@ from .state_machine import (
     PipetteOffsetWithTipLengthStateMachine,
 )
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 
 MODULE_LOG = logging.getLogger(__name__)

--- a/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
+++ b/robot-server/robot_server/robot/calibration/tip_length/user_flow.py
@@ -9,8 +9,8 @@ from opentrons.protocols.api_support.deck_type import (
 from opentrons.protocol_api import labware
 from opentrons.protocol_api.core.legacy.deck import Deck
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareDefinition
+from opentrons_shared_data.pipette.types import LabwareUri
 
 from robot_server.robot.calibration import util
 from robot_server.service.errors import RobotServerError

--- a/robot-server/robot_server/robot/calibration/util.py
+++ b/robot-server/robot_server/robot/calibration/util.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
     from .tip_length.user_flow import TipCalibrationUserFlow
     from .pipette_offset.user_flow import PipetteOffsetCalibrationUserFlow
     from .check.user_flow import CheckCalibrationUserFlow
-    from opentrons_shared_data.pipette.dev_types import LabwareUri
-    from opentrons_shared_data.labware.dev_types import LabwareDefinition
+    from opentrons_shared_data.pipette.types import LabwareUri
+    from opentrons_shared_data.labware.types import LabwareDefinition
 
 ValidState = Union[
     TipCalibrationState,

--- a/robot-server/robot_server/robot/control/router.py
+++ b/robot-server/robot_server/robot/control/router.py
@@ -2,8 +2,8 @@
 from fastapi import APIRouter, status, Depends
 from typing import TYPE_CHECKING
 
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.robot.types import RobotTypeEnum
 from robot_server.hardware import get_robot_type
 
 from robot_server.errors.error_responses import ErrorBody

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -5,7 +5,7 @@ from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolStore
 from sqlalchemy.engine import Engine as SQLEngine
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.protocol_engine import DeckType

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -7,8 +7,8 @@ from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
 from opentrons.protocol_engine.types import PostRunHardwareState, RunTimeParameter
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
@@ -44,7 +44,7 @@ from opentrons.protocol_engine.types import (
     RunTimeParamValuesType,
     EngineStatus,
 )
-from opentrons_shared_data.labware.dev_types import LabwareUri
+from opentrons_shared_data.labware.types import LabwareUri
 
 
 _log = logging.getLogger(__name__)

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -56,7 +56,7 @@ from robot_server.persistence.fastapi_dependencies import (
     get_persistence_resetter,
 )
 from robot_server.persistence.persistence_directory import PersistenceResetter
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 log = logging.getLogger(__name__)
 

--- a/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/pipette_offset_calibration.py
@@ -2,7 +2,7 @@ import logging
 from typing import Awaitable, Optional, cast
 from opentrons.types import Mount
 from opentrons.protocol_api import labware
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 from robot_server.robot.calibration.pipette_offset.user_flow import (
     PipetteOffsetCalibrationUserFlow,
 )

--- a/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
+++ b/robot-server/robot_server/service/session/session_types/tip_length_calibration.py
@@ -1,6 +1,6 @@
 from typing import cast, Awaitable, Optional, Any, Union
 from opentrons.types import Mount
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 from robot_server.robot.calibration.tip_length.user_flow import TipCalibrationUserFlow
 from robot_server.robot.calibration.models import SessionCreateParams
 from robot_server.robot.calibration.tip_length.models import TipCalibrationSessionStatus

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -12,7 +12,7 @@ from robot_server.service.errors import RobotServerError, CommonErrorDef
 from robot_server.service.shared_models import calibration as cal_model
 
 from opentrons.hardware_control import API
-from opentrons_shared_data.pipette.dev_types import LabwareUri
+from opentrons_shared_data.pipette.types import LabwareUri
 
 
 router = APIRouter()

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 from fastapi import routing
 from starlette.testclient import TestClient
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 from opentrons import config
 from opentrons.hardware_control import API, HardwareControlAPI, ThreadedAsyncLock

--- a/robot-server/tests/instruments/test_router.py
+++ b/robot-server/tests/instruments/test_router.py
@@ -25,7 +25,7 @@ from opentrons_shared_data.gripper.gripper_definition import (
     GripperModelStr,
     GripperModel,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteName, PipetteModel
+from opentrons_shared_data.pipette.types import PipetteName, PipetteModel
 from opentrons.hardware_control.protocols.types import FlexRobotType, OT2RobotType
 
 from robot_server.instruments.instrument_models import (

--- a/robot-server/tests/integration/fixtures.py
+++ b/robot-server/tests/integration/fixtures.py
@@ -9,7 +9,7 @@ from opentrons.protocol_api import (
     MIN_SUPPORTED_VERSION_FOR_FLEX,
 )
 from opentrons import __version__, config
-from opentrons_shared_data.module.dev_types import ModuleModel
+from opentrons_shared_data.module.types import ModuleModel
 
 
 def check_health_response(response: Response) -> None:

--- a/robot-server/tests/maintenance_runs/router/test_labware_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_labware_router.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import EngineStatus, types as pe_types

--- a/robot-server/tests/maintenance_runs/test_engine_store.py
+++ b/robot-server/tests/maintenance_runs/test_engine_store.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import pytest
 from decoy import Decoy, matchers
 
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
 from opentrons.types import DeckSlotName

--- a/robot-server/tests/protocols/test_analyses_manager.py
+++ b/robot-server/tests/protocols/test_analyses_manager.py
@@ -8,7 +8,7 @@ from opentrons.protocol_runner import RunOrchestrator
 import opentrons.protocol_runner.create_simulating_orchestrator as simulating_runner
 from opentrons.protocol_engine.types import BooleanParameter
 from opentrons.protocol_reader import ProtocolSource, JsonProtocolConfig
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from robot_server.protocols import protocol_analyzer
 from robot_server.protocols.protocol_models import ProtocolKind

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine.types import RunTimeParamValuesType
 
 from sqlalchemy.engine import Engine as SQLEngine
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.errors import ErrorCodes
 
 from opentrons.types import MountType, DeckSlotName

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from pathlib import Path
 
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons_shared_data.robot.dev_types import RobotType
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.pipette.types import PipetteNameType
 
 from opentrons.types import MountType, DeckSlotName
 from opentrons.protocol_engine import (

--- a/robot-server/tests/runs/router/test_labware_router.py
+++ b/robot-server/tests/runs/router/test_labware_router.py
@@ -3,7 +3,7 @@ import pytest
 from datetime import datetime
 from decoy import Decoy
 
-from opentrons_shared_data.labware.dev_types import LabwareDefinition as LabwareDefDict
+from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 
 from opentrons.types import DeckSlotName
 from opentrons.protocol_engine import EngineStatus, types as pe_types

--- a/robot-server/tests/runs/test_engine_store.py
+++ b/robot-server/tests/runs/test_engine_store.py
@@ -4,7 +4,7 @@ import pytest
 from decoy import Decoy, matchers
 
 from opentrons_shared_data import get_shared_data_root
-from opentrons_shared_data.robot.dev_types import RobotType
+from opentrons_shared_data.robot.types import RobotType
 
 from opentrons.protocol_engine.errors.exceptions import EStopActivatedError
 from opentrons.types import DeckSlotName

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -7,7 +7,7 @@ from decoy import Decoy
 from sqlalchemy.engine import Engine
 from unittest import mock
 
-from opentrons_shared_data.pipette.dev_types import PipetteNameType
+from opentrons_shared_data.pipette.types import PipetteNameType
 from opentrons_shared_data.errors.codes import ErrorCodes
 
 from robot_server.protocols.protocol_store import ProtocolNotFoundError

--- a/robot-server/tests/service/legacy/routers/test_settings.py
+++ b/robot-server/tests/service/legacy/routers/test_settings.py
@@ -15,7 +15,7 @@ from opentrons_shared_data.pipette import (
     pipette_definition as pip_def,
 )
 from opentrons.types import Mount
-from opentrons_shared_data.robot.dev_types import RobotTypeEnum
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 
 from robot_server.app import app

--- a/shared-data/protocol/README.md
+++ b/shared-data/protocol/README.md
@@ -2,7 +2,7 @@
 
 1. Create new JSON schema in `shared-data/protocol/schemas/${schemaVersion}.json`
 2. Create TS types for new schema in `shared-data/protocol/types`
-3. Create or modify Python types as necessary in both `python/opentrons_shared_data/protocol/dev_types` and in the python api `dev_types` in `api/src/opentrons/protocol_api/dev_types.py`
+3. Create or modify Python types as necessary in both `python/opentrons_shared_data/protocol/types` and in the python api `types` in `api/src/opentrons/protocol_api/types.py`
 4. Create new executor in api to handle new schema. Be sure to include unit tests
 5. Add new test in `api/tests/opentrons/test_execute.py` for the schema
 6. Add new test in `shared-data/js/__tests__/protocolSchemaV${schemaVersion}.test.js` to ensure new schema definition functions as intended

--- a/shared-data/python/opentrons_shared_data/deck/__init__.py
+++ b/shared-data/python/opentrons_shared_data/deck/__init__.py
@@ -8,7 +8,7 @@ import json
 from .. import get_shared_data_root, load_shared_data
 
 if TYPE_CHECKING:
-    from .dev_types import (
+    from .types import (
         DeckSchema,
         DeckDefinition,
         DeckDefinitionV3,

--- a/shared-data/python/opentrons_shared_data/deck/types.py
+++ b/shared-data/python/opentrons_shared_data/deck/types.py
@@ -1,5 +1,5 @@
 """
-opentrons_shared_data.deck.dev_types: types for deck defs
+opentrons_shared_data.deck.types: types for deck defs
 
 This should only be imported if typing.TYPE_CHECKING is True
 """
@@ -7,7 +7,7 @@ This should only be imported if typing.TYPE_CHECKING is True
 from typing import Any, Dict, List, NewType, Union
 from typing_extensions import Literal, TypedDict
 
-from ..module.dev_types import ModuleType
+from ..module.types import ModuleType
 
 
 DeckSchemaVersion5 = Literal[5]

--- a/shared-data/python/opentrons_shared_data/labware/__init__.py
+++ b/shared-data/python/opentrons_shared_data/labware/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, NewType, TYPE_CHECKING
 from .. import load_shared_data
 
 if TYPE_CHECKING:
-    from .dev_types import LabwareDefinition
+    from .types import LabwareDefinition
 
 Schema = NewType("Schema", Dict[str, Any])
 

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -1,4 +1,4 @@
-""" opentrons_shared_data.labware.dev_types: types for labware defs
+""" opentrons_shared_data.labware.types: types for labware defs
 
 types in this file by and large require the use of typing_extensions.
 this module shouldn't be imported unless typing.TYPE_CHECKING is true.

--- a/shared-data/python/opentrons_shared_data/module/__init__.py
+++ b/shared-data/python/opentrons_shared_data/module/__init__.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Union, cast, overload
 
 from ..load import load_shared_data
-from .dev_types import (
+from .types import (
     SchemaVersions,
     ModuleSchema,
     SchemaV1,

--- a/shared-data/python/opentrons_shared_data/module/types.py
+++ b/shared-data/python/opentrons_shared_data/module/types.py
@@ -1,5 +1,5 @@
 """
-opentrons_shared_data.module.dev_types: types requiring typing_extensions
+opentrons_shared_data.module.types: types requiring typing_extensions
 for modules
 """
 

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from .. import load_shared_data
 
 if TYPE_CHECKING:
-    from .dev_types import (
+    from .types import (
         PipetteNameSpecs,
         PipetteModelSpecs,
         PipetteName,

--- a/shared-data/python/opentrons_shared_data/pipette/dev_types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/dev_types.py
@@ -1,5 +1,5 @@
 """
-opentrons_shared_data.pipette.dev_types: types for pipette config that
+opentrons_shared_data.pipette.types: types for pipette config that
 require typing_extensions.
 
 This module should only be imported if typing.TYPE_CHECKING is True.
@@ -11,7 +11,7 @@ from typing_extensions import Literal, TypedDict
 
 # TODO(mc, 2022-06-16): remove type alias when able
 # and when certain removal will not break any pickling
-from ..labware.dev_types import LabwareUri as LabwareUri
+from ..labware.types import LabwareUri as LabwareUri
 
 
 PipetteName = Literal[

--- a/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
+++ b/shared-data/python/opentrons_shared_data/pipette/mutable_configurations.py
@@ -31,7 +31,7 @@ from .file_operation_helpers import (
     MutableConfigurationEncoder,
     MutableConfigurationDecoder,
 )
-from .dev_types import PipetteModel, PipetteName
+from .types import PipetteModel, PipetteName
 
 
 log = logging.getLogger(__name__)

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_definition.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field, validator
 from typing_extensions import Literal
 from dataclasses import dataclass
 
-from . import types as pip_types, dev_types
+from . import types as pip_types, types
 
 # The highest and lowest existing overlap version values.
 TIP_OVERLAP_VERSION_MINIMUM = 0
@@ -302,7 +302,7 @@ class PipettePhysicalPropertiesDefinition(BaseModel):
         description="The display or full product name of the pipette.",
         alias="displayName",
     )
-    pipette_backcompat_names: List[dev_types.PipetteName] = Field(
+    pipette_backcompat_names: List[types.PipetteName] = Field(
         ...,
         description="A list of pipette names that are compatible with this pipette.",
         alias="backCompatNames",

--- a/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
+++ b/shared-data/python/opentrons_shared_data/pipette/pipette_load_name_conversions.py
@@ -2,7 +2,7 @@ import re
 from functools import lru_cache
 from typing import List, Optional, Union, cast, Literal, Tuple
 from opentrons_shared_data import get_shared_data_root
-from .dev_types import PipetteModel, PipetteName
+from .types import PipetteModel, PipetteName
 
 from .types import (
     PipetteChannelType,

--- a/shared-data/python/opentrons_shared_data/pipette/scripts/build_json_script.py
+++ b/shared-data/python/opentrons_shared_data/pipette/scripts/build_json_script.py
@@ -23,7 +23,7 @@ from ..pipette_definition import (
     PlungerEjectDropTipConfiguration,
 )
 
-from ..dev_types import PipetteModelSpec
+from ..types import PipetteModelSpec
 
 
 PIPETTE_DEFINITION_ROOT = Path("pipette") / "definitions" / "2"

--- a/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
+++ b/shared-data/python/opentrons_shared_data/pipette/scripts/update_configuration_files.py
@@ -31,7 +31,7 @@ from ..types import (
 )
 from ..load_data import _geometry, _physical, _liquid
 from ..pipette_load_name_conversions import convert_pipette_model
-from ..dev_types import PipetteModel
+from ..types import PipetteModel
 
 """
 Instructions:

--- a/shared-data/python/opentrons_shared_data/pipette/types.py
+++ b/shared-data/python/opentrons_shared_data/pipette/types.py
@@ -1,7 +1,12 @@
 import enum
 from dataclasses import dataclass
-from typing import Union, Dict, Mapping, Tuple, cast
-from typing_extensions import Literal
+from typing_extensions import Literal, TypedDict
+from typing import Dict, List, Mapping, NewType, Union, Tuple, cast
+
+
+# TODO(mc, 2022-06-16): remove type alias when able
+# and when certain removal will not break any pickling
+from ..labware.types import LabwareUri as LabwareUri
 
 """Pipette Definition V2 Types"""
 
@@ -191,3 +196,166 @@ class QuirkConfig:
 TypeOverrides = Mapping[str, Union[float, bool, None]]
 
 OverrideType = Dict[str, Union[Dict[str, QuirkConfig], MutableConfig, str]]
+
+
+PipetteName = Literal[
+    "p10_single",
+    "p10_multi",
+    "p20_single_gen2",
+    "p20_multi_gen2",
+    "p50_single",
+    "p50_multi",
+    "p50_single_flex",
+    "p50_multi_flex",
+    "p300_single",
+    "p300_multi",
+    "p300_single_gen2",
+    "p300_multi_gen2",
+    "p1000_single",
+    "p1000_single_gen2",
+    "p1000_single_flex",
+    "p1000_multi_flex",
+    "p1000_96",
+]
+
+
+class PipetteNameType(str, enum.Enum):
+    """Pipette load name values."""
+
+    value: PipetteName
+
+    P10_SINGLE = "p10_single"
+    P10_MULTI = "p10_multi"
+    P20_SINGLE_GEN2 = "p20_single_gen2"
+    P20_MULTI_GEN2 = "p20_multi_gen2"
+    P50_SINGLE = "p50_single"
+    P50_MULTI = "p50_multi"
+    P50_SINGLE_FLEX = "p50_single_flex"
+    P50_MULTI_FLEX = "p50_multi_flex"
+    P300_SINGLE = "p300_single"
+    P300_MULTI = "p300_multi"
+    P300_SINGLE_GEN2 = "p300_single_gen2"
+    P300_MULTI_GEN2 = "p300_multi_gen2"
+    P1000_SINGLE = "p1000_single"
+    P1000_SINGLE_GEN2 = "p1000_single_gen2"
+    P1000_SINGLE_FLEX = "p1000_single_flex"
+    P1000_MULTI_FLEX = "p1000_multi_flex"
+    P1000_96 = "p1000_96"
+
+
+# Generic NewType for models because we get new ones frequently and theres
+# a huge number of them
+PipetteModel = NewType("PipetteModel", str)
+
+DisplayCategory = Literal["GEN1", "GEN2", "FLEX"]
+
+# todo(mm, 2022-03-18):
+# The JSON schema defines this as any string, not as an enum of string literals.
+# Check if it's safe to simplify this to just str.
+ConfigUnit = Literal[
+    "mm",
+    "amps",
+    "mm/sec",
+    "mm/s",  # todo(mm, 2022-03-18): Standardize specs to mm/sec or mm/s.
+    "presses",
+]
+
+Quirk = NewType("Quirk", str)
+
+ChannelCount = Literal[1, 8, 96]
+
+UlPerMmAction = Literal["aspirate", "dispense", "blowout"]
+
+
+class PipetteConfigElement(TypedDict):
+    value: float
+    min: float
+    max: float
+
+
+class PipetteConfigElementWithPerApiLevelValue(TypedDict):
+    value: float
+    min: float
+    max: float
+    valuesByApiLevel: Dict[str, float]
+
+
+# TypedDicts can't be generic sadly
+class PipetteCustomizableConfigElementFloat(TypedDict):
+    value: float
+    min: float
+    max: float
+    units: ConfigUnit
+    type: Literal["float"]
+
+
+class PipetteCustomizableConfigElementInt(TypedDict):
+    value: int
+    min: int
+    max: int
+    units: ConfigUnit
+    type: Literal["int"]
+
+
+PipetteCustomizableConfigElement = Union[
+    PipetteCustomizableConfigElementFloat, PipetteCustomizableConfigElementInt
+]
+
+SmoothieConfigs = TypedDict(
+    "SmoothieConfigs",
+    {"stepsPerMM": float, "homePosition": float, "travelDistance": float},
+)
+
+
+class PipetteNameSpec(TypedDict):
+    displayName: str
+    displayCategory: DisplayCategory
+    minVolume: Union[float, int]
+    maxVolume: Union[float, int]
+    channels: ChannelCount
+    defaultAspirateFlowRate: PipetteConfigElementWithPerApiLevelValue
+    defaultDispenseFlowRate: PipetteConfigElementWithPerApiLevelValue
+    defaultBlowOutFlowRate: PipetteConfigElementWithPerApiLevelValue
+    smoothieConfigs: SmoothieConfigs
+    defaultTipracks: List[LabwareUri]
+
+
+PipetteNameSpecs = Dict[PipetteName, PipetteNameSpec]
+
+UlPerMm = Dict[UlPerMmAction, List[List[float]]]
+
+
+class PipetteModelSpec(TypedDict, total=False):
+    name: PipetteName
+    top: PipetteCustomizableConfigElementFloat
+    bottom: PipetteCustomizableConfigElementFloat
+    blowout: PipetteCustomizableConfigElementFloat
+    dropTip: PipetteCustomizableConfigElementFloat
+    pickUpCurrent: PipetteCustomizableConfigElementFloat
+    pickUpDistance: PipetteCustomizableConfigElementFloat
+    pickUpIncrement: PipetteCustomizableConfigElementFloat
+    pickUpPresses: PipetteCustomizableConfigElementInt
+    pickUpSpeed: PipetteCustomizableConfigElementFloat
+    plungerCurrent: PipetteCustomizableConfigElementFloat
+    dropTipCurrent: PipetteCustomizableConfigElementFloat
+    dropTipSpeed: PipetteCustomizableConfigElementFloat
+    modelOffset: List[float]
+    nozzleOffset: List[float]
+    ulPerMm: List[UlPerMm]
+    tipOverlap: Dict[str, float]
+    tipLength: PipetteCustomizableConfigElementFloat
+    quirks: List[Quirk]
+    # these keys are not present in some pipette definitions
+    backCompatNames: List[PipetteName]
+    idleCurrent: float
+    returnTipHeight: float
+
+
+class PipetteFusedSpec(PipetteNameSpec, PipetteModelSpec, total=False):
+    pass
+
+
+class PipetteModelSpecs(TypedDict):
+    config: Dict[PipetteModel, PipetteModelSpec]
+    mutableConfigs: List[str]
+    validQuirks: List[str]

--- a/shared-data/python/opentrons_shared_data/protocol/constants.py
+++ b/shared-data/python/opentrons_shared_data/protocol/constants.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 
 if TYPE_CHECKING:
-    from .dev_types import (
+    from .types import (
         DelayCommandId,
         BlowoutCommandId,
         PickUpTipCommandId,

--- a/shared-data/python/opentrons_shared_data/protocol/types.py
+++ b/shared-data/python/opentrons_shared_data/protocol/types.py
@@ -1,14 +1,14 @@
 """
-opentrons_shared_data.protocol.dev_types: types for json protocols
+opentrons_shared_data.protocol.types: types for json protocols
 """
 
 from typing import Any, Dict, List, Optional, Union
 from enum import Enum
 
 from typing_extensions import TypedDict, Literal
-from ..pipette.dev_types import PipetteName
-from ..labware.dev_types import LabwareDefinition
-from ..module.dev_types import ModuleModel
+from ..pipette.types import PipetteName
+from ..labware.types import LabwareDefinition
+from ..module.types import ModuleModel
 
 SlotSpan = Literal["span7_8_10_11"]
 

--- a/shared-data/python/opentrons_shared_data/robot/__init__.py
+++ b/shared-data/python/opentrons_shared_data/robot/__init__.py
@@ -7,7 +7,7 @@ import json
 
 from .. import get_shared_data_root
 
-from .dev_types import RobotDefinition, RobotType
+from .types import RobotDefinition, RobotType
 
 DEFAULT_ROBOT_DEFINITION_VERSION: Final = 1
 

--- a/shared-data/python/opentrons_shared_data/robot/types.py
+++ b/shared-data/python/opentrons_shared_data/robot/types.py
@@ -1,4 +1,4 @@
-"""opentrons_shared_data.robot.dev_types: types for robot def."""
+"""opentrons_shared_data.robot.types: types for robot def."""
 import enum
 from typing import NewType, List, Dict, Any
 from typing_extensions import Literal, TypedDict, NotRequired

--- a/shared-data/python/tests/deck/test_position.py
+++ b/shared-data/python/tests/deck/test_position.py
@@ -6,7 +6,7 @@ from opentrons_shared_data.deck import (
     list_names as list_deck_definition_names,
     load as load_deck_definition,
 )
-from opentrons_shared_data.deck.dev_types import (
+from opentrons_shared_data.deck.types import (
     AddressableArea,
     Cutout,
     CutoutFixture,

--- a/shared-data/python/tests/deck/test_typechecks.py
+++ b/shared-data/python/tests/deck/test_typechecks.py
@@ -5,7 +5,7 @@ from opentrons_shared_data.deck import (
     list_names as list_deck_definition_names,
     load as load_deck_definition,
 )
-from opentrons_shared_data.deck.dev_types import (
+from opentrons_shared_data.deck.types import (
     DeckDefinitionV3,
     DeckDefinitionV5,
 )

--- a/shared-data/python/tests/labware/test_typechecks.py
+++ b/shared-data/python/tests/labware/test_typechecks.py
@@ -2,7 +2,7 @@ import pytest
 import typeguard
 
 from opentrons_shared_data.labware import load_definition
-from opentrons_shared_data.labware.dev_types import LabwareDefinition
+from opentrons_shared_data.labware.types import LabwareDefinition
 
 from . import get_ot_defs
 

--- a/shared-data/python/tests/module/test_typechecks.py
+++ b/shared-data/python/tests/module/test_typechecks.py
@@ -2,7 +2,7 @@ import pytest
 import typeguard
 
 from opentrons_shared_data import module
-from opentrons_shared_data.module import dev_types
+from opentrons_shared_data.module import types
 
 from . import list_v2_defs, list_v3_defs
 
@@ -11,16 +11,16 @@ from . import list_v2_defs, list_v3_defs
 def test_v3_definitions_match_types(defname: str) -> None:
     """Test that V3 module definitions match ModuleDefinitionV3."""
     def_dict = module.load_definition("3", defname)
-    typeguard.check_type(def_dict, dev_types.ModuleDefinitionV3)
+    typeguard.check_type(def_dict, types.ModuleDefinitionV3)
 
 
 @pytest.mark.parametrize("defname", list_v2_defs())
 def test_v2_definitions_match_types(defname: str) -> None:
     defdict = module.load_definition("2", defname)  # type: ignore [call-overload]
-    typeguard.check_type(defdict, dev_types.ModuleDefinitionV2)
+    typeguard.check_type(defdict, types.ModuleDefinitionV2)
 
 
 @pytest.mark.parametrize("defname", ["magdeck", "tempdeck", "thermocycler"])
 def test_v1_definitions_match_types(defname: str) -> None:
     defdict = module.load_definition("1", defname)
-    typeguard.check_type(defdict, dev_types.ModuleDefinitionV1)
+    typeguard.check_type(defdict, types.ModuleDefinitionV1)

--- a/shared-data/python/tests/pipette/test_load_data.py
+++ b/shared-data/python/tests/pipette/test_load_data.py
@@ -3,7 +3,7 @@ from typing import Dict, Any, cast
 from opentrons_shared_data.pipette import (
     load_data,
     pipette_load_name_conversions,
-    dev_types,
+    types,
 )
 from opentrons_shared_data.pipette.types import (
     PipetteChannelType,
@@ -80,7 +80,7 @@ def test_update_pipette_configuration(
 
     liquid_class = LiquidClasses.default
     model_name = pipette_load_name_conversions.convert_pipette_model(
-        cast(dev_types.PipetteModel, pipette_model)
+        cast(types.PipetteModel, pipette_model)
     )
     base_configurations = load_data.load_definition(
         model_name.pipette_type, model_name.pipette_channels, model_name.pipette_version

--- a/shared-data/python/tests/pipette/test_max_flow_rates_per_volume.py
+++ b/shared-data/python/tests/pipette/test_max_flow_rates_per_volume.py
@@ -8,7 +8,7 @@ from opentrons_shared_data.pipette.pipette_load_name_conversions import (
 from opentrons_shared_data.pipette.load_data import load_definition
 from opentrons_shared_data.pipette.ul_per_mm import piecewise_volume_conversion
 
-from opentrons_shared_data.pipette.dev_types import PipetteModel
+from opentrons_shared_data.pipette.types import PipetteModel
 from opentrons_shared_data.pipette.pipette_definition import (
     ulPerMMDefinition,
 )

--- a/shared-data/python/tests/pipette/test_mutable_configurations.py
+++ b/shared-data/python/tests/pipette/test_mutable_configurations.py
@@ -11,7 +11,6 @@ from opentrons_shared_data.pipette import (
     pipette_definition,
     pipette_load_name_conversions as pip_conversions,
     load_data,
-    dev_types,
 )
 
 
@@ -243,13 +242,13 @@ def test_save_invalid_overrides(
     argvalues=[
         [
             pip_conversions.convert_pipette_model(
-                cast(dev_types.PipetteModel, "p1000_96_v3.3")
+                cast(types.PipetteModel, "p1000_96_v3.3")
             ),
             "P1KHV3320230629",
         ],
         [
             pip_conversions.convert_pipette_model(
-                cast(dev_types.PipetteModel, "p50_multi_v1.5")
+                cast(types.PipetteModel, "p50_multi_v1.5")
             ),
             TEST_SERIAL_NUMBER,
         ],

--- a/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
+++ b/shared-data/python/tests/pipette/test_pipette_load_name_conversions.py
@@ -7,7 +7,7 @@ from opentrons_shared_data.pipette.types import (
     PipetteVersionType,
     PipetteGenerationType,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteModel, PipetteName
+from opentrons_shared_data.pipette.types import PipetteModel, PipetteName
 from opentrons_shared_data.pipette import (
     pipette_definition as pc,
     pipette_load_name_conversions as ps,

--- a/shared-data/python/tests/pipette/test_typechecks.py
+++ b/shared-data/python/tests/pipette/test_typechecks.py
@@ -7,7 +7,7 @@ from opentrons_shared_data.pipette import (
     fuse_specs,
     dummy_model_for_name,
 )
-from opentrons_shared_data.pipette.dev_types import (
+from opentrons_shared_data.pipette.types import (
     PipetteModelSpecs,
     PipetteNameSpecs,
     PipetteFusedSpec,

--- a/shared-data/python/tests/pipette/test_validate_schema.py
+++ b/shared-data/python/tests/pipette/test_validate_schema.py
@@ -13,7 +13,7 @@ from opentrons_shared_data.pipette.load_data import (
 from opentrons_shared_data.pipette.pipette_load_name_conversions import (
     convert_pipette_model,
 )
-from opentrons_shared_data.pipette.dev_types import PipetteModel
+from opentrons_shared_data.pipette.types import PipetteModel
 
 
 def iterate_models() -> Iterator[PipetteModel]:

--- a/shared-data/python/tests/protocol/test_typechecks.py
+++ b/shared-data/python/tests/protocol/test_typechecks.py
@@ -3,7 +3,7 @@ import pytest
 import typeguard
 
 from opentrons_shared_data import load_shared_data
-from opentrons_shared_data.protocol.dev_types import (
+from opentrons_shared_data.protocol.types import (
     JsonProtocolV3,
     JsonProtocolV4,
     JsonProtocolV5,

--- a/shared-data/python/tests/robot/test_typechecks.py
+++ b/shared-data/python/tests/robot/test_typechecks.py
@@ -3,7 +3,7 @@ import typeguard
 
 
 from opentrons_shared_data.robot import load
-from opentrons_shared_data.robot.dev_types import RobotDefinition, RobotType
+from opentrons_shared_data.robot.types import RobotDefinition, RobotType
 
 
 @pytest.mark.parametrize("defname", ["OT-2 Standard", "OT-3 Standard"])


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

The dev_types submodule is vestigial. This PR moves dev_types definitions to the respective types file and deletes dev_types. If there was no existing types file, dev_types just gets renamed as types.

[EXEC-220](https://opentrons.atlassian.net/browse/EXEC-220)

Originally this was #15761 but I just made this new PR since it was easier to start from scratch.
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog

<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment

<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-220]: https://opentrons.atlassian.net/browse/EXEC-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ