### PR TITLE
docs(protocol-engine): Suggest updating position estimates after an `overpressure` error

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/pipetting_common.py
+++ b/api/src/opentrons/protocol_engine/commands/pipetting_common.py
@@ -132,9 +132,11 @@ class ErrorLocationInfo(TypedDict):
 class OverpressureError(ErrorOccurrence):
     """Returned when sensors detect an overpressure error while moving liquid.
 
-    The pipette plunger motion is stopped at the point of the error. The next thing to
-    move the plunger must be a `home` or `blowout` command; commands like `aspirate`
-    will return an error.
+    The pipette plunger motion is stopped at the point of the error.
+
+    The next thing to move the plunger must account for the robot not having a valid
+    estimate of its position. It should be a `home`, `unsafe/updatePositionEstimators`,
+    `unsafe/dropTipInPlace`, or `unsafe/blowOutInPlace`.
     """
 
     isDefined: bool = True


### PR DESCRIPTION
# Overview

The new commands in #15816 come into play whenever robot stops abruptly. My understanding is that pipette overpressure errors count as stopping abruptly. So let's suggest using the new commands to recover from a defined `overpressure` error.

# Review requests

Is this technically correct?

# Risk assessment

No risk.