### PR TITLE
fix(components): invert cornerOffsetFromSlot values if adapter orientation is flipped

### DIFF
--- a/components/src/hardware-sim/Labware/LabwareRender.tsx
+++ b/components/src/hardware-sim/Labware/LabwareRender.tsx
@@ -78,7 +78,11 @@ export const LabwareRender = (props: LabwareRenderProps): JSX.Element => {
         }
       >
         <g
-          transform={`translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`}
+          transform={
+            shouldRotateAdapterOrientation
+              ? `translate(${-cornerOffsetFromSlot.x}, ${-cornerOffsetFromSlot.y})`
+              : `translate(${cornerOffsetFromSlot.x}, ${cornerOffsetFromSlot.y})`
+          }
           ref={gRef}
         >
           <LabwareAdapter


### PR DESCRIPTION
<!--
Thanks for taking the time to open a Pull Request (PR)! Please make sure you've read the "Opening Pull Requests" section of our Contributing Guide:

https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md#opening-pull-requests

GitHub provides robust markdown to format your PR. Links, diagrams, pictures, and videos along with text formatting make it possible to create a rich and informative PR. For more information on GitHub markdown, see:

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

To ensure your code is reviewed quickly and thoroughly, please fill out the sections below to the best of your ability!
-->

# Overview
The `opentrons_universal_flat_adapter` Heater-Shaker adapter has an asymmetrical SVG. To ensure the prongs are displayed on the correct side of the deck map, we flip the SVG if the heater shaker is on the left side of the deck. This was causing the `cornerOffsetFromSlot` values to be incorrect and the adapter to be misaligned from the heater shaker when it was on the left side of the deck.
<!--
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.
-->

## Test Plan and Hands on Testing
I made two protocols with a heater shaker on each side of the deck and looked at the deck map view of both run setup and protocol details. The adapter is now in the correct position for both sides of the deck

<!--
Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.
-->
![Screen Shot 2024-08-01 at 12 15 45 PM](https://github.com/user-attachments/assets/5b5f2ead-8a66-4445-b7b4-6c4b101c0282)
![Screen Shot 2024-08-01 at 12 15 35 PM](https://github.com/user-attachments/assets/f3b2c73b-69f7-4561-a7d6-ec4cf24d13b5)

## Changelog
Negate the `cornerOffsetFromSlot` values when we are rotating the SVG 180 degrees
<!--
List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.
-->

## Review requests
Look over code & screenshots
<!--
- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.
-->

## Risk assessment
Low
<!--
- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
-->
