### PR TITLE
feat(api): Allow changing the error recovery policy during a run

### DIFF
--- a/api/src/opentrons/protocol_engine/actions/actions.py
+++ b/api/src/opentrons/protocol_engine/actions/actions.py
@@ -20,7 +20,7 @@ from ..commands import (
     CommandDefinedErrorData,
     CommandPrivateResult,
 )
-from ..error_recovery_policy import ErrorRecoveryType
+from ..error_recovery_policy import ErrorRecoveryPolicy, ErrorRecoveryType
 from ..notes.notes import CommandNote
 from ..types import (
     LabwareOffsetCreate,
@@ -266,6 +266,13 @@ class SetPipetteMovementSpeedAction:
     speed: Optional[float]
 
 
+@dataclass(frozen=True)
+class SetErrorRecoveryPolicyAction:
+    """See `ProtocolEngine.set_error_recovery_policy()`."""
+
+    error_recovery_policy: ErrorRecoveryPolicy
+
+
 Action = Union[
     PlayAction,
     PauseAction,
@@ -286,4 +293,5 @@ Action = Union[
     AddLiquidAction,
     ResetTipsAction,
     SetPipetteMovementSpeedAction,
+    SetErrorRecoveryPolicyAction,
 ]

--- a/api/src/opentrons/protocol_engine/create_protocol_engine.py
+++ b/api/src/opentrons/protocol_engine/create_protocol_engine.py
@@ -53,6 +53,7 @@ async def create_protocol_engine(
         deck_fixed_labware=deck_fixed_labware,
         robot_definition=robot_definition,
         is_door_open=hardware_api.door_state is DoorState.OPEN,
+        error_recovery_policy=error_recovery_policy,
         module_calibration_offsets=module_calibration_offsets,
         deck_configuration=deck_configuration,
         notify_publishers=notify_publishers,
@@ -61,7 +62,6 @@ async def create_protocol_engine(
     return ProtocolEngine(
         state_store=state_store,
         hardware_api=hardware_api,
-        error_recovery_policy=error_recovery_policy,
     )
 
 

--- a/api/src/opentrons/protocol_engine/error_recovery_policy.py
+++ b/api/src/opentrons/protocol_engine/error_recovery_policy.py
@@ -56,28 +56,6 @@ class ErrorRecoveryPolicy(Protocol):
         ...
 
 
-# todo(mm, 2024-07-05): This "static" policy will need to somehow become dynamic for
-# https://opentrons.atlassian.net/browse/EXEC-589.
-def standard_run_policy(
-    config: Config,
-    failed_command: Command,
-    defined_error_data: Optional[CommandDefinedErrorData],
-) -> ErrorRecoveryType:
-    """An error recovery policy suitable for normal protocol runs via robot-server."""
-    # Although error recovery can theoretically work on OT-2s, we haven't tested it,
-    # and it's generally scarier because the OT-2 has much less hardware feedback.
-    robot_is_flex = config.robot_type == "OT-3 Standard"
-    # If the error is defined, we're taking that to mean that we should
-    # WAIT_FOR_RECOVERY. This is not necessarily the right long-term logic--we might
-    # want to FAIL_RUN on certain defined errors and WAIT_FOR_RECOVERY on certain
-    # undefined errors--but this is convenient for now.
-    error_is_defined = defined_error_data is not None
-    if robot_is_flex and error_is_defined:
-        return ErrorRecoveryType.WAIT_FOR_RECOVERY
-    else:
-        return ErrorRecoveryType.FAIL_RUN
-
-
 def never_recover(
     config: Config,
     failed_command: Command,

--- a/api/src/opentrons/protocol_engine/execution/command_executor.py
+++ b/api/src/opentrons/protocol_engine/execution/command_executor.py
@@ -12,7 +12,6 @@ from opentrons_shared_data.errors.exceptions import (
 )
 
 from opentrons.protocol_engine.commands.command import SuccessData
-from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 
 from ..state import StateStore
 from ..resources import ModelUtils
@@ -84,7 +83,6 @@ class CommandExecutor:
         run_control: RunControlHandler,
         rail_lights: RailLightsHandler,
         status_bar: StatusBarHandler,
-        error_recovery_policy: ErrorRecoveryPolicy,
         model_utils: Optional[ModelUtils] = None,
         command_note_tracker_provider: Optional[CommandNoteTrackerProvider] = None,
     ) -> None:
@@ -105,7 +103,6 @@ class CommandExecutor:
         self._command_note_tracker_provider = (
             command_note_tracker_provider or _NoteTracker
         )
-        self._error_recovery_policy = error_recovery_policy
 
     async def execute(self, command_id: str) -> None:
         """Run a given command's execution procedure.
@@ -138,6 +135,7 @@ class CommandExecutor:
             RunCommandAction(command_id=queued_command.id, started_at=started_at)
         )
         running_command = self._state_store.commands.get(queued_command.id)
+        error_recovery_policy = self._state_store.commands.get_error_recovery_policy()
 
         log.debug(
             f"Executing {running_command.id}, {running_command.commandType}, {running_command.params}"
@@ -168,7 +166,7 @@ class CommandExecutor:
                     error_id=self._model_utils.generate_id(),
                     failed_at=self._model_utils.get_timestamp(),
                     notes=note_tracker.get_notes(),
-                    type=self._error_recovery_policy(
+                    type=error_recovery_policy(
                         self._state_store.config,
                         running_command,
                         None,
@@ -200,7 +198,7 @@ class CommandExecutor:
                         error_id=result.public.id,
                         failed_at=result.public.createdAt,
                         notes=note_tracker.get_notes(),
-                        type=self._error_recovery_policy(
+                        type=error_recovery_policy(
                             self._state_store.config,
                             running_command,
                             result,

--- a/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
+++ b/api/src/opentrons/protocol_engine/execution/create_queue_worker.py
@@ -2,7 +2,6 @@
 from typing import AsyncGenerator, Callable
 
 from opentrons.hardware_control import HardwareControlAPI
-from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 from opentrons.protocol_engine.execution.rail_lights import RailLightsHandler
 
 from ..state import StateStore
@@ -23,7 +22,6 @@ def create_queue_worker(
     hardware_api: HardwareControlAPI,
     state_store: StateStore,
     action_dispatcher: ActionDispatcher,
-    error_recovery_policy: ErrorRecoveryPolicy,
     command_generator: Callable[[], AsyncGenerator[str, None]],
 ) -> QueueWorker:
     """Create a ready-to-use QueueWorker instance.
@@ -91,7 +89,6 @@ def create_queue_worker(
         run_control=run_control_handler,
         rail_lights=rail_lights_handler,
         status_bar=status_bar_handler,
-        error_recovery_policy=error_recovery_policy,
     )
 
     return QueueWorker(

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -15,8 +15,12 @@ from opentrons.hardware_control.types import DoorState
 from opentrons.protocol_engine.actions.actions import (
     ResumeFromRecoveryAction,
     RunCommandAction,
+    SetErrorRecoveryPolicyAction,
 )
-from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
+from opentrons.protocol_engine.error_recovery_policy import (
+    ErrorRecoveryPolicy,
+    ErrorRecoveryType,
+)
 from opentrons.protocol_engine.notes.notes import CommandNote
 
 from ..actions import (
@@ -202,6 +206,9 @@ class CommandState:
     stopped_by_estop: bool
     """If this is set to True, the engine was stopped by an estop event."""
 
+    error_recovery_policy: ErrorRecoveryPolicy
+    """See `CommandView.get_error_recovery_policy()`."""
+
 
 class CommandStore(HasState[CommandState], HandlesActions):
     """Command state container for run-level command concerns."""
@@ -213,6 +220,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
         *,
         config: Config,
         is_door_open: bool,
+        error_recovery_policy: ErrorRecoveryPolicy,
     ) -> None:
         """Initialize a CommandStore and its state."""
         self._config = config
@@ -230,6 +238,7 @@ class CommandStore(HasState[CommandState], HandlesActions):
             run_started_at=None,
             latest_protocol_command_hash=None,
             stopped_by_estop=False,
+            error_recovery_policy=error_recovery_policy,
         )
 
     def handle_action(self, action: Action) -> None:
@@ -257,6 +266,8 @@ class CommandStore(HasState[CommandState], HandlesActions):
                 self._handle_hardware_stopped_action(action)
             case DoorChangeAction():
                 self._handle_door_change_action(action)
+            case SetErrorRecoveryPolicyAction():
+                self._handle_set_error_recovery_policy_action(action)
             case _:
                 pass
 
@@ -458,6 +469,11 @@ class CommandStore(HasState[CommandState], HandlesActions):
                         self._state.queue_status = QueueStatus.AWAITING_RECOVERY_PAUSED
             elif action.door_state == DoorState.CLOSED:
                 self._state.is_door_blocking = False
+
+    def _handle_set_error_recovery_policy_action(
+        self, action: SetErrorRecoveryPolicyAction
+    ) -> None:
+        self._state.error_recovery_policy = action.error_recovery_policy
 
     def _update_to_failed(
         self,
@@ -985,3 +1001,12 @@ class CommandView(HasState[CommandState]):
     def get_latest_protocol_command_hash(self) -> Optional[str]:
         """Get the command hash of the last queued command, if any."""
         return self._state.latest_protocol_command_hash
+
+    def get_error_recovery_policy(self) -> ErrorRecoveryPolicy:
+        """Return the run's current error recovery policy (see `ErrorRecoveryPolicy`).
+
+        This error recovery policy is not ever evaluated by
+        `CommandStore`/`CommandView`. It's stored here for convenience, but evaluated by
+        higher-level code.
+        """
+        return self._state.error_recovery_policy

--- a/api/src/opentrons/protocol_engine/state/state.py
+++ b/api/src/opentrons/protocol_engine/state/state.py
@@ -8,6 +8,7 @@ from typing_extensions import ParamSpec
 from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.robot.types import RobotDefinition
 
+from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 from opentrons.protocol_engine.types import ModuleOffsetData
 from opentrons.util.change_notifier import ChangeNotifier
 
@@ -147,6 +148,7 @@ class StateStore(StateView, ActionHandler):
         deck_fixed_labware: Sequence[DeckFixedLabware],
         robot_definition: RobotDefinition,
         is_door_open: bool,
+        error_recovery_policy: ErrorRecoveryPolicy,
         change_notifier: Optional[ChangeNotifier] = None,
         module_calibration_offsets: Optional[Dict[str, ModuleOffsetData]] = None,
         deck_configuration: Optional[DeckConfigurationType] = None,
@@ -161,13 +163,18 @@ class StateStore(StateView, ActionHandler):
             deck_fixed_labware: Labware definitions from the deck
                 definition to preload into labware state.
             is_door_open: Whether the robot's door is currently open.
+            error_recovery_policy: The run's initial error recovery policy.
             change_notifier: Internal state change notifier.
             module_calibration_offsets: Module offsets to preload.
             deck_configuration: The initial deck configuration the addressable area store will be instantiated with.
             robot_definition: Static information about the robot type being used.
             notify_publishers: Notifies robot server publishers of internal state change.
         """
-        self._command_store = CommandStore(config=config, is_door_open=is_door_open)
+        self._command_store = CommandStore(
+            config=config,
+            is_door_open=is_door_open,
+            error_recovery_policy=error_recovery_policy,
+        )
         self._pipette_store = PipetteStore()
         if deck_configuration is None:
             deck_configuration = []

--- a/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_command_executor.py
@@ -140,9 +140,11 @@ def command_note_tracker_provider(decoy: Decoy) -> CommandNoteTrackerProvider:
 
 
 @pytest.fixture
-def error_recovery_policy(decoy: Decoy) -> ErrorRecoveryPolicy:
+def error_recovery_policy(state_store: StateStore, decoy: Decoy) -> ErrorRecoveryPolicy:
     """Get a mock error recovery policy."""
-    return decoy.mock(cls=ErrorRecoveryPolicy)
+    mock = decoy.mock(cls=ErrorRecoveryPolicy)
+    decoy.when(state_store.commands.get_error_recovery_policy()).then_return(mock)
+    return mock
 
 
 def get_next_tracker(
@@ -182,7 +184,6 @@ def subject(
     status_bar: StatusBarHandler,
     model_utils: ModelUtils,
     command_note_tracker_provider: CommandNoteTrackerProvider,
-    error_recovery_policy: ErrorRecoveryPolicy,
 ) -> CommandExecutor:
     """Get a CommandExecutor test subject with its dependencies mocked out."""
     return CommandExecutor(
@@ -200,7 +201,6 @@ def subject(
         rail_lights=rail_lights,
         status_bar=status_bar,
         command_note_tracker_provider=command_note_tracker_provider,
-        error_recovery_policy=error_recovery_policy,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -15,7 +15,10 @@ from opentrons_shared_data.errors import ErrorCodes, PythonException
 from opentrons.hardware_control.types import DoorState
 from opentrons.ordered_set import OrderedSet
 from opentrons.protocol_engine import actions, commands, errors
-from opentrons.protocol_engine.actions.actions import PlayAction
+from opentrons.protocol_engine.actions.actions import (
+    PlayAction,
+    SetErrorRecoveryPolicyAction,
+)
 from opentrons.protocol_engine.commands.command import CommandIntent
 from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryType
 from opentrons.protocol_engine.errors.error_occurrence import ErrorOccurrence
@@ -856,3 +859,18 @@ def test_final_state_after_error_recovery_stop() -> None:
     assert subject_view.get_status() == EngineStatus.STOPPED
     assert subject_view.get_recovery_target() is None
     assert subject_view.get_error() is None
+
+
+def test_set_and_get_error_recovery_policy() -> None:
+    """Test storage of `ErrorRecoveryPolicy`s."""
+    initial_policy = sentinel.initial_policy
+    new_policy = sentinel.new_policy
+    subject = CommandStore(
+        config=_make_config(),
+        error_recovery_policy=initial_policy,
+        is_door_open=False,
+    )
+    subject_view = CommandView(subject.state)
+    assert subject_view.get_error_recovery_policy() is initial_policy
+    subject.handle_action(SetErrorRecoveryPolicyAction(sentinel.new_policy))
+    assert subject_view.get_error_recovery_policy() is new_policy

--- a/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_store_old.py
@@ -5,8 +5,10 @@ Add new tests to test_command_state.py, where they can be tested together.
 """
 
 
+from decoy import matchers
 import pytest
 from datetime import datetime
+from typing import Any
 
 from opentrons_shared_data.errors import ErrorCodes
 
@@ -50,6 +52,15 @@ def _make_config(block_on_door_open: bool = False) -> Config:
     )
 
 
+def _placeholder_error_recovery_policy(*args: object, **kwargs: object) -> Any:
+    """A placeholder `ErrorRecoveryPolicy` for tests that don't care about it.
+
+    That should be all the tests in this file, since error recovery was added
+    after this file was deprecated.
+    """
+    raise NotImplementedError()
+
+
 def test_command_queue_and_unqueue() -> None:
     """It should queue on QueueCommandAction and dequeue on RunCommandAction."""
     queue_1 = QueueCommandAction(
@@ -77,7 +88,11 @@ def test_command_queue_and_unqueue() -> None:
         command=create_succeeded_command(command_id="command-id-2"),
     )
 
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(queue_1)
     assert subject.state.command_history.get_queue_ids() == OrderedSet(["command-id-1"])
@@ -126,7 +141,11 @@ def test_setup_command_queue_and_unqueue() -> None:
         command=create_succeeded_command(command_id="command-id-2"),
     )
 
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(queue_1)
     assert subject.state.command_history.get_setup_queue_ids() == OrderedSet(
@@ -170,7 +189,11 @@ def test_setup_queue_action_updates_command_intent() -> None:
         intent=commands.CommandIntent.SETUP,
     )
 
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(queue_cmd)
     assert subject.state.command_history.get("command-id-1") == CommandEntry(
@@ -195,7 +218,11 @@ def test_running_command_id() -> None:
         command=create_succeeded_command(command_id="command-id-1"),
     )
 
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(queue)
     assert subject.state.command_history.get_running_command() is None
@@ -222,7 +249,11 @@ def test_command_store_keeps_commands_in_queue_order() -> None:
         params=commands.CommentParams(message="hello world"),
     )
 
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(
         QueueCommandAction(
@@ -285,7 +316,11 @@ def test_command_store_keeps_commands_in_queue_order() -> None:
 @pytest.mark.parametrize("pause_source", PauseSource)
 def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
     """It should clear the running flag on pause."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
     subject.handle_action(PauseAction(source=pause_source))
 
     assert subject.state == CommandState(
@@ -302,13 +337,18 @@ def test_command_store_handles_pause_action(pause_source: PauseSource) -> None:
         recovery_target_command_id=None,
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
 
 
 @pytest.mark.parametrize("pause_source", PauseSource)
 def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
     """It should set the running flag on play."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
 
     assert subject.state == CommandState(
@@ -325,6 +365,7 @@ def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -334,7 +375,11 @@ def test_command_store_handles_play_action(pause_source: PauseSource) -> None:
 
 def test_command_store_handles_finish_action() -> None:
     """It should change to a succeeded state with FinishAction."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(FinishAction())
@@ -353,6 +398,7 @@ def test_command_store_handles_finish_action() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -362,7 +408,11 @@ def test_command_store_handles_finish_action() -> None:
 
 def test_command_store_handles_finish_action_with_stopped() -> None:
     """It should change to a stopped state if FinishAction has set_run_status=False."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(FinishAction(set_run_status=False))
@@ -378,7 +428,11 @@ def test_command_store_handles_stop_action(
     from_estop: bool, expected_run_result: RunResult
 ) -> None:
     """It should mark the engine as non-gracefully stopped on StopAction."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(StopAction(from_estop=from_estop))
@@ -397,6 +451,7 @@ def test_command_store_handles_stop_action(
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_estop=from_estop,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -406,7 +461,11 @@ def test_command_store_handles_stop_action(
 
 def test_command_store_handles_stop_action_when_awaiting_recovery() -> None:
     """It should mark the engine as non-gracefully stopped on StopAction."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
 
@@ -428,6 +487,7 @@ def test_command_store_handles_stop_action_when_awaiting_recovery() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -437,7 +497,11 @@ def test_command_store_handles_stop_action_when_awaiting_recovery() -> None:
 
 def test_command_store_cannot_restart_after_should_stop() -> None:
     """It should reject a play action after finish."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
     subject.handle_action(FinishAction())
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
 
@@ -455,6 +519,7 @@ def test_command_store_cannot_restart_after_should_stop() -> None:
         run_started_at=None,
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -464,7 +529,11 @@ def test_command_store_cannot_restart_after_should_stop() -> None:
 
 def test_command_store_save_started_completed_run_timestamp() -> None:
     """It should save started and completed timestamps."""
-    subject = CommandStore(config=_make_config(), is_door_open=False)
+    subject = CommandStore(
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+        is_door_open=False,
+    )
     start_time = datetime(year=2021, month=1, day=1)
     hardware_stopped_time = datetime(year=2022, month=2, day=2)
 
@@ -481,7 +550,11 @@ def test_command_store_save_started_completed_run_timestamp() -> None:
 
 def test_timestamps_are_latched() -> None:
     """It should not change startedAt or completedAt once set."""
-    subject = CommandStore(config=_make_config(), is_door_open=False)
+    subject = CommandStore(
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+        is_door_open=False,
+    )
 
     play_time_1 = datetime(year=2021, month=1, day=1)
     play_time_2 = datetime(year=2022, month=2, day=2)
@@ -512,7 +585,11 @@ def test_command_store_wraps_unknown_errors() -> None:
     The wrapping EnumeratedError should be an UnexpectedProtocolError for errors that happened
     in the main part of the protocol run, or a PythonException for errors that happened elsewhere.
     """
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(
         FinishAction(
@@ -587,6 +664,7 @@ def test_command_store_wraps_unknown_errors() -> None:
         recovery_target_command_id=None,
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -601,7 +679,11 @@ def test_command_store_preserves_enumerated_errors() -> None:
         def __init__(self, message: str) -> None:
             super().__init__(ErrorCodes.PIPETTE_NOT_PRESENT, message)
 
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(
         FinishAction(
@@ -650,6 +732,7 @@ def test_command_store_preserves_enumerated_errors() -> None:
         run_started_at=None,
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -659,7 +742,11 @@ def test_command_store_preserves_enumerated_errors() -> None:
 
 def test_command_store_ignores_stop_after_graceful_finish() -> None:
     """It should no-op on stop if already gracefully finished."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(FinishAction())
@@ -679,6 +766,7 @@ def test_command_store_ignores_stop_after_graceful_finish() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -688,7 +776,11 @@ def test_command_store_ignores_stop_after_graceful_finish() -> None:
 
 def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
     """It should no-op on finish if already ungracefully stopped."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
 
     subject.handle_action(PlayAction(requested_at=datetime(year=2021, month=1, day=1)))
     subject.handle_action(StopAction())
@@ -708,6 +800,7 @@ def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
         run_started_at=datetime(year=2021, month=1, day=1),
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []
@@ -717,7 +810,11 @@ def test_command_store_ignores_finish_after_non_graceful_stop() -> None:
 
 def test_handles_hardware_stopped() -> None:
     """It should mark the hardware as stopped on HardwareStoppedAction."""
-    subject = CommandStore(is_door_open=False, config=_make_config())
+    subject = CommandStore(
+        is_door_open=False,
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+    )
     completed_at = datetime(year=2021, day=1, month=1)
     subject.handle_action(
         HardwareStoppedAction(completed_at=completed_at, finish_error_details=None)
@@ -737,6 +834,7 @@ def test_handles_hardware_stopped() -> None:
         run_started_at=None,
         latest_protocol_command_hash=None,
         stopped_by_estop=False,
+        error_recovery_policy=matchers.Anything(),
     )
     assert subject.state.command_history.get_running_command() is None
     assert subject.state.command_history.get_all_ids() == []

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -8,7 +8,7 @@ Add new tests to test_command_state.py, where they can be tested together.
 import pytest
 from contextlib import nullcontext as does_not_raise
 from datetime import datetime
-from typing import Dict, List, NamedTuple, Optional, Sequence, Type, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Type, Union
 
 from opentrons.protocol_engine import EngineStatus, commands as cmd, errors
 from opentrons.protocol_engine.actions import (
@@ -44,6 +44,15 @@ from .command_fixtures import (
     create_failed_command,
     create_succeeded_command,
 )
+
+
+def _placeholder_error_recovery_policy(*args: object, **kwargs: object) -> Any:
+    """A placeholder `ErrorRecoveryPolicy` for tests that don't care about it.
+
+    That should be all the tests in this file, since error recovery was added
+    after this file was deprecated.
+    """
+    raise NotImplementedError()
 
 
 def get_command_view(  # noqa: C901
@@ -99,6 +108,7 @@ def get_command_view(  # noqa: C901
         run_started_at=run_started_at,
         latest_protocol_command_hash=latest_command_hash,
         stopped_by_estop=False,
+        error_recovery_policy=_placeholder_error_recovery_policy,
     )
 
     return CommandView(state=state)

--- a/api/tests/opentrons/protocol_engine/state/test_state_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_state_store.py
@@ -1,5 +1,5 @@
 """Tests for the top-level StateStore/StateView."""
-from typing import Callable, Union
+from typing import Any, Callable, Union
 from datetime import datetime
 
 import pytest
@@ -36,6 +36,10 @@ def subject(
     engine_config: Config,
 ) -> StateStore:
     """Get a StateStore test subject."""
+
+    def placeholder_error_recovery_policy(*args: object, **kwargs: object) -> Any:
+        raise NotImplementedError()
+
     return StateStore(
         config=engine_config,
         deck_definition=ot2_standard_deck_def,
@@ -49,6 +53,7 @@ def subject(
         deck_fixed_labware=[],
         change_notifier=change_notifier,
         is_door_open=False,
+        error_recovery_policy=placeholder_error_recovery_policy,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -9,6 +9,7 @@ from decoy import Decoy
 
 from opentrons_shared_data.robot.types import RobotType
 
+from opentrons.protocol_engine.actions.actions import SetErrorRecoveryPolicyAction
 from opentrons.types import DeckSlotName
 from opentrons.hardware_control import HardwareControlAPI, OT2HardwareControlAPI
 from opentrons.hardware_control.modules import MagDeck, TempDeck
@@ -1188,4 +1189,14 @@ def test_reset_tips(
     decoy.verify(
         action_dispatcher.dispatch(ResetTipsAction(labware_id="cool-labware")),
         times=1,
+    )
+
+
+async def test_set_error_recovery_policy(
+    decoy: Decoy, action_dispatcher: ActionDispatcher, subject: ProtocolEngine
+) -> None:
+    """It should set the error recovery policy by dispatching an action."""
+    await subject.set_error_recovery_policy(sentinel.new_policy)
+    decoy.verify(
+        action_dispatcher.dispatch(SetErrorRecoveryPolicyAction(sentinel.new_policy))
     )

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -1196,7 +1196,7 @@ async def test_set_error_recovery_policy(
     decoy: Decoy, action_dispatcher: ActionDispatcher, subject: ProtocolEngine
 ) -> None:
     """It should set the error recovery policy by dispatching an action."""
-    await subject.set_error_recovery_policy(sentinel.new_policy)
+    subject.set_error_recovery_policy(sentinel.new_policy)
     decoy.verify(
         action_dispatcher.dispatch(SetErrorRecoveryPolicyAction(sentinel.new_policy))
     )

--- a/api/tests/opentrons/protocol_engine/test_protocol_engine.py
+++ b/api/tests/opentrons/protocol_engine/test_protocol_engine.py
@@ -32,7 +32,6 @@ from opentrons.protocol_engine.types import (
     PostRunHardwareState,
     AddressableAreaLocation,
 )
-from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
 from opentrons.protocol_engine.execution import (
     QueueWorker,
     HardwareStopper,
@@ -117,12 +116,6 @@ def module_data_provider(decoy: Decoy) -> ModuleDataProvider:
     return decoy.mock(cls=ModuleDataProvider)
 
 
-@pytest.fixture
-def error_recovery_policy(decoy: Decoy) -> ErrorRecoveryPolicy:
-    """Get a mock ErrorRecoveryPolicy."""
-    return decoy.mock(cls=ErrorRecoveryPolicy)
-
-
 @pytest.fixture(autouse=True)
 def _mock_slot_standardization_module(
     decoy: Decoy, monkeypatch: pytest.MonkeyPatch
@@ -146,7 +139,6 @@ def _mock_hash_command_params_module(
 def subject(
     hardware_api: HardwareControlAPI,
     state_store: StateStore,
-    error_recovery_policy: ErrorRecoveryPolicy,
     action_dispatcher: ActionDispatcher,
     plugin_starter: PluginStarter,
     queue_worker: QueueWorker,
@@ -159,7 +151,6 @@ def subject(
     return ProtocolEngine(
         hardware_api=hardware_api,
         state_store=state_store,
-        error_recovery_policy=error_recovery_policy,
         action_dispatcher=action_dispatcher,
         plugin_starter=plugin_starter,
         queue_worker=queue_worker,

--- a/robot-server/robot_server/runs/error_recovery_mapping.py
+++ b/robot-server/robot_server/runs/error_recovery_mapping.py
@@ -9,7 +9,6 @@ from opentrons.protocol_engine.commands.command_unions import (
 from opentrons.protocol_engine.error_recovery_policy import (
     ErrorRecoveryPolicy,
     ErrorRecoveryType,
-    standard_run_policy,
 )
 
 
@@ -41,6 +40,30 @@ def create_error_recovery_policy_from_rules(
                 elif rule.ifMatch == ReactionIfMatch.WAIT_FOR_RECOVERY:
                     return ErrorRecoveryType.WAIT_FOR_RECOVERY
 
-        return standard_run_policy(config, failed_command, defined_error_data)
+        return default_error_recovery_policy(config, failed_command, defined_error_data)
 
     return _policy
+
+
+def default_error_recovery_policy(
+    config: Config,
+    failed_command: Command,
+    defined_error_data: Optional[CommandDefinedErrorData],
+) -> ErrorRecoveryType:
+    """The `ErrorRecoveryPolicy` to use when none has been set on a run.
+
+    This is only appropriate for normal protocol runs, not maintenance runs,
+    since it assumes
+    """
+    # Although error recovery can theoretically work on OT-2s, we haven't tested it,
+    # and it's generally scarier because the OT-2 has much less hardware feedback.
+    robot_is_flex = config.robot_type == "OT-3 Standard"
+    # If the error is defined, we're taking that to mean that we should
+    # WAIT_FOR_RECOVERY. This is not necessarily the right long-term logic--we might
+    # want to FAIL_RUN on certain defined errors and WAIT_FOR_RECOVERY on certain
+    # undefined errors--but this is convenient for now.
+    error_is_defined = defined_error_data is not None
+    if robot_is_flex and error_is_defined:
+        return ErrorRecoveryType.WAIT_FOR_RECOVERY
+    else:
+        return ErrorRecoveryType.FAIL_RUN

--- a/robot-server/robot_server/runs/error_recovery_mapping.py
+++ b/robot-server/robot_server/runs/error_recovery_mapping.py
@@ -23,8 +23,6 @@ def create_error_recovery_policy_from_rules(
         failed_command: Command,
         defined_error_data: Optional[CommandDefinedErrorData],
     ) -> ErrorRecoveryType:
-        if rules is None:
-            return standard_run_policy(config, failed_command, defined_error_data)
         for rule in rules:
             command_type_matches = (
                 failed_command.commandType == rule.matchCriteria.command.commandType

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -46,7 +46,7 @@ from opentrons.protocol_engine.types import (
 )
 from opentrons_shared_data.labware.types import LabwareUri
 
-from opentrons.protocol_engine.error_recovery_policy import ErrorRecoveryPolicy
+from .error_recovery_mapping import default_error_recovery_policy
 
 _log = logging.getLogger(__name__)
 
@@ -222,7 +222,7 @@ class RunOrchestratorStore:
                     RobotTypeEnum.robot_literal_to_enum(self._robot_type)
                 ),
             ),
-            error_recovery_policy=error_recovery_policy.standard_run_policy,
+            error_recovery_policy=default_error_recovery_policy,
             load_fixed_trash=load_fixed_trash,
             deck_configuration=deck_configuration,
             notify_publishers=notify_publishers,
@@ -362,7 +362,9 @@ class RunOrchestratorStore:
         """Add a new labware definition to state."""
         return self.run_orchestrator.add_labware_definition(definition)
 
-    def set_error_recovery_policy(self, policy: ErrorRecoveryPolicy) -> None:
+    def set_error_recovery_policy(
+        self, policy: error_recovery_policy.ErrorRecoveryPolicy
+    ) -> None:
         """Create run policy rules for error recovery."""
         self.run_orchestrator.set_error_recovery_policy(policy)
 


### PR DESCRIPTION
# Overview

This allows changing a run's error recovery policy after the `ProtocolEngine` has been created.

Supports #15812 in closing EXEC-589.

## Test Plan and Hands on Testing

* [x] Use the HTTP API in #15812 to change the error recovery policy mid-run and see that it takes effect.
  * Works, but exposes another bug, EXEC-634.

## Changelog

* Turn the error recovery policy into a piece of Protocol Engine state, where it's stored in the state stores and modified via actions.

  It's still just a function, which is unusual for us to consider "state" in Protocol Engine, but, you know, it's Python, functions are objects too.
  
  I stashed it in `CommandState` because that's where the rest of error recovery lives, but in principle it's its own isolated thing.
  
* Have `CommandExecutor` read the current policy and use it any time a command fails.

Thanks to @TamarZanzouri for hinting to me that we didn't have to fundamentally modify `QueueWorker` or `CommandExecutor` construction for this.

## Review requests

None in particular.

## Risk assessment

Low.