### PR TITLE
refactor(labware-library): aluminum flat bottom plate compatible for …

### DIFF
--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -85,19 +85,15 @@ export function StackingOffsets(): JSX.Element | null {
         definition.parameters.loadName === 'opentrons_96_well_aluminum_block'
     )
   }
-  if (isFlatBottom && isReservoir) {
-    modifiedAdapterDefinitions = adapterDefinitions.filter(
-      definition =>
-        definition.parameters.loadName === 'opentrons_universal_flat_adapter'
-    )
-  }
   if (isFlatBottom && (isReservoir || isWellPlate)) {
     modifiedAdapterDefinitions = adapterDefinitions.filter(
       definition =>
         definition.parameters.loadName ===
-        'opentrons_aluminum_flat_bottom_plate'
+          'opentrons_aluminum_flat_bottom_plate' ||
+        definition.parameters.loadName === 'opentrons_universal_flat_adapter'
     )
   }
+
   if (
     isFlatBottom &&
     isCircular &&

--- a/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
+++ b/labware-library/src/labware-creator/components/sections/StackingOffsets.tsx
@@ -64,6 +64,7 @@ export function StackingOffsets(): JSX.Element | null {
   const isFlatBottom = values.wellBottomShape === 'flat'
   const isCircular = values.wellShape === 'circular'
   const isReservoir = values.labwareType === 'reservoir'
+  const isWellPlate = values.labwareType === 'wellPlate'
   const labwareHeight = values.labwareZDimension
   const has12Columns =
     values.gridColumns != null && parseInt(values.gridColumns) === 12
@@ -87,9 +88,14 @@ export function StackingOffsets(): JSX.Element | null {
   if (isFlatBottom && isReservoir) {
     modifiedAdapterDefinitions = adapterDefinitions.filter(
       definition =>
-        definition.parameters.loadName ===
-          'opentrons_aluminum_flat_bottom_plate' ||
         definition.parameters.loadName === 'opentrons_universal_flat_adapter'
+    )
+  }
+  if (isFlatBottom && (isReservoir || isWellPlate)) {
+    modifiedAdapterDefinitions = adapterDefinitions.filter(
+      definition =>
+        definition.parameters.loadName ===
+        'opentrons_aluminum_flat_bottom_plate'
     )
   }
   if (


### PR DESCRIPTION
…multiple types

closes AUTH-572

# Overview

Fix when the  `opentrons_aluminum_flat_bottom_plate` and `opentrons_universal_flat_adapter` show up

# Test Plan

Open the labware-library dev env. Navigate to Labware Creator. Create a custom labware for a `wellPlate` and scroll down to see that the flat bottom aluminum adapter and the universal heater-shaker adapter shows up.

# Changelog

-  `opentrons_aluminum_flat_bottom_plate` && `opentrons_universal_flat_adapter`  shows up for flat bottom + if type is reservoir or wellPlate

# Review requests

see test plan

# Risk assessment

low
