### PR TITLE
fix(robot-server): Set the max quick transfer runs to 2 to account for cloning an active run.

### DIFF
--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -181,7 +181,8 @@ async def get_quick_transfer_run_auto_deleter(
     return RunAutoDeleter(
         run_store=run_store,
         protocol_store=protocol_store,
-        # We dont store quick transfer runs
-        deletion_planner=RunDeletionPlanner(maximum_runs=1),
+        # NOTE: We dont store quick transfer runs, however we need an additional
+        # run slot so we can clone an active run.
+        deletion_planner=RunDeletionPlanner(maximum_runs=2),
         protocol_kind=ProtocolKind.QUICK_TRANSFER,
     )


### PR DESCRIPTION
# Overview

When cloning a run, we first make space for a new run by deleting the old run (current run), creating a new one, and copying any old run data. Since we delete the old run before cloning we can't use the old resources which leads to an issue. Since the client is responsible for deleting quick transfer runs at the end of the run, let's increase the maximum number of runs for quick transfer to 2 so we can account for this cloning case.

## Test Plan

- [x] Make sure that when a quick transfer protocol runs there is only 1 quick transfer run available (the current run)
- [x] Make sure that when a quick transfer protocol is canceled BEFORE being started we delete the run.
- [x] Make sure that when a quick transfer protocol is canceled WHILE running the run is deleted when the run is finished and the user clicks on "back to dashboard".
- [x] Make sure that when a quick transfer protocol finishes successfully the run is deleted when the user clicks on "back to dashboard"
- [x] Make sure that when a quick transfer protocol finishes successfully and the user clicks on "Run again" the previous run is cloned, a new one is created, and the old one is deleted.

## Changelog

- Increase the maximum number of quick transfer runs to 2 to account for cloning a run.

## Review requests

## Risk assessment
Low, unreleased