### PR TITLE
feat: add commandSchema9 in protocols

### DIFF
--- a/shared-data/command/index.ts
+++ b/shared-data/command/index.ts
@@ -1,5 +1,6 @@
 import commandSchemaV7 from './schemas/7.json'
 import commandSchemaV8 from './schemas/8.json'
+import commandSchemaV9 from './schemas/9.json'
 export * from './types/index'
 
-export { commandSchemaV7, commandSchemaV8 }
+export { commandSchemaV7, commandSchemaV8, commandSchemaV9 }

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -1,0 +1,4778 @@
+{
+  "title": "CreateCommandUnion",
+  "description": "Model that validates a union of all CommandCreate models.",
+  "discriminator": {
+    "propertyName": "commandType",
+    "mapping": {
+      "aspirate": "#/definitions/AspirateCreate",
+      "aspirateInPlace": "#/definitions/AspirateInPlaceCreate",
+      "comment": "#/definitions/CommentCreate",
+      "configureForVolume": "#/definitions/ConfigureForVolumeCreate",
+      "configureNozzleLayout": "#/definitions/ConfigureNozzleLayoutCreate",
+      "custom": "#/definitions/CustomCreate",
+      "dispense": "#/definitions/DispenseCreate",
+      "dispenseInPlace": "#/definitions/DispenseInPlaceCreate",
+      "blowout": "#/definitions/BlowOutCreate",
+      "blowOutInPlace": "#/definitions/BlowOutInPlaceCreate",
+      "dropTip": "#/definitions/DropTipCreate",
+      "dropTipInPlace": "#/definitions/DropTipInPlaceCreate",
+      "home": "#/definitions/HomeCreate",
+      "retractAxis": "#/definitions/RetractAxisCreate",
+      "loadLabware": "#/definitions/LoadLabwareCreate",
+      "reloadLabware": "#/definitions/ReloadLabwareCreate",
+      "loadLiquid": "#/definitions/LoadLiquidCreate",
+      "loadModule": "#/definitions/LoadModuleCreate",
+      "loadPipette": "#/definitions/LoadPipetteCreate",
+      "moveLabware": "#/definitions/MoveLabwareCreate",
+      "moveRelative": "#/definitions/MoveRelativeCreate",
+      "moveToCoordinates": "#/definitions/MoveToCoordinatesCreate",
+      "moveToWell": "#/definitions/MoveToWellCreate",
+      "moveToAddressableArea": "#/definitions/MoveToAddressableAreaCreate",
+      "moveToAddressableAreaForDropTip": "#/definitions/MoveToAddressableAreaForDropTipCreate",
+      "prepareToAspirate": "#/definitions/PrepareToAspirateCreate",
+      "waitForResume": "#/definitions/WaitForResumeCreate",
+      "pause": "#/definitions/WaitForResumeCreate",
+      "waitForDuration": "#/definitions/WaitForDurationCreate",
+      "pickUpTip": "#/definitions/PickUpTipCreate",
+      "savePosition": "#/definitions/SavePositionCreate",
+      "setRailLights": "#/definitions/SetRailLightsCreate",
+      "touchTip": "#/definitions/TouchTipCreate",
+      "setStatusBar": "#/definitions/SetStatusBarCreate",
+      "verifyTipPresence": "#/definitions/VerifyTipPresenceCreate",
+      "getTipPresence": "#/definitions/GetTipPresenceCreate",
+      "liquidProbe": "#/definitions/LiquidProbeCreate",
+      "tryLiquidProbe": "#/definitions/TryLiquidProbeCreate",
+      "heaterShaker/waitForTemperature": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate",
+      "heaterShaker/setTargetTemperature": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate",
+      "heaterShaker/deactivateHeater": "#/definitions/DeactivateHeaterCreate",
+      "heaterShaker/setAndWaitForShakeSpeed": "#/definitions/SetAndWaitForShakeSpeedCreate",
+      "heaterShaker/deactivateShaker": "#/definitions/DeactivateShakerCreate",
+      "heaterShaker/openLabwareLatch": "#/definitions/OpenLabwareLatchCreate",
+      "heaterShaker/closeLabwareLatch": "#/definitions/CloseLabwareLatchCreate",
+      "magneticModule/disengage": "#/definitions/DisengageCreate",
+      "magneticModule/engage": "#/definitions/EngageCreate",
+      "temperatureModule/setTargetTemperature": "#/definitions/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate",
+      "temperatureModule/waitForTemperature": "#/definitions/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate",
+      "temperatureModule/deactivate": "#/definitions/DeactivateTemperatureCreate",
+      "thermocycler/setTargetBlockTemperature": "#/definitions/SetTargetBlockTemperatureCreate",
+      "thermocycler/waitForBlockTemperature": "#/definitions/WaitForBlockTemperatureCreate",
+      "thermocycler/setTargetLidTemperature": "#/definitions/SetTargetLidTemperatureCreate",
+      "thermocycler/waitForLidTemperature": "#/definitions/WaitForLidTemperatureCreate",
+      "thermocycler/deactivateBlock": "#/definitions/DeactivateBlockCreate",
+      "thermocycler/deactivateLid": "#/definitions/DeactivateLidCreate",
+      "thermocycler/openLid": "#/definitions/OpenLidCreate",
+      "thermocycler/closeLid": "#/definitions/CloseLidCreate",
+      "thermocycler/runProfile": "#/definitions/RunProfileCreate",
+      "absorbanceReader/initialize": "#/definitions/InitializeCreate",
+      "absorbanceReader/measure": "#/definitions/MeasureAbsorbanceCreate",
+      "calibration/calibrateGripper": "#/definitions/CalibrateGripperCreate",
+      "calibration/calibratePipette": "#/definitions/CalibratePipetteCreate",
+      "calibration/calibrateModule": "#/definitions/CalibrateModuleCreate",
+      "calibration/moveToMaintenancePosition": "#/definitions/MoveToMaintenancePositionCreate"
+    }
+  },
+  "oneOf": [
+    {
+      "$ref": "#/definitions/AspirateCreate"
+    },
+    {
+      "$ref": "#/definitions/AspirateInPlaceCreate"
+    },
+    {
+      "$ref": "#/definitions/CommentCreate"
+    },
+    {
+      "$ref": "#/definitions/ConfigureForVolumeCreate"
+    },
+    {
+      "$ref": "#/definitions/ConfigureNozzleLayoutCreate"
+    },
+    {
+      "$ref": "#/definitions/CustomCreate"
+    },
+    {
+      "$ref": "#/definitions/DispenseCreate"
+    },
+    {
+      "$ref": "#/definitions/DispenseInPlaceCreate"
+    },
+    {
+      "$ref": "#/definitions/BlowOutCreate"
+    },
+    {
+      "$ref": "#/definitions/BlowOutInPlaceCreate"
+    },
+    {
+      "$ref": "#/definitions/DropTipCreate"
+    },
+    {
+      "$ref": "#/definitions/DropTipInPlaceCreate"
+    },
+    {
+      "$ref": "#/definitions/HomeCreate"
+    },
+    {
+      "$ref": "#/definitions/RetractAxisCreate"
+    },
+    {
+      "$ref": "#/definitions/LoadLabwareCreate"
+    },
+    {
+      "$ref": "#/definitions/ReloadLabwareCreate"
+    },
+    {
+      "$ref": "#/definitions/LoadLiquidCreate"
+    },
+    {
+      "$ref": "#/definitions/LoadModuleCreate"
+    },
+    {
+      "$ref": "#/definitions/LoadPipetteCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveLabwareCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveRelativeCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveToCoordinatesCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveToWellCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveToAddressableAreaCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveToAddressableAreaForDropTipCreate"
+    },
+    {
+      "$ref": "#/definitions/PrepareToAspirateCreate"
+    },
+    {
+      "$ref": "#/definitions/WaitForResumeCreate"
+    },
+    {
+      "$ref": "#/definitions/WaitForDurationCreate"
+    },
+    {
+      "$ref": "#/definitions/PickUpTipCreate"
+    },
+    {
+      "$ref": "#/definitions/SavePositionCreate"
+    },
+    {
+      "$ref": "#/definitions/SetRailLightsCreate"
+    },
+    {
+      "$ref": "#/definitions/TouchTipCreate"
+    },
+    {
+      "$ref": "#/definitions/SetStatusBarCreate"
+    },
+    {
+      "$ref": "#/definitions/VerifyTipPresenceCreate"
+    },
+    {
+      "$ref": "#/definitions/GetTipPresenceCreate"
+    },
+    {
+      "$ref": "#/definitions/LiquidProbeCreate"
+    },
+    {
+      "$ref": "#/definitions/TryLiquidProbeCreate"
+    },
+    {
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/DeactivateHeaterCreate"
+    },
+    {
+      "$ref": "#/definitions/SetAndWaitForShakeSpeedCreate"
+    },
+    {
+      "$ref": "#/definitions/DeactivateShakerCreate"
+    },
+    {
+      "$ref": "#/definitions/OpenLabwareLatchCreate"
+    },
+    {
+      "$ref": "#/definitions/CloseLabwareLatchCreate"
+    },
+    {
+      "$ref": "#/definitions/DisengageCreate"
+    },
+    {
+      "$ref": "#/definitions/EngageCreate"
+    },
+    {
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/DeactivateTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/SetTargetBlockTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/WaitForBlockTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/SetTargetLidTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/WaitForLidTemperatureCreate"
+    },
+    {
+      "$ref": "#/definitions/DeactivateBlockCreate"
+    },
+    {
+      "$ref": "#/definitions/DeactivateLidCreate"
+    },
+    {
+      "$ref": "#/definitions/OpenLidCreate"
+    },
+    {
+      "$ref": "#/definitions/CloseLidCreate"
+    },
+    {
+      "$ref": "#/definitions/RunProfileCreate"
+    },
+    {
+      "$ref": "#/definitions/InitializeCreate"
+    },
+    {
+      "$ref": "#/definitions/MeasureAbsorbanceCreate"
+    },
+    {
+      "$ref": "#/definitions/CalibrateGripperCreate"
+    },
+    {
+      "$ref": "#/definitions/CalibratePipetteCreate"
+    },
+    {
+      "$ref": "#/definitions/CalibrateModuleCreate"
+    },
+    {
+      "$ref": "#/definitions/MoveToMaintenancePositionCreate"
+    }
+  ],
+  "definitions": {
+    "WellOrigin": {
+      "title": "WellOrigin",
+      "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
+      "type": "string"
+    },
+    "WellOffset": {
+      "title": "WellOffset",
+      "description": "An offset vector in (x, y, z).",
+      "type": "object",
+      "properties": {
+        "x": {
+          "title": "X",
+          "default": 0,
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "default": 0,
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "default": 0,
+          "type": "number"
+        }
+      }
+    },
+    "WellLocation": {
+      "title": "WellLocation",
+      "description": "A relative location in reference to a well's location.",
+      "type": "object",
+      "properties": {
+        "origin": {
+          "default": "top",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellOrigin"
+            }
+          ]
+        },
+        "offset": {
+          "$ref": "#/definitions/WellOffset"
+        }
+      }
+    },
+    "AspirateParams": {
+      "title": "AspirateParams",
+      "description": "Parameters required to aspirate from a specific well.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
+    },
+    "CommandIntent": {
+      "title": "CommandIntent",
+      "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
+      "enum": [
+        "protocol",
+        "setup",
+        "fixit"
+      ],
+      "type": "string"
+    },
+    "AspirateCreate": {
+      "title": "AspirateCreate",
+      "description": "Create aspirate command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "aspirate",
+          "enum": [
+            "aspirate"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/AspirateParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "AspirateInPlaceParams": {
+      "title": "AspirateInPlaceParams",
+      "description": "Payload required to aspirate in place.",
+      "type": "object",
+      "properties": {
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "The amount of liquid to aspirate, in \u00b5L. Must not be greater than the remaining available amount, which depends on the pipette (see `loadPipette`), its configuration (see `configureForVolume`), the tip (see `pickUpTip`), and the amount you've aspirated so far. There is some tolerance for floating point rounding errors.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
+    },
+    "AspirateInPlaceCreate": {
+      "title": "AspirateInPlaceCreate",
+      "description": "AspirateInPlace command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "aspirateInPlace",
+          "enum": [
+            "aspirateInPlace"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/AspirateInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CommentParams": {
+      "title": "CommentParams",
+      "description": "Payload required to annotate execution with a comment.",
+      "type": "object",
+      "properties": {
+        "message": {
+          "title": "Message",
+          "description": "A user-facing message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message"
+      ]
+    },
+    "CommentCreate": {
+      "title": "CommentCreate",
+      "description": "Comment command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "comment",
+          "enum": [
+            "comment"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CommentParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "ConfigureForVolumeParams": {
+      "title": "ConfigureForVolumeParams",
+      "description": "Parameters required to configure volume for a specific pipette.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "Amount of liquid in uL. Must be at least 0 and no greater than a pipette-specific maximum volume.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "tipOverlapNotAfterVersion": {
+          "title": "Tipoverlapnotafterversion",
+          "description": "A version of tip overlap data to not exceed. The highest-versioned tip overlap data that does not exceed this version will be used. Versions are expressed as vN where N is an integer, counting up from v0. If None, the current highest version will be used.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pipetteId",
+        "volume"
+      ]
+    },
+    "ConfigureForVolumeCreate": {
+      "title": "ConfigureForVolumeCreate",
+      "description": "Configure for volume command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "configureForVolume",
+          "enum": [
+            "configureForVolume"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/ConfigureForVolumeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "AllNozzleLayoutConfiguration": {
+      "title": "AllNozzleLayoutConfiguration",
+      "description": "All basemodel to represent a reset to the nozzle configuration. Sending no parameters resets to default.",
+      "type": "object",
+      "properties": {
+        "style": {
+          "title": "Style",
+          "default": "ALL",
+          "enum": [
+            "ALL"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "SingleNozzleLayoutConfiguration": {
+      "title": "SingleNozzleLayoutConfiguration",
+      "description": "Minimum information required for a new nozzle configuration.",
+      "type": "object",
+      "properties": {
+        "style": {
+          "title": "Style",
+          "default": "SINGLE",
+          "enum": [
+            "SINGLE"
+          ],
+          "type": "string"
+        },
+        "primaryNozzle": {
+          "title": "Primarynozzle",
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "primaryNozzle"
+      ]
+    },
+    "RowNozzleLayoutConfiguration": {
+      "title": "RowNozzleLayoutConfiguration",
+      "description": "Minimum information required for a new nozzle configuration.",
+      "type": "object",
+      "properties": {
+        "style": {
+          "title": "Style",
+          "default": "ROW",
+          "enum": [
+            "ROW"
+          ],
+          "type": "string"
+        },
+        "primaryNozzle": {
+          "title": "Primarynozzle",
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "primaryNozzle"
+      ]
+    },
+    "ColumnNozzleLayoutConfiguration": {
+      "title": "ColumnNozzleLayoutConfiguration",
+      "description": "Information required for nozzle configurations of type ROW and COLUMN.",
+      "type": "object",
+      "properties": {
+        "style": {
+          "title": "Style",
+          "default": "COLUMN",
+          "enum": [
+            "COLUMN"
+          ],
+          "type": "string"
+        },
+        "primaryNozzle": {
+          "title": "Primarynozzle",
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "primaryNozzle"
+      ]
+    },
+    "QuadrantNozzleLayoutConfiguration": {
+      "title": "QuadrantNozzleLayoutConfiguration",
+      "description": "Information required for nozzle configurations of type QUADRANT.",
+      "type": "object",
+      "properties": {
+        "style": {
+          "title": "Style",
+          "default": "QUADRANT",
+          "enum": [
+            "QUADRANT"
+          ],
+          "type": "string"
+        },
+        "primaryNozzle": {
+          "title": "Primarynozzle",
+          "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
+          "type": "string"
+        },
+        "frontRightNozzle": {
+          "title": "Frontrightnozzle",
+          "description": "The front right nozzle in your configuration.",
+          "pattern": "[A-Z]\\d{1,2}",
+          "type": "string"
+        },
+        "backLeftNozzle": {
+          "title": "Backleftnozzle",
+          "description": "The back left nozzle in your configuration.",
+          "pattern": "[A-Z]\\d{1,2}",
+          "type": "string"
+        }
+      },
+      "required": [
+        "primaryNozzle",
+        "frontRightNozzle",
+        "backLeftNozzle"
+      ]
+    },
+    "ConfigureNozzleLayoutParams": {
+      "title": "ConfigureNozzleLayoutParams",
+      "description": "Parameters required to configure the nozzle layout for a specific pipette.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "configurationParams": {
+          "title": "Configurationparams",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/definitions/SingleNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/definitions/RowNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/definitions/ColumnNozzleLayoutConfiguration"
+            },
+            {
+              "$ref": "#/definitions/QuadrantNozzleLayoutConfiguration"
+            }
+          ]
+        }
+      },
+      "required": [
+        "pipetteId",
+        "configurationParams"
+      ]
+    },
+    "ConfigureNozzleLayoutCreate": {
+      "title": "ConfigureNozzleLayoutCreate",
+      "description": "Configure nozzle layout creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "configureNozzleLayout",
+          "enum": [
+            "configureNozzleLayout"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/ConfigureNozzleLayoutParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CustomParams": {
+      "title": "CustomParams",
+      "description": "Payload used by a custom command.",
+      "type": "object",
+      "properties": {}
+    },
+    "CustomCreate": {
+      "title": "CustomCreate",
+      "description": "A request to create a custom command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "custom",
+          "enum": [
+            "custom"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CustomParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DispenseParams": {
+      "title": "DispenseParams",
+      "description": "Payload required to dispense to a specific well.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "pushOut": {
+          "title": "Pushout",
+          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+          "type": "number"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
+    },
+    "DispenseCreate": {
+      "title": "DispenseCreate",
+      "description": "Create dispense command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "dispense",
+          "enum": [
+            "dispense"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DispenseParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DispenseInPlaceParams": {
+      "title": "DispenseInPlaceParams",
+      "description": "Payload required to dispense in place.",
+      "type": "object",
+      "properties": {
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "The amount of liquid to dispense, in \u00b5L. Must not be greater than the currently aspirated volume. There is some tolerance for floating point rounding errors.",
+          "minimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "pushOut": {
+          "title": "Pushout",
+          "description": "push the plunger a small amount farther than necessary for accurate low-volume dispensing",
+          "type": "number"
+        }
+      },
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ]
+    },
+    "DispenseInPlaceCreate": {
+      "title": "DispenseInPlaceCreate",
+      "description": "DispenseInPlace command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "dispenseInPlace",
+          "enum": [
+            "dispenseInPlace"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DispenseInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "BlowOutParams": {
+      "title": "BlowOutParams",
+      "description": "Payload required to blow-out a specific well.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ]
+    },
+    "BlowOutCreate": {
+      "title": "BlowOutCreate",
+      "description": "Create blow-out command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "blowout",
+          "enum": [
+            "blowout"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/BlowOutParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "BlowOutInPlaceParams": {
+      "title": "BlowOutInPlaceParams",
+      "description": "Payload required to blow-out in place.",
+      "type": "object",
+      "properties": {
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ]
+    },
+    "BlowOutInPlaceCreate": {
+      "title": "BlowOutInPlaceCreate",
+      "description": "BlowOutInPlace command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "blowOutInPlace",
+          "enum": [
+            "blowOutInPlace"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/BlowOutInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DropTipWellOrigin": {
+      "title": "DropTipWellOrigin",
+      "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
+      "type": "string"
+    },
+    "DropTipWellLocation": {
+      "title": "DropTipWellLocation",
+      "description": "Like WellLocation, but for dropping tips.\n\nUnlike a typical WellLocation, the location for a drop tip\ndefaults to location based on the tip length rather than the well's top.",
+      "type": "object",
+      "properties": {
+        "origin": {
+          "default": "default",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DropTipWellOrigin"
+            }
+          ]
+        },
+        "offset": {
+          "$ref": "#/definitions/WellOffset"
+        }
+      }
+    },
+    "DropTipParams": {
+      "title": "DropTipParams",
+      "description": "Payload required to drop a tip in a specific well.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to drop the tip.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DropTipWellLocation"
+            }
+          ]
+        },
+        "homeAfter": {
+          "title": "Homeafter",
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "type": "boolean"
+        },
+        "alternateDropLocation": {
+          "title": "Alternatedroplocation",
+          "description": "Whether to alternate location where tip is dropped within the labware. If True, this command will ignore the wellLocation provided and alternate between dropping tips at two predetermined locations inside the specified labware well. If False, the tip will be dropped at the top center of the well.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ]
+    },
+    "DropTipCreate": {
+      "title": "DropTipCreate",
+      "description": "Drop tip command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "dropTip",
+          "enum": [
+            "dropTip"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DropTipParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DropTipInPlaceParams": {
+      "title": "DropTipInPlaceParams",
+      "description": "Payload required to drop a tip in place.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "homeAfter": {
+          "title": "Homeafter",
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipetteId"
+      ]
+    },
+    "DropTipInPlaceCreate": {
+      "title": "DropTipInPlaceCreate",
+      "description": "Drop tip in place command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "dropTipInPlace",
+          "enum": [
+            "dropTipInPlace"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DropTipInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "MotorAxis": {
+      "title": "MotorAxis",
+      "description": "Motor axis on which to issue a home command.",
+      "enum": [
+        "x",
+        "y",
+        "leftZ",
+        "rightZ",
+        "leftPlunger",
+        "rightPlunger",
+        "extensionZ",
+        "extensionJaw"
+      ],
+      "type": "string"
+    },
+    "MountType": {
+      "title": "MountType",
+      "description": "An enumeration.",
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
+      "type": "string"
+    },
+    "HomeParams": {
+      "title": "HomeParams",
+      "description": "Payload required for a Home command.",
+      "type": "object",
+      "properties": {
+        "axes": {
+          "description": "Axes to return to their home positions. If omitted, will home all motors. Extra axes may be implicitly homed to ensure accurate homing of the explicitly specified axes.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MotorAxis"
+          }
+        },
+        "skipIfMountPositionOk": {
+          "description": "If this parameter is provided, the gantry will only be homed if the specified mount has an invalid position. If omitted, the homing action will be executed unconditionally.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MountType"
+            }
+          ]
+        }
+      }
+    },
+    "HomeCreate": {
+      "title": "HomeCreate",
+      "description": "Data to create a Home command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "home",
+          "enum": [
+            "home"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/HomeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "RetractAxisParams": {
+      "title": "RetractAxisParams",
+      "description": "Payload required for a Retract Axis command.",
+      "type": "object",
+      "properties": {
+        "axis": {
+          "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MotorAxis"
+            }
+          ]
+        }
+      },
+      "required": [
+        "axis"
+      ]
+    },
+    "RetractAxisCreate": {
+      "title": "RetractAxisCreate",
+      "description": "Data to create a Retract Axis command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "retractAxis",
+          "enum": [
+            "retractAxis"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/RetractAxisParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeckSlotName": {
+      "title": "DeckSlotName",
+      "description": "Deck slot identifiers.",
+      "enum": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "A1",
+        "A2",
+        "A3",
+        "B1",
+        "B2",
+        "B3",
+        "C1",
+        "C2",
+        "C3",
+        "D1",
+        "D2",
+        "D3"
+      ]
+    },
+    "DeckSlotLocation": {
+      "title": "DeckSlotLocation",
+      "description": "The location of something placed in a single deck slot.",
+      "type": "object",
+      "properties": {
+        "slotName": {
+          "description": "A slot on the robot's deck.\n\nThe plain numbers like `\"5\"` are for the OT-2, and the coordinates like `\"C2\"` are for the Flex.\n\nWhen you provide one of these values, you can use either style. It will automatically be converted to match the robot.\n\nWhen one of these values is returned, it will always match the robot.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeckSlotName"
+            }
+          ]
+        }
+      },
+      "required": [
+        "slotName"
+      ]
+    },
+    "ModuleLocation": {
+      "title": "ModuleLocation",
+      "description": "The location of something placed atop a hardware module.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "The ID of a loaded module from a prior `loadModule` command.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "OnLabwareLocation": {
+      "title": "OnLabwareLocation",
+      "description": "The location of something placed atop another labware.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "The ID of a loaded Labware from a prior `loadLabware` command.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId"
+      ]
+    },
+    "AddressableAreaLocation": {
+      "title": "AddressableAreaLocation",
+      "description": "The location of something place in an addressable area. This is a superset of deck slots.",
+      "type": "object",
+      "properties": {
+        "addressableAreaName": {
+          "title": "Addressableareaname",
+          "description": "The name of the addressable area that you want to use. Valid values are the `id`s of `addressableArea`s in the [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "addressableAreaName"
+      ]
+    },
+    "LoadLabwareParams": {
+      "title": "LoadLabwareParams",
+      "description": "Payload required to load a labware into a slot.",
+      "type": "object",
+      "properties": {
+        "location": {
+          "title": "Location",
+          "description": "Location the labware should be loaded into.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/definitions/ModuleLocation"
+            },
+            {
+              "$ref": "#/definitions/OnLabwareLocation"
+            },
+            {
+              "enum": [
+                "offDeck"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/AddressableAreaLocation"
+            }
+          ]
+        },
+        "loadName": {
+          "title": "Loadname",
+          "description": "Name used to reference a labware definition.",
+          "type": "string"
+        },
+        "namespace": {
+          "title": "Namespace",
+          "description": "The namespace the labware definition belongs to.",
+          "type": "string"
+        },
+        "version": {
+          "title": "Version",
+          "description": "The labware definition version.",
+          "type": "integer"
+        },
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "An optional ID to assign to this labware. If None, an ID will be generated.",
+          "type": "string"
+        },
+        "displayName": {
+          "title": "Displayname",
+          "description": "An optional user-specified display name or label for this labware.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ]
+    },
+    "LoadLabwareCreate": {
+      "title": "LoadLabwareCreate",
+      "description": "Load labware command creation request.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "loadLabware",
+          "enum": [
+            "loadLabware"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/LoadLabwareParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "ReloadLabwareParams": {
+      "title": "ReloadLabwareParams",
+      "description": "Payload required to load a labware into a slot.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "The already-loaded labware instance to update.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId"
+      ]
+    },
+    "ReloadLabwareCreate": {
+      "title": "ReloadLabwareCreate",
+      "description": "Reload labware command creation request.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "reloadLabware",
+          "enum": [
+            "reloadLabware"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/ReloadLabwareParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "LoadLiquidParams": {
+      "title": "LoadLiquidParams",
+      "description": "Payload required to load a liquid into a well.",
+      "type": "object",
+      "properties": {
+        "liquidId": {
+          "title": "Liquidid",
+          "description": "Unique identifier of the liquid to load.",
+          "type": "string"
+        },
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Unique identifier of labware to load liquid into.",
+          "type": "string"
+        },
+        "volumeByWell": {
+          "title": "Volumebywell",
+          "description": "Volume of liquid, in \u00b5L, loaded into each well by name, in this labware.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          }
+        }
+      },
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ]
+    },
+    "LoadLiquidCreate": {
+      "title": "LoadLiquidCreate",
+      "description": "Load liquid command creation request.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "loadLiquid",
+          "enum": [
+            "loadLiquid"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/LoadLiquidParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "ModuleModel": {
+      "title": "ModuleModel",
+      "description": "All available modules' models.",
+      "enum": [
+        "temperatureModuleV1",
+        "temperatureModuleV2",
+        "magneticModuleV1",
+        "magneticModuleV2",
+        "thermocyclerModuleV1",
+        "thermocyclerModuleV2",
+        "heaterShakerModuleV1",
+        "magneticBlockV1",
+        "absorbanceReaderV1"
+      ],
+      "type": "string"
+    },
+    "LoadModuleParams": {
+      "title": "LoadModuleParams",
+      "description": "Payload required to load a module.",
+      "type": "object",
+      "properties": {
+        "model": {
+          "description": "The model name of the module to load.\n\nProtocol Engine will look for a connected module that either exactly matches this one, or is compatible.\n\n For example, if you request a `temperatureModuleV1` here, Protocol Engine might load a `temperatureModuleV1` or a `temperatureModuleV2`.\n\n The model that it finds connected will be available through `result.model`.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ModuleModel"
+            }
+          ]
+        },
+        "location": {
+          "title": "Location",
+          "description": "The location into which this module should be loaded.\n\nFor the Thermocycler Module, which occupies multiple deck slots, this should be the front-most occupied slot (normally slot 7).",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeckSlotLocation"
+            }
+          ]
+        },
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "An optional ID to assign to this module. If None, an ID will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "model",
+        "location"
+      ]
+    },
+    "LoadModuleCreate": {
+      "title": "LoadModuleCreate",
+      "description": "The model for a creation request for a load module command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "loadModule",
+          "enum": [
+            "loadModule"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/LoadModuleParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "PipetteNameType": {
+      "title": "PipetteNameType",
+      "description": "Pipette load name values.",
+      "enum": [
+        "p10_single",
+        "p10_multi",
+        "p20_single_gen2",
+        "p20_multi_gen2",
+        "p50_single",
+        "p50_multi",
+        "p50_single_flex",
+        "p50_multi_flex",
+        "p300_single",
+        "p300_multi",
+        "p300_single_gen2",
+        "p300_multi_gen2",
+        "p1000_single",
+        "p1000_single_gen2",
+        "p1000_single_flex",
+        "p1000_multi_flex",
+        "p1000_96"
+      ],
+      "type": "string"
+    },
+    "LoadPipetteParams": {
+      "title": "LoadPipetteParams",
+      "description": "Payload needed to load a pipette on to a mount.",
+      "type": "object",
+      "properties": {
+        "pipetteName": {
+          "description": "The load name of the pipette to be required.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PipetteNameType"
+            }
+          ]
+        },
+        "mount": {
+          "description": "The mount the pipette should be present on.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MountType"
+            }
+          ]
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "An optional ID to assign to this pipette. If None, an ID will be generated.",
+          "type": "string"
+        },
+        "tipOverlapNotAfterVersion": {
+          "title": "Tipoverlapnotafterversion",
+          "description": "A version of tip overlap data to not exceed. The highest-versioned tip overlap data that does not exceed this version will be used. Versions are expressed as vN where N is an integer, counting up from v0. If None, the current highest version will be used.",
+          "type": "string"
+        },
+        "liquidPresenceDetection": {
+          "title": "Liquidpresencedetection",
+          "description": "Enable liquid presence detection for this pipette. Defaults to False.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipetteName",
+        "mount"
+      ]
+    },
+    "LoadPipetteCreate": {
+      "title": "LoadPipetteCreate",
+      "description": "Load pipette command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "loadPipette",
+          "enum": [
+            "loadPipette"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/LoadPipetteParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "LabwareMovementStrategy": {
+      "title": "LabwareMovementStrategy",
+      "description": "Strategy to use for labware movement.",
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
+      "type": "string"
+    },
+    "LabwareOffsetVector": {
+      "title": "LabwareOffsetVector",
+      "description": "Offset, in deck coordinates from nominal to actual position.",
+      "type": "object",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
+    },
+    "MoveLabwareParams": {
+      "title": "MoveLabwareParams",
+      "description": "Input parameters for a ``moveLabware`` command.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "The ID of the labware to move.",
+          "type": "string"
+        },
+        "newLocation": {
+          "title": "Newlocation",
+          "description": "Where to move the labware.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DeckSlotLocation"
+            },
+            {
+              "$ref": "#/definitions/ModuleLocation"
+            },
+            {
+              "$ref": "#/definitions/OnLabwareLocation"
+            },
+            {
+              "enum": [
+                "offDeck"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/AddressableAreaLocation"
+            }
+          ]
+        },
+        "strategy": {
+          "description": "Whether to use the gripper to perform the labware movement or to perform a manual movement with an option to pause.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LabwareMovementStrategy"
+            }
+          ]
+        },
+        "pickUpOffset": {
+          "title": "Pickupoffset",
+          "description": "Offset to use when picking up labware. Experimental param, subject to change",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LabwareOffsetVector"
+            }
+          ]
+        },
+        "dropOffset": {
+          "title": "Dropoffset",
+          "description": "Offset to use when dropping off labware. Experimental param, subject to change",
+          "allOf": [
+            {
+              "$ref": "#/definitions/LabwareOffsetVector"
+            }
+          ]
+        }
+      },
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ]
+    },
+    "MoveLabwareCreate": {
+      "title": "MoveLabwareCreate",
+      "description": "A request to create a ``moveLabware`` command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "moveLabware",
+          "enum": [
+            "moveLabware"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveLabwareParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "MovementAxis": {
+      "title": "MovementAxis",
+      "description": "Axis on which to issue a relative movement.",
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
+      "type": "string"
+    },
+    "MoveRelativeParams": {
+      "title": "MoveRelativeParams",
+      "description": "Payload required for a MoveRelative command.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Pipette to move.",
+          "type": "string"
+        },
+        "axis": {
+          "description": "Axis along which to move.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MovementAxis"
+            }
+          ]
+        },
+        "distance": {
+          "title": "Distance",
+          "description": "Distance to move in millimeters. A positive number will move towards the right (x), back (y), top (z) of the deck.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ]
+    },
+    "MoveRelativeCreate": {
+      "title": "MoveRelativeCreate",
+      "description": "Data to create a MoveRelative command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "moveRelative",
+          "enum": [
+            "moveRelative"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveRelativeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeckPoint": {
+      "title": "DeckPoint",
+      "description": "Coordinates of a point in deck space.",
+      "type": "object",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
+    },
+    "MoveToCoordinatesParams": {
+      "title": "MoveToCoordinatesParams",
+      "description": "Payload required to move a pipette to coordinates.",
+      "type": "object",
+      "properties": {
+        "minimumZHeight": {
+          "title": "Minimumzheight",
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "type": "number"
+        },
+        "forceDirect": {
+          "title": "Forcedirect",
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "default": false,
+          "type": "boolean"
+        },
+        "speed": {
+          "title": "Speed",
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "coordinates": {
+          "title": "Coordinates",
+          "description": "X, Y and Z coordinates in mm from deck's origin location (left-front-bottom corner of work space)",
+          "allOf": [
+            {
+              "$ref": "#/definitions/DeckPoint"
+            }
+          ]
+        }
+      },
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ]
+    },
+    "MoveToCoordinatesCreate": {
+      "title": "MoveToCoordinatesCreate",
+      "description": "Move to coordinates command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "moveToCoordinates",
+          "enum": [
+            "moveToCoordinates"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveToCoordinatesParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "MoveToWellParams": {
+      "title": "MoveToWellParams",
+      "description": "Payload required to move a pipette to a specific well.",
+      "type": "object",
+      "properties": {
+        "minimumZHeight": {
+          "title": "Minimumzheight",
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "type": "number"
+        },
+        "forceDirect": {
+          "title": "Forcedirect",
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "default": false,
+          "type": "boolean"
+        },
+        "speed": {
+          "title": "Speed",
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "type": "number"
+        },
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
+    },
+    "MoveToWellCreate": {
+      "title": "MoveToWellCreate",
+      "description": "Move to well command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "moveToWell",
+          "enum": [
+            "moveToWell"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveToWellParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "AddressableOffsetVector": {
+      "title": "AddressableOffsetVector",
+      "description": "Offset, in deck coordinates, from nominal to actual position of an addressable area.",
+      "type": "object",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
+    },
+    "MoveToAddressableAreaParams": {
+      "title": "MoveToAddressableAreaParams",
+      "description": "Payload required to move a pipette to a specific addressable area.\n\nAn *addressable area* is a space in the robot that may or may not be usable depending on how\nthe robot's deck is configured. For example, if a Flex is configured with a waste chute, it will\nhave additional addressable areas representing the opening of the waste chute, where tips and\nlabware can be dropped.\n\nThis moves the pipette so all of its nozzles are centered over the addressable area.\nIf the pipette is currently configured with a partial tip layout, this centering is over all\nthe pipette's physical nozzles, not just the nozzles that are active.\n\nThe z-position will be chosen to put the bottom of the tips---or the bottom of the nozzles,\nif there are no tips---level with the top of the addressable area.\n\nWhen this command is executed, Protocol Engine will make sure the robot's deck is configured\nsuch that the requested addressable area actually exists. For example, if you request\nthe addressable area B4, it will make sure the robot is set up with a B3/B4 staging area slot.\nIf that's not the case, the command will fail.",
+      "type": "object",
+      "properties": {
+        "minimumZHeight": {
+          "title": "Minimumzheight",
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "type": "number"
+        },
+        "forceDirect": {
+          "title": "Forcedirect",
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "default": false,
+          "type": "boolean"
+        },
+        "speed": {
+          "title": "Speed",
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "addressableAreaName": {
+          "title": "Addressableareaname",
+          "description": "The name of the addressable area that you want to use. Valid values are the `id`s of `addressableArea`s in the [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck).",
+          "type": "string"
+        },
+        "offset": {
+          "title": "Offset",
+          "description": "Relative offset of addressable area to move pipette's critical point.",
+          "default": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/AddressableOffsetVector"
+            }
+          ]
+        },
+        "stayAtHighestPossibleZ": {
+          "title": "Stayathighestpossiblez",
+          "description": "If `true`, the pipette will retract to its highest possible height and stay there instead of descending to the destination. `minimumZHeight` will be ignored.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
+    },
+    "MoveToAddressableAreaCreate": {
+      "title": "MoveToAddressableAreaCreate",
+      "description": "Move to addressable area command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "moveToAddressableArea",
+          "enum": [
+            "moveToAddressableArea"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveToAddressableAreaParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "MoveToAddressableAreaForDropTipParams": {
+      "title": "MoveToAddressableAreaForDropTipParams",
+      "description": "Payload required to move a pipette to a specific addressable area.\n\nAn *addressable area* is a space in the robot that may or may not be usable depending on how\nthe robot's deck is configured. For example, if a Flex is configured with a waste chute, it will\nhave additional addressable areas representing the opening of the waste chute, where tips and\nlabware can be dropped.\n\nThis moves the pipette so all of its nozzles are centered over the addressable area.\nIf the pipette is currently configured with a partial tip layout, this centering is over all\nthe pipette's physical nozzles, not just the nozzles that are active.\n\nThe z-position will be chosen to put the bottom of the tips---or the bottom of the nozzles,\nif there are no tips---level with the top of the addressable area.\n\nWhen this command is executed, Protocol Engine will make sure the robot's deck is configured\nsuch that the requested addressable area actually exists. For example, if you request\nthe addressable area B4, it will make sure the robot is set up with a B3/B4 staging area slot.\nIf that's not the case, the command will fail.",
+      "type": "object",
+      "properties": {
+        "minimumZHeight": {
+          "title": "Minimumzheight",
+          "description": "Optional minimal Z margin in mm. If this is larger than the API's default safe Z margin, it will make the arc higher. If it's smaller, it will have no effect.",
+          "type": "number"
+        },
+        "forceDirect": {
+          "title": "Forcedirect",
+          "description": "If true, moving from one labware/well to another will not arc to the default safe z, but instead will move directly to the specified location. This will also force the `minimumZHeight` param to be ignored. A 'direct' movement is in X/Y/Z simultaneously.",
+          "default": false,
+          "type": "boolean"
+        },
+        "speed": {
+          "title": "Speed",
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "addressableAreaName": {
+          "title": "Addressableareaname",
+          "description": "The name of the addressable area that you want to use. Valid values are the `id`s of `addressableArea`s in the [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck).",
+          "type": "string"
+        },
+        "offset": {
+          "title": "Offset",
+          "description": "Relative offset of addressable area to move pipette's critical point.",
+          "default": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/AddressableOffsetVector"
+            }
+          ]
+        },
+        "alternateDropLocation": {
+          "title": "Alternatedroplocation",
+          "description": "Whether to alternate location where tip is dropped within the addressable area. If True, this command will ignore the offset provided and alternate between dropping tips at two predetermined locations inside the specified labware well. If False, the tip will be dropped at the top center of the area.",
+          "default": false,
+          "type": "boolean"
+        },
+        "ignoreTipConfiguration": {
+          "title": "Ignoretipconfiguration",
+          "description": "Whether to utilize the critical point of the tip configuraiton when moving to an addressable area. If True, this command will ignore the tip configuration and use the center of the entire instrument as the critical point for movement. If False, this command will use the critical point provided by the current tip configuration.",
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ]
+    },
+    "MoveToAddressableAreaForDropTipCreate": {
+      "title": "MoveToAddressableAreaForDropTipCreate",
+      "description": "Move to addressable area for drop tip command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "moveToAddressableAreaForDropTip",
+          "enum": [
+            "moveToAddressableAreaForDropTip"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveToAddressableAreaForDropTipParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "PrepareToAspirateParams": {
+      "title": "PrepareToAspirateParams",
+      "description": "Parameters required to prepare a specific pipette for aspiration.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pipetteId"
+      ]
+    },
+    "PrepareToAspirateCreate": {
+      "title": "PrepareToAspirateCreate",
+      "description": "Prepare for aspirate command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "prepareToAspirate",
+          "enum": [
+            "prepareToAspirate"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/PrepareToAspirateParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "WaitForResumeParams": {
+      "title": "WaitForResumeParams",
+      "description": "Payload required to pause the protocol.",
+      "type": "object",
+      "properties": {
+        "message": {
+          "title": "Message",
+          "description": "A user-facing message associated with the pause",
+          "type": "string"
+        }
+      }
+    },
+    "WaitForResumeCreate": {
+      "title": "WaitForResumeCreate",
+      "description": "Wait for resume command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "waitForResume",
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/WaitForResumeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "WaitForDurationParams": {
+      "title": "WaitForDurationParams",
+      "description": "Payload required to pause the protocol.",
+      "type": "object",
+      "properties": {
+        "seconds": {
+          "title": "Seconds",
+          "description": "Duration, in seconds, to wait for.",
+          "type": "number"
+        },
+        "message": {
+          "title": "Message",
+          "description": "A user-facing message associated with the pause",
+          "type": "string"
+        }
+      },
+      "required": [
+        "seconds"
+      ]
+    },
+    "WaitForDurationCreate": {
+      "title": "WaitForDurationCreate",
+      "description": "Wait for duration command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "waitForDuration",
+          "enum": [
+            "waitForDuration"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/WaitForDurationParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "PickUpTipParams": {
+      "title": "PickUpTipParams",
+      "description": "Payload needed to move a pipette to a specific well.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
+    },
+    "PickUpTipCreate": {
+      "title": "PickUpTipCreate",
+      "description": "Pick up tip command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "pickUpTip",
+          "enum": [
+            "pickUpTip"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/PickUpTipParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "SavePositionParams": {
+      "title": "SavePositionParams",
+      "description": "Payload needed to save a pipette's current position.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Unique identifier of the pipette in question.",
+          "type": "string"
+        },
+        "positionId": {
+          "title": "Positionid",
+          "description": "An optional ID to assign to this command instance. Auto-assigned if not defined.",
+          "type": "string"
+        },
+        "failOnNotHomed": {
+          "title": "Failonnothomed",
+          "default": true,
+          "descrption": "Require all axes to be homed before saving position.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "pipetteId"
+      ]
+    },
+    "SavePositionCreate": {
+      "title": "SavePositionCreate",
+      "description": "Save position command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "savePosition",
+          "enum": [
+            "savePosition"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SavePositionParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "SetRailLightsParams": {
+      "title": "SetRailLightsParams",
+      "description": "Payload required to set the rail lights on or off.",
+      "type": "object",
+      "properties": {
+        "on": {
+          "title": "On",
+          "description": "The field that determines if the light is turned off or on.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "on"
+      ]
+    },
+    "SetRailLightsCreate": {
+      "title": "SetRailLightsCreate",
+      "description": "setRailLights command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "setRailLights",
+          "enum": [
+            "setRailLights"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SetRailLightsParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "TouchTipParams": {
+      "title": "TouchTipParams",
+      "description": "Payload needed to touch a pipette tip the sides of a specific well.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "radius": {
+          "title": "Radius",
+          "description": "The proportion of the target well's radius the pipette tip will move towards.",
+          "default": 1.0,
+          "type": "number"
+        },
+        "speed": {
+          "title": "Speed",
+          "description": "Override the travel speed in mm/s. This controls the straight linear speed of motion.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
+    },
+    "TouchTipCreate": {
+      "title": "TouchTipCreate",
+      "description": "Touch tip command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "touchTip",
+          "enum": [
+            "touchTip"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/TouchTipParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "StatusBarAnimation": {
+      "title": "StatusBarAnimation",
+      "description": "Status Bar animation options.",
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ]
+    },
+    "SetStatusBarParams": {
+      "title": "SetStatusBarParams",
+      "description": "Payload required to set the status bar to run an animation.",
+      "type": "object",
+      "properties": {
+        "animation": {
+          "description": "The animation that should be executed on the status bar.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/StatusBarAnimation"
+            }
+          ]
+        }
+      },
+      "required": [
+        "animation"
+      ]
+    },
+    "SetStatusBarCreate": {
+      "title": "SetStatusBarCreate",
+      "description": "setStatusBar command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "setStatusBar",
+          "enum": [
+            "setStatusBar"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SetStatusBarParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "TipPresenceStatus": {
+      "title": "TipPresenceStatus",
+      "description": "Tip presence status reported by a pipette.",
+      "enum": [
+        "present",
+        "absent",
+        "unknown"
+      ],
+      "type": "string"
+    },
+    "InstrumentSensorId": {
+      "title": "InstrumentSensorId",
+      "description": "Primary and secondary sensor ids.",
+      "enum": [
+        "primary",
+        "secondary",
+        "both"
+      ],
+      "type": "string"
+    },
+    "VerifyTipPresenceParams": {
+      "title": "VerifyTipPresenceParams",
+      "description": "Payload required for a VerifyTipPresence command.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "expectedState": {
+          "description": "The expected tip presence status on the pipette.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/TipPresenceStatus"
+            }
+          ]
+        },
+        "followSingularSensor": {
+          "description": "The sensor id to follow if the other can be ignored.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/InstrumentSensorId"
+            }
+          ]
+        }
+      },
+      "required": [
+        "pipetteId",
+        "expectedState"
+      ]
+    },
+    "VerifyTipPresenceCreate": {
+      "title": "VerifyTipPresenceCreate",
+      "description": "VerifyTipPresence command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "verifyTipPresence",
+          "enum": [
+            "verifyTipPresence"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/VerifyTipPresenceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "GetTipPresenceParams": {
+      "title": "GetTipPresenceParams",
+      "description": "Payload required for a GetTipPresence command.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pipetteId"
+      ]
+    },
+    "GetTipPresenceCreate": {
+      "title": "GetTipPresenceCreate",
+      "description": "GetTipPresence command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "getTipPresence",
+          "enum": [
+            "getTipPresence"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/GetTipPresenceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "LiquidProbeParams": {
+      "title": "LiquidProbeParams",
+      "description": "Parameters required for a `liquidProbe` command.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
+    },
+    "LiquidProbeCreate": {
+      "title": "LiquidProbeCreate",
+      "description": "The request model for a `liquidProbe` command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "liquidProbe",
+          "enum": [
+            "liquidProbe"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/LiquidProbeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "TryLiquidProbeParams": {
+      "title": "TryLiquidProbeParams",
+      "description": "Parameters required for a `tryLiquidProbe` command.",
+      "type": "object",
+      "properties": {
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "Identifier of labware to use.",
+          "type": "string"
+        },
+        "wellName": {
+          "title": "Wellname",
+          "description": "Name of well to use in labware.",
+          "type": "string"
+        },
+        "wellLocation": {
+          "title": "Welllocation",
+          "description": "Relative well location at which to perform the operation",
+          "allOf": [
+            {
+              "$ref": "#/definitions/WellLocation"
+            }
+          ]
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ]
+    },
+    "TryLiquidProbeCreate": {
+      "title": "TryLiquidProbeCreate",
+      "description": "The request model for a `tryLiquidProbe` command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "tryLiquidProbe",
+          "enum": [
+            "tryLiquidProbe"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/TryLiquidProbeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
+      "title": "WaitForTemperatureParams",
+      "description": "Input parameters to wait for a Heater-Shaker's target temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        },
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C. If not specified, will default to the module's target temperature. Specifying a celsius parameter other than the target temperature could lead to unpredictable behavior and hence is not recommended for use. This parameter can be removed in a future version without prior notice.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
+      "title": "WaitForTemperatureCreate",
+      "description": "A request to create a Heater-Shaker's wait for temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/waitForTemperature",
+          "enum": [
+            "heaterShaker/waitForTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
+      "title": "SetTargetTemperatureParams",
+      "description": "Input parameters to set a Heater-Shaker's target temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        },
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
+    },
+    "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
+      "title": "SetTargetTemperatureCreate",
+      "description": "A request to create a Heater-Shaker's set temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/setTargetTemperature",
+          "enum": [
+            "heaterShaker/setTargetTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeactivateHeaterParams": {
+      "title": "DeactivateHeaterParams",
+      "description": "Input parameters to unset a Heater-Shaker's target temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "DeactivateHeaterCreate": {
+      "title": "DeactivateHeaterCreate",
+      "description": "A request to create a Heater-Shaker's deactivate heater command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/deactivateHeater",
+          "enum": [
+            "heaterShaker/deactivateHeater"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DeactivateHeaterParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "SetAndWaitForShakeSpeedParams": {
+      "title": "SetAndWaitForShakeSpeedParams",
+      "description": "Input parameters to set and wait for a shake speed for a Heater-Shaker Module.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        },
+        "rpm": {
+          "title": "Rpm",
+          "description": "Target speed in rotations per minute.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "rpm"
+      ]
+    },
+    "SetAndWaitForShakeSpeedCreate": {
+      "title": "SetAndWaitForShakeSpeedCreate",
+      "description": "A request to create a Heater-Shaker's set and wait for shake speed command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/setAndWaitForShakeSpeed",
+          "enum": [
+            "heaterShaker/setAndWaitForShakeSpeed"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SetAndWaitForShakeSpeedParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeactivateShakerParams": {
+      "title": "DeactivateShakerParams",
+      "description": "Input parameters to deactivate shaker for a Heater-Shaker Module.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "DeactivateShakerCreate": {
+      "title": "DeactivateShakerCreate",
+      "description": "A request to create a Heater-Shaker's deactivate shaker command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/deactivateShaker",
+          "enum": [
+            "heaterShaker/deactivateShaker"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DeactivateShakerParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "OpenLabwareLatchParams": {
+      "title": "OpenLabwareLatchParams",
+      "description": "Input parameters to open a Heater-Shaker Module's labware latch.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "OpenLabwareLatchCreate": {
+      "title": "OpenLabwareLatchCreate",
+      "description": "A request to create a Heater-Shaker's open labware latch command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/openLabwareLatch",
+          "enum": [
+            "heaterShaker/openLabwareLatch"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/OpenLabwareLatchParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CloseLabwareLatchParams": {
+      "title": "CloseLabwareLatchParams",
+      "description": "Input parameters to close a Heater-Shaker Module's labware latch.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Heater-Shaker Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "CloseLabwareLatchCreate": {
+      "title": "CloseLabwareLatchCreate",
+      "description": "A request to create a Heater-Shaker's close latch command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "heaterShaker/closeLabwareLatch",
+          "enum": [
+            "heaterShaker/closeLabwareLatch"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CloseLabwareLatchParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DisengageParams": {
+      "title": "DisengageParams",
+      "description": "Input data to disengage a Magnetic Module's magnets.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "The ID of the Magnetic Module whose magnets you want to disengage, from a prior `loadModule` command.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "DisengageCreate": {
+      "title": "DisengageCreate",
+      "description": "A request to create a Magnetic Module disengage command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "magneticModule/disengage",
+          "enum": [
+            "magneticModule/disengage"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DisengageParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "EngageParams": {
+      "title": "EngageParams",
+      "description": "Input data to engage a Magnetic Module.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "The ID of the Magnetic Module whose magnets you want to raise, from a prior `loadModule` command.",
+          "type": "string"
+        },
+        "height": {
+          "title": "Height",
+          "description": "How high, in millimeters, to raise the magnets.\n\nZero means the tops of the magnets are level with the ledge that the labware rests on. This will be slightly above the magnets' minimum height, the hardware home position. Negative values are allowed, to put the magnets below the ledge.\n\nUnits are always true millimeters. This is unlike certain labware definitions, engage commands in the Python Protocol API, and engage commands in older versions of the JSON protocol schema. Take care to convert properly.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "height"
+      ]
+    },
+    "EngageCreate": {
+      "title": "EngageCreate",
+      "description": "A request to create a Magnetic Module engage command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "magneticModule/engage",
+          "enum": [
+            "magneticModule/engage"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/EngageParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
+      "title": "SetTargetTemperatureParams",
+      "description": "Input parameters to set a Temperature Module's target temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Temperature Module.",
+          "type": "string"
+        },
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
+    },
+    "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
+      "title": "SetTargetTemperatureCreate",
+      "description": "A request to create a Temperature Module's set temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "temperatureModule/setTargetTemperature",
+          "enum": [
+            "temperatureModule/setTargetTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
+      "title": "WaitForTemperatureParams",
+      "description": "Input parameters to wait for a Temperature Module's target temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Temperature Module.",
+          "type": "string"
+        },
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C. If not specified, will default to the module's target temperature. Specifying a celsius parameter other than the target temperature could lead to unpredictable behavior and hence is not recommended for use. This parameter can be removed in a future version without prior notice.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
+      "title": "WaitForTemperatureCreate",
+      "description": "A request to create a Temperature Module's wait for temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "temperatureModule/waitForTemperature",
+          "enum": [
+            "temperatureModule/waitForTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeactivateTemperatureParams": {
+      "title": "DeactivateTemperatureParams",
+      "description": "Input parameters to deactivate a Temperature Module.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Temperature Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "DeactivateTemperatureCreate": {
+      "title": "DeactivateTemperatureCreate",
+      "description": "A request to deactivate a Temperature Module.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "temperatureModule/deactivate",
+          "enum": [
+            "temperatureModule/deactivate"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DeactivateTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "SetTargetBlockTemperatureParams": {
+      "title": "SetTargetBlockTemperatureParams",
+      "description": "Input parameters to set a Thermocycler's target block temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler Module.",
+          "type": "string"
+        },
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C.",
+          "type": "number"
+        },
+        "blockMaxVolumeUl": {
+          "title": "Blockmaxvolumeul",
+          "description": "Amount of liquid in uL of the most-full well in labware loaded onto the thermocycler.",
+          "type": "number"
+        },
+        "holdTimeSeconds": {
+          "title": "Holdtimeseconds",
+          "description": "Amount of time, in seconds, to hold the temperature for. If specified, a waitForBlockTemperature command will block until the given hold time has elapsed.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
+    },
+    "SetTargetBlockTemperatureCreate": {
+      "title": "SetTargetBlockTemperatureCreate",
+      "description": "A request to create a Thermocycler's set block temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/setTargetBlockTemperature",
+          "enum": [
+            "thermocycler/setTargetBlockTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SetTargetBlockTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "WaitForBlockTemperatureParams": {
+      "title": "WaitForBlockTemperatureParams",
+      "description": "Input parameters to wait for Thermocycler's target block temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "WaitForBlockTemperatureCreate": {
+      "title": "WaitForBlockTemperatureCreate",
+      "description": "A request to create Thermocycler's wait for block temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/waitForBlockTemperature",
+          "enum": [
+            "thermocycler/waitForBlockTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/WaitForBlockTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "SetTargetLidTemperatureParams": {
+      "title": "SetTargetLidTemperatureParams",
+      "description": "Input parameters to set a Thermocycler's target lid temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler Module.",
+          "type": "string"
+        },
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "celsius"
+      ]
+    },
+    "SetTargetLidTemperatureCreate": {
+      "title": "SetTargetLidTemperatureCreate",
+      "description": "A request to create a Thermocycler's set lid temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/setTargetLidTemperature",
+          "enum": [
+            "thermocycler/setTargetLidTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/SetTargetLidTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "WaitForLidTemperatureParams": {
+      "title": "WaitForLidTemperatureParams",
+      "description": "Input parameters to wait for Thermocycler's lid temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler Module.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "WaitForLidTemperatureCreate": {
+      "title": "WaitForLidTemperatureCreate",
+      "description": "A request to create Thermocycler's wait for lid temperature command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/waitForLidTemperature",
+          "enum": [
+            "thermocycler/waitForLidTemperature"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/WaitForLidTemperatureParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeactivateBlockParams": {
+      "title": "DeactivateBlockParams",
+      "description": "Input parameters to unset a Thermocycler's target block temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "DeactivateBlockCreate": {
+      "title": "DeactivateBlockCreate",
+      "description": "A request to create a Thermocycler's deactivate block command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/deactivateBlock",
+          "enum": [
+            "thermocycler/deactivateBlock"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DeactivateBlockParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "DeactivateLidParams": {
+      "title": "DeactivateLidParams",
+      "description": "Input parameters to unset a Thermocycler's target lid temperature.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "DeactivateLidCreate": {
+      "title": "DeactivateLidCreate",
+      "description": "A request to create a Thermocycler's deactivate lid command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/deactivateLid",
+          "enum": [
+            "thermocycler/deactivateLid"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/DeactivateLidParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "OpenLidParams": {
+      "title": "OpenLidParams",
+      "description": "Input parameters to open a Thermocycler's lid.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "OpenLidCreate": {
+      "title": "OpenLidCreate",
+      "description": "A request to open a Thermocycler's lid.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/openLid",
+          "enum": [
+            "thermocycler/openLid"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/OpenLidParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CloseLidParams": {
+      "title": "CloseLidParams",
+      "description": "Input parameters to close a Thermocycler's lid.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "moduleId"
+      ]
+    },
+    "CloseLidCreate": {
+      "title": "CloseLidCreate",
+      "description": "A request to close a Thermocycler's lid.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/closeLid",
+          "enum": [
+            "thermocycler/closeLid"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CloseLidParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "RunProfileStepParams": {
+      "title": "RunProfileStepParams",
+      "description": "Input parameters for an individual Thermocycler profile step.",
+      "type": "object",
+      "properties": {
+        "celsius": {
+          "title": "Celsius",
+          "description": "Target temperature in \u00b0C.",
+          "type": "number"
+        },
+        "holdSeconds": {
+          "title": "Holdseconds",
+          "description": "Time to hold target temperature at in seconds.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ]
+    },
+    "RunProfileParams": {
+      "title": "RunProfileParams",
+      "description": "Input parameters to run a Thermocycler profile.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Thermocycler.",
+          "type": "string"
+        },
+        "profile": {
+          "title": "Profile",
+          "description": "Array of profile steps with target temperature and temperature hold time.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RunProfileStepParams"
+          }
+        },
+        "blockMaxVolumeUl": {
+          "title": "Blockmaxvolumeul",
+          "description": "Amount of liquid in uL of the most-full well in labware loaded onto the thermocycler.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "moduleId",
+        "profile"
+      ]
+    },
+    "RunProfileCreate": {
+      "title": "RunProfileCreate",
+      "description": "A request to execute a Thermocycler profile run.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "thermocycler/runProfile",
+          "enum": [
+            "thermocycler/runProfile"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/RunProfileParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "InitializeParams": {
+      "title": "InitializeParams",
+      "description": "Input parameters to initialize an absorbance reading.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the absorbance reader.",
+          "type": "string"
+        },
+        "sampleWavelength": {
+          "title": "Samplewavelength",
+          "description": "Sample wavelength in nm.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "moduleId",
+        "sampleWavelength"
+      ]
+    },
+    "InitializeCreate": {
+      "title": "InitializeCreate",
+      "description": "A request to execute an Absorbance Reader measurement.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "absorbanceReader/initialize",
+          "enum": [
+            "absorbanceReader/initialize"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/InitializeParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "MeasureAbsorbanceParams": {
+      "title": "MeasureAbsorbanceParams",
+      "description": "Input parameters for a single absorbance reading.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "Unique ID of the Absorbance Reader.",
+          "type": "string"
+        },
+        "sampleWavelength": {
+          "title": "Samplewavelength",
+          "description": "Sample wavelength in nm.",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "moduleId",
+        "sampleWavelength"
+      ]
+    },
+    "MeasureAbsorbanceCreate": {
+      "title": "MeasureAbsorbanceCreate",
+      "description": "A request to execute an Absorbance Reader measurement.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "absorbanceReader/measure",
+          "enum": [
+            "absorbanceReader/measure"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MeasureAbsorbanceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CalibrateGripperParamsJaw": {
+      "title": "CalibrateGripperParamsJaw",
+      "description": "An enumeration.",
+      "enum": [
+        "front",
+        "rear"
+      ]
+    },
+    "Vec3f": {
+      "title": "Vec3f",
+      "description": "A 3D vector of floats.",
+      "type": "object",
+      "properties": {
+        "x": {
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "title": "Z",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z"
+      ]
+    },
+    "CalibrateGripperParams": {
+      "title": "CalibrateGripperParams",
+      "description": "Parameters for a `calibrateGripper` command.",
+      "type": "object",
+      "properties": {
+        "jaw": {
+          "description": "Which of the gripper's jaws to use to measure its offset. The robot will assume that a human operator has already attached the capacitive probe to the jaw and none is attached to the other jaw.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CalibrateGripperParamsJaw"
+            }
+          ]
+        },
+        "otherJawOffset": {
+          "title": "Otherjawoffset",
+          "description": "If an offset for the other probe is already found, then specifying it here will enable the CalibrateGripper command to complete the calibration process by calculating the total offset and saving it to disk. If this param is not specified then the command will only find and return the offset for the specified probe.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Vec3f"
+            }
+          ]
+        }
+      },
+      "required": [
+        "jaw"
+      ]
+    },
+    "CalibrateGripperCreate": {
+      "title": "CalibrateGripperCreate",
+      "description": "A request to create a `calibrateGripper` command.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "calibration/calibrateGripper",
+          "enum": [
+            "calibration/calibrateGripper"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CalibrateGripperParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CalibratePipetteParams": {
+      "title": "CalibratePipetteParams",
+      "description": "Payload required to calibrate-pipette.",
+      "type": "object",
+      "properties": {
+        "mount": {
+          "description": "Instrument mount to calibrate.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MountType"
+            }
+          ]
+        }
+      },
+      "required": [
+        "mount"
+      ]
+    },
+    "CalibratePipetteCreate": {
+      "title": "CalibratePipetteCreate",
+      "description": "Create calibrate-pipette command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "calibration/calibratePipette",
+          "enum": [
+            "calibration/calibratePipette"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CalibratePipetteParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "CalibrateModuleParams": {
+      "title": "CalibrateModuleParams",
+      "description": "Payload required to calibrate-module.",
+      "type": "object",
+      "properties": {
+        "moduleId": {
+          "title": "Moduleid",
+          "description": "The unique id of module to calibrate.",
+          "type": "string"
+        },
+        "labwareId": {
+          "title": "Labwareid",
+          "description": "The unique id of module calibration adapter labware.",
+          "type": "string"
+        },
+        "mount": {
+          "description": "The instrument mount used to calibrate the module.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MountType"
+            }
+          ]
+        }
+      },
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ]
+    },
+    "CalibrateModuleCreate": {
+      "title": "CalibrateModuleCreate",
+      "description": "Create calibrate-module command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "calibration/calibrateModule",
+          "enum": [
+            "calibration/calibrateModule"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/CalibrateModuleParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    },
+    "MaintenancePosition": {
+      "title": "MaintenancePosition",
+      "description": "Maintenance position options.",
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ]
+    },
+    "MoveToMaintenancePositionParams": {
+      "title": "MoveToMaintenancePositionParams",
+      "description": "Calibration set up position command parameters.",
+      "type": "object",
+      "properties": {
+        "mount": {
+          "description": "Gantry mount to move maintenance position.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MountType"
+            }
+          ]
+        },
+        "maintenancePosition": {
+          "description": "The position the gantry mount needs to move to.",
+          "default": "attachInstrument",
+          "allOf": [
+            {
+              "$ref": "#/definitions/MaintenancePosition"
+            }
+          ]
+        }
+      },
+      "required": [
+        "mount"
+      ]
+    },
+    "MoveToMaintenancePositionCreate": {
+      "title": "MoveToMaintenancePositionCreate",
+      "description": "Calibration set up position command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "calibration/moveToMaintenancePosition",
+          "enum": [
+            "calibration/moveToMaintenancePosition"
+          ],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/MoveToMaintenancePositionParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "params"
+      ]
+    }
+  },
+  "$id": "opentronsCommandSchemaV9",
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -269,11 +269,7 @@
     "WellOrigin": {
       "title": "WellOrigin",
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "type": "string"
     },
     "WellOffset": {
@@ -358,22 +354,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "CommandIntent": {
       "title": "CommandIntent",
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup",
-        "fixit"
-      ],
+      "enum": ["protocol", "setup", "fixit"],
       "type": "string"
     },
     "AspirateCreate": {
@@ -384,9 +370,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirate",
-          "enum": [
-            "aspirate"
-          ],
+          "enum": ["aspirate"],
           "type": "string"
         },
         "params": {
@@ -406,9 +390,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AspirateInPlaceParams": {
       "title": "AspirateInPlaceParams",
@@ -433,11 +415,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "AspirateInPlaceCreate": {
       "title": "AspirateInPlaceCreate",
@@ -447,9 +425,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "aspirateInPlace",
-          "enum": [
-            "aspirateInPlace"
-          ],
+          "enum": ["aspirateInPlace"],
           "type": "string"
         },
         "params": {
@@ -469,9 +445,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CommentParams": {
       "title": "CommentParams",
@@ -484,9 +458,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ]
+      "required": ["message"]
     },
     "CommentCreate": {
       "title": "CommentCreate",
@@ -496,9 +468,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "comment",
-          "enum": [
-            "comment"
-          ],
+          "enum": ["comment"],
           "type": "string"
         },
         "params": {
@@ -518,9 +488,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ConfigureForVolumeParams": {
       "title": "ConfigureForVolumeParams",
@@ -544,10 +512,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "volume"
-      ]
+      "required": ["pipetteId", "volume"]
     },
     "ConfigureForVolumeCreate": {
       "title": "ConfigureForVolumeCreate",
@@ -557,9 +522,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureForVolume",
-          "enum": [
-            "configureForVolume"
-          ],
+          "enum": ["configureForVolume"],
           "type": "string"
         },
         "params": {
@@ -579,9 +542,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AllNozzleLayoutConfiguration": {
       "title": "AllNozzleLayoutConfiguration",
@@ -591,9 +552,7 @@
         "style": {
           "title": "Style",
           "default": "ALL",
-          "enum": [
-            "ALL"
-          ],
+          "enum": ["ALL"],
           "type": "string"
         }
       }
@@ -606,26 +565,17 @@
         "style": {
           "title": "Style",
           "default": "SINGLE",
-          "enum": [
-            "SINGLE"
-          ],
+          "enum": ["SINGLE"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "RowNozzleLayoutConfiguration": {
       "title": "RowNozzleLayoutConfiguration",
@@ -635,26 +585,17 @@
         "style": {
           "title": "Style",
           "default": "ROW",
-          "enum": [
-            "ROW"
-          ],
+          "enum": ["ROW"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "ColumnNozzleLayoutConfiguration": {
       "title": "ColumnNozzleLayoutConfiguration",
@@ -664,26 +605,17 @@
         "style": {
           "title": "Style",
           "default": "COLUMN",
-          "enum": [
-            "COLUMN"
-          ],
+          "enum": ["COLUMN"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ]
+      "required": ["primaryNozzle"]
     },
     "QuadrantNozzleLayoutConfiguration": {
       "title": "QuadrantNozzleLayoutConfiguration",
@@ -693,20 +625,13 @@
         "style": {
           "title": "Style",
           "default": "QUADRANT",
-          "enum": [
-            "QUADRANT"
-          ],
+          "enum": ["QUADRANT"],
           "type": "string"
         },
         "primaryNozzle": {
           "title": "Primarynozzle",
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "type": "string"
         },
         "frontRightNozzle": {
@@ -722,11 +647,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle",
-        "frontRightNozzle",
-        "backLeftNozzle"
-      ]
+      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"]
     },
     "ConfigureNozzleLayoutParams": {
       "title": "ConfigureNozzleLayoutParams",
@@ -759,10 +680,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "configurationParams"
-      ]
+      "required": ["pipetteId", "configurationParams"]
     },
     "ConfigureNozzleLayoutCreate": {
       "title": "ConfigureNozzleLayoutCreate",
@@ -772,9 +690,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "configureNozzleLayout",
-          "enum": [
-            "configureNozzleLayout"
-          ],
+          "enum": ["configureNozzleLayout"],
           "type": "string"
         },
         "params": {
@@ -794,9 +710,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CustomParams": {
       "title": "CustomParams",
@@ -812,9 +726,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "custom",
-          "enum": [
-            "custom"
-          ],
+          "enum": ["custom"],
           "type": "string"
         },
         "params": {
@@ -834,9 +746,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseParams": {
       "title": "DispenseParams",
@@ -885,13 +795,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"]
     },
     "DispenseCreate": {
       "title": "DispenseCreate",
@@ -901,9 +805,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispense",
-          "enum": [
-            "dispense"
-          ],
+          "enum": ["dispense"],
           "type": "string"
         },
         "params": {
@@ -923,9 +825,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DispenseInPlaceParams": {
       "title": "DispenseInPlaceParams",
@@ -955,11 +855,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "volume", "pipetteId"]
     },
     "DispenseInPlaceCreate": {
       "title": "DispenseInPlaceCreate",
@@ -969,9 +865,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dispenseInPlace",
-          "enum": [
-            "dispenseInPlace"
-          ],
+          "enum": ["dispenseInPlace"],
           "type": "string"
         },
         "params": {
@@ -991,9 +885,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutParams": {
       "title": "BlowOutParams",
@@ -1031,12 +923,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"]
     },
     "BlowOutCreate": {
       "title": "BlowOutCreate",
@@ -1046,9 +933,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowout",
-          "enum": [
-            "blowout"
-          ],
+          "enum": ["blowout"],
           "type": "string"
         },
         "params": {
@@ -1068,9 +953,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "BlowOutInPlaceParams": {
       "title": "BlowOutInPlaceParams",
@@ -1089,10 +972,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ]
+      "required": ["flowRate", "pipetteId"]
     },
     "BlowOutInPlaceCreate": {
       "title": "BlowOutInPlaceCreate",
@@ -1102,9 +982,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "blowOutInPlace",
-          "enum": [
-            "blowOutInPlace"
-          ],
+          "enum": ["blowOutInPlace"],
           "type": "string"
         },
         "params": {
@@ -1124,19 +1002,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipWellOrigin": {
       "title": "DropTipWellOrigin",
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "type": "string"
     },
     "DropTipWellLocation": {
@@ -1198,11 +1069,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ]
+      "required": ["pipetteId", "labwareId", "wellName"]
     },
     "DropTipCreate": {
       "title": "DropTipCreate",
@@ -1212,9 +1079,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTip",
-          "enum": [
-            "dropTip"
-          ],
+          "enum": ["dropTip"],
           "type": "string"
         },
         "params": {
@@ -1234,9 +1099,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DropTipInPlaceParams": {
       "title": "DropTipInPlaceParams",
@@ -1254,9 +1117,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "DropTipInPlaceCreate": {
       "title": "DropTipInPlaceCreate",
@@ -1266,9 +1127,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "dropTipInPlace",
-          "enum": [
-            "dropTipInPlace"
-          ],
+          "enum": ["dropTipInPlace"],
           "type": "string"
         },
         "params": {
@@ -1288,9 +1147,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MotorAxis": {
       "title": "MotorAxis",
@@ -1310,11 +1167,7 @@
     "MountType": {
       "title": "MountType",
       "description": "An enumeration.",
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "type": "string"
     },
     "HomeParams": {
@@ -1347,9 +1200,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "home",
-          "enum": [
-            "home"
-          ],
+          "enum": ["home"],
           "type": "string"
         },
         "params": {
@@ -1369,9 +1220,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RetractAxisParams": {
       "title": "RetractAxisParams",
@@ -1387,9 +1236,7 @@
           ]
         }
       },
-      "required": [
-        "axis"
-      ]
+      "required": ["axis"]
     },
     "RetractAxisCreate": {
       "title": "RetractAxisCreate",
@@ -1399,9 +1246,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "retractAxis",
-          "enum": [
-            "retractAxis"
-          ],
+          "enum": ["retractAxis"],
           "type": "string"
         },
         "params": {
@@ -1421,9 +1266,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckSlotName": {
       "title": "DeckSlotName",
@@ -1469,9 +1312,7 @@
           ]
         }
       },
-      "required": [
-        "slotName"
-      ]
+      "required": ["slotName"]
     },
     "ModuleLocation": {
       "title": "ModuleLocation",
@@ -1484,9 +1325,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OnLabwareLocation": {
       "title": "OnLabwareLocation",
@@ -1499,9 +1338,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "AddressableAreaLocation": {
       "title": "AddressableAreaLocation",
@@ -1514,9 +1351,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "addressableAreaName"
-      ]
+      "required": ["addressableAreaName"]
     },
     "LoadLabwareParams": {
       "title": "LoadLabwareParams",
@@ -1537,9 +1372,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -1573,12 +1406,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ]
+      "required": ["location", "loadName", "namespace", "version"]
     },
     "LoadLabwareCreate": {
       "title": "LoadLabwareCreate",
@@ -1588,9 +1416,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLabware",
-          "enum": [
-            "loadLabware"
-          ],
+          "enum": ["loadLabware"],
           "type": "string"
         },
         "params": {
@@ -1610,9 +1436,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ReloadLabwareParams": {
       "title": "ReloadLabwareParams",
@@ -1625,9 +1449,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ]
+      "required": ["labwareId"]
     },
     "ReloadLabwareCreate": {
       "title": "ReloadLabwareCreate",
@@ -1637,9 +1459,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "reloadLabware",
-          "enum": [
-            "reloadLabware"
-          ],
+          "enum": ["reloadLabware"],
           "type": "string"
         },
         "params": {
@@ -1659,9 +1479,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LoadLiquidParams": {
       "title": "LoadLiquidParams",
@@ -1687,11 +1505,7 @@
           }
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ]
+      "required": ["liquidId", "labwareId", "volumeByWell"]
     },
     "LoadLiquidCreate": {
       "title": "LoadLiquidCreate",
@@ -1701,9 +1515,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadLiquid",
-          "enum": [
-            "loadLiquid"
-          ],
+          "enum": ["loadLiquid"],
           "type": "string"
         },
         "params": {
@@ -1723,9 +1535,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "ModuleModel": {
       "title": "ModuleModel",
@@ -1771,10 +1581,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ]
+      "required": ["model", "location"]
     },
     "LoadModuleCreate": {
       "title": "LoadModuleCreate",
@@ -1784,9 +1591,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadModule",
-          "enum": [
-            "loadModule"
-          ],
+          "enum": ["loadModule"],
           "type": "string"
         },
         "params": {
@@ -1806,9 +1611,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PipetteNameType": {
       "title": "PipetteNameType",
@@ -1871,10 +1674,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ]
+      "required": ["pipetteName", "mount"]
     },
     "LoadPipetteCreate": {
       "title": "LoadPipetteCreate",
@@ -1884,9 +1684,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "loadPipette",
-          "enum": [
-            "loadPipette"
-          ],
+          "enum": ["loadPipette"],
           "type": "string"
         },
         "params": {
@@ -1906,18 +1704,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LabwareMovementStrategy": {
       "title": "LabwareMovementStrategy",
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "type": "string"
     },
     "LabwareOffsetVector": {
@@ -1938,11 +1730,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveLabwareParams": {
       "title": "MoveLabwareParams",
@@ -1968,9 +1756,7 @@
               "$ref": "#/definitions/OnLabwareLocation"
             },
             {
-              "enum": [
-                "offDeck"
-              ],
+              "enum": ["offDeck"],
               "type": "string"
             },
             {
@@ -2005,11 +1791,7 @@
           ]
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ]
+      "required": ["labwareId", "newLocation", "strategy"]
     },
     "MoveLabwareCreate": {
       "title": "MoveLabwareCreate",
@@ -2019,9 +1801,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveLabware",
-          "enum": [
-            "moveLabware"
-          ],
+          "enum": ["moveLabware"],
           "type": "string"
         },
         "params": {
@@ -2041,18 +1821,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MovementAxis": {
       "title": "MovementAxis",
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "type": "string"
     },
     "MoveRelativeParams": {
@@ -2079,11 +1853,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ]
+      "required": ["pipetteId", "axis", "distance"]
     },
     "MoveRelativeCreate": {
       "title": "MoveRelativeCreate",
@@ -2093,9 +1863,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveRelative",
-          "enum": [
-            "moveRelative"
-          ],
+          "enum": ["moveRelative"],
           "type": "string"
         },
         "params": {
@@ -2115,9 +1883,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeckPoint": {
       "title": "DeckPoint",
@@ -2137,11 +1903,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToCoordinatesParams": {
       "title": "MoveToCoordinatesParams",
@@ -2179,10 +1941,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ]
+      "required": ["pipetteId", "coordinates"]
     },
     "MoveToCoordinatesCreate": {
       "title": "MoveToCoordinatesCreate",
@@ -2192,9 +1951,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToCoordinates",
-          "enum": [
-            "moveToCoordinates"
-          ],
+          "enum": ["moveToCoordinates"],
           "type": "string"
         },
         "params": {
@@ -2214,9 +1971,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToWellParams": {
       "title": "MoveToWellParams",
@@ -2264,11 +2019,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "MoveToWellCreate": {
       "title": "MoveToWellCreate",
@@ -2278,9 +2029,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToWell",
-          "enum": [
-            "moveToWell"
-          ],
+          "enum": ["moveToWell"],
           "type": "string"
         },
         "params": {
@@ -2300,9 +2049,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "AddressableOffsetVector": {
       "title": "AddressableOffsetVector",
@@ -2322,11 +2069,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "MoveToAddressableAreaParams": {
       "title": "MoveToAddressableAreaParams",
@@ -2380,10 +2123,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaCreate": {
       "title": "MoveToAddressableAreaCreate",
@@ -2393,9 +2133,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableArea",
-          "enum": [
-            "moveToAddressableArea"
-          ],
+          "enum": ["moveToAddressableArea"],
           "type": "string"
         },
         "params": {
@@ -2415,9 +2153,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MoveToAddressableAreaForDropTipParams": {
       "title": "MoveToAddressableAreaForDropTipParams",
@@ -2477,10 +2213,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ]
+      "required": ["pipetteId", "addressableAreaName"]
     },
     "MoveToAddressableAreaForDropTipCreate": {
       "title": "MoveToAddressableAreaForDropTipCreate",
@@ -2490,9 +2223,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "moveToAddressableAreaForDropTip",
-          "enum": [
-            "moveToAddressableAreaForDropTip"
-          ],
+          "enum": ["moveToAddressableAreaForDropTip"],
           "type": "string"
         },
         "params": {
@@ -2512,9 +2243,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PrepareToAspirateParams": {
       "title": "PrepareToAspirateParams",
@@ -2527,9 +2256,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "PrepareToAspirateCreate": {
       "title": "PrepareToAspirateCreate",
@@ -2539,9 +2266,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "prepareToAspirate",
-          "enum": [
-            "prepareToAspirate"
-          ],
+          "enum": ["prepareToAspirate"],
           "type": "string"
         },
         "params": {
@@ -2561,9 +2286,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForResumeParams": {
       "title": "WaitForResumeParams",
@@ -2585,10 +2308,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "type": "string"
         },
         "params": {
@@ -2608,9 +2328,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForDurationParams": {
       "title": "WaitForDurationParams",
@@ -2628,9 +2346,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "seconds"
-      ]
+      "required": ["seconds"]
     },
     "WaitForDurationCreate": {
       "title": "WaitForDurationCreate",
@@ -2640,9 +2356,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "waitForDuration",
-          "enum": [
-            "waitForDuration"
-          ],
+          "enum": ["waitForDuration"],
           "type": "string"
         },
         "params": {
@@ -2662,9 +2376,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "PickUpTipParams": {
       "title": "PickUpTipParams",
@@ -2696,11 +2408,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "PickUpTipCreate": {
       "title": "PickUpTipCreate",
@@ -2710,9 +2418,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "pickUpTip",
-          "enum": [
-            "pickUpTip"
-          ],
+          "enum": ["pickUpTip"],
           "type": "string"
         },
         "params": {
@@ -2732,9 +2438,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SavePositionParams": {
       "title": "SavePositionParams",
@@ -2758,9 +2462,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "SavePositionCreate": {
       "title": "SavePositionCreate",
@@ -2770,9 +2472,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "savePosition",
-          "enum": [
-            "savePosition"
-          ],
+          "enum": ["savePosition"],
           "type": "string"
         },
         "params": {
@@ -2792,9 +2492,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetRailLightsParams": {
       "title": "SetRailLightsParams",
@@ -2807,9 +2505,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ]
+      "required": ["on"]
     },
     "SetRailLightsCreate": {
       "title": "SetRailLightsCreate",
@@ -2819,9 +2515,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setRailLights",
-          "enum": [
-            "setRailLights"
-          ],
+          "enum": ["setRailLights"],
           "type": "string"
         },
         "params": {
@@ -2841,9 +2535,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TouchTipParams": {
       "title": "TouchTipParams",
@@ -2886,11 +2578,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TouchTipCreate": {
       "title": "TouchTipCreate",
@@ -2900,9 +2588,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "touchTip",
-          "enum": [
-            "touchTip"
-          ],
+          "enum": ["touchTip"],
           "type": "string"
         },
         "params": {
@@ -2922,20 +2608,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "StatusBarAnimation": {
       "title": "StatusBarAnimation",
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ]
+      "enum": ["idle", "confirm", "updating", "disco", "off"]
     },
     "SetStatusBarParams": {
       "title": "SetStatusBarParams",
@@ -2951,9 +2629,7 @@
           ]
         }
       },
-      "required": [
-        "animation"
-      ]
+      "required": ["animation"]
     },
     "SetStatusBarCreate": {
       "title": "SetStatusBarCreate",
@@ -2963,9 +2639,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "setStatusBar",
-          "enum": [
-            "setStatusBar"
-          ],
+          "enum": ["setStatusBar"],
           "type": "string"
         },
         "params": {
@@ -2985,28 +2659,18 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TipPresenceStatus": {
       "title": "TipPresenceStatus",
       "description": "Tip presence status reported by a pipette.",
-      "enum": [
-        "present",
-        "absent",
-        "unknown"
-      ],
+      "enum": ["present", "absent", "unknown"],
       "type": "string"
     },
     "InstrumentSensorId": {
       "title": "InstrumentSensorId",
       "description": "Primary and secondary sensor ids.",
-      "enum": [
-        "primary",
-        "secondary",
-        "both"
-      ],
+      "enum": ["primary", "secondary", "both"],
       "type": "string"
     },
     "VerifyTipPresenceParams": {
@@ -3036,10 +2700,7 @@
           ]
         }
       },
-      "required": [
-        "pipetteId",
-        "expectedState"
-      ]
+      "required": ["pipetteId", "expectedState"]
     },
     "VerifyTipPresenceCreate": {
       "title": "VerifyTipPresenceCreate",
@@ -3049,9 +2710,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "verifyTipPresence",
-          "enum": [
-            "verifyTipPresence"
-          ],
+          "enum": ["verifyTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3071,9 +2730,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "GetTipPresenceParams": {
       "title": "GetTipPresenceParams",
@@ -3086,9 +2743,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ]
+      "required": ["pipetteId"]
     },
     "GetTipPresenceCreate": {
       "title": "GetTipPresenceCreate",
@@ -3098,9 +2753,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "getTipPresence",
-          "enum": [
-            "getTipPresence"
-          ],
+          "enum": ["getTipPresence"],
           "type": "string"
         },
         "params": {
@@ -3120,9 +2773,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "LiquidProbeParams": {
       "title": "LiquidProbeParams",
@@ -3154,11 +2805,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "LiquidProbeCreate": {
       "title": "LiquidProbeCreate",
@@ -3168,9 +2815,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "liquidProbe",
-          "enum": [
-            "liquidProbe"
-          ],
+          "enum": ["liquidProbe"],
           "type": "string"
         },
         "params": {
@@ -3190,9 +2835,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "TryLiquidProbeParams": {
       "title": "TryLiquidProbeParams",
@@ -3224,11 +2867,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ]
+      "required": ["labwareId", "wellName", "pipetteId"]
     },
     "TryLiquidProbeCreate": {
       "title": "TryLiquidProbeCreate",
@@ -3238,9 +2877,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "tryLiquidProbe",
-          "enum": [
-            "tryLiquidProbe"
-          ],
+          "enum": ["tryLiquidProbe"],
           "type": "string"
         },
         "params": {
@@ -3260,9 +2897,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3280,9 +2915,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3292,9 +2925,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/waitForTemperature",
-          "enum": [
-            "heaterShaker/waitForTemperature"
-          ],
+          "enum": ["heaterShaker/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3314,9 +2945,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3334,10 +2963,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3347,9 +2973,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setTargetTemperature",
-          "enum": [
-            "heaterShaker/setTargetTemperature"
-          ],
+          "enum": ["heaterShaker/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3369,9 +2993,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateHeaterParams": {
       "title": "DeactivateHeaterParams",
@@ -3384,9 +3006,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateHeaterCreate": {
       "title": "DeactivateHeaterCreate",
@@ -3396,9 +3016,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateHeater",
-          "enum": [
-            "heaterShaker/deactivateHeater"
-          ],
+          "enum": ["heaterShaker/deactivateHeater"],
           "type": "string"
         },
         "params": {
@@ -3418,9 +3036,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetAndWaitForShakeSpeedParams": {
       "title": "SetAndWaitForShakeSpeedParams",
@@ -3438,10 +3054,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ]
+      "required": ["moduleId", "rpm"]
     },
     "SetAndWaitForShakeSpeedCreate": {
       "title": "SetAndWaitForShakeSpeedCreate",
@@ -3451,9 +3064,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/setAndWaitForShakeSpeed",
-          "enum": [
-            "heaterShaker/setAndWaitForShakeSpeed"
-          ],
+          "enum": ["heaterShaker/setAndWaitForShakeSpeed"],
           "type": "string"
         },
         "params": {
@@ -3473,9 +3084,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateShakerParams": {
       "title": "DeactivateShakerParams",
@@ -3488,9 +3097,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateShakerCreate": {
       "title": "DeactivateShakerCreate",
@@ -3500,9 +3107,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/deactivateShaker",
-          "enum": [
-            "heaterShaker/deactivateShaker"
-          ],
+          "enum": ["heaterShaker/deactivateShaker"],
           "type": "string"
         },
         "params": {
@@ -3522,9 +3127,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLabwareLatchParams": {
       "title": "OpenLabwareLatchParams",
@@ -3537,9 +3140,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLabwareLatchCreate": {
       "title": "OpenLabwareLatchCreate",
@@ -3549,9 +3150,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/openLabwareLatch",
-          "enum": [
-            "heaterShaker/openLabwareLatch"
-          ],
+          "enum": ["heaterShaker/openLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3571,9 +3170,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLabwareLatchParams": {
       "title": "CloseLabwareLatchParams",
@@ -3586,9 +3183,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLabwareLatchCreate": {
       "title": "CloseLabwareLatchCreate",
@@ -3598,9 +3193,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "heaterShaker/closeLabwareLatch",
-          "enum": [
-            "heaterShaker/closeLabwareLatch"
-          ],
+          "enum": ["heaterShaker/closeLabwareLatch"],
           "type": "string"
         },
         "params": {
@@ -3620,9 +3213,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DisengageParams": {
       "title": "DisengageParams",
@@ -3635,9 +3226,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DisengageCreate": {
       "title": "DisengageCreate",
@@ -3647,9 +3236,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/disengage",
-          "enum": [
-            "magneticModule/disengage"
-          ],
+          "enum": ["magneticModule/disengage"],
           "type": "string"
         },
         "params": {
@@ -3669,9 +3256,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "EngageParams": {
       "title": "EngageParams",
@@ -3689,10 +3274,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ]
+      "required": ["moduleId", "height"]
     },
     "EngageCreate": {
       "title": "EngageCreate",
@@ -3702,9 +3284,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "magneticModule/engage",
-          "enum": [
-            "magneticModule/engage"
-          ],
+          "enum": ["magneticModule/engage"],
           "type": "string"
         },
         "params": {
@@ -3724,9 +3304,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams": {
       "title": "SetTargetTemperatureParams",
@@ -3744,10 +3322,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureCreate": {
       "title": "SetTargetTemperatureCreate",
@@ -3757,9 +3332,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/setTargetTemperature",
-          "enum": [
-            "temperatureModule/setTargetTemperature"
-          ],
+          "enum": ["temperatureModule/setTargetTemperature"],
           "type": "string"
         },
         "params": {
@@ -3779,9 +3352,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams": {
       "title": "WaitForTemperatureParams",
@@ -3799,9 +3370,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureCreate": {
       "title": "WaitForTemperatureCreate",
@@ -3811,9 +3380,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/waitForTemperature",
-          "enum": [
-            "temperatureModule/waitForTemperature"
-          ],
+          "enum": ["temperatureModule/waitForTemperature"],
           "type": "string"
         },
         "params": {
@@ -3833,9 +3400,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateTemperatureParams": {
       "title": "DeactivateTemperatureParams",
@@ -3848,9 +3413,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateTemperatureCreate": {
       "title": "DeactivateTemperatureCreate",
@@ -3860,9 +3423,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "temperatureModule/deactivate",
-          "enum": [
-            "temperatureModule/deactivate"
-          ],
+          "enum": ["temperatureModule/deactivate"],
           "type": "string"
         },
         "params": {
@@ -3882,9 +3443,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetBlockTemperatureParams": {
       "title": "SetTargetBlockTemperatureParams",
@@ -3912,10 +3471,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetBlockTemperatureCreate": {
       "title": "SetTargetBlockTemperatureCreate",
@@ -3925,9 +3481,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetBlockTemperature",
-          "enum": [
-            "thermocycler/setTargetBlockTemperature"
-          ],
+          "enum": ["thermocycler/setTargetBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -3947,9 +3501,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForBlockTemperatureParams": {
       "title": "WaitForBlockTemperatureParams",
@@ -3962,9 +3514,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForBlockTemperatureCreate": {
       "title": "WaitForBlockTemperatureCreate",
@@ -3974,9 +3524,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForBlockTemperature",
-          "enum": [
-            "thermocycler/waitForBlockTemperature"
-          ],
+          "enum": ["thermocycler/waitForBlockTemperature"],
           "type": "string"
         },
         "params": {
@@ -3996,9 +3544,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "SetTargetLidTemperatureParams": {
       "title": "SetTargetLidTemperatureParams",
@@ -4016,10 +3562,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ]
+      "required": ["moduleId", "celsius"]
     },
     "SetTargetLidTemperatureCreate": {
       "title": "SetTargetLidTemperatureCreate",
@@ -4029,9 +3572,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/setTargetLidTemperature",
-          "enum": [
-            "thermocycler/setTargetLidTemperature"
-          ],
+          "enum": ["thermocycler/setTargetLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -4051,9 +3592,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "WaitForLidTemperatureParams": {
       "title": "WaitForLidTemperatureParams",
@@ -4066,9 +3605,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "WaitForLidTemperatureCreate": {
       "title": "WaitForLidTemperatureCreate",
@@ -4078,9 +3615,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/waitForLidTemperature",
-          "enum": [
-            "thermocycler/waitForLidTemperature"
-          ],
+          "enum": ["thermocycler/waitForLidTemperature"],
           "type": "string"
         },
         "params": {
@@ -4100,9 +3635,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateBlockParams": {
       "title": "DeactivateBlockParams",
@@ -4115,9 +3648,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateBlockCreate": {
       "title": "DeactivateBlockCreate",
@@ -4127,9 +3658,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateBlock",
-          "enum": [
-            "thermocycler/deactivateBlock"
-          ],
+          "enum": ["thermocycler/deactivateBlock"],
           "type": "string"
         },
         "params": {
@@ -4149,9 +3678,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "DeactivateLidParams": {
       "title": "DeactivateLidParams",
@@ -4164,9 +3691,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "DeactivateLidCreate": {
       "title": "DeactivateLidCreate",
@@ -4176,9 +3701,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/deactivateLid",
-          "enum": [
-            "thermocycler/deactivateLid"
-          ],
+          "enum": ["thermocycler/deactivateLid"],
           "type": "string"
         },
         "params": {
@@ -4198,9 +3721,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "OpenLidParams": {
       "title": "OpenLidParams",
@@ -4213,9 +3734,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "OpenLidCreate": {
       "title": "OpenLidCreate",
@@ -4225,9 +3744,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/openLid",
-          "enum": [
-            "thermocycler/openLid"
-          ],
+          "enum": ["thermocycler/openLid"],
           "type": "string"
         },
         "params": {
@@ -4247,9 +3764,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CloseLidParams": {
       "title": "CloseLidParams",
@@ -4262,9 +3777,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ]
+      "required": ["moduleId"]
     },
     "CloseLidCreate": {
       "title": "CloseLidCreate",
@@ -4274,9 +3787,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/closeLid",
-          "enum": [
-            "thermocycler/closeLid"
-          ],
+          "enum": ["thermocycler/closeLid"],
           "type": "string"
         },
         "params": {
@@ -4296,9 +3807,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "RunProfileStepParams": {
       "title": "RunProfileStepParams",
@@ -4316,10 +3825,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ]
+      "required": ["celsius", "holdSeconds"]
     },
     "RunProfileParams": {
       "title": "RunProfileParams",
@@ -4345,10 +3851,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ]
+      "required": ["moduleId", "profile"]
     },
     "RunProfileCreate": {
       "title": "RunProfileCreate",
@@ -4358,9 +3861,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "thermocycler/runProfile",
-          "enum": [
-            "thermocycler/runProfile"
-          ],
+          "enum": ["thermocycler/runProfile"],
           "type": "string"
         },
         "params": {
@@ -4380,9 +3881,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "InitializeParams": {
       "title": "InitializeParams",
@@ -4400,10 +3899,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "moduleId",
-        "sampleWavelength"
-      ]
+      "required": ["moduleId", "sampleWavelength"]
     },
     "InitializeCreate": {
       "title": "InitializeCreate",
@@ -4413,9 +3909,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/initialize",
-          "enum": [
-            "absorbanceReader/initialize"
-          ],
+          "enum": ["absorbanceReader/initialize"],
           "type": "string"
         },
         "params": {
@@ -4435,9 +3929,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MeasureAbsorbanceParams": {
       "title": "MeasureAbsorbanceParams",
@@ -4455,10 +3947,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "moduleId",
-        "sampleWavelength"
-      ]
+      "required": ["moduleId", "sampleWavelength"]
     },
     "MeasureAbsorbanceCreate": {
       "title": "MeasureAbsorbanceCreate",
@@ -4468,9 +3957,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "absorbanceReader/measure",
-          "enum": [
-            "absorbanceReader/measure"
-          ],
+          "enum": ["absorbanceReader/measure"],
           "type": "string"
         },
         "params": {
@@ -4490,17 +3977,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateGripperParamsJaw": {
       "title": "CalibrateGripperParamsJaw",
       "description": "An enumeration.",
-      "enum": [
-        "front",
-        "rear"
-      ]
+      "enum": ["front", "rear"]
     },
     "Vec3f": {
       "title": "Vec3f",
@@ -4520,11 +4002,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ]
+      "required": ["x", "y", "z"]
     },
     "CalibrateGripperParams": {
       "title": "CalibrateGripperParams",
@@ -4549,9 +4027,7 @@
           ]
         }
       },
-      "required": [
-        "jaw"
-      ]
+      "required": ["jaw"]
     },
     "CalibrateGripperCreate": {
       "title": "CalibrateGripperCreate",
@@ -4561,9 +4037,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateGripper",
-          "enum": [
-            "calibration/calibrateGripper"
-          ],
+          "enum": ["calibration/calibrateGripper"],
           "type": "string"
         },
         "params": {
@@ -4583,9 +4057,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibratePipetteParams": {
       "title": "CalibratePipetteParams",
@@ -4601,9 +4073,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "CalibratePipetteCreate": {
       "title": "CalibratePipetteCreate",
@@ -4613,9 +4083,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibratePipette",
-          "enum": [
-            "calibration/calibratePipette"
-          ],
+          "enum": ["calibration/calibratePipette"],
           "type": "string"
         },
         "params": {
@@ -4635,9 +4103,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "CalibrateModuleParams": {
       "title": "CalibrateModuleParams",
@@ -4663,11 +4129,7 @@
           ]
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ]
+      "required": ["moduleId", "labwareId", "mount"]
     },
     "CalibrateModuleCreate": {
       "title": "CalibrateModuleCreate",
@@ -4677,9 +4139,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/calibrateModule",
-          "enum": [
-            "calibration/calibrateModule"
-          ],
+          "enum": ["calibration/calibrateModule"],
           "type": "string"
         },
         "params": {
@@ -4699,17 +4159,12 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     },
     "MaintenancePosition": {
       "title": "MaintenancePosition",
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ]
+      "enum": ["attachPlate", "attachInstrument"]
     },
     "MoveToMaintenancePositionParams": {
       "title": "MoveToMaintenancePositionParams",
@@ -4734,9 +4189,7 @@
           ]
         }
       },
-      "required": [
-        "mount"
-      ]
+      "required": ["mount"]
     },
     "MoveToMaintenancePositionCreate": {
       "title": "MoveToMaintenancePositionCreate",
@@ -4746,9 +4199,7 @@
         "commandType": {
           "title": "Commandtype",
           "default": "calibration/moveToMaintenancePosition",
-          "enum": [
-            "calibration/moveToMaintenancePosition"
-          ],
+          "enum": ["calibration/moveToMaintenancePosition"],
           "type": "string"
         },
         "params": {
@@ -4768,9 +4219,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "params"
-      ]
+      "required": ["params"]
     }
   },
   "$id": "opentronsCommandSchemaV9",

--- a/shared-data/js/protocols.ts
+++ b/shared-data/js/protocols.ts
@@ -4,6 +4,7 @@
 
 import Ajv from 'ajv'
 
+import commandSchema9 from '../command/schemas/9.json'
 import commandSchema8 from '../command/schemas/8.json'
 import commandSchema7 from '../command/schemas/7.json'
 import commandAnnotationSchema1 from '../commandAnnotation/schemas/1.json'
@@ -29,6 +30,9 @@ const validateCommands8 = (
   new Promise((resolve, reject) => {
     const requestedSchema = toValidate.commandSchemaId
     switch (requestedSchema) {
+      case 'opentronsCommandSchemaV9':
+        resolve(commandSchema9)
+        break
       case 'opentronsCommandSchemaV8':
         resolve(commandSchema8)
         break

--- a/shared-data/protocol/fixtures/8/simpleFlexV9CommandsV8.json
+++ b/shared-data/protocol/fixtures/8/simpleFlexV9CommandsV8.json
@@ -1,0 +1,1475 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Simple test protocol",
+    "author": "engineering <engineering@opentrons.com>",
+    "description": "A short test protocol",
+    "created": 1223131231,
+    "tags": ["unitTest"]
+  },
+  "robot": {
+    "model": "OT-3 Standard",
+    "deckId": "ot3_standard"
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "waterId": {
+      "displayName": "Water",
+      "description": "Liquid H2O",
+      "displayColor": "#7332a8"
+    }
+  },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": ["fixedTrash", "centerMultichannelOnWells"]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 77,
+          "x": 82.84,
+          "y": 53.56,
+          "z": 5
+        }
+      },
+      "brand": {
+        "brand": "Opentrons"
+      },
+      "groups": [
+        {
+          "wells": ["A1"],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_96_tiprack_10ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 Tip Rack 10 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.69
+      },
+      "wells": {
+        "A1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 25.49
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 39.2,
+        "tipOverlap": 3.29,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_10ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "example/plate/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1"],
+        ["A2", "B2", "C2", "D2"]
+      ],
+      "brand": {
+        "brand": "foo",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Foo 8 Well Plate 33uL",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL"
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.5,
+        "zDimension": 100
+      },
+      "wells": {
+        "A1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 75.43,
+          "z": 75
+        },
+        "B1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 56.15,
+          "z": 75
+        },
+        "C1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 36.87,
+          "z": 75
+        },
+        "D1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 17.59,
+          "z": 75
+        },
+        "A2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 75.43,
+          "z": 75
+        },
+        "B2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 56.15,
+          "z": 75
+        },
+        "C2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 36.87,
+          "z": 75
+        },
+        "D2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 17.59,
+          "z": 75
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": ["A1", "B1", "C1", "A2", "B2", "C2"]
+        }
+      ],
+      "parameters": {
+        "format": "irregular",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "foo_8_plate_33ul"
+      },
+      "namespace": "example",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV9",
+  "commands": [
+    {
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteId": "pipetteId",
+        "pipetteName": "p1000_96",
+        "mount": "left"
+      }
+    },
+    {
+      "commandType": "loadModule",
+      "params": {
+        "moduleId": "magneticBlockId",
+        "model": "magneticBlockV1",
+        "location": { "slotName": "3" }
+      }
+    },
+    {
+      "commandType": "loadModule",
+      "params": {
+        "moduleId": "temperatureModuleId",
+        "model": "temperatureModuleV2",
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "sourcePlateId",
+        "loadName": "armadillo_96_wellplate_200ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "temperatureModuleId"
+        },
+        "displayName": "Source Plate"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "destPlateId",
+        "loadName": "armadillo_96_wellplate_200ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "magneticBlockId"
+        },
+        "displayName": "Sample Collection Plate"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "tipRackId",
+        "location": { "slotName": "8" },
+        "loadName": "opentrons_96_tiprack_1000ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "displayName": "Opentrons 96 Tip Rack 1000 µL"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "fixedTrash",
+        "location": {
+          "slotName": "12"
+        },
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "namespace": "opentrons",
+        "version": 1,
+        "displayName": "Trash"
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "params": {
+        "liquidId": "waterId",
+        "labwareId": "sourcePlateId",
+        "volumeByWell": {
+          "A1": 100,
+          "B1": 100
+        }
+      }
+    },
+    {
+      "commandType": "home",
+      "params": {}
+    },
+    {
+      "commandType": "pickUpTip",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "tipRackId",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "sourcePlateId",
+        "wellName": "A1",
+        "volume": 5,
+        "flowRate": 3,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 2 }
+        }
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "params": {
+        "seconds": 42
+      }
+    },
+    {
+      "commandType": "dispense",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "volume": 4.5,
+        "flowRate": 2.5,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 1 }
+        }
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "speed": 42.0,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 11 }
+        }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "flowRate": 2,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 12 }
+        }
+      }
+    },
+    {
+      "commandType": "moveToCoordinates",
+      "params": {
+        "pipetteId": "pipetteId",
+        "coordinates": { "x": 100, "y": 100, "z": 100 }
+      }
+    },
+    {
+      "commandType": "moveToWell",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B2",
+        "speed": 12.3
+      }
+    },
+    {
+      "commandType": "moveToWell",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 2, "y": 3, "z": 10 }
+        },
+        "minimumZHeight": 35,
+        "forceDirect": true
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "fixedTrash",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "waitForResume",
+      "params": {
+        "message": "pause command"
+      }
+    },
+    {
+      "commandType": "moveToCoordinates",
+      "params": {
+        "pipetteId": "pipetteId",
+        "coordinates": { "x": 0, "y": 0, "z": 0 },
+        "minimumZHeight": 35,
+        "forceDirect": true
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "x",
+        "distance": 1
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "y",
+        "distance": 0.1
+      }
+    },
+    {
+      "commandType": "savePosition",
+      "params": {
+        "pipetteId": "pipetteId"
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "z",
+        "distance": 10
+      }
+    },
+    {
+      "commandType": "savePosition",
+      "params": {
+        "pipetteId": "pipetteId",
+        "positionId": "positionId"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": [
+    {
+      "commandKeys": [
+        "1abc123",
+        "2abc123",
+        "3abc123",
+        "4abc123",
+        "5abc123",
+        "6abc123",
+        "7abc123"
+      ],
+      "annotationType": "custom"
+    }
+  ]
+}

--- a/shared-data/protocol/fixtures/8/simpleV9CommandsV8.json
+++ b/shared-data/protocol/fixtures/8/simpleV9CommandsV8.json
@@ -1,0 +1,1473 @@
+{
+  "$otSharedSchema": "#/protocol/schemas/8",
+  "schemaVersion": 8,
+  "metadata": {
+    "protocolName": "Simple test protocol",
+    "author": "engineering <engineering@opentrons.com>",
+    "description": "A short test protocol",
+    "created": 1223131231,
+    "tags": ["unitTest"]
+  },
+  "robot": {
+    "model": "OT-2 Standard",
+    "deckId": "ot2_standard"
+  },
+  "liquidSchemaId": "opentronsLiquidSchemaV1",
+  "liquids": {
+    "waterId": {
+      "displayName": "Water",
+      "description": "Liquid H2O",
+      "displayColor": "#7332a8"
+    }
+  },
+  "labwareDefinitionSchemaId": "opentronsLabwareSchemaV2",
+  "labwareDefinitions": {
+    "opentrons/opentrons_1_trash_1100ml_fixed/1": {
+      "ordering": [["A1"]],
+      "metadata": {
+        "displayCategory": "trash",
+        "displayVolumeUnits": "mL",
+        "displayName": "Opentrons Fixed Trash",
+        "tags": []
+      },
+      "schemaVersion": 2,
+      "version": 1,
+      "namespace": "opentrons",
+      "dimensions": {
+        "xDimension": 172.86,
+        "yDimension": 165.86,
+        "zDimension": 82
+      },
+      "parameters": {
+        "format": "trash",
+        "isTiprack": false,
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "isMagneticModuleCompatible": false,
+        "quirks": ["fixedTrash", "centerMultichannelOnWells"]
+      },
+      "wells": {
+        "A1": {
+          "shape": "rectangular",
+          "yDimension": 165.67,
+          "xDimension": 107.11,
+          "totalLiquidVolume": 1100000,
+          "depth": 77,
+          "x": 82.84,
+          "y": 53.56,
+          "z": 5
+        }
+      },
+      "brand": {
+        "brand": "Opentrons"
+      },
+      "groups": [
+        {
+          "wells": ["A1"],
+          "metadata": {}
+        }
+      ],
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "opentrons/opentrons_96_tiprack_10ul/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+        ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+        ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+        ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+        ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+        ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+        ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+        ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+        ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+        ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+        ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+        ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
+      ],
+      "brand": {
+        "brand": "Opentrons",
+        "brandId": [],
+        "links": [
+          "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+        ]
+      },
+      "metadata": {
+        "displayName": "Opentrons 96 Tip Rack 10 µL",
+        "displayCategory": "tipRack",
+        "displayVolumeUnits": "µL",
+        "tags": []
+      },
+      "dimensions": {
+        "xDimension": 127.76,
+        "yDimension": 85.48,
+        "zDimension": 64.69
+      },
+      "wells": {
+        "A1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H1": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 14.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H2": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 23.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H3": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 32.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H4": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 41.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H5": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 50.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H6": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 59.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H7": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 68.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H8": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 77.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H9": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 86.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H10": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 95.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H11": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 104.38,
+          "y": 11.24,
+          "z": 25.49
+        },
+        "A12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 74.24,
+          "z": 25.49
+        },
+        "B12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 65.24,
+          "z": 25.49
+        },
+        "C12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 56.24,
+          "z": 25.49
+        },
+        "D12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 47.24,
+          "z": 25.49
+        },
+        "E12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 38.24,
+          "z": 25.49
+        },
+        "F12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 29.24,
+          "z": 25.49
+        },
+        "G12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 20.24,
+          "z": 25.49
+        },
+        "H12": {
+          "depth": 39.2,
+          "shape": "circular",
+          "diameter": 3.27,
+          "totalLiquidVolume": 10,
+          "x": 113.38,
+          "y": 11.24,
+          "z": 25.49
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": [
+            "A1",
+            "B1",
+            "C1",
+            "D1",
+            "E1",
+            "F1",
+            "G1",
+            "H1",
+            "A2",
+            "B2",
+            "C2",
+            "D2",
+            "E2",
+            "F2",
+            "G2",
+            "H2",
+            "A3",
+            "B3",
+            "C3",
+            "D3",
+            "E3",
+            "F3",
+            "G3",
+            "H3",
+            "A4",
+            "B4",
+            "C4",
+            "D4",
+            "E4",
+            "F4",
+            "G4",
+            "H4",
+            "A5",
+            "B5",
+            "C5",
+            "D5",
+            "E5",
+            "F5",
+            "G5",
+            "H5",
+            "A6",
+            "B6",
+            "C6",
+            "D6",
+            "E6",
+            "F6",
+            "G6",
+            "H6",
+            "A7",
+            "B7",
+            "C7",
+            "D7",
+            "E7",
+            "F7",
+            "G7",
+            "H7",
+            "A8",
+            "B8",
+            "C8",
+            "D8",
+            "E8",
+            "F8",
+            "G8",
+            "H8",
+            "A9",
+            "B9",
+            "C9",
+            "D9",
+            "E9",
+            "F9",
+            "G9",
+            "H9",
+            "A10",
+            "B10",
+            "C10",
+            "D10",
+            "E10",
+            "F10",
+            "G10",
+            "H10",
+            "A11",
+            "B11",
+            "C11",
+            "D11",
+            "E11",
+            "F11",
+            "G11",
+            "H11",
+            "A12",
+            "B12",
+            "C12",
+            "D12",
+            "E12",
+            "F12",
+            "G12",
+            "H12"
+          ]
+        }
+      ],
+      "parameters": {
+        "format": "96Standard",
+        "isTiprack": true,
+        "tipLength": 39.2,
+        "tipOverlap": 3.29,
+        "isMagneticModuleCompatible": false,
+        "loadName": "opentrons_96_tiprack_10ul"
+      },
+      "namespace": "opentrons",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    },
+    "example/plate/1": {
+      "ordering": [
+        ["A1", "B1", "C1", "D1"],
+        ["A2", "B2", "C2", "D2"]
+      ],
+      "brand": {
+        "brand": "foo",
+        "brandId": []
+      },
+      "metadata": {
+        "displayName": "Foo 8 Well Plate 33uL",
+        "displayCategory": "wellPlate",
+        "displayVolumeUnits": "µL"
+      },
+      "dimensions": {
+        "xDimension": 127.75,
+        "yDimension": 85.5,
+        "zDimension": 100
+      },
+      "wells": {
+        "A1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 75.43,
+          "z": 75
+        },
+        "B1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 56.15,
+          "z": 75
+        },
+        "C1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 36.87,
+          "z": 75
+        },
+        "D1": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 18.21,
+          "y": 17.59,
+          "z": 75
+        },
+        "A2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 75.43,
+          "z": 75
+        },
+        "B2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 56.15,
+          "z": 75
+        },
+        "C2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 36.87,
+          "z": 75
+        },
+        "D2": {
+          "depth": 25,
+          "totalLiquidVolume": 33,
+          "shape": "circular",
+          "diameter": 10,
+          "x": 38.1,
+          "y": 17.59,
+          "z": 75
+        }
+      },
+      "groups": [
+        {
+          "metadata": {},
+          "wells": ["A1", "B1", "C1", "A2", "B2", "C2"]
+        }
+      ],
+      "parameters": {
+        "format": "irregular",
+        "quirks": [],
+        "isTiprack": false,
+        "isMagneticModuleCompatible": false,
+        "loadName": "foo_8_plate_33ul"
+      },
+      "namespace": "example",
+      "version": 1,
+      "schemaVersion": 2,
+      "cornerOffsetFromSlot": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      }
+    }
+  },
+  "commandSchemaId": "opentronsCommandSchemaV9",
+  "commands": [
+    {
+      "commandType": "loadPipette",
+      "params": {
+        "pipetteId": "pipetteId",
+        "pipetteName": "p10_single",
+        "mount": "left"
+      }
+    },
+    {
+      "commandType": "loadModule",
+      "params": {
+        "moduleId": "magneticModuleId",
+        "model": "magneticModuleV2",
+        "location": { "slotName": "3" }
+      }
+    },
+    {
+      "commandType": "loadModule",
+      "params": {
+        "moduleId": "temperatureModuleId",
+        "model": "temperatureModuleV2",
+        "location": { "slotName": "1" }
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "sourcePlateId",
+        "loadName": "armadillo_96_wellplate_200ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "temperatureModuleId"
+        },
+        "displayName": "Source Plate"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "destPlateId",
+        "loadName": "armadillo_96_wellplate_200ul_pcr_full_skirt",
+        "namespace": "opentrons",
+        "version": 1,
+        "location": {
+          "moduleId": "magneticModuleId"
+        },
+        "displayName": "Sample Collection Plate"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "tipRackId",
+        "location": { "slotName": "8" },
+        "loadName": "opentrons_96_tiprack_10ul",
+        "namespace": "opentrons",
+        "version": 1,
+        "displayName": "Opentrons 96 Tip Rack 10 µL"
+      }
+    },
+    {
+      "commandType": "loadLabware",
+      "params": {
+        "labwareId": "fixedTrash",
+        "location": {
+          "slotName": "12"
+        },
+        "loadName": "opentrons_1_trash_1100ml_fixed",
+        "namespace": "opentrons",
+        "version": 1,
+        "displayName": "Trash"
+      }
+    },
+    {
+      "commandType": "loadLiquid",
+      "params": {
+        "liquidId": "waterId",
+        "labwareId": "sourcePlateId",
+        "volumeByWell": {
+          "A1": 100,
+          "B1": 100
+        }
+      }
+    },
+    {
+      "commandType": "home",
+      "params": {}
+    },
+    {
+      "commandType": "pickUpTip",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "tipRackId",
+        "wellName": "B1"
+      }
+    },
+    {
+      "commandType": "aspirate",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "sourcePlateId",
+        "wellName": "A1",
+        "volume": 5,
+        "flowRate": 3,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 2 }
+        }
+      }
+    },
+    {
+      "commandType": "waitForDuration",
+      "params": {
+        "seconds": 42
+      }
+    },
+    {
+      "commandType": "dispense",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "volume": 4.5,
+        "flowRate": 2.5,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 1 }
+        }
+      }
+    },
+    {
+      "commandType": "touchTip",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 11 }
+        }
+      }
+    },
+    {
+      "commandType": "blowout",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B1",
+        "flowRate": 2,
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 0, "y": 0, "z": 12 }
+        }
+      }
+    },
+    {
+      "commandType": "moveToCoordinates",
+      "params": {
+        "pipetteId": "pipetteId",
+        "coordinates": { "x": 100, "y": 100, "z": 100 }
+      }
+    },
+    {
+      "commandType": "moveToWell",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B2"
+      }
+    },
+    {
+      "commandType": "moveToWell",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "destPlateId",
+        "wellName": "B2",
+        "wellLocation": {
+          "origin": "bottom",
+          "offset": { "x": 2, "y": 3, "z": 10 }
+        },
+        "minimumZHeight": 35,
+        "forceDirect": true
+      }
+    },
+    {
+      "commandType": "dropTip",
+      "params": {
+        "pipetteId": "pipetteId",
+        "labwareId": "fixedTrash",
+        "wellName": "A1"
+      }
+    },
+    {
+      "commandType": "waitForResume",
+      "params": {
+        "message": "pause command"
+      }
+    },
+    {
+      "commandType": "moveToCoordinates",
+      "params": {
+        "pipetteId": "pipetteId",
+        "coordinates": { "x": 0, "y": 0, "z": 0 },
+        "minimumZHeight": 35,
+        "forceDirect": true
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "x",
+        "distance": 1
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "y",
+        "distance": 0.1
+      }
+    },
+    {
+      "commandType": "savePosition",
+      "params": {
+        "pipetteId": "pipetteId"
+      }
+    },
+    {
+      "commandType": "moveRelative",
+      "params": {
+        "pipetteId": "pipetteId",
+        "axis": "z",
+        "distance": 10
+      }
+    },
+    {
+      "commandType": "savePosition",
+      "params": {
+        "pipetteId": "pipetteId",
+        "positionId": "positionId"
+      }
+    }
+  ],
+  "commandAnnotationSchemaId": "opentronsCommandAnnotationSchemaV1",
+  "commandAnnotations": [
+    {
+      "commandKeys": [
+        "1abc123",
+        "2abc123",
+        "3abc123",
+        "4abc123",
+        "5abc123",
+        "6abc123",
+        "7abc123"
+      ],
+      "annotationType": "custom"
+    }
+  ]
+}

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -22,6 +22,11 @@ export interface CommandV8Mixin {
   commands: CreateCommand[]
 }
 
+export interface CommandV9Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV9'
+  commands: CreateCommand[]
+}
+
 export interface CommandAnnotationsStructure {
   commandAnnotationSchemaId: string
   commandAnnotations: any[]
@@ -110,7 +115,7 @@ export type ProtocolFile<
   (OT2RobotMixin | OT3RobotMixin) &
   LabwareV2Mixin &
   LiquidV1Mixin &
-  CommandV8Mixin &
+  (CommandV8Mixin | CommandV9Mixin) &
   CommandAnnotationV1Mixin
 
 export type ProtocolStructure = ProtocolBase<{}> &

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v8.py
@@ -100,7 +100,7 @@ class ProtocolSchemaV8(BaseModel):
     liquids: Dict[str, Liquid]
     labwareDefinitionSchemaId: Literal["opentronsLabwareSchemaV2"]
     labwareDefinitions: Dict[str, LabwareDefinition]
-    commandSchemaId: Literal["opentronsCommandSchemaV8"]
+    commandSchemaId: Literal["opentronsCommandSchemaV8", "opentronsCommandSchemaV9"]
     commands: List[Command]
     commandAnnotationSchemaId: Literal["opentronsCommandAnnotationSchemaV1"]
     commandAnnotations: List[CommandAnnotation]


### PR DESCRIPTION
We have implemented, and are going to continue to implement, new commands for the 8.0 release that should not be in the same command schema as previous releases. So,
- Make command schema 9
- Allow its presence in protocol schema 8
- Allow its presence in the python side checkers
- Allow its presence in the JS side checkers

## Testing
- [x] Load a protocol schema 8 json protocol containing a command schema 9 requirement in the app and check that it analyzes (there's one in shared-data/protocol/fixtures)
- [x] Load a protocol schema 8 json protocol containing a command schema 8 requirement in the app and check that it analyzes
- [x] Load a protocol schema 8 json protocol containing a command schema 9 requirement onto a robot and check that it analyzes
- [x] Load a protocol schema 8 json protocol containing a command schema 8 requirement onto a robot and cehck that it analyzes
- [x] Check that if you load a protocol schema 8 json protocol containing a command schema 9 requirement into an app and robot that support it and then downgrade the app and robot, the machines and app still run but display the protocol as invalid


Closes EXEC-613
