### PR TITLE
fix(app, api-client): fix response interface for /protocols/{id}/dataFiles

### DIFF
--- a/api-client/src/dataFiles/types.ts
+++ b/api-client/src/dataFiles/types.ts
@@ -18,7 +18,5 @@ export interface UploadedCsvFileResponse {
 }
 
 export interface UploadedCsvFilesResponse {
-  data: {
-    files: CsvFileData[]
-  }
+  data: CsvFileData[]
 }

--- a/app/src/organisms/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRun.tsx
@@ -44,7 +44,7 @@ export function HistoricalProtocolRun(
   const [drawerOpen, setDrawerOpen] = React.useState(false)
   const { data: protocolFileData } = useAllCsvFilesQuery(run.protocolId ?? '')
   const allProtocolDataFiles =
-    protocolFileData != null ? protocolFileData.data.files : []
+    protocolFileData != null ? protocolFileData.data : []
   const runStatus = run.status
   const runDisplayName = formatTimestamp(run.createdAt)
   let duration = EMPTY_TIMESTAMP
@@ -89,9 +89,7 @@ export function HistoricalProtocolRun(
           >
             {protocolName}
           </LegacyStyledText>
-          {enableCsvFile &&
-          allProtocolDataFiles != null &&
-          allProtocolDataFiles.length > 0 ? (
+          {enableCsvFile ? (
             <LegacyStyledText
               as="p"
               width="5%"

--- a/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
+++ b/app/src/organisms/Devices/HistoricalProtocolRunDrawer.tsx
@@ -49,7 +49,7 @@ export function HistoricalProtocolRunDrawer(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
   const { data } = useAllCsvFilesQuery(run.protocolId ?? '')
-  const allProtocolDataFiles = data != null ? data.data.files : []
+  const allProtocolDataFiles = data != null ? data.data : []
   const uniqueLabwareOffsets = allLabwareOffsets?.filter(
     (offset, index, array) => {
       return (


### PR DESCRIPTION
# Overview

There was an error in the client's expected response interface from `/protocols/{id}/dataFiles`, causing the app to error when expanding `HistoricalProtocolRunDrawer`. This PR fixes that response interface and the implicated endpoint's implementation in `HistoricalProtocolRun` and `HistoricalProtocolRunDrawer`.


## Test Plan and Hands on Testing

- initiate run for a protocol with CSV RTP
- navigate to device page for robot on which the run was initiated
- navigate down to "Recent Protocol Runs" and expand the most recent historical run 
- verify that CSV files used in the protocol are shown and the app does not whitescreen
- repeat above for a protocol without CSV RTP and verify that "No protocol files included" infoscreen shows

## Changelog

- flatten response interface for `/protocols/{id}/dataFiles`
- fix data in `HistoricalProtocolRun` and `HistoricalProtocolRunDrawer`

## Review requests

see test plan

## Risk assessment

low-medium. Other components using this endpoint correctly unpack the data