### PR TITLE
fix(protocol-designer): fix well depth for blowout field

### DIFF
--- a/protocol-designer/src/components/StepEditForm/fields/BlowoutZOffsetField.tsx
+++ b/protocol-designer/src/components/StepEditForm/fields/BlowoutZOffsetField.tsx
@@ -4,6 +4,7 @@ import {
   DEST_WELL_BLOWOUT_DESTINATION,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '@opentrons/step-generation'
+import { getWellDepth } from '@opentrons/shared-data'
 import {
   COLORS,
   Flex,
@@ -45,9 +46,9 @@ export function BlowoutZOffsetField(
     labwareId = destLabwareId
   }
 
-  const labwareZDimension =
-    labwareId != null
-      ? labwareEntities[String(labwareId)]?.def.dimensions.zDimension
+  const labwareWellDepth =
+    labwareId != null && labwareEntities[String(labwareId)]?.def != null
+      ? getWellDepth(labwareEntities[String(labwareId)].def, 'A1')
       : 0
 
   return (
@@ -61,7 +62,7 @@ export function BlowoutZOffsetField(
           name={name}
           zValue={Number(value)}
           updateValue={updateValue}
-          wellDepthMm={labwareZDimension}
+          wellDepthMm={labwareWellDepth}
         />
       ) : null}
       <Flex


### PR DESCRIPTION
closes RESC-309

# Overview

Good catch by the user here. instead of taking the well's depth, it was taking the labware's full height

# Test Plan

Create an ot-2 or flex protocol and add a labware to the deck. make a transfer step and add a touchtip and blowout. verify that the touch tip tip position height and the blowout tip position height are the same. 

# Changelog

- get well depth instead of z dimension

# Review requests

see test plan

# Risk assessment

low
