### PR TITLE
refactor(robot-server): Use a non-nullable indexed enum for `protocol_kind`

### DIFF
--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -12,6 +12,7 @@ from .schema_6 import (
     action_table,
     data_files_table,
     PrimitiveParamSQLEnum,
+    ProtocolKindSQLEnum,
 )
 
 
@@ -26,4 +27,5 @@ __all__ = [
     "action_table",
     "data_files_table",
     "PrimitiveParamSQLEnum",
+    "ProtocolKindSQLEnum",
 ]

--- a/robot-server/robot_server/persistence/tables/schema_6.py
+++ b/robot-server/robot_server/persistence/tables/schema_6.py
@@ -16,6 +16,13 @@ class PrimitiveParamSQLEnum(enum.Enum):
     STR = "str"
 
 
+class ProtocolKindSQLEnum(enum.Enum):
+    """What kind a stored protocol is."""
+
+    STANDARD = "standard"
+    QUICK_TRANSFER = "quick-transfer"
+
+
 protocol_table = sqlalchemy.Table(
     "protocol",
     metadata,
@@ -30,7 +37,16 @@ protocol_table = sqlalchemy.Table(
         nullable=False,
     ),
     sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
-    sqlalchemy.Column("protocol_kind", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "protocol_kind",
+        sqlalchemy.Enum(
+            ProtocolKindSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            create_constraint=True,
+        ),
+        index=True,
+        nullable=False,
+    ),
 )
 
 analysis_table = sqlalchemy.Table(

--- a/robot-server/robot_server/protocols/protocol_auto_deleter.py
+++ b/robot-server/robot_server/protocols/protocol_auto_deleter.py
@@ -27,7 +27,7 @@ class ProtocolAutoDeleter:  # noqa: D101
         protocols = {
             p.protocol_id
             for p in self._protocol_store.get_all()
-            if p.protocol_kind == self._protocol_kind.value
+            if p.protocol_kind == self._protocol_kind
         }
 
         protocol_run_usage_info = [

--- a/robot-server/robot_server/protocols/protocol_models.py
+++ b/robot-server/robot_server/protocols/protocol_models.py
@@ -22,14 +22,6 @@ class ProtocolKind(str, Enum):
     STANDARD = "standard"
     QUICK_TRANSFER = "quick-transfer"
 
-    @staticmethod
-    def from_string(name: Optional[str]) -> Optional["ProtocolKind"]:
-        """Get the ProtocolKind from a string."""
-        for item in ProtocolKind:
-            if name == item.value:
-                return item
-        return None
-
 
 class ProtocolFile(BaseModel):
     """A file in a protocol."""

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -283,7 +283,7 @@ async def create_protocol(  # noqa: C901
         quick_transfer_protocols = [
             protocol
             for protocol in protocol_store.get_all()
-            if protocol.protocol_kind == ProtocolKind.QUICK_TRANSFER.value
+            if protocol.protocol_kind == ProtocolKind.QUICK_TRANSFER
         ]
         if len(quick_transfer_protocols) >= maximum_quick_transfer_protocols:
             raise HTTPException(

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -219,8 +219,8 @@ async def create_protocol(  # noqa: C901
         " always trigger an analysis (for now).",
         alias="runTimeParameterValues",
     ),
-    protocol_kind: Optional[ProtocolKind] = Form(
-        default=None,
+    protocol_kind: ProtocolKind = Form(
+        default=ProtocolKind.STANDARD,
         description=(
             "Whether this is a `standard` protocol or a `quick-transfer` protocol."
             "if omitted, the protocol will be `standard` by default."
@@ -277,8 +277,7 @@ async def create_protocol(  # noqa: C901
         created_at: Timestamp to attach to the new resource.
         maximum_quick_transfer_protocols: Robot setting value limiting stored quick transfers protocols.
     """
-    kind = ProtocolKind.from_string(protocol_kind) or ProtocolKind.STANDARD
-    if kind == ProtocolKind.QUICK_TRANSFER:
+    if protocol_kind == ProtocolKind.QUICK_TRANSFER:
         quick_transfer_protocols = [
             protocol
             for protocol in protocol_store.get_all()
@@ -340,7 +339,7 @@ async def create_protocol(  # noqa: C901
             data = Protocol.construct(
                 id=cached_protocol_id,
                 createdAt=resource.created_at,
-                protocolKind=ProtocolKind.from_string(resource.protocol_kind),
+                protocolKind=resource.protocol_kind,
                 protocolType=resource.source.config.protocol_type,
                 robotType=resource.source.robot_type,
                 metadata=Metadata.parse_obj(resource.source.metadata),
@@ -390,11 +389,11 @@ async def create_protocol(  # noqa: C901
         created_at=created_at,
         source=source,
         protocol_key=key,
-        protocol_kind=kind.value,
+        protocol_kind=protocol_kind,
     )
 
     protocol_deleter: ProtocolAutoDeleter = protocol_auto_deleter
-    if kind == ProtocolKind.QUICK_TRANSFER:
+    if protocol_kind == ProtocolKind.QUICK_TRANSFER:
         protocol_deleter = quick_transfer_protocol_auto_deleter
     protocol_deleter.make_room_for_new_protocol()
     protocol_store.insert(protocol_resource)
@@ -413,7 +412,7 @@ async def create_protocol(  # noqa: C901
     data = Protocol(
         id=protocol_id,
         createdAt=created_at,
-        protocolKind=kind,
+        protocolKind=protocol_kind,
         protocolType=source.config.protocol_type,
         robotType=source.robot_type,
         metadata=Metadata.parse_obj(source.metadata),
@@ -523,7 +522,7 @@ async def get_protocols(
         Protocol.construct(
             id=r.protocol_id,
             createdAt=r.created_at,
-            protocolKind=ProtocolKind.from_string(r.protocol_kind),
+            protocolKind=r.protocol_kind,
             protocolType=r.source.config.protocol_type,
             robotType=r.source.robot_type,
             metadata=Metadata.parse_obj(r.source.metadata),
@@ -604,7 +603,7 @@ async def get_protocol_by_id(
     data = Protocol.construct(
         id=protocolId,
         createdAt=resource.created_at,
-        protocolKind=ProtocolKind.from_string(resource.protocol_kind),
+        protocolKind=resource.protocol_kind,
         protocolType=resource.source.config.protocol_type,
         robotType=resource.source.robot_type,
         metadata=Metadata.parse_obj(resource.source.metadata),

--- a/robot-server/robot_server/runs/run_auto_deleter.py
+++ b/robot-server/robot_server/runs/run_auto_deleter.py
@@ -29,9 +29,7 @@ class RunAutoDeleter:  # noqa: D101
         protocols = self._protocol_store.get_all()
         protocol_ids = [p.protocol_id for p in protocols]
         filtered_protocol_ids = [
-            p.protocol_id
-            for p in protocols
-            if p.protocol_kind == self._protocol_kind.value
+            p.protocol_id for p in protocols if p.protocol_kind == self._protocol_kind
         ]
 
         # runs with no protocols first, then oldest to newest.

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -33,8 +33,9 @@ EXPECTED_STATEMENTS_LATEST = [
         id VARCHAR NOT NULL,
         created_at DATETIME NOT NULL,
         protocol_key VARCHAR,
-        protocol_kind VARCHAR,
-        PRIMARY KEY (id)
+        protocol_kind VARCHAR(14) NOT NULL,
+        PRIMARY KEY (id),
+        CONSTRAINT protocolkindsqlenum CHECK (protocol_kind IN ('standard', 'quick-transfer'))
     )
     """,
     """
@@ -112,6 +113,9 @@ EXPECTED_STATEMENTS_LATEST = [
     """,
     """
     CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
+    """,
+    """
+    CREATE INDEX ix_protocol_protocol_kind ON protocol (protocol_kind)
     """,
     """
     CREATE TABLE data_files (

--- a/robot-server/tests/protocols/test_analyses_manager.py
+++ b/robot-server/tests/protocols/test_analyses_manager.py
@@ -83,7 +83,7 @@ async def test_initialize_analyzer(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     analyzer = decoy.mock(cls=protocol_analyzer.ProtocolAnalyzer)
     decoy.when(
@@ -128,7 +128,7 @@ async def test_raises_error_and_saves_result_if_initialization_errors(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     raised_exception = Exception("Oh noooo!")
     enumerated_error = EnumeratedError(
@@ -197,7 +197,7 @@ async def test_start_analysis(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     bool_parameter = BooleanParameter(
         displayName="Foo", variableName="Bar", default=True, value=False

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -50,6 +50,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisStore,
     CompletedAnalysisResource,
 )
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
@@ -96,7 +97,7 @@ def make_dummy_protocol_resource(protocol_id: str) -> ProtocolResource:
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
 

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -29,6 +29,7 @@ from robot_server.protocols.analysis_models import (
     AnalysisStatus,
     RunTimeParameterAnalysisData,
 )
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
@@ -95,7 +96,7 @@ def make_dummy_protocol_resource(protocol_id: str) -> ProtocolResource:
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
 

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -87,7 +87,7 @@ async def test_load_orchestrator(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     subject = ProtocolAnalyzer(
         analysis_store=analysis_store, protocol_resource=protocol_resource
@@ -136,7 +136,7 @@ async def test_analyze(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     analysis_command = pe_commands.WaitForResume(
@@ -232,7 +232,7 @@ async def test_analyze_updates_pending_on_error(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     raised_exception = Exception("You got me!!")

--- a/robot-server/tests/protocols/test_protocol_auto_deleter.py
+++ b/robot-server/tests/protocols/test_protocol_auto_deleter.py
@@ -46,7 +46,7 @@ def test_make_room_for_new_protocol(
             created_at=datetime(year=2020, month=1, day=1),
             source=mock_protocol_source,
             protocol_key=f"{p.protocol_id}{idx}",
-            protocol_kind=ProtocolKind.STANDARD.value,
+            protocol_kind=ProtocolKind.STANDARD,
         )
         for idx, p in enumerate(usage_info)
     ]
@@ -96,9 +96,9 @@ def test_make_room_for_new_quick_transfer_protocol(
             created_at=datetime(year=2020, month=1, day=1),
             source=mock_protocol_source,
             protocol_key=f"{p.protocol_id}{idx}",
-            protocol_kind=ProtocolKind.STANDARD.value
+            protocol_kind=ProtocolKind.STANDARD
             if idx not in [3, 4]
-            else ProtocolKind.QUICK_TRANSFER.value,
+            else ProtocolKind.QUICK_TRANSFER,
         )
         for idx, p in enumerate(usage_info_all)
     ]

--- a/robot-server/tests/protocols/test_protocol_store.py
+++ b/robot-server/tests/protocols/test_protocol_store.py
@@ -25,6 +25,7 @@ from robot_server.protocols.completed_analysis_store import (
     CompletedAnalysisResource,
     CompletedAnalysisStore,
 )
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolStore,
     ProtocolResource,
@@ -98,7 +99,7 @@ async def test_insert_and_get_protocol(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     assert subject.has("protocol-id") is False
@@ -127,7 +128,7 @@ async def test_insert_with_duplicate_key_raises(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     protocol_resource_2 = ProtocolResource(
         protocol_id="protocol-id",
@@ -142,7 +143,7 @@ async def test_insert_with_duplicate_key_raises(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-222",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     subject.insert(protocol_resource_1)
 
@@ -180,7 +181,7 @@ async def test_get_all_protocols(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     resource_2 = ProtocolResource(
         protocol_id="123",
@@ -195,7 +196,7 @@ async def test_get_all_protocols(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-222",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(resource_1)
@@ -232,7 +233,7 @@ async def test_remove_protocol(
             content_hash="abc123",
         ),
         protocol_key="dummy-data-111",
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource)
@@ -272,7 +273,7 @@ def test_remove_protocol_conflict(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource)
@@ -307,7 +308,7 @@ def test_get_usage_info(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     protocol_resource_2 = ProtocolResource(
         protocol_id="protocol-id-2",
@@ -322,7 +323,7 @@ def test_get_usage_info(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource_1)
@@ -392,7 +393,7 @@ def test_get_referencing_run_ids(
             content_hash="abc123",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     subject.insert(protocol_resource_1)
@@ -436,7 +437,7 @@ def test_get_protocol_ids(
             content_hash="abc1",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     protocol_resource_2 = ProtocolResource(
@@ -452,7 +453,7 @@ def test_get_protocol_ids(
             content_hash="abc2",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     assert subject.get_all_ids() == []
@@ -487,7 +488,7 @@ async def test_insert_and_get_quick_transfer_protocol(
             content_hash="abc123",
         ),
         protocol_key="dummy-key-111",
-        protocol_kind="quick-transfer",
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
 
     assert subject.has("protocol-id") is False
@@ -496,7 +497,7 @@ async def test_insert_and_get_quick_transfer_protocol(
     result = subject.get("protocol-id")
 
     assert result == protocol_resource
-    assert result.protocol_kind == "quick-transfer"
+    assert result.protocol_kind == ProtocolKind.QUICK_TRANSFER
     assert subject.has("protocol-id") is True
 
 
@@ -542,7 +543,7 @@ async def test_get_referenced_data_files(
             content_hash="abc1",
         ),
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
     analysis_resource1 = CompletedAnalysisResource(
         "analysis-id-1",

--- a/robot-server/tests/protocols/test_protocols_router.py
+++ b/robot-server/tests/protocols/test_protocols_router.py
@@ -157,7 +157,7 @@ async def test_get_protocols(
             content_hash="a_b_c",
         ),
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     resource_2 = ProtocolResource(
         protocol_id="123",
@@ -172,7 +172,7 @@ async def test_get_protocols(
             content_hash="1_2_3",
         ),
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     resource_3 = ProtocolResource(
         protocol_id="333",
@@ -187,7 +187,7 @@ async def test_get_protocols(
             content_hash="3_3_3",
         ),
         protocol_key="dummy-key-333",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
 
     analysis_1 = AnalysisSummary(id="analysis-id-abc", status=AnalysisStatus.PENDING)
@@ -330,7 +330,7 @@ async def test_get_protocol_by_id(
             content_hash="a_b_c",
         ),
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     analysis_summary = AnalysisSummary(
@@ -426,7 +426,7 @@ async def test_create_existing_protocol(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     completed_analysis = AnalysisSummary(
@@ -537,7 +537,7 @@ async def test_create_protocol(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     pending_analysis = AnalysisSummary(
@@ -659,7 +659,7 @@ async def test_create_new_protocol_with_run_time_params(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -777,7 +777,7 @@ async def test_create_existing_protocol_with_no_previous_analysis(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -899,7 +899,7 @@ async def test_create_existing_protocol_with_different_run_time_params(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     completed_summary = AnalysisSummary(
@@ -1033,7 +1033,7 @@ async def test_create_existing_protocol_with_same_run_time_params(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -1158,7 +1158,7 @@ async def test_create_existing_protocol_with_pending_analysis_raises(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -1603,7 +1603,7 @@ async def test_create_protocol_analyses_with_same_rtp_values(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     decoy.when(protocol_store.has(protocol_id="protocol-id")).then_return(True)
     decoy.when(protocol_store.get(protocol_id="protocol-id")).then_return(
@@ -1679,7 +1679,7 @@ async def test_update_protocol_analyses_with_new_rtp_values(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     analysis_summaries = [
         AnalysisSummary(
@@ -1794,7 +1794,7 @@ async def test_update_protocol_analyses_with_forced_reanalysis(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.STANDARD.value,
+        protocol_kind=ProtocolKind.STANDARD,
     )
     decoy.when(protocol_store.has(protocol_id="protocol-id")).then_return(True)
     decoy.when(
@@ -1872,7 +1872,7 @@ async def test_create_protocol_kind_quick_transfer(
         created_at=datetime(year=2021, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-111",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
     run_time_parameter = NumberParameter(
         displayName="My parameter",
@@ -2000,7 +2000,7 @@ async def test_create_protocol_maximum_quick_transfer_protocols_exceeded(
         created_at=datetime(year=2020, month=1, day=1),
         source=protocol_source,
         protocol_key="dummy-key-222",
-        protocol_kind=ProtocolKind.QUICK_TRANSFER.value,
+        protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )
 
     decoy.when(protocol_store.get_all()).then_return([stored_protocol_resource])

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -18,6 +18,7 @@ from robot_server.service.json_api import (
     ResourceLink,
 )
 
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import (
     ProtocolNotFoundError,
     ProtocolResource,
@@ -132,7 +133,7 @@ async def test_create_protocol_run(
     protocol_resource = ProtocolResource(
         protocol_id=protocol_id,
         protocol_key=None,
-        protocol_kind=None,
+        protocol_kind=ProtocolKind.STANDARD,
         created_at=datetime(year=2022, month=2, day=2),
         source=ProtocolSource(
             directory=Path("/dev/null"),

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -24,6 +24,8 @@ from opentrons.types import DeckSlotName
 
 from opentrons_shared_data.errors.exceptions import InvalidStoredData
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+
+from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.runs import error_recovery_mapping
 from robot_server.runs.error_recovery_models import ErrorRecoveryRule
@@ -218,7 +220,7 @@ async def test_create_with_options(
         created_at=datetime(year=2022, month=2, day=2),
         source=None,  # type: ignore[arg-type]
         protocol_key=None,
-        protocol_kind="standard",
+        protocol_kind=ProtocolKind.STANDARD,
     )
 
     labware_offset = pe_types.LabwareOffsetCreate(


### PR DESCRIPTION
## Overview

Some tweaks to the `protocol.protocol_kind` SQL column, to throw in with database changes that we're doing anyway. 

## Changelog

* Use an enum (both in the SQL sense and in the Python sense), to stop us from storing bad values, and to make the whole Python side a bit more type-safe. Follows the pattern set in #15650. Before, we were just using a plain `str`.
* Do not allow `NULL` values. `NULL` was semantically identical to `ProtocolKind.STANDARD` and was only stored by the 4->5 migration. Our older migration system could only add `nullable=True` columns, but that's no longer the case.
* Add an index so queries like "get all the quick-transfer protocols" or "count how many standard protocols there are" don't have to linearly scan the whole table. The higher-level code doesn't take advantage of this yet because it currently does its filtering in Python, but we should aim to move this kind of thing into SQL.

## Database compatibility and merge sequencing

This intends to follow the plan started in #15650, which I understand as this:

<strike>The current public release is on schema 4. `edge` is on schema 5. #15650 abandons schema 5 in favor of 5.1. After #15650 merges, this PR, and a few others from @sanni-t, will merge in quick succession to modify 5.1 in-place. Then, a final PR will turn 5.1 into 6 and create a 5.0->6 migration. The aim of all of this is to make a few improvements on the database from what we have in 5, without introducing a migration for *each* of those improvements, and without tossing away the schema-5.0 data that's accumulated on all our internal robots.</strike>

## Test Plan and Hands on Testing

* [x] Run `EXPLAIN QUERY PLAN` in the `sqlite3` CLI and make sure the index is working properly.
* [x] Manually set up a dev server with an old database and inspect the SQL to make sure the migration happens properly. 

Otherwise, I'm leaning on automated tests.

## Review requests

* Am I understanding the merge sequencing plan correctly?
* Is the merge sequence stack already too precarious for us to put this on top of it, too?

## Risk assessment

This will make the final PR in the plan, which finalizes the 5->6 split, slightly more complicated. It's one more change that we have to remember to handle correctly.