### PR TITLE
fix(app): desktop app reroute path

### DIFF
--- a/app-shell/Makefile
+++ b/app-shell/Makefile
@@ -71,6 +71,15 @@ electron := yarn electron . \
 	--ui.url.path="localhost:$(PORT)" \
 	--python.pathToPythonOverride=$(shell cd ../api && pipenv --venv)
 
+electron-dist := yarn electron . \
+	--devtools \
+	--log.level.console="debug" \
+	--disable_ui.webPreferences.webSecurity \
+	--ui.url.protocol="file:" \
+	--ui.url.path="$(ui_dir)/dist/index.html"
+	--python.pathToPythonOverride=$(shell cd ../api && pipenv --venv)
+
+
 # standard targets
 #####################################################################
 
@@ -181,6 +190,13 @@ dev: export OPENTRONS_PROJECT := $(OPENTRONS_PROJECT)
 dev: dev-app-update-file
 	vite build
 	$(electron)
+
+.PHONY: dev-dist
+dev: export NODE_ENV := development
+dev-dist: export OPENTRONS_PROJECT := $(OPENTRONS_PROJECT)
+dev-dist: package-deps
+	vite build
+	$(electron-dist)
 
 .PHONY: test
 test:

--- a/app/Makefile
+++ b/app/Makefile
@@ -74,6 +74,11 @@ dev-server: export OPENTRONS_PROJECT := $(OPENTRONS_PROJECT)
 dev-server:
 	vite serve
 
+.PHONY: dev-dist
+dev-dist: export NODE_ENV := development
+dev-dist:
+	$(MAKE) -C $(shell_dir) dev-dist OPENTRONS_PROJECT=$(OPENTRONS_PROJECT)
+
 .PHONY: dev-shell
 dev-shell:
 	$(MAKE) -C $(shell_dir) dev OPENTRONS_PROJECT=$(OPENTRONS_PROJECT)

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -144,7 +144,7 @@ export const DesktopApp = (): JSX.Element => {
                         />
                       )
                     })}
-                    <Route path="/" element={<Navigate to="/protocols" />} />
+                    <Route path="*" element={<Navigate to="/protocols" />} />
                   </Routes>
                   <RobotControlTakeover />
                 </Alerts>

--- a/app/src/index.tsx
+++ b/app/src/index.tsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import ReactDom from 'react-dom/client'
 import { Provider } from 'react-redux'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 
 import { ApiClientProvider } from '@opentrons/react-api-client'
 
@@ -32,10 +32,10 @@ if (container == null) throw new Error('Failed to find the root element')
 const root = ReactDom.createRoot(container)
 root.render(
   <Provider store={store}>
-    <BrowserRouter>
+    <HashRouter>
       <ApiClientProvider>
         <App />
       </ApiClientProvider>
-    </BrowserRouter>
+    </HashRouter>
   </Provider>
 )


### PR DESCRIPTION
closes RQA-2877

# Overview

Fix rerouting path, migrating to using `HashRouter`, and adding a patch to makefile

## Test Plan and Hands on Testing

make sure the desktop app renders correctly on a built app off of this branch

## Changelog

change rerouting path to `*` instead of `/`

## Review requests

see test plan

## Risk assessment

high-ish, a blocker for the current internal release
