### PR TITLE
chore(release): internal release notes 2.0.0-alpha.3

### DIFF
--- a/api/release-notes-internal.md
+++ b/api/release-notes-internal.md
@@ -2,15 +2,31 @@ For more details about this release, please see the full [technical change log][
 
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.0.0-alpha.3
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
+
+- [Opentrons changes since the latest stable release](https://github.com/Opentrons/opentrons/compare/v7.3.1...ot3@2.0.0-alpha.3)
+- [Opentrons changes since the last internal release](https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.2...ot3@2.0.0-alpha.3)
+- [Flex changes](https://github.com/Opentrons/oe-core/compare/internal@2.0.0-alpha.2...internal@2.0.0-alpha.3)
+- [Flex firmware changes](https://github.com/Opentrons/ot3-firmware/compare/internal@v9...internal@v10)
+- [OT2 changes](https://github.com/Opentrons/buildroot/compare/v1.17.7...internal@2.0.0-alpha.0)
+
+## Internal Release 2.0.0-alpha.2
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.1...ot3@2.0.0-alpha.2>
+
 ## Internal Release 2.0.0-alpha.1
 
-This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
 
 <https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.0...ot3@2.0.0-alpha.1>
 
 ## Internal Release 2.0.0-alpha.0
 
-This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
 
 <https://github.com/Opentrons/opentrons/compare/ot3@1.5.0...ot3@2.0.0-alpha.0>
 

--- a/app-shell/build/release-notes-internal.md
+++ b/app-shell/build/release-notes-internal.md
@@ -1,15 +1,31 @@
 For more details about this release, please see the full [technical changelog][].
 [technical change log]: https://github.com/Opentrons/opentrons/releases
 
+## Internal Release 2.0.0-alpha.3
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
+
+- [Opentrons changes since the latest stable release](https://github.com/Opentrons/opentrons/compare/v7.3.1...ot3@2.0.0-alpha.3)
+- [Opentrons changes since the last internal release](https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.2...ot3@2.0.0-alpha.3)
+- [Flex changes](https://github.com/Opentrons/oe-core/compare/internal@2.0.0-alpha.2...internal@2.0.0-alpha.3)
+- [Flex firmware changes](https://github.com/Opentrons/ot3-firmware/compare/internal@v9...internal@v10)
+- [OT2 changes](https://github.com/Opentrons/buildroot/compare/v1.17.7...internal@2.0.0-alpha.0)
+
+## Internal Release 2.0.0-alpha.2
+
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
+
+<https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.1...ot3@2.0.0-alpha.2>
+
 ## Internal Release 2.0.0-alpha.1
 
-This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
 
 <https://github.com/Opentrons/opentrons/compare/ot3@2.0.0-alpha.0...ot3@2.0.0-alpha.1>
 
 ## Internal Release 2.0.0-alpha.0
 
-This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only. Usage may require a robot factory reset to restore robot stability.
+This internal release, pulled from the `edge` branch, contains features being developed for 8.0.0. It's for internal testing only.
 
 <https://github.com/Opentrons/opentrons/compare/ot3@1.5.0...ot3@2.0.0-alpha.0>
 


### PR DESCRIPTION
## Overview

### Update internal release notes.  

- tag `ot3@2.0.0-alpha.3` is not created yet so the Opentrons change links won't work but all the other tags are ready to go.
- we have adjusted our practices on DB migrations so that even internal release alphas should have safe migrations and not require DB reset.  It is impossible to grantee this 💯 , there might be bugs.
- if you have had some edge build on your robot, definitely reset the DB 