### PR TITLE
fix(app): desktop app reroute path

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -144,7 +144,7 @@ export const DesktopApp = (): JSX.Element => {
                         />
                       )
                     })}
-                    <Route path="/" element={<Navigate to="/protocols" />} />
+                    <Route path="*" element={<Navigate to="/protocols" />} />
                   </Routes>
                   <RobotControlTakeover />
                 </Alerts>


### PR DESCRIPTION
closes RQA-2877

# Overview

Fix rerouting path

## Test Plan and Hands on Testing

make sure the desktop app renders correctly on a built app off of this branch

## Changelog

change rerouting path to `*` instead of `/`

## Review requests

see test plan

## Risk assessment

high-ish, a blocker for the current internal release
