### PR TITLE
feat(app): add userInfo to redux config

### DIFF
--- a/app-shell-odd/src/config/__fixtures__/index.ts
+++ b/app-shell-odd/src/config/__fixtures__/index.ts
@@ -11,6 +11,7 @@ import type {
   ConfigV21,
   ConfigV22,
   ConfigV23,
+  ConfigV24,
 } from '@opentrons/app/src/redux/config/types'
 
 const PKG_VERSION: string = _PKG_VERSION_
@@ -157,5 +158,16 @@ export const MOCK_CONFIG_V23: ConfigV23 = {
     pinnedQuickTransferIds: [],
     quickTransfersOnDeviceSortKey: null,
     hasDismissedQuickTransferIntro: false,
+  },
+}
+
+export const MOCK_CONFIG_V24: ConfigV24 = {
+  ...(() => {
+    const { support, ...rest } = MOCK_CONFIG_V23
+    return rest
+  })(),
+  version: 24,
+  userInfo: {
+    userId: 'MOCK_UUIDv4',
   },
 }

--- a/app-shell-odd/src/config/__tests__/migrate.test.ts
+++ b/app-shell-odd/src/config/__tests__/migrate.test.ts
@@ -1,5 +1,7 @@
 // config migration tests
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import uuid from 'uuid/v4'
+
 import {
   MOCK_CONFIG_V12,
   MOCK_CONFIG_V13,
@@ -13,18 +15,26 @@ import {
   MOCK_CONFIG_V21,
   MOCK_CONFIG_V22,
   MOCK_CONFIG_V23,
+  MOCK_CONFIG_V24,
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
-const NEWEST_VERSION = 23
+vi.mock('uuid/v4')
+
+const NEWEST_VERSION = 24
+const NEWEST_MOCK_CONFIG = MOCK_CONFIG_V24
 
 describe('config migration', () => {
+  beforeEach(() => {
+    vi.mocked(uuid).mockReturnValue('MOCK_UUIDv4')
+  })
+
   it('should migrate version 12 to latest', () => {
     const v12Config = MOCK_CONFIG_V12
     const result = migrate(v12Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 13 to latest', () => {
@@ -32,7 +42,7 @@ describe('config migration', () => {
     const result = migrate(v13Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 14 to latest', () => {
@@ -40,7 +50,7 @@ describe('config migration', () => {
     const result = migrate(v14Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 15 to latest', () => {
@@ -48,7 +58,7 @@ describe('config migration', () => {
     const result = migrate(v15Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 16 to latest', () => {
@@ -56,7 +66,7 @@ describe('config migration', () => {
     const result = migrate(v16Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 17 to latest', () => {
@@ -64,7 +74,7 @@ describe('config migration', () => {
     const result = migrate(v17Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migration version 18 to latest', () => {
@@ -72,7 +82,7 @@ describe('config migration', () => {
     const result = migrate(v18Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migration version 19 to latest', () => {
@@ -80,7 +90,7 @@ describe('config migration', () => {
     const result = migrate(v19Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migration version 20 to latest', () => {
@@ -88,27 +98,34 @@ describe('config migration', () => {
     const result = migrate(v20Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should migration version 21 to latest', () => {
     const v21Config = MOCK_CONFIG_V21
     const result = migrate(v21Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should migration version 22 to latest', () => {
     const v22Config = MOCK_CONFIG_V22
     const result = migrate(v22Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
-  it('should keep version 23', () => {
+  it('should migrate version 23 to latest', () => {
     const v23Config = MOCK_CONFIG_V23
     const result = migrate(v23Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(v23Config)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
+  })
+  it('should keep version 24', () => {
+    const v24Config = MOCK_CONFIG_V24
+    const result = migrate(v24Config)
+
+    expect(result.version).toBe(NEWEST_VERSION)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 })

--- a/app-shell-odd/src/config/migrate.ts
+++ b/app-shell-odd/src/config/migrate.ts
@@ -16,6 +16,7 @@ import type {
   ConfigV21,
   ConfigV22,
   ConfigV23,
+  ConfigV24,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v12 defaults
@@ -214,6 +215,17 @@ const toVersion23 = (prevConfig: ConfigV22): ConfigV23 => {
   return nextConfig
 }
 
+const toVersion24 = (prevConfig: ConfigV23): ConfigV24 => {
+  const { support, ...rest } = prevConfig
+  return {
+    ...rest,
+    version: 24 as const,
+    userInfo: {
+      userId: uuid(),
+    },
+  }
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV12) => ConfigV13,
   (prevConfig: ConfigV13) => ConfigV14,
@@ -225,7 +237,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV19) => ConfigV20,
   (prevConfig: ConfigV20) => ConfigV21,
   (prevConfig: ConfigV21) => ConfigV22,
-  (prevConfig: ConfigV22) => ConfigV23
+  (prevConfig: ConfigV22) => ConfigV23,
+  (prevConfig: ConfigV23) => ConfigV24
 ] = [
   toVersion13,
   toVersion14,
@@ -238,6 +251,7 @@ const MIGRATIONS: [
   toVersion21,
   toVersion22,
   toVersion23,
+  toVersion24,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V12)
@@ -256,6 +270,7 @@ export function migrate(
     | ConfigV21
     | ConfigV22
     | ConfigV23
+    | ConfigV24
 ): Config {
   let result = prevConfig
   // loop through the migrations, skipping any migrations that are unnecessary

--- a/app-shell/src/__fixtures__/config.ts
+++ b/app-shell/src/__fixtures__/config.ts
@@ -23,6 +23,7 @@ import type {
   ConfigV21,
   ConfigV22,
   ConfigV23,
+  ConfigV24,
 } from '@opentrons/app/src/redux/config/types'
 
 export const MOCK_CONFIG_V0: ConfigV0 = {
@@ -288,5 +289,16 @@ export const MOCK_CONFIG_V23: ConfigV23 = {
     pinnedQuickTransferIds: [],
     quickTransfersOnDeviceSortKey: null,
     hasDismissedQuickTransferIntro: false,
+  },
+}
+
+export const MOCK_CONFIG_V24: ConfigV24 = {
+  ...(() => {
+    const { support, ...rest } = MOCK_CONFIG_V23
+    return rest
+  })(),
+  version: 24,
+  userInfo: {
+    userId: 'MOCK_UUIDv4',
   },
 }

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -1,5 +1,7 @@
 // config migration tests
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import uuid from 'uuid/v4'
+
 import {
   MOCK_CONFIG_V0,
   MOCK_CONFIG_V1,
@@ -25,18 +27,26 @@ import {
   MOCK_CONFIG_V21,
   MOCK_CONFIG_V22,
   MOCK_CONFIG_V23,
+  MOCK_CONFIG_V24,
 } from '../../__fixtures__'
 import { migrate } from '../migrate'
 
-const NEWEST_VERSION = 23
+vi.mock('uuid/v4')
+
+const NEWEST_VERSION = 24
+const NEWEST_MOCK_CONFIG = MOCK_CONFIG_V24
 
 describe('config migration', () => {
+  beforeEach(() => {
+    vi.mocked(uuid).mockReturnValue('MOCK_UUIDv4')
+  })
+
   it('should migrate version 0 to latest', () => {
     const v0Config = MOCK_CONFIG_V0
     const result = migrate(v0Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 1 to latest', () => {
@@ -44,7 +54,7 @@ describe('config migration', () => {
     const result = migrate(v1Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 2 to latest', () => {
@@ -52,7 +62,7 @@ describe('config migration', () => {
     const result = migrate(v2Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 3 to latest', () => {
@@ -60,7 +70,7 @@ describe('config migration', () => {
     const result = migrate(v3Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 4 to latest', () => {
@@ -68,7 +78,7 @@ describe('config migration', () => {
     const result = migrate(v4Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 5 to latest', () => {
@@ -76,7 +86,7 @@ describe('config migration', () => {
     const result = migrate(v5Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 6 to latest', () => {
@@ -84,7 +94,7 @@ describe('config migration', () => {
     const result = migrate(v6Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 7 to latest', () => {
@@ -92,7 +102,7 @@ describe('config migration', () => {
     const result = migrate(v7Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 8 to latest', () => {
@@ -100,7 +110,7 @@ describe('config migration', () => {
     const result = migrate(v8Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 9 to latest', () => {
@@ -108,7 +118,7 @@ describe('config migration', () => {
     const result = migrate(v9Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 10 to latest', () => {
@@ -116,7 +126,7 @@ describe('config migration', () => {
     const result = migrate(v10Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 11 to latest', () => {
@@ -124,7 +134,7 @@ describe('config migration', () => {
     const result = migrate(v11Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 12 to latest', () => {
@@ -132,7 +142,7 @@ describe('config migration', () => {
     const result = migrate(v12Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 13 to latest', () => {
@@ -140,7 +150,7 @@ describe('config migration', () => {
     const result = migrate(v13Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 14 to latest', () => {
@@ -148,7 +158,7 @@ describe('config migration', () => {
     const result = migrate(v14Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 15 to latest', () => {
@@ -156,7 +166,7 @@ describe('config migration', () => {
     const result = migrate(v15Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 16 to latest', () => {
@@ -164,7 +174,7 @@ describe('config migration', () => {
     const result = migrate(v16Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 
   it('should migrate version 17 to latest', () => {
@@ -172,48 +182,55 @@ describe('config migration', () => {
     const result = migrate(v17Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should migrate version 18 to latest', () => {
     const v18Config = MOCK_CONFIG_V18
     const result = migrate(v18Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should keep migrate version 19 to latest', () => {
     const v19Config = MOCK_CONFIG_V19
     const result = migrate(v19Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should migration version 20 to latest', () => {
     const v20Config = MOCK_CONFIG_V20
     const result = migrate(v20Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should migration version 21 to latest', () => {
     const v21Config = MOCK_CONFIG_V21
     const result = migrate(v21Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
   it('should migration version 22 to latest', () => {
     const v22Config = MOCK_CONFIG_V22
     const result = migrate(v22Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
-  it('should keep version 23', () => {
+  it('should migrate version 23 to latest', () => {
     const v23Config = MOCK_CONFIG_V23
     const result = migrate(v23Config)
 
     expect(result.version).toBe(NEWEST_VERSION)
-    expect(result).toEqual(MOCK_CONFIG_V23)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
+  })
+  it('should keep version 24', () => {
+    const v24Config = MOCK_CONFIG_V24
+    const result = migrate(v24Config)
+
+    expect(result.version).toBe(NEWEST_VERSION)
+    expect(result).toEqual(NEWEST_MOCK_CONFIG)
   })
 })

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -27,6 +27,7 @@ import type {
   ConfigV21,
   ConfigV22,
   ConfigV23,
+  ConfigV24,
 } from '@opentrons/app/src/redux/config/types'
 // format
 // base config v0 defaults
@@ -418,6 +419,17 @@ const toVersion23 = (prevConfig: ConfigV22): ConfigV23 => {
   return nextConfig
 }
 
+const toVersion24 = (prevConfig: ConfigV23): ConfigV24 => {
+  const { support, ...rest } = prevConfig
+  return {
+    ...rest,
+    version: 24 as const,
+    userInfo: {
+      userId: uuid(),
+    },
+  }
+}
+
 const MIGRATIONS: [
   (prevConfig: ConfigV0) => ConfigV1,
   (prevConfig: ConfigV1) => ConfigV2,
@@ -441,7 +453,8 @@ const MIGRATIONS: [
   (prevConfig: ConfigV19) => ConfigV20,
   (prevConfig: ConfigV20) => ConfigV21,
   (prevConfig: ConfigV21) => ConfigV22,
-  (prevConfig: ConfigV22) => ConfigV23
+  (prevConfig: ConfigV22) => ConfigV23,
+  (prevConfig: ConfigV23) => ConfigV24
 ] = [
   toVersion1,
   toVersion2,
@@ -466,6 +479,7 @@ const MIGRATIONS: [
   toVersion21,
   toVersion22,
   toVersion23,
+  toVersion24,
 ]
 
 export const DEFAULTS: Config = migrate(DEFAULTS_V0)
@@ -496,6 +510,7 @@ export function migrate(
     | ConfigV21
     | ConfigV22
     | ConfigV23
+    | ConfigV24
 ): Config {
   const prevVersion = prevConfig.version
   let result = prevConfig

--- a/app/src/organisms/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Devices/RobotOverview.tsx
@@ -66,7 +66,7 @@ export function RobotOverview({
   const isRobotViewable = useIsRobotViewable(robot?.name ?? '')
   const { lightsOn, toggleLights } = useLights()
 
-  const userId = useSelector(getConfig)?.support?.userId ?? 'Opentrons-user'
+  const userId = useSelector(getConfig)?.userInfo?.userId ?? 'Opentrons-user'
 
   const addresses = useSelector((state: State) =>
     getRobotAddressesByName(state, robot?.name ?? '')

--- a/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
+++ b/app/src/organisms/Devices/__tests__/RobotOverview.test.tsx
@@ -151,7 +151,7 @@ describe('RobotOverview', () => {
       .calledWith(MOCK_STATE, mockConnectableRobot.name)
       .thenReturn([])
     vi.mocked(getConfig).mockReturnValue({
-      support: { userId: 'opentrons-robot-user' },
+      userInfo: { userId: 'opentrons-robot-user' },
     } as Config)
     when(useAuthorization)
       .calledWith({

--- a/app/src/redux/config/__tests__/selectors.test.ts
+++ b/app/src/redux/config/__tests__/selectors.test.ts
@@ -282,4 +282,20 @@ describe('shell selectors', () => {
       expect(Selectors.getApplyHistoricOffsets(state)).toEqual(true)
     })
   })
+
+  describe('getUserId', () => {
+    it('should return userId if it exists in config', () => {
+      const state: State = {
+        config: {
+          userInfo: { userId: 'test-user-id' },
+        },
+      } as any
+      expect(Selectors.getUserId(state)).toEqual('test-user-id')
+    })
+
+    it('should return an empty string if config is null', () => {
+      const state: State = { config: null } as any
+      expect(Selectors.getUserId(state)).toEqual('')
+    })
+  })
 })

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -268,4 +268,11 @@ export type ConfigV23 = Omit<ConfigV22, 'version'> & {
   }
 }
 
-export type Config = ConfigV23
+export type ConfigV24 = Omit<ConfigV23, 'version' | 'support'> & {
+  version: 24
+  userInfo: {
+    userId: string
+  }
+}
+
+export type Config = ConfigV24

--- a/app/src/redux/config/selectors.ts
+++ b/app/src/redux/config/selectors.ts
@@ -145,3 +145,8 @@ export const getOnDeviceDisplaySettings: (
     unfinishedUnboxingFlowRoute: '/welcome',
   }
 })
+
+export const getUserId: (state: State) => string = createSelector(
+  getConfig,
+  config => config?.userInfo.userId ?? ''
+)


### PR DESCRIPTION
Closes [EXEC-628](https://opentrons.atlassian.net/browse/EXEC-628)

<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Works toward [EXEC-420](https://opentrons.atlassian.net/browse/EXEC-420). In the (near) future, apps will stake ownership in error recovery and perhaps later on, protocol runs. A basis for staking ownership requires some sort of unique identification, which we can do via UUIDs. Let's have a client generate a UUID that's persisted in the electron config file. 

I deleted a largely unused "support" store after running it by @shlokamin. It's used somewhat in one spot in `RobotOverview`, but we can readily replace this with our new UUID and avoid issues. 

<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan
- Check the redux devtools and notice the new UUID in config > userInfo. Reopen the app and verify the UUID remains the same. Repeat for ODD.
<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- Added a new `userInfo` field to the app's config.
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests
- Does this new `userInfo` store seem like what we want?
<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
-low/med - merging this PR commits us to config changes that require a permanent config migration to correct.
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->


[EXEC-628]: https://opentrons.atlassian.net/browse/EXEC-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXEC-420]: https://opentrons.atlassian.net/browse/EXEC-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ