### PR TITLE
chore(release): update release notes post 7.4.0 revocation

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -10,19 +10,12 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.5.0 release of the Opentrons robot software!
 
-This release adds support for the latest Flex Gripper hardware.
-
----
-
-## Opentrons Robot Software Changes in 7.4.0
-
-Welcome to the v7.4.0 release of the Opentrons robot software!
-
-This release adds support for the [Opentrons Flex HEPA/UV Module](https://opentrons.com/products/opentrons-flex-hepa-uv-module).
+This release adds support for the latest Flex Gripper hardware and the [Opentrons Flex HEPA/UV Module](https://opentrons.com/products/opentrons-flex-hepa-uv-module).
 
 ### Bug Fixes
 
 - Fixed certain string runtime parameter values being misinterpreted as an incorrect type.
+
 ---
 
 ## Opentrons Robot Software Changes in 7.3.1

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -10,15 +10,7 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 Welcome to the v7.5.0 release of the Opentrons App!
 
-There are no changes to the Opentrons App in v7.5.0, but it is required for updating the robot software to improve some features.
-
----
-
-## Opentrons App Changes in 7.4.0
-
-Welcome to the v7.4.0 release of the Opentrons App!
-
-This release adds support for the [Opentrons Flex HEPA/UV Module](https://opentrons.com/products/opentrons-flex-hepa-uv-module).
+There are no changes to the Opentrons App in v7.5.0, but it is required for updating the robot software to support the latest Flex Gripper hardware and the [Opentrons Flex HEPA/UV Module](https://opentrons.com/products/opentrons-flex-hepa-uv-module).
 
 ---
 


### PR DESCRIPTION
## Overview

Update the release notes now that 7.4.0 is revoked and 7.5.0 will handle the new gripper hardware and the support for the HEPA/UV.

Should we have a comment stating something about 7.4.0 being revoked?