### PR TITLE
feat(api,app): Allow blowout and droptip when unhomed

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -761,7 +761,7 @@ class OT3API(
 
     @ExecutionManagerProvider.wait_for_running
     async def _update_position_estimation(
-        self, axes: Optional[List[Axis]] = None
+        self, axes: Optional[Sequence[Axis]] = None
     ) -> None:
         """
         Function to update motor estimation for a set of axes
@@ -1140,6 +1140,10 @@ class OT3API(
             y=cur_pos[Axis.Y],
             z=cur_pos[Axis.by_mount(realmount)],
         )
+
+    async def update_axis_position_estimations(self, axes: Sequence[Axis]) -> None:
+        """Update specified axes position estimators from their encoders."""
+        await self._update_position_estimation(axes)
 
     async def move_to(
         self,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1144,6 +1144,8 @@ class OT3API(
     async def update_axis_position_estimations(self, axes: Sequence[Axis]) -> None:
         """Update specified axes position estimators from their encoders."""
         await self._update_position_estimation(axes)
+        await self._cache_current_position()
+        await self._cache_encoder_position()
 
     async def move_to(
         self,

--- a/api/src/opentrons/hardware_control/protocols/__init__.py
+++ b/api/src/opentrons/hardware_control/protocols/__init__.py
@@ -1,8 +1,6 @@
 """Typing protocols describing a hardware controller."""
 from typing_extensions import Protocol, Type
 
-from opentrons.hardware_control.types import Axis
-
 from .module_provider import ModuleProvider
 from .hardware_manager import HardwareManager
 from .chassis_accessory_manager import ChassisAccessoryManager
@@ -20,6 +18,7 @@ from .identifiable import Identifiable
 from .gripper_controller import GripperController
 from .flex_calibratable import FlexCalibratable
 from .flex_instrument_configurer import FlexInstrumentConfigurer
+from .position_estimator import PositionEstimator
 
 from .types import (
     CalibrationType,
@@ -64,6 +63,7 @@ class HardwareControlInterface(
 
 
 class FlexHardwareControlInterface(
+    PositionEstimator,
     ModuleProvider,
     ExecutionControllable,
     LiquidHandler[CalibrationType, MountArgType, ConfigType],
@@ -86,12 +86,6 @@ class FlexHardwareControlInterface(
 
     def get_robot_type(self) -> Type[FlexRobotType]:
         return FlexRobotType
-
-    def motor_status_ok(self, axis: Axis) -> bool:
-        ...
-
-    def encoder_status_ok(self, axis: Axis) -> bool:
-        ...
 
     def cache_tip(self, mount: MountArgType, tip_length: float) -> None:
         ...

--- a/api/src/opentrons/hardware_control/protocols/position_estimator.py
+++ b/api/src/opentrons/hardware_control/protocols/position_estimator.py
@@ -1,0 +1,43 @@
+from typing import Protocol, Sequence
+
+from ..types import Axis
+
+
+class PositionEstimator(Protocol):
+    """Position-control extensions for harwdare with encoders."""
+
+    async def update_axis_position_estimations(self, axes: Sequence[Axis]) -> None:
+        """Update the specified axes' position estimators from their encoders.
+
+        This will allow these axes to make a non-home move even if they do not currently have
+        a position estimation (unless there is no tracked poition from the encoders, as would be
+        true immediately after boot).
+
+        Axis encoders have less precision than their position estimators. Calling this function will
+        cause absolute position drift. After this function is called, the axis should be homed before
+        it is relied upon for accurate motion.
+
+        This function updates only the requested axes. If other axes have bad position estimation,
+        moves that require those axes or attempts to get the position of those axes will still fail.
+        """
+        ...
+
+    def motor_status_ok(self, axis: Axis) -> bool:
+        """Return whether an axis' position estimator is healthy.
+
+        The position estimator is healthy if the axis has
+        1) been homed
+        2) not suffered a loss-of-positioning (from a cancel or stall, for instance) since being homed
+
+        If this function returns false, getting the position of this axis or asking it to move will fail.
+        """
+        ...
+
+    def encoder_status_ok(self, axis: Axis) -> bool:
+        """Return whether an axis' position encoder tracking is healthy.
+
+        The encoder status is healthy if the axis has been homed since booting up.
+
+        If this function returns false, updating the estimator from the encoder will fail.
+        """
+        ...

--- a/api/src/opentrons/protocol_engine/commands/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/__init__.py
@@ -19,6 +19,7 @@ from . import magnetic_module
 from . import temperature_module
 from . import thermocycler
 from . import calibration
+from . import unsafe
 
 from .hash_command_params import hash_protocol_command_params
 from .generate_command_schema import generate_command_schema
@@ -548,6 +549,8 @@ __all__ = [
     "thermocycler",
     # calibration command bundle
     "calibration",
+    # unsafe command bundle
+    "unsafe",
     # configure pipette volume command bundle
     "ConfigureForVolume",
     "ConfigureForVolumeCreate",

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -389,6 +389,7 @@ Command = Annotated[
         calibration.CalibrateModule,
         calibration.MoveToMaintenancePosition,
         unsafe.UnsafeBlowOutInPlace,
+        unsafe.UnsafeDropTipInPlace,
     ],
     Field(discriminator="commandType"),
 ]
@@ -459,6 +460,7 @@ CommandParams = Union[
     calibration.CalibrateModuleParams,
     calibration.MoveToMaintenancePositionParams,
     unsafe.UnsafeBlowOutInPlaceParams,
+    unsafe.UnsafeDropTipInPlaceParams,
 ]
 
 CommandType = Union[
@@ -527,6 +529,7 @@ CommandType = Union[
     calibration.CalibrateModuleCommandType,
     calibration.MoveToMaintenancePositionCommandType,
     unsafe.UnsafeBlowOutInPlaceCommandType,
+    unsafe.UnsafeDropTipInPlaceCommandType,
 ]
 
 CommandCreate = Annotated[
@@ -596,6 +599,7 @@ CommandCreate = Annotated[
         calibration.CalibrateModuleCreate,
         calibration.MoveToMaintenancePositionCreate,
         unsafe.UnsafeBlowOutInPlaceCreate,
+        unsafe.UnsafeDropTipInPlaceCreate,
     ],
     Field(discriminator="commandType"),
 ]
@@ -665,7 +669,8 @@ CommandResult = Union[
     calibration.CalibratePipetteResult,
     calibration.CalibrateModuleResult,
     calibration.MoveToMaintenancePositionResult,
-    unsafe.UnsafeBlowOutInPlaceResult
+    unsafe.UnsafeBlowOutInPlaceResult,
+    unsafe.UnsafeDropTipInPlaceResult,
 ]
 
 # todo(mm, 2024-06-12): Ideally, command return types would have specific

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -390,6 +390,7 @@ Command = Annotated[
         calibration.MoveToMaintenancePosition,
         unsafe.UnsafeBlowOutInPlace,
         unsafe.UnsafeDropTipInPlace,
+        unsafe.UpdatePositionEstimators,
     ],
     Field(discriminator="commandType"),
 ]
@@ -461,6 +462,7 @@ CommandParams = Union[
     calibration.MoveToMaintenancePositionParams,
     unsafe.UnsafeBlowOutInPlaceParams,
     unsafe.UnsafeDropTipInPlaceParams,
+    unsafe.UpdatePositionEstimatorsParams,
 ]
 
 CommandType = Union[
@@ -530,6 +532,7 @@ CommandType = Union[
     calibration.MoveToMaintenancePositionCommandType,
     unsafe.UnsafeBlowOutInPlaceCommandType,
     unsafe.UnsafeDropTipInPlaceCommandType,
+    unsafe.UpdatePositionEstimatorsCommandType,
 ]
 
 CommandCreate = Annotated[
@@ -600,6 +603,7 @@ CommandCreate = Annotated[
         calibration.MoveToMaintenancePositionCreate,
         unsafe.UnsafeBlowOutInPlaceCreate,
         unsafe.UnsafeDropTipInPlaceCreate,
+        unsafe.UpdatePositionEstimatorsCreate,
     ],
     Field(discriminator="commandType"),
 ]
@@ -671,6 +675,7 @@ CommandResult = Union[
     calibration.MoveToMaintenancePositionResult,
     unsafe.UnsafeBlowOutInPlaceResult,
     unsafe.UnsafeDropTipInPlaceResult,
+    unsafe.UpdatePositionEstimatorsResult,
 ]
 
 # todo(mm, 2024-06-12): Ideally, command return types would have specific

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -22,6 +22,7 @@ from . import temperature_module
 from . import thermocycler
 
 from . import calibration
+from . import unsafe
 
 from .set_rail_lights import (
     SetRailLights,
@@ -387,6 +388,7 @@ Command = Annotated[
         calibration.CalibratePipette,
         calibration.CalibrateModule,
         calibration.MoveToMaintenancePosition,
+        unsafe.UnsafeBlowOutInPlace,
     ],
     Field(discriminator="commandType"),
 ]
@@ -456,6 +458,7 @@ CommandParams = Union[
     calibration.CalibratePipetteParams,
     calibration.CalibrateModuleParams,
     calibration.MoveToMaintenancePositionParams,
+    unsafe.UnsafeBlowOutInPlaceParams,
 ]
 
 CommandType = Union[
@@ -523,6 +526,7 @@ CommandType = Union[
     calibration.CalibratePipetteCommandType,
     calibration.CalibrateModuleCommandType,
     calibration.MoveToMaintenancePositionCommandType,
+    unsafe.UnsafeBlowOutInPlaceCommandType,
 ]
 
 CommandCreate = Annotated[
@@ -591,6 +595,7 @@ CommandCreate = Annotated[
         calibration.CalibratePipetteCreate,
         calibration.CalibrateModuleCreate,
         calibration.MoveToMaintenancePositionCreate,
+        unsafe.UnsafeBlowOutInPlaceCreate,
     ],
     Field(discriminator="commandType"),
 ]
@@ -660,6 +665,7 @@ CommandResult = Union[
     calibration.CalibratePipetteResult,
     calibration.CalibrateModuleResult,
     calibration.MoveToMaintenancePositionResult,
+    unsafe.UnsafeBlowOutInPlaceResult
 ]
 
 # todo(mm, 2024-06-12): Ideally, command return types would have specific

--- a/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
@@ -15,6 +15,14 @@ from .unsafe_drop_tip_in_place import (
     UnsafeDropTipInPlaceCreate,
 )
 
+from .update_position_estimators import (
+    UpdatePositionEstimatorsCommandType,
+    UpdatePositionEstimatorsParams,
+    UpdatePositionEstimatorsResult,
+    UpdatePositionEstimators,
+    UpdatePositionEstimatorsCreate,
+)
+
 __all__ = [
     # Unsafe blow-out-in-place command models
     "UnsafeBlowOutInPlaceCommandType",
@@ -28,4 +36,10 @@ __all__ = [
     "UnsafeDropTipInPlaceResult",
     "UnsafeDropTipInPlace",
     "UnsafeDropTipInPlaceCreate",
+    # Update position estimate command models
+    "UpdatePositionEstimatorsCommandType",
+    "UpdatePositionEstimatorsParams",
+    "UpdatePositionEstimatorsResult",
+    "UpdatePositionEstimators",
+    "UpdatePositionEstimatorsCreate",
 ]

--- a/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
@@ -7,6 +7,13 @@ from .unsafe_blow_out_in_place import (
     UnsafeBlowOutInPlace,
     UnsafeBlowOutInPlaceCreate,
 )
+from .unsafe_drop_tip_in_place import (
+    UnsafeDropTipInPlaceCommandType,
+    UnsafeDropTipInPlaceParams,
+    UnsafeDropTipInPlaceResult,
+    UnsafeDropTipInPlace,
+    UnsafeDropTipInPlaceCreate,
+)
 
 __all__ = [
     # Unsafe blow-out-in-place command models
@@ -15,4 +22,10 @@ __all__ = [
     "UnsafeBlowOutInPlaceResult",
     "UnsafeBlowOutInPlace",
     "UnsafeBlowOutInPlaceCreate",
+    # Unsafe drop-tip command models
+    "UnsafeDropTipInPlaceCommandType",
+    "UnsafeDropTipInPlaceParams",
+    "UnsafeDropTipInPlaceResult",
+    "UnsafeDropTipInPlace",
+    "UnsafeDropTipInPlaceCreate",
 ]

--- a/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/__init__.py
@@ -1,0 +1,18 @@
+"""Commands that will cause inaccuracy or incorrect behavior but are still necessary."""
+
+from .unsafe_blow_out_in_place import (
+    UnsafeBlowOutInPlaceCommandType,
+    UnsafeBlowOutInPlaceParams,
+    UnsafeBlowOutInPlaceResult,
+    UnsafeBlowOutInPlace,
+    UnsafeBlowOutInPlaceCreate,
+)
+
+__all__ = [
+    # Unsafe blow-out-in-place command models
+    "UnsafeBlowOutInPlaceCommandType",
+    "UnsafeBlowOutInPlaceParams",
+    "UnsafeBlowOutInPlaceResult",
+    "UnsafeBlowOutInPlace",
+    "UnsafeBlowOutInPlaceCreate",
+]

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_blow_out_in_place.py
@@ -1,0 +1,93 @@
+"""Command models to blow out in place while plunger positions are unknown."""
+
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional, Type
+from typing_extensions import Literal
+
+from pydantic import BaseModel
+
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ..pipetting_common import PipetteIdMixin, FlowRateMixin
+from ...resources import ensure_ot3_hardware
+from ...errors.error_occurrence import ErrorOccurrence
+
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import Axis
+
+if TYPE_CHECKING:
+    from ...execution import PipettingHandler
+    from ...state import StateView
+
+
+UnsafeBlowOutInPlaceCommandType = Literal["unsafe/blowOutInPlace"]
+
+
+class UnsafeBlowOutInPlaceParams(PipetteIdMixin, FlowRateMixin):
+    """Payload required to blow-out in place while position is unknown."""
+
+    pass
+
+
+class UnsafeBlowOutInPlaceResult(BaseModel):
+    """Result data from an UnsafeBlowOutInPlace command."""
+
+    pass
+
+
+class UnsafeBlowOutInPlaceImplementation(
+    AbstractCommandImpl[
+        UnsafeBlowOutInPlaceParams, SuccessData[UnsafeBlowOutInPlaceResult, None]
+    ]
+):
+    """UnsafeBlowOutInPlace command implementation."""
+
+    def __init__(
+        self,
+        pipetting: PipettingHandler,
+        state_view: StateView,
+        hardware_api: HardwareControlAPI,
+        **kwargs: object,
+    ) -> None:
+        self._pipetting = pipetting
+        self._state_view = state_view
+        self._hardware_api = hardware_api
+
+    async def execute(
+        self, params: UnsafeBlowOutInPlaceParams
+    ) -> SuccessData[UnsafeBlowOutInPlaceResult, None]:
+        """Blow-out without moving the pipette even when position is unknown."""
+        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
+        pipette_location = self._state_view.motion.get_pipette_location(
+            params.pipetteId
+        )
+        await ot3_hardware_api.update_axis_position_estimations(
+            [Axis.of_main_tool_actuator(pipette_location.mount.to_hw_mount())]
+        )
+        await self._pipetting.blow_out_in_place(
+            pipette_id=params.pipetteId, flow_rate=params.flowRate
+        )
+
+        return SuccessData(public=UnsafeBlowOutInPlaceResult(), private=None)
+
+
+class UnsafeBlowOutInPlace(
+    BaseCommand[UnsafeBlowOutInPlaceParams, UnsafeBlowOutInPlaceResult, ErrorOccurrence]
+):
+    """UnsafeBlowOutInPlace command model."""
+
+    commandType: UnsafeBlowOutInPlaceCommandType = "unsafe/blowOutInPlace"
+    params: UnsafeBlowOutInPlaceParams
+    result: Optional[UnsafeBlowOutInPlaceResult]
+
+    _ImplementationCls: Type[
+        UnsafeBlowOutInPlaceImplementation
+    ] = UnsafeBlowOutInPlaceImplementation
+
+
+class UnsafeBlowOutInPlaceCreate(BaseCommandCreate[UnsafeBlowOutInPlaceParams]):
+    """UnsafeBlowOutInPlace command request model."""
+
+    commandType: UnsafeBlowOutInPlaceCommandType = "unsafe/blowOutInPlace"
+    params: UnsafeBlowOutInPlaceParams
+
+    _CommandCls: Type[UnsafeBlowOutInPlace] = UnsafeBlowOutInPlace

--- a/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/unsafe_drop_tip_in_place.py
@@ -1,0 +1,98 @@
+"""Command models to drop tip in place while plunger positions are unknown."""
+from __future__ import annotations
+from pydantic import Field, BaseModel
+from typing import TYPE_CHECKING, Optional, Type
+from typing_extensions import Literal
+
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import Axis
+
+from ..pipetting_common import PipetteIdMixin
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
+from ...resources import ensure_ot3_hardware
+
+if TYPE_CHECKING:
+    from ...execution import TipHandler
+    from ...state import StateView
+
+
+UnsafeDropTipInPlaceCommandType = Literal["unsafe/dropTipInPlace"]
+
+
+class UnsafeDropTipInPlaceParams(PipetteIdMixin):
+    """Payload required to drop a tip in place even if the plunger position is not known."""
+
+    homeAfter: Optional[bool] = Field(
+        None,
+        description=(
+            "Whether to home this pipette's plunger after dropping the tip."
+            " You should normally leave this unspecified to let the robot choose"
+            " a safe default depending on its hardware."
+        ),
+    )
+
+
+class UnsafeDropTipInPlaceResult(BaseModel):
+    """Result data from the execution of an UnsafeDropTipInPlace command."""
+
+    pass
+
+
+class UnsafeDropTipInPlaceImplementation(
+    AbstractCommandImpl[
+        UnsafeDropTipInPlaceParams, SuccessData[UnsafeDropTipInPlaceResult, None]
+    ]
+):
+    """Unsafe drop tip in place command implementation."""
+
+    def __init__(
+        self,
+        tip_handler: TipHandler,
+        state_view: StateView,
+        hardware_api: HardwareControlAPI,
+        **kwargs: object,
+    ) -> None:
+        self._state_view = state_view
+        self._tip_handler = tip_handler
+        self._hardware_api = hardware_api
+
+    async def execute(
+        self, params: UnsafeDropTipInPlaceParams
+    ) -> SuccessData[UnsafeDropTipInPlaceResult, None]:
+        """Drop a tip using the requested pipette, even if the plunger position is not known."""
+        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
+        pipette_location = self._state_view.motion.get_pipette_location(
+            params.pipetteId
+        )
+        await ot3_hardware_api.update_axis_position_estimations(
+            [Axis.of_main_tool_actuator(pipette_location.mount.to_hw_mount())]
+        )
+        await self._tip_handler.drop_tip(
+            pipette_id=params.pipetteId, home_after=params.homeAfter
+        )
+
+        return SuccessData(public=UnsafeDropTipInPlaceResult(), private=None)
+
+
+class UnsafeDropTipInPlace(
+    BaseCommand[UnsafeDropTipInPlaceParams, UnsafeDropTipInPlaceResult, ErrorOccurrence]
+):
+    """Drop tip in place command model."""
+
+    commandType: UnsafeDropTipInPlaceCommandType = "unsafe/dropTipInPlace"
+    params: UnsafeDropTipInPlaceParams
+    result: Optional[UnsafeDropTipInPlaceResult]
+
+    _ImplementationCls: Type[
+        UnsafeDropTipInPlaceImplementation
+    ] = UnsafeDropTipInPlaceImplementation
+
+
+class UnsafeDropTipInPlaceCreate(BaseCommandCreate[UnsafeDropTipInPlaceParams]):
+    """Drop tip in place command creation request model."""
+
+    commandType: UnsafeDropTipInPlaceCommandType = "unsafe/dropTipInPlace"
+    params: UnsafeDropTipInPlaceParams
+
+    _CommandCls: Type[UnsafeDropTipInPlace] = UnsafeDropTipInPlace

--- a/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
+++ b/api/src/opentrons/protocol_engine/commands/unsafe/update_position_estimators.py
@@ -1,0 +1,87 @@
+"""Update position estimators payload, result, and implementaiton."""
+
+from __future__ import annotations
+from pydantic import BaseModel, Field
+from typing import TYPE_CHECKING, Optional, List, Type
+from typing_extensions import Literal
+
+from ...types import MotorAxis
+from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
+from ...errors.error_occurrence import ErrorOccurrence
+from ...resources import ensure_ot3_hardware
+
+from opentrons.hardware_control import HardwareControlAPI
+
+if TYPE_CHECKING:
+    from ...execution import GantryMover
+
+
+UpdatePositionEstimatorsCommandType = Literal["unsafe/updatePositionEstimators"]
+
+
+class UpdatePositionEstimatorsParams(BaseModel):
+    """Payload required for an UpdatePositionEstimators command."""
+
+    axes: List[MotorAxis] = Field(
+        ..., description="The axes for which to update the position estimators."
+    )
+
+
+class UpdatePositionEstimatorsResult(BaseModel):
+    """Result data from the execution of an UpdatePositionEstimators command."""
+
+
+class UpdatePositionEstimatorsImplementation(
+    AbstractCommandImpl[
+        UpdatePositionEstimatorsParams,
+        SuccessData[UpdatePositionEstimatorsResult, None],
+    ]
+):
+    """Update position estimators command implementation."""
+
+    def __init__(
+        self,
+        hardware_api: HardwareControlAPI,
+        gantry_mover: GantryMover,
+        **kwargs: object,
+    ) -> None:
+        self._hardware_api = hardware_api
+        self._gantry_mover = gantry_mover
+
+    async def execute(
+        self, params: UpdatePositionEstimatorsParams
+    ) -> SuccessData[UpdatePositionEstimatorsResult, None]:
+        """Update axis position estimators from their encoders."""
+        ot3_hardware_api = ensure_ot3_hardware(self._hardware_api)
+        await ot3_hardware_api.update_axis_position_estimations(
+            [
+                self._gantry_mover.motor_axis_to_hardware_axis(axis)
+                for axis in params.axes
+            ]
+        )
+        return SuccessData(public=UpdatePositionEstimatorsResult(), private=None)
+
+
+class UpdatePositionEstimators(
+    BaseCommand[
+        UpdatePositionEstimatorsParams, UpdatePositionEstimatorsResult, ErrorOccurrence
+    ]
+):
+    """UpdatePositionEstimators command model."""
+
+    commandType: UpdatePositionEstimatorsCommandType = "unsafe/updatePositionEstimators"
+    params: UpdatePositionEstimatorsParams
+    result: Optional[UpdatePositionEstimatorsResult]
+
+    _ImplementationCls: Type[
+        UpdatePositionEstimatorsImplementation
+    ] = UpdatePositionEstimatorsImplementation
+
+
+class UpdatePositionEstimatorsCreate(BaseCommandCreate[UpdatePositionEstimatorsParams]):
+    """UpdatePositionEstimators command request model."""
+
+    commandType: UpdatePositionEstimatorsCommandType = "unsafe/updatePositionEstimators"
+    params: UpdatePositionEstimatorsParams
+
+    _CommandCls: Type[UpdatePositionEstimators] = UpdatePositionEstimators

--- a/api/src/opentrons/protocol_engine/execution/gantry_mover.py
+++ b/api/src/opentrons/protocol_engine/execution/gantry_mover.py
@@ -81,6 +81,10 @@ class GantryMover(TypingProtocol):
         """Retract the 'idle' mount if necessary."""
         ...
 
+    def motor_axis_to_hardware_axis(self, motor_axis: MotorAxis) -> HardwareAxis:
+        """Transform an engine motor axis into a hardware axis."""
+        ...
+
 
 class HardwareGantryMover(GantryMover):
     """Hardware API based gantry movement handler."""
@@ -88,6 +92,10 @@ class HardwareGantryMover(GantryMover):
     def __init__(self, hardware_api: HardwareControlAPI, state_view: StateView) -> None:
         self._hardware_api = hardware_api
         self._state_view = state_view
+
+    def motor_axis_to_hardware_axis(self, motor_axis: MotorAxis) -> HardwareAxis:
+        """Transform an engine motor axis into a hardware axis."""
+        return _MOTOR_AXIS_TO_HARDWARE_AXIS[motor_axis]
 
     async def get_position(
         self,
@@ -226,6 +234,10 @@ class VirtualGantryMover(GantryMover):
 
     def __init__(self, state_view: StateView) -> None:
         self._state_view = state_view
+
+    def motor_axis_to_hardware_axis(self, motor_axis: MotorAxis) -> HardwareAxis:
+        """Transform an engine motor axis into a hardware axis."""
+        return _MOTOR_AXIS_TO_HARDWARE_AXIS[motor_axis]
 
     async def get_position(
         self,

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -53,6 +53,7 @@ from ..commands import (
     RetractAxisResult,
     BlowOutResult,
     BlowOutInPlaceResult,
+    unsafe,
     TouchTipResult,
     thermocycler,
     heater_shaker,
@@ -483,7 +484,8 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
             self._state.aspirated_volume_by_id[pipette_id] = next_volume
 
         elif isinstance(action, SucceedCommandAction) and isinstance(
-            action.command.result, (BlowOutResult, BlowOutInPlaceResult)
+            action.command.result,
+            (BlowOutResult, BlowOutInPlaceResult, unsafe.UnsafeBlowOutInPlaceResult),
         ):
             pipette_id = action.command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = None

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -279,7 +279,10 @@ class PipetteStore(HasState[PipetteState], HandlesActions):
                     default_dispense=tip_configuration.default_dispense_flowrate.values_by_api_level,
                 )
 
-        elif isinstance(command.result, (DropTipResult, DropTipInPlaceResult)):
+        elif isinstance(
+            command.result,
+            (DropTipResult, DropTipInPlaceResult, unsafe.UnsafeDropTipInPlaceResult),
+        ):
             pipette_id = command.params.pipetteId
             self._state.aspirated_volume_by_id[pipette_id] = None
             self._state.attached_tip_by_id[pipette_id] = None

--- a/api/src/opentrons/protocol_engine/state/tips.py
+++ b/api/src/opentrons/protocol_engine/state/tips.py
@@ -17,6 +17,7 @@ from ..commands import (
     PickUpTipResult,
     DropTipResult,
     DropTipInPlaceResult,
+    unsafe,
 )
 from ..commands.configuring_common import (
     PipetteConfigUpdateResultMixin,
@@ -126,7 +127,10 @@ class TipStore(HasState[TipState], HandlesActions):
             )
             self._state.length_by_pipette_id[pipette_id] = length
 
-        elif isinstance(command.result, (DropTipResult, DropTipInPlaceResult)):
+        elif isinstance(
+            command.result,
+            (DropTipResult, DropTipInPlaceResult, unsafe.UnsafeDropTipInPlaceResult),
+        ):
             pipette_id = command.params.pipetteId
             self._state.length_by_pipette_id.pop(pipette_id, None)
 

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_blow_out_in_place.py
@@ -1,0 +1,49 @@
+"""Test blow-out-in-place commands."""
+from decoy import Decoy
+
+from opentrons.types import MountType
+from opentrons.protocol_engine.state import StateView
+from opentrons.protocol_engine.commands.unsafe.unsafe_blow_out_in_place import (
+    UnsafeBlowOutInPlaceParams,
+    UnsafeBlowOutInPlaceResult,
+    UnsafeBlowOutInPlaceImplementation,
+)
+from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.execution import (
+    PipettingHandler,
+)
+from opentrons.protocol_engine.state.motion import PipetteLocationData
+from opentrons.hardware_control import OT3HardwareControlAPI
+from opentrons.hardware_control.types import Axis
+
+
+async def test_blow_out_in_place_implementation(
+    decoy: Decoy,
+    state_view: StateView,
+    ot3_hardware_api: OT3HardwareControlAPI,
+    pipetting: PipettingHandler,
+) -> None:
+    """Test UnsafeBlowOut command execution."""
+    subject = UnsafeBlowOutInPlaceImplementation(
+        state_view=state_view,
+        hardware_api=ot3_hardware_api,
+        pipetting=pipetting,
+    )
+
+    data = UnsafeBlowOutInPlaceParams(
+        pipetteId="pipette-id",
+        flowRate=1.234,
+    )
+
+    decoy.when(
+        state_view.motion.get_pipette_location(pipette_id="pipette-id")
+    ).then_return(PipetteLocationData(mount=MountType.LEFT, critical_point=None))
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(public=UnsafeBlowOutInPlaceResult(), private=None)
+
+    decoy.verify(
+        await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),
+        await pipetting.blow_out_in_place(pipette_id="pipette-id", flow_rate=1.234),
+    )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_unsafe_drop_tip_in_place.py
@@ -1,0 +1,53 @@
+"""Test unsafe drop tip in place commands."""
+import pytest
+from decoy import Decoy
+
+from opentrons.types import MountType
+from opentrons.protocol_engine.state import StateView
+
+from opentrons.protocol_engine.execution import TipHandler
+
+from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.commands.unsafe.unsafe_drop_tip_in_place import (
+    UnsafeDropTipInPlaceParams,
+    UnsafeDropTipInPlaceResult,
+    UnsafeDropTipInPlaceImplementation,
+)
+from opentrons.protocol_engine.state.motion import PipetteLocationData
+from opentrons.hardware_control import OT3HardwareControlAPI
+from opentrons.hardware_control.types import Axis
+
+
+@pytest.fixture
+def mock_tip_handler(decoy: Decoy) -> TipHandler:
+    """Get a mock TipHandler."""
+    return decoy.mock(cls=TipHandler)
+
+
+async def test_drop_tip_implementation(
+    decoy: Decoy,
+    mock_tip_handler: TipHandler,
+    state_view: StateView,
+    ot3_hardware_api: OT3HardwareControlAPI,
+) -> None:
+    """A DropTip command should have an execution implementation."""
+    subject = UnsafeDropTipInPlaceImplementation(
+        tip_handler=mock_tip_handler,
+        state_view=state_view,
+        hardware_api=ot3_hardware_api,
+    )
+
+    params = UnsafeDropTipInPlaceParams(pipetteId="abc", homeAfter=False)
+    decoy.when(state_view.motion.get_pipette_location(pipette_id="abc")).then_return(
+        PipetteLocationData(mount=MountType.LEFT, critical_point=None)
+    )
+
+    result = await subject.execute(params)
+
+    assert result == SuccessData(public=UnsafeDropTipInPlaceResult(), private=None)
+
+    decoy.verify(
+        await ot3_hardware_api.update_axis_position_estimations([Axis.P_L]),
+        await mock_tip_handler.drop_tip(pipette_id="abc", home_after=False),
+        times=1,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/unsafe/test_update_position_estimators.py
+++ b/api/tests/opentrons/protocol_engine/commands/unsafe/test_update_position_estimators.py
@@ -1,0 +1,54 @@
+"""Test update-position-estimator commands."""
+from decoy import Decoy
+
+from opentrons.protocol_engine.commands.unsafe.update_position_estimators import (
+    UpdatePositionEstimatorsParams,
+    UpdatePositionEstimatorsResult,
+    UpdatePositionEstimatorsImplementation,
+)
+from opentrons.protocol_engine.commands.command import SuccessData
+from opentrons.protocol_engine.execution import GantryMover
+from opentrons.protocol_engine.types import MotorAxis
+from opentrons.hardware_control import OT3HardwareControlAPI
+from opentrons.hardware_control.types import Axis
+
+
+async def test_update_position_estimators_implementation(
+    decoy: Decoy, ot3_hardware_api: OT3HardwareControlAPI, gantry_mover: GantryMover
+) -> None:
+    """Test UnsafeBlowOut command execution."""
+    subject = UpdatePositionEstimatorsImplementation(
+        hardware_api=ot3_hardware_api, gantry_mover=gantry_mover
+    )
+
+    data = UpdatePositionEstimatorsParams(
+        axes=[MotorAxis.LEFT_Z, MotorAxis.LEFT_PLUNGER, MotorAxis.X, MotorAxis.Y]
+    )
+
+    decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.LEFT_Z)).then_return(
+        Axis.Z_L
+    )
+    decoy.when(
+        gantry_mover.motor_axis_to_hardware_axis(MotorAxis.LEFT_PLUNGER)
+    ).then_return(Axis.P_L)
+    decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.X)).then_return(
+        Axis.X
+    )
+    decoy.when(gantry_mover.motor_axis_to_hardware_axis(MotorAxis.Y)).then_return(
+        Axis.Y
+    )
+    decoy.when(
+        await ot3_hardware_api.update_axis_position_estimations(
+            [Axis.Z_L, Axis.P_L, Axis.X, Axis.Y]
+        )
+    ).then_return(None)
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(public=UpdatePositionEstimatorsResult(), private=None)
+
+    decoy.verify(
+        await ot3_hardware_api.update_axis_position_estimations(
+            [Axis.Z_L, Axis.P_L, Axis.X, Axis.Y]
+        ),
+    )

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -603,3 +603,23 @@ def create_reload_labware_command(
         params=params,
         result=result,
     )
+
+
+def create_unsafe_blow_out_in_place_command(
+    pipette_id: str,
+    flow_rate: float,
+) -> cmd.unsafe.UnsafeBlowOutInPlace:
+    """Create a completed UnsafeBlowOutInPlace command."""
+    params = cmd.unsafe.UnsafeBlowOutInPlaceParams(
+        pipetteId=pipette_id, flowRate=flow_rate
+    )
+    result = cmd.unsafe.UnsafeBlowOutInPlaceResult()
+
+    return cmd.unsafe.UnsafeBlowOutInPlace(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime.now(),
+        params=params,
+        result=result,
+    )

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -623,3 +623,21 @@ def create_unsafe_blow_out_in_place_command(
         params=params,
         result=result,
     )
+
+
+def create_unsafe_drop_tip_in_place_command(
+    pipette_id: str,
+) -> cmd.unsafe.UnsafeDropTipInPlace:
+    """Get a completed UnsafeDropTipInPlace command."""
+    params = cmd.unsafe.UnsafeDropTipInPlaceParams(pipetteId=pipette_id)
+
+    result = cmd.unsafe.UnsafeDropTipInPlaceResult()
+
+    return cmd.unsafe.UnsafeDropTipInPlace(
+        id="command-id",
+        key="command-key",
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=datetime.now(),
+        params=params,
+        result=result,
+    )

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -58,6 +58,7 @@ from .command_fixtures import (
     create_move_to_coordinates_command,
     create_move_relative_command,
     create_prepare_to_aspirate_command,
+    create_unsafe_blow_out_in_place_command,
 )
 from ..pipette_fixtures import get_default_nozzle_map
 
@@ -261,6 +262,7 @@ def test_dispense_subtracts_volume(
     [
         create_blow_out_command("pipette-id", 1.23),
         create_blow_out_in_place_command("pipette-id", 1.23),
+        create_unsafe_blow_out_in_place_command("pipette-id", 1.23),
     ],
 )
 def test_blow_out_clears_volume(

--- a/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
+++ b/api/tests/opentrons/protocol_engine/state/test_pipette_store.py
@@ -50,6 +50,7 @@ from .command_fixtures import (
     create_pick_up_tip_command,
     create_drop_tip_command,
     create_drop_tip_in_place_command,
+    create_unsafe_drop_tip_in_place_command,
     create_touch_tip_command,
     create_move_to_well_command,
     create_blow_out_command,
@@ -172,6 +173,42 @@ def test_handles_drop_tip_in_place(subject: PipetteStore) -> None:
 
     subject.handle_action(
         SucceedCommandAction(private_result=None, command=drop_tip_in_place_command)
+    )
+    assert subject.state.attached_tip_by_id["xyz"] is None
+    assert subject.state.aspirated_volume_by_id["xyz"] is None
+
+
+def test_handles_unsafe_drop_tip_in_place(subject: PipetteStore) -> None:
+    """It should clear tip and volume details after a drop tip in place."""
+    load_pipette_command = create_load_pipette_command(
+        pipette_id="xyz",
+        pipette_name=PipetteNameType.P300_SINGLE,
+        mount=MountType.LEFT,
+    )
+
+    pick_up_tip_command = create_pick_up_tip_command(
+        pipette_id="xyz", tip_volume=42, tip_length=101, tip_diameter=8.0
+    )
+
+    unsafe_drop_tip_in_place_command = create_unsafe_drop_tip_in_place_command(
+        pipette_id="xyz",
+    )
+
+    subject.handle_action(
+        SucceedCommandAction(private_result=None, command=load_pipette_command)
+    )
+    subject.handle_action(
+        SucceedCommandAction(private_result=None, command=pick_up_tip_command)
+    )
+    assert subject.state.attached_tip_by_id["xyz"] == TipGeometry(
+        volume=42, length=101, diameter=8.0
+    )
+    assert subject.state.aspirated_volume_by_id["xyz"] == 0
+
+    subject.handle_action(
+        SucceedCommandAction(
+            private_result=None, command=unsafe_drop_tip_in_place_command
+        )
     )
     assert subject.state.attached_tip_by_id["xyz"] is None
     assert subject.state.aspirated_volume_by_id["xyz"] is None

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType/useDropTipCommands.ts
@@ -119,8 +119,12 @@ export function useDropTipCommands({
 
       if (addressableAreaFromConfig != null) {
         const moveToAACommand = buildMoveToAACommand(addressableAreaFromConfig)
-
-        return chainRunCommands([moveToAACommand], true)
+        return chainRunCommands(
+          isFlex
+            ? [UPDATE_ESTIMATORS_EXCEPT_PLUNGERS, moveToAACommand]
+            : [moveToAACommand],
+          true
+        )
           .then((commandData: CommandData[]) => {
             const error = commandData[0].data.error
             if (error != null) {
@@ -264,6 +268,11 @@ const HOME: CreateCommand = {
 
 const HOME_EXCEPT_PLUNGERS: CreateCommand = {
   commandType: 'home' as const,
+  params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
+}
+
+const UPDATE_ESTIMATORS_EXCEPT_PLUNGERS: CreateCommand = {
+  commandType: 'unsafe/updatePositionEstimators' as const,
   params: { axes: ['leftZ', 'rightZ', 'x', 'y'] },
 }
 

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -68,7 +68,8 @@
       "calibration/calibrateGripper": "#/definitions/CalibrateGripperCreate",
       "calibration/calibratePipette": "#/definitions/CalibratePipetteCreate",
       "calibration/calibrateModule": "#/definitions/CalibrateModuleCreate",
-      "calibration/moveToMaintenancePosition": "#/definitions/MoveToMaintenancePositionCreate"
+      "calibration/moveToMaintenancePosition": "#/definitions/MoveToMaintenancePositionCreate",
+      "unsafe/blowOutInPlace": "#/definitions/UnsafeBlowOutInPlaceCreate"
     }
   },
   "oneOf": [
@@ -263,6 +264,9 @@
     },
     {
       "$ref": "#/definitions/MoveToMaintenancePositionCreate"
+    },
+    {
+      "$ref": "#/definitions/UnsafeBlowOutInPlaceCreate"
     }
   ],
   "definitions": {
@@ -4204,6 +4208,55 @@
         },
         "params": {
           "$ref": "#/definitions/MoveToMaintenancePositionParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "UnsafeBlowOutInPlaceParams": {
+      "title": "UnsafeBlowOutInPlaceParams",
+      "description": "Payload required to blow-out in place while position is unknown.",
+      "type": "object",
+      "properties": {
+        "flowRate": {
+          "title": "Flowrate",
+          "description": "Speed in \u00b5L/s configured for the pipette",
+          "exclusiveMinimum": 0,
+          "type": "number"
+        },
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        }
+      },
+      "required": ["flowRate", "pipetteId"]
+    },
+    "UnsafeBlowOutInPlaceCreate": {
+      "title": "UnsafeBlowOutInPlaceCreate",
+      "description": "UnsafeBlowOutInPlace command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "unsafe/blowOutInPlace",
+          "enum": ["unsafe/blowOutInPlace"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/UnsafeBlowOutInPlaceParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -69,7 +69,8 @@
       "calibration/calibratePipette": "#/definitions/CalibratePipetteCreate",
       "calibration/calibrateModule": "#/definitions/CalibrateModuleCreate",
       "calibration/moveToMaintenancePosition": "#/definitions/MoveToMaintenancePositionCreate",
-      "unsafe/blowOutInPlace": "#/definitions/UnsafeBlowOutInPlaceCreate"
+      "unsafe/blowOutInPlace": "#/definitions/UnsafeBlowOutInPlaceCreate",
+      "unsafe/dropTipInPlace": "#/definitions/UnsafeDropTipInPlaceCreate"
     }
   },
   "oneOf": [
@@ -267,6 +268,9 @@
     },
     {
       "$ref": "#/definitions/UnsafeBlowOutInPlaceCreate"
+    },
+    {
+      "$ref": "#/definitions/UnsafeDropTipInPlaceCreate"
     }
   ],
   "definitions": {
@@ -4257,6 +4261,54 @@
         },
         "params": {
           "$ref": "#/definitions/UnsafeBlowOutInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "UnsafeDropTipInPlaceParams": {
+      "title": "UnsafeDropTipInPlaceParams",
+      "description": "Payload required to drop a tip in place even if the plunger position is not known.",
+      "type": "object",
+      "properties": {
+        "pipetteId": {
+          "title": "Pipetteid",
+          "description": "Identifier of pipette to use for liquid handling.",
+          "type": "string"
+        },
+        "homeAfter": {
+          "title": "Homeafter",
+          "description": "Whether to home this pipette's plunger after dropping the tip. You should normally leave this unspecified to let the robot choose a safe default depending on its hardware.",
+          "type": "boolean"
+        }
+      },
+      "required": ["pipetteId"]
+    },
+    "UnsafeDropTipInPlaceCreate": {
+      "title": "UnsafeDropTipInPlaceCreate",
+      "description": "Drop tip in place command creation request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "unsafe/dropTipInPlace",
+          "enum": ["unsafe/dropTipInPlace"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/UnsafeDropTipInPlaceParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",

--- a/shared-data/command/schemas/9.json
+++ b/shared-data/command/schemas/9.json
@@ -70,7 +70,8 @@
       "calibration/calibrateModule": "#/definitions/CalibrateModuleCreate",
       "calibration/moveToMaintenancePosition": "#/definitions/MoveToMaintenancePositionCreate",
       "unsafe/blowOutInPlace": "#/definitions/UnsafeBlowOutInPlaceCreate",
-      "unsafe/dropTipInPlace": "#/definitions/UnsafeDropTipInPlaceCreate"
+      "unsafe/dropTipInPlace": "#/definitions/UnsafeDropTipInPlaceCreate",
+      "unsafe/updatePositionEstimators": "#/definitions/UpdatePositionEstimatorsCreate"
     }
   },
   "oneOf": [
@@ -271,6 +272,9 @@
     },
     {
       "$ref": "#/definitions/UnsafeDropTipInPlaceCreate"
+    },
+    {
+      "$ref": "#/definitions/UpdatePositionEstimatorsCreate"
     }
   ],
   "definitions": {
@@ -4309,6 +4313,51 @@
         },
         "params": {
           "$ref": "#/definitions/UnsafeDropTipInPlaceParams"
+        },
+        "intent": {
+          "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CommandIntent"
+            }
+          ]
+        },
+        "key": {
+          "title": "Key",
+          "description": "A key value, unique in this run, that can be used to track the same logical command across multiple runs of the same protocol. If a value is not provided, one will be generated.",
+          "type": "string"
+        }
+      },
+      "required": ["params"]
+    },
+    "UpdatePositionEstimatorsParams": {
+      "title": "UpdatePositionEstimatorsParams",
+      "description": "Payload required for an UpdatePositionEstimators command.",
+      "type": "object",
+      "properties": {
+        "axes": {
+          "description": "The axes for which to update the position estimators.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MotorAxis"
+          }
+        }
+      },
+      "required": ["axes"]
+    },
+    "UpdatePositionEstimatorsCreate": {
+      "title": "UpdatePositionEstimatorsCreate",
+      "description": "UpdatePositionEstimators command request model.",
+      "type": "object",
+      "properties": {
+        "commandType": {
+          "title": "Commandtype",
+          "default": "unsafe/updatePositionEstimators",
+          "enum": ["unsafe/updatePositionEstimators"],
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/definitions/UpdatePositionEstimatorsParams"
         },
         "intent": {
           "description": "The reason the command was added. If not specified or `protocol`, the command will be treated as part of the protocol run itself, and added to the end of the existing command queue.\n\nIf `setup`, the command will be treated as part of run setup. A setup command may only be enqueued if the run has not started.\n\nUse setup commands for activities like pre-run calibration checks and module setup, like pre-heating.",

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -19,6 +19,7 @@ import type {
   CalibrationRunTimeCommand,
   CalibrationCreateCommand,
 } from './calibration'
+import type { UnsafeRunTimeCommand, UnsafeCreateCommand } from './unsafe'
 
 export * from './annotation'
 export * from './calibration'
@@ -28,6 +29,7 @@ export * from './module'
 export * from './pipetting'
 export * from './setup'
 export * from './timing'
+export * from './unsafe'
 
 // NOTE: these key/value pairs will only be present on commands at analysis/run time
 // they pertain only to the actual execution status of a command on hardware, as opposed to
@@ -67,6 +69,7 @@ export type CreateCommand =
   | CalibrationCreateCommand // for automatic pipette calibration
   | AnnotationCreateCommand // annotating command execution
   | IncidentalCreateCommand // command with only incidental effects (status bar animations)
+  | UnsafeCreateCommand // command providing capabilities that are not safe for scientific uses
 
 // commands will be required to have a key, but will not be created with one
 export type RunTimeCommand =
@@ -78,6 +81,7 @@ export type RunTimeCommand =
   | CalibrationRunTimeCommand // for automatic pipette calibration
   | AnnotationRunTimeCommand // annotating command execution
   | IncidentalRunTimeCommand // command with only incidental effects (status bar animations)
+  | UnsafeRunTimeCommand // command providing capabilities that are not safe for scientific uses
 
 export type RunCommandError =
   | RunCommandErrorUndefined

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -1,4 +1,5 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+import type { MotorAxes } from '../../js/types'
 
 export type UnsafeRunTimeCommand =
   | UnsafeBlowoutInPlaceRunTimeCommand
@@ -36,5 +37,20 @@ export interface UnsafeDropTipInPlaceCreateCommand
 export interface UnsafeDropTipInPlaceRunTimeCommand
   extends CommonCommandRunTimeInfo,
     UnsafeDropTipInPlaceCreateCommand {
+  result?: any
+}
+
+export interface UnsafeUpdatePositionEstimatorsParams {
+  axes: MotorAxes
+}
+
+export interface UnsafeUpdatePositionEstimatorsCreateCommand
+  extends CommonCommandCreateInfo {
+  commandType: 'unsafe/updatePositionEstimators'
+  params: UnsafeUpdatePositionEstimatorsParams
+}
+export interface UnsafeUpdatePositionEstimatorsRunTimeCommand
+  extends CommonCommandRunTimeInfo,
+    UnsafeUpdatePositionEstimatorsCreateCommand {
   result?: any
 }

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -1,0 +1,21 @@
+import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
+
+export type UnsafeRunTimeCommand = UnsafeBlowoutInPlaceRunTimeCommand
+
+export type UnsafeCreateCommand = UnsafeBlowoutInPlaceCreateCommand
+
+export interface UnsafeBlowoutInPlaceParams {
+    pipetteId: string
+    flowRate: number // µL/s
+}
+
+export interface UnsafeBlowoutInPlaceCreateCommand
+    extends CommonCommandCreateInfo {
+    commandType: 'unsafe/blowOutInPlace'
+    params: UnsafeBlowoutInPlaceParams
+}
+export interface UnsafeBlowoutInPlaceRunTimeCommand
+    extends CommonCommandRunTimeInfo,
+        UnsafeBlowoutInPlaceCreateCommand {
+    result?: {}
+}

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -1,40 +1,40 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
 
 export type UnsafeRunTimeCommand =
-    | UnsafeBlowoutInPlaceRunTimeCommand
-    | UnsafeDropTipInPlaceRunTimeCommand
+  | UnsafeBlowoutInPlaceRunTimeCommand
+  | UnsafeDropTipInPlaceRunTimeCommand
 
 export type UnsafeCreateCommand =
-    | UnsafeBlowoutInPlaceCreateCommand
-    | UnsafeDropTipInPlaceCreateCommand
+  | UnsafeBlowoutInPlaceCreateCommand
+  | UnsafeDropTipInPlaceCreateCommand
 
 export interface UnsafeBlowoutInPlaceParams {
-    pipetteId: string
-    flowRate: number // µL/s
+  pipetteId: string
+  flowRate: number // µL/s
 }
 
 export interface UnsafeBlowoutInPlaceCreateCommand
-    extends CommonCommandCreateInfo {
-    commandType: 'unsafe/blowOutInPlace'
-    params: UnsafeBlowoutInPlaceParams
+  extends CommonCommandCreateInfo {
+  commandType: 'unsafe/blowOutInPlace'
+  params: UnsafeBlowoutInPlaceParams
 }
 export interface UnsafeBlowoutInPlaceRunTimeCommand
-    extends CommonCommandRunTimeInfo,
-        UnsafeBlowoutInPlaceCreateCommand {
-    result?: {}
+  extends CommonCommandRunTimeInfo,
+    UnsafeBlowoutInPlaceCreateCommand {
+  result?: {}
 }
 
 export interface UnsafeDropTipInPlaceParams {
-    pipetteId: string
+  pipetteId: string
 }
 
 export interface UnsafeDropTipInPlaceCreateCommand
-    extends CommonCommandCreateInfo {
-    commandType: 'unsafe/dropTipInPlace'
-    params: UnsafeDropTipInPlaceParams
+  extends CommonCommandCreateInfo {
+  commandType: 'unsafe/dropTipInPlace'
+  params: UnsafeDropTipInPlaceParams
 }
 export interface UnsafeDropTipInPlaceRunTimeCommand
-    extends CommonCommandRunTimeInfo,
-        UnsafeDropTipInPlaceCreateCommand {
-    result?: any
+  extends CommonCommandRunTimeInfo,
+    UnsafeDropTipInPlaceCreateCommand {
+  result?: any
 }

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -1,8 +1,12 @@
 import type { CommonCommandRunTimeInfo, CommonCommandCreateInfo } from '.'
 
-export type UnsafeRunTimeCommand = UnsafeBlowoutInPlaceRunTimeCommand
+export type UnsafeRunTimeCommand =
+    | UnsafeBlowoutInPlaceRunTimeCommand
+    | UnsafeDropTipInPlaceRunTimeCommand
 
-export type UnsafeCreateCommand = UnsafeBlowoutInPlaceCreateCommand
+export type UnsafeCreateCommand =
+    | UnsafeBlowoutInPlaceCreateCommand
+    | UnsafeDropTipInPlaceCreateCommand
 
 export interface UnsafeBlowoutInPlaceParams {
     pipetteId: string
@@ -18,4 +22,19 @@ export interface UnsafeBlowoutInPlaceRunTimeCommand
     extends CommonCommandRunTimeInfo,
         UnsafeBlowoutInPlaceCreateCommand {
     result?: {}
+}
+
+export interface UnsafeDropTipInPlaceParams {
+    pipetteId: string
+}
+
+export interface UnsafeDropTipInPlaceCreateCommand
+    extends CommonCommandCreateInfo {
+    commandType: 'unsafe/dropTipInPlace'
+    params: UnsafeDropTipInPlaceParams
+}
+export interface UnsafeDropTipInPlaceRunTimeCommand
+    extends CommonCommandRunTimeInfo,
+        UnsafeDropTipInPlaceCreateCommand {
+    result?: any
 }

--- a/shared-data/command/types/unsafe.ts
+++ b/shared-data/command/types/unsafe.ts
@@ -4,10 +4,12 @@ import type { MotorAxes } from '../../js/types'
 export type UnsafeRunTimeCommand =
   | UnsafeBlowoutInPlaceRunTimeCommand
   | UnsafeDropTipInPlaceRunTimeCommand
+  | UnsafeUpdatePositionEstimatorsRunTimeCommand
 
 export type UnsafeCreateCommand =
   | UnsafeBlowoutInPlaceCreateCommand
   | UnsafeDropTipInPlaceCreateCommand
+  | UnsafeUpdatePositionEstimatorsCreateCommand
 
 export interface UnsafeBlowoutInPlaceParams {
   pipetteId: string


### PR DESCRIPTION
We have this flow called the drop tip wizard, which happens after a protocol fails and there are still tips. It offers the user a way to get rid of the liquid stuck in the tips and the tips stuck on the pipette, which is very important on the well-sealed Flex pipette and the 96 channel.

However, if the protocol failed in the middle of a plunger motion, you can't actually do any of that because the plunger stopped abruptly and lost its position estimation.

The nice thing is that we have encoders! So let's add some new code that lets us use those to do things like blowout and drop tip even if we don't know the position of the plunger.

It's important not to just generally expose the ability to update from the encoders, because critically the encoders have a coarser position resolution than our internal position accumulators. Updating from the encoder position will introduce a small offset into the position of the axis, and that could be a real problem if it's being used for scientific tasks. So while we're adding a hardware control method to reset the position estimators of axes, we're not adding a command.

That's not a problem for quick commands that are going to fix up the state of the system, so we can make new commands in an `unsafe` command domain (just made up terminology, but it's the stuff before the slash) to indicate that they're not generally useful that will refresh the position before doing whatever it is.

Also, these will work generally on a flex, so we can just unconditionally use them if it's a flex in DTWiz and not mess around with dealing with partial tip configurations or whatever.

Unfortunately we also move to positions. We could make an unsafe equivalent of every movement command, but that seems like much especially since the thing they're doing lasts beyond their call. Instead, let's add `unsafe/updatePositionEstimators`, which we can call once at the beginning of DTWiz. In the future, we should add software tracking of the position estimators, and fail safe commands if the position comes from the encoders while letting the unsafe commands through.

## Testing
- [x] Can you actually use this stuff in the DTwiz after a failed aspirate
   - [x] on an LT pipette
   - [x] on a 96channel


Closes EXEC-401