### PR TITLE
chore: rename RobotContextTracker to RobotActivityTracker

### DIFF
--- a/api/src/opentrons/util/performance_helpers.py
+++ b/api/src/opentrons/util/performance_helpers.py
@@ -1,4 +1,4 @@
-"""Performance helpers for tracking robot context."""
+"""Performance helpers for tracking robot activity."""
 
 import functools
 from pathlib import Path
@@ -12,7 +12,7 @@ from opentrons.config import (
 )
 
 if typing.TYPE_CHECKING:
-    from performance_metrics import RobotContextState, SupportsTracking
+    from performance_metrics import RobotActivityState, SupportsTracking
 
 
 _UnderlyingFunctionParameters = typing.ParamSpec("_UnderlyingFunctionParameters")
@@ -36,7 +36,7 @@ class _StubbedTracker:
 
     def track(
         self,
-        state: "RobotContextState",
+        state: "RobotActivityState",
     ) -> typing.Callable[
         [_UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn]],
         _UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn],
@@ -72,35 +72,35 @@ def _handle_package_import() -> typing.Type["SupportsTracking"]:
     If the package is not available, return a stubbed tracker.
     """
     try:
-        from performance_metrics import RobotContextTracker
+        from performance_metrics import RobotActivityTracker
 
-        return RobotContextTracker
+        return RobotActivityTracker
     except ImportError:
         return _StubbedTracker
 
 
 _package_to_use = _handle_package_import()
-_robot_context_tracker: typing.Optional["SupportsTracking"] = None
+_robot_activity_tracker: typing.Optional["SupportsTracking"] = None
 
 # TODO: derek maggio (06-03-2024): investigate if _should_track should be
-# reevaluated each time _get_robot_context_tracker is called. I think this
+# reevaluated each time _get_robot_activity_tracker is called. I think this
 # might get stuck in a state where after the first call, _should_track is
 # always considered the initial value. It might miss changes to the feature
 # flag. The easiest way to test this is on a robot when that is working.
 
 
-def _get_robot_context_tracker() -> "SupportsTracking":
-    """Singleton for the robot context tracker."""
-    global _robot_context_tracker
-    if _robot_context_tracker is None:
-        _robot_context_tracker = _package_to_use(
+def _get_robot_activity_tracker() -> "SupportsTracking":
+    """Singleton for the robot activity tracker."""
+    global _robot_activity_tracker
+    if _robot_activity_tracker is None:
+        _robot_activity_tracker = _package_to_use(
             get_performance_metrics_data_dir(), _should_track
         )
-    return _robot_context_tracker
+    return _robot_activity_tracker
 
 
 def _track_a_function(
-    state_name: "RobotContextState",
+    state_name: "RobotActivityState",
     func: _UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn],
 ) -> typing.Callable[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn]:
     """Track a function.
@@ -115,7 +115,7 @@ def _track_a_function(
     Returns:
         The decorated function.
     """
-    tracker: SupportsTracking = _get_robot_context_tracker()
+    tracker: SupportsTracking = _get_robot_activity_tracker()
     wrapped = tracker.track(state=state_name)(func)
 
     @functools.wraps(func)

--- a/api/tests/opentrons/util/test_performance_helpers.py
+++ b/api/tests/opentrons/util/test_performance_helpers.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from opentrons.util.performance_helpers import (
     _StubbedTracker,
-    _get_robot_context_tracker,
+    _get_robot_activity_tracker,
 )
 
 
@@ -19,6 +19,6 @@ def test_return_function_unchanged() -> None:
 
 def test_singleton_tracker() -> None:
     """Test that the tracker is a singleton."""
-    tracker = _get_robot_context_tracker()
-    tracker2 = _get_robot_context_tracker()
+    tracker = _get_robot_activity_tracker()
+    tracker2 = _get_robot_activity_tracker()
     assert tracker is tracker2

--- a/performance-metrics/src/performance_metrics/__init__.py
+++ b/performance-metrics/src/performance_metrics/__init__.py
@@ -1,11 +1,11 @@
 """Opentrons performance metrics library."""
 
-from ._robot_context_tracker import RobotContextTracker
-from ._types import RobotContextState, SupportsTracking
+from ._robot_activity_tracker import RobotActivityTracker
+from ._types import RobotActivityState, SupportsTracking
 
 
 __all__ = [
-    "RobotContextTracker",
-    "RobotContextState",
+    "RobotActivityTracker",
+    "RobotActivityState",
     "SupportsTracking",
 ]

--- a/performance-metrics/src/performance_metrics/_data_shapes.py
+++ b/performance-metrics/src/performance_metrics/_data_shapes.py
@@ -4,34 +4,34 @@ import dataclasses
 import typing
 from pathlib import Path
 
-from ._types import SupportsCSVStorage, StorableData, RobotContextState
+from ._types import SupportsCSVStorage, StorableData, RobotActivityState
 from ._util import get_timing_function
 
 _timing_function = get_timing_function()
 
 
 @dataclasses.dataclass(frozen=True)
-class RawContextData(SupportsCSVStorage):
-    """Represents raw duration data with context state information.
+class RawActivityData(SupportsCSVStorage):
+    """Represents raw duration data with activity state information.
 
     Attributes:
     - function_start_time (int): The start time of the function.
     - duration_measurement_start_time (int): The start time for duration measurement.
     - duration_measurement_end_time (int): The end time for duration measurement.
-    - state (RobotContextStates): The current state of the context.
+    - state (RobotActivityStates): The current state of the activity.
     """
 
-    state: RobotContextState
+    state: RobotActivityState
     func_start: int
     duration: int
 
     @classmethod
     def headers(self) -> typing.Tuple[str, str, str]:
-        """Returns the headers for the raw context data."""
+        """Returns the headers for the raw activity data."""
         return ("state_name", "function_start_time", "duration")
 
     def csv_row(self) -> typing.Tuple[str, int, int]:
-        """Returns the raw context data as a string."""
+        """Returns the raw activity data as a string."""
         return (
             self.state,
             self.func_start,
@@ -40,9 +40,9 @@ class RawContextData(SupportsCSVStorage):
 
     @classmethod
     def from_csv_row(cls, row: typing.Sequence[StorableData]) -> SupportsCSVStorage:
-        """Returns a RawContextData object from a CSV row."""
+        """Returns a RawActivityData object from a CSV row."""
         return cls(
-            state=typing.cast(RobotContextState, row[0]),
+            state=typing.cast(RobotActivityState, row[0]),
             func_start=int(row[1]),
             duration=int(row[2]),
         )

--- a/performance-metrics/src/performance_metrics/_metrics_store.py
+++ b/performance-metrics/src/performance_metrics/_metrics_store.py
@@ -13,20 +13,20 @@ T = typing.TypeVar("T", bound=SupportsCSVStorage)
 
 
 class MetricsStore(typing.Generic[T]):
-    """Dataclass to store data for tracking robot context."""
+    """Dataclass to store data for tracking robot activity."""
 
     def __init__(self, metadata: MetricsMetadata) -> None:
         """Initialize the metrics store."""
         self.metadata = metadata
-        self._data: typing.List[T] = []
+        self._data_store: typing.List[T] = []
 
-    def add(self, context_data: T) -> None:
+    def add(self, data: T) -> None:
         """Add data to the store."""
-        self._data.append(context_data)
+        self._data_store.append(data)
 
-    def add_all(self, context_data: typing.Iterable[T]) -> None:
+    def add_all(self, data: typing.Iterable[T]) -> None:
         """Add data to the store."""
-        self._data.extend(context_data)
+        self._data_store.extend(data)
 
     def setup(self) -> None:
         """Set up the data store."""
@@ -40,9 +40,9 @@ class MetricsStore(typing.Generic[T]):
 
     def store(self) -> None:
         """Clear the stored data and write it to the storage file."""
-        stored_data = self._data.copy()
-        self._data.clear()
-        rows_to_write = [context_data.csv_row() for context_data in stored_data]
+        stored_data = self._data_store.copy()
+        self._data_store.clear()
+        rows_to_write = [activity_data.csv_row() for activity_data in stored_data]
         with open(self.metadata.data_file_location, "a") as storage_file:
             logger.debug(
                 f"Writing {len(rows_to_write)} rows to {self.metadata.data_file_location}"

--- a/performance-metrics/src/performance_metrics/_robot_activity_tracker.py
+++ b/performance-metrics/src/performance_metrics/_robot_activity_tracker.py
@@ -1,4 +1,4 @@
-"""Module for tracking robot context and execution duration for different operations."""
+"""Module for tracking robot activity and execution duration for different operations."""
 
 import inspect
 from pathlib import Path
@@ -8,8 +8,8 @@ from time import perf_counter_ns
 import typing
 
 from ._metrics_store import MetricsStore
-from ._data_shapes import RawContextData, MetricsMetadata
-from ._types import SupportsTracking, RobotContextState
+from ._data_shapes import RawActivityData, MetricsMetadata
+from ._types import SupportsTracking, RobotActivityState
 from ._util import get_timing_function
 
 _UnderlyingFunctionParameters = typing.ParamSpec("_UnderlyingFunctionParameters")
@@ -22,20 +22,20 @@ _UnderlyingFunction = typing.Callable[
 _timing_function = get_timing_function()
 
 
-class RobotContextTracker(SupportsTracking):
-    """Tracks and stores robot context and execution duration for different operations."""
+class RobotActivityTracker(SupportsTracking):
+    """Tracks and stores robot activity and execution duration for different operations."""
 
     METADATA_NAME: typing.Final[
-        typing.Literal["robot_context_data"]
-    ] = "robot_context_data"
+        typing.Literal["robot_activity_data"]
+    ] = "robot_activity_data"
 
     def __init__(self, storage_location: Path, should_track: bool) -> None:
-        """Initializes the RobotContextTracker with an empty storage list."""
-        self._store = MetricsStore[RawContextData](
+        """Initializes the RobotActivityTracker with an empty storage list."""
+        self._store = MetricsStore[RawActivityData](
             MetricsMetadata(
                 name=self.METADATA_NAME,
                 storage_dir=storage_location,
-                headers=RawContextData.headers(),
+                headers=RawActivityData.headers(),
             )
         )
         self._should_track = should_track
@@ -45,7 +45,7 @@ class RobotContextTracker(SupportsTracking):
 
     def track(
         self,
-        state: RobotContextState,
+        state: RobotActivityState,
     ) -> typing.Callable[
         [_UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn]],
         _UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn],
@@ -56,7 +56,7 @@ class RobotContextTracker(SupportsTracking):
 
         Args:
             func_to_track: The function to track.
-            state: The state of the robot context during the function execution.
+            state: The state of the robot activity during the function execution.
             *args: The arguments to pass to the function.
             **kwargs: The keyword arguments to pass to the function.
 
@@ -90,7 +90,7 @@ class RobotContextTracker(SupportsTracking):
                         duration_end_time = perf_counter_ns()
 
                         self._store.add(
-                            RawContextData(
+                            RawActivityData(
                                 func_start=function_start_time,
                                 duration=duration_end_time - duration_start_time,
                                 state=state,
@@ -116,7 +116,7 @@ class RobotContextTracker(SupportsTracking):
                         duration_end_time = perf_counter_ns()
 
                         self._store.add(
-                            RawContextData(
+                            RawActivityData(
                                 func_start=function_start_time,
                                 duration=duration_end_time - duration_start_time,
                                 state=state,
@@ -130,7 +130,7 @@ class RobotContextTracker(SupportsTracking):
         return inner_decorator
 
     def store(self) -> None:
-        """Returns the stored context data and clears the storage list."""
+        """Returns the stored activity data and clears the storage list."""
         if not self._should_track:
             return
         self._store.store()

--- a/performance-metrics/src/performance_metrics/_types.py
+++ b/performance-metrics/src/performance_metrics/_types.py
@@ -10,7 +10,7 @@ _UnderlyingFunction = typing.Callable[
 ]
 
 
-RobotContextState = typing.Literal[
+RobotActivityState = typing.Literal[
     "ANALYZING_PROTOCOL",
     "GETTING_CACHED_ANALYSIS",
     "RUNNING_PROTOCOL",
@@ -21,7 +21,7 @@ RobotContextState = typing.Literal[
 
 
 class SupportsTracking(typing.Protocol):
-    """Protocol for classes that support tracking of robot context."""
+    """Protocol for classes that support tracking of robot activity."""
 
     def __init__(self, storage_location: Path, should_track: bool) -> None:
         """Initialize the tracker."""
@@ -29,7 +29,7 @@ class SupportsTracking(typing.Protocol):
 
     def track(
         self,
-        state: "RobotContextState",
+        state: "RobotActivityState",
     ) -> typing.Callable[
         [_UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn]],
         _UnderlyingFunction[_UnderlyingFunctionParameters, _UnderlyingFunctionReturn],

--- a/performance-metrics/tests/performance_metrics/test_metrics_store.py
+++ b/performance-metrics/tests/performance_metrics/test_metrics_store.py
@@ -3,8 +3,8 @@
 from pathlib import Path
 from time import sleep
 
-from performance_metrics._robot_context_tracker import RobotContextTracker
-from performance_metrics._data_shapes import RawContextData
+from performance_metrics._robot_activity_tracker import RobotActivityTracker
+from performance_metrics._data_shapes import RawActivityData
 
 # Corrected times in seconds
 STARTING_TIME = 0.001
@@ -16,17 +16,17 @@ SHUTTING_DOWN_TIME = 0.005
 
 async def test_storing_to_file(tmp_path: Path) -> None:
     """Tests storing the tracked data to a file."""
-    robot_context_tracker = RobotContextTracker(tmp_path, should_track=True)
+    robot_activity_tracker = RobotActivityTracker(tmp_path, should_track=True)
 
-    @robot_context_tracker.track("ROBOT_STARTING_UP")
+    @robot_activity_tracker.track("ROBOT_STARTING_UP")
     def starting_robot() -> None:
         sleep(STARTING_TIME)
 
-    @robot_context_tracker.track("CALIBRATING")
+    @robot_activity_tracker.track("CALIBRATING")
     async def calibrating_robot() -> None:
         sleep(CALIBRATING_TIME)
 
-    @robot_context_tracker.track("ANALYZING_PROTOCOL")
+    @robot_activity_tracker.track("ANALYZING_PROTOCOL")
     def analyzing_protocol() -> None:
         sleep(ANALYZING_TIME)
 
@@ -34,9 +34,9 @@ async def test_storing_to_file(tmp_path: Path) -> None:
     await calibrating_robot()
     analyzing_protocol()
 
-    robot_context_tracker.store()
+    robot_activity_tracker.store()
 
-    with open(robot_context_tracker._store.metadata.data_file_location, "r") as file:
+    with open(robot_activity_tracker._store.metadata.data_file_location, "r") as file:
         lines = file.readlines()
         assert len(lines) == 3, "All stored data should be written to the file."
 
@@ -44,10 +44,12 @@ async def test_storing_to_file(tmp_path: Path) -> None:
             line.replace('"', "").strip().split(",") for line in lines
         ]
         assert all(
-            RawContextData.from_csv_row(line) for line in split_lines
-        ), "All lines should be valid RawContextData instances."
+            RawActivityData.from_csv_row(line) for line in split_lines
+        ), "All lines should be valid RawActivityData instances."
 
-    with open(robot_context_tracker._store.metadata.headers_file_location, "r") as file:
+    with open(
+        robot_activity_tracker._store.metadata.headers_file_location, "r"
+    ) as file:
         headers = file.readlines()
         assert len(headers) == 1, "Header should be written to the headers file."
-        assert tuple(headers[0].strip().split(",")) == RawContextData.headers()
+        assert tuple(headers[0].strip().split(",")) == RawActivityData.headers()

--- a/performance-metrics/tests/performance_metrics/test_robot_context_tracker.py
+++ b/performance-metrics/tests/performance_metrics/test_robot_context_tracker.py
@@ -1,9 +1,9 @@
-"""Tests for the RobotContextTracker class in performance_metrics._robot_context_tracker."""
+"""Tests for the RobotActivityTracker class in performance_metrics._robot_activity_tracker."""
 
 import asyncio
 from pathlib import Path
 import pytest
-from performance_metrics._robot_context_tracker import RobotContextTracker
+from performance_metrics._robot_activity_tracker import RobotActivityTracker
 from time import sleep, time_ns
 from unittest.mock import patch
 
@@ -16,43 +16,43 @@ SHUTTING_DOWN_TIME = 0.005
 
 
 @pytest.fixture
-def robot_context_tracker(tmp_path: Path) -> RobotContextTracker:
-    """Fixture to provide a fresh instance of RobotContextTracker for each test."""
-    return RobotContextTracker(storage_location=tmp_path, should_track=True)
+def robot_activity_tracker(tmp_path: Path) -> RobotActivityTracker:
+    """Fixture to provide a fresh instance of RobotActivityTracker for each test."""
+    return RobotActivityTracker(storage_location=tmp_path, should_track=True)
 
 
-async def test_robot_context_tracker(
-    robot_context_tracker: RobotContextTracker,
+async def test_robot_activity_tracker(
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
-    """Tests the tracking of various robot context states through RobotContextTracker."""
+    """Tests the tracking of various robot activity states through RobotActivityTracker."""
 
-    @robot_context_tracker.track(state="ROBOT_STARTING_UP")
+    @robot_activity_tracker.track(state="ROBOT_STARTING_UP")
     async def starting_robot() -> str:
         sleep(STARTING_TIME)
         return "Robot is starting up."
 
-    @robot_context_tracker.track(state="CALIBRATING")
+    @robot_activity_tracker.track(state="CALIBRATING")
     def calibrating_robot() -> None:
         sleep(CALIBRATING_TIME)
 
-    @robot_context_tracker.track(state="ANALYZING_PROTOCOL")
+    @robot_activity_tracker.track(state="ANALYZING_PROTOCOL")
     def analyzing_protocol() -> None:
         sleep(ANALYZING_TIME)
 
-    @robot_context_tracker.track(state="RUNNING_PROTOCOL")
+    @robot_activity_tracker.track(state="RUNNING_PROTOCOL")
     async def running_protocol(run_time: int) -> int:
         sleep(RUNNING_TIME)
 
         return run_time
 
-    @robot_context_tracker.track(state="ROBOT_SHUTTING_DOWN")
+    @robot_activity_tracker.track(state="ROBOT_SHUTTING_DOWN")
     def shutting_down_robot() -> str:
         sleep(SHUTTING_DOWN_TIME)
         return "Robot is shutting down."
 
     # Ensure storage is initially empty
     assert (
-        len(robot_context_tracker._store._data) == 0
+        len(robot_activity_tracker._store._data_store) == 0
     ), "Storage should be initially empty."
 
     assert await starting_robot() == "Robot is starting up.", "Operation should return."
@@ -64,7 +64,9 @@ async def test_robot_context_tracker(
     ), "Operation should return."
 
     # Verify that all states were tracked
-    assert len(robot_context_tracker._store._data) == 5, "All states should be tracked."
+    assert (
+        len(robot_activity_tracker._store._data_store) == 5
+    ), "All states should be tracked."
 
     # Validate the sequence and accuracy of tracked states
     expected_states = [
@@ -76,44 +78,44 @@ async def test_robot_context_tracker(
     ]
     for i, state in enumerate(expected_states):
         assert (
-            robot_context_tracker._store._data[i].state == state
+            robot_activity_tracker._store._data_store[i].state == state
         ), f"State at index {i} should be {state}."
 
 
 async def test_multiple_operations_single_state(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
-    """Tests tracking multiple operations within a single robot context state."""
+    """Tests tracking multiple operations within a single robot activity state."""
 
     async def first_operation() -> None:
         sleep(RUNNING_TIME)
 
-    @robot_context_tracker.track(state="RUNNING_PROTOCOL")
+    @robot_activity_tracker.track(state="RUNNING_PROTOCOL")
     def second_operation() -> None:
         sleep(RUNNING_TIME)
 
-    wrapped_first_operation = robot_context_tracker.track(state="RUNNING_PROTOCOL")(
+    wrapped_first_operation = robot_activity_tracker.track(state="RUNNING_PROTOCOL")(
         first_operation
     )
     await wrapped_first_operation()
     second_operation()
 
     assert (
-        len(robot_context_tracker._store._data) == 2
+        len(robot_activity_tracker._store._data_store) == 2
     ), "Both operations should be tracked."
     assert (
-        robot_context_tracker._store._data[0].state
-        == robot_context_tracker._store._data[1].state
+        robot_activity_tracker._store._data_store[0].state
+        == robot_activity_tracker._store._data_store[1].state
         == "RUNNING_PROTOCOL"
     ), "Both operations should have the same state."
 
 
 async def test_exception_handling_in_tracked_function(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
     """Ensures exceptions in tracked operations are handled correctly."""
 
-    @robot_context_tracker.track(state="ROBOT_SHUTTING_DOWN")
+    @robot_activity_tracker.track(state="ROBOT_SHUTTING_DOWN")
     async def error_prone_operation() -> None:
         sleep(SHUTTING_DOWN_TIME)
         raise RuntimeError("Simulated operation failure")
@@ -122,45 +124,45 @@ async def test_exception_handling_in_tracked_function(
         await error_prone_operation()
 
     assert (
-        len(robot_context_tracker._store._data) == 1
+        len(robot_activity_tracker._store._data_store) == 1
     ), "Failed operation should still be tracked."
     assert (
-        robot_context_tracker._store._data[0].state == "ROBOT_SHUTTING_DOWN"
+        robot_activity_tracker._store._data_store[0].state == "ROBOT_SHUTTING_DOWN"
     ), "State should be correctly logged despite the exception."
 
 
 @pytest.mark.asyncio
 async def test_async_operation_tracking(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
     """Tests tracking of an asynchronous operation."""
 
-    @robot_context_tracker.track(state="ANALYZING_PROTOCOL")
+    @robot_activity_tracker.track(state="ANALYZING_PROTOCOL")
     async def async_analyzing_operation() -> None:
         await asyncio.sleep(ANALYZING_TIME)
 
     await async_analyzing_operation()
 
     assert (
-        len(robot_context_tracker._store._data) == 1
+        len(robot_activity_tracker._store._data_store) == 1
     ), "Async operation should be tracked."
     assert (
-        robot_context_tracker._store._data[0].state == "ANALYZING_PROTOCOL"
+        robot_activity_tracker._store._data_store[0].state == "ANALYZING_PROTOCOL"
     ), "State should be ANALYZING_PROTOCOL."
 
 
 def test_sync_operation_timing_accuracy(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
     """Tests the timing accuracy of a synchronous operation tracking."""
 
-    @robot_context_tracker.track(state="RUNNING_PROTOCOL")
+    @robot_activity_tracker.track(state="RUNNING_PROTOCOL")
     def running_operation() -> None:
         sleep(RUNNING_TIME)
 
     running_operation()
 
-    duration_data = robot_context_tracker._store._data[0]
+    duration_data = robot_activity_tracker._store._data_store[0]
     assert (
         abs(duration_data.duration - RUNNING_TIME * 1e9) < 1e7
     ), "Measured duration for sync operation should closely match the expected duration."
@@ -168,17 +170,17 @@ def test_sync_operation_timing_accuracy(
 
 @pytest.mark.asyncio
 async def test_async_operation_timing_accuracy(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
     """Tests the timing accuracy of an async operation tracking."""
 
-    @robot_context_tracker.track(state="RUNNING_PROTOCOL")
+    @robot_activity_tracker.track(state="RUNNING_PROTOCOL")
     async def async_running_operation() -> None:
         await asyncio.sleep(RUNNING_TIME)
 
     await async_running_operation()
 
-    duration_data = robot_context_tracker._store._data[0]
+    duration_data = robot_activity_tracker._store._data_store[0]
     assert (
         abs(duration_data.duration - RUNNING_TIME * 1e9) < 1e7
     ), "Measured duration for async operation should closely match the expected duration."
@@ -186,11 +188,11 @@ async def test_async_operation_timing_accuracy(
 
 @pytest.mark.asyncio
 async def test_exception_in_async_operation(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
     """Ensures exceptions in tracked async operations are correctly handled."""
 
-    @robot_context_tracker.track(state="ROBOT_SHUTTING_DOWN")
+    @robot_activity_tracker.track(state="ROBOT_SHUTTING_DOWN")
     async def async_error_prone_operation() -> None:
         await asyncio.sleep(SHUTTING_DOWN_TIME)
         raise RuntimeError("Simulated async operation failure")
@@ -199,58 +201,59 @@ async def test_exception_in_async_operation(
         await async_error_prone_operation()
 
     assert (
-        len(robot_context_tracker._store._data) == 1
+        len(robot_activity_tracker._store._data_store) == 1
     ), "Failed async operation should still be tracked."
     assert (
-        robot_context_tracker._store._data[0].state == "ROBOT_SHUTTING_DOWN"
+        robot_activity_tracker._store._data_store[0].state == "ROBOT_SHUTTING_DOWN"
     ), "State should be ROBOT_SHUTTING_DOWN despite the exception."
 
 
 @pytest.mark.asyncio
 async def test_concurrent_async_operations(
-    robot_context_tracker: RobotContextTracker,
+    robot_activity_tracker: RobotActivityTracker,
 ) -> None:
     """Tests tracking of concurrent async operations."""
 
-    @robot_context_tracker.track(state="CALIBRATING")
+    @robot_activity_tracker.track(state="CALIBRATING")
     async def first_async_calibrating() -> None:
         await asyncio.sleep(CALIBRATING_TIME)
 
-    @robot_context_tracker.track(state="CALIBRATING")
+    @robot_activity_tracker.track(state="CALIBRATING")
     async def second_async_calibrating() -> None:
         await asyncio.sleep(CALIBRATING_TIME)
 
     await asyncio.gather(first_async_calibrating(), second_async_calibrating())
 
     assert (
-        len(robot_context_tracker._store._data) == 2
+        len(robot_activity_tracker._store._data_store) == 2
     ), "Both concurrent async operations should be tracked."
     assert all(
-        data.state == "CALIBRATING" for data in robot_context_tracker._store._data
+        data.state == "CALIBRATING"
+        for data in robot_activity_tracker._store._data_store
     ), "All tracked operations should be in CALIBRATING state."
 
 
 def test_no_tracking(tmp_path: Path) -> None:
     """Tests that operations are not tracked when tracking is disabled."""
-    robot_context_tracker = RobotContextTracker(tmp_path, should_track=False)
+    robot_activity_tracker = RobotActivityTracker(tmp_path, should_track=False)
 
-    @robot_context_tracker.track(state="ROBOT_STARTING_UP")
+    @robot_activity_tracker.track(state="ROBOT_STARTING_UP")
     def operation_without_tracking() -> None:
         sleep(STARTING_TIME)
 
     operation_without_tracking()
 
     assert (
-        len(robot_context_tracker._store._data) == 0
+        len(robot_activity_tracker._store._data_store) == 0
     ), "Operation should not be tracked when tracking is disabled."
 
 
 @pytest.mark.asyncio
 async def test_async_exception_handling_when_not_tracking(tmp_path: Path) -> None:
     """Ensures exceptions in operations are still raised when tracking is disabled."""
-    robot_context_tracker = RobotContextTracker(tmp_path, should_track=False)
+    robot_activity_tracker = RobotActivityTracker(tmp_path, should_track=False)
 
-    @robot_context_tracker.track(state="ROBOT_SHUTTING_DOWN")
+    @robot_activity_tracker.track(state="ROBOT_SHUTTING_DOWN")
     async def error_prone_operation() -> None:
         sleep(SHUTTING_DOWN_TIME)
         raise RuntimeError("Simulated operation failure")
@@ -261,9 +264,9 @@ async def test_async_exception_handling_when_not_tracking(tmp_path: Path) -> Non
 
 def test_sync_exception_handling_when_not_tracking(tmp_path: Path) -> None:
     """Ensures exceptions in operations are still raised when tracking is disabled."""
-    robot_context_tracker = RobotContextTracker(tmp_path, should_track=False)
+    robot_activity_tracker = RobotActivityTracker(tmp_path, should_track=False)
 
-    @robot_context_tracker.track(state="ROBOT_SHUTTING_DOWN")
+    @robot_activity_tracker.track(state="ROBOT_SHUTTING_DOWN")
     def error_prone_operation() -> None:
         sleep(SHUTTING_DOWN_TIME)
         raise RuntimeError("Simulated operation failure")
@@ -279,20 +282,20 @@ def test_sync_exception_handling_when_not_tracking(tmp_path: Path) -> None:
 def test_using_non_linux_time_functions(tmp_path: Path) -> None:
     """Tests tracking operations using non-Linux time functions."""
     file_path = tmp_path / "test_file.csv"
-    robot_context_tracker = RobotContextTracker(file_path, should_track=True)
+    robot_activity_tracker = RobotActivityTracker(file_path, should_track=True)
 
-    @robot_context_tracker.track(state="ROBOT_STARTING_UP")
+    @robot_activity_tracker.track(state="ROBOT_STARTING_UP")
     def starting_robot() -> None:
         sleep(STARTING_TIME)
 
-    @robot_context_tracker.track(state="CALIBRATING")
+    @robot_activity_tracker.track(state="CALIBRATING")
     def calibrating_robot() -> None:
         sleep(CALIBRATING_TIME)
 
     starting_robot()
     calibrating_robot()
 
-    storage = robot_context_tracker._store._data
+    storage = robot_activity_tracker._store._data_store
     assert all(
         data.func_start > 0 for data in storage
     ), "All function start times should be greater than 0."


### PR DESCRIPTION
# Overview

Closes https://opentrons.atlassian.net/browse/EXEC-623

Renames RobotContextTracker and RobotContextState to RobotActivityTracker and RobotActivityState. This is to prevent confusion with the `RobotContext` class added in https://github.com/Opentrons/opentrons/pull/15745

# Test Plan

- [x] Make sure linting and testing passes
