### PR TITLE
feat(robot-server): split database into v5 and v6

### DIFF
--- a/robot-server/robot_server/persistence/_files_and_directories.py
+++ b/robot-server/robot_server/persistence/_files_and_directories.py
@@ -4,4 +4,4 @@ from typing import Final
 DECK_CONFIGURATION_FILE: Final = "deck_configuration.json"
 PROTOCOLS_DIRECTORY: Final = "protocols"
 DB_FILE: Final = "robot_server.db"
-LATEST_VERSION_DIRECTORY: Final = "5.1"
+LATEST_VERSION_DIRECTORY: Final = "6"

--- a/robot-server/robot_server/persistence/_files_and_directories.py
+++ b/robot-server/robot_server/persistence/_files_and_directories.py
@@ -3,5 +3,6 @@ from typing import Final
 
 DECK_CONFIGURATION_FILE: Final = "deck_configuration.json"
 PROTOCOLS_DIRECTORY: Final = "protocols"
+DATA_FILES_DIRECTORY: Final = "data_files"
 DB_FILE: Final = "robot_server.db"
 LATEST_VERSION_DIRECTORY: Final = "6"

--- a/robot-server/robot_server/persistence/_migrations/v4_to_v5.py
+++ b/robot-server/robot_server/persistence/_migrations/v4_to_v5.py
@@ -4,128 +4,50 @@ Summary of changes from schema 4:
 
 - Adds a new "protocol_kind" column to protocols table
 - Adds a new "data_files" table
-- Removes the "run_time_parameter_values_and_defaults" column of analysis_table and
-  creates a separate analysis_primitive_type_rtp_table instead. The migration does not
-  port the data from run_time_parameter_values_and_defaults into analysis_primitive_type_rtp_table.
-  The consequence of which is that any checks for previous matching analysis (for protocols with RTPs only)
-  will fail and a new analysis will be triggered. This new analysis will then save its
-  RTP data to the new table. RTP data belonging to previous analyses will still be available
-  as part of the completed analysis blob.
 """
 
 from pathlib import Path
 from contextlib import ExitStack
+import shutil
+from typing import Any
 
 import sqlalchemy
 
-from ..database import sql_engine_ctx, sqlite_rowid
-from ..tables import schema_5, schema_4
+from ..database import sql_engine_ctx
+from ..tables import schema_5
 from .._folder_migrator import Migration
 
-from ._util import copy_rows_unmodified, copy_if_exists, copytree_if_exists
-from .._files_and_directories import (
-    DECK_CONFIGURATION_FILE,
-    PROTOCOLS_DIRECTORY,
-    DB_FILE,
-)
+_DB_FILE = "robot_server.db"
 
 
 class Migration4to5(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
         """Migrate the persistence directory from schema 4 to 5."""
-        # Copy over unmodified directories and files to new version
-        copy_if_exists(
-            source_dir / DECK_CONFIGURATION_FILE, dest_dir / DECK_CONFIGURATION_FILE
-        )
-        copytree_if_exists(
-            source_dir / PROTOCOLS_DIRECTORY, dest_dir / PROTOCOLS_DIRECTORY
-        )
-
-        source_db_file = source_dir / DB_FILE
-        dest_db_file = dest_dir / DB_FILE
+        # Copy over all existing directories and files to new version
+        for item in source_dir.iterdir():
+            if item.is_dir():
+                shutil.copytree(src=item, dst=dest_dir / item.name)
+            else:
+                shutil.copy(src=item, dst=dest_dir / item.name)
+        dest_db_file = dest_dir / _DB_FILE
 
         # Append the new column to existing protocols in v4 database
         with ExitStack() as exit_stack:
-            source_engine = exit_stack.enter_context(sql_engine_ctx(source_db_file))
-
             dest_engine = exit_stack.enter_context(sql_engine_ctx(dest_db_file))
             schema_5.metadata.create_all(dest_engine)
 
-            source_transaction = exit_stack.enter_context(source_engine.begin())
-            dest_transaction = exit_stack.enter_context(dest_engine.begin())
+            def add_column(
+                engine: sqlalchemy.engine.Engine,
+                table_name: str,
+                column: Any,
+            ) -> None:
+                column_type = column.type.compile(engine.dialect)
+                engine.execute(
+                    f"ALTER TABLE {table_name} ADD COLUMN {column.key} {column_type}"
+                )
 
-            _migrate_db_with_changes(source_transaction, dest_transaction)
-
-
-def _migrate_db_with_changes(
-    source_transaction: sqlalchemy.engine.Connection,
-    dest_transaction: sqlalchemy.engine.Connection,
-) -> None:
-    _migrate_protocol_table_with_new_protocol_kind_col(
-        source_transaction,
-        dest_transaction,
-    )
-    _migrate_analysis_table_excluding_rtp_defaults_and_vals(
-        source_transaction,
-        dest_transaction,
-    )
-    copy_rows_unmodified(
-        schema_4.run_table,
-        schema_5.run_table,
-        source_transaction,
-        dest_transaction,
-        order_by_rowid=True,
-    )
-    copy_rows_unmodified(
-        schema_4.action_table,
-        schema_5.action_table,
-        source_transaction,
-        dest_transaction,
-        order_by_rowid=True,
-    )
-    copy_rows_unmodified(
-        schema_4.run_command_table,
-        schema_5.run_command_table,
-        source_transaction,
-        dest_transaction,
-        order_by_rowid=True,
-    )
-
-
-def _migrate_protocol_table_with_new_protocol_kind_col(
-    source_transaction: sqlalchemy.engine.Connection,
-    dest_transaction: sqlalchemy.engine.Connection,
-) -> None:
-    """Add a new 'protocol_kind' column to protocols table."""
-    select_old_protocols = sqlalchemy.select(schema_4.protocol_table).order_by(
-        sqlite_rowid
-    )
-    insert_new_protocols = sqlalchemy.insert(schema_5.protocol_table)
-    for old_row in source_transaction.execute(select_old_protocols).all():
-        dest_transaction.execute(
-            insert_new_protocols,
-            id=old_row.id,
-            created_at=old_row.created_at,
-            protocol_key=old_row.protocol_key,
-            protocol_kind=None,
-        )
-
-
-def _migrate_analysis_table_excluding_rtp_defaults_and_vals(
-    source_transaction: sqlalchemy.engine.Connection,
-    dest_transaction: sqlalchemy.engine.Connection,
-) -> None:
-    """Remove run_time_parameter_values_and_defaults column from analysis_table."""
-    select_old_analyses = sqlalchemy.select(schema_4.analysis_table).order_by(
-        sqlite_rowid
-    )
-    insert_new_analyses = sqlalchemy.insert(schema_5.analysis_table)
-    for old_row in source_transaction.execute(select_old_analyses).all():
-        dest_transaction.execute(
-            insert_new_analyses,
-            id=old_row.id,
-            protocol_id=old_row.protocol_id,
-            analyzer_version=old_row.analyzer_version,
-            completed_analysis=old_row.completed_analysis,
-            # run_time_parameter_values_and_defaults column is omitted
-        )
+            add_column(
+                dest_engine,
+                schema_5.protocol_table.name,
+                schema_5.protocol_table.c.protocol_kind,
+            )

--- a/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
+++ b/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
@@ -1,0 +1,116 @@
+"""Migrate the persistence directory from schema 5 to 6.
+
+Summary of changes from schema 5:
+
+- Removes the "run_time_parameter_values_and_defaults" column of analysis_table
+- Adds a separate analysis_primitive_type_rtp_table to store fully validated primitive
+  run time parameters.
+  - NOTE: V5 to V6 migration does not port the data from run_time_parameter_values_and_defaults
+          into analysis_primitive_type_rtp_table. The consequence of which is that
+          any checks for previous matching analysis (for protocols with RTPs only)
+          will fail and a new analysis will be triggered. This new analysis will then
+          save its RTP data to the new table. RTP data belonging to previous analyses
+          will still be available as part of the completed analysis blob.
+- Adds a new analysis_csv_rtp_table to store the CSV parameters' file IDs used in analysis
+"""
+
+from pathlib import Path
+from contextlib import ExitStack
+
+import sqlalchemy
+
+from ..database import sql_engine_ctx, sqlite_rowid
+from ..tables import schema_5, schema_6
+from .._folder_migrator import Migration
+
+from ._util import copy_rows_unmodified, copy_if_exists, copytree_if_exists
+from .._files_and_directories import (
+    DECK_CONFIGURATION_FILE,
+    PROTOCOLS_DIRECTORY,
+    DB_FILE,
+)
+
+
+class Migration5to6(Migration):  # noqa: D101
+    def migrate(self, source_dir: Path, dest_dir: Path) -> None:
+        """Migrate the persistence directory from schema 4 to 5."""
+        # Copy over unmodified directories and files to new version
+        copy_if_exists(
+            source_dir / DECK_CONFIGURATION_FILE, dest_dir / DECK_CONFIGURATION_FILE
+        )
+        copytree_if_exists(
+            source_dir / PROTOCOLS_DIRECTORY, dest_dir / PROTOCOLS_DIRECTORY
+        )
+
+        source_db_file = source_dir / DB_FILE
+        dest_db_file = dest_dir / DB_FILE
+
+        # Append the new column to existing protocols in v4 database
+        with ExitStack() as exit_stack:
+            source_engine = exit_stack.enter_context(sql_engine_ctx(source_db_file))
+
+            dest_engine = exit_stack.enter_context(sql_engine_ctx(dest_db_file))
+            schema_6.metadata.create_all(dest_engine)
+
+            source_transaction = exit_stack.enter_context(source_engine.begin())
+            dest_transaction = exit_stack.enter_context(dest_engine.begin())
+
+            _migrate_db_with_changes(source_transaction, dest_transaction)
+
+
+def _migrate_db_with_changes(
+    source_transaction: sqlalchemy.engine.Connection,
+    dest_transaction: sqlalchemy.engine.Connection,
+) -> None:
+    copy_rows_unmodified(
+        schema_5.protocol_table,
+        schema_6.protocol_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+    _migrate_analysis_table_excluding_rtp_defaults_and_vals(
+        source_transaction,
+        dest_transaction,
+    )
+    copy_rows_unmodified(
+        schema_5.run_table,
+        schema_6.run_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+    copy_rows_unmodified(
+        schema_5.action_table,
+        schema_6.action_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+    copy_rows_unmodified(
+        schema_5.run_command_table,
+        schema_6.run_command_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
+
+
+def _migrate_analysis_table_excluding_rtp_defaults_and_vals(
+    source_transaction: sqlalchemy.engine.Connection,
+    dest_transaction: sqlalchemy.engine.Connection,
+) -> None:
+    """Remove run_time_parameter_values_and_defaults column from analysis_table."""
+    select_old_analyses = sqlalchemy.select(schema_5.analysis_table).order_by(
+        sqlite_rowid
+    )
+    insert_new_analyses = sqlalchemy.insert(schema_6.analysis_table)
+    for old_row in source_transaction.execute(select_old_analyses).all():
+        dest_transaction.execute(
+            insert_new_analyses,
+            id=old_row.id,
+            protocol_id=old_row.protocol_id,
+            analyzer_version=old_row.analyzer_version,
+            completed_analysis=old_row.completed_analysis,
+            # run_time_parameter_values_and_defaults column is omitted
+        )

--- a/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
+++ b/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
@@ -30,6 +30,7 @@ from ._util import copy_rows_unmodified, copy_if_exists, copytree_if_exists
 from .._files_and_directories import (
     DECK_CONFIGURATION_FILE,
     PROTOCOLS_DIRECTORY,
+    DATA_FILES_DIRECTORY,
     DB_FILE,
 )
 
@@ -43,6 +44,9 @@ class Migration5to6(Migration):  # noqa: D101
         )
         copytree_if_exists(
             source_dir / PROTOCOLS_DIRECTORY, dest_dir / PROTOCOLS_DIRECTORY
+        )
+        copytree_if_exists(
+            source_dir / DATA_FILES_DIRECTORY, dest_dir / DATA_FILES_DIRECTORY
         )
 
         source_db_file = source_dir / DB_FILE

--- a/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
+++ b/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
@@ -65,6 +65,13 @@ def _migrate_db_with_changes(
     source_transaction: sqlalchemy.engine.Connection,
     dest_transaction: sqlalchemy.engine.Connection,
 ) -> None:
+    copy_rows_unmodified(
+        schema_5.data_files_table,
+        schema_6.data_files_table,
+        source_transaction,
+        dest_transaction,
+        order_by_rowid=True,
+    )
     _migrate_protocol_table_with_new_protocol_kind_col(
         source_transaction,
         dest_transaction,

--- a/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
+++ b/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
@@ -12,6 +12,7 @@ Summary of changes from schema 5:
           save its RTP data to the new table. RTP data belonging to previous analyses
           will still be available as part of the completed analysis blob.
 - Adds a new analysis_csv_rtp_table to store the CSV parameters' file IDs used in analysis
+- Adds a new run_csv_rtp_table to store the CSV parameters' file IDs used in runs
 """
 
 from pathlib import Path

--- a/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
+++ b/robot-server/robot_server/persistence/_migrations/v5_to_v6.py
@@ -33,7 +33,7 @@ from .._files_and_directories import (
 
 class Migration5to6(Migration):  # noqa: D101
     def migrate(self, source_dir: Path, dest_dir: Path) -> None:
-        """Migrate the persistence directory from schema 4 to 5."""
+        """Migrate the persistence directory from schema 5 to 6."""
         # Copy over unmodified directories and files to new version
         copy_if_exists(
             source_dir / DECK_CONFIGURATION_FILE, dest_dir / DECK_CONFIGURATION_FILE

--- a/robot-server/robot_server/persistence/persistence_directory.py
+++ b/robot-server/robot_server/persistence/persistence_directory.py
@@ -11,7 +11,7 @@ from typing_extensions import Final
 from anyio import Path as AsyncPath, to_thread
 
 from ._folder_migrator import MigrationOrchestrator
-from ._migrations import up_to_3, v3_to_v4, v4_to_v5
+from ._migrations import up_to_3, v3_to_v4, v4_to_v5, v5_to_v6
 from . import LATEST_VERSION_DIRECTORY
 
 _TEMP_PERSISTENCE_DIR_PREFIX: Final = "opentrons-robot-server-"
@@ -50,7 +50,8 @@ async def prepare_active_subdirectory(prepared_root: Path) -> Path:
         migrations=[
             up_to_3.MigrationUpTo3(subdirectory="3"),
             v3_to_v4.Migration3to4(subdirectory="4"),
-            v4_to_v5.Migration4to5(subdirectory=LATEST_VERSION_DIRECTORY),
+            v4_to_v5.Migration4to5(subdirectory="5"),
+            v5_to_v6.Migration5to6(subdirectory=LATEST_VERSION_DIRECTORY),
         ],
         temp_file_prefix="temp-",
     )

--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -1,7 +1,7 @@
 """SQL database schemas."""
 
 # Re-export the latest schema.
-from .schema_5 import (
+from .schema_6 import (
     metadata,
     protocol_table,
     analysis_table,

--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -12,6 +12,7 @@ from .schema_6 import (
     action_table,
     data_files_table,
     PrimitiveParamSQLEnum,
+    ProtocolKindSQLEnum,
 )
 
 
@@ -26,4 +27,5 @@ __all__ = [
     "action_table",
     "data_files_table",
     "PrimitiveParamSQLEnum",
+    "ProtocolKindSQLEnum",
 ]

--- a/robot-server/robot_server/persistence/tables/schema_6.py
+++ b/robot-server/robot_server/persistence/tables/schema_6.py
@@ -220,3 +220,28 @@ data_files_table = sqlalchemy.Table(
         nullable=False,
     ),
 )
+
+run_csv_rtp_table = sqlalchemy.Table(
+    "run_csv_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=True,
+    ),
+)

--- a/robot-server/robot_server/persistence/tables/schema_6.py
+++ b/robot-server/robot_server/persistence/tables/schema_6.py
@@ -16,6 +16,13 @@ class PrimitiveParamSQLEnum(enum.Enum):
     STR = "str"
 
 
+class ProtocolKindSQLEnum(enum.Enum):
+    """What kind a stored protocol is."""
+
+    STANDARD = "standard"
+    QUICK_TRANSFER = "quick-transfer"
+
+
 protocol_table = sqlalchemy.Table(
     "protocol",
     metadata,
@@ -30,7 +37,16 @@ protocol_table = sqlalchemy.Table(
         nullable=False,
     ),
     sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
-    sqlalchemy.Column("protocol_kind", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "protocol_kind",
+        sqlalchemy.Enum(
+            ProtocolKindSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            create_constraint=True,
+        ),
+        index=True,
+        nullable=False,
+    ),
 )
 
 analysis_table = sqlalchemy.Table(

--- a/robot-server/robot_server/persistence/tables/schema_6.py
+++ b/robot-server/robot_server/persistence/tables/schema_6.py
@@ -1,10 +1,20 @@
-"""v5 of our SQLite schema."""
-
+"""v6 of our SQLite schema."""
+import enum
 import sqlalchemy
 
 from robot_server.persistence._utc_datetime import UTCDateTime
 
 metadata = sqlalchemy.MetaData()
+
+
+class PrimitiveParamSQLEnum(enum.Enum):
+    """Enum type to store primitive param type."""
+
+    INT = "int"
+    FLOAT = "float"
+    BOOL = "bool"
+    STR = "str"
+
 
 protocol_table = sqlalchemy.Table(
     "protocol",
@@ -49,10 +59,63 @@ analysis_table = sqlalchemy.Table(
         sqlalchemy.String,
         nullable=False,
     ),
-    # column added in schema v4
+)
+
+analysis_primitive_type_rtp_table = sqlalchemy.Table(
+    "analysis_primitive_rtp_table",
+    metadata,
     sqlalchemy.Column(
-        "run_time_parameter_values_and_defaults",
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "analysis_id",
+        sqlalchemy.ForeignKey("analysis.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
         sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_type",
+        sqlalchemy.Enum(
+            PrimitiveParamSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            create_constraint=True,
+        ),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_value",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+)
+
+analysis_csv_rtp_table = sqlalchemy.Table(
+    "analysis_csv_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "analysis_id",
+        sqlalchemy.ForeignKey("analysis.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.ForeignKey("data_files.id"),
         nullable=True,
     ),
 )
@@ -76,17 +139,13 @@ run_table = sqlalchemy.Table(
         sqlalchemy.ForeignKey("protocol.id"),
         nullable=True,
     ),
-    # column added in schema v1
     sqlalchemy.Column(
         "state_summary",
         sqlalchemy.String,
         nullable=True,
     ),
-    # column added in schema v1
     sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
-    # column added in schema v1
     sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
-    # column added in schema v4
     sqlalchemy.Column(
         "run_time_parameters",
         # Stores a JSON string. See RunStore.

--- a/robot-server/robot_server/protocols/protocol_auto_deleter.py
+++ b/robot-server/robot_server/protocols/protocol_auto_deleter.py
@@ -27,7 +27,7 @@ class ProtocolAutoDeleter:  # noqa: D101
         protocols = {
             p.protocol_id
             for p in self._protocol_store.get_all()
-            if p.protocol_kind == self._protocol_kind.value
+            if p.protocol_kind == self._protocol_kind
         }
 
         protocol_run_usage_info = [

--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -22,14 +22,6 @@ class ProtocolKind(str, Enum):
     STANDARD = "standard"
     QUICK_TRANSFER = "quick-transfer"
 
-    @staticmethod
-    def from_string(name: Optional[str]) -> Optional["ProtocolKind"]:
-        """Get the ProtocolKind from a string."""
-        for item in ProtocolKind:
-            if name == item.value:
-                return item
-        return None
-
 
 class ProtocolFile(BaseModel):
     """A file in a protocol."""

--- a/robot-server/robot_server/runs/run_auto_deleter.py
+++ b/robot-server/robot_server/runs/run_auto_deleter.py
@@ -29,9 +29,7 @@ class RunAutoDeleter:  # noqa: D101
         protocols = self._protocol_store.get_all()
         protocol_ids = [p.protocol_id for p in protocols]
         filtered_protocol_ids = [
-            p.protocol_id
-            for p in protocols
-            if p.protocol_kind == self._protocol_kind.value
+            p.protocol_id for p in protocols if p.protocol_kind == self._protocol_kind
         ]
 
         # runs with no protocols first, then oldest to newest.

--- a/robot-server/tests/integration/http_api/persistence/test_reset.py
+++ b/robot-server/tests/integration/http_api/persistence/test_reset.py
@@ -40,9 +40,9 @@ async def _assert_reset_was_successful(
     all_files_and_directories = set(persistence_directory.glob("**/*"))
     expected_files_and_directories = {
         persistence_directory / "robot_server.db",
-        persistence_directory / "5.1",
-        persistence_directory / "5.1" / "protocols",
-        persistence_directory / "5.1" / "robot_server.db",
+        persistence_directory / "6",
+        persistence_directory / "6" / "protocols",
+        persistence_directory / "6" / "robot_server.db",
     }
     assert all_files_and_directories == expected_files_and_directories
 

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -122,6 +122,17 @@ EXPECTED_STATEMENTS_LATEST = [
         PRIMARY KEY (id)
     )
     """,
+    """
+    CREATE TABLE run_csv_rtp_table (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        file_id VARCHAR,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id) REFERENCES run (id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id)
+    )
+    """,
 ]
 
 EXPECTED_STATEMENTS_V6 = EXPECTED_STATEMENTS_LATEST

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -12,6 +12,7 @@ from robot_server.persistence.tables import (
     schema_2,
     schema_4,
     schema_5,
+    schema_6,
 )
 
 # The statements that we expect to emit when we create a fresh database.
@@ -123,7 +124,82 @@ EXPECTED_STATEMENTS_LATEST = [
     """,
 ]
 
-EXPECTED_STATEMENTS_V5 = EXPECTED_STATEMENTS_LATEST
+EXPECTED_STATEMENTS_V6 = EXPECTED_STATEMENTS_LATEST
+
+EXPECTED_STATEMENTS_V5 = [
+    """
+    CREATE TABLE protocol (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_key VARCHAR,
+        protocol_kind VARCHAR,
+        PRIMARY KEY (id)
+    )
+    """,
+    """
+    CREATE TABLE analysis (
+        id VARCHAR NOT NULL,
+        protocol_id VARCHAR NOT NULL,
+        analyzer_version VARCHAR NOT NULL,
+        completed_analysis VARCHAR NOT NULL,
+        run_time_parameter_values_and_defaults VARCHAR,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_analysis_protocol_id ON analysis (protocol_id)
+    """,
+    """
+    CREATE TABLE run (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_id VARCHAR,
+        state_summary VARCHAR,
+        engine_status VARCHAR,
+        _updated_at DATETIME,
+        run_time_parameters VARCHAR,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE TABLE action (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        action_type VARCHAR NOT NULL,
+        run_id VARCHAR NOT NULL,
+        PRIMARY KEY (id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE TABLE run_command (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        index_in_run INTEGER NOT NULL,
+        command_id VARCHAR NOT NULL,
+        command VARCHAR NOT NULL,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_command_id ON run_command (run_id, command_id)
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
+    """,
+    """
+    CREATE TABLE data_files (
+        id VARCHAR NOT NULL,
+        name VARCHAR NOT NULL,
+        file_hash VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        PRIMARY KEY (id)
+    )
+    """,
+]
 
 EXPECTED_STATEMENTS_V4 = [
     """
@@ -329,6 +405,7 @@ def _normalize_statement(statement: str) -> str:
     ("metadata", "expected_statements"),
     [
         (latest_metadata, EXPECTED_STATEMENTS_LATEST),
+        (schema_6.metadata, EXPECTED_STATEMENTS_V6),
         (schema_5.metadata, EXPECTED_STATEMENTS_V5),
         (schema_4.metadata, EXPECTED_STATEMENTS_V4),
         (schema_3.metadata, EXPECTED_STATEMENTS_V3),

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -33,8 +33,9 @@ EXPECTED_STATEMENTS_LATEST = [
         id VARCHAR NOT NULL,
         created_at DATETIME NOT NULL,
         protocol_key VARCHAR,
-        protocol_kind VARCHAR,
-        PRIMARY KEY (id)
+        protocol_kind VARCHAR(14) NOT NULL,
+        PRIMARY KEY (id),
+        CONSTRAINT protocolkindsqlenum CHECK (protocol_kind IN ('standard', 'quick-transfer'))
     )
     """,
     """
@@ -112,6 +113,9 @@ EXPECTED_STATEMENTS_LATEST = [
     """,
     """
     CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
+    """,
+    """
+    CREATE INDEX ix_protocol_protocol_kind ON protocol (protocol_kind)
     """,
     """
     CREATE TABLE data_files (

--- a/robot-server/tests/protocols/test_analyses_manager.py
+++ b/robot-server/tests/protocols/test_analyses_manager.py
@@ -83,7 +83,7 @@ async def test_initialize_analyzer(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     analyzer = decoy.mock(cls=protocol_analyzer.ProtocolAnalyzer)
     decoy.when(
@@ -128,7 +128,7 @@ async def test_raises_error_and_saves_result_if_initialization_errors(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     raised_exception = Exception("Oh noooo!")
     enumerated_error = EnumeratedError(
@@ -197,7 +197,7 @@ async def test_start_analysis(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     bool_parameter = BooleanParameter(
         displayName="Foo", variableName="Bar", default=True, value=False

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -50,6 +50,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisStore,
     CompletedAnalysisResource,
 )
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
@@ -96,7 +97,7 @@ def make_dummy_protocol_resource(protocol_id: str) -> ProtocolResource:
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
 

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -29,6 +29,7 @@ from robot_server.protocols.analysis_models import (
     AnalysisStatus,
     RunTimeParameterAnalysisData,
 )
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
@@ -95,7 +96,7 @@ def make_dummy_protocol_resource(protocol_id: str) -> ProtocolResource:
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
 

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -87,7 +87,7 @@ async def test_load_orchestrator(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     subject = ProtocolAnalyzer(
         analysis_store=analysis_store, protocol_resource=protocol_resource
@@ -136,7 +136,7 @@ async def test_analyze(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     analysis_command = pe_commands.WaitForResume(
@@ -232,7 +232,7 @@ async def test_analyze_updates_pending_on_error(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     raised_exception = Exception("You got me!!")

--- a/robot-server/tests/protocols/test_protocol_auto_deleter.py
+++ b/robot-server/tests/protocols/test_protocol_auto_deleter.py
@@ -46,7 +46,7 @@ def test_make_room_for_new_protocol(
             created_at=datetime(year=2020, month=1, day=1),
             source=mock_protocol_source,
             protocol_key=f"{p.protocol_id}{idx}",
-            protocol_kind=ProtocolKind.STANDARD.value,
+            protocol_kind=ProtocolKind.STANDARD,
         )
         for idx, p in enumerate(usage_info)
     ]
@@ -96,9 +96,9 @@ def test_make_room_for_new_quick_transfer_protocol(
             created_at=datetime(year=2020, month=1, day=1),
             source=mock_protocol_source,
             protocol_key=f"{p.protocol_id}{idx}",
-            protocol_kind=ProtocolKind.STANDARD.value
+            protocol_kind=ProtocolKind.STANDARD
             if idx not in [3, 4]
-            else ProtocolKind.QUICK_TRANSFER.value,
+            else ProtocolKind.QUICK_TRANSFER,
         )
         for idx, p in enumerate(usage_info_all)
     ]

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -25,6 +25,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisResource,
     CompletedAnalysisStore,
 )
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
@@ -98,7 +99,7 @@ async def test_insert_and_get_protocol(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     assert subject.has("protocol-id") is False
@@ -127,7 +128,7 @@ async def test_insert_with_duplicate_key_raises(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     protocol_resource_2 = ProtocolResource(
         protocol_id="protocol-id",
@@ -142,7 +143,7 @@ async def test_insert_with_duplicate_key_raises(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-222",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     subject.insert(protocol_resource_1)
 
@@ -180,7 +181,7 @@ async def test_get_all_protocols(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     resource_2 = ProtocolResource(
         protocol_id="123",
@@ -195,7 +196,7 @@ async def test_get_all_protocols(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-222",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(resource_1)
@@ -232,7 +233,7 @@ async def test_remove_protocol(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource)
@@ -272,7 +273,7 @@ def test_remove_protocol_conflict(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource)
@@ -307,7 +308,7 @@ def test_get_usage_info(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     protocol_resource_2 = ProtocolResource(
         protocol_id="protocol-id-2",
@@ -322,7 +323,7 @@ def test_get_usage_info(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource_1)
@@ -392,7 +393,7 @@ def test_get_referencing_run_ids(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource_1)
@@ -436,7 +437,7 @@ def test_get_protocol_ids(
             content_hash="abc1",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     protocol_resource_2 = ProtocolResource(
@@ -452,7 +453,7 @@ def test_get_protocol_ids(
             content_hash="abc2",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     assert subject.get_all_ids() == []
@@ -487,7 +488,7 @@ async def test_insert_and_get_quick_transfer_protocol(
             content_hash="abc123",
         ),
         protocol_key="dummy-key-111",
-        protocol_kind="quick-transfer",
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
 
     assert subject.has("protocol-id") is False
@@ -496,7 +497,7 @@ async def test_insert_and_get_quick_transfer_protocol(
     result = subject.get("protocol-id")
 
     assert result == protocol_resource
-    assert result.protocol_kind == "quick-transfer"
+    assert result.protocol_kind == ProtocolKind.QUICK_TRANSFER
     assert subject.has("protocol-id") is True
 
 
@@ -542,7 +543,7 @@ async def test_get_referenced_data_files(
             content_hash="abc1",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     analysis_resource1 = CompletedAnalysisResource(
         "analysis-id-1",

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -157,7 +157,7 @@ async def test_get_protocols(
             content_hash="a_b_c",
         ),
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     resource_2 = ProtocolResource(
         protocol_id="123",
@@ -172,7 +172,7 @@ async def test_get_protocols(
             content_hash="1_2_3",
         ),
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     resource_3 = ProtocolResource(
         protocol_id="333",
@@ -187,7 +187,7 @@ async def test_get_protocols(
             content_hash="3_3_3",
         ),
         protocol_key="dummy-key-333",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
 
     analysis_1 = AnalysisSummary(id="analysis-id-abc", status=AnalysisStatus.PENDING)
@@ -330,7 +330,7 @@ async def test_get_protocol_by_id(
             content_hash="a_b_c",
         ),
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     analysis_summary = AnalysisSummary(
@@ -426,7 +426,7 @@ async def test_create_existing_protocol(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     completed_analysis = AnalysisSummary(
@@ -537,7 +537,7 @@ async def test_create_protocol(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     pending_analysis = AnalysisSummary(
@@ -659,7 +659,7 @@ async def test_create_new_protocol_with_run_time_params(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -777,7 +777,7 @@ async def test_create_existing_protocol_with_no_previous_analysis(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -899,7 +899,7 @@ async def test_create_existing_protocol_with_different_run_time_params(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     completed_summary = AnalysisSummary(
@@ -1033,7 +1033,7 @@ async def test_create_existing_protocol_with_same_run_time_params(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -1158,7 +1158,7 @@ async def test_create_existing_protocol_with_pending_analysis_raises(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -1603,7 +1603,7 @@ async def test_create_protocol_analyses_with_same_rtp_values(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     decoy.when(protocol_store.has(protocol_id="protocol-id")).then_return(True)
     decoy.when(protocol_store.get(protocol_id="protocol-id")).then_return(
@@ -1679,7 +1679,7 @@ async def test_update_protocol_analyses_with_new_rtp_values(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     analysis_summaries = [
         AnalysisSummary(
@@ -1794,7 +1794,7 @@ async def test_update_protocol_analyses_with_forced_reanalysis(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     decoy.when(protocol_store.has(protocol_id="protocol-id")).then_return(True)
     decoy.when(
@@ -1872,7 +1872,7 @@ async def test_create_protocol_kind_quick_transfer(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -2000,7 +2000,7 @@ async def test_create_protocol_maximum_quick_transfer_protocols_exceeded(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
 
     decoy.when(protocol_store.get_all()).then_return([stored_protocol_resource])

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -18,6 +18,7 @@ from robot_server.service.json_api import (
     ResourceLink,
 )
 
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolNotFoundError,
     ProtocolResource,
@@ -132,7 +133,7 @@ async def test_create_protocol_run(
     protocol_resource = ProtocolResource(
         protocol_id=protocol_id,
         protocol_key=None,
-        protocol_kind=None,
+        protocol_kind=ProtocolKind.STANDARD,
         created_at=datetime(year=2022, month=2, day=2),
         source=ProtocolSource(
             directory=Path("/dev/null"),

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -24,6 +24,8 @@ from opentrons.types import DeckSlotName
 
 from opentrons_shared_data.errors.exceptions import InvalidStoredData
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs import error_recovery_mapping
 from robot_server.runs.error_recovery_models import ErrorRecoveryRule
@@ -218,7 +220,7 @@ async def test_create_with_options(
         created_at=datetime(year=2022, month=2, day=2),
         source=None,  # type: ignore[arg-type]
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     labware_offset = pe_types.LabwareOffsetCreate(


### PR DESCRIPTION
# Overview

Splits up the changes we have so far into a v5 schema that's already in QA and anything on top of that to be in v6 so that QA & ABR don't have to do database resets while testing.

This branch is currently pointing to edge that has the v5 schema that's in QA. This is done on purpose so that we can check that the database changes diff between current edge (without v5.1) and introduction of v6 is correct and is not affected by the intermediate v5.1 DB changes.

Only look at the changes in the persistence directory (and its tests). Everything else is part of the outstanding PRs that introduced v5.1 changes and is irrelevant to the matter at hand.

Will rebase the changes onto edge once edge has the 5.1 changes.
