### PR TITLE
fix(analyses-snapshot-testing): trigger test run on test library change

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -28,6 +28,8 @@ on:
       - 'shared-data/**/*'
       - '!shared-data/js/**'
       - '.github/workflows/analyses-snapshot-test.yaml'
+      - 'analyses-snapshot-testing/**'
+
     types:
       - opened #default
       - synchronize #default

--- a/analyses-snapshot-testing/automation/data/protocols.py
+++ b/analyses-snapshot-testing/automation/data/protocols.py
@@ -635,6 +635,12 @@ class Protocols:
         robot="Flex",
     )
 
+    Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke: Protocol = Protocol(
+        file_stem="Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke",
+        file_extension="py",
+        robot="Flex",
+    )
+
     OT2_X_v2_18_None_None_duplicateRTPVariableName: Protocol = Protocol(
         file_stem="OT2_X_v2_18_None_None_duplicateRTPVariableName",
         file_extension="py",
@@ -661,6 +667,12 @@ class Protocols:
 
     OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2: Protocol = Protocol(
         file_stem="OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2",
+        file_extension="py",
+        robot="OT2",
+    )
+
+    OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3: Protocol = Protocol(
+        file_stem="OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3",
         file_extension="py",
         robot="OT2",
     )

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[057de2035d][OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[057de2035d][OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -1,0 +1,9684 @@
+{
+  "commands": [
+    {
+      "commandType": "home",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "50c7ae73a4e3f7129874f39dfb514803",
+      "notes": [],
+      "params": {},
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "setRailLights",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c0f556802f0eafbdbce20c171f217b13",
+      "notes": [],
+      "params": {
+        "on": true
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "comment",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b0ba40f2987795790258bb3b52aef419",
+      "notes": [],
+      "params": {
+        "message": "Let there be light! True 🌠🌠🌠"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "comment",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f69df71d649b9cbb0f560491504b17bf",
+      "notes": [],
+      "params": {
+        "message": "Is the door is closed? True 🚪🚪🚪"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "comment",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "252352128dcb2c6ac11f78895872a7bb",
+      "notes": [],
+      "params": {
+        "message": "Is this a simulation? True 🔮🔮🔮"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "comment",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "22812ba0d8d8f561d6f94d12dbd191a6",
+      "notes": [],
+      "params": {
+        "message": "Running against API Version: 2.19"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2fef6b1c39bcc1af9b9d88c5ae54d919",
+      "notes": [],
+      "params": {
+        "displayName": "300ul tips",
+        "loadName": "opentrons_96_tiprack_300ul",
+        "location": {
+          "slotName": "5"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": [],
+            "links": [
+              "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 64.49
+          },
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {},
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "tipRack",
+            "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": true,
+            "loadName": "opentrons_96_tiprack_300ul",
+            "tipLength": 59.3,
+            "tipOverlap": 7.47
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "A9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 5.39
+            },
+            "B1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "B9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 5.39
+            },
+            "C1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "C9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 5.39
+            },
+            "D1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "D9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 5.39
+            },
+            "E1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "E9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 5.39
+            },
+            "F1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "F9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 5.39
+            },
+            "G1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "G9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 5.39
+            },
+            "H1": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H10": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H11": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H12": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H2": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H3": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H4": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H5": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H6": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H7": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H8": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 5.39
+            },
+            "H9": {
+              "depth": 59.3,
+              "diameter": 5.23,
+              "shape": "circular",
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 5.39
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "641d89a1769e495364a6511b4123aaee",
+      "notes": [],
+      "params": {
+        "displayName": "20ul tips",
+        "loadName": "opentrons_96_tiprack_20ul",
+        "location": {
+          "slotName": "4"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": [],
+            "links": [
+              "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-10ul-tips"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 64.69
+          },
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {},
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "tipRack",
+            "displayName": "Opentrons OT-2 96 Tip Rack 20 µL",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": true,
+            "loadName": "opentrons_96_tiprack_20ul",
+            "tipLength": 39.2,
+            "tipOverlap": 8.25
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "A9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 25.49
+            },
+            "B1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "B9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 25.49
+            },
+            "C1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "C9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 25.49
+            },
+            "D1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "D9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 25.49
+            },
+            "E1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "E9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 25.49
+            },
+            "F1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "F9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 25.49
+            },
+            "G1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "G9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 25.49
+            },
+            "H1": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H10": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H11": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H12": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H2": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H3": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H4": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H5": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H6": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H7": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H8": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 25.49
+            },
+            "H9": {
+              "depth": 39.2,
+              "diameter": 3.27,
+              "shape": "circular",
+              "totalLiquidVolume": 20,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 25.49
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadPipette",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2925ebb53a28d20bb95d53e4773e40c6",
+      "notes": [],
+      "params": {
+        "liquidPresenceDetection": false,
+        "mount": "left",
+        "pipetteName": "p300_multi_gen2",
+        "tipOverlapNotAfterVersion": "v1"
+      },
+      "result": {
+        "pipetteId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadPipette",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3b864d00b2bf4e88edb0dc034c1afeaf",
+      "notes": [],
+      "params": {
+        "liquidPresenceDetection": false,
+        "mount": "right",
+        "pipetteName": "p20_single_gen2",
+        "tipOverlapNotAfterVersion": "v1"
+      },
+      "result": {
+        "pipetteId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "be987e9fdcf2dbe0234a88c9fa47f418",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "1"
+        },
+        "model": "heaterShakerModuleV1"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 12.0,
+            "y": 8.75,
+            "z": 68.275
+          },
+          "compatibleWith": [],
+          "dimensions": {
+            "bareOverallHeight": 82.0,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Heater-Shaker Module GEN1",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": -0.125,
+            "y": 1.125,
+            "z": 68.275
+          },
+          "model": "heaterShakerModuleV1",
+          "moduleType": "heaterShakerModuleType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot2_short_trash": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot2_standard": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot3_standard": {
+              "A1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "A3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "B1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "B3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "C1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "C3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "D1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "D3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "model": "heaterShakerModuleV1",
+        "moduleId": "UUID",
+        "serialNumber": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "53acfbfde5c1f9c0e34b2d3ac8d26926",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "9"
+        },
+        "model": "temperatureModuleV2"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 11.7,
+            "y": 8.75,
+            "z": 80.09
+          },
+          "compatibleWith": [
+            "temperatureModuleV1"
+          ],
+          "dimensions": {
+            "bareOverallHeight": 84.0,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Temperature Module GEN2",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": -1.45,
+            "y": -0.15,
+            "z": 80.09
+          },
+          "model": "temperatureModuleV2",
+          "moduleType": "temperatureModuleType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot2_short_trash": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.15,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.15,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.15,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot2_standard": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.3,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.3,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.3,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot3_standard": {
+              "A1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "A3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "B1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "B3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "C1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "C3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "D1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "D3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "model": "temperatureModuleV2",
+        "moduleId": "UUID",
+        "serialNumber": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "dc701dc10e773175dfe266b65d1ff3e6",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "7"
+        },
+        "model": "thermocyclerModuleV2"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 14.4,
+            "y": 64.93,
+            "z": 97.8
+          },
+          "compatibleWith": [],
+          "dimensions": {
+            "bareOverallHeight": 108.96,
+            "lidHeight": 61.7,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Thermocycler Module GEN2",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 5.6
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 4.6
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": 0.0,
+            "y": 68.8,
+            "z": 108.96
+          },
+          "model": "thermocyclerModuleV2",
+          "moduleType": "thermocyclerModuleType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot3_standard": {
+              "B1": {
+                "cornerOffsetFromSlot": [
+                  [
+                    -98,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -20.005,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -0.84,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ],
+                "labwareOffset": [
+                  [
+                    -98,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -20.005,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -0.84,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "model": "thermocyclerModuleV2",
+        "moduleId": "UUID",
+        "serialNumber": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "760eaed99cc2a56688adb15cc79ca09b",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_96_well_aluminum_block",
+        "location": {
+          "moduleId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [
+            "adapter"
+          ],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 18.16
+          },
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+              }
+            }
+          },
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "aluminumBlock",
+            "displayName": "Opentrons 96 Well Aluminum Block",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": false,
+            "loadName": "opentrons_96_well_aluminum_block",
+            "quirks": []
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "B1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "C1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "D1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "E1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "F1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "G1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "H1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 3.38
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "018c33eefca131b3f7a2381ee5dd4451",
+      "notes": [],
+      "params": {
+        "displayName": "Temperature-Controlled plate",
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+        "location": {
+          "labwareId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 2
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "NEST",
+            "brandId": [
+              "402501"
+            ],
+            "links": [
+              "https://www.nest-biotech.com/pcr-plates/58773587.html"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 15.7
+          },
+          "gripForce": 15.0,
+          "gripHeightFromLabwareBottom": 10.65,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "wellPlate",
+            "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": true,
+            "isTiprack": false,
+            "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+            "magneticModuleEngageHeight": 20
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_96_pcr_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 10.2
+            },
+            "opentrons_96_well_aluminum_block": {
+              "x": 0,
+              "y": 0,
+              "z": 12.66
+            }
+          },
+          "stackingOffsetWithModule": {
+            "thermocyclerModuleV2": {
+              "x": 0,
+              "y": 0,
+              "z": 10.8
+            }
+          },
+          "version": 2,
+          "wells": {
+            "A1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "B1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "C1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "D1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "E1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "F1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "G1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "H1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 0.92
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c721864b5eca3153a587771422848a84",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_96_pcr_adapter",
+        "location": {
+          "moduleId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [
+            "adapter"
+          ],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 8.5,
+            "y": 5.5,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 111,
+            "yDimension": 75,
+            "zDimension": 13.85
+          },
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+              }
+            }
+          },
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "adapter",
+            "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": false,
+            "loadName": "opentrons_96_pcr_adapter",
+            "quirks": []
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 69,
+              "z": 1.85
+            },
+            "A10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 69,
+              "z": 1.85
+            },
+            "A11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 69,
+              "z": 1.85
+            },
+            "A12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 69,
+              "z": 1.85
+            },
+            "A2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 69,
+              "z": 1.85
+            },
+            "A3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 69,
+              "z": 1.85
+            },
+            "A4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 69,
+              "z": 1.85
+            },
+            "A5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 69,
+              "z": 1.85
+            },
+            "A6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 69,
+              "z": 1.85
+            },
+            "A7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 69,
+              "z": 1.85
+            },
+            "A8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 69,
+              "z": 1.85
+            },
+            "A9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 69,
+              "z": 1.85
+            },
+            "B1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 60,
+              "z": 1.85
+            },
+            "B10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 60,
+              "z": 1.85
+            },
+            "B11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 60,
+              "z": 1.85
+            },
+            "B12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 60,
+              "z": 1.85
+            },
+            "B2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 60,
+              "z": 1.85
+            },
+            "B3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 60,
+              "z": 1.85
+            },
+            "B4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 60,
+              "z": 1.85
+            },
+            "B5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 60,
+              "z": 1.85
+            },
+            "B6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 60,
+              "z": 1.85
+            },
+            "B7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 60,
+              "z": 1.85
+            },
+            "B8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 60,
+              "z": 1.85
+            },
+            "B9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 60,
+              "z": 1.85
+            },
+            "C1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 51,
+              "z": 1.85
+            },
+            "C10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 51,
+              "z": 1.85
+            },
+            "C11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 51,
+              "z": 1.85
+            },
+            "C12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 51,
+              "z": 1.85
+            },
+            "C2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 51,
+              "z": 1.85
+            },
+            "C3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 51,
+              "z": 1.85
+            },
+            "C4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 51,
+              "z": 1.85
+            },
+            "C5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 51,
+              "z": 1.85
+            },
+            "C6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 51,
+              "z": 1.85
+            },
+            "C7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 51,
+              "z": 1.85
+            },
+            "C8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 51,
+              "z": 1.85
+            },
+            "C9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 51,
+              "z": 1.85
+            },
+            "D1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 42,
+              "z": 1.85
+            },
+            "D10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 42,
+              "z": 1.85
+            },
+            "D11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 42,
+              "z": 1.85
+            },
+            "D12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 42,
+              "z": 1.85
+            },
+            "D2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 42,
+              "z": 1.85
+            },
+            "D3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 42,
+              "z": 1.85
+            },
+            "D4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 42,
+              "z": 1.85
+            },
+            "D5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 42,
+              "z": 1.85
+            },
+            "D6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 42,
+              "z": 1.85
+            },
+            "D7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 42,
+              "z": 1.85
+            },
+            "D8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 42,
+              "z": 1.85
+            },
+            "D9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 42,
+              "z": 1.85
+            },
+            "E1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 33,
+              "z": 1.85
+            },
+            "E10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 33,
+              "z": 1.85
+            },
+            "E11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 33,
+              "z": 1.85
+            },
+            "E12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 33,
+              "z": 1.85
+            },
+            "E2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 33,
+              "z": 1.85
+            },
+            "E3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 33,
+              "z": 1.85
+            },
+            "E4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 33,
+              "z": 1.85
+            },
+            "E5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 33,
+              "z": 1.85
+            },
+            "E6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 33,
+              "z": 1.85
+            },
+            "E7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 33,
+              "z": 1.85
+            },
+            "E8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 33,
+              "z": 1.85
+            },
+            "E9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 33,
+              "z": 1.85
+            },
+            "F1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 24,
+              "z": 1.85
+            },
+            "F10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 24,
+              "z": 1.85
+            },
+            "F11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 24,
+              "z": 1.85
+            },
+            "F12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 24,
+              "z": 1.85
+            },
+            "F2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 24,
+              "z": 1.85
+            },
+            "F3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 24,
+              "z": 1.85
+            },
+            "F4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 24,
+              "z": 1.85
+            },
+            "F5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 24,
+              "z": 1.85
+            },
+            "F6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 24,
+              "z": 1.85
+            },
+            "F7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 24,
+              "z": 1.85
+            },
+            "F8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 24,
+              "z": 1.85
+            },
+            "F9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 24,
+              "z": 1.85
+            },
+            "G1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 15,
+              "z": 1.85
+            },
+            "G10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 15,
+              "z": 1.85
+            },
+            "G11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 15,
+              "z": 1.85
+            },
+            "G12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 15,
+              "z": 1.85
+            },
+            "G2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 15,
+              "z": 1.85
+            },
+            "G3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 15,
+              "z": 1.85
+            },
+            "G4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 15,
+              "z": 1.85
+            },
+            "G5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 15,
+              "z": 1.85
+            },
+            "G6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 15,
+              "z": 1.85
+            },
+            "G7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 15,
+              "z": 1.85
+            },
+            "G8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 15,
+              "z": 1.85
+            },
+            "G9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 15,
+              "z": 1.85
+            },
+            "H1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 6,
+              "z": 1.85
+            },
+            "H10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 6,
+              "z": 1.85
+            },
+            "H11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 6,
+              "z": 1.85
+            },
+            "H12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 6,
+              "z": 1.85
+            },
+            "H2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 6,
+              "z": 1.85
+            },
+            "H3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 6,
+              "z": 1.85
+            },
+            "H4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 6,
+              "z": 1.85
+            },
+            "H5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 6,
+              "z": 1.85
+            },
+            "H6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 6,
+              "z": 1.85
+            },
+            "H7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 6,
+              "z": 1.85
+            },
+            "H8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 6,
+              "z": 1.85
+            },
+            "H9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 6,
+              "z": 1.85
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "0137be81e4cddff6b188c578784942ec",
+      "notes": [],
+      "params": {
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+        "location": {
+          "labwareId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 2
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "NEST",
+            "brandId": [
+              "402501"
+            ],
+            "links": [
+              "https://www.nest-biotech.com/pcr-plates/58773587.html"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 15.7
+          },
+          "gripForce": 15.0,
+          "gripHeightFromLabwareBottom": 10.65,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "wellPlate",
+            "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": true,
+            "isTiprack": false,
+            "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+            "magneticModuleEngageHeight": 20
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_96_pcr_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 10.2
+            },
+            "opentrons_96_well_aluminum_block": {
+              "x": 0,
+              "y": 0,
+              "z": 12.66
+            }
+          },
+          "stackingOffsetWithModule": {
+            "thermocyclerModuleV2": {
+              "x": 0,
+              "y": 0,
+              "z": 10.8
+            }
+          },
+          "version": 2,
+          "wells": {
+            "A1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "B1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "C1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "D1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "E1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "F1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "G1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "H1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 0.92
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7feed4cbc55e2030e0692ba1082065f4",
+      "notes": [],
+      "params": {
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+        "location": {
+          "moduleId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 2
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "NEST",
+            "brandId": [
+              "402501"
+            ],
+            "links": [
+              "https://www.nest-biotech.com/pcr-plates/58773587.html"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 15.7
+          },
+          "gripForce": 15.0,
+          "gripHeightFromLabwareBottom": 10.65,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "wellPlate",
+            "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": true,
+            "isTiprack": false,
+            "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+            "magneticModuleEngageHeight": 20
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_96_pcr_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 10.2
+            },
+            "opentrons_96_well_aluminum_block": {
+              "x": 0,
+              "y": 0,
+              "z": 12.66
+            }
+          },
+          "stackingOffsetWithModule": {
+            "thermocyclerModuleV2": {
+              "x": 0,
+              "y": 0,
+              "z": 10.8
+            }
+          },
+          "version": 2,
+          "wells": {
+            "A1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "B1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "C1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "D1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "E1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "F1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "G1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "H1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 0.92
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "error": {
+        "createdAt": "TIMESTAMP",
+        "detail": "FileNotFoundError: Labware \"cpx_4_tuberack_100ul\" not found with version 1 in namespace \"opentrons\".",
+        "errorCode": "4000",
+        "errorInfo": {
+          "args": "('Labware \"cpx_4_tuberack_100ul\" not found with version 1 in namespace \"opentrons\".',)",
+          "class": "FileNotFoundError",
+          "errno": "None",
+          "filename": "None",
+          "filename2": "None",
+          "strerror": "None",
+          "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/execution/command_executor.py\", line N, in execute\n    result = await command_impl.execute(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/commands/load_labware.py\", line N, in execute\n    loaded_labware = await self._equipment.load_labware(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/execution/equipment.py\", line N, in load_labware\n    definition = await self._labware_data_provider.get_labware_definition(\n\n  File \"/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py\", line N, in run_sync_in_worker_thread\n    return await future\n\n  File \"/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py\", line N, in run\n    result = context.run(func, *args)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/resources/labware_data_provider.py\", line N, in _get_labware_definition_sync\n    get_labware_definition(load_name, namespace, version)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/labware.py\", line N, in get_labware_definition\n    return _get_standard_labware_definition(load_name, namespace, version)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/labware.py\", line N, in _get_standard_labware_definition\n    raise FileNotFoundError(\n"
+        },
+        "errorType": "PythonException",
+        "id": "UUID",
+        "isDefined": false,
+        "wrappedErrors": [
+          {
+            "createdAt": "TIMESTAMP",
+            "detail": "opentrons.protocol_engine.errors.exceptions.LabwareDefinitionDoesNotExistError: Error 4000 GENERAL_ERROR (LabwareDefinitionDoesNotExistError): Labware definition for matching opentrons/cpx_4_tuberack_100ul/1 not found.",
+            "errorCode": "4000",
+            "errorInfo": {
+              "args": "('Labware definition for matching opentrons/cpx_4_tuberack_100ul/1 not found.',)",
+              "class": "LabwareDefinitionDoesNotExistError",
+              "code": "ErrorCodes.GENERAL_ERROR",
+              "detail": "{}",
+              "message": "Labware definition for matching opentrons/cpx_4_tuberack_100ul/1 not found.",
+              "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/execution/equipment.py\", line N, in load_labware\n    definition = self._state_store.labware.get_definition_by_uri(definition_uri)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/state/labware.py\", line N, in get_definition_by_uri\n    raise errors.LabwareDefinitionDoesNotExistError(\n",
+              "wrapping": "[]"
+            },
+            "errorType": "PythonException",
+            "id": "UUID",
+            "isDefined": false,
+            "wrappedErrors": [
+              {
+                "createdAt": "TIMESTAMP",
+                "detail": "KeyError: 'opentrons/cpx_4_tuberack_100ul/1'",
+                "errorCode": "4000",
+                "errorInfo": {
+                  "args": "('opentrons/cpx_4_tuberack_100ul/1',)",
+                  "class": "KeyError",
+                  "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/state/labware.py\", line N, in get_definition_by_uri\n    return self._state.definitions_by_uri[uri]\n"
+                },
+                "errorType": "PythonException",
+                "id": "UUID",
+                "isDefined": false,
+                "wrappedErrors": []
+              },
+              {
+                "createdAt": "TIMESTAMP",
+                "detail": "KeyError: 'opentrons/cpx_4_tuberack_100ul/1'",
+                "errorCode": "4000",
+                "errorInfo": {
+                  "args": "('opentrons/cpx_4_tuberack_100ul/1',)",
+                  "class": "KeyError",
+                  "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/state/labware.py\", line N, in get_definition_by_uri\n    return self._state.definitions_by_uri[uri]\n"
+                },
+                "errorType": "PythonException",
+                "id": "UUID",
+                "isDefined": false,
+                "wrappedErrors": []
+              }
+            ]
+          }
+        ]
+      },
+      "id": "UUID",
+      "key": "08e16a2cac011d4bef561f8b0854d19e",
+      "notes": [],
+      "params": {
+        "displayName": "4 custom tubes",
+        "loadName": "cpx_4_tuberack_100ul",
+        "location": {
+          "slotName": "6"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "failed"
+    }
+  ],
+  "config": {
+    "apiVersion": [
+      2,
+      19
+    ],
+    "protocolType": "python"
+  },
+  "createdAt": "TIMESTAMP",
+  "errors": [
+    {
+      "createdAt": "TIMESTAMP",
+      "detail": "ProtocolCommandFailedError [line 232]: Error 4000 GENERAL_ERROR (ProtocolCommandFailedError): PythonException: FileNotFoundError: Labware \"cpx_4_tuberack_100ul\" not found with version 1 in namespace \"opentrons\".",
+      "errorCode": "4000",
+      "errorInfo": {},
+      "errorType": "ExceptionInProtocolError",
+      "id": "UUID",
+      "isDefined": false,
+      "wrappedErrors": [
+        {
+          "createdAt": "TIMESTAMP",
+          "detail": "PythonException: FileNotFoundError: Labware \"cpx_4_tuberack_100ul\" not found with version 1 in namespace \"opentrons\".",
+          "errorCode": "4000",
+          "errorInfo": {},
+          "errorType": "ProtocolCommandFailedError",
+          "id": "UUID",
+          "isDefined": false,
+          "wrappedErrors": [
+            {
+              "createdAt": "TIMESTAMP",
+              "detail": "FileNotFoundError: Labware \"cpx_4_tuberack_100ul\" not found with version 1 in namespace \"opentrons\".",
+              "errorCode": "4000",
+              "errorInfo": {
+                "args": "('Labware \"cpx_4_tuberack_100ul\" not found with version 1 in namespace \"opentrons\".',)",
+                "class": "FileNotFoundError",
+                "errno": "None",
+                "filename": "None",
+                "filename2": "None",
+                "strerror": "None",
+                "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/execution/command_executor.py\", line N, in execute\n    result = await command_impl.execute(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/commands/load_labware.py\", line N, in execute\n    loaded_labware = await self._equipment.load_labware(\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/execution/equipment.py\", line N, in load_labware\n    definition = await self._labware_data_provider.get_labware_definition(\n\n  File \"/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py\", line N, in run_sync_in_worker_thread\n    return await future\n\n  File \"/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py\", line N, in run\n    result = context.run(func, *args)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/resources/labware_data_provider.py\", line N, in _get_labware_definition_sync\n    get_labware_definition(load_name, namespace, version)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/labware.py\", line N, in get_labware_definition\n    return _get_standard_labware_definition(load_name, namespace, version)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocols/labware.py\", line N, in _get_standard_labware_definition\n    raise FileNotFoundError(\n"
+              },
+              "errorType": "PythonException",
+              "id": "UUID",
+              "isDefined": false,
+              "wrappedErrors": [
+                {
+                  "createdAt": "TIMESTAMP",
+                  "detail": "opentrons.protocol_engine.errors.exceptions.LabwareDefinitionDoesNotExistError: Error 4000 GENERAL_ERROR (LabwareDefinitionDoesNotExistError): Labware definition for matching opentrons/cpx_4_tuberack_100ul/1 not found.",
+                  "errorCode": "4000",
+                  "errorInfo": {
+                    "args": "('Labware definition for matching opentrons/cpx_4_tuberack_100ul/1 not found.',)",
+                    "class": "LabwareDefinitionDoesNotExistError",
+                    "code": "ErrorCodes.GENERAL_ERROR",
+                    "detail": "{}",
+                    "message": "Labware definition for matching opentrons/cpx_4_tuberack_100ul/1 not found.",
+                    "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/execution/equipment.py\", line N, in load_labware\n    definition = self._state_store.labware.get_definition_by_uri(definition_uri)\n\n  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/state/labware.py\", line N, in get_definition_by_uri\n    raise errors.LabwareDefinitionDoesNotExistError(\n",
+                    "wrapping": "[]"
+                  },
+                  "errorType": "PythonException",
+                  "id": "UUID",
+                  "isDefined": false,
+                  "wrappedErrors": [
+                    {
+                      "createdAt": "TIMESTAMP",
+                      "detail": "KeyError: 'opentrons/cpx_4_tuberack_100ul/1'",
+                      "errorCode": "4000",
+                      "errorInfo": {
+                        "args": "('opentrons/cpx_4_tuberack_100ul/1',)",
+                        "class": "KeyError",
+                        "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/state/labware.py\", line N, in get_definition_by_uri\n    return self._state.definitions_by_uri[uri]\n"
+                      },
+                      "errorType": "PythonException",
+                      "id": "UUID",
+                      "isDefined": false,
+                      "wrappedErrors": []
+                    },
+                    {
+                      "createdAt": "TIMESTAMP",
+                      "detail": "KeyError: 'opentrons/cpx_4_tuberack_100ul/1'",
+                      "errorCode": "4000",
+                      "errorInfo": {
+                        "args": "('opentrons/cpx_4_tuberack_100ul/1',)",
+                        "class": "KeyError",
+                        "traceback": "  File \"/usr/local/lib/python3.10/site-packages/opentrons/protocol_engine/state/labware.py\", line N, in get_definition_by_uri\n    return self._state.definitions_by_uri[uri]\n"
+                      },
+                      "errorType": "PythonException",
+                      "id": "UUID",
+                      "isDefined": false,
+                      "wrappedErrors": []
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "files": [
+    {
+      "name": "OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3.py",
+      "role": "main"
+    }
+  ],
+  "labware": [
+    {
+      "definitionUri": "opentrons/opentrons_96_tiprack_300ul/1",
+      "displayName": "300ul tips",
+      "id": "UUID",
+      "loadName": "opentrons_96_tiprack_300ul",
+      "location": {
+        "slotName": "5"
+      }
+    },
+    {
+      "definitionUri": "opentrons/opentrons_96_tiprack_20ul/1",
+      "displayName": "20ul tips",
+      "id": "UUID",
+      "loadName": "opentrons_96_tiprack_20ul",
+      "location": {
+        "slotName": "4"
+      }
+    },
+    {
+      "definitionUri": "opentrons/opentrons_96_well_aluminum_block/1",
+      "id": "UUID",
+      "loadName": "opentrons_96_well_aluminum_block",
+      "location": {
+        "moduleId": "UUID"
+      }
+    },
+    {
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "displayName": "Temperature-Controlled plate",
+      "id": "UUID",
+      "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "location": {
+        "labwareId": "UUID"
+      }
+    },
+    {
+      "definitionUri": "opentrons/opentrons_96_pcr_adapter/1",
+      "id": "UUID",
+      "loadName": "opentrons_96_pcr_adapter",
+      "location": {
+        "moduleId": "UUID"
+      }
+    },
+    {
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "location": {
+        "labwareId": "UUID"
+      }
+    },
+    {
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "location": {
+        "moduleId": "UUID"
+      }
+    }
+  ],
+  "liquids": [],
+  "metadata": {
+    "author": "Opentrons Engineering <engineering@opentrons.com>",
+    "description": "Description of the protocol that is longish \n has \n returns and \n emoji 😊 ⬆️ ",
+    "protocolName": "🛠️ 2.19 Smoke Test V3 🪄",
+    "source": "Software Testing Team"
+  },
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "1"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "9"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "7"
+      },
+      "model": "thermocyclerModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
+  "pipettes": [
+    {
+      "id": "UUID",
+      "mount": "left",
+      "pipetteName": "p300_multi_gen2"
+    },
+    {
+      "id": "UUID",
+      "mount": "right",
+      "pipetteName": "p20_single_gen2"
+    }
+  ],
+  "result": "not-ok",
+  "robotType": "OT-2 Standard",
+  "runTimeParameters": [
+    {
+      "choices": [
+        {
+          "displayName": "Nest 12 Well 15 mL",
+          "value": "nest_12_reservoir_15ml"
+        },
+        {
+          "displayName": "USA Scientific 12 Well 22 mL",
+          "value": "usascientific_12_reservoir_22ml"
+        }
+      ],
+      "default": "nest_12_reservoir_15ml",
+      "description": "Name of the reservoir",
+      "displayName": "Reservoir Name",
+      "type": "str",
+      "value": "nest_12_reservoir_15ml",
+      "variableName": "reservoir_name"
+    },
+    {
+      "choices": [
+        {
+          "displayName": "Nest 96 Well 100 µL",
+          "value": "nest_96_wellplate_100ul_pcr_full_skirt"
+        },
+        {
+          "displayName": "Corning 96 Well 360 µL",
+          "value": "corning_96_wellplate_360ul_flat"
+        },
+        {
+          "displayName": "Opentrons Tough 96 Well 200 µL",
+          "value": "opentrons_96_wellplate_200ul_pcr_full_skirt"
+        }
+      ],
+      "default": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "description": "Name of the well plate",
+      "displayName": "Well Plate Name",
+      "type": "str",
+      "value": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "variableName": "well_plate_name"
+    },
+    {
+      "default": 3.0,
+      "description": "Time to delay in seconds",
+      "displayName": "Delay Time",
+      "max": 10.0,
+      "min": 1.0,
+      "suffix": "seconds",
+      "type": "int",
+      "value": 3.0,
+      "variableName": "delay_time"
+    },
+    {
+      "default": true,
+      "description": "Turn on the robot lights?",
+      "displayName": "Robot Lights",
+      "type": "bool",
+      "value": true,
+      "variableName": "robot_lights"
+    },
+    {
+      "default": 38.0,
+      "description": "Temperature to set the heater shaker to",
+      "displayName": "Heater Shaker Temperature",
+      "max": 100.0,
+      "min": 37.0,
+      "suffix": "°C",
+      "type": "float",
+      "value": 38.0,
+      "variableName": "heater_shaker_temperature"
+    }
+  ]
+}

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -1,0 +1,13236 @@
+{
+  "commands": [
+    {
+      "commandType": "home",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "50c7ae73a4e3f7129874f39dfb514803",
+      "notes": [],
+      "params": {},
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "8511b05ba5565bf0e6dcccd800e2ee23",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "B1"
+        },
+        "model": "thermocyclerModuleV2"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 14.4,
+            "y": 64.93,
+            "z": 97.8
+          },
+          "compatibleWith": [],
+          "dimensions": {
+            "bareOverallHeight": 108.96,
+            "lidHeight": 61.7,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Thermocycler Module GEN2",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 5.6
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 4.6
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": 0.0,
+            "y": 68.8,
+            "z": 108.96
+          },
+          "model": "thermocyclerModuleV2",
+          "moduleType": "thermocyclerModuleType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot3_standard": {
+              "B1": {
+                "cornerOffsetFromSlot": [
+                  [
+                    -98,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -20.005,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -0.84,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ],
+                "labwareOffset": [
+                  [
+                    -98,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -20.005,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -0.84,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "model": "thermocyclerModuleV2",
+        "moduleId": "UUID",
+        "serialNumber": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b97e4480a1578eb15e73787ba193bdd5",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "C1"
+        },
+        "model": "magneticBlockV1"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "compatibleWith": [],
+          "dimensions": {
+            "bareOverallHeight": 45.0,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Magnetic Block GEN1",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 38.0
+          },
+          "model": "magneticBlockV1",
+          "moduleType": "magneticBlockType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot2_short_trash": {},
+            "ot2_standard": {},
+            "ot3_standard": {}
+          }
+        },
+        "model": "magneticBlockV1",
+        "moduleId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5f5358348287e62e64a99dc4423561f5",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "A3"
+        },
+        "model": "heaterShakerModuleV1"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 12.0,
+            "y": 8.75,
+            "z": 68.275
+          },
+          "compatibleWith": [],
+          "dimensions": {
+            "bareOverallHeight": 82.0,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Heater-Shaker Module GEN1",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": -0.125,
+            "y": 1.125,
+            "z": 68.275
+          },
+          "model": "heaterShakerModuleV1",
+          "moduleType": "heaterShakerModuleType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot2_short_trash": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot2_standard": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    -1,
+                    0,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot3_standard": {
+              "A1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "A3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "B1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "B3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "C1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "C3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "D1": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              },
+              "D3": {
+                "labwareOffset": [
+                  [
+                    -49.325,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    -1.125,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.125,
+                    1
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "model": "heaterShakerModuleV1",
+        "moduleId": "UUID",
+        "serialNumber": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadModule",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1bdb1d25a2f030a6ee69219303e3b8df",
+      "notes": [],
+      "params": {
+        "location": {
+          "slotName": "D1"
+        },
+        "model": "temperatureModuleV2"
+      },
+      "result": {
+        "definition": {
+          "calibrationPoint": {
+            "x": 11.7,
+            "y": 8.75,
+            "z": 80.09
+          },
+          "compatibleWith": [
+            "temperatureModuleV1"
+          ],
+          "dimensions": {
+            "bareOverallHeight": 84.0,
+            "overLabwareHeight": 0.0
+          },
+          "displayName": "Temperature Module GEN2",
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0.0,
+                "y": 0.0,
+                "z": 0.0
+              }
+            }
+          },
+          "labwareOffset": {
+            "x": -1.45,
+            "y": -0.15,
+            "z": 80.09
+          },
+          "model": "temperatureModuleV2",
+          "moduleType": "temperatureModuleType",
+          "otSharedSchema": "module/schemas/2",
+          "quirks": [],
+          "slotTransforms": {
+            "ot2_short_trash": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.15,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.15,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.15,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot2_standard": {
+              "3": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.3,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "6": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.3,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              },
+              "9": {
+                "labwareOffset": [
+                  [
+                    -1,
+                    -0.3,
+                    0,
+                    0
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ]
+                ]
+              }
+            },
+            "ot3_standard": {
+              "A1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "A3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "B1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "B3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "C1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "C3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "D1": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              },
+              "D3": {
+                "labwareOffset": [
+                  [
+                    -71.09,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    0.15,
+                    1
+                  ],
+                  [
+                    0,
+                    0,
+                    1,
+                    1.45
+                  ]
+                ]
+              }
+            }
+          }
+        },
+        "model": "temperatureModuleV2",
+        "moduleId": "UUID",
+        "serialNumber": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/openLid",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6715dfdabd16f6acb7c207dbf23a87d9",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/openLabwareLatch",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "983d3f6fe64a3f60de367ee4ff439714",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {
+        "pipetteRetracted": true
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9b3efe722729a38b24e14fabc8fe10cd",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_96_well_aluminum_block",
+        "location": {
+          "moduleId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [
+            "adapter"
+          ],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 18.16
+          },
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+              }
+            }
+          },
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "aluminumBlock",
+            "displayName": "Opentrons 96 Well Aluminum Block",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": false,
+            "loadName": "opentrons_96_well_aluminum_block",
+            "quirks": []
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "A9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 3.38
+            },
+            "B1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "B9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 3.38
+            },
+            "C1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "C9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 3.38
+            },
+            "D1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "D9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 3.38
+            },
+            "E1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "E9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 3.38
+            },
+            "F1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "F9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 3.38
+            },
+            "G1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "G9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 3.38
+            },
+            "H1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 3.38
+            },
+            "H9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 3.38
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "567e61648ee88976deb8d73faac0e083",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_96_pcr_adapter",
+        "location": {
+          "moduleId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [
+            "adapter"
+          ],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 8.5,
+            "y": 5.5,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 111,
+            "yDimension": 75,
+            "zDimension": 13.85
+          },
+          "gripperOffsets": {
+            "default": {
+              "dropOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 1.0
+              },
+              "pickUpOffset": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+              }
+            }
+          },
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "adapter",
+            "displayName": "Opentrons 96 PCR Heater-Shaker Adapter",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": false,
+            "loadName": "opentrons_96_pcr_adapter",
+            "quirks": []
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 69,
+              "z": 1.85
+            },
+            "A10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 69,
+              "z": 1.85
+            },
+            "A11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 69,
+              "z": 1.85
+            },
+            "A12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 69,
+              "z": 1.85
+            },
+            "A2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 69,
+              "z": 1.85
+            },
+            "A3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 69,
+              "z": 1.85
+            },
+            "A4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 69,
+              "z": 1.85
+            },
+            "A5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 69,
+              "z": 1.85
+            },
+            "A6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 69,
+              "z": 1.85
+            },
+            "A7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 69,
+              "z": 1.85
+            },
+            "A8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 69,
+              "z": 1.85
+            },
+            "A9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 69,
+              "z": 1.85
+            },
+            "B1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 60,
+              "z": 1.85
+            },
+            "B10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 60,
+              "z": 1.85
+            },
+            "B11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 60,
+              "z": 1.85
+            },
+            "B12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 60,
+              "z": 1.85
+            },
+            "B2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 60,
+              "z": 1.85
+            },
+            "B3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 60,
+              "z": 1.85
+            },
+            "B4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 60,
+              "z": 1.85
+            },
+            "B5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 60,
+              "z": 1.85
+            },
+            "B6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 60,
+              "z": 1.85
+            },
+            "B7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 60,
+              "z": 1.85
+            },
+            "B8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 60,
+              "z": 1.85
+            },
+            "B9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 60,
+              "z": 1.85
+            },
+            "C1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 51,
+              "z": 1.85
+            },
+            "C10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 51,
+              "z": 1.85
+            },
+            "C11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 51,
+              "z": 1.85
+            },
+            "C12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 51,
+              "z": 1.85
+            },
+            "C2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 51,
+              "z": 1.85
+            },
+            "C3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 51,
+              "z": 1.85
+            },
+            "C4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 51,
+              "z": 1.85
+            },
+            "C5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 51,
+              "z": 1.85
+            },
+            "C6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 51,
+              "z": 1.85
+            },
+            "C7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 51,
+              "z": 1.85
+            },
+            "C8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 51,
+              "z": 1.85
+            },
+            "C9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 51,
+              "z": 1.85
+            },
+            "D1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 42,
+              "z": 1.85
+            },
+            "D10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 42,
+              "z": 1.85
+            },
+            "D11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 42,
+              "z": 1.85
+            },
+            "D12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 42,
+              "z": 1.85
+            },
+            "D2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 42,
+              "z": 1.85
+            },
+            "D3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 42,
+              "z": 1.85
+            },
+            "D4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 42,
+              "z": 1.85
+            },
+            "D5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 42,
+              "z": 1.85
+            },
+            "D6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 42,
+              "z": 1.85
+            },
+            "D7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 42,
+              "z": 1.85
+            },
+            "D8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 42,
+              "z": 1.85
+            },
+            "D9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 42,
+              "z": 1.85
+            },
+            "E1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 33,
+              "z": 1.85
+            },
+            "E10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 33,
+              "z": 1.85
+            },
+            "E11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 33,
+              "z": 1.85
+            },
+            "E12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 33,
+              "z": 1.85
+            },
+            "E2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 33,
+              "z": 1.85
+            },
+            "E3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 33,
+              "z": 1.85
+            },
+            "E4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 33,
+              "z": 1.85
+            },
+            "E5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 33,
+              "z": 1.85
+            },
+            "E6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 33,
+              "z": 1.85
+            },
+            "E7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 33,
+              "z": 1.85
+            },
+            "E8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 33,
+              "z": 1.85
+            },
+            "E9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 33,
+              "z": 1.85
+            },
+            "F1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 24,
+              "z": 1.85
+            },
+            "F10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 24,
+              "z": 1.85
+            },
+            "F11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 24,
+              "z": 1.85
+            },
+            "F12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 24,
+              "z": 1.85
+            },
+            "F2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 24,
+              "z": 1.85
+            },
+            "F3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 24,
+              "z": 1.85
+            },
+            "F4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 24,
+              "z": 1.85
+            },
+            "F5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 24,
+              "z": 1.85
+            },
+            "F6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 24,
+              "z": 1.85
+            },
+            "F7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 24,
+              "z": 1.85
+            },
+            "F8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 24,
+              "z": 1.85
+            },
+            "F9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 24,
+              "z": 1.85
+            },
+            "G1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 15,
+              "z": 1.85
+            },
+            "G10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 15,
+              "z": 1.85
+            },
+            "G11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 15,
+              "z": 1.85
+            },
+            "G12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 15,
+              "z": 1.85
+            },
+            "G2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 15,
+              "z": 1.85
+            },
+            "G3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 15,
+              "z": 1.85
+            },
+            "G4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 15,
+              "z": 1.85
+            },
+            "G5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 15,
+              "z": 1.85
+            },
+            "G6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 15,
+              "z": 1.85
+            },
+            "G7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 15,
+              "z": 1.85
+            },
+            "G8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 15,
+              "z": 1.85
+            },
+            "G9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 15,
+              "z": 1.85
+            },
+            "H1": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 6,
+              "y": 6,
+              "z": 1.85
+            },
+            "H10": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 87,
+              "y": 6,
+              "z": 1.85
+            },
+            "H11": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 96,
+              "y": 6,
+              "z": 1.85
+            },
+            "H12": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 105,
+              "y": 6,
+              "z": 1.85
+            },
+            "H2": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 15,
+              "y": 6,
+              "z": 1.85
+            },
+            "H3": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 24,
+              "y": 6,
+              "z": 1.85
+            },
+            "H4": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 33,
+              "y": 6,
+              "z": 1.85
+            },
+            "H5": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 42,
+              "y": 6,
+              "z": 1.85
+            },
+            "H6": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 51,
+              "y": 6,
+              "z": 1.85
+            },
+            "H7": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 60,
+              "y": 6,
+              "z": 1.85
+            },
+            "H8": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 69,
+              "y": 6,
+              "z": 1.85
+            },
+            "H9": {
+              "depth": 12,
+              "diameter": 5.64,
+              "shape": "circular",
+              "totalLiquidVolume": 0,
+              "x": 78,
+              "y": 6,
+              "z": 1.85
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b9260591301549a7e5b967fca505245c",
+      "notes": [],
+      "params": {
+        "loadName": "nest_1_reservoir_290ml",
+        "location": {
+          "slotName": "D2"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "NEST",
+            "brandId": [
+              "360206",
+              "360266"
+            ],
+            "links": [
+              "https://www.nest-biotech.com/reagent-reserviors"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.47,
+            "zDimension": 44.4
+          },
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "reservoir",
+            "displayName": "NEST 1 Well Reservoir 290 mL",
+            "displayVolumeUnits": "mL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1"
+            ]
+          ],
+          "parameters": {
+            "format": "trough",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": false,
+            "loadName": "nest_1_reservoir_290ml",
+            "quirks": [
+              "centerMultichannelOnWells",
+              "touchTipDisabled"
+            ]
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 39.55,
+              "shape": "rectangular",
+              "totalLiquidVolume": 290000,
+              "x": 63.88,
+              "xDimension": 106.8,
+              "y": 42.74,
+              "yDimension": 71.2,
+              "z": 4.85
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ab92268f4b504e3234fad5d7d617170f",
+      "notes": [],
+      "params": {
+        "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+        "location": {
+          "slotName": "C2"
+        },
+        "namespace": "opentrons",
+        "version": 2
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "NEST",
+            "brandId": [
+              "402501"
+            ],
+            "links": [
+              "https://www.nest-biotech.com/pcr-plates/58773587.html"
+            ]
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.76,
+            "yDimension": 85.48,
+            "zDimension": 15.7
+          },
+          "gripForce": 15.0,
+          "gripHeightFromLabwareBottom": 10.65,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {
+                "wellBottomShape": "v"
+              },
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "wellPlate",
+            "displayName": "NEST 96 Well Plate 100 µL PCR Full Skirt",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": true,
+            "isTiprack": false,
+            "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+            "magneticModuleEngageHeight": 20
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_96_pcr_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 10.2
+            },
+            "opentrons_96_well_aluminum_block": {
+              "x": 0,
+              "y": 0,
+              "z": 12.66
+            }
+          },
+          "stackingOffsetWithModule": {
+            "thermocyclerModuleV2": {
+              "x": 0,
+              "y": 0,
+              "z": 10.8
+            }
+          },
+          "version": 2,
+          "wells": {
+            "A1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "A9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 74.24,
+              "z": 0.92
+            },
+            "B1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "B9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 65.24,
+              "z": 0.92
+            },
+            "C1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "C9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 56.24,
+              "z": 0.92
+            },
+            "D1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "D9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 47.24,
+              "z": 0.92
+            },
+            "E1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "E9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 38.24,
+              "z": 0.92
+            },
+            "F1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "F9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 29.24,
+              "z": 0.92
+            },
+            "G1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "G9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 20.24,
+              "z": 0.92
+            },
+            "H1": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 14.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H10": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 95.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H11": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 104.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H12": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 113.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H2": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 23.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H3": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 32.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H4": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 41.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H5": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 50.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H6": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 59.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H7": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 68.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H8": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 77.38,
+              "y": 11.24,
+              "z": 0.92
+            },
+            "H9": {
+              "depth": 14.78,
+              "diameter": 5.34,
+              "shape": "circular",
+              "totalLiquidVolume": 100,
+              "x": 86.38,
+              "y": 11.24,
+              "z": 0.92
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b78a4996a5952413f60b9207cb19867d",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_flex_96_tiprack_adapter",
+        "location": {
+          "slotName": "A2"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [
+            "adapter"
+          ],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": -14.25,
+            "y": -3.5,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 156.5,
+            "yDimension": 93,
+            "zDimension": 132
+          },
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {},
+              "wells": []
+            }
+          ],
+          "metadata": {
+            "displayCategory": "adapter",
+            "displayName": "Opentrons Flex 96 Tip Rack Adapter",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": false,
+            "loadName": "opentrons_flex_96_tiprack_adapter",
+            "quirks": [
+              "tiprackAdapterFor96Channel"
+            ]
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {}
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5651f92e0b3fa3005baf4698ab8d0591",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_flex_96_tiprack_1000ul",
+        "location": {
+          "labwareId": "UUID"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.75,
+            "yDimension": 85.75,
+            "zDimension": 99
+          },
+          "gripForce": 16.0,
+          "gripHeightFromLabwareBottom": 23.9,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {},
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "tipRack",
+            "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": true,
+            "loadName": "opentrons_flex_96_tiprack_1000ul",
+            "quirks": [],
+            "tipLength": 95.6,
+            "tipOverlap": 10.5
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_flex_96_tiprack_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 121
+            }
+          },
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "B1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "C1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "D1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "E1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "F1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "G1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "H1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 11.38,
+              "z": 1.5
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a7aa955a3b241ebff1821c35e8eb6bdf",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_flex_96_tiprack_1000ul",
+        "location": {
+          "slotName": "C3"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.75,
+            "yDimension": 85.75,
+            "zDimension": 99
+          },
+          "gripForce": 16.0,
+          "gripHeightFromLabwareBottom": 23.9,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {},
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "tipRack",
+            "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": true,
+            "loadName": "opentrons_flex_96_tiprack_1000ul",
+            "quirks": [],
+            "tipLength": 95.6,
+            "tipOverlap": 10.5
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_flex_96_tiprack_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 121
+            }
+          },
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "B1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "C1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "D1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "E1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "F1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "G1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "H1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 11.38,
+              "z": 1.5
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "393a8041bc4a5079a30a7e2e0b416d0b",
+      "notes": [],
+      "params": {
+        "loadName": "opentrons_flex_96_tiprack_1000ul",
+        "location": {
+          "addressableAreaName": "C4"
+        },
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "definition": {
+          "allowedRoles": [],
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": []
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "dimensions": {
+            "xDimension": 127.75,
+            "yDimension": 85.75,
+            "zDimension": 99
+          },
+          "gripForce": 16.0,
+          "gripHeightFromLabwareBottom": 23.9,
+          "gripperOffsets": {},
+          "groups": [
+            {
+              "metadata": {},
+              "wells": [
+                "A1",
+                "A10",
+                "A11",
+                "A12",
+                "A2",
+                "A3",
+                "A4",
+                "A5",
+                "A6",
+                "A7",
+                "A8",
+                "A9",
+                "B1",
+                "B10",
+                "B11",
+                "B12",
+                "B2",
+                "B3",
+                "B4",
+                "B5",
+                "B6",
+                "B7",
+                "B8",
+                "B9",
+                "C1",
+                "C10",
+                "C11",
+                "C12",
+                "C2",
+                "C3",
+                "C4",
+                "C5",
+                "C6",
+                "C7",
+                "C8",
+                "C9",
+                "D1",
+                "D10",
+                "D11",
+                "D12",
+                "D2",
+                "D3",
+                "D4",
+                "D5",
+                "D6",
+                "D7",
+                "D8",
+                "D9",
+                "E1",
+                "E10",
+                "E11",
+                "E12",
+                "E2",
+                "E3",
+                "E4",
+                "E5",
+                "E6",
+                "E7",
+                "E8",
+                "E9",
+                "F1",
+                "F10",
+                "F11",
+                "F12",
+                "F2",
+                "F3",
+                "F4",
+                "F5",
+                "F6",
+                "F7",
+                "F8",
+                "F9",
+                "G1",
+                "G10",
+                "G11",
+                "G12",
+                "G2",
+                "G3",
+                "G4",
+                "G5",
+                "G6",
+                "G7",
+                "G8",
+                "G9",
+                "H1",
+                "H10",
+                "H11",
+                "H12",
+                "H2",
+                "H3",
+                "H4",
+                "H5",
+                "H6",
+                "H7",
+                "H8",
+                "H9"
+              ]
+            }
+          ],
+          "metadata": {
+            "displayCategory": "tipRack",
+            "displayName": "Opentrons Flex 96 Tip Rack 1000 µL",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "namespace": "opentrons",
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ]
+          ],
+          "parameters": {
+            "format": "96Standard",
+            "isMagneticModuleCompatible": false,
+            "isTiprack": true,
+            "loadName": "opentrons_flex_96_tiprack_1000ul",
+            "quirks": [],
+            "tipLength": 95.6,
+            "tipOverlap": 10.5
+          },
+          "schemaVersion": 2,
+          "stackingOffsetWithLabware": {
+            "opentrons_flex_96_tiprack_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 121
+            }
+          },
+          "stackingOffsetWithModule": {},
+          "version": 1,
+          "wells": {
+            "A1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "A9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 74.38,
+              "z": 1.5
+            },
+            "B1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "B9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 65.38,
+              "z": 1.5
+            },
+            "C1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "C9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 56.38,
+              "z": 1.5
+            },
+            "D1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "D9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 47.38,
+              "z": 1.5
+            },
+            "E1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "E9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 38.38,
+              "z": 1.5
+            },
+            "F1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "F9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 29.38,
+              "z": 1.5
+            },
+            "G1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "G9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 20.38,
+              "z": 1.5
+            },
+            "H1": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 14.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H10": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 95.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H11": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 104.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H12": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 113.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H2": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 23.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H3": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 32.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H4": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 41.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H5": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 50.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H6": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 59.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H7": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 68.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H8": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 77.38,
+              "y": 11.38,
+              "z": 1.5
+            },
+            "H9": {
+              "depth": 97.5,
+              "diameter": 5.47,
+              "shape": "circular",
+              "totalLiquidVolume": 1000,
+              "x": 86.38,
+              "y": 11.38,
+              "z": 1.5
+            }
+          }
+        },
+        "labwareId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadPipette",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d37878e4a76e56d1c9f78661c19fc268",
+      "notes": [],
+      "params": {
+        "liquidPresenceDetection": false,
+        "mount": "left",
+        "pipetteName": "p1000_96",
+        "tipOverlapNotAfterVersion": "v1"
+      },
+      "result": {
+        "pipetteId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "loadLiquid",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ed3eae81517739fb8732a8c33660a711",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "liquidId": "UUID",
+        "volumeByWell": {
+          "A1": 29000.0
+        }
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "configureNozzleLayout",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2d531312465be507684de1d74b786e5d",
+      "notes": [],
+      "params": {
+        "configurationParams": {
+          "primaryNozzle": "A12",
+          "style": "COLUMN"
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "71b4dacb427e6f6bffccd915d013e8e4",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 342.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7e5f17ae8d0f29f168e5912bde10adc6",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "fde6a3018b3952d6b3e5038eb0da9842",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "737d00e8af88f6106a69291b3774a334",
+      "notes": [],
+      "params": {
+        "message": "Watch this next tip drop in the waste chute. We are going to compare it against the next drop in the waste chute."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "136ab01b35f7645925a5a772a2cf1b5e",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "96ChannelWasteChute",
+        "forceDirect": false,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID",
+        "stayAtHighestPossibleZ": false
+      },
+      "result": {
+        "position": {
+          "x": 391.945,
+          "y": 10.585,
+          "z": 114.5
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "140b261e88c4c6dfb7bb22243f05e1c3",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "529bb1ff92101ceebf086866dce08749",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A2"
+      },
+      "result": {
+        "position": {
+          "x": 351.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "74a5d3594180c7914c947ce8772dc467",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5fe5c3ef924f24957267740883f451dc",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A2"
+      },
+      "result": {
+        "position": {
+          "x": 187.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d78e3169a284434442095668a85c896e",
+      "notes": [],
+      "params": {
+        "message": "Watch this next tip drop in the waste chute. It should drop in a different location than the previous drop."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2153b23b18fc0912f28e60ebd44bd19f",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": true,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 466.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4be843dfe95cbc9c51d3d9a143c230af",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d1d38afd5ca73bcaa38bc5517ae9aeca",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A3"
+      },
+      "result": {
+        "position": {
+          "x": 360.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "acbb4946ad49f071c843d6c0ec8d400d",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d80d56bfb4ae6bed1079191e77332bbc",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A3"
+      },
+      "result": {
+        "position": {
+          "x": 196.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "31bd451e64123dcbdaaaae7f8cdd203c",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ef24273115ed0d7a3b9082948368e5d9",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "997094b10367e3b4c54342ca6709d511",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A4"
+      },
+      "result": {
+        "position": {
+          "x": 369.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7a3f9efb6bf02bd6e268a349a6a8aa2e",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b97a854748fee541d65c3fbaaed79ffc",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A4"
+      },
+      "result": {
+        "position": {
+          "x": 205.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "995bbfbdf9462fae9e633f300f75f3f3",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9fb2a736746160f6ddbdccf215e716c1",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "838336a67eab9798fb8f8b4c11f1f498",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A5"
+      },
+      "result": {
+        "position": {
+          "x": 378.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "0287a4dd7c406290aef242da06bd93cc",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c819578ece99ddbe3105450a14fe38dc",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A5"
+      },
+      "result": {
+        "position": {
+          "x": 214.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4c61b9776d93f178e8817aed0a3d4113",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9adfd7ad1927d998c32d896d3b3a4c0c",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5b407a4561742d53f4764f1ee080355c",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A6"
+      },
+      "result": {
+        "position": {
+          "x": 387.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3fe7e3b2cd692cd018963854ad46f636",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "e098701f0d883d66e7f0043291a8a7ea",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A6"
+      },
+      "result": {
+        "position": {
+          "x": 223.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4ed1139e9fa176861436700eb549e63c",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7a0706a6752115866aea9c74a3073c03",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "cda957cc63b8bca863d0e6b1b18274ee",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A7"
+      },
+      "result": {
+        "position": {
+          "x": 396.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a37858df7638086f7b13397a95924418",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "cb198e468644948976e46996738ee070",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A7"
+      },
+      "result": {
+        "position": {
+          "x": 232.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "47cdb4266a0f3992c3be0bce84d91ace",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1901ecc7b664d90a81e9fdd95eabeaf5",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "03ec35758a340692e9910e8d4bbde18e",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A8"
+      },
+      "result": {
+        "position": {
+          "x": 405.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "67ed9e8092a71a19e5ad3506b3b82045",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "32d6f6f302080d0737d35146f9d7962e",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A8"
+      },
+      "result": {
+        "position": {
+          "x": 241.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a95dd8f3e9ba2ac4089909bf6414ebf5",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ecf1419bcf9906e98e6405262d3debfc",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "36a56828b2f81b4ccfcfebe423a4b3fa",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A9"
+      },
+      "result": {
+        "position": {
+          "x": 414.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a12f4438255de6a8902274ad1a62a921",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "582afe7bd1564a6e9f6d6b4607b95104",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A9"
+      },
+      "result": {
+        "position": {
+          "x": 250.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7b335fd958008f5947a4dcc1a0bf4f19",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3c48219dcc5f23489c590efb076dd94c",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a64fd253c1e0891dbf266e46a1bcb424",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A10"
+      },
+      "result": {
+        "position": {
+          "x": 423.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "97b1b7da3cb8a586c4ab184838e09292",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9eb61c9387bd891c204e6a4061479c0e",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A10"
+      },
+      "result": {
+        "position": {
+          "x": 259.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9cff67de46a45cb055d50947afcdecb4",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d201058c88cd48141b21c6d259571857",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "0ac0a4a2aa3d84d895c2f83ff38acdaf",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A11"
+      },
+      "result": {
+        "position": {
+          "x": 432.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "29a279105f69a2309d73058e3d4983ef",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "11cb9af5ede3f0642861520e7621dcb5",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A11"
+      },
+      "result": {
+        "position": {
+          "x": 268.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "930758db855014596bfa19b1c1529bd1",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1e3120f6ad4fc16b39c06a47c4a1611c",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "e544dd10d11033ab0d4623b8d9f9e512",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A12"
+      },
+      "result": {
+        "position": {
+          "x": 441.38,
+          "y": 181.38,
+          "z": 99.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "39010129d0b58c303ab66fc296688790",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5bac9325bb5f7bbec4e4404173de46ce",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A12"
+      },
+      "result": {
+        "position": {
+          "x": 277.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f0a9749b2ac87cc6af972d9812f4f706",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTipInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f1131c7320aa73be4a3056cc5f490d22",
+      "notes": [],
+      "params": {
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a7ff27922283214930ea97630e68a1df",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": "offDeck",
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "configureNozzleLayout",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "fb78431e9807e7ad279d9e3aacc25321",
+      "notes": [],
+      "params": {
+        "configurationParams": {
+          "style": "ALL"
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3fad7505f312db97b533fc37f1c4fcfc",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 395.38,
+          "z": 110.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "41ee13ca47528f8a69a38241ad62ee92",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 10.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 10.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f752cea04bc326b8f91d05dbe24cf477",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 29.999999999999993
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 74.39999999999998
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5fe884095744c9b86e6b89273bcdff32",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 990.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 29.999999999999993
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 74.39999999999998
+        },
+        "volume": 990.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "39eb47551939017fd9c2c61536e8965d",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 10.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 10.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableArea",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6ba70f1e65749b3ce1cfb55a5f52a6af",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "96ChannelWasteChute",
+        "forceDirect": false,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID",
+        "stayAtHighestPossibleZ": false
+      },
+      "result": {
+        "position": {
+          "x": 391.945,
+          "y": 10.585,
+          "z": 114.5
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5b9de7703b5060c5ad36828e1c2af497",
+      "notes": [],
+      "params": {
+        "flowRate": 80.0,
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2203608fa4f4f82959f4a0b5d4e82be7",
+      "notes": [],
+      "params": {
+        "alternateDropLocation": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "origin": "default"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 395.38,
+          "z": 90.88
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "fbf547207d3091d7e144257ca660187f",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": "offDeck",
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b3d15d6b27ee21f5f94c28b6af98e449",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "fe2dcdd1096d8f10bc6f7c1e08afba32",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 395.38,
+          "z": 110.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6f454d64b916f2622b6eaeef969359c8",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "45771a871fe661d32db5ec1728ec253e",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "pushOut": 0.0,
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "42367b3d46709d62f72cc29a5e44c7a2",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "8fe076a253930698bb48c1ae02d5df41",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "pushOut": 0.0,
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "086b29b955fc444e72abfbabd0864bba",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "313f01a8a81c4c32484ed2529618c09f",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 5.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 5.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "dfcfd66f05b9efe9c398f8235700f5bf",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 10.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -38.55
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 5.85
+        },
+        "volume": 10.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "88c96216497a2360391135c7f6df743f",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 10.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 10.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f45d0387f245571d753d4d2698398053",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "297958a056744a17134d3ac02184a893",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "pushOut": 0.0,
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "83abe3ff7cd4e66bd1619ffe7d86514e",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1b804e4e3057f049715c4e876fbdab1a",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "pushOut": 0.0,
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d583be183d5d0252c49840aa4c5f4e17",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ebf7b91a638db36c212c7816de35d62a",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "pushOut": 0.0,
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "074950bd6544c5682e96e6266457e3e7",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ff2d7c53a987593d9e40fd7359029243",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "pushOut": 0.0,
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "aspirate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "0c23c9fc9b148efcad4542b8b1c981cb",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dispense",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6065049d6cb26a02713bab91f45409fb",
+      "notes": [],
+      "params": {
+        "flowRate": 160.0,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "volume": 15.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -13.78
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 1.92
+        },
+        "volume": 15.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "touchTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d8c9b0e21562d9e8a2d71bd1a3088120",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "radius": 1.0,
+        "speed": 60.0,
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": -1.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 14.7
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToAddressableAreaForDropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "216b5144155e6328c29185e03e04d9fc",
+      "notes": [],
+      "params": {
+        "addressableAreaName": "movableTrashB3",
+        "alternateDropLocation": false,
+        "forceDirect": false,
+        "ignoreTipConfiguration": true,
+        "offset": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "pipetteId": "UUID"
+      },
+      "result": {
+        "position": {
+          "x": 434.25,
+          "y": 257.0,
+          "z": 40.0
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "blowOutInPlace",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "76d8d70471c849fbb67590c55569e0d3",
+      "notes": [],
+      "params": {
+        "flowRate": 80.0,
+        "pipetteId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d5f11283aab1b275929aa6646e2501c2",
+      "notes": [],
+      "params": {
+        "alternateDropLocation": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "origin": "default"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 395.38,
+          "z": 90.88
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "160a7ab232d0bde9614f5b50222e6c47",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "B2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "0b2e5f3f7e608c2e7809bd44834e49de",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c1b1f44c9384e17cee9f4803cb6677a6",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "10afb0f01a2fb77a5782f457a43d2e6f",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c7450aedb2378d40924e4cc7ca21c1be",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "bedc428849a98177a0948e3ba09aa2fb",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "995e4fa6089b0cedb71bd5b09166f328",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "bc07c3745e60ace9bd79e32da0282c78",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "bd7ca9ffc5e07f93ec347f82c91ce0d8",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b2160ce092056873801d0a32dce0a4b8",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3f57afd0650f406adf94d5a92458aeb7",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f90db57f7711f960a031e604bbfd3527",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "73e73a08e679ca0a7cbe7429f8a19b4a",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6692e58ba746f30a1b20687b8e99f4db",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4937b5c0e66d249d5ea96c43fa6d3b2c",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d371cbd83b68cbffb7be6e25c3b68254",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ed9ecc43aab2bd29ad40098a385c93f9",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a9e809dd92546b32573d4ad6bcf3ece7",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c09f686c7dfe6697f6a3650094dbbc84",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "57506d028b0bcce90126749a1fd78c14",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "95a76257deaafc3511b4371fd4fdfe7c",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9170705ba451d685ebfaf3f76ee1f1c3",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "bf641708f9433ec6744081d5573913ab",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "c6a63df9d1acc9e73b5f53f2245450bb",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "85fca02411de028dbfdbbdc6c1449f04",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C3"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b3191029b7084631dbe2a973173fa0fd",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a2149fb398199b39e9e20632f6d86267",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "C4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4b59c64f39d68ad908977acf4f00d679",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "292d13a13702fc64e5a545f66084a9ed",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5f28890d1583622413104e78e49b972f",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1a8be3a9a462d031db7b4e83d006043d",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7192937c83a4e042b1de5f4e3ed7a369",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9db1443bddce9820e6b2a0c9ebc06fbc",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d4fb5f99aa44449ee8e8fb97e826adb7",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "b2cb512ab153071d3a68707d72641970",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "413db0f9371d377115869f86146fcfdf",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7b77a6ee758490ba92d9c680f05c2260",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "8241488919ed3ef8f98b798f5fe6dcbe",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "96567f35c139359e0dd78d2e2efa2f4e",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4943cfdb3c86ccd8d7d1a11fb475f735",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "94e6e80c5c1825072c8cd5d2ebb08d58",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "58bfa52776a904da1e9f1b712e921bab",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "064d7ea7cb0199e8940a61bd8ef4a304",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2ae533a493737ec7675837e6d2cf5b12",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "71d14cb299af0a874e39a12e99622ac8",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "83f9d678c823c6871201a8b8b2b25016",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5eae1da80a301e29d1cc96bc9a29e469",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5a8d298ec5e6d6874e893b82db46a522",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3dccee169c309dd15da64f18169cf442",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6727a0e54c2c0f7700a43624095ec428",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "19561ef0794ab922a456e8c45915ff37",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "114a0dcbd0064a8ed77cea50000d9b7c",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "97f2d2f8c37f5c63a2fcb149b2909a23",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "267d50a0e30718468d7c2bb196e5d595",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "109b0d6cc2de4a735a725661c4f53dff",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "85291ee0a8adc54d24f054a67fb02403",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "363dfae708e94787fc96b8bb7aa0603f",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7fd72c0a3dcc8a53bcee5a0a8798c362",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "71d26c514a7f9e4f58d5c295865ad52f",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "e8be22847742ce9065c4553921286c9f",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "acc5a3b11a76a3b94fd2ea1c50be5524",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "moduleId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "9b181dc059582b482ffa981202edcb04",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "14065f8e3ac83f81fd739499a2da7f4b",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7647627c7c4e481c781ee10a041dbb29",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "labwareId": "UUID"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a6e7f07768306bb5569bcb5e709e8f90",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/closeLid",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "42e95cae75c0eb587706690e34d41856",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/setTargetBlockTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "815b8e29cd92839a9881d53248c2b76d",
+      "notes": [],
+      "params": {
+        "celsius": 60.0,
+        "holdTimeSeconds": 5.0,
+        "moduleId": "UUID"
+      },
+      "result": {
+        "targetBlockTemperature": 60.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/waitForBlockTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "56aaddcfd610c2ef06fce593f5078359",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/setTargetLidTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7ab0747b1e81aba42ba062b7844445da",
+      "notes": [],
+      "params": {
+        "celsius": 80.0,
+        "moduleId": "UUID"
+      },
+      "result": {
+        "targetLidTemperature": 80.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/waitForLidTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3b0b16b60e7c54da388623e97b9abfe1",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/deactivateBlock",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4c5a8cdcf1b80f8b52784c617c6a3935",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "thermocycler/deactivateLid",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "89f39e33eeea745fecab5677e73dd375",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/openLabwareLatch",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1c9e89c5ad50b1e55f2e067c61e7a1e5",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {
+        "pipetteRetracted": true
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/closeLabwareLatch",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "260b10dd96e32aaa9819280862ef4de1",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/setTargetTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "e9fda4fea2acd77b7dc906ec137b9993",
+      "notes": [],
+      "params": {
+        "celsius": 50.0,
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/setAndWaitForShakeSpeed",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "cf976c11efc8a4838c9b6519eac529be",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID",
+        "rpm": 1000.0
+      },
+      "result": {
+        "pipetteRetracted": true
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/waitForTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "2805479d9b17392b077dceb0104fec1b",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/deactivateHeater",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4f94f50070ec9fc5a620c23719aafd01",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "heaterShaker/deactivateShaker",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "86d319fee8ceae8095389836864b2d43",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "temperatureModule/setTargetTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "ebba384aa94f7264d7c484a31cbb738f",
+      "notes": [],
+      "params": {
+        "celsius": 50.0,
+        "moduleId": "UUID"
+      },
+      "result": {
+        "targetTemperature": 50.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "temperatureModule/waitForTemperature",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "d043d5ac8a84b6974db1bbbbcba211e0",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "temperatureModule/deactivate",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "550806039eea80d5525c6001c3a7666d",
+      "notes": [],
+      "params": {
+        "moduleId": "UUID"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "47c406a0d89c37753d88aa54bf7f72b3",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "D4"
+        },
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "72676cdca5ae8394dd6e6158b9dab9ee",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": "offDeck",
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "pickUpTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "1a284def350e912e902a648cba064cce",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 395.38,
+          "z": 110.0
+        },
+        "tipDiameter": 5.47,
+        "tipLength": 85.38999999999999,
+        "tipVolume": 1000.0
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "20d79f182152c0f3b5c8bcafc07aa4c8",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 15.7
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "217563003b8a0a95100c4e1153819c38",
+      "notes": [],
+      "params": {
+        "message": "Is the pipette tip in the middle of the PCR Plate, well A1, in slot C2? It should be at the LPC calibrated height."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "reloadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "efc8bf902896ebfa2df28b5309c0ad2b",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID"
+      },
+      "result": {
+        "labwareId": "UUID",
+        "offsetId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "953c0d4cf00b4b15bad57b0068917a1a",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 25.700000000000003
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "11fccc4812167d91db9c6794d60377d2",
+      "notes": [],
+      "params": {
+        "message": "Is the pipette tip in the middle of the PCR Plate, well A1, in slot C2? It should be 10mm higher than the LPC calibrated height."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "87397b0bc4efe14e59047204629bac0c",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "D2"
+        },
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "5504d2c0b6725179832363f618535123",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 74.24,
+          "z": 15.7
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "6db8184e49b8f0dc341fab21cd407193",
+      "notes": [],
+      "params": {
+        "message": "Is the pipette tip in the middle of the PCR Plate, well A1, in slot D2? It should be at the LPC calibrated height."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "reloadLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "598d9f8200e30e4b18930759933c177e",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID"
+      },
+      "result": {
+        "labwareId": "UUID",
+        "offsetId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "3e47d788bbb80170708184edfe5d5855",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 74.24,
+          "z": 25.700000000000003
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "4d36a2b966013bbc7b01c4b09ff722a5",
+      "notes": [],
+      "params": {
+        "message": "Is the pipette tip in the middle of the PCR Plate, well A1, in slot D2? It should be 10mm higher than the LPC calibrated height."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "7105ddfa795ef939e45de1f624ad74e2",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "C2"
+        },
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {
+        "offsetId": "UUID"
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "96531fb16b3554d5394f56a186180323",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 181.24,
+          "z": 25.700000000000003
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "8ce8f477d0773532932dc9ce801b5161",
+      "notes": [],
+      "params": {
+        "message": "Is the pipette tip in the middle of the PCR Plate, well A1, in slot C2? It should be 10mm higher than the LPC calibrated height."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "a756799f8ef42de5f9dc552e9361a39c",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "slotName": "D2"
+        },
+        "strategy": "manualMoveWithPause"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveToWell",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "8a2981064bc103a5a4f9b865d234d674",
+      "notes": [],
+      "params": {
+        "forceDirect": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          "origin": "top"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 227.88,
+          "y": 42.74,
+          "z": 44.4
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "77bb267c15b76e8e075a1d8d6e626960",
+      "notes": [],
+      "params": {
+        "message": "Is the pipette tip in the middle of the reservoir , well A1, in slot D2? It should be at the LPC calibrated height."
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "dropTip",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "f98e7bf42290f6ec61132a6d11b082fc",
+      "notes": [],
+      "params": {
+        "alternateDropLocation": false,
+        "labwareId": "UUID",
+        "pipetteId": "UUID",
+        "wellLocation": {
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "origin": "default"
+        },
+        "wellName": "A1"
+      },
+      "result": {
+        "position": {
+          "x": 178.38,
+          "y": 395.38,
+          "z": 90.88
+        }
+      },
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "waitForResume",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "dba1918199fa07e1b9158aeecf0d4794",
+      "notes": [],
+      "params": {
+        "message": "!!!!!!!!!!YOU NEED TO REDO LPC!!!!!!!!!!"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "09d6512b2e7f3d96cac736da70819111",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "gripperWasteChute"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    },
+    {
+      "commandType": "moveLabware",
+      "completedAt": "TIMESTAMP",
+      "createdAt": "TIMESTAMP",
+      "id": "UUID",
+      "key": "624e7ca7028f54c8442ef1de0638b427",
+      "notes": [],
+      "params": {
+        "labwareId": "UUID",
+        "newLocation": {
+          "addressableAreaName": "gripperWasteChute"
+        },
+        "strategy": "usingGripper"
+      },
+      "result": {},
+      "startedAt": "TIMESTAMP",
+      "status": "succeeded"
+    }
+  ],
+  "config": {
+    "apiVersion": [
+      2,
+      19
+    ],
+    "protocolType": "python"
+  },
+  "createdAt": "TIMESTAMP",
+  "errors": [],
+  "files": [
+    {
+      "name": "Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke.py",
+      "role": "main"
+    }
+  ],
+  "labware": [
+    {
+      "definitionUri": "opentrons/opentrons_96_well_aluminum_block/1",
+      "id": "UUID",
+      "loadName": "opentrons_96_well_aluminum_block",
+      "location": {
+        "moduleId": "UUID"
+      }
+    },
+    {
+      "definitionUri": "opentrons/opentrons_96_pcr_adapter/1",
+      "id": "UUID",
+      "loadName": "opentrons_96_pcr_adapter",
+      "location": {
+        "moduleId": "UUID"
+      }
+    },
+    {
+      "definitionUri": "opentrons/nest_1_reservoir_290ml/1",
+      "id": "UUID",
+      "loadName": "nest_1_reservoir_290ml",
+      "location": "offDeck"
+    },
+    {
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "loadName": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "location": "offDeck"
+    },
+    {
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_adapter/1",
+      "id": "UUID",
+      "loadName": "opentrons_flex_96_tiprack_adapter",
+      "location": {
+        "slotName": "A2"
+      }
+    },
+    {
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+      "id": "UUID",
+      "loadName": "opentrons_flex_96_tiprack_1000ul",
+      "location": "offDeck"
+    },
+    {
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+      "id": "UUID",
+      "loadName": "opentrons_flex_96_tiprack_1000ul",
+      "location": "offDeck"
+    },
+    {
+      "definitionUri": "opentrons/opentrons_flex_96_tiprack_1000ul/1",
+      "id": "UUID",
+      "loadName": "opentrons_flex_96_tiprack_1000ul",
+      "location": {
+        "labwareId": "UUID"
+      }
+    }
+  ],
+  "liquids": [
+    {
+      "description": "High Quality H₂O",
+      "displayColor": "#42AB2D",
+      "displayName": "water",
+      "id": "UUID"
+    }
+  ],
+  "metadata": {
+    "author": "Derek Maggio <derek.maggio@opentrons.com>",
+    "protocolName": "Flex Smoke Test - v2.19"
+  },
+  "modules": [
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "B1"
+      },
+      "model": "thermocyclerModuleV2",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "C1"
+      },
+      "model": "magneticBlockV1"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "A3"
+      },
+      "model": "heaterShakerModuleV1",
+      "serialNumber": "UUID"
+    },
+    {
+      "id": "UUID",
+      "location": {
+        "slotName": "D1"
+      },
+      "model": "temperatureModuleV2",
+      "serialNumber": "UUID"
+    }
+  ],
+  "pipettes": [
+    {
+      "id": "UUID",
+      "mount": "left",
+      "pipetteName": "p1000_96"
+    }
+  ],
+  "result": "ok",
+  "robotType": "OT-3 Standard",
+  "runTimeParameters": [
+    {
+      "choices": [
+        {
+          "displayName": "QA Smoke Test",
+          "value": "qa"
+        },
+        {
+          "displayName": "Developer Validation",
+          "value": "dev"
+        }
+      ],
+      "default": "qa",
+      "description": "Configuration of QA test to perform",
+      "displayName": "Test Configuration",
+      "type": "str",
+      "value": "qa",
+      "variableName": "test_configuration"
+    },
+    {
+      "choices": [
+        {
+          "displayName": "Agilent 1 Well 290 mL",
+          "value": "agilent_1_reservoir_290ml"
+        },
+        {
+          "displayName": "Nest 1 Well 290 mL",
+          "value": "nest_1_reservoir_290ml"
+        }
+      ],
+      "default": "nest_1_reservoir_290ml",
+      "description": "Name of the reservoir",
+      "displayName": "Reservoir Name",
+      "type": "str",
+      "value": "nest_1_reservoir_290ml",
+      "variableName": "reservoir_name"
+    },
+    {
+      "choices": [
+        {
+          "displayName": "Nest 96 Well 100 µL",
+          "value": "nest_96_wellplate_100ul_pcr_full_skirt"
+        },
+        {
+          "displayName": "Corning 96 Well 360 µL",
+          "value": "corning_96_wellplate_360ul_flat"
+        },
+        {
+          "displayName": "Opentrons Tough 96 Well 200 µL",
+          "value": "opentrons_96_wellplate_200ul_pcr_full_skirt"
+        }
+      ],
+      "default": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "description": "Name of the well plate",
+      "displayName": "Well Plate Name",
+      "type": "str",
+      "value": "nest_96_wellplate_100ul_pcr_full_skirt",
+      "variableName": "well_plate_name"
+    },
+    {
+      "default": false,
+      "description": "Prefer to use the gripper to dispose of labware, instead of manual moves off deck",
+      "displayName": "I LOVE TO REFILL TIP RACKS",
+      "type": "bool",
+      "value": false,
+      "variableName": "prefer_gripper_disposal"
+    }
+  ]
+}


### PR DESCRIPTION
# Overview

Changes to `analyses-snapshot-testing` should trigger the tests to run.

# Test Plan

- [x] ~~due to merge of #15805 test should fail~~ doesn't fail because I forgot how file addition works
- [x] trigger update PR with the label (added during PR creation)
- [x] added the files to the test but no snapshot so the test should fail
- [x] merge the snapshot heal
- [x] see the test pass