### PR TITLE
refactor(robot-server): Rename `.../errorRecoveryPolicies` to `.../errorRecoveryPolicy`

### DIFF
--- a/robot-server/robot_server/runs/error_recovery_models.py
+++ b/robot-server/robot_server/runs/error_recovery_models.py
@@ -71,7 +71,7 @@ class ErrorRecoveryRule(BaseModel):
     )
 
 
-class ErrorRecoveryPolicies(BaseModel):
+class ErrorRecoveryPolicy(BaseModel):
     """Request/Response model for new error recovery policy rules creation."""
 
     policyRules: List[ErrorRecoveryRule] = Field(

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -381,7 +381,7 @@ async def update_run(
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunStopped]},
     },
 )
-async def set_run_policies(
+async def put_error_recovery_policy(
     runId: str,
     request_body: RequestModel[ErrorRecoveryPolicy],
     run_data_manager: RunDataManager = Depends(get_run_data_manager),

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -45,7 +45,7 @@ from ..dependencies import (
     get_run_auto_deleter,
     get_quick_transfer_run_auto_deleter,
 )
-from ..error_recovery_models import ErrorRecoveryPolicies
+from ..error_recovery_models import ErrorRecoveryPolicy
 
 from robot_server.deck_configuration.fastapi_dependencies import (
     get_deck_configuration_store,
@@ -367,7 +367,7 @@ async def update_run(
 
 @PydanticResponse.wrap_route(
     base_router.put,
-    path="/runs/{runId}/errorRecoveryPolicies",
+    path="/runs/{runId}/errorRecoveryPolicy",
     summary="Set run policies",
     description=dedent(
         """
@@ -383,7 +383,7 @@ async def update_run(
 )
 async def set_run_policies(
     runId: str,
-    request_body: RequestModel[ErrorRecoveryPolicies],
+    request_body: RequestModel[ErrorRecoveryPolicy],
     run_data_manager: RunDataManager = Depends(get_run_data_manager),
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Create run polices.

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -9,7 +9,7 @@ from opentrons.protocol_engine import LabwareOffsetCreate, types as pe_types
 from opentrons.protocol_reader import ProtocolSource, JsonProtocolConfig
 
 from robot_server.errors.error_responses import ApiError
-from robot_server.runs.error_recovery_models import ErrorRecoveryPolicies
+from robot_server.runs.error_recovery_models import ErrorRecoveryPolicy
 from robot_server.service.json_api import (
     RequestModel,
     SimpleBody,
@@ -577,7 +577,7 @@ async def test_create_policies(
     decoy: Decoy, mock_run_data_manager: RunDataManager
 ) -> None:
     """It should call RunDataManager create run policies."""
-    policies = decoy.mock(cls=ErrorRecoveryPolicies)
+    policies = decoy.mock(cls=ErrorRecoveryPolicy)
     await set_run_policies(
         runId="rud-id",
         request_body=RequestModel(data=policies),
@@ -594,7 +594,7 @@ async def test_create_policies_raises_not_active_run(
     decoy: Decoy, mock_run_data_manager: RunDataManager
 ) -> None:
     """It should raise that the run is not current."""
-    policies = decoy.mock(cls=ErrorRecoveryPolicies)
+    policies = decoy.mock(cls=ErrorRecoveryPolicy)
     decoy.when(
         mock_run_data_manager.set_policies(
             run_id="rud-id", policies=policies.policyRules

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -38,7 +38,7 @@ from robot_server.runs.router.base_router import (
     get_runs,
     remove_run,
     update_run,
-    set_run_policies,
+    put_error_recovery_policy,
 )
 
 from robot_server.deck_configuration.store import DeckConfigurationStore
@@ -578,7 +578,7 @@ async def test_create_policies(
 ) -> None:
     """It should call RunDataManager create run policies."""
     policies = decoy.mock(cls=ErrorRecoveryPolicy)
-    await set_run_policies(
+    await put_error_recovery_policy(
         runId="rud-id",
         request_body=RequestModel(data=policies),
         run_data_manager=mock_run_data_manager,
@@ -601,7 +601,7 @@ async def test_create_policies_raises_not_active_run(
         )
     ).then_raise(RunNotCurrentError())
     with pytest.raises(ApiError) as exc_info:
-        await set_run_policies(
+        await put_error_recovery_policy(
             runId="rud-id",
             request_body=RequestModel(data=policies),
             run_data_manager=mock_run_data_manager,


### PR DESCRIPTION
# Overview

This is a minor terminology fixup so we consistently say that a run always has exactly one "error recovery policy" (and that policy is currently defined in terms of a list of rules).

The HTTP endpoints currently call it plural "error recovery policies." This isn't fundamentally wrong, it just happens to be inconsistent with the concepts as we've been working with them so far. This PR arbitrarily breaks the tie in favor of calling it a singular "error recovery policy."

## Test Plan and Hands on Testing

None needed.

## Risk assessment

Low.