### PR TITLE
feat(api-client, react-api-client): Add client support for `/runs/:runId/errorRecoveryPolicy`

### DIFF
--- a/api-client/src/runs/index.ts
+++ b/api-client/src/runs/index.ts
@@ -12,5 +12,7 @@ export { createRunAction } from './createRunAction'
 export * from './createLabwareOffset'
 export * from './createLabwareDefinition'
 export * from './constants'
+export * from './updateErrorRecoveryPolicy'
+
 export * from './types'
 export type { CreateRunData } from './createRun'

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -146,3 +146,29 @@ export interface CommandData {
 // Although run errors are semantically different from command errors,
 // the server currently happens to use the exact same model for both.
 export type RunError = RunCommandError
+
+/**
+ * Error Policy
+ */
+
+export type IfMatchType = 'ignoreAndContinue' | 'failRun' | 'waitForRecovery'
+
+export interface ErrorRecoveryPolicy {
+  policyRules: Array<{
+    matchCriteria: {
+      command: {
+        commandType: RunTimeCommand['commandType']
+        error: {
+          errorType: RunCommandError['errorType']
+        }
+      }
+    }
+    ifMatch: IfMatchType
+  }>
+}
+
+export interface UpdateErrorRecoveryPolicyRequest {
+  data: ErrorRecoveryPolicy
+}
+
+export type UpdateErrorRecoveryPolicyResponse = Record<string, never>

--- a/api-client/src/runs/updateErrorRecoveryPolicy.ts
+++ b/api-client/src/runs/updateErrorRecoveryPolicy.ts
@@ -1,0 +1,48 @@
+import { PUT, request } from '../request'
+
+import type { HostConfig } from '../types'
+import type { ResponsePromise } from '../request'
+import type {
+  ErrorRecoveryPolicy,
+  IfMatchType,
+  UpdateErrorRecoveryPolicyRequest,
+  UpdateErrorRecoveryPolicyResponse,
+} from './types'
+import type { RunCommandError, RunTimeCommand } from '@opentrons/shared-data'
+
+export type RecoveryPolicyRulesParams = Array<{
+  commandType: RunTimeCommand['commandType']
+  errorType: RunCommandError['errorType']
+  ifMatch: IfMatchType
+}>
+
+export function updateErrorRecoveryPolicy(
+  config: HostConfig,
+  runId: string,
+  policyRules: RecoveryPolicyRulesParams
+): ResponsePromise<UpdateErrorRecoveryPolicyResponse> {
+  const policy = buildErrorRecoveryPolicyBody(policyRules)
+
+  return request<
+    UpdateErrorRecoveryPolicyResponse,
+    UpdateErrorRecoveryPolicyRequest
+  >(PUT, `/runs/${runId}/errorRecoveryPolicy`, { data: policy }, config)
+}
+
+function buildErrorRecoveryPolicyBody(
+  policyRules: RecoveryPolicyRulesParams
+): ErrorRecoveryPolicy {
+  return {
+    policyRules: policyRules.map(rule => ({
+      matchCriteria: {
+        command: {
+          commandType: rule.commandType,
+          error: {
+            errorType: rule.errorType,
+          },
+        },
+      },
+      ifMatch: rule.ifMatch,
+    })),
+  }
+}

--- a/react-api-client/src/runs/index.ts
+++ b/react-api-client/src/runs/index.ts
@@ -15,6 +15,7 @@ export { useAllCommandsAsPreSerializedList } from './useAllCommandsAsPreSerializ
 export { useCommandQuery } from './useCommandQuery'
 export * from './useCreateLabwareOffsetMutation'
 export * from './useCreateLabwareDefinitionMutation'
+export * from './useUpdateErrorRecoveryPolicy'
 
 export type { UsePlayRunMutationResult } from './usePlayRunMutation'
 export type { UsePauseRunMutationResult } from './usePauseRunMutation'

--- a/react-api-client/src/runs/useUpdateErrorRecoveryPolicy.ts
+++ b/react-api-client/src/runs/useUpdateErrorRecoveryPolicy.ts
@@ -1,0 +1,62 @@
+import { useMutation } from 'react-query'
+
+import { updateErrorRecoveryPolicy } from '@opentrons/api-client'
+
+import { useHost } from '../api'
+
+import type {
+  UseMutationOptions,
+  UseMutationResult,
+  UseMutateFunction,
+} from 'react-query'
+import type { AxiosError } from 'axios'
+import type {
+  RecoveryPolicyRulesParams,
+  UpdateErrorRecoveryPolicyResponse,
+  HostConfig,
+} from '@opentrons/api-client'
+
+export type UseUpdateErrorRecoveryPolicyResponse = UseMutationResult<
+  UpdateErrorRecoveryPolicyResponse,
+  AxiosError,
+  RecoveryPolicyRulesParams
+> & {
+  updateErrorRecoveryPolicy: UseMutateFunction<
+    UpdateErrorRecoveryPolicyResponse,
+    AxiosError,
+    RecoveryPolicyRulesParams
+  >
+}
+
+export type UseUpdateErrorRecoveryPolicyOptions = UseMutationOptions<
+  UpdateErrorRecoveryPolicyResponse,
+  AxiosError,
+  RecoveryPolicyRulesParams
+>
+
+export function useUpdateErrorRecoveryPolicy(
+  runId: string,
+  options: UseUpdateErrorRecoveryPolicyOptions = {}
+): UseUpdateErrorRecoveryPolicyResponse {
+  const host = useHost()
+
+  const mutation = useMutation<
+    UpdateErrorRecoveryPolicyResponse,
+    AxiosError,
+    RecoveryPolicyRulesParams
+  >(
+    [host, 'runs', runId, 'errorRecoveryPolicy'],
+    (policyRules: RecoveryPolicyRulesParams) =>
+      updateErrorRecoveryPolicy(host as HostConfig, runId, policyRules)
+        .then(response => response.data)
+        .catch(e => {
+          throw e
+        }),
+    options
+  )
+
+  return {
+    ...mutation,
+    updateErrorRecoveryPolicy: mutation.mutate,
+  }
+}


### PR DESCRIPTION
Works towards [EXEC-560](https://opentrons.atlassian.net/browse/EXEC-560)

<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview

Adds client support for `PUT /runs/:runId/errorRecoveryPolicy`.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
- Nothing to really test here, but @SyntaxColoring and I tested the implementation of this work in a future PR that adds "ignore all errors of this type". It works!
<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->

## Changelog
- Added client support for updating the error recovery policy.
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
- I did not put the error recovery policy types in `shared-data`, because I don't know what our future plans are for policies. Will we have more policies? I'm down for adding a TODO to move the types over when things become more solidified, if we decide that is best.
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
- low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->


[EXEC-560]: https://opentrons.atlassian.net/browse/EXEC-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ