### PR TITLE
fix(app): Fix spinner sizing on ODD and desktop

### DIFF
--- a/app/src/molecules/InProgressModal/InProgressModal.stories.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.stories.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import { InProgressModal as InProgressModalComponent } from './'
+import { SimpleWizardInProgressBody } from '../SimpleWizardBody'
+
+const meta: Meta<typeof InProgressModalComponent> = {
+  title: 'App/Molecules/InProgressModal',
+  component: InProgressModalComponent,
+  argTypes: {
+    description: {
+      control: {
+        type: 'text',
+      },
+    },
+    body: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
+}
+
+export default meta
+
+export type Story = StoryObj<typeof InProgressModalComponent>
+
+export const InProgressModal: Story = {
+  args: {
+    description: 'here is a description',
+    body: 'Here is the body of the whole thing',
+  },
+}
+
+export const InProgressModalSimpleWizard: Story = {
+  args: {
+    description: 'here is a description',
+    body: 'Here is the body of the whole thing',
+  },
+  render: args => <SimpleWizardInProgressBody {...args} />,
+}

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import { css } from 'styled-components'
-import { useSelector } from 'react-redux'
 import {
   ALIGN_CENTER,
   COLORS,
@@ -13,7 +12,6 @@ import {
   LegacyStyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { getIsOnDevice } from '../../redux/config'
 
 interface Props {
   //  optional override of the spinner
@@ -61,28 +59,35 @@ const MODAL_STYLE = css`
 `
 const SPINNER_STYLE = css`
   color: ${COLORS.grey60};
+  width: 5.125rem;
+  height: 5.125rem;
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    width: 6.25rem;
+    height: 6.25rem;
+  }
+`
+
+const DESCRIPTION_CONTAINER_STYLE = css`
+  padding-x: 6.5625rem;
+  gap: ${SPACING.spacing8};
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    padding-x: ${SPACING.spacing40};
+    gap: ${SPACING.spacing4};
+  }
 `
 
 export function InProgressModal(props: Props): JSX.Element {
   const { alternativeSpinner, children, description, body } = props
-  const isOnDevice = useSelector(getIsOnDevice)
 
   return (
     <Flex css={MODAL_STYLE}>
       {alternativeSpinner ?? (
-        <Icon
-          name="ot-spinner"
-          aria-label="spinner"
-          size={isOnDevice ? '6.25rem' : '5.125rem'}
-          css={SPINNER_STYLE}
-          spin
-        />
+        <Icon name="ot-spinner" aria-label="spinner" css={SPINNER_STYLE} spin />
       )}
       <Flex
-        paddingX={isOnDevice ? SPACING.spacing40 : '6.5625rem'}
-        gridGap={isOnDevice ? SPACING.spacing4 : SPACING.spacing8}
         flexDirection={DIRECTION_COLUMN}
         alignItems={ALIGN_CENTER}
+        css={DESCRIPTION_CONTAINER_STYLE}
       >
         {description != null && (
           <LegacyStyledText css={DESCRIPTION_STYLE}>

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -61,11 +61,6 @@ const MODAL_STYLE = css`
 `
 const SPINNER_STYLE = css`
   color: ${COLORS.grey60};
-  opacity: 100%;
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    color: ${COLORS.black90};
-    opacity: 70%;
-  }
 `
 
 export function InProgressModal(props: Props): JSX.Element {

--- a/app/src/molecules/InProgressModal/index.tsx
+++ b/app/src/molecules/InProgressModal/index.tsx
@@ -1,0 +1,1 @@
+export { InProgressModal } from './InProgressModal'

--- a/app/src/molecules/SimpleWizardBody/SimpleWizardBodyContainer.tsx
+++ b/app/src/molecules/SimpleWizardBody/SimpleWizardBodyContainer.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { css } from 'styled-components'
+
+import {
+  Flex,
+  DIRECTION_COLUMN,
+  JUSTIFY_SPACE_BETWEEN,
+  RESPONSIVENESS,
+} from '@opentrons/components'
+import type { StyleProps } from '@opentrons/components'
+
+const WIZARD_CONTAINER_STYLE = css`
+  min-height: 394px;
+  flex-direction: ${DIRECTION_COLUMN};
+  justify-content: ${JUSTIFY_SPACE_BETWEEN};
+  height: 'auto';
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    height: 472px;
+  }
+`
+
+export interface SimpleWizardBodyContainerProps extends StyleProps {
+  children?: JSX.Element | JSX.Element[] | null
+}
+
+export function SimpleWizardBodyContainer({
+  children,
+  ...styleProps
+}: SimpleWizardBodyContainerProps): JSX.Element {
+  return (
+    <Flex css={WIZARD_CONTAINER_STYLE} {...styleProps}>
+      {children}
+    </Flex>
+  )
+}

--- a/app/src/molecules/SimpleWizardBody/SimpleWizardBodyContent.tsx
+++ b/app/src/molecules/SimpleWizardBody/SimpleWizardBodyContent.tsx
@@ -1,0 +1,178 @@
+import * as React from 'react'
+import { useSelector } from 'react-redux'
+import { css } from 'styled-components'
+import {
+  ALIGN_CENTER,
+  DIRECTION_COLUMN,
+  Flex,
+  Icon,
+  JUSTIFY_CENTER,
+  JUSTIFY_FLEX_END,
+  JUSTIFY_FLEX_START,
+  JUSTIFY_SPACE_BETWEEN,
+  POSITION_ABSOLUTE,
+  RESPONSIVENESS,
+  SPACING,
+  LegacyStyledText,
+  TYPOGRAPHY,
+} from '@opentrons/components'
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import SuccessIcon from '../../assets/images/icon_success.png'
+import { getIsOnDevice } from '../../redux/config'
+
+import { Skeleton } from '../../atoms/Skeleton'
+import type { RobotType } from '@opentrons/shared-data'
+
+interface Props {
+  iconColor: string
+  header: string
+  isSuccess: boolean
+  children?: React.ReactNode
+  subHeader?: string | JSX.Element
+  isPending?: boolean
+  robotType?: RobotType
+  /**
+   *  this prop is to change justifyContent of OnDeviceDisplay buttons
+   *  TODO(jr, 8/9/23): this SHOULD be refactored so the
+   *  buttons' justifyContent is specified at the parent level
+   */
+  justifyContentForOddButton?: string
+}
+
+const BACKGROUND_SIZE = '47rem'
+
+const HEADER_STYLE = css`
+  ${TYPOGRAPHY.h1Default};
+  margin-top: ${SPACING.spacing24};
+  margin-bottom: ${SPACING.spacing8};
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: ${SPACING.spacing40};
+  }
+`
+const SUBHEADER_STYLE = css`
+  ${TYPOGRAPHY.pRegular};
+  margin-left: 6.25rem;
+  margin-right: 6.25rem;
+  margin-bottom: ${SPACING.spacing32};
+  text-align: ${TYPOGRAPHY.textAlignCenter};
+  height: 1.75rem;
+
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    font-size: ${TYPOGRAPHY.fontSize28};
+    line-height: ${TYPOGRAPHY.lineHeight36};
+    margin-left: 4.5rem;
+    margin-right: 4.5rem;
+  }
+`
+
+const FLEX_SPACING_STYLE = css`
+  height: 1.75rem;
+  margin-bottom: ${SPACING.spacing32};
+  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+    height: 0rem;
+  }
+`
+
+export function SimpleWizardBodyContent(props: Props): JSX.Element {
+  const {
+    iconColor,
+    children,
+    header,
+    subHeader,
+    isSuccess,
+    isPending,
+    robotType = FLEX_ROBOT_TYPE,
+  } = props
+  const isOnDevice = useSelector(getIsOnDevice)
+
+  const BUTTON_STYLE = css`
+    width: 100%;
+    justify-content: ${JUSTIFY_FLEX_END};
+    padding-right: ${SPACING.spacing32};
+    padding-bottom: ${SPACING.spacing32};
+
+    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+      justify-content: ${props.justifyContentForOddButton ??
+      JUSTIFY_SPACE_BETWEEN};
+      padding-bottom: ${SPACING.spacing32};
+      padding-left: ${SPACING.spacing32};
+    }
+  `
+
+  const ICON_POSITION_STYLE = css`
+    justify-content: ${JUSTIFY_CENTER};
+
+    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
+      justify-content: ${JUSTIFY_FLEX_START};
+      margin-top: ${isSuccess ? SPACING.spacing32 : '8.1875rem'};
+    }
+  `
+
+  return (
+    <>
+      <Flex
+        width="100%"
+        alignItems={ALIGN_CENTER}
+        css={ICON_POSITION_STYLE}
+        flexDirection={DIRECTION_COLUMN}
+        flex="1 0 auto"
+      >
+        {isPending ? (
+          <Flex
+            gridGap={SPACING.spacing24}
+            flexDirection={DIRECTION_COLUMN}
+            justifyContent={JUSTIFY_CENTER}
+          >
+            <Skeleton
+              width="6.25rem"
+              height="6.25rem"
+              backgroundSize={BACKGROUND_SIZE}
+            />
+            <Skeleton
+              width="18rem"
+              height="1.125rem"
+              backgroundSize={BACKGROUND_SIZE}
+            />
+          </Flex>
+        ) : (
+          <>
+            {isSuccess ? (
+              <img
+                width={robotType === FLEX_ROBOT_TYPE ? '170px' : '160px'}
+                height={robotType === FLEX_ROBOT_TYPE ? '141px' : '120px'}
+                src={SuccessIcon}
+                alt="Success Icon"
+              />
+            ) : (
+              <Icon
+                name="ot-alert"
+                size={isOnDevice ? '3.75rem' : '2.5rem'}
+                color={iconColor}
+                aria-label="ot-alert"
+              />
+            )}
+            <LegacyStyledText css={HEADER_STYLE}>{header}</LegacyStyledText>
+            {subHeader != null ? (
+              <LegacyStyledText css={SUBHEADER_STYLE}>
+                {subHeader}
+              </LegacyStyledText>
+            ) : (
+              <Flex aria-label="flex_spacing" css={FLEX_SPACING_STYLE} />
+            )}
+          </>
+        )}
+      </Flex>
+      <Flex
+        position={POSITION_ABSOLUTE}
+        bottom={0}
+        right={0}
+        css={BUTTON_STYLE}
+      >
+        {children}
+      </Flex>
+    </>
+  )
+}

--- a/app/src/molecules/SimpleWizardBody/SimpleWizardInProgressBody.tsx
+++ b/app/src/molecules/SimpleWizardBody/SimpleWizardInProgressBody.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import type { StyleProps } from '@opentrons/components'
+import { InProgressModal } from '../InProgressModal/InProgressModal'
+import { SimpleWizardBodyContainer } from './SimpleWizardBodyContainer'
+
+export type SimpleWizardInProgressBodyProps = React.ComponentProps<
+  typeof InProgressModal
+> &
+  StyleProps
+
+export function SimpleWizardInProgressBody({
+  alternativeSpinner,
+  description,
+  body,
+  children,
+  ...styleProps
+}: SimpleWizardInProgressBodyProps): JSX.Element {
+  return (
+    <SimpleWizardBodyContainer {...styleProps}>
+      <InProgressModal
+        alternativeSpinner={alternativeSpinner}
+        description={description}
+        body={body}
+      >
+        {children}
+      </InProgressModal>
+    </SimpleWizardBodyContainer>
+  )
+}

--- a/app/src/molecules/SimpleWizardBody/index.tsx
+++ b/app/src/molecules/SimpleWizardBody/index.tsx
@@ -1,187 +1,22 @@
 import * as React from 'react'
-import { useSelector } from 'react-redux'
-import { css } from 'styled-components'
-import {
-  ALIGN_CENTER,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_CENTER,
-  JUSTIFY_FLEX_END,
-  JUSTIFY_FLEX_START,
-  JUSTIFY_SPACE_BETWEEN,
-  POSITION_ABSOLUTE,
-  RESPONSIVENESS,
-  SPACING,
-  LegacyStyledText,
-  TYPOGRAPHY,
-} from '@opentrons/components'
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
-import SuccessIcon from '../../assets/images/icon_success.png'
-import { getIsOnDevice } from '../../redux/config'
 
-import { Skeleton } from '../../atoms/Skeleton'
-import type { RobotType } from '@opentrons/shared-data'
-import type { StyleProps } from '@opentrons/components'
-interface Props extends StyleProps {
-  iconColor: string
-  header: string
-  isSuccess: boolean
-  children?: React.ReactNode
-  subHeader?: string | JSX.Element
-  isPending?: boolean
-  robotType?: RobotType
-  /**
-   *  this prop is to change justifyContent of OnDeviceDisplay buttons
-   *  TODO(jr, 8/9/23): this SHOULD be refactored so the
-   *  buttons' justifyContent is specified at the parent level
-   */
-  justifyContentForOddButton?: string
+import { SimpleWizardBodyContainer } from './SimpleWizardBodyContainer'
+import { SimpleWizardBodyContent } from './SimpleWizardBodyContent'
+import { SimpleWizardInProgressBody } from './SimpleWizardInProgressBody'
+export {
+  SimpleWizardBodyContainer,
+  SimpleWizardBodyContent,
+  SimpleWizardInProgressBody,
 }
 
-const BACKGROUND_SIZE = '47rem'
-
-const HEADER_STYLE = css`
-  ${TYPOGRAPHY.h1Default};
-  margin-top: ${SPACING.spacing24};
-  margin-bottom: ${SPACING.spacing8};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    font-size: 2rem;
-    font-weight: 700;
-    line-height: ${SPACING.spacing40};
-  }
-`
-const SUBHEADER_STYLE = css`
-  ${TYPOGRAPHY.pRegular};
-  margin-left: 6.25rem;
-  margin-right: 6.25rem;
-  margin-bottom: ${SPACING.spacing32};
-  text-align: ${TYPOGRAPHY.textAlignCenter};
-  height: 1.75rem;
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    font-size: ${TYPOGRAPHY.fontSize28};
-    line-height: ${TYPOGRAPHY.lineHeight36};
-    margin-left: 4.5rem;
-    margin-right: 4.5rem;
-  }
-`
-const WIZARD_CONTAINER_STYLE = css`
-  min-height: 394px;
-  flex-direction: ${DIRECTION_COLUMN};
-  justify-content: ${JUSTIFY_SPACE_BETWEEN};
-  height: 'auto';
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    height: 472px;
-  }
-`
-const FLEX_SPACING_STYLE = css`
-  height: 1.75rem;
-  margin-bottom: ${SPACING.spacing32};
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    height: 0rem;
-  }
-`
-
-export function SimpleWizardBody(props: Props): JSX.Element {
-  const {
-    iconColor,
-    children,
-    header,
-    subHeader,
-    isSuccess,
-    isPending,
-    robotType = FLEX_ROBOT_TYPE,
-    ...styleProps
-  } = props
-  const isOnDevice = useSelector(getIsOnDevice)
-
-  const BUTTON_STYLE = css`
-    width: 100%;
-    justify-content: ${JUSTIFY_FLEX_END};
-    padding-right: ${SPACING.spacing32};
-    padding-bottom: ${SPACING.spacing32};
-
-    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-      justify-content: ${props.justifyContentForOddButton ??
-      JUSTIFY_SPACE_BETWEEN};
-      padding-bottom: ${SPACING.spacing32};
-      padding-left: ${SPACING.spacing32};
-    }
-  `
-
-  const ICON_POSITION_STYLE = css`
-    justify-content: ${JUSTIFY_CENTER};
-
-    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-      justify-content: ${JUSTIFY_FLEX_START};
-      margin-top: ${isSuccess ? SPACING.spacing32 : '8.1875rem'};
-    }
-  `
-
+export function SimpleWizardBody(
+  props: React.ComponentProps<typeof SimpleWizardBodyContent> &
+    React.ComponentProps<typeof SimpleWizardBodyContainer>
+): JSX.Element {
+  const { children, ...rest } = props
   return (
-    <Flex css={WIZARD_CONTAINER_STYLE} {...styleProps}>
-      <Flex
-        width="100%"
-        alignItems={ALIGN_CENTER}
-        css={ICON_POSITION_STYLE}
-        flexDirection={DIRECTION_COLUMN}
-        flex="1 0 auto"
-      >
-        {isPending ? (
-          <Flex
-            gridGap={SPACING.spacing24}
-            flexDirection={DIRECTION_COLUMN}
-            justifyContent={JUSTIFY_CENTER}
-          >
-            <Skeleton
-              width="6.25rem"
-              height="6.25rem"
-              backgroundSize={BACKGROUND_SIZE}
-            />
-            <Skeleton
-              width="18rem"
-              height="1.125rem"
-              backgroundSize={BACKGROUND_SIZE}
-            />
-          </Flex>
-        ) : (
-          <>
-            {isSuccess ? (
-              <img
-                width={robotType === FLEX_ROBOT_TYPE ? '170px' : '160px'}
-                height={robotType === FLEX_ROBOT_TYPE ? '141px' : '120px'}
-                src={SuccessIcon}
-                alt="Success Icon"
-              />
-            ) : (
-              <Icon
-                name="ot-alert"
-                size={isOnDevice ? '3.75rem' : '2.5rem'}
-                color={iconColor}
-                aria-label="ot-alert"
-              />
-            )}
-            <LegacyStyledText css={HEADER_STYLE}>{header}</LegacyStyledText>
-            {subHeader != null ? (
-              <LegacyStyledText css={SUBHEADER_STYLE}>
-                {subHeader}
-              </LegacyStyledText>
-            ) : (
-              <Flex aria-label="flex_spacing" css={FLEX_SPACING_STYLE} />
-            )}
-          </>
-        )}
-      </Flex>
-      <Flex
-        position={POSITION_ABSOLUTE}
-        bottom={0}
-        right={0}
-        css={BUTTON_STYLE}
-      >
-        {children}
-      </Flex>
-    </Flex>
+    <SimpleWizardBodyContainer {...rest}>
+      <SimpleWizardBodyContent {...rest}>{children}</SimpleWizardBodyContent>
+    </SimpleWizardBodyContainer>
   )
 }

--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -3,8 +3,10 @@ import { Trans, useTranslation } from 'react-i18next'
 import { COLORS, LegacyStyledText } from '@opentrons/components'
 import { EXTENSION } from '@opentrons/shared-data'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { WizardRequiredEquipmentList } from '../../molecules/WizardRequiredEquipmentList'
 import {
   GRIPPER_FLOW_TYPES,
@@ -119,7 +121,7 @@ export const BeforeBeginning = (
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )

--- a/app/src/organisms/GripperWizardFlows/ExitConfirmation.tsx
+++ b/app/src/organisms/GripperWizardFlows/ExitConfirmation.tsx
@@ -10,8 +10,10 @@ import {
   JUSTIFY_FLEX_END,
 } from '@opentrons/components'
 import { getIsOnDevice } from '../../redux/config'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { SmallButton } from '../../atoms/buttons'
 import { GRIPPER_FLOW_TYPES } from './constants'
 import type { GripperWizardFlowType } from './types'
@@ -37,7 +39,7 @@ export function ExitConfirmation(props: ExitConfirmationProps): JSX.Element {
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -19,8 +19,10 @@ import { useTranslation } from 'react-i18next'
 import { getIsOnDevice } from '../../redux/config'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import mountGripper from '../../assets/videos/gripper-wizards/MOUNT_GRIPPER.webm'
 
 import type { GripperWizardStepProps } from './types'
@@ -83,7 +85,7 @@ export const MountGripper = (
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -9,9 +9,11 @@ import {
   LegacyStyledText,
 } from '@opentrons/components'
 import { css } from 'styled-components'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import {
   MOVE_PIN_FROM_FRONT_JAW_TO_REAR_JAW,
   MOVE_PIN_TO_FRONT_JAW,
@@ -245,7 +247,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
   } = infoByMovement[movement]
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={
           errorMessage == null && !isExiting
             ? inProgressText

--- a/app/src/organisms/GripperWizardFlows/Success.tsx
+++ b/app/src/organisms/GripperWizardFlows/Success.tsx
@@ -10,8 +10,10 @@ import {
   Flex,
 } from '@opentrons/components'
 import { getIsOnDevice } from '../../redux/config'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { SmallButton } from '../../atoms/buttons'
 import {
   SUCCESSFULLY_ATTACHED,
@@ -70,7 +72,7 @@ export const Success = (
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )

--- a/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
@@ -19,8 +19,10 @@ import { css } from 'styled-components'
 import { getIsOnDevice } from '../../redux/config'
 import { SmallButton } from '../../atoms/buttons'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import unmountGripper from '../../assets/videos/gripper-wizards/UNMOUNT_GRIPPER.webm'
 
 import type { GripperWizardStepProps } from './types'
@@ -93,7 +95,7 @@ export const UnmountGripper = (
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -12,7 +12,7 @@ import { LEFT, WASTE_CHUTE_FIXTURES } from '@opentrons/shared-data'
 import attachProbe1 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_1.webm'
 import attachProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_8.webm'
 import attachProbe96 from '../../assets/videos/pipette-wizard-flows/Pipette_Attach_Probe_96.webm'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import { SimpleWizardInProgressBody } from '../../molecules/SimpleWizardBody'
 
 import type {
   CreateCommand,
@@ -161,7 +161,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         // TODO ND: 9/6/23 use spinner until animations are made
         alternativeSpinner={null}
         description={t('stand_back')}

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -27,7 +27,7 @@ import {
   THERMOCYCLER_V2_FRONT_FIXTURE,
 } from '@opentrons/shared-data'
 
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import { SimpleWizardInProgressBody } from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
 import { LEFT_SLOTS } from './constants'
 
@@ -222,7 +222,7 @@ export const PlaceAdapter = (props: PlaceAdapterProps): JSX.Element | null => {
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -16,7 +16,6 @@ import {
 } from '@opentrons/shared-data'
 import { LegacyModalShell } from '../../molecules/LegacyModal'
 import { getTopPortalEl } from '../../App/portal'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { WizardHeader } from '../../molecules/WizardHeader'
 import { useAttachedPipettesFromInstrumentsQuery } from '../../organisms/Devices/hooks'
 import {
@@ -24,7 +23,10 @@ import {
   useCreateTargetedMaintenanceRunMutation,
 } from '../../resources/runs'
 import { getIsOnDevice } from '../../redux/config'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { getModuleCalibrationSteps } from './getModuleCalibrationSteps'
 import { FLEX_SLOT_NAMES_BY_MOD_TYPE, SECTIONS } from './constants'
 import { BeforeBeginning } from './BeforeBeginning'
@@ -263,7 +265,7 @@ export const ModuleWizardFlows = (
   let modalContent: JSX.Element = <div>UNASSIGNED STEP</div>
   if (isPrepCommandLoading) {
     modalContent = (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         description={t('prepping_module', {
           module: getModuleDisplayName(attachedModule.moduleModel),
         })}
@@ -296,7 +298,9 @@ export const ModuleWizardFlows = (
       />
     )
   } else if (isExiting) {
-    modalContent = <InProgressModal description={t('stand_back_exiting')} />
+    modalContent = (
+      <SimpleWizardInProgressBody description={t('stand_back_exiting')} />
+    )
   } else if (currentStep.section === SECTIONS.BEFORE_BEGINNING) {
     modalContent = <BeforeBeginning {...currentStep} {...calibrateBaseProps} />
   } else if (currentStep.section === SECTIONS.SELECT_LOCATION) {

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -12,8 +12,10 @@ import {
 import { LEFT, WASTE_CHUTE_CUTOUT } from '@opentrons/shared-data'
 import { Banner } from '../../atoms/Banner'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import pipetteProbe1 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_1.webm'
 import pipetteProbe8 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_8.webm'
 import probing96 from '../../assets/videos/pipette-wizard-flows/Pipette_Probing_96.webm'
@@ -156,7 +158,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   if (isRobotMoving)
     return (
-      <InProgressModal
+      <SimpleWizardInProgressBody
         alternativeSpinner={isExiting ? null : pipetteProbeVid}
         description={
           isExiting
@@ -173,7 +175,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
             </LegacyStyledText>
           </Flex>
         )}
-      </InProgressModal>
+      </SimpleWizardInProgressBody>
     )
   else if (showUnableToDetect)
     return (

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -15,9 +15,11 @@ import {
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import { Banner } from '../../atoms/Banner'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { WizardRequiredEquipmentList } from '../../molecules/WizardRequiredEquipmentList'
 import { usePipetteNameSpecs } from '../../resources/instruments/hooks'
 import {
@@ -231,7 +233,8 @@ export const BeforeBeginning = (
       })
   }
 
-  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
+  if (isRobotMoving)
+    return <SimpleWizardInProgressBody description={t('stand_back')} />
 
   return errorMessage != null ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -19,10 +19,12 @@ import {
 } from '@opentrons/components'
 import { Banner } from '../../atoms/Banner'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { Skeleton } from '../../atoms/Skeleton'
 import { SmallButton } from '../../atoms/buttons'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { BODY_STYLE, SECTIONS } from './constants'
 import { getPipetteAnimations, getPipetteAnimations96 } from './utils'
 import type { PipetteWizardStepProps } from './types'
@@ -175,7 +177,8 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     )
   }
 
-  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
+  if (isRobotMoving)
+    return <SimpleWizardInProgressBody description={t('stand_back')} />
   if (showPipetteStillAttached) {
     return (
       <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/DetachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachProbe.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useTranslation } from 'react-i18next'
 import { LegacyStyledText } from '@opentrons/components'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
+import { SimpleWizardInProgressBody } from '../../molecules/SimpleWizardBody'
 import { BODY_STYLE, SECTIONS } from './constants'
 import { getPipetteAnimations } from './utils'
 import type { PipetteWizardStepProps } from './types'
@@ -25,7 +25,8 @@ export const DetachProbe = (props: DetachProbeProps): JSX.Element => {
   const pipetteWizardStep = { mount, flowType, section: SECTIONS.DETACH_PROBE }
   const channel = attachedPipettes[mount]?.data.channels
 
-  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
+  if (isRobotMoving)
+    return <SimpleWizardInProgressBody description={t('stand_back')} />
   return (
     <GenericWizardTile
       header={i18n.format(t('remove_cal_probe'), 'capitalize')}

--- a/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
@@ -10,8 +10,10 @@ import {
   JUSTIFY_FLEX_END,
 } from '@opentrons/components'
 import { SmallButton } from '../../atoms/buttons'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { FLOWS } from './constants'
 import type { PipetteWizardFlow } from './types'
 
@@ -39,7 +41,7 @@ export function ExitModal(props: ExitModalProps): JSX.Element {
     }
   }
   if (Boolean(isRobotMoving))
-    return <InProgressModal description={t('stand_back')} />
+    return <SimpleWizardInProgressBody description={t('stand_back')} />
 
   return (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -2,9 +2,11 @@ import * as React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { LEFT } from '@opentrons/shared-data'
 import { COLORS, SPACING, LegacyStyledText } from '@opentrons/components'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { GenericWizardTile } from '../../molecules/GenericWizardTile'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
 import { getPipetteAnimations96 } from './utils'
 import { BODY_STYLE, FLOWS, SECTIONS } from './constants'
 import type { PipetteWizardStepProps } from './types'
@@ -47,7 +49,8 @@ export const MountingPlate = (
       })
   }
 
-  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
+  if (isRobotMoving)
+    return <SimpleWizardInProgressBody description={t('stand_back')} />
   return errorMessage != null ? (
     <SimpleWizardBody
       iconColor={COLORS.red50}

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -14,8 +14,10 @@ import {
 } from '@opentrons/components'
 import { LEFT, RIGHT, NINETY_SIX_CHANNEL } from '@opentrons/shared-data'
 import { SmallButton } from '../../atoms/buttons'
-import { InProgressModal } from '../../molecules/InProgressModal/InProgressModal'
-import { SimpleWizardBody } from '../../molecules/SimpleWizardBody'
+import {
+  SimpleWizardBody,
+  SimpleWizardInProgressBody,
+} from '../../molecules/SimpleWizardBody'
 import { usePipetteNameSpecs } from '../../resources/instruments/hooks'
 import { CheckPipetteButton } from './CheckPipetteButton'
 import { FLOWS } from './constants'
@@ -304,7 +306,8 @@ export const Results = (props: ResultsProps): JSX.Element => {
       </>
     )
   }
-  if (isRobotMoving) return <InProgressModal description={t('stand_back')} />
+  if (isRobotMoving)
+    return <SimpleWizardInProgressBody description={t('stand_back')} />
   if (errorMessage != null) {
     return (
       <SimpleWizardBody


### PR DESCRIPTION
There's a lot of places in the ODD that return either an InProgressModal
or a SimpleWizardBody. This used to be fine because the InProgressMOdal
had sizing, but now it doesn't so that it can be used inside other
components, so those places all have an in-progress modal collapsed on
top of the spinner icon.

To fix this, let's make a component that is explicitly "InProgressModal
designed to work alongside SimpleWizardBody", defined in
SimpleWizardBody. We can make sure it's the same by splittin SWB into a
container component and a contents component, and reusing the container.
The container is also where styleprops go.

Finally, take all the component that return (cond ? <InProgressModal /> :
<SimpleWizardBody>...</SimpleWizardBody) and make them use a
SimpleWizardInProgressBody instead of an InProgressModal. Since the
SimpleWizardInProgressBody uses the same sizing as the SWB, the result
will always be the correct size.

## Testing
- [x] On the ODD, change pipette and pipette calibration have the right size spinners
- [x] On the ODD, change gripper and gripper calibration have the right size spinners

