### PR TITLE
refactor(app): add id prop for a case that there are 2 same label

### DIFF
--- a/app/src/atoms/buttons/RadioButton.tsx
+++ b/app/src/atoms/buttons/RadioButton.tsx
@@ -20,6 +20,7 @@ interface RadioButtonProps extends StyleProps {
   isSelected?: boolean
   radioButtonType?: 'large' | 'small'
   subButtonLabel?: string
+  id?: string
 }
 
 export function RadioButton(props: RadioButtonProps): JSX.Element {
@@ -31,6 +32,7 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
     onChange,
     radioButtonType = 'large',
     subButtonLabel,
+    id = buttonLabel,
   } = props
 
   const isLarge = radioButtonType === 'large'
@@ -84,12 +86,12 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
       <SettingButton
         checked={isSelected}
         disabled={disabled}
-        id={buttonLabel}
+        id={id}
         onChange={onChange}
         type="radio"
         value={buttonValue}
       />
-      <SettingButtonLabel role="label" htmlFor={buttonLabel}>
+      <SettingButtonLabel role="label" htmlFor={id}>
         <StyledText
           oddStyle={isLarge ? 'level4HeaderRegular' : 'bodyTextRegular'}
           desktopStyle="bodyDefaultRegular"

--- a/app/src/atoms/buttons/__tests__/RadioButton.test.tsx
+++ b/app/src/atoms/buttons/__tests__/RadioButton.test.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import '@testing-library/jest-dom/vitest'
+import { screen, queryByAttribute } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { COLORS, SPACING } from '@opentrons/components'
 import { renderWithProviders } from '../../../__testing-utils__'
 
 import { RadioButton } from '..'
-import { screen } from '@testing-library/react'
 
 const render = (props: React.ComponentProps<typeof RadioButton>) => {
   return renderWithProviders(<RadioButton {...props} />)[0]
@@ -20,6 +20,7 @@ describe('RadioButton', () => {
       buttonValue: 1,
     }
   })
+
   it('renders the large button', () => {
     props = {
       ...props,
@@ -30,6 +31,7 @@ describe('RadioButton', () => {
     expect(label).toHaveStyle(`background-color: ${COLORS.blue35}`)
     expect(label).toHaveStyle(`padding: ${SPACING.spacing24}`)
   })
+
   it('renders the large selected button', () => {
     props = {
       ...props,
@@ -41,6 +43,7 @@ describe('RadioButton', () => {
     expect(label).toHaveStyle(`background-color: ${COLORS.blue50}`)
     expect(label).toHaveStyle(`padding: ${SPACING.spacing24}`)
   })
+
   it('renders the small button', () => {
     props = {
       ...props,
@@ -51,6 +54,7 @@ describe('RadioButton', () => {
     expect(label).toHaveStyle(`background-color: ${COLORS.blue35}`)
     expect(label).toHaveStyle(`padding: ${SPACING.spacing20}`)
   })
+
   it('renders the small selected button', () => {
     props = {
       ...props,
@@ -61,5 +65,24 @@ describe('RadioButton', () => {
     const label = screen.getByRole('label')
     expect(label).toHaveStyle(`background-color: ${COLORS.blue50}`)
     expect(label).toHaveStyle(`padding: ${SPACING.spacing20}`)
+  })
+
+  it('renders id instead of buttonLabel when id is set', () => {
+    props = {
+      ...props,
+      id: 'mock-radio-button-id',
+    }
+    render(props)
+    const getById = queryByAttribute.bind(null, 'id')
+    const idRadioButton = getById(
+      render(props).container,
+      'mock-radio-button-id'
+    )
+    expect(idRadioButton).toBeInTheDocument()
+    const buttonLabelIdRadioButton = getById(
+      render(props).container,
+      props.buttonLabel
+    )
+    expect(buttonLabelIdRadioButton).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
<!--
Thanks for taking the time to open a pull request! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
Add `id` as a new prop. We need this because the current implementation does not anticipate that the same label will be used on the same screen.

fix AUTH-604 partially (the rest of tasks, updating radio button in ChooseCSVFile is followed by https://github.com/Opentrons/opentrons/pull/15731 )
<!--
Use this section to describe your pull-request at a high level. If the PR addresses any open issues, please tag the issues here.
-->

# Test Plan

<!--
Use this section to describe the steps that you took to test your Pull Request.
If you did not perform any testing provide justification why.

OT-3 Developers: You should default to testing on actual physical hardware.
Once again, if you did not perform testing against hardware, justify why.

Note: It can be helpful to write a test plan before doing development

Example Test Plan (HTTP API Change)

- Verified that new optional argument `dance-party` causes the robot to flash its lights, move the pipettes,
then home.
- Verified that when you omit the `dance-party` option the robot homes normally
- Added protocol that uses `dance-party` argument to G-Code Testing Suite
- Ran protocol that did not use `dance-party` argument and everything was successful
- Added unit tests to validate that changes to pydantic model are correct

-->

# Changelog
- add `id` as a prop
- add a test case for `id`
<!--
List out the changes to the code in this PR. Please try your best to categorize your changes and describe what has changed and why.

Example changelog:
- Fixed app crash when trying to calibrate an illegal pipette
- Added state to API to track pipette usage
- Updated API docs to mention only two pipettes are supported

IMPORTANT: MAKE SURE ANY BREAKING CHANGES ARE PROPERLY COMMUNICATED
-->

# Review requests

<!--
Describe any requests for your reviewers here.
-->

# Risk assessment
low (this pr doesn't have any impact on existing radio buttons)
<!--
Carefully go over your pull request and look at the other parts of the codebase it may affect. Look for the possibility, even if you think it's small, that your change may affect some other part of the system - for instance, changing return tip behavior in protocol may also change the behavior of labware calibration.

Identify the other parts of the system your codebase may affect, so that in addition to your own review and testing, other people who may not have the system internalized as much as you can focus their attention and testing there.
-->
